### PR TITLE
[GenAI] Add support for org.apache.hadoop:hadoop-yarn-server-common:2.7.3 using gpt-5.5

### DIFF
--- a/metadata/org.apache.hadoop/hadoop-yarn-server-common/2.7.3/reachability-metadata.json
+++ b/metadata/org.apache.hadoop/hadoop-yarn-server-common/2.7.3/reachability-metadata.json
@@ -1,0 +1,242 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.conf.Configuration"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.conf.Configuration"
+      },
+      "type": "java.lang.Thread",
+      "methods": [
+        {
+          "name": "getContextClassLoader",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.conf.Configuration"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.conf.Configuration"
+      },
+      "type": "org.apache.commons.logging.LogFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.conf.Configuration"
+      },
+      "type": "org.apache.commons.logging.impl.Jdk14Logger",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.conf.Configuration"
+      },
+      "type": "org.apache.commons.logging.impl.LogFactoryImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.conf.Configuration"
+      },
+      "type": "org.apache.commons.logging.impl.SimpleLog",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.conf.Configuration"
+      },
+      "type": "org.apache.commons.logging.impl.WeakHashtable",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.server.api.protocolrecords.impl.pb.NMContainerStatusPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.server.api.protocolrecords.impl.pb.NodeHeartbeatRequestPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.server.api.protocolrecords.impl.pb.NodeHeartbeatResponsePBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.server.api.protocolrecords.impl.pb.RegisterNodeManagerRequestPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.server.api.protocolrecords.impl.pb.RegisterNodeManagerResponsePBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.server.api.protocolrecords.impl.pb.SCMUploaderCanUploadRequestPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.server.api.protocolrecords.impl.pb.SCMUploaderCanUploadResponsePBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.server.api.protocolrecords.impl.pb.SCMUploaderNotifyRequestPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.server.api.protocolrecords.impl.pb.SCMUploaderNotifyResponsePBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.server.api.records.impl.pb.MasterKeyPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.server.api.records.impl.pb.NodeHealthStatusPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.server.api.records.impl.pb.NodeStatusPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.server.records.impl.pb.VersionPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.apache.hadoop/hadoop-yarn-server-common/index.json
+++ b/metadata/org.apache.hadoop/hadoop-yarn-server-common/index.json
@@ -1,17 +1,18 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "2.7.3",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/hadoop/hadoop-yarn-server-common/$version$/hadoop-yarn-server-common-$version$-sources.jar",
-    "repository-url" : "https://github.com/apache/hadoop",
-    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/hadoop/hadoop-yarn-server-common/$version$/hadoop-yarn-server-common-$version$-test-sources.jar",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/hadoop/hadoop-yarn-server-common/$version$/hadoop-yarn-server-common-$version$-javadoc.jar",
-    "description" : "Apache Hadoop YARN Server Common contains shared server-side services, protocol helpers, and utility classes used by YARN ResourceManager, NodeManager, and related server components. It supports coordination of cluster resource management features such as node registration, container lifecycle handling, shared cache management, and server configuration within Hadoop YARN.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "2.7.3",
+    "source-code-url": "https://repo.maven.apache.org/maven2/org/apache/hadoop/hadoop-yarn-server-common/$version$/hadoop-yarn-server-common-$version$-sources.jar",
+    "repository-url": "https://github.com/apache/hadoop",
+    "test-code-url": "https://repo.maven.apache.org/maven2/org/apache/hadoop/hadoop-yarn-server-common/$version$/hadoop-yarn-server-common-$version$-test-sources.jar",
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/apache/hadoop/hadoop-yarn-server-common/$version$/hadoop-yarn-server-common-$version$-javadoc.jar",
+    "description": "Apache Hadoop YARN Server Common contains shared server-side services, protocol helpers, and utility classes used by YARN ResourceManager, NodeManager, and related server components. It supports coordination of cluster resource management features such as node registration, container lifecycle handling, shared cache management, and server configuration within Hadoop YARN.",
+    "tested-versions": [
       "2.7.3"
     ],
-    "allowed-packages" : [
-      "org.apache.hadoop.yarn"
+    "allowed-packages": [
+      "org.apache.hadoop.yarn",
+      "org.apache.hadoop.conf"
     ]
   }
 ]

--- a/metadata/org.apache.hadoop/hadoop-yarn-server-common/index.json
+++ b/metadata/org.apache.hadoop/hadoop-yarn-server-common/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.7.3",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/hadoop/hadoop-yarn-server-common/$version$/hadoop-yarn-server-common-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/hadoop",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/hadoop/hadoop-yarn-server-common/$version$/hadoop-yarn-server-common-$version$-test-sources.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/hadoop/hadoop-yarn-server-common/$version$/hadoop-yarn-server-common-$version$-javadoc.jar",
+    "description" : "Apache Hadoop YARN Server Common contains shared server-side services, protocol helpers, and utility classes used by YARN ResourceManager, NodeManager, and related server components. It supports coordination of cluster resource management features such as node registration, container lifecycle handling, shared cache management, and server configuration within Hadoop YARN.",
+    "tested-versions" : [
+      "2.7.3"
+    ],
+    "allowed-packages" : [
+      "org.apache.hadoop.yarn"
+    ]
+  }
+]

--- a/stats/org.apache.hadoop/hadoop-yarn-server-common/2.7.3/execution-metrics.json
+++ b/stats/org.apache.hadoop/hadoop-yarn-server-common/2.7.3/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-09": {
+    "timestamp": "2026-05-09T06:15:57.017820Z",
+    "library": "org.apache.hadoop:hadoop-yarn-server-common:2.7.3",
+    "starting_commit": "776fd096273c85508c01542514b1352e83bb0c24",
+    "ending_commit": "9d4a5639f426193ac3340306e0fc465951ffc50c",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.7.3",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3875,
+          "missed": 29073,
+          "ratio": 0.11761,
+          "total": 32948
+        },
+        "line": {
+          "covered": 1244,
+          "missed": 7202,
+          "ratio": 0.147289,
+          "total": 8446
+        },
+        "method": {
+          "covered": 386,
+          "missed": 1518,
+          "ratio": 0.202731,
+          "total": 1904
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 218750,
+      "cached_input_tokens_used": 2534912,
+      "output_tokens_used": 22152,
+      "iterations": 5,
+      "cost_usd": 1.9321,
+      "generated_loc": 363,
+      "tested_library_loc": 1244,
+      "metadata_entries": 39,
+      "code_coverage_percent": 14.73
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.7.3/src/test/java/org_apache_hadoop/hadoop_yarn_server_common/Hadoop_yarn_server_commonTest.java",
+      "metadata_file": "metadata/org.apache.hadoop/hadoop-yarn-server-common/2.7.3/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.hadoop/hadoop-yarn-server-common/2.7.3/stats.json
+++ b/stats/org.apache.hadoop/hadoop-yarn-server-common/2.7.3/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.7.3",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3875,
+        "missed" : 29073,
+        "ratio" : 0.11761,
+        "total" : 32948
+      },
+      "line" : {
+        "covered" : 1244,
+        "missed" : 7202,
+        "ratio" : 0.147289,
+        "total" : 8446
+      },
+      "method" : {
+        "covered" : 386,
+        "missed" : 1518,
+        "ratio" : 0.202731,
+        "total" : 1904
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.7.3/.gitignore
+++ b/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.7.3/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.7.3/build.gradle
+++ b/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.7.3/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.apache.hadoop:hadoop-yarn-server-common:$libraryVersion"
+    testImplementation "org.apache.hadoop:hadoop-common:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.7.3/build.gradle
+++ b/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.7.3/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.hadoop:hadoop-yarn-server-common:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.7.3/gradle.properties
+++ b/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.7.3/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.hadoop:hadoop-yarn-server-common:2.7.3
+library.version = 2.7.3
+metadata.dir = org.apache.hadoop/hadoop-yarn-server-common/2.7.3/

--- a/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.7.3/settings.gradle
+++ b/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.7.3/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.hadoop.hadoop-yarn-server-common_tests'

--- a/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.7.3/src/test/java/org_apache_hadoop/hadoop_yarn_server_common/Hadoop_yarn_server_commonTest.java
+++ b/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.7.3/src/test/java/org_apache_hadoop/hadoop_yarn_server_common/Hadoop_yarn_server_commonTest.java
@@ -6,11 +6,331 @@
  */
 package org_apache_hadoop.hadoop_yarn_server_common;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.api.records.Container;
+import org.apache.hadoop.yarn.api.records.ContainerId;
+import org.apache.hadoop.yarn.api.records.ContainerState;
+import org.apache.hadoop.yarn.api.records.ContainerStatus;
+import org.apache.hadoop.yarn.api.records.LocalResource;
+import org.apache.hadoop.yarn.api.records.LocalResourceType;
+import org.apache.hadoop.yarn.api.records.LocalResourceVisibility;
+import org.apache.hadoop.yarn.api.records.NodeId;
+import org.apache.hadoop.yarn.api.records.Priority;
+import org.apache.hadoop.yarn.api.records.Resource;
+import org.apache.hadoop.yarn.api.records.ResourceRequest;
+import org.apache.hadoop.yarn.api.records.Token;
+import org.apache.hadoop.yarn.api.records.URL;
+import org.apache.hadoop.yarn.server.api.protocolrecords.NMContainerStatus;
+import org.apache.hadoop.yarn.server.api.protocolrecords.NodeHeartbeatRequest;
+import org.apache.hadoop.yarn.server.api.protocolrecords.NodeHeartbeatResponse;
+import org.apache.hadoop.yarn.server.api.protocolrecords.RegisterNodeManagerRequest;
+import org.apache.hadoop.yarn.server.api.protocolrecords.RegisterNodeManagerResponse;
+import org.apache.hadoop.yarn.server.api.protocolrecords.SCMUploaderCanUploadRequest;
+import org.apache.hadoop.yarn.server.api.protocolrecords.SCMUploaderCanUploadResponse;
+import org.apache.hadoop.yarn.server.api.protocolrecords.SCMUploaderNotifyRequest;
+import org.apache.hadoop.yarn.server.api.protocolrecords.SCMUploaderNotifyResponse;
+import org.apache.hadoop.yarn.server.api.records.MasterKey;
+import org.apache.hadoop.yarn.server.api.records.NodeAction;
+import org.apache.hadoop.yarn.server.api.records.NodeHealthStatus;
+import org.apache.hadoop.yarn.server.api.records.NodeStatus;
+import org.apache.hadoop.yarn.server.records.Version;
+import org.apache.hadoop.yarn.server.security.MasterKeyData;
+import org.apache.hadoop.yarn.server.sharedcache.SharedCacheUtil;
+import org.apache.hadoop.yarn.server.utils.BuilderUtils;
+import org.apache.hadoop.yarn.server.utils.YarnServerBuilderUtils;
+import org.apache.hadoop.yarn.server.webapp.WebPageUtils;
+import org.apache.hadoop.yarn.server.webapp.dao.AppAttemptsInfo;
+import org.apache.hadoop.yarn.server.webapp.dao.AppsInfo;
+import org.apache.hadoop.yarn.server.webapp.dao.ContainersInfo;
+import org.apache.hadoop.yarn.util.Records;
 import org.junit.jupiter.api.Test;
 
-class Hadoop_yarn_server_commonTest {
+public class Hadoop_yarn_server_commonTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void nodeManagerRegistrationCarriesResourceContainersAndRunningApplications() {
+        NodeId nodeId = NodeId.newInstance("worker.example.test", 45454);
+        Resource nodeResource = Resource.newInstance(8192, 4);
+        ApplicationId applicationId = ApplicationId.newInstance(1234L, 7);
+        ContainerId containerId = containerId(applicationId, 1, 99L);
+        Priority priority = Priority.newInstance(3);
+        NMContainerStatus containerStatus = NMContainerStatus.newInstance(
+                containerId,
+                ContainerState.RUNNING,
+                Resource.newInstance(1024, 1),
+                "healthy container",
+                0,
+                priority,
+                44L);
+
+        RegisterNodeManagerRequest request = RegisterNodeManagerRequest.newInstance(
+                nodeId,
+                8042,
+                nodeResource,
+                "test-nm-version",
+                Collections.singletonList(containerStatus),
+                Collections.singletonList(applicationId));
+
+        assertThat(request.getNodeId()).isEqualTo(nodeId);
+        assertThat(request.getHttpPort()).isEqualTo(8042);
+        assertThat(request.getResource().getMemory()).isEqualTo(8192);
+        assertThat(request.getResource().getVirtualCores()).isEqualTo(4);
+        assertThat(request.getNMVersion()).isEqualTo("test-nm-version");
+        assertThat(request.getRunningApplications()).containsExactly(applicationId);
+
+        NMContainerStatus roundTrippedStatus = request.getNMContainerStatuses().get(0);
+        assertThat(roundTrippedStatus.getContainerId()).isEqualTo(containerId);
+        assertThat(roundTrippedStatus.getContainerState()).isEqualTo(ContainerState.RUNNING);
+        assertThat(roundTrippedStatus.getAllocatedResource().getMemory()).isEqualTo(1024);
+        assertThat(roundTrippedStatus.getDiagnostics()).isEqualTo("healthy container");
+        assertThat(roundTrippedStatus.getPriority().getPriority()).isEqualTo(3);
+        assertThat(roundTrippedStatus.getCreationTime()).isEqualTo(44L);
+    }
+
+    @Test
+    void heartbeatRequestAndResponseRoundTripNodeStatusCleanupListsAndCredentials() {
+        ApplicationId applicationId = ApplicationId.newInstance(5678L, 11);
+        ContainerId runningContainer = containerId(applicationId, 2, 3L);
+        ContainerStatus containerStatus = BuilderUtils.newContainerStatus(
+                runningContainer,
+                ContainerState.COMPLETE,
+                "finished",
+                0);
+        NodeHealthStatus healthStatus = NodeHealthStatus.newInstance(true, "all disks healthy", 99L);
+        NodeStatus nodeStatus = NodeStatus.newInstance(
+                NodeId.newInstance("nm.example.test", 1234),
+                5,
+                Collections.singletonList(containerStatus),
+                Collections.singletonList(applicationId),
+                healthStatus);
+        MasterKey containerTokenKey = masterKey(17, new byte[] {1, 2, 3, 4});
+        MasterKey nmTokenKey = masterKey(23, new byte[] {5, 6, 7, 8});
+
+        NodeHeartbeatRequest request = NodeHeartbeatRequest.newInstance(nodeStatus, containerTokenKey, nmTokenKey);
+
+        assertThat(request.getNodeStatus().getResponseId()).isEqualTo(5);
+        assertThat(request.getNodeStatus().getContainersStatuses()).hasSize(1);
+        assertThat(request.getNodeStatus().getNodeHealthStatus().getHealthReport()).isEqualTo("all disks healthy");
+        assertThat(request.getLastKnownContainerTokenMasterKey().getKeyId()).isEqualTo(17);
+        assertThat(bytes(request.getLastKnownNMTokenMasterKey().getBytes()))
+                .containsExactly((byte) 5, (byte) 6, (byte) 7, (byte) 8);
+
+        NodeHeartbeatResponse response = YarnServerBuilderUtils.newNodeHeartbeatResponse(
+                6,
+                NodeAction.NORMAL,
+                Collections.singletonList(runningContainer),
+                Collections.singletonList(applicationId),
+                containerTokenKey,
+                nmTokenKey,
+                1000L);
+        ContainerId removedContainer = containerId(applicationId, 2, 4L);
+        Map<ApplicationId, ByteBuffer> credentials = new HashMap<ApplicationId, ByteBuffer>();
+        credentials.put(applicationId, ByteBuffer.wrap(new byte[] {9, 10, 11}));
+
+        response.addContainersToBeRemovedFromNM(Collections.singletonList(removedContainer));
+        response.setDiagnosticsMessage("continue processing");
+        response.setSystemCredentialsForApps(credentials);
+
+        assertThat(response.getResponseId()).isEqualTo(6);
+        assertThat(response.getNodeAction()).isEqualTo(NodeAction.NORMAL);
+        assertThat(response.getContainersToCleanup()).containsExactly(runningContainer);
+        assertThat(response.getContainersToBeRemovedFromNM()).containsExactly(removedContainer);
+        assertThat(response.getApplicationsToCleanup()).containsExactly(applicationId);
+        assertThat(response.getNextHeartBeatInterval()).isEqualTo(1000L);
+        assertThat(response.getDiagnosticsMessage()).isEqualTo("continue processing");
+        assertThat(response.getContainerTokenMasterKey().getKeyId()).isEqualTo(17);
+        assertThat(response.getNMTokenMasterKey().getKeyId()).isEqualTo(23);
+        assertThat(bytes(response.getSystemCredentialsForApps().get(applicationId)))
+                .containsExactly((byte) 9, (byte) 10, (byte) 11);
+    }
+
+    @Test
+    void registerNodeManagerResponseExposesMasterKeysAndDiagnostics() {
+        RegisterNodeManagerResponse response = Records.newRecord(RegisterNodeManagerResponse.class);
+        MasterKey containerTokenKey = masterKey(101, new byte[] {12, 13});
+        MasterKey nmTokenKey = masterKey(102, new byte[] {14, 15});
+
+        response.setContainerTokenMasterKey(containerTokenKey);
+        response.setNMTokenMasterKey(nmTokenKey);
+        response.setNodeAction(NodeAction.RESYNC);
+        response.setRMIdentifier(987654321L);
+        response.setDiagnosticsMessage("resync requested");
+        response.setRMVersion("rm-test-version");
+
+        assertThat(response.getContainerTokenMasterKey().getKeyId()).isEqualTo(101);
+        assertThat(bytes(response.getNMTokenMasterKey().getBytes())).containsExactly((byte) 14, (byte) 15);
+        assertThat(response.getNodeAction()).isEqualTo(NodeAction.RESYNC);
+        assertThat(response.getRMIdentifier()).isEqualTo(987654321L);
+        assertThat(response.getDiagnosticsMessage()).isEqualTo("resync requested");
+        assertThat(response.getRMVersion()).isEqualTo("rm-test-version");
+    }
+
+    @Test
+    void sharedCacheUtilitiesBuildDepthAwarePathsAndGlobPatterns() {
+        assertThat(SharedCacheUtil.getCacheEntryPath(3, "/shared-cache", "abcdef"))
+                .isEqualTo("/shared-cache/a/b/c/abcdef");
+        assertThat(SharedCacheUtil.getCacheEntryGlobPattern(3)).isEqualTo("*/*/*/*");
+
+        assertThatThrownBy(() -> SharedCacheUtil.getCacheEntryPath(0, "/shared-cache", "abcdef"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("cache depth");
+        assertThatThrownBy(() -> SharedCacheUtil.getCacheEntryPath(4, "/shared-cache", "abc"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("checksum");
+    }
+
+    @Test
+    void builderUtilitiesCreateYarnRecordsWithExpectedValues() throws Exception {
+        URL resourceUrl = BuilderUtils.newURL("hdfs", "namenode.example.test", 8020, "/apps/app.jar");
+        LocalResource localResource = BuilderUtils.newLocalResource(
+                resourceUrl,
+                LocalResourceType.FILE,
+                LocalResourceVisibility.APPLICATION,
+                4096L,
+                12345L,
+                true);
+        LocalResource uriResource = BuilderUtils.newLocalResource(
+                new URI("hdfs://namenode.example.test:8020/apps/lib.jar"),
+                LocalResourceType.ARCHIVE,
+                LocalResourceVisibility.PUBLIC,
+                8192L,
+                54321L,
+                false);
+
+        assertThat(localResource.getResource().getHost()).isEqualTo("namenode.example.test");
+        assertThat(localResource.getResource().getPort()).isEqualTo(8020);
+        assertThat(localResource.getResource().getFile()).isEqualTo("/apps/app.jar");
+        assertThat(localResource.getType()).isEqualTo(LocalResourceType.FILE);
+        assertThat(localResource.getVisibility()).isEqualTo(LocalResourceVisibility.APPLICATION);
+        assertThat(localResource.getSize()).isEqualTo(4096L);
+        assertThat(localResource.getTimestamp()).isEqualTo(12345L);
+        assertThat(localResource.getShouldBeUploadedToSharedCache()).isTrue();
+        assertThat(uriResource.getType()).isEqualTo(LocalResourceType.ARCHIVE);
+        assertThat(uriResource.getShouldBeUploadedToSharedCache()).isFalse();
+
+        ResourceRequest request = BuilderUtils.newResourceRequest(
+                Priority.newInstance(9),
+                ResourceRequest.ANY,
+                Resource.newInstance(2048, 2),
+                3);
+        assertThat(request.getPriority().getPriority()).isEqualTo(9);
+        assertThat(request.getResourceName()).isEqualTo(ResourceRequest.ANY);
+        assertThat(request.getCapability().getMemory()).isEqualTo(2048);
+        assertThat(request.getCapability().getVirtualCores()).isEqualTo(2);
+        assertThat(request.getNumContainers()).isEqualTo(3);
+
+        Token token = BuilderUtils.newDelegationToken(
+                new byte[] {1, 2},
+                "kind",
+                new byte[] {3, 4},
+                "service");
+        NodeId nodeId = BuilderUtils.newNodeId("worker.example.test", 8041);
+        ContainerId containerId = containerId(ApplicationId.newInstance(2000L, 3), 4, 5L);
+        Container container = BuilderUtils.newContainer(
+                containerId,
+                nodeId,
+                "worker.example.test:8042",
+                Resource.newInstance(1024, 1),
+                Priority.newInstance(1),
+                token);
+
+        assertThat(container.getId()).isEqualTo(containerId);
+        assertThat(container.getNodeId()).isEqualTo(nodeId);
+        assertThat(container.getNodeHttpAddress()).isEqualTo("worker.example.test:8042");
+        assertThat(container.getResource().getMemory()).isEqualTo(1024);
+        assertThat(container.getPriority().getPriority()).isEqualTo(1);
+        assertThat(container.getContainerToken().getKind()).isEqualTo("kind");
+    }
+
+    @Test
+    void sharedCacheUploaderRecordsExposeRequestAndResponseState() {
+        SCMUploaderCanUploadRequest canUploadRequest = Records.newRecord(SCMUploaderCanUploadRequest.class);
+        SCMUploaderCanUploadResponse canUploadResponse = Records.newRecord(SCMUploaderCanUploadResponse.class);
+        SCMUploaderNotifyRequest notifyRequest = Records.newRecord(SCMUploaderNotifyRequest.class);
+        SCMUploaderNotifyResponse notifyResponse = Records.newRecord(SCMUploaderNotifyResponse.class);
+
+        canUploadRequest.setResourceKey("resource-checksum");
+        canUploadResponse.setUploadable(true);
+        notifyRequest.setResourceKey("resource-checksum");
+        notifyRequest.setFilename("archive.tar.gz");
+        notifyResponse.setAccepted(true);
+
+        assertThat(canUploadRequest.getResourceKey()).isEqualTo("resource-checksum");
+        assertThat(canUploadResponse.getUploadable()).isTrue();
+        assertThat(notifyRequest.getResourceKey()).isEqualTo("resource-checksum");
+        assertThat(notifyRequest.getFileName()).isEqualTo("archive.tar.gz");
+        assertThat(notifyResponse.getAccepted()).isTrue();
+    }
+
+    @Test
+    void versionsCompareCompatibilityAndMasterKeyDataPublishesEncodedSecret() {
+        Version version = Version.newInstance(2, 7);
+        Version sameMajorNewerMinor = Version.newInstance(2, 9);
+        Version differentMajor = Version.newInstance(3, 0);
+
+        assertThat(version.getMajorVersion()).isEqualTo(2);
+        assertThat(version.getMinorVersion()).isEqualTo(7);
+        assertThat(version.toString()).isEqualTo("2.7");
+        assertThat(version.isCompatibleTo(sameMajorNewerMinor)).isTrue();
+        assertThat(version.isCompatibleTo(differentMajor)).isFalse();
+        assertThat(version).isEqualTo(Version.newInstance(2, 7));
+
+        SecretKey secretKey = new SecretKeySpec(new byte[] {21, 22, 23, 24}, "HmacSHA1");
+        MasterKeyData keyData = new MasterKeyData(77, secretKey);
+
+        assertThat(keyData.getMasterKey().getKeyId()).isEqualTo(77);
+        assertThat(bytes(keyData.getMasterKey().getBytes()))
+                .containsExactly((byte) 21, (byte) 22, (byte) 23, (byte) 24);
+        assertThat(keyData.getSecretKey()).isSameAs(secretKey);
+    }
+
+    @Test
+    void webContainerDaoCollectionsAndTableInitializersAreUsableWithoutWebServer() {
+        AppsInfo appsInfo = new AppsInfo();
+        AppAttemptsInfo attemptsInfo = new AppAttemptsInfo();
+        ContainersInfo containersInfo = new ContainersInfo();
+
+        appsInfo.add(null);
+        attemptsInfo.add(null);
+        containersInfo.add(null);
+
+        assertThat(appsInfo.getApps()).hasSize(1).containsNull();
+        assertThat(attemptsInfo.getAttempts()).hasSize(1).containsNull();
+        assertThat(containersInfo.getContainers()).hasSize(1).containsNull();
+        assertThat(WebPageUtils.appsTableInit()).contains("natural").contains("renderHadoopDate");
+        assertThat(WebPageUtils.appsTableInit(true)).contains("'aaData'").contains("renderHadoopDate");
+        assertThat(WebPageUtils.attemptsTableInit()).contains("natural");
+        assertThat(WebPageUtils.containersTableInit()).contains("natural");
+    }
+
+    private static ContainerId containerId(ApplicationId applicationId, int attemptId, long containerSequence) {
+        ApplicationAttemptId applicationAttemptId = ApplicationAttemptId.newInstance(applicationId, attemptId);
+        return BuilderUtils.newContainerId(applicationAttemptId, containerSequence);
+    }
+
+    private static MasterKey masterKey(int keyId, byte[] keyBytes) {
+        MasterKey masterKey = Records.newRecord(MasterKey.class);
+        masterKey.setKeyId(keyId);
+        masterKey.setBytes(ByteBuffer.wrap(Arrays.copyOf(keyBytes, keyBytes.length)));
+        return masterKey;
+    }
+
+    private static byte[] bytes(ByteBuffer buffer) {
+        ByteBuffer duplicate = buffer.duplicate();
+        byte[] bytes = new byte[duplicate.remaining()];
+        duplicate.get(bytes);
+        return bytes;
     }
 }

--- a/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.7.3/src/test/java/org_apache_hadoop/hadoop_yarn_server_common/Hadoop_yarn_server_commonTest.java
+++ b/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.7.3/src/test/java/org_apache_hadoop/hadoop_yarn_server_common/Hadoop_yarn_server_commonTest.java
@@ -19,6 +19,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.http.FilterContainer;
 import org.apache.hadoop.security.KerberosInfo;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
@@ -36,6 +37,7 @@ import org.apache.hadoop.yarn.api.records.ResourceRequest;
 import org.apache.hadoop.yarn.api.records.Token;
 import org.apache.hadoop.yarn.api.records.URL;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.security.client.RMDelegationTokenIdentifier;
 import org.apache.hadoop.yarn.server.RMNMSecurityInfoClass;
 import org.apache.hadoop.yarn.server.api.ResourceTrackerPB;
 import org.apache.hadoop.yarn.server.api.SCMUploaderProtocolPB;
@@ -54,6 +56,8 @@ import org.apache.hadoop.yarn.server.api.records.NodeHealthStatus;
 import org.apache.hadoop.yarn.server.api.records.NodeStatus;
 import org.apache.hadoop.yarn.server.records.Version;
 import org.apache.hadoop.yarn.server.security.MasterKeyData;
+import org.apache.hadoop.yarn.server.security.http.RMAuthenticationFilter;
+import org.apache.hadoop.yarn.server.security.http.RMAuthenticationFilterInitializer;
 import org.apache.hadoop.yarn.server.sharedcache.SharedCacheUtil;
 import org.apache.hadoop.yarn.server.utils.BuilderUtils;
 import org.apache.hadoop.yarn.server.utils.YarnServerBuilderUtils;
@@ -295,6 +299,31 @@ public class Hadoop_yarn_server_commonTest {
     }
 
     @Test
+    void resourceManagerAuthenticationFilterInitializerInstallsFilterWithTokenAndProxySettings() {
+        Configuration configuration = new Configuration(false);
+        configuration.set("hadoop.http.authentication.type", "kerberos");
+        configuration.set("hadoop.http.authentication.kerberos.principal", "HTTP/rm.example.test@EXAMPLE.COM");
+        configuration.set("hadoop.http.authentication.signature.secret", "shared-secret");
+        configuration.set("hadoop.proxyuser.alice.hosts", "host-a.example.test,host-b.example.test");
+        configuration.set("hadoop.proxyuser.alice.groups", "analytics,operators");
+        RecordingFilterContainer container = new RecordingFilterContainer();
+
+        new RMAuthenticationFilterInitializer().initFilter(container, configuration);
+
+        assertThat(container.filterName).isEqualTo("RMAuthenticationFilter");
+        assertThat(container.filterClassName).isEqualTo(RMAuthenticationFilter.class.getName());
+        assertThat(container.globalFilter).isFalse();
+        assertThat(container.filterConfig)
+                .containsEntry("type", "kerberos")
+                .containsEntry("kerberos.principal", "HTTP/rm.example.test@EXAMPLE.COM")
+                .containsEntry("signature.secret", "shared-secret")
+                .containsEntry("cookie.path", "/")
+                .containsEntry("proxyuser.alice.hosts", "host-a.example.test,host-b.example.test")
+                .containsEntry("proxyuser.alice.groups", "analytics,operators")
+                .containsEntry("delegation-token.token-kind", RMDelegationTokenIdentifier.KIND_NAME.toString());
+    }
+
+    @Test
     void versionsCompareCompatibilityAndMasterKeyDataPublishesEncodedSecret() {
         Version version = Version.newInstance(2, 7);
         Version sameMajorNewerMinor = Version.newInstance(2, 9);
@@ -352,5 +381,28 @@ public class Hadoop_yarn_server_commonTest {
         byte[] bytes = new byte[duplicate.remaining()];
         duplicate.get(bytes);
         return bytes;
+    }
+
+    private static final class RecordingFilterContainer implements FilterContainer {
+        private String filterName;
+        private String filterClassName;
+        private Map<String, String> filterConfig;
+        private boolean globalFilter;
+
+        @Override
+        public void addFilter(String name, String classname, Map<String, String> parameters) {
+            filterName = name;
+            filterClassName = classname;
+            filterConfig = new HashMap<String, String>(parameters);
+            globalFilter = false;
+        }
+
+        @Override
+        public void addGlobalFilter(String name, String classname, Map<String, String> parameters) {
+            filterName = name;
+            filterClassName = classname;
+            filterConfig = new HashMap<String, String>(parameters);
+            globalFilter = true;
+        }
     }
 }

--- a/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.7.3/src/test/java/org_apache_hadoop/hadoop_yarn_server_common/Hadoop_yarn_server_commonTest.java
+++ b/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.7.3/src/test/java/org_apache_hadoop/hadoop_yarn_server_common/Hadoop_yarn_server_commonTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_hadoop.hadoop_yarn_server_common;
+
+import org.junit.jupiter.api.Test;
+
+class Hadoop_yarn_server_commonTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.7.3/src/test/java/org_apache_hadoop/hadoop_yarn_server_common/Hadoop_yarn_server_commonTest.java
+++ b/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.7.3/src/test/java/org_apache_hadoop/hadoop_yarn_server_common/Hadoop_yarn_server_commonTest.java
@@ -18,6 +18,8 @@ import java.util.Map;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.KerberosInfo;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.Container;
@@ -33,6 +35,10 @@ import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.api.records.ResourceRequest;
 import org.apache.hadoop.yarn.api.records.Token;
 import org.apache.hadoop.yarn.api.records.URL;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.server.RMNMSecurityInfoClass;
+import org.apache.hadoop.yarn.server.api.ResourceTrackerPB;
+import org.apache.hadoop.yarn.server.api.SCMUploaderProtocolPB;
 import org.apache.hadoop.yarn.server.api.protocolrecords.NMContainerStatus;
 import org.apache.hadoop.yarn.server.api.protocolrecords.NodeHeartbeatRequest;
 import org.apache.hadoop.yarn.server.api.protocolrecords.NodeHeartbeatResponse;
@@ -272,6 +278,20 @@ public class Hadoop_yarn_server_commonTest {
         assertThat(notifyRequest.getResourceKey()).isEqualTo("resource-checksum");
         assertThat(notifyRequest.getFileName()).isEqualTo("archive.tar.gz");
         assertThat(notifyResponse.getAccepted()).isTrue();
+    }
+
+    @Test
+    void resourceTrackerSecurityInfoPublishesResourceManagerAndNodeManagerPrincipals() {
+        RMNMSecurityInfoClass securityInfo = new RMNMSecurityInfoClass();
+        Configuration configuration = new Configuration(false);
+
+        KerberosInfo kerberosInfo = securityInfo.getKerberosInfo(ResourceTrackerPB.class, configuration);
+
+        assertThat(kerberosInfo).isNotNull();
+        assertThat(kerberosInfo.serverPrincipal()).isEqualTo(YarnConfiguration.RM_PRINCIPAL);
+        assertThat(kerberosInfo.clientPrincipal()).isEqualTo(YarnConfiguration.NM_PRINCIPAL);
+        assertThat(securityInfo.getTokenInfo(ResourceTrackerPB.class, configuration)).isNull();
+        assertThat(securityInfo.getKerberosInfo(SCMUploaderProtocolPB.class, configuration)).isNull();
     }
 
     @Test

--- a/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.7.3/user-code-filter.json
+++ b/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.7.3/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.apache.hadoop.yarn.**"
+    }
+  ]
+}

--- a/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.7.3/user-code-filter.json
+++ b/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.7.3/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.apache.hadoop.yarn.**"
+      "includeClasses" : "org.apache.hadoop.yarn.**"
+    },
+    {
+      "includeClasses" : "org_apache_hadoop.hadoop_yarn_server_common.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #2961

This PR introduces tests and metadata for org.apache.hadoop:hadoop-yarn-server-common:2.7.3, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 218750
- Cached input tokens: 2534912
- Output tokens: 22152
- Metadata entries: 39
- Iterations: 5
- Library coverage percentage: 14.73
- Generated lines of code: 363
- Tested library lines of code: 1244

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `5411de5c643414d6833ab473567e7478cde78720`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 3875/32948 (11.76%)
- Line: 1244/8446 (14.73%)
- Method: 386/1904 (20.27%)

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
