### PR TITLE
[GenAI] Mark org.fusesource.leveldbjni:leveldbjni-linux32 as not for Native Image

### DIFF
--- a/metadata/org.fusesource.leveldbjni/leveldbjni-linux32/index.json
+++ b/metadata/org.fusesource.leveldbjni/leveldbjni-linux32/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published leveldbjni-linux32 JAR contains Maven metadata and META-INF/native/linux32/libleveldbjni.so but no JVM class files; JVM classes are provided by org.fusesource.leveldbjni:leveldbjni:1.8.",
+    "replacement": "org.fusesource.leveldbjni:leveldbjni:1.8"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #2922

This PR records `org.fusesource.leveldbjni:leveldbjni-linux32` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published leveldbjni-linux32 JAR contains Maven metadata and META-INF/native/linux32/libleveldbjni.so but no JVM class files; JVM classes are provided by org.fusesource.leveldbjni:leveldbjni:1.8.

Replacement guidance:
- org.fusesource.leveldbjni:leveldbjni:1.8

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `d79410f921e568ff13a338064e449757099f0e87`

### Local CI Verification

- Status: `success`
- Commands run: 6
- Fixup attempts: 0
