### PR TITLE
[GenAI] Mark org.springframework.boot:spring-boot-starter-webflux as not for Native Image

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-starter-webflux/index.json
+++ b/metadata/org.springframework.boot/spring-boot-starter-webflux/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published JAR for org.springframework.boot:spring-boot-starter-webflux:2.7.18 contains only META-INF files and no JVM class files; it is a dependency starter whose runtime classes are supplied by its dependencies.",
+    "replacement": "Use the class-bearing dependencies such as org.springframework:spring-webflux:5.3.31, org.springframework:spring-web:5.3.31, and org.springframework.boot:spring-boot-autoconfigure:2.7.18."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #3635

This PR records `org.springframework.boot:spring-boot-starter-webflux` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published JAR for org.springframework.boot:spring-boot-starter-webflux:2.7.18 contains only META-INF files and no JVM class files; it is a dependency starter whose runtime classes are supplied by its dependencies.

Replacement guidance:
- Use the class-bearing dependencies such as org.springframework:spring-webflux:5.3.31, org.springframework:spring-web:5.3.31, and org.springframework.boot:spring-boot-autoconfigure:2.7.18.

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `18abc1a26d1180bbcef35eab0fd063dd6bd89f36`

### Local CI Verification

- Status: `success`
- Commands run: 6
- Fixup attempts: 0
