### PR TITLE
[GenAI] Add support for com.google.inject.extensions:guice-servlet:3.0 using gpt-5.5

### DIFF
--- a/metadata/com.google.inject.extensions/guice-servlet/3.0/reachability-metadata.json
+++ b/metadata/com.google.inject.extensions/guice-servlet/3.0/reachability-metadata.json
@@ -1,0 +1,19 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.google.inject.internal.util.$FinalizableReferenceQueue"
+      },
+      "type": "com.google.inject.internal.util.$Finalizer",
+      "methods": [
+        {
+          "name": "startFinalizer",
+          "parameterTypes": [
+            "java.lang.Class",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/com.google.inject.extensions/guice-servlet/index.json
+++ b/metadata/com.google.inject.extensions/guice-servlet/index.json
@@ -1,17 +1,18 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "3.0",
-    "source-code-url" : "https://repo1.maven.org/maven2/com/google/inject/extensions/guice-servlet/$version$/guice-servlet-$version$-sources.jar",
-    "repository-url" : "https://github.com/google/guice",
-    "test-code-url" : "https://repo1.maven.org/maven2/com/google/inject/extensions/guice-servlet/$version$/guice-servlet-$version$-tests.jar",
-    "documentation-url" : "https://repo1.maven.org/maven2/com/google/inject/extensions/guice-servlet/$version$/guice-servlet-$version$-javadoc.jar",
-    "description" : "Guice Servlet extends Google Guice for Java servlet applications, adding request and session scopes plus servlet and filter binding support. It integrates Guice-managed dependency injection into servlet containers through APIs such as ServletModule, GuiceFilter, and GuiceServletContextListener.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "3.0",
+    "source-code-url": "https://repo1.maven.org/maven2/com/google/inject/extensions/guice-servlet/$version$/guice-servlet-$version$-sources.jar",
+    "repository-url": "https://github.com/google/guice",
+    "test-code-url": "https://repo1.maven.org/maven2/com/google/inject/extensions/guice-servlet/$version$/guice-servlet-$version$-tests.jar",
+    "documentation-url": "https://repo1.maven.org/maven2/com/google/inject/extensions/guice-servlet/$version$/guice-servlet-$version$-javadoc.jar",
+    "description": "Guice Servlet extends Google Guice for Java servlet applications, adding request and session scopes plus servlet and filter binding support. It integrates Guice-managed dependency injection into servlet containers through APIs such as ServletModule, GuiceFilter, and GuiceServletContextListener.",
+    "tested-versions": [
       "3.0"
     ],
-    "allowed-packages" : [
-      "com.google.inject.servlet"
+    "allowed-packages": [
+      "com.google.inject.servlet",
+      "com.google.inject.internal.util"
     ]
   }
 ]

--- a/metadata/com.google.inject.extensions/guice-servlet/index.json
+++ b/metadata/com.google.inject.extensions/guice-servlet/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/google/inject/extensions/guice-servlet/$version$/guice-servlet-$version$-sources.jar",
+    "repository-url" : "https://github.com/google/guice",
+    "test-code-url" : "https://repo1.maven.org/maven2/com/google/inject/extensions/guice-servlet/$version$/guice-servlet-$version$-tests.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/google/inject/extensions/guice-servlet/$version$/guice-servlet-$version$-javadoc.jar",
+    "description" : "Guice Servlet extends Google Guice for Java servlet applications, adding request and session scopes plus servlet and filter binding support. It integrates Guice-managed dependency injection into servlet containers through APIs such as ServletModule, GuiceFilter, and GuiceServletContextListener.",
+    "tested-versions" : [
+      "3.0"
+    ],
+    "allowed-packages" : [
+      "com.google.inject.servlet"
+    ]
+  }
+]

--- a/stats/com.google.inject.extensions/guice-servlet/3.0/execution-metrics.json
+++ b/stats/com.google.inject.extensions/guice-servlet/3.0/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-09": {
+    "timestamp": "2026-05-09T07:05:07.593635Z",
+    "library": "com.google.inject.extensions:guice-servlet:3.0",
+    "starting_commit": "5be8217374f106c117b6c1270bd1b1e159f53c46",
+    "ending_commit": "91687de3c46be10d17170ee223f968d9e089874d",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1353,
+          "missed": 1276,
+          "ratio": 0.514644,
+          "total": 2629
+        },
+        "line": {
+          "covered": 272,
+          "missed": 262,
+          "ratio": 0.509363,
+          "total": 534
+        },
+        "method": {
+          "covered": 89,
+          "missed": 95,
+          "ratio": 0.483696,
+          "total": 184
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 339409,
+      "cached_input_tokens_used": 3305984,
+      "output_tokens_used": 47512,
+      "iterations": 6,
+      "cost_usd": 3.0784,
+      "generated_loc": 772,
+      "tested_library_loc": 272,
+      "metadata_entries": 2,
+      "code_coverage_percent": 50.94
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.google.inject.extensions/guice-servlet/3.0/src/test/java/com_google_inject_extensions/guice_servlet/Guice_servletTest.java",
+      "metadata_file": "metadata/com.google.inject.extensions/guice-servlet/3.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.google.inject.extensions/guice-servlet/3.0/stats.json
+++ b/stats/com.google.inject.extensions/guice-servlet/3.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1353,
+        "missed" : 1276,
+        "ratio" : 0.514644,
+        "total" : 2629
+      },
+      "line" : {
+        "covered" : 272,
+        "missed" : 262,
+        "ratio" : 0.509363,
+        "total" : 534
+      },
+      "method" : {
+        "covered" : 89,
+        "missed" : 95,
+        "ratio" : 0.483696,
+        "total" : 184
+      }
+    }
+  } ]
+}

--- a/tests/src/com.google.inject.extensions/guice-servlet/3.0/.gitignore
+++ b/tests/src/com.google.inject.extensions/guice-servlet/3.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.google.inject.extensions/guice-servlet/3.0/build.gradle
+++ b/tests/src/com.google.inject.extensions/guice-servlet/3.0/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "com.google.inject.extensions:guice-servlet:$libraryVersion"
+    testImplementation 'javax.servlet:servlet-api:2.5'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/com.google.inject.extensions/guice-servlet/3.0/build.gradle
+++ b/tests/src/com.google.inject.extensions/guice-servlet/3.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.google.inject.extensions:guice-servlet:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.google.inject.extensions/guice-servlet/3.0/gradle.properties
+++ b/tests/src/com.google.inject.extensions/guice-servlet/3.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.google.inject.extensions:guice-servlet:3.0
+library.version = 3.0
+metadata.dir = com.google.inject.extensions/guice-servlet/3.0/

--- a/tests/src/com.google.inject.extensions/guice-servlet/3.0/settings.gradle
+++ b/tests/src/com.google.inject.extensions/guice-servlet/3.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.google.inject.extensions.guice-servlet_tests'

--- a/tests/src/com.google.inject.extensions/guice-servlet/3.0/src/test/java/com_google_inject_extensions/guice_servlet/Guice_servletTest.java
+++ b/tests/src/com.google.inject.extensions/guice-servlet/3.0/src/test/java/com_google_inject_extensions/guice_servlet/Guice_servletTest.java
@@ -15,6 +15,7 @@ import com.google.inject.OutOfScopeException;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
 import com.google.inject.name.Names;
+import com.google.inject.servlet.GuiceFilter;
 import com.google.inject.servlet.InstanceFilterBinding;
 import com.google.inject.servlet.InstanceServletBinding;
 import com.google.inject.servlet.LinkedFilterBinding;
@@ -28,18 +29,33 @@ import com.google.inject.spi.DefaultBindingTargetVisitor;
 import com.google.inject.spi.Element;
 import com.google.inject.spi.Elements;
 import com.google.inject.spi.Message;
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.security.Principal;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
+import javax.servlet.ServletInputStream;
+import javax.servlet.ServletOutputStream;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpSessionContext;
 import org.junit.jupiter.api.Test;
 
 public class Guice_servletTest {
@@ -130,6 +146,26 @@ public class Guice_servletTest {
                 .anySatisfy(message -> assertThat(message)
                         .contains("More than one servlet was mapped")
                         .contains("/duplicate"));
+    }
+
+    @Test
+    void sessionScopeCachesValuesAcrossRequestsUsingTheSameHttpSession() throws Exception {
+        Provider<SessionScopedValue> sessionScopedProvider = ServletScopes.SESSION.scope(
+                Key.get(SessionScopedValue.class), new SessionScopedValueProvider());
+        TestHttpSession session = new TestHttpSession();
+        TestHttpSession otherSession = new TestHttpSession();
+
+        ScopedSessionResult first = executeWithSession(session, () -> new ScopedSessionResult(
+                sessionScopedProvider.get(), sessionScopedProvider.get()));
+        ScopedSessionResult second = executeWithSession(session, () -> new ScopedSessionResult(
+                sessionScopedProvider.get(), sessionScopedProvider.get()));
+        ScopedSessionResult third = executeWithSession(otherSession, () -> new ScopedSessionResult(
+                sessionScopedProvider.get(), sessionScopedProvider.get()));
+
+        assertThat(first.firstValue).isSameAs(first.secondValue);
+        assertThat(second.firstValue).isSameAs(first.firstValue);
+        assertThat(third.firstValue).isSameAs(third.secondValue);
+        assertThat(third.firstValue).isNotSameAs(first.firstValue);
     }
 
     private static ScopedRequestResult executeInRequestScope(
@@ -230,6 +266,555 @@ public class Guice_servletTest {
         }
     }
 
+    private static <T> T executeWithSession(HttpSession session, ValueSupplier<T> supplier)
+            throws IOException, ServletException {
+        ValueCapturingFilterChain<T> chain = new ValueCapturingFilterChain<>(supplier);
+        new GuiceFilter().doFilter(new TestHttpServletRequest(session), new TestHttpServletResponse(), chain);
+        return chain.value;
+    }
+
+    private interface ValueSupplier<T> {
+        T get();
+    }
+
+    private static final class ValueCapturingFilterChain<T> implements FilterChain {
+        private final ValueSupplier<T> supplier;
+        private T value;
+
+        private ValueCapturingFilterChain(ValueSupplier<T> supplier) {
+            this.supplier = supplier;
+        }
+
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response) {
+            value = supplier.get();
+        }
+    }
+
+    private static final class ScopedSessionResult {
+        private final SessionScopedValue firstValue;
+        private final SessionScopedValue secondValue;
+
+        private ScopedSessionResult(SessionScopedValue firstValue, SessionScopedValue secondValue) {
+            this.firstValue = firstValue;
+            this.secondValue = secondValue;
+        }
+    }
+
+    private static final class TestHttpSession implements HttpSession {
+        private final Map<String, Object> attributes = new LinkedHashMap<>();
+
+        @Override
+        public long getCreationTime() {
+            return 0L;
+        }
+
+        @Override
+        public String getId() {
+            return "test-session";
+        }
+
+        @Override
+        public long getLastAccessedTime() {
+            return 0L;
+        }
+
+        @Override
+        public ServletContext getServletContext() {
+            return null;
+        }
+
+        @Override
+        public void setMaxInactiveInterval(int interval) {
+        }
+
+        @Override
+        public int getMaxInactiveInterval() {
+            return 0;
+        }
+
+        @Override
+        @SuppressWarnings("deprecation")
+        public HttpSessionContext getSessionContext() {
+            return null;
+        }
+
+        @Override
+        public Object getAttribute(String name) {
+            return attributes.get(name);
+        }
+
+        @Override
+        public Object getValue(String name) {
+            return getAttribute(name);
+        }
+
+        @Override
+        public Enumeration<String> getAttributeNames() {
+            return Collections.enumeration(attributes.keySet());
+        }
+
+        @Override
+        public String[] getValueNames() {
+            return attributes.keySet().toArray(new String[0]);
+        }
+
+        @Override
+        public void setAttribute(String name, Object value) {
+            attributes.put(name, value);
+        }
+
+        @Override
+        public void putValue(String name, Object value) {
+            setAttribute(name, value);
+        }
+
+        @Override
+        public void removeAttribute(String name) {
+            attributes.remove(name);
+        }
+
+        @Override
+        public void removeValue(String name) {
+            removeAttribute(name);
+        }
+
+        @Override
+        public void invalidate() {
+            attributes.clear();
+        }
+
+        @Override
+        public boolean isNew() {
+            return false;
+        }
+    }
+
+    private static final class TestHttpServletRequest implements HttpServletRequest {
+        private final HttpSession session;
+        private final Map<String, Object> attributes = new LinkedHashMap<>();
+
+        private TestHttpServletRequest(HttpSession session) {
+            this.session = session;
+        }
+
+        @Override
+        public String getAuthType() {
+            return null;
+        }
+
+        @Override
+        public Cookie[] getCookies() {
+            return new Cookie[0];
+        }
+
+        @Override
+        public long getDateHeader(String name) {
+            return -1L;
+        }
+
+        @Override
+        public String getHeader(String name) {
+            return null;
+        }
+
+        @Override
+        public Enumeration<String> getHeaders(String name) {
+            return Collections.emptyEnumeration();
+        }
+
+        @Override
+        public Enumeration<String> getHeaderNames() {
+            return Collections.emptyEnumeration();
+        }
+
+        @Override
+        public int getIntHeader(String name) {
+            return -1;
+        }
+
+        @Override
+        public String getMethod() {
+            return "GET";
+        }
+
+        @Override
+        public String getPathInfo() {
+            return null;
+        }
+
+        @Override
+        public String getPathTranslated() {
+            return null;
+        }
+
+        @Override
+        public String getContextPath() {
+            return "";
+        }
+
+        @Override
+        public String getQueryString() {
+            return null;
+        }
+
+        @Override
+        public String getRemoteUser() {
+            return null;
+        }
+
+        @Override
+        public boolean isUserInRole(String role) {
+            return false;
+        }
+
+        @Override
+        public Principal getUserPrincipal() {
+            return null;
+        }
+
+        @Override
+        public String getRequestedSessionId() {
+            return session.getId();
+        }
+
+        @Override
+        public String getRequestURI() {
+            return "/session";
+        }
+
+        @Override
+        public StringBuffer getRequestURL() {
+            return new StringBuffer("http://localhost/session");
+        }
+
+        @Override
+        public String getServletPath() {
+            return "/session";
+        }
+
+        @Override
+        public HttpSession getSession(boolean create) {
+            return session;
+        }
+
+        @Override
+        public HttpSession getSession() {
+            return session;
+        }
+
+        @Override
+        public boolean isRequestedSessionIdValid() {
+            return true;
+        }
+
+        @Override
+        public boolean isRequestedSessionIdFromCookie() {
+            return false;
+        }
+
+        @Override
+        public boolean isRequestedSessionIdFromURL() {
+            return false;
+        }
+
+        @Override
+        @SuppressWarnings("deprecation")
+        public boolean isRequestedSessionIdFromUrl() {
+            return false;
+        }
+
+        @Override
+        public Object getAttribute(String name) {
+            return attributes.get(name);
+        }
+
+        @Override
+        public Enumeration<String> getAttributeNames() {
+            return Collections.enumeration(attributes.keySet());
+        }
+
+        @Override
+        public String getCharacterEncoding() {
+            return "UTF-8";
+        }
+
+        @Override
+        public void setCharacterEncoding(String encoding) {
+        }
+
+        @Override
+        public int getContentLength() {
+            return 0;
+        }
+
+        @Override
+        public String getContentType() {
+            return null;
+        }
+
+        @Override
+        public ServletInputStream getInputStream() {
+            return null;
+        }
+
+        @Override
+        public String getParameter(String name) {
+            return null;
+        }
+
+        @Override
+        public Enumeration<String> getParameterNames() {
+            return Collections.emptyEnumeration();
+        }
+
+        @Override
+        public String[] getParameterValues(String name) {
+            return null;
+        }
+
+        @Override
+        public Map<String, String[]> getParameterMap() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public String getProtocol() {
+            return "HTTP/1.1";
+        }
+
+        @Override
+        public String getScheme() {
+            return "http";
+        }
+
+        @Override
+        public String getServerName() {
+            return "localhost";
+        }
+
+        @Override
+        public int getServerPort() {
+            return 80;
+        }
+
+        @Override
+        public BufferedReader getReader() {
+            return null;
+        }
+
+        @Override
+        public String getRemoteAddr() {
+            return "127.0.0.1";
+        }
+
+        @Override
+        public String getRemoteHost() {
+            return "localhost";
+        }
+
+        @Override
+        public void setAttribute(String name, Object object) {
+            attributes.put(name, object);
+        }
+
+        @Override
+        public void removeAttribute(String name) {
+            attributes.remove(name);
+        }
+
+        @Override
+        public Locale getLocale() {
+            return Locale.ROOT;
+        }
+
+        @Override
+        public Enumeration<Locale> getLocales() {
+            return Collections.enumeration(List.of(Locale.ROOT));
+        }
+
+        @Override
+        public boolean isSecure() {
+            return false;
+        }
+
+        @Override
+        public RequestDispatcher getRequestDispatcher(String path) {
+            return null;
+        }
+
+        @Override
+        @SuppressWarnings("deprecation")
+        public String getRealPath(String path) {
+            return null;
+        }
+
+        @Override
+        public int getRemotePort() {
+            return 0;
+        }
+
+        @Override
+        public String getLocalName() {
+            return "localhost";
+        }
+
+        @Override
+        public String getLocalAddr() {
+            return "127.0.0.1";
+        }
+
+        @Override
+        public int getLocalPort() {
+            return 80;
+        }
+    }
+
+    private static final class TestHttpServletResponse implements HttpServletResponse {
+        @Override
+        public void addCookie(Cookie cookie) {
+        }
+
+        @Override
+        public boolean containsHeader(String name) {
+            return false;
+        }
+
+        @Override
+        public String encodeURL(String url) {
+            return url;
+        }
+
+        @Override
+        public String encodeRedirectURL(String url) {
+            return url;
+        }
+
+        @Override
+        @SuppressWarnings("deprecation")
+        public String encodeUrl(String url) {
+            return url;
+        }
+
+        @Override
+        @SuppressWarnings("deprecation")
+        public String encodeRedirectUrl(String url) {
+            return url;
+        }
+
+        @Override
+        public void sendError(int statusCode, String message) {
+        }
+
+        @Override
+        public void sendError(int statusCode) {
+        }
+
+        @Override
+        public void sendRedirect(String location) {
+        }
+
+        @Override
+        public void setDateHeader(String name, long date) {
+        }
+
+        @Override
+        public void addDateHeader(String name, long date) {
+        }
+
+        @Override
+        public void setHeader(String name, String value) {
+        }
+
+        @Override
+        public void addHeader(String name, String value) {
+        }
+
+        @Override
+        public void setIntHeader(String name, int value) {
+        }
+
+        @Override
+        public void addIntHeader(String name, int value) {
+        }
+
+        @Override
+        public void setStatus(int statusCode) {
+        }
+
+        @Override
+        @SuppressWarnings("deprecation")
+        public void setStatus(int statusCode, String message) {
+        }
+
+        @Override
+        public String getCharacterEncoding() {
+            return "UTF-8";
+        }
+
+        @Override
+        public String getContentType() {
+            return null;
+        }
+
+        @Override
+        public ServletOutputStream getOutputStream() {
+            return null;
+        }
+
+        @Override
+        public PrintWriter getWriter() {
+            return null;
+        }
+
+        @Override
+        public void setCharacterEncoding(String encoding) {
+        }
+
+        @Override
+        public void setContentLength(int length) {
+        }
+
+        @Override
+        public void setContentType(String type) {
+        }
+
+        @Override
+        public void setBufferSize(int size) {
+        }
+
+        @Override
+        public int getBufferSize() {
+            return 0;
+        }
+
+        @Override
+        public void flushBuffer() {
+        }
+
+        @Override
+        public void resetBuffer() {
+        }
+
+        @Override
+        public boolean isCommitted() {
+            return false;
+        }
+
+        @Override
+        public void reset() {
+        }
+
+        @Override
+        public void setLocale(Locale locale) {
+        }
+
+        @Override
+        public Locale getLocale() {
+            return Locale.ROOT;
+        }
+    }
+
     private static final class ScopedRequestResult {
         private final RequestScopedValue firstValue;
         private final RequestScopedValue secondValue;
@@ -256,7 +841,17 @@ public class Guice_servletTest {
         }
     }
 
+    private static final class SessionScopedValueProvider implements Provider<SessionScopedValue> {
+        @Override
+        public SessionScopedValue get() {
+            return new SessionScopedValue();
+        }
+    }
+
     private static final class RequestScopedValue {
+    }
+
+    private static final class SessionScopedValue {
     }
 
     private static class ApiFilter implements Filter {

--- a/tests/src/com.google.inject.extensions/guice-servlet/3.0/src/test/java/com_google_inject_extensions/guice_servlet/Guice_servletTest.java
+++ b/tests/src/com.google.inject.extensions/guice-servlet/3.0/src/test/java/com_google_inject_extensions/guice_servlet/Guice_servletTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_inject_extensions.guice_servlet;
+
+import org.junit.jupiter.api.Test;
+
+class Guice_servletTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/com.google.inject.extensions/guice-servlet/3.0/src/test/java/com_google_inject_extensions/guice_servlet/Guice_servletTest.java
+++ b/tests/src/com.google.inject.extensions/guice-servlet/3.0/src/test/java/com_google_inject_extensions/guice_servlet/Guice_servletTest.java
@@ -40,6 +40,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
@@ -168,6 +169,28 @@ public class Guice_servletTest {
         assertThat(third.firstValue).isNotSameAs(first.firstValue);
     }
 
+    @Test
+    void continueRequestCreatesCallableThatUsesRequestScopeAfterServletFilterReturns() throws Exception {
+        Provider<RequestScopedValue> requestScopedProvider = ServletScopes.REQUEST.scope(
+                Key.get(RequestScopedValue.class), new RequestScopedValueProvider());
+        Provider<String> userProvider = ServletScopes.REQUEST.scope(REQUEST_USER_KEY, new DefaultRequestUserProvider());
+        Provider<SessionScopedValue> sessionScopedProvider = ServletScopes.SESSION.scope(
+                Key.get(SessionScopedValue.class), new SessionScopedValueProvider());
+        ContinuedRequestCapture capture = new ContinuedRequestCapture(
+                requestScopedProvider, userProvider, sessionScopedProvider);
+
+        new GuiceFilter().doFilter(
+                new TestHttpServletRequest(new TestHttpSession()), new TestHttpServletResponse(), capture);
+
+        ContinuedRequestResult result = capture.continuedRequest.call();
+
+        assertThat(result.firstValue).isSameAs(result.secondValue);
+        assertThat(result.user).isEqualTo(ContinuedRequestCapture.CONTINUED_USER);
+        assertThatThrownBy(() -> capture.continuedSessionAccess.call())
+                .isInstanceOf(OutOfScopeException.class)
+                .hasMessageContaining("Cannot access the session");
+    }
+
     private static ScopedRequestResult executeInRequestScope(
             Provider<RequestScopedValue> requestScopedProvider,
             Provider<String> userProvider,
@@ -288,6 +311,46 @@ public class Guice_servletTest {
         @Override
         public void doFilter(ServletRequest request, ServletResponse response) {
             value = supplier.get();
+        }
+    }
+
+    private static final class ContinuedRequestCapture implements FilterChain {
+        private static final String CONTINUED_USER = "continued-user";
+
+        private final Provider<RequestScopedValue> requestScopedProvider;
+        private final Provider<String> userProvider;
+        private final Provider<SessionScopedValue> sessionScopedProvider;
+        private Callable<ContinuedRequestResult> continuedRequest;
+        private Callable<SessionScopedValue> continuedSessionAccess;
+
+        private ContinuedRequestCapture(
+                Provider<RequestScopedValue> requestScopedProvider,
+                Provider<String> userProvider,
+                Provider<SessionScopedValue> sessionScopedProvider) {
+            this.requestScopedProvider = requestScopedProvider;
+            this.userProvider = userProvider;
+            this.sessionScopedProvider = sessionScopedProvider;
+        }
+
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response) {
+            Map<Key<?>, Object> seedMap = new LinkedHashMap<>();
+            seedMap.put(REQUEST_USER_KEY, CONTINUED_USER);
+            continuedRequest = ServletScopes.continueRequest(() -> new ContinuedRequestResult(
+                    requestScopedProvider.get(), requestScopedProvider.get(), userProvider.get()), seedMap);
+            continuedSessionAccess = ServletScopes.continueRequest(sessionScopedProvider::get, Collections.emptyMap());
+        }
+    }
+
+    private static final class ContinuedRequestResult {
+        private final RequestScopedValue firstValue;
+        private final RequestScopedValue secondValue;
+        private final String user;
+
+        private ContinuedRequestResult(RequestScopedValue firstValue, RequestScopedValue secondValue, String user) {
+            this.firstValue = firstValue;
+            this.secondValue = secondValue;
+            this.user = user;
         }
     }
 

--- a/tests/src/com.google.inject.extensions/guice-servlet/3.0/src/test/java/com_google_inject_extensions/guice_servlet/Guice_servletTest.java
+++ b/tests/src/com.google.inject.extensions/guice-servlet/3.0/src/test/java/com_google_inject_extensions/guice_servlet/Guice_servletTest.java
@@ -6,11 +6,284 @@
  */
 package com_google_inject_extensions.guice_servlet;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.inject.Binding;
+import com.google.inject.Key;
+import com.google.inject.OutOfScopeException;
+import com.google.inject.Provider;
+import com.google.inject.Singleton;
+import com.google.inject.name.Names;
+import com.google.inject.servlet.InstanceFilterBinding;
+import com.google.inject.servlet.InstanceServletBinding;
+import com.google.inject.servlet.LinkedFilterBinding;
+import com.google.inject.servlet.LinkedServletBinding;
+import com.google.inject.servlet.ServletModule;
+import com.google.inject.servlet.ServletModuleBinding;
+import com.google.inject.servlet.ServletModuleTargetVisitor;
+import com.google.inject.servlet.ServletScopes;
+import com.google.inject.servlet.UriPatternType;
+import com.google.inject.spi.DefaultBindingTargetVisitor;
+import com.google.inject.spi.Element;
+import com.google.inject.spi.Elements;
+import com.google.inject.spi.Message;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServlet;
 import org.junit.jupiter.api.Test;
 
-class Guice_servletTest {
+public class Guice_servletTest {
+    private static final Key<String> REQUEST_USER_KEY = Key.get(String.class, Names.named("requestUser"));
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void servletModuleExposesLinkedAndInstanceBindingsWithMatchingRules() {
+        List<ServletModuleBinding> bindings = servletModuleBindings(new RoutingModule());
+
+        assertThat(bindings).hasSize(7);
+
+        LinkedFilterBinding apiFilter = binding(bindings, LinkedFilterBinding.class, "/api/*");
+        assertThat(apiFilter.getUriPatternType()).isEqualTo(UriPatternType.SERVLET);
+        assertThat(apiFilter.getLinkedKey()).isEqualTo(Key.get(ApiFilter.class));
+        assertThat(apiFilter.getInitParams()).containsEntry("filter", "api");
+        assertThat(apiFilter.matchesUri("/api/customers")).isTrue();
+        assertThat(apiFilter.matchesUri("/admin/42")).isFalse();
+
+        LinkedFilterBinding htmlFilter = binding(bindings, LinkedFilterBinding.class, "*.html");
+        assertThat(htmlFilter.matchesUri("/index.html")).isTrue();
+        assertThat(htmlFilter.matchesUri("/index.json")).isFalse();
+
+        InstanceFilterBinding adminFilter = binding(bindings, InstanceFilterBinding.class, "^/admin/[0-9]+$");
+        assertThat(adminFilter.getUriPatternType()).isEqualTo(UriPatternType.REGEX);
+        assertThat(adminFilter.getFilterInstance()).isSameAs(RoutingModule.ADMIN_FILTER);
+        assertThat(adminFilter.getInitParams()).containsEntry("filter", "admin");
+        assertThat(adminFilter.matchesUri("/admin/42")).isTrue();
+        assertThat(adminFilter.matchesUri("/admin/users")).isFalse();
+
+        LinkedServletBinding healthServlet = binding(bindings, LinkedServletBinding.class, "/health");
+        assertThat(healthServlet.getLinkedKey()).isEqualTo(Key.get(HealthServlet.class));
+        assertThat(healthServlet.getInitParams()).containsEntry("servlet", "health");
+        assertThat(healthServlet.matchesUri("/health")).isTrue();
+        assertThat(healthServlet.matchesUri("/health/check")).isFalse();
+
+        LinkedServletBinding staticServlet = binding(bindings, LinkedServletBinding.class, "/static/*");
+        assertThat(staticServlet.matchesUri("/static/app.js")).isTrue();
+        assertThat(staticServlet.matchesUri("/assets/app.js")).isFalse();
+
+        InstanceServletBinding assetServlet = binding(bindings, InstanceServletBinding.class, "^/assets/.+");
+        assertThat(assetServlet.getUriPatternType()).isEqualTo(UriPatternType.REGEX);
+        assertThat(assetServlet.getServletInstance()).isSameAs(RoutingModule.ASSET_SERVLET);
+        assertThat(assetServlet.getInitParams()).containsEntry("servlet", "asset");
+        assertThat(assetServlet.matchesUri("/assets/app.css")).isTrue();
+        assertThat(assetServlet.matchesUri("/static/app.css")).isFalse();
+
+        LinkedServletBinding namedServlet = binding(bindings, LinkedServletBinding.class, "/named/*");
+        assertThat(namedServlet.getLinkedKey()).isEqualTo(Key.get(NamedServlet.class, Names.named("namedServlet")));
+    }
+
+    @Test
+    void requestScopeCachesValuesAndUsesSeededRequestData() throws Exception {
+        Provider<RequestScopedValue> requestScopedProvider = ServletScopes.REQUEST.scope(
+                Key.get(RequestScopedValue.class), new RequestScopedValueProvider());
+        Provider<String> userProvider = ServletScopes.REQUEST.scope(REQUEST_USER_KEY, new DefaultRequestUserProvider());
+
+        assertThatThrownBy(requestScopedProvider::get).isInstanceOf(OutOfScopeException.class);
+
+        ScopedRequestResult first = executeInRequestScope(requestScopedProvider, userProvider, "alice");
+        ScopedRequestResult second = executeInRequestScope(requestScopedProvider, userProvider, "bob");
+
+        assertThat(first.firstValue).isSameAs(first.secondValue);
+        assertThat(first.user).isEqualTo("alice");
+        assertThat(second.firstValue).isSameAs(second.secondValue);
+        assertThat(second.user).isEqualTo("bob");
+        assertThat(first.firstValue).isNotSameAs(second.firstValue);
+    }
+
+    @Test
+    void requestScopeRejectsSeedValuesWithTheWrongType() {
+        Map<Key<?>, Object> seedMap = new LinkedHashMap<>();
+        seedMap.put(REQUEST_USER_KEY, 42);
+
+        assertThatThrownBy(() -> ServletScopes.scopeRequest(() -> null, seedMap))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not compatible")
+                .hasMessageContaining(REQUEST_USER_KEY.toString());
+    }
+
+    @Test
+    void duplicateServletMappingsAreReportedByServletModuleElements() {
+        List<Message> messages = Elements.getElements(new DuplicateServletMappingModule()).stream()
+                .filter(Message.class::isInstance)
+                .map(Message.class::cast)
+                .toList();
+
+        assertThat(messages.stream().map(Message::getMessage).toList())
+                .anySatisfy(message -> assertThat(message)
+                        .contains("More than one servlet was mapped")
+                        .contains("/duplicate"));
+    }
+
+    private static ScopedRequestResult executeInRequestScope(
+            Provider<RequestScopedValue> requestScopedProvider,
+            Provider<String> userProvider,
+            String user) throws Exception {
+        Map<Key<?>, Object> seedMap = new LinkedHashMap<>();
+        seedMap.put(REQUEST_USER_KEY, user);
+
+        return ServletScopes.scopeRequest(() -> new ScopedRequestResult(
+                requestScopedProvider.get(),
+                requestScopedProvider.get(),
+                userProvider.get()), seedMap).call();
+    }
+
+    private static List<ServletModuleBinding> servletModuleBindings(ServletModule module) {
+        List<ServletModuleBinding> bindings = new ArrayList<>();
+        BindingCollector collector = new BindingCollector();
+        for (Element element : Elements.getElements(module)) {
+            if (element instanceof Binding) {
+                ServletModuleBinding servletBinding = ((Binding<?>) element).acceptTargetVisitor(collector);
+                if (servletBinding != null) {
+                    bindings.add(servletBinding);
+                }
+            }
+        }
+        return bindings;
+    }
+
+    private static <T extends ServletModuleBinding> T binding(
+            List<ServletModuleBinding> bindings, Class<T> bindingType, String pattern) {
+        return bindings.stream()
+                .filter(bindingType::isInstance)
+                .map(bindingType::cast)
+                .filter(binding -> pattern.equals(binding.getPattern()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No " + bindingType.getSimpleName() + " for " + pattern));
+    }
+
+    private static final class BindingCollector extends DefaultBindingTargetVisitor<Object, ServletModuleBinding>
+            implements ServletModuleTargetVisitor<Object, ServletModuleBinding> {
+        @Override
+        public ServletModuleBinding visit(LinkedFilterBinding binding) {
+            return binding;
+        }
+
+        @Override
+        public ServletModuleBinding visit(InstanceFilterBinding binding) {
+            return binding;
+        }
+
+        @Override
+        public ServletModuleBinding visit(LinkedServletBinding binding) {
+            return binding;
+        }
+
+        @Override
+        public ServletModuleBinding visit(InstanceServletBinding binding) {
+            return binding;
+        }
+    }
+
+    private static final class RoutingModule extends ServletModule {
+        private static final Filter ADMIN_FILTER = new AdminFilter();
+        private static final HttpServlet ASSET_SERVLET = new AssetServlet();
+
+        @Override
+        protected void configureServlets() {
+            Map<String, String> apiFilterParams = new LinkedHashMap<>();
+            apiFilterParams.put("filter", "api");
+            filter("/api/*", "*.html").through(ApiFilter.class, apiFilterParams);
+
+            Map<String, String> adminFilterParams = new LinkedHashMap<>();
+            adminFilterParams.put("filter", "admin");
+            filterRegex("^/admin/[0-9]+$").through(ADMIN_FILTER, adminFilterParams);
+
+            Map<String, String> healthServletParams = new LinkedHashMap<>();
+            healthServletParams.put("servlet", "health");
+            serve("/health", "/static/*").with(HealthServlet.class, healthServletParams);
+
+            Map<String, String> assetServletParams = new LinkedHashMap<>();
+            assetServletParams.put("servlet", "asset");
+            serveRegex("^/assets/.+").with(ASSET_SERVLET, assetServletParams);
+
+            bind(NamedServlet.class)
+                    .annotatedWith(Names.named("namedServlet"))
+                    .to(NamedServlet.class)
+                    .in(Singleton.class);
+            serve("/named/*").with(Key.get(NamedServlet.class, Names.named("namedServlet")));
+        }
+    }
+
+    private static final class DuplicateServletMappingModule extends ServletModule {
+        @Override
+        protected void configureServlets() {
+            serve("/duplicate").with(HealthServlet.class);
+            serve("/duplicate").with(AssetServlet.class);
+        }
+    }
+
+    private static final class ScopedRequestResult {
+        private final RequestScopedValue firstValue;
+        private final RequestScopedValue secondValue;
+        private final String user;
+
+        private ScopedRequestResult(RequestScopedValue firstValue, RequestScopedValue secondValue, String user) {
+            this.firstValue = firstValue;
+            this.secondValue = secondValue;
+            this.user = user;
+        }
+    }
+
+    private static final class DefaultRequestUserProvider implements Provider<String> {
+        @Override
+        public String get() {
+            return "unseeded-user";
+        }
+    }
+
+    private static final class RequestScopedValueProvider implements Provider<RequestScopedValue> {
+        @Override
+        public RequestScopedValue get() {
+            return new RequestScopedValue();
+        }
+    }
+
+    private static final class RequestScopedValue {
+    }
+
+    private static class ApiFilter implements Filter {
+        @Override
+        public void init(FilterConfig filterConfig) throws ServletException {
+        }
+
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+                throws IOException, ServletException {
+            chain.doFilter(request, response);
+        }
+
+        @Override
+        public void destroy() {
+        }
+    }
+
+    private static final class AdminFilter extends ApiFilter {
+    }
+
+    private static final class HealthServlet extends HttpServlet {
+    }
+
+    private static final class AssetServlet extends HttpServlet {
+    }
+
+    private static final class NamedServlet extends HttpServlet {
     }
 }

--- a/tests/src/com.google.inject.extensions/guice-servlet/3.0/src/test/java/com_google_inject_extensions/guice_servlet/Guice_servletTest.java
+++ b/tests/src/com.google.inject.extensions/guice-servlet/3.0/src/test/java/com_google_inject_extensions/guice_servlet/Guice_servletTest.java
@@ -548,7 +548,7 @@ public class Guice_servletTest {
 
         @Override
         public StringBuffer getRequestURL() {
-            return new StringBuffer("http://localhost/session");
+            return new java.lang.StringBuffer("http://localhost/session");
         }
 
         @Override

--- a/tests/src/com.google.inject.extensions/guice-servlet/3.0/user-code-filter.json
+++ b/tests/src/com.google.inject.extensions/guice-servlet/3.0/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.google.inject.servlet.**"
+      "includeClasses" : "com.google.inject.servlet.**"
+    },
+    {
+      "includeClasses" : "com_google_inject_extensions.guice_servlet.**"
     }
   ]
 }

--- a/tests/src/com.google.inject.extensions/guice-servlet/3.0/user-code-filter.json
+++ b/tests/src/com.google.inject.extensions/guice-servlet/3.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.google.inject.servlet.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #2934

This PR introduces tests and metadata for com.google.inject.extensions:guice-servlet:3.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 339409
- Cached input tokens: 3305984
- Output tokens: 47512
- Metadata entries: 2
- Iterations: 6
- Library coverage percentage: 50.94
- Generated lines of code: 772
- Tested library lines of code: 272

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `e28a714d1df9251f37bdf74b7d4499713c1479e6`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1353/2629 (51.46%)
- Line: 272/534 (50.94%)
- Method: 89/184 (48.37%)

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
