### PR TITLE
[GenAI] Mark org.seleniumhq.selenium:selenium-java as not for Native Image

### DIFF
--- a/metadata/org.seleniumhq.selenium/selenium-java/index.json
+++ b/metadata/org.seleniumhq.selenium/selenium-java/index.json
@@ -1,0 +1,6 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "Artifact JAR contains no JVM class files, so there is no library code for native-image metadata."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #3606

This PR records `org.seleniumhq.selenium:selenium-java` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- Artifact JAR contains no JVM class files, so there is no library code for native-image metadata.

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `18abc1a26d1180bbcef35eab0fd063dd6bd89f36`

### Local CI Verification

- Status: `success`
- Commands run: 6
- Fixup attempts: 0
