### PR TITLE
[GenAI] Add support for org.apache.hadoop:hadoop-mapreduce-client-jobclient:2.7.3 using gpt-5.5

### DIFF
--- a/metadata/org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3/reachability-metadata.json
+++ b/metadata/org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3/reachability-metadata.json
@@ -1,0 +1,180 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.mapred.ClientCache"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.mapred.ClientCache"
+      },
+      "type": "java.lang.Thread",
+      "methods": [
+        {
+          "name": "getContextClassLoader",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.mapred.ClientCache"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.mapred.ClientCache"
+      },
+      "type": "org.apache.commons.logging.LogFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.mapred.ClientCache"
+      },
+      "type": "org.apache.commons.logging.impl.Jdk14Logger",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.mapred.ClientCache"
+      },
+      "type": "org.apache.commons.logging.impl.LogFactoryImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.mapred.ClientCache"
+      },
+      "type": "org.apache.commons.logging.impl.SimpleLog",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.mapred.ClientCache"
+      },
+      "type": "org.apache.commons.logging.impl.WeakHashtable",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.mapred.YarnClientProtocolProvider"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.mapred.YarnClientProtocolProvider"
+      },
+      "type": "java.lang.Thread",
+      "methods": [
+        {
+          "name": "getContextClassLoader",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.mapred.YarnClientProtocolProvider"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.mapred.YarnClientProtocolProvider"
+      },
+      "type": "org.apache.commons.logging.LogFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.mapred.YarnClientProtocolProvider"
+      },
+      "type": "org.apache.commons.logging.impl.Jdk14Logger",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.mapred.YarnClientProtocolProvider"
+      },
+      "type": "org.apache.commons.logging.impl.LogFactoryImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.mapred.YarnClientProtocolProvider"
+      },
+      "type": "org.apache.commons.logging.impl.SimpleLog",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.mapred.YarnClientProtocolProvider"
+      },
+      "type": "org.apache.commons.logging.impl.WeakHashtable",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.mapred.ClientServiceDelegate"
+      },
+      "type": "org.apache.hadoop.mapreduce.v2.api.records.impl.pb.JobIdPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.apache.hadoop/hadoop-mapreduce-client-jobclient/index.json
+++ b/metadata/org.apache.hadoop/hadoop-mapreduce-client-jobclient/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.7.3",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/hadoop/hadoop-mapreduce-client-jobclient/$version$/hadoop-mapreduce-client-jobclient-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/hadoop",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/hadoop/hadoop-mapreduce-client-jobclient/$version$/hadoop-mapreduce-client-jobclient-$version$-test-sources.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/hadoop/hadoop-mapreduce-client-jobclient/$version$/hadoop-mapreduce-client-jobclient-$version$-javadoc.jar",
+    "description" : "Apache Hadoop MapReduce Client JobClient provides the YARN-backed implementation used by Hadoop's MapReduce client APIs to submit jobs and communicate with the resource manager and application master. It includes client-side support classes such as YARNRunner, ResourceMgrDelegate, and ClientServiceDelegate for tracking, controlling, and querying MapReduce jobs.",
+    "tested-versions" : [
+      "2.7.3"
+    ],
+    "allowed-packages" : [
+      "org.apache.hadoop.mapred"
+    ]
+  }
+]

--- a/stats/org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3/execution-metrics.json
+++ b/stats/org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3/execution-metrics.json
@@ -1,0 +1,62 @@
+{
+  "add_new_library_support:2026-05-09": {
+    "timestamp": "2026-05-09T05:49:30.053264Z",
+    "library": "org.apache.hadoop:hadoop-mapreduce-client-jobclient:2.7.3",
+    "starting_commit": "5cc2c0ad5b8ff47f199ee6fcafbde037265d629e",
+    "ending_commit": "78c31c94f650cff7e8d133f6fa4a52f14fea1b24",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.7.3",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.0,
+            "coveredCalls": 0,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 0.0,
+        "coveredCalls": 0,
+        "totalCalls": 2
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 199,
+          "missed": 2954,
+          "ratio": 0.063114,
+          "total": 3153
+        },
+        "line": {
+          "covered": 56,
+          "missed": 731,
+          "ratio": 0.071156,
+          "total": 787
+        },
+        "method": {
+          "covered": 12,
+          "missed": 135,
+          "ratio": 0.081633,
+          "total": 147
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 419068,
+      "cached_input_tokens_used": 5946880,
+      "output_tokens_used": 42827,
+      "iterations": 12,
+      "cost_usd": 4.2582,
+      "generated_loc": 260,
+      "tested_library_loc": 56,
+      "metadata_entries": 28,
+      "code_coverage_percent": 7.12
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3/src/test/java/org_apache_hadoop/hadoop_mapreduce_client_jobclient/Hadoop_mapreduce_client_jobclientTest.java",
+      "metadata_file": "metadata/org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3/stats.json
+++ b/stats/org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "2.7.3",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.0,
+          "coveredCalls" : 0,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 0.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 2
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 199,
+        "missed" : 2954,
+        "ratio" : 0.063114,
+        "total" : 3153
+      },
+      "line" : {
+        "covered" : 56,
+        "missed" : 731,
+        "ratio" : 0.071156,
+        "total" : 787
+      },
+      "method" : {
+        "covered" : 12,
+        "missed" : 135,
+        "ratio" : 0.081633,
+        "total" : 147
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3/.gitignore
+++ b/tests/src/org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3/build.gradle
+++ b/tests/src/org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3/build.gradle
@@ -10,8 +10,14 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 
+configurations.configureEach {
+    exclude group: 'com.sun.jersey'
+    exclude group: 'com.sun.jersey.contribs'
+}
+
 dependencies {
     testImplementation "org.apache.hadoop:hadoop-mapreduce-client-jobclient:$libraryVersion"
+    testImplementation "org.apache.hadoop:hadoop-common:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3/build.gradle
+++ b/tests/src/org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.hadoop:hadoop-mapreduce-client-jobclient:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3/gradle.properties
+++ b/tests/src/org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.hadoop:hadoop-mapreduce-client-jobclient:2.7.3
+library.version = 2.7.3
+metadata.dir = org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3/

--- a/tests/src/org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3/settings.gradle
+++ b/tests/src/org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.hadoop.hadoop-mapreduce-client-jobclient_tests'

--- a/tests/src/org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3/src/test/java/org_apache_hadoop/hadoop_mapreduce_client_jobclient/Hadoop_mapreduce_client_jobclientTest.java
+++ b/tests/src/org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3/src/test/java/org_apache_hadoop/hadoop_mapreduce_client_jobclient/Hadoop_mapreduce_client_jobclientTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_hadoop.hadoop_mapreduce_client_jobclient;
+
+import org.junit.jupiter.api.Test;
+
+class Hadoop_mapreduce_client_jobclientTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3/src/test/java/org_apache_hadoop/hadoop_mapreduce_client_jobclient/Hadoop_mapreduce_client_jobclientTest.java
+++ b/tests/src/org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3/src/test/java/org_apache_hadoop/hadoop_mapreduce_client_jobclient/Hadoop_mapreduce_client_jobclientTest.java
@@ -6,11 +6,41 @@
  */
 package org_apache_hadoop.hadoop_mapreduce_client_jobclient;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapred.ClientCache;
+import org.apache.hadoop.mapred.ClientServiceDelegate;
+import org.apache.hadoop.mapreduce.JobID;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
-class Hadoop_mapreduce_client_jobclientTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Timeout(60)
+public class Hadoop_mapreduce_client_jobclientTest {
     @Test
     void test() throws Exception {
         System.out.println("This is just a placeholder, implement your test");
+    }
+
+    @Test
+    void clientCacheReusesClientServiceDelegateForTheSameJob() throws Exception {
+        ClientCache cache = new ClientCache(clientCacheConfiguration(), null);
+        JobID firstJob = new JobID("123456789", 1);
+        JobID secondJob = new JobID("123456789", 2);
+
+        try {
+            ClientServiceDelegate firstClient = cache.getClient(firstJob);
+            ClientServiceDelegate sameJobClient = cache.getClient(firstJob);
+            ClientServiceDelegate otherJobClient = cache.getClient(secondJob);
+
+            assertThat(sameJobClient).isSameAs(firstClient);
+            assertThat(otherJobClient).isNotSameAs(firstClient);
+        } finally {
+            cache.close();
+        }
+    }
+
+    private static Configuration clientCacheConfiguration() {
+        return new Configuration(false);
     }
 }

--- a/tests/src/org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3/src/test/java/org_apache_hadoop/hadoop_mapreduce_client_jobclient/YarnClientProtocolProviderTest.java
+++ b/tests/src/org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3/src/test/java/org_apache_hadoop/hadoop_mapreduce_client_jobclient/YarnClientProtocolProviderTest.java
@@ -6,11 +6,31 @@
  */
 package org_apache_hadoop.hadoop_mapreduce_client_jobclient;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.ipc.ProtocolSignature;
 import org.apache.hadoop.mapred.YarnClientProtocolProvider;
+import org.apache.hadoop.mapreduce.Cluster.JobTrackerStatus;
+import org.apache.hadoop.mapreduce.ClusterMetrics;
+import org.apache.hadoop.mapreduce.Counters;
+import org.apache.hadoop.mapreduce.JobID;
+import org.apache.hadoop.mapreduce.JobStatus;
+import org.apache.hadoop.mapreduce.QueueAclsInfo;
+import org.apache.hadoop.mapreduce.QueueInfo;
+import org.apache.hadoop.mapreduce.TaskAttemptID;
+import org.apache.hadoop.mapreduce.TaskCompletionEvent;
+import org.apache.hadoop.mapreduce.TaskReport;
+import org.apache.hadoop.mapreduce.TaskTrackerInfo;
+import org.apache.hadoop.mapreduce.TaskType;
 import org.apache.hadoop.mapreduce.protocol.ClientProtocol;
+import org.apache.hadoop.mapreduce.security.token.delegation.DelegationTokenIdentifier;
+import org.apache.hadoop.mapreduce.v2.LogParams;
+import org.apache.hadoop.security.Credentials;
+import org.apache.hadoop.security.authorize.AccessControlList;
+import org.apache.hadoop.security.token.Token;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -30,6 +50,16 @@ public class YarnClientProtocolProviderTest {
     }
 
     @Test
+    void closeIgnoresNonYarnClientProtocol() throws Exception {
+        YarnClientProtocolProvider provider = new YarnClientProtocolProvider();
+        ThrowingClientProtocol protocol = new ThrowingClientProtocol();
+
+        provider.close(protocol);
+
+        assertThat(protocol.wasUsed()).isFalse();
+    }
+
+    @Test
     void addressedProtocolCreationReturnsNullForLocalFramework() throws Exception {
         YarnClientProtocolProvider provider = new YarnClientProtocolProvider();
         Configuration configuration = localMapReduceConfiguration();
@@ -45,5 +75,195 @@ public class YarnClientProtocolProviderTest {
         Configuration configuration = new Configuration(false);
         configuration.set("mapreduce.framework.name", "local");
         return configuration;
+    }
+
+    private static final class ThrowingClientProtocol implements ClientProtocol {
+        private boolean used;
+
+        boolean wasUsed() {
+            return used;
+        }
+
+        @Override
+        public JobID getNewJobID() throws IOException, InterruptedException {
+            throw unused();
+        }
+
+        @Override
+        public JobStatus submitJob(JobID jobId, String jobSubmitDir, Credentials ts)
+                throws IOException, InterruptedException {
+            throw unused();
+        }
+
+        @Override
+        public ClusterMetrics getClusterMetrics() throws IOException, InterruptedException {
+            throw unused();
+        }
+
+        @Override
+        public JobTrackerStatus getJobTrackerStatus() throws IOException, InterruptedException {
+            throw unused();
+        }
+
+        @Override
+        public long getTaskTrackerExpiryInterval() throws IOException, InterruptedException {
+            throw unused();
+        }
+
+        @Override
+        public AccessControlList getQueueAdmins(String queueName) throws IOException {
+            throw unused();
+        }
+
+        @Override
+        public void killJob(JobID jobid) throws IOException, InterruptedException {
+            throw unused();
+        }
+
+        @Override
+        public void setJobPriority(JobID jobid, String priority)
+                throws IOException, InterruptedException {
+            throw unused();
+        }
+
+        @Override
+        public boolean killTask(TaskAttemptID taskId, boolean shouldFail)
+                throws IOException, InterruptedException {
+            throw unused();
+        }
+
+        @Override
+        public JobStatus getJobStatus(JobID jobid) throws IOException, InterruptedException {
+            throw unused();
+        }
+
+        @Override
+        public Counters getJobCounters(JobID jobid) throws IOException, InterruptedException {
+            throw unused();
+        }
+
+        @Override
+        public TaskReport[] getTaskReports(JobID jobid, TaskType type)
+                throws IOException, InterruptedException {
+            throw unused();
+        }
+
+        @Override
+        public String getFilesystemName() throws IOException, InterruptedException {
+            throw unused();
+        }
+
+        @Override
+        public JobStatus[] getAllJobs() throws IOException, InterruptedException {
+            throw unused();
+        }
+
+        @Override
+        public TaskCompletionEvent[] getTaskCompletionEvents(
+                JobID jobid,
+                int fromEventId,
+                int maxEvents) throws IOException, InterruptedException {
+            throw unused();
+        }
+
+        @Override
+        public String[] getTaskDiagnostics(TaskAttemptID taskId)
+                throws IOException, InterruptedException {
+            throw unused();
+        }
+
+        @Override
+        public TaskTrackerInfo[] getActiveTrackers() throws IOException, InterruptedException {
+            throw unused();
+        }
+
+        @Override
+        public TaskTrackerInfo[] getBlacklistedTrackers() throws IOException, InterruptedException {
+            throw unused();
+        }
+
+        @Override
+        public String getSystemDir() throws IOException, InterruptedException {
+            throw unused();
+        }
+
+        @Override
+        public String getStagingAreaDir() throws IOException, InterruptedException {
+            throw unused();
+        }
+
+        @Override
+        public String getJobHistoryDir() throws IOException, InterruptedException {
+            throw unused();
+        }
+
+        @Override
+        public QueueInfo[] getQueues() throws IOException, InterruptedException {
+            throw unused();
+        }
+
+        @Override
+        public QueueInfo getQueue(String queueName) throws IOException, InterruptedException {
+            throw unused();
+        }
+
+        @Override
+        public QueueAclsInfo[] getQueueAclsForCurrentUser()
+                throws IOException, InterruptedException {
+            throw unused();
+        }
+
+        @Override
+        public QueueInfo[] getRootQueues() throws IOException, InterruptedException {
+            throw unused();
+        }
+
+        @Override
+        public QueueInfo[] getChildQueues(String queueName)
+                throws IOException, InterruptedException {
+            throw unused();
+        }
+
+        @Override
+        public Token<DelegationTokenIdentifier> getDelegationToken(Text renewer)
+                throws IOException, InterruptedException {
+            throw unused();
+        }
+
+        @Override
+        public long renewDelegationToken(Token<DelegationTokenIdentifier> token)
+                throws IOException, InterruptedException {
+            throw unused();
+        }
+
+        @Override
+        public void cancelDelegationToken(Token<DelegationTokenIdentifier> token)
+                throws IOException, InterruptedException {
+            throw unused();
+        }
+
+        @Override
+        public LogParams getLogFileParams(JobID jobID, TaskAttemptID taskAttemptID)
+                throws IOException, InterruptedException {
+            throw unused();
+        }
+
+        @Override
+        public long getProtocolVersion(String protocol, long clientVersion) throws IOException {
+            throw unused();
+        }
+
+        @Override
+        public ProtocolSignature getProtocolSignature(
+                String protocol,
+                long clientVersion,
+                int clientMethodsHash) throws IOException {
+            throw unused();
+        }
+
+        private AssertionError unused() {
+            used = true;
+            return new AssertionError("Non-YARN protocols must not be used when closing");
+        }
     }
 }

--- a/tests/src/org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3/src/test/java/org_apache_hadoop/hadoop_mapreduce_client_jobclient/YarnClientProtocolProviderTest.java
+++ b/tests/src/org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3/src/test/java/org_apache_hadoop/hadoop_mapreduce_client_jobclient/YarnClientProtocolProviderTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_hadoop.hadoop_mapreduce_client_jobclient;
+
+import java.net.InetSocketAddress;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapred.YarnClientProtocolProvider;
+import org.apache.hadoop.mapreduce.protocol.ClientProtocol;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Timeout(60)
+public class YarnClientProtocolProviderTest {
+    @Test
+    void directProtocolCreationReturnsNullForLocalFramework() throws Exception {
+        YarnClientProtocolProvider provider = new YarnClientProtocolProvider();
+        Configuration configuration = localMapReduceConfiguration();
+
+        ClientProtocol protocol = provider.create(configuration);
+
+        assertThat(protocol).isNull();
+        provider.close(protocol);
+    }
+
+    @Test
+    void addressedProtocolCreationReturnsNullForLocalFramework() throws Exception {
+        YarnClientProtocolProvider provider = new YarnClientProtocolProvider();
+        Configuration configuration = localMapReduceConfiguration();
+        InetSocketAddress address = InetSocketAddress.createUnresolved("localhost", 8032);
+
+        ClientProtocol protocol = provider.create(address, configuration);
+
+        assertThat(protocol).isNull();
+        provider.close(protocol);
+    }
+
+    private static Configuration localMapReduceConfiguration() {
+        Configuration configuration = new Configuration(false);
+        configuration.set("mapreduce.framework.name", "local");
+        return configuration;
+    }
+}

--- a/tests/src/org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3/user-code-filter.json
+++ b/tests/src/org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.apache.hadoop.mapred.**"
+      "includeClasses" : "org.apache.hadoop.mapred.**"
+    },
+    {
+      "includeClasses" : "org_apache_hadoop.hadoop_mapreduce_client_jobclient.**"
     }
   ]
 }

--- a/tests/src/org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3/user-code-filter.json
+++ b/tests/src/org.apache.hadoop/hadoop-mapreduce-client-jobclient/2.7.3/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.apache.hadoop.mapred.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #2972

This PR introduces tests and metadata for org.apache.hadoop:hadoop-mapreduce-client-jobclient:2.7.3, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 419068
- Cached input tokens: 5946880
- Output tokens: 42827
- Metadata entries: 28
- Iterations: 12
- Library coverage percentage: 7.12
- Generated lines of code: 260
- Tested library lines of code: 56

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `5411de5c643414d6833ab473567e7478cde78720`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/2 covered calls (0.00%)
- Reflection: 0/2 covered calls (0.00%)

Library coverage:
- Instruction: 199/3153 (6.31%)
- Line: 56/787 (7.12%)
- Method: 12/147 (8.16%)

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
