### PR TITLE
[GenAI] Mark org.fusesource.leveldbjni:leveldbjni-win64 as not for Native Image

### DIFF
--- a/metadata/org.fusesource.leveldbjni/leveldbjni-win64/index.json
+++ b/metadata/org.fusesource.leveldbjni/leveldbjni-win64/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The leveldbjni-win64 1.8 JAR contains only the Windows 64-bit native DLL and Maven metadata, with no JVM class files for native-image reachability metadata.",
+    "replacement": "org.fusesource.leveldbjni:leveldbjni:1.8"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #2929

This PR records `org.fusesource.leveldbjni:leveldbjni-win64` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The leveldbjni-win64 1.8 JAR contains only the Windows 64-bit native DLL and Maven metadata, with no JVM class files for native-image reachability metadata.

Replacement guidance:
- org.fusesource.leveldbjni:leveldbjni:1.8

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `e28a714d1df9251f37bdf74b7d4499713c1479e6`

### Local CI Verification

- Status: `success`
- Commands run: 6
- Fixup attempts: 0
