### PR TITLE
[GenAI] Add support for org.apache.arrow:arrow-vector:7.0.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.arrow/arrow-vector/7.0.0/reachability-metadata.json
+++ b/metadata/org.apache.arrow/arrow-vector/7.0.0/reachability-metadata.json
@@ -1,0 +1,148 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.arrow.memory.BaseAllocator"
+      },
+      "type" : "org.apache.arrow.memory.DefaultAllocationManagerFactory",
+      "fields" : [
+        {
+          "name" : "FACTORY"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.arrow.vector.types.pojo.Schema"
+      },
+      "type" : "com.fasterxml.jackson.databind.ext.Java7HandlersImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.arrow.vector.types.pojo.Schema"
+      },
+      "type" : "com.fasterxml.jackson.databind.ext.Java7SupportImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.arrow.vector.types.pojo.Schema"
+      },
+      "type" : "org.apache.arrow.vector.types.pojo.Schema",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true,
+      "methods" : [
+        {
+          "name" : "getCustomMetadataForJson",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.arrow.vector.types.pojo.Schema"
+      },
+      "type" : "org.apache.arrow.vector.types.pojo.Field",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true,
+      "methods" : [
+        {
+          "name" : "getMetadataForJson",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.arrow.vector.types.pojo.Schema"
+      },
+      "type" : "org.apache.arrow.vector.types.pojo.FieldType",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.arrow.vector.types.pojo.Schema"
+      },
+      "type" : "org.apache.arrow.vector.types.pojo.DictionaryEncoding",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.arrow.vector.types.pojo.Schema"
+      },
+      "type" : "org.apache.arrow.vector.types.pojo.ArrowType",
+      "allDeclaredConstructors" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.arrow.vector.types.pojo.Schema"
+      },
+      "type" : "org.apache.arrow.vector.types.pojo.ArrowType$Int",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.arrow.vector.types.pojo.Schema"
+      },
+      "type" : "org.apache.arrow.vector.types.pojo.ArrowType$FloatingPoint",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.arrow.vector.types.pojo.Schema"
+      },
+      "type" : "org.apache.arrow.vector.types.pojo.ArrowType$List",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.arrow.vector.types.pojo.Schema"
+      },
+      "type" : "org.apache.arrow.vector.types.pojo.ArrowType$Struct",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.arrow.vector.types.pojo.Schema"
+      },
+      "type" : "org.apache.arrow.vector.types.pojo.ArrowType$Utf8",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.arrow.memory.BaseAllocator"
+      },
+      "glob" : "org/apache/arrow/memory/DefaultAllocationManagerFactory.class"
+    }
+  ]
+}

--- a/metadata/org.apache.arrow/arrow-vector/index.json
+++ b/metadata/org.apache.arrow/arrow-vector/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "7.0.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/arrow/arrow-vector/$version$/arrow-vector-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/arrow",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/arrow/arrow-vector/$version$/arrow-vector-$version$-tests.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/arrow/arrow-vector/$version$/arrow-vector-$version$-javadoc.jar",
+    "description" : "Apache Arrow Vector provides an off-heap Java implementation of the Apache Arrow columnar memory format, including value vectors, schemas, IPC support, and utilities for working with columnar data. It is used by JVM applications to create, read, validate, and exchange Arrow data efficiently with low-copy memory buffers.",
+    "tested-versions" : [
+      "7.0.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.arrow.vector"
+    ]
+  }
+]

--- a/metadata/org.apache.arrow/arrow-vector/index.json
+++ b/metadata/org.apache.arrow/arrow-vector/index.json
@@ -1,17 +1,18 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "7.0.0",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/arrow/arrow-vector/$version$/arrow-vector-$version$-sources.jar",
-    "repository-url" : "https://github.com/apache/arrow",
-    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/arrow/arrow-vector/$version$/arrow-vector-$version$-tests.jar",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/arrow/arrow-vector/$version$/arrow-vector-$version$-javadoc.jar",
-    "description" : "Apache Arrow Vector provides an off-heap Java implementation of the Apache Arrow columnar memory format, including value vectors, schemas, IPC support, and utilities for working with columnar data. It is used by JVM applications to create, read, validate, and exchange Arrow data efficiently with low-copy memory buffers.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "7.0.0",
+    "source-code-url": "https://repo.maven.apache.org/maven2/org/apache/arrow/arrow-vector/$version$/arrow-vector-$version$-sources.jar",
+    "repository-url": "https://github.com/apache/arrow",
+    "test-code-url": "https://repo.maven.apache.org/maven2/org/apache/arrow/arrow-vector/$version$/arrow-vector-$version$-tests.jar",
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/apache/arrow/arrow-vector/$version$/arrow-vector-$version$-javadoc.jar",
+    "description": "Apache Arrow Vector provides an off-heap Java implementation of the Apache Arrow columnar memory format, including value vectors, schemas, IPC support, and utilities for working with columnar data. It is used by JVM applications to create, read, validate, and exchange Arrow data efficiently with low-copy memory buffers.",
+    "tested-versions": [
       "7.0.0"
     ],
-    "allowed-packages" : [
-      "org.apache.arrow.vector"
+    "allowed-packages": [
+      "org.apache.arrow.vector",
+      "org.apache.arrow.memory"
     ]
   }
 ]

--- a/stats/org.apache.arrow/arrow-vector/7.0.0/execution-metrics.json
+++ b/stats/org.apache.arrow/arrow-vector/7.0.0/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-08": {
+    "timestamp": "2026-05-08T23:12:47.200805Z",
+    "library": "org.apache.arrow:arrow-vector:7.0.0",
+    "starting_commit": "c5b57d22a134869b42d9a1117981a742e62b50c7",
+    "ending_commit": "46dc0c5773cdcd6fffb3a84fcf64f63583528159",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "7.0.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 12628,
+          "missed": 95618,
+          "ratio": 0.11666,
+          "total": 108246
+        },
+        "line": {
+          "covered": 2445,
+          "missed": 21777,
+          "ratio": 0.100941,
+          "total": 24222
+        },
+        "method": {
+          "covered": 752,
+          "missed": 6762,
+          "ratio": 0.10008,
+          "total": 7514
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 207779,
+      "cached_input_tokens_used": 2641920,
+      "output_tokens_used": 27215,
+      "iterations": 7,
+      "cost_usd": 2.1375,
+      "generated_loc": 373,
+      "tested_library_loc": 2445,
+      "metadata_entries": 48,
+      "code_coverage_percent": 10.09
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.arrow/arrow-vector/7.0.0/src/test/java/org_apache_arrow/arrow_vector/Arrow_vectorTest.java",
+      "metadata_file": "metadata/org.apache.arrow/arrow-vector/7.0.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.arrow/arrow-vector/7.0.0/stats.json
+++ b/stats/org.apache.arrow/arrow-vector/7.0.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "7.0.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 12628,
+        "missed" : 95618,
+        "ratio" : 0.11666,
+        "total" : 108246
+      },
+      "line" : {
+        "covered" : 2445,
+        "missed" : 21777,
+        "ratio" : 0.100941,
+        "total" : 24222
+      },
+      "method" : {
+        "covered" : 752,
+        "missed" : 6762,
+        "ratio" : 0.10008,
+        "total" : 7514
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.arrow/arrow-vector/7.0.0/.gitignore
+++ b/tests/src/org.apache.arrow/arrow-vector/7.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.arrow/arrow-vector/7.0.0/build.gradle
+++ b/tests/src/org.apache.arrow/arrow-vector/7.0.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.arrow:arrow-vector:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.arrow/arrow-vector/7.0.0/build.gradle
+++ b/tests/src/org.apache.arrow/arrow-vector/7.0.0/build.gradle
@@ -12,7 +12,14 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.apache.arrow:arrow-vector:$libraryVersion"
+    testRuntimeOnly "org.apache.arrow:arrow-memory-unsafe:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+tasks.withType(Test).configureEach {
+    jvmArgs += [
+        "--add-opens=java.base/java.nio=ALL-UNNAMED"
+    ]
 }
 
 graalvmNative {
@@ -22,6 +29,11 @@ graalvmNative {
             conditional {
                 userCodeFilterPath = "user-code-filter.json"
             }
+        }
+    }
+    binaries {
+        all {
+            buildArgs.add('--add-opens=java.base/java.nio=ALL-UNNAMED')
         }
     }
 }

--- a/tests/src/org.apache.arrow/arrow-vector/7.0.0/gradle.properties
+++ b/tests/src/org.apache.arrow/arrow-vector/7.0.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.arrow:arrow-vector:7.0.0
+library.version = 7.0.0
+metadata.dir = org.apache.arrow/arrow-vector/7.0.0/

--- a/tests/src/org.apache.arrow/arrow-vector/7.0.0/settings.gradle
+++ b/tests/src/org.apache.arrow/arrow-vector/7.0.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.arrow.arrow-vector_tests'

--- a/tests/src/org.apache.arrow/arrow-vector/7.0.0/src/test/java/org_apache_arrow/arrow_vector/Arrow_vectorTest.java
+++ b/tests/src/org.apache.arrow/arrow-vector/7.0.0/src/test/java/org_apache_arrow/arrow_vector/Arrow_vectorTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_arrow.arrow_vector;
+
+import org.junit.jupiter.api.Test;
+
+class Arrow_vectorTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.apache.arrow/arrow-vector/7.0.0/src/test/java/org_apache_arrow/arrow_vector/Arrow_vectorTest.java
+++ b/tests/src/org.apache.arrow/arrow-vector/7.0.0/src/test/java/org_apache_arrow/arrow_vector/Arrow_vectorTest.java
@@ -47,6 +47,7 @@ import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.arrow.vector.util.Text;
 import org.apache.arrow.vector.util.TransferPair;
+import org.apache.arrow.vector.util.VectorSchemaRootAppender;
 import org.apache.arrow.vector.validate.ValidateVectorDataVisitor;
 import org.apache.arrow.vector.validate.ValidateVectorVisitor;
 import org.junit.jupiter.api.Test;
@@ -271,6 +272,43 @@ public class Arrow_vectorTest {
     }
 
     @Test
+    void vectorSchemaRootAppenderCombinesBatchesWithNullsAndVariableWidthValues() {
+        try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+                VectorSchemaRoot targetRoot = createBatchRoot(
+                        allocator,
+                        new Integer[] {101, null},
+                        new String[] {"initial", "missing-id"});
+                VectorSchemaRoot firstAppendRoot = createBatchRoot(
+                        allocator,
+                        new Integer[] {201, 202, null},
+                        new String[] {"first", null, "first-null-id"});
+                VectorSchemaRoot secondAppendRoot = createBatchRoot(
+                        allocator,
+                        new Integer[] {301},
+                        new String[] {"second"})) {
+            VectorSchemaRootAppender.append(targetRoot, firstAppendRoot, secondAppendRoot);
+
+            assertThat(targetRoot.getRowCount()).isEqualTo(6);
+            assertThat(targetRoot.getSchema()).isEqualTo(firstAppendRoot.getSchema());
+            assertThat(targetRoot.getVector("id").getValueCount()).isEqualTo(6);
+            assertThat(targetRoot.getVector("label").getValueCount()).isEqualTo(6);
+
+            assertThat(targetRoot.getVector("id").getObject(0)).isEqualTo(101);
+            assertThat(targetRoot.getVector("label").getObject(0).toString()).isEqualTo("initial");
+            assertThat(targetRoot.getVector("id").getObject(1)).isNull();
+            assertThat(targetRoot.getVector("label").getObject(1).toString()).isEqualTo("missing-id");
+            assertThat(targetRoot.getVector("id").getObject(2)).isEqualTo(201);
+            assertThat(targetRoot.getVector("label").getObject(2).toString()).isEqualTo("first");
+            assertThat(targetRoot.getVector("id").getObject(3)).isEqualTo(202);
+            assertThat(targetRoot.getVector("label").getObject(3)).isNull();
+            assertThat(targetRoot.getVector("id").getObject(4)).isNull();
+            assertThat(targetRoot.getVector("label").getObject(4).toString()).isEqualTo("first-null-id");
+            assertThat(targetRoot.getVector("id").getObject(5)).isEqualTo(301);
+            assertThat(targetRoot.getVector("label").getObject(5).toString()).isEqualTo("second");
+        }
+    }
+
+    @Test
     void complexListStructAndFixedSizeListVectorsExposeNestedObjectsAndValidate() {
         try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
                 ListVector numbers = ListVector.empty("numbers", allocator);
@@ -297,6 +335,33 @@ public class Arrow_vectorTest {
             person.accept(new ValidateVectorVisitor(), null);
             coordinates.accept(new ValidateVectorVisitor(), null);
         }
+    }
+
+    private static VectorSchemaRoot createBatchRoot(BufferAllocator allocator, Integer[] ids, String[] labels) {
+        IntVector idVector = new IntVector("id", allocator);
+        VarCharVector labelVector = new VarCharVector("label", allocator);
+        idVector.allocateNew(ids.length);
+        labelVector.allocateNew();
+
+        for (int index = 0; index < ids.length; index++) {
+            if (ids[index] == null) {
+                idVector.setNull(index);
+            } else {
+                idVector.setSafe(index, ids[index]);
+            }
+
+            if (labels[index] == null) {
+                labelVector.setNull(index);
+            } else {
+                labelVector.setSafe(index, new Text(labels[index]));
+            }
+        }
+
+        idVector.setValueCount(ids.length);
+        labelVector.setValueCount(labels.length);
+        VectorSchemaRoot root = VectorSchemaRoot.of(idVector, labelVector);
+        root.setRowCount(ids.length);
+        return root;
     }
 
     private static void writeIntegerLists(ListVector numbers) {

--- a/tests/src/org.apache.arrow/arrow-vector/7.0.0/src/test/java/org_apache_arrow/arrow_vector/Arrow_vectorTest.java
+++ b/tests/src/org.apache.arrow/arrow-vector/7.0.0/src/test/java/org_apache_arrow/arrow_vector/Arrow_vectorTest.java
@@ -6,11 +6,311 @@
  */
 package org_apache_arrow.arrow_vector;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.DecimalVector;
+import org.apache.arrow.vector.Float8Vector;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.ValueVector;
+import org.apache.arrow.vector.VarBinaryVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.compare.Range;
+import org.apache.arrow.vector.compare.RangeEqualsVisitor;
+import org.apache.arrow.vector.complex.FixedSizeListVector;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.complex.impl.NullableStructWriter;
+import org.apache.arrow.vector.complex.impl.UnionListWriter;
+import org.apache.arrow.vector.complex.reader.FieldReader;
+import org.apache.arrow.vector.dictionary.Dictionary;
+import org.apache.arrow.vector.dictionary.DictionaryEncoder;
+import org.apache.arrow.vector.holders.NullableIntHolder;
+import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.DictionaryEncoding;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.arrow.vector.util.Text;
+import org.apache.arrow.vector.util.TransferPair;
+import org.apache.arrow.vector.validate.ValidateVectorDataVisitor;
+import org.apache.arrow.vector.validate.ValidateVectorVisitor;
 import org.junit.jupiter.api.Test;
 
-class Arrow_vectorTest {
+public class Arrow_vectorTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void fixedWidthVectorsSupportNullsReadersTransfersAndSchemaRootOperations() {
+        try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+            IntVector ids = new IntVector("id", allocator);
+            Float8Vector scores = new Float8Vector("score", allocator);
+            BitVector active = new BitVector("active", allocator);
+
+            ids.allocateNew(5);
+            scores.allocateNew(5);
+            active.allocateNew(5);
+            for (int index = 0; index < 5; index++) {
+                ids.setSafe(index, index * 10);
+                scores.setSafe(index, index + 0.25D);
+                active.setSafe(index, index % 2);
+            }
+            ids.setNull(2);
+            scores.setNull(4);
+            ids.setValueCount(5);
+            scores.setValueCount(5);
+            active.setValueCount(5);
+
+            assertThat(ids.getNullCount()).isEqualTo(1);
+            assertThat(ids.getObject(2)).isNull();
+            assertThat(scores.getObject(1)).isEqualTo(1.25D);
+            assertThat(active.getObject(3)).isEqualTo(Boolean.TRUE);
+
+            NullableIntHolder holder = new NullableIntHolder();
+            ids.get(3, holder);
+            assertThat(holder.isSet).isEqualTo(1);
+            assertThat(holder.value).isEqualTo(30);
+
+            FieldReader reader = ids.getReader();
+            reader.setPosition(1);
+            assertThat(reader.readInteger()).isEqualTo(10);
+            reader.setPosition(2);
+            assertThat(reader.isSet()).isFalse();
+
+            TransferPair transferPair = ids.getTransferPair("idCopy", allocator);
+            transferPair.splitAndTransfer(1, 3);
+            try (ValueVector copied = transferPair.getTo()) {
+                assertThat(copied.getValueCount()).isEqualTo(3);
+                assertThat(copied.getObject(0)).isEqualTo(10);
+                assertThat(copied.getObject(1)).isNull();
+                assertThat(copied.getObject(2)).isEqualTo(30);
+            }
+
+            try (VectorSchemaRoot root = VectorSchemaRoot.of(ids, scores, active)) {
+                root.setRowCount(5);
+                assertThat(root.getSchema().getFields())
+                        .extracting(Field::getName)
+                        .containsExactly("id", "score", "active");
+                assertThat(root.getVector("score")).isSameAs(scores);
+                assertThat(root.contentToTSVString()).contains("id\tscore\tactive").contains("10\t1.25");
+
+                try (VectorSchemaRoot slice = root.slice(1, 3)) {
+                    assertThat(slice.getRowCount()).isEqualTo(3);
+                    assertThat(slice.getVector("id").getObject(0)).isEqualTo(10);
+                    assertThat(slice.getVector("id").getObject(1)).isNull();
+                    assertThat(slice.getVector("active").getObject(2)).isEqualTo(Boolean.TRUE);
+                }
+            }
+        }
+    }
+
+    @Test
+    void variableWidthDecimalAndDictionaryVectorsRoundTripValues() {
+        try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+                VarCharVector words = new VarCharVector("words", allocator);
+                VarBinaryVector payloads = new VarBinaryVector("payloads", allocator);
+                DecimalVector prices = new DecimalVector("prices", allocator, 10, 2)) {
+            words.allocateNew();
+            words.setSafe(0, new Text("alpha"));
+            words.setSafe(1, new Text("beta"));
+            words.setSafe(2, new Text("alpha"));
+            words.setSafe(3, new Text("gamma"));
+            words.setValueCount(4);
+
+            payloads.allocateNew();
+            payloads.setSafe(0, "first".getBytes(StandardCharsets.UTF_8));
+            payloads.setSafe(1, "second".getBytes(StandardCharsets.UTF_8));
+            payloads.setNull(2);
+            payloads.setValueCount(3);
+
+            prices.allocateNew();
+            prices.setSafe(0, new BigDecimal("12.34"));
+            prices.setSafe(1, new BigDecimal("56.78"));
+            prices.setNull(2);
+            prices.setValueCount(3);
+
+            assertThat(words.getObject(1).toString()).isEqualTo("beta");
+            assertThat(payloads.get(0)).isEqualTo("first".getBytes(StandardCharsets.UTF_8));
+            assertThat(payloads.getObject(2)).isNull();
+            assertThat(prices.getObject(0)).isEqualByComparingTo("12.34");
+            assertThat(prices.getPrecision()).isEqualTo(10);
+            assertThat(prices.getScale()).isEqualTo(2);
+
+            try (VarCharVector dictionaryValues = new VarCharVector("dictionary", allocator)) {
+                dictionaryValues.allocateNew();
+                dictionaryValues.setSafe(0, new Text("alpha"));
+                dictionaryValues.setSafe(1, new Text("beta"));
+                dictionaryValues.setSafe(2, new Text("gamma"));
+                dictionaryValues.setValueCount(3);
+
+                DictionaryEncoding encoding = new DictionaryEncoding(7L, false, new ArrowType.Int(8, true));
+                Dictionary dictionary = new Dictionary(dictionaryValues, encoding);
+                try (ValueVector encoded = DictionaryEncoder.encode(words, dictionary);
+                        ValueVector decoded = DictionaryEncoder.decode(encoded, dictionary)) {
+                    assertThat(encoded.getField().getDictionary()).isEqualTo(encoding);
+                    assertThat(decoded.getValueCount()).isEqualTo(words.getValueCount());
+                    assertThat(decoded.getObject(0).toString()).isEqualTo("alpha");
+                    assertThat(decoded.getObject(1).toString()).isEqualTo("beta");
+                    assertThat(decoded.getObject(2).toString()).isEqualTo("alpha");
+                    assertThat(decoded.getObject(3).toString()).isEqualTo("gamma");
+                    assertThat(DictionaryEncoder.getIndexType(dictionaryValues.getValueCount()).getBitWidth())
+                            .isEqualTo(8);
+                }
+            }
+
+            TransferPair copyPair = words.getTransferPair("wordsCopy", allocator);
+            copyPair.copyValueSafe(3, 0);
+            copyPair.copyValueSafe(0, 1);
+            try (ValueVector copied = copyPair.getTo()) {
+                copied.setValueCount(2);
+                assertThat(copied.getObject(0).toString()).isEqualTo("gamma");
+                assertThat(copied.getObject(1).toString()).isEqualTo("alpha");
+                assertThat(new RangeEqualsVisitor(words, words).rangeEquals(new Range(0, 2, 1))).isTrue();
+            }
+        }
+    }
+
+    @Test
+    void schemaJsonFlatbufferAndVectorCreationPreserveNestedFieldMetadata() throws IOException {
+        Map<String, String> fieldMetadata = Map.of("unit", "test");
+        Field id = new Field(
+                "id",
+                new FieldType(false, new ArrowType.Int(32, true), null, fieldMetadata),
+                List.of());
+        Field name = Field.nullable("name", ArrowType.Utf8.INSTANCE);
+        Field score = Field.nullable("score", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE));
+        Field tags = new Field(
+                "tags",
+                FieldType.nullable(ArrowType.List.INSTANCE),
+                List.of(Field.nullable("element", ArrowType.Utf8.INSTANCE)));
+        Field person = new Field(
+                "person",
+                FieldType.nullable(ArrowType.Struct.INSTANCE),
+                List.of(name, Field.nullable("age", new ArrowType.Int(32, true))));
+        Schema schema = new Schema(List.of(id, score, tags, person), Map.of("owner", "arrow-vector-test"));
+
+        String json = schema.toJson();
+        Schema fromJson = Schema.fromJSON(json);
+        Schema fromFlatBuffer = Schema.deserialize(ByteBuffer.wrap(schema.toByteArray()));
+
+        assertThat(fromJson).isEqualTo(schema);
+        assertThat(fromFlatBuffer).isEqualTo(schema);
+        assertThat(fromJson.findField("person").getChildren())
+                .extracting(Field::getName)
+                .containsExactly("name", "age");
+        assertThat(fromJson.findField("id").getMetadata()).containsEntry("unit", "test");
+        assertThat(fromJson.getCustomMetadata()).containsEntry("owner", "arrow-vector-test");
+
+        try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+                VectorSchemaRoot root = VectorSchemaRoot.create(fromJson, allocator)) {
+            root.allocateNew();
+            root.setRowCount(2);
+
+            assertThat(root.getVector("id")).isInstanceOf(IntVector.class);
+            assertThat(root.getVector("score")).isInstanceOf(Float8Vector.class);
+            assertThat(root.getVector("tags")).isInstanceOf(ListVector.class);
+            assertThat(root.getVector("person")).isInstanceOf(StructVector.class);
+            root.syncSchema();
+            assertThat(root.getSchema().getFields())
+                    .extracting(Field::getName)
+                    .containsExactly("id", "score", "tags", "person");
+        }
+    }
+
+    @Test
+    void complexListStructAndFixedSizeListVectorsExposeNestedObjectsAndValidate() {
+        try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+                ListVector numbers = ListVector.empty("numbers", allocator);
+                StructVector person = StructVector.empty("person", allocator);
+                FixedSizeListVector coordinates = FixedSizeListVector.empty("coordinates", 2, allocator)) {
+            writeIntegerLists(numbers);
+            writeStructRows(person);
+            writeFixedSizeLists(coordinates);
+
+            assertThat(numbers.getObject(0)).isEqualTo(List.of(1, 2, 3));
+            assertThat(numbers.getObject(1)).isNull();
+            assertThat(numbers.getObject(2)).isEqualTo(List.of(5));
+
+            assertThat(person.getObject(0)).isEqualTo(Map.of("age", 41));
+            assertThat(person.getObject(1)).isNull();
+            assertThat(person.getObject(2)).isEqualTo(Map.of("age", 7));
+
+            assertThat(coordinates.getObject(0)).isEqualTo(List.of(1.5D, 2.5D));
+            assertThat(coordinates.getObject(1)).isNull();
+            assertThat(coordinates.getObject(2)).isEqualTo(List.of(-1.0D, 4.0D));
+
+            numbers.accept(new ValidateVectorVisitor(), null);
+            numbers.accept(new ValidateVectorDataVisitor(), null);
+            person.accept(new ValidateVectorVisitor(), null);
+            coordinates.accept(new ValidateVectorVisitor(), null);
+        }
+    }
+
+    private static void writeIntegerLists(ListVector numbers) {
+        UnionListWriter writer = numbers.getWriter();
+        writer.allocate();
+
+        writer.setPosition(0);
+        writer.startList();
+        writer.writeInt(1);
+        writer.writeInt(2);
+        writer.writeInt(3);
+        writer.endList();
+
+        writer.setPosition(1);
+        writer.writeNull();
+
+        writer.setPosition(2);
+        writer.startList();
+        writer.writeInt(5);
+        writer.endList();
+
+        writer.setValueCount(3);
+    }
+
+    private static void writeStructRows(StructVector person) {
+        NullableStructWriter writer = person.getWriter();
+        writer.allocate();
+
+        writer.setPosition(0);
+        writer.start();
+        writer.integer("age").writeInt(41);
+        writer.end();
+
+        writer.setPosition(1);
+        writer.writeNull();
+
+        writer.setPosition(2);
+        writer.start();
+        writer.integer("age").writeInt(7);
+        writer.end();
+
+        writer.setValueCount(3);
+    }
+
+    private static void writeFixedSizeLists(FixedSizeListVector coordinates) {
+        FieldType valueType = FieldType.nullable(new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE));
+        coordinates.addOrGetVector(valueType);
+        coordinates.allocateNew();
+
+        Float8Vector values = (Float8Vector) coordinates.getDataVector();
+        coordinates.setNotNull(0);
+        values.setSafe(0, 1.5D);
+        values.setSafe(1, 2.5D);
+        coordinates.setNull(1);
+        coordinates.setNotNull(2);
+        values.setSafe(4, -1.0D);
+        values.setSafe(5, 4.0D);
+        values.setValueCount(6);
+        coordinates.setValueCount(3);
     }
 }

--- a/tests/src/org.apache.arrow/arrow-vector/7.0.0/src/test/java/org_apache_arrow/arrow_vector/Arrow_vectorTest.java
+++ b/tests/src/org.apache.arrow/arrow-vector/7.0.0/src/test/java/org_apache_arrow/arrow_vector/Arrow_vectorTest.java
@@ -24,7 +24,9 @@ import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorLoader;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.VectorUnloader;
 import org.apache.arrow.vector.compare.Range;
 import org.apache.arrow.vector.compare.RangeEqualsVisitor;
 import org.apache.arrow.vector.complex.FixedSizeListVector;
@@ -36,6 +38,7 @@ import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.dictionary.Dictionary;
 import org.apache.arrow.vector.dictionary.DictionaryEncoder;
 import org.apache.arrow.vector.holders.NullableIntHolder;
+import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.DictionaryEncoding;
@@ -223,6 +226,47 @@ public class Arrow_vectorTest {
             assertThat(root.getSchema().getFields())
                     .extracting(Field::getName)
                     .containsExactly("id", "score", "tags", "person");
+        }
+    }
+
+    @Test
+    void vectorLoaderAndUnloaderRoundTripRecordBatchesBetweenSchemaRoots() {
+        try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+            IntVector ids = new IntVector("id", allocator);
+            VarCharVector labels = new VarCharVector("label", allocator);
+
+            ids.allocateNew(4);
+            labels.allocateNew();
+            ids.setSafe(0, 11);
+            labels.setSafe(0, new Text("first"));
+            ids.setNull(1);
+            labels.setSafe(1, new Text("missing-id"));
+            ids.setSafe(2, 33);
+            labels.setNull(2);
+            ids.setSafe(3, 44);
+            labels.setSafe(3, new Text("last"));
+            ids.setValueCount(4);
+            labels.setValueCount(4);
+
+            try (VectorSchemaRoot sourceRoot = VectorSchemaRoot.of(ids, labels)) {
+                sourceRoot.setRowCount(4);
+                VectorUnloader unloader = new VectorUnloader(sourceRoot);
+
+                try (ArrowRecordBatch recordBatch = unloader.getRecordBatch();
+                        VectorSchemaRoot targetRoot = VectorSchemaRoot.create(sourceRoot.getSchema(), allocator)) {
+                    VectorLoader loader = new VectorLoader(targetRoot);
+                    loader.load(recordBatch);
+
+                    assertThat(targetRoot.getRowCount()).isEqualTo(4);
+                    assertThat(targetRoot.getSchema()).isEqualTo(sourceRoot.getSchema());
+                    assertThat(targetRoot.getVector("id").getObject(0)).isEqualTo(11);
+                    assertThat(targetRoot.getVector("id").getObject(1)).isNull();
+                    assertThat(targetRoot.getVector("id").getObject(3)).isEqualTo(44);
+                    assertThat(targetRoot.getVector("label").getObject(0).toString()).isEqualTo("first");
+                    assertThat(targetRoot.getVector("label").getObject(2)).isNull();
+                    assertThat(targetRoot.getVector("label").getObject(3).toString()).isEqualTo("last");
+                }
+            }
         }
     }
 

--- a/tests/src/org.apache.arrow/arrow-vector/7.0.0/user-code-filter.json
+++ b/tests/src/org.apache.arrow/arrow-vector/7.0.0/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.apache.arrow.vector.**"
+      "includeClasses" : "org.apache.arrow.vector.**"
+    },
+    {
+      "includeClasses" : "org_apache_arrow.arrow_vector.**"
     }
   ]
 }

--- a/tests/src/org.apache.arrow/arrow-vector/7.0.0/user-code-filter.json
+++ b/tests/src/org.apache.arrow/arrow-vector/7.0.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.apache.arrow.vector.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #3149

This PR introduces tests and metadata for org.apache.arrow:arrow-vector:7.0.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 207779
- Cached input tokens: 2641920
- Output tokens: 27215
- Metadata entries: 48
- Iterations: 7
- Library coverage percentage: 10.09
- Generated lines of code: 373
- Tested library lines of code: 2445

### Metadata Forge

- Forge monitored branch: `origin/forge/shared-issue-search-cache`
- Forge branch: `master`
- Forge commit hash: `0d7f1ac496d758456ac5885710982fc775d89e05`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 12628/108246 (11.67%)
- Line: 2445/24222 (10.09%)
- Method: 752/7514 (10.01%)

### Local CI Verification

- Status: `success`
- Commands run: 81
- Fixup attempts: 1
- Human intervention: required because repository-level files changed during verification.
- Repository-level fix paths:
  - `tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle`
