### PR TITLE
[GenAI] Mark org.fusesource.leveldbjni:leveldbjni-osx as not for Native Image

### DIFF
--- a/metadata/org.fusesource.leveldbjni/leveldbjni-osx/index.json
+++ b/metadata/org.fusesource.leveldbjni/leveldbjni-osx/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published JAR contains no JVM class files; it packages only Maven metadata and the OS X native libleveldbjni.jnilib resource.",
+    "replacement": "org.fusesource.leveldbjni:leveldbjni:1.8"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #2926

This PR records `org.fusesource.leveldbjni:leveldbjni-osx` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published JAR contains no JVM class files; it packages only Maven metadata and the OS X native libleveldbjni.jnilib resource.

Replacement guidance:
- org.fusesource.leveldbjni:leveldbjni:1.8

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `d79410f921e568ff13a338064e449757099f0e87`

### Local CI Verification

- Status: `success`
- Commands run: 6
- Fixup attempts: 0
