### PR TITLE
[GenAI] Add support for org.apache.hadoop:hadoop-mapreduce-client-shuffle:2.7.3 using gpt-5.5

### DIFF
--- a/metadata/org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3/reachability-metadata.json
+++ b/metadata/org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3/reachability-metadata.json
@@ -1,0 +1,90 @@
+{
+  "reflection": [
+    {
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "type": "java.lang.Thread",
+      "methods": [
+        {
+          "name": "getContextClassLoader",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "type": "org.apache.commons.logging.LogFactory"
+    },
+    {
+      "type": "org.apache.commons.logging.impl.Jdk14Logger",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.apache.commons.logging.impl.LogFactoryImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.apache.commons.logging.impl.SimpleLog",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.apache.commons.logging.impl.WeakHashtable",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.mapred.ShuffleHandler"
+      },
+      "type": "org.apache.hadoop.mapred.ShuffleHandler$ShuffleMetrics",
+      "allDeclaredFields": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.mapred.ShuffleHandler"
+      },
+      "type": "org.apache.hadoop.yarn.server.records.impl.pb.VersionPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "glob": "META-INF/services/org.apache.commons.logging.LogFactory"
+    },
+    {
+      "glob": "commons-logging.properties"
+    }
+  ]
+}

--- a/metadata/org.apache.hadoop/hadoop-mapreduce-client-shuffle/index.json
+++ b/metadata/org.apache.hadoop/hadoop-mapreduce-client-shuffle/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.7.3",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/hadoop/hadoop-mapreduce-client-shuffle/$version$/hadoop-mapreduce-client-shuffle-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/hadoop",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/hadoop/hadoop-mapreduce-client-shuffle/$version$/hadoop-mapreduce-client-shuffle-$version$-test-sources.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/hadoop/hadoop-mapreduce-client-shuffle/$version$/hadoop-mapreduce-client-shuffle-$version$-javadoc.jar",
+    "description" : "hadoop-mapreduce-client-shuffle provides the MapReduce shuffle service implementation used by Hadoop YARN NodeManager to serve intermediate map outputs to reducers over HTTP. It includes shuffle handler logic, recovery state handling, metrics, and protocol support needed by Hadoop MapReduce jobs during the reduce-side fetch phase.",
+    "tested-versions" : [
+      "2.7.3"
+    ],
+    "allowed-packages" : [
+      "org.apache.hadoop.mapred"
+    ]
+  }
+]

--- a/stats/org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3/execution-metrics.json
+++ b/stats/org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-09": {
+    "timestamp": "2026-05-09T05:37:44.184474Z",
+    "library": "org.apache.hadoop:hadoop-mapreduce-client-shuffle:2.7.3",
+    "starting_commit": "8371075372bbf99b2d9bb4c27d116ea121132972",
+    "ending_commit": "75bd4fa13cfb1725e5213ddbc21fccc092a6f717",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.7.3",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 609,
+          "missed": 2962,
+          "ratio": 0.17054,
+          "total": 3571
+        },
+        "line": {
+          "covered": 153,
+          "missed": 730,
+          "ratio": 0.173273,
+          "total": 883
+        },
+        "method": {
+          "covered": 27,
+          "missed": 121,
+          "ratio": 0.182432,
+          "total": 148
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 115719,
+      "cached_input_tokens_used": 1338368,
+      "output_tokens_used": 17692,
+      "iterations": 5,
+      "cost_usd": 1.2,
+      "generated_loc": 215,
+      "tested_library_loc": 153,
+      "metadata_entries": 20,
+      "code_coverage_percent": 17.33
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3/src/test/java/org_apache_hadoop/hadoop_mapreduce_client_shuffle/Hadoop_mapreduce_client_shuffleTest.java",
+      "metadata_file": "metadata/org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3/stats.json
+++ b/stats/org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.7.3",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 609,
+        "missed" : 2962,
+        "ratio" : 0.17054,
+        "total" : 3571
+      },
+      "line" : {
+        "covered" : 153,
+        "missed" : 730,
+        "ratio" : 0.173273,
+        "total" : 883
+      },
+      "method" : {
+        "covered" : 27,
+        "missed" : 121,
+        "ratio" : 0.182432,
+        "total" : 148
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3/.gitignore
+++ b/tests/src/org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3/build.gradle
+++ b/tests/src/org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.hadoop:hadoop-mapreduce-client-shuffle:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3/build.gradle
+++ b/tests/src/org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.apache.hadoop:hadoop-mapreduce-client-shuffle:$libraryVersion"
+    testImplementation "org.apache.hadoop:hadoop-common:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3/gradle.properties
+++ b/tests/src/org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.hadoop:hadoop-mapreduce-client-shuffle:2.7.3
+library.version = 2.7.3
+metadata.dir = org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3/

--- a/tests/src/org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3/settings.gradle
+++ b/tests/src/org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.hadoop.hadoop-mapreduce-client-shuffle_tests'

--- a/tests/src/org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3/src/test/java/org_apache_hadoop/hadoop_mapreduce_client_shuffle/Hadoop_mapreduce_client_shuffleTest.java
+++ b/tests/src/org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3/src/test/java/org_apache_hadoop/hadoop_mapreduce_client_shuffle/Hadoop_mapreduce_client_shuffleTest.java
@@ -6,11 +6,187 @@
  */
 package org_apache_hadoop.hadoop_mapreduce_client_shuffle;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapred.FadvisedChunkedFile;
+import org.apache.hadoop.mapred.FadvisedFileRegion;
+import org.apache.hadoop.mapred.ShuffleHandler;
+import org.apache.hadoop.mapreduce.security.token.JobTokenIdentifier;
+import org.apache.hadoop.security.token.Token;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.jboss.netty.buffer.ChannelBuffer;
 import org.junit.jupiter.api.Test;
 
-class Hadoop_mapreduce_client_shuffleTest {
+public class Hadoop_mapreduce_client_shuffleTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void metadataSerializationRoundTripsPortNumbers() throws Exception {
+        int[] ports = {0, 1, ShuffleHandler.DEFAULT_SHUFFLE_PORT, 65535, Integer.MAX_VALUE};
+
+        for (int port : ports) {
+            ByteBuffer serialized = ShuffleHandler.serializeMetaData(port);
+
+            assertThat(serialized.remaining()).isEqualTo(Integer.BYTES);
+            assertThat(ShuffleHandler.deserializeMetaData(serialized.duplicate())).isEqualTo(port);
+        }
+    }
+
+    @Test
+    void serviceDataSerializationWritesCompleteJobToken() throws Exception {
+        byte[] identifier = "job_0001".getBytes(StandardCharsets.UTF_8);
+        byte[] password = "shuffle-secret".getBytes(StandardCharsets.UTF_8);
+        Text kind = new Text("mapreduce.job");
+        Text service = new Text("shuffle-service");
+        Token<JobTokenIdentifier> token = new Token<>(identifier, password, kind, service);
+
+        ByteBuffer serialized = ShuffleHandler.serializeServiceData(token);
+        byte[] tokenBytes = new byte[serialized.remaining()];
+        serialized.get(tokenBytes);
+        Token<JobTokenIdentifier> decoded = new Token<>();
+        decoded.readFields(new DataInputStream(new ByteArrayInputStream(tokenBytes)));
+
+        assertThat(decoded.getIdentifier()).isEqualTo(identifier);
+        assertThat(decoded.getPassword()).isEqualTo(password);
+        assertThat(decoded.getKind()).isEqualTo(kind);
+        assertThat(decoded.getService()).isEqualTo(service);
+    }
+
+    @Test
+    void chunkedFileStreamsFileInConfiguredChunkSizes() throws Exception {
+        Path file = writeTempFile("abcdefghij");
+
+        try (RandomAccessFile randomAccessFile = new RandomAccessFile(file.toFile(), "r")) {
+            FadvisedChunkedFile chunkedFile = new FadvisedChunkedFile(
+                    randomAccessFile,
+                    0,
+                    randomAccessFile.length(),
+                    4,
+                    false,
+                    0,
+                    null,
+                    "chunked-test");
+            try {
+                assertThat(readChunk(chunkedFile.nextChunk())).isEqualTo("abcd");
+                assertThat(readChunk(chunkedFile.nextChunk())).isEqualTo("efgh");
+                assertThat(readChunk(chunkedFile.nextChunk())).isEqualTo("ij");
+                assertThat(chunkedFile.isEndOfInput()).isTrue();
+                assertThat(chunkedFile.nextChunk()).isNull();
+            } finally {
+                chunkedFile.close();
+            }
+        }
+    }
+
+    @Test
+    void fileRegionTransfersRequestedRangeWithCustomShuffleBuffer() throws Exception {
+        Path file = writeTempFile("abcdefghijklmnopqrstuvwxyz");
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        try (RandomAccessFile randomAccessFile = new RandomAccessFile(file.toFile(), "r")) {
+            FadvisedFileRegion region = new FadvisedFileRegion(
+                    randomAccessFile,
+                    2,
+                    9,
+                    false,
+                    0,
+                    null,
+                    "region-test",
+                    4,
+                    false);
+            try {
+                long transferred = region.transferTo(Channels.newChannel(output), 0);
+
+                assertThat(transferred).isEqualTo(9);
+                assertThat(new String(output.toByteArray(), StandardCharsets.UTF_8)).isEqualTo("cdefghijk");
+                region.transferSuccessful();
+            } finally {
+                region.releaseExternalResources();
+            }
+        }
+    }
+
+    @Test
+    void fileRegionTransfersFromRelativePositionAndRejectsOutOfRangePositions() throws Exception {
+        Path file = writeTempFile("0123456789abcdef");
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        try (RandomAccessFile randomAccessFile = new RandomAccessFile(file.toFile(), "r")) {
+            FadvisedFileRegion region = new FadvisedFileRegion(
+                    randomAccessFile,
+                    3,
+                    8,
+                    false,
+                    0,
+                    null,
+                    "relative-region-test",
+                    3,
+                    false);
+            try {
+                long transferred = region.transferTo(Channels.newChannel(output), 2);
+
+                assertThat(transferred).isEqualTo(6);
+                assertThat(new String(output.toByteArray(), StandardCharsets.UTF_8)).isEqualTo("56789a");
+                assertThat(region.transferTo(Channels.newChannel(new ByteArrayOutputStream()), 8)).isZero();
+                assertThatThrownBy(() -> region.transferTo(Channels.newChannel(new ByteArrayOutputStream()), -1))
+                        .isInstanceOf(IllegalArgumentException.class)
+                        .hasMessageContaining("position out of range");
+                assertThatThrownBy(() -> region.transferTo(Channels.newChannel(new ByteArrayOutputStream()), 9))
+                        .isInstanceOf(IllegalArgumentException.class)
+                        .hasMessageContaining("position out of range");
+            } finally {
+                region.releaseExternalResources();
+            }
+        }
+    }
+
+    @Test
+    void shuffleHandlerStartsOnEphemeralPortAndPublishesMetadata() throws Exception {
+        Configuration configuration = new Configuration(false);
+        configuration.setBoolean(YarnConfiguration.NM_RECOVERY_ENABLED, false);
+        configuration.setInt(ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY, 0);
+        configuration.setInt(ShuffleHandler.MAX_SHUFFLE_THREADS, 1);
+        configuration.setInt(ShuffleHandler.SHUFFLE_CONNECTION_KEEP_ALIVE_TIME_OUT, 1);
+        configuration.setInt(ShuffleHandler.SHUFFLE_MAPOUTPUT_META_INFO_CACHE_SIZE, 1);
+
+        ShuffleHandler handler = new ShuffleHandler();
+        try {
+            handler.init(configuration);
+            handler.start();
+
+            int publishedPort = ShuffleHandler.deserializeMetaData(handler.getMetaData());
+
+            assertThat(publishedPort).isPositive();
+            assertThat(handler.getConfig().getInt(ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY, -1)).isEqualTo(publishedPort);
+        } finally {
+            handler.stop();
+        }
+    }
+
+    private static Path writeTempFile(String contents) throws IOException {
+        Path file = Files.createTempFile("shuffle-test", ".data");
+        Files.write(file, contents.getBytes(StandardCharsets.UTF_8));
+        file.toFile().deleteOnExit();
+        return file;
+    }
+
+    private static String readChunk(Object chunk) {
+        assertThat(chunk).isInstanceOf(ChannelBuffer.class);
+        ChannelBuffer buffer = (ChannelBuffer) chunk;
+        byte[] bytes = new byte[buffer.readableBytes()];
+        buffer.readBytes(bytes);
+        return new String(bytes, StandardCharsets.UTF_8);
     }
 }

--- a/tests/src/org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3/src/test/java/org_apache_hadoop/hadoop_mapreduce_client_shuffle/Hadoop_mapreduce_client_shuffleTest.java
+++ b/tests/src/org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3/src/test/java/org_apache_hadoop/hadoop_mapreduce_client_shuffle/Hadoop_mapreduce_client_shuffleTest.java
@@ -177,6 +177,33 @@ public class Hadoop_mapreduce_client_shuffleTest {
     }
 
     @Test
+    void fileRegionUsesZeroCopyTransferWhenAllowed() throws Exception {
+        Path file = writeTempFile("zero-copy-transfer");
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        try (RandomAccessFile randomAccessFile = new RandomAccessFile(file.toFile(), "r")) {
+            FadvisedFileRegion region = new FadvisedFileRegion(
+                    randomAccessFile,
+                    5,
+                    4,
+                    false,
+                    0,
+                    null,
+                    "zero-copy-region-test",
+                    2,
+                    true);
+            try {
+                long transferred = region.transferTo(Channels.newChannel(output), 0);
+
+                assertThat(transferred).isEqualTo(4);
+                assertThat(new String(output.toByteArray(), StandardCharsets.UTF_8)).isEqualTo("copy");
+            } finally {
+                region.releaseExternalResources();
+            }
+        }
+    }
+
+    @Test
     void shuffleHandlerStartsOnEphemeralPortAndPublishesMetadata() throws Exception {
         Configuration configuration = new Configuration(false);
         configuration.setBoolean(YarnConfiguration.NM_RECOVERY_ENABLED, false);

--- a/tests/src/org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3/src/test/java/org_apache_hadoop/hadoop_mapreduce_client_shuffle/Hadoop_mapreduce_client_shuffleTest.java
+++ b/tests/src/org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3/src/test/java/org_apache_hadoop/hadoop_mapreduce_client_shuffle/Hadoop_mapreduce_client_shuffleTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_hadoop.hadoop_mapreduce_client_shuffle;
+
+import org.junit.jupiter.api.Test;
+
+class Hadoop_mapreduce_client_shuffleTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3/src/test/java/org_apache_hadoop/hadoop_mapreduce_client_shuffle/Hadoop_mapreduce_client_shuffleTest.java
+++ b/tests/src/org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3/src/test/java/org_apache_hadoop/hadoop_mapreduce_client_shuffle/Hadoop_mapreduce_client_shuffleTest.java
@@ -91,6 +91,30 @@ public class Hadoop_mapreduce_client_shuffleTest {
     }
 
     @Test
+    void chunkedFileStreamsOnlyRequestedRangeFromOffset() throws Exception {
+        Path file = writeTempFile("0123456789abcdef");
+
+        try (RandomAccessFile randomAccessFile = new RandomAccessFile(file.toFile(), "r")) {
+            FadvisedChunkedFile chunkedFile = new FadvisedChunkedFile(
+                    randomAccessFile,
+                    4,
+                    5,
+                    16,
+                    false,
+                    0,
+                    null,
+                    "offset-chunked-test");
+            try {
+                assertThat(readChunk(chunkedFile.nextChunk())).isEqualTo("45678");
+                assertThat(chunkedFile.isEndOfInput()).isTrue();
+                assertThat(chunkedFile.nextChunk()).isNull();
+            } finally {
+                chunkedFile.close();
+            }
+        }
+    }
+
+    @Test
     void fileRegionTransfersRequestedRangeWithCustomShuffleBuffer() throws Exception {
         Path file = writeTempFile("abcdefghijklmnopqrstuvwxyz");
         ByteArrayOutputStream output = new ByteArrayOutputStream();

--- a/tests/src/org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3/user-code-filter.json
+++ b/tests/src/org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.apache.hadoop.mapred.**"
+    }
+  ]
+}

--- a/tests/src/org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3/user-code-filter.json
+++ b/tests/src/org.apache.hadoop/hadoop-mapreduce-client-shuffle/2.7.3/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.apache.hadoop.mapred.**"
+      "includeClasses" : "org.apache.hadoop.mapred.**"
+    },
+    {
+      "includeClasses" : "org_apache_hadoop.hadoop_mapreduce_client_shuffle.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #2967

This PR introduces tests and metadata for org.apache.hadoop:hadoop-mapreduce-client-shuffle:2.7.3, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 115719
- Cached input tokens: 1338368
- Output tokens: 17692
- Metadata entries: 20
- Iterations: 5
- Library coverage percentage: 17.33
- Generated lines of code: 215
- Tested library lines of code: 153

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `5411de5c643414d6833ab473567e7478cde78720`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 609/3571 (17.05%)
- Line: 153/883 (17.33%)
- Method: 27/148 (18.24%)

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
