### PR TITLE
[GenAI] Mark io.ktor:ktor-client-core as not for Native Image

### DIFF
--- a/metadata/io.ktor/ktor-client-core/index.json
+++ b/metadata/io.ktor/ktor-client-core/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published root JAR contains Kotlin Multiplatform metadata/linkdata and no JVM class files; Gradle module metadata redirects JVM variants to io.ktor:ktor-client-core-jvm:3.4.2.",
+    "replacement": "io.ktor:ktor-client-core-jvm:3.4.2"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #3629

This PR records `io.ktor:ktor-client-core` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published root JAR contains Kotlin Multiplatform metadata/linkdata and no JVM class files; Gradle module metadata redirects JVM variants to io.ktor:ktor-client-core-jvm:3.4.2.

Replacement guidance:
- io.ktor:ktor-client-core-jvm:3.4.2

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `ai/vjovanov/human-intervention/issue-5418-library-new-request-com.typesafe.akka-akka-slf4j_2.13-2.6.21-821e2fdd`
- Forge commit hash: `455927c56274f70ee7b38e681ae72cbcb1adb56f`

### Local CI Verification

- Status: `success`
- Commands run: 78
- Fixup attempts: 2
- Human intervention: required because repository-level files changed during verification.
- Repository-level fix paths:
  - `tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle`
  - `tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle`
