### PR TITLE
[GenAI] Mark org.fusesource.leveldbjni:leveldbjni-linux64 as not for Native Image

### DIFF
--- a/metadata/org.fusesource.leveldbjni/leveldbjni-linux64/index.json
+++ b/metadata/org.fusesource.leveldbjni/leveldbjni-linux64/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published leveldbjni-linux64 JAR contains no JVM class files; it packages only the Linux 64-bit native shared library and Maven metadata.",
+    "replacement": "org.fusesource.leveldbjni:leveldbjni:1.8"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #2924

This PR records `org.fusesource.leveldbjni:leveldbjni-linux64` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published leveldbjni-linux64 JAR contains no JVM class files; it packages only the Linux 64-bit native shared library and Maven metadata.

Replacement guidance:
- org.fusesource.leveldbjni:leveldbjni:1.8

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `d79410f921e568ff13a338064e449757099f0e87`

### Local CI Verification

- Status: `success`
- Commands run: 6
- Fixup attempts: 0
