### PR TITLE
[GenAI] Mark org.fusesource.leveldbjni:leveldbjni-win32 as not for Native Image

### DIFF
--- a/metadata/org.fusesource.leveldbjni/leveldbjni-win32/index.json
+++ b/metadata/org.fusesource.leveldbjni/leveldbjni-win32/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published leveldbjni-win32 1.8 JAR contains only META-INF/native/windows32/leveldbjni.dll and Maven metadata, with no JVM class files; Java classes are supplied by org.fusesource.leveldbjni:leveldbjni:1.8.",
+    "replacement": "org.fusesource.leveldbjni:leveldbjni:1.8"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #2928

This PR records `org.fusesource.leveldbjni:leveldbjni-win32` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published leveldbjni-win32 1.8 JAR contains only META-INF/native/windows32/leveldbjni.dll and Maven metadata, with no JVM class files; Java classes are supplied by org.fusesource.leveldbjni:leveldbjni:1.8.

Replacement guidance:
- org.fusesource.leveldbjni:leveldbjni:1.8

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `e28a714d1df9251f37bdf74b7d4499713c1479e6`

### Local CI Verification

- Status: `success`
- Commands run: 6
- Fixup attempts: 0
