### PR TITLE
[GenAI] Add support for com.sun.jersey:jersey-json:1.9 using gpt-5.5

### DIFF
--- a/metadata/com.sun.jersey/jersey-json/1.9/reachability-metadata.json
+++ b/metadata/com.sun.jersey/jersey-json/1.9/reachability-metadata.json
@@ -1,0 +1,30 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jersey.api.json.JSONJAXBContext"
+      },
+      "type" : "com.sun.xml.bind.v2.ContextFactory",
+      "methods" : [
+        {
+          "name" : "createContext",
+          "parameterTypes" : [
+            "java.lang.Class[]",
+            "java.util.Map"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jersey.api.json.JSONJAXBContext"
+      },
+      "type" : {
+        "proxy" : [
+          "javax.xml.bind.annotation.XmlAccessorType",
+          "com.sun.xml.bind.v2.model.annotation.Locatable"
+        ]
+      }
+    }
+  ]
+}

--- a/metadata/com.sun.jersey/jersey-json/index.json
+++ b/metadata/com.sun.jersey/jersey-json/index.json
@@ -1,0 +1,18 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.9",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/sun/jersey/jersey-json/$version$/jersey-json-$version$-sources.jar",
+    "repository-url" : "https://github.com/javaee/jersey-1.x",
+    "test-code-url" : "https://github.com/javaee/jersey-1.x/tree/post-$version$/jersey-json/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/sun/jersey/jersey-json/$version$/jersey-json-$version$-javadoc.jar",
+    "description" : "Jersey JSON is the Jersey 1.x extension module that adds JSON entity provider support for JAX-RS applications. It integrates Jersey with JAXB/Jettison and Jackson-based JSON processing so resources and clients can serialize and deserialize JSON payloads.",
+    "tested-versions" : [
+      "1.9"
+    ],
+    "allowed-packages" : [
+      "com.sun.jersey.api.json",
+      "com.sun.jersey.json.impl"
+    ]
+  }
+]

--- a/stats/com.sun.jersey/jersey-json/1.9/execution-metrics.json
+++ b/stats/com.sun.jersey/jersey-json/1.9/execution-metrics.json
@@ -1,0 +1,50 @@
+{
+  "add_new_library_support:2026-05-09": {
+    "timestamp": "2026-05-09T08:42:40.230207Z",
+    "library": "com.sun.jersey:jersey-json:1.9",
+    "starting_commit": "98a7976e68c04d87e45b2ac737331b764ea6d16b",
+    "ending_commit": "922df76850928b7bc4e5a5ef6c8cbfb06462bf7d",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.9",
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 6020,
+          "missed": 6946,
+          "ratio": 0.464291,
+          "total": 12966
+        },
+        "line": {
+          "covered": 1220,
+          "missed": 1541,
+          "ratio": 0.441869,
+          "total": 2761
+        },
+        "method": {
+          "covered": 287,
+          "missed": 532,
+          "ratio": 0.350427,
+          "total": 819
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 243855,
+      "cached_input_tokens_used": 2191360,
+      "output_tokens_used": 25430,
+      "iterations": 8,
+      "cost_usd": 1.8586,
+      "generated_loc": 239,
+      "tested_library_loc": 1220,
+      "metadata_entries": 3,
+      "code_coverage_percent": 44.19
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.sun.jersey/jersey-json/1.9/src/test/java/com_sun_jersey/jersey_json/Jersey_jsonTest.java",
+      "metadata_file": "metadata/com.sun.jersey/jersey-json/1.9/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.sun.jersey/jersey-json/1.9/stats.json
+++ b/stats/com.sun.jersey/jersey-json/1.9/stats.json
@@ -1,0 +1,26 @@
+{
+  "versions" : [ {
+    "version" : "1.9",
+    "dynamicAccess" : "N/A",
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 6020,
+        "missed" : 6946,
+        "ratio" : 0.464291,
+        "total" : 12966
+      },
+      "line" : {
+        "covered" : 1220,
+        "missed" : 1541,
+        "ratio" : 0.441869,
+        "total" : 2761
+      },
+      "method" : {
+        "covered" : 287,
+        "missed" : 532,
+        "ratio" : 0.350427,
+        "total" : 819
+      }
+    }
+  } ]
+}

--- a/tests/src/com.sun.jersey/jersey-json/1.9/.gitignore
+++ b/tests/src/com.sun.jersey/jersey-json/1.9/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.sun.jersey/jersey-json/1.9/build.gradle
+++ b/tests/src/com.sun.jersey/jersey-json/1.9/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.sun.jersey:jersey-json:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.sun.jersey/jersey-json/1.9/build.gradle
+++ b/tests/src/com.sun.jersey/jersey-json/1.9/build.gradle
@@ -16,6 +16,12 @@ dependencies {
 }
 
 graalvmNative {
+    binaries {
+        all {
+            buildArgs.add('--initialize-at-run-time=com.sun.xml.bind.v2.runtime.unmarshaller.UnmarshallingContext')
+            buildArgs.add('--initialize-at-run-time=com.sun.xml.bind.v2.runtime.reflect.opt')
+        }
+    }
     agent {
         defaultMode = "conditional"
         modes {

--- a/tests/src/com.sun.jersey/jersey-json/1.9/gradle.properties
+++ b/tests/src/com.sun.jersey/jersey-json/1.9/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.sun.jersey:jersey-json:1.9
+library.version = 1.9
+metadata.dir = com.sun.jersey/jersey-json/1.9/

--- a/tests/src/com.sun.jersey/jersey-json/1.9/settings.gradle
+++ b/tests/src/com.sun.jersey/jersey-json/1.9/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.sun.jersey.jersey-json_tests'

--- a/tests/src/com.sun.jersey/jersey-json/1.9/src/test/java/com_sun_jersey/jersey_json/Jersey_jsonTest.java
+++ b/tests/src/com.sun.jersey/jersey-json/1.9/src/test/java/com_sun_jersey/jersey_json/Jersey_jsonTest.java
@@ -25,6 +25,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import javax.xml.bind.JAXBElement;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
@@ -33,6 +34,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.namespace.QName;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -126,6 +128,23 @@ public class Jersey_jsonTest {
     }
 
     @Test
+    void jsonUnmarshallerCreatesJaxbElementForClassWithoutRootAnnotation() throws JAXBException {
+        String json = """
+                {"headline":"Native JSON support","section":"features"}
+                """;
+        JSONConfiguration configuration = JSONConfiguration.natural().rootUnwrapping(true).build();
+        JSONJAXBContext context = new JSONJAXBContext(configuration, Article.class);
+
+        JAXBElement<Article> element = context.createJSONUnmarshaller()
+                .unmarshalJAXBElementFromJSON(new StringReader(json), Article.class);
+
+        assertThat(element.getName()).isEqualTo(new QName("article"));
+        assertThat(element.getDeclaredType()).isEqualTo(Article.class);
+        assertThat(element.getValue().headline).isEqualTo("Native JSON support");
+        assertThat(element.getValue().section).isEqualTo("features");
+    }
+
+    @Test
     void mappedJsonContextHonorsArrayNonStringAndAttributeElementMappings() throws Exception {
         Book book = new Book("978-1491950357", "Building Microservices", 280, true, Arrays.asList("architecture"));
         JSONConfiguration configuration = JSONConfiguration.mapped()
@@ -198,6 +217,18 @@ public class Jersey_jsonTest {
                 .isEqualTo("{\"status\":\"ok\",\"count\":2}");
         assertThatThrownBy(() -> new JSONWithPadding(null, "callback"))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    public static class Article {
+        @XmlElement
+        public String headline;
+
+        @XmlElement
+        public String section;
+
+        public Article() {
+        }
     }
 
     @XmlRootElement(name = "book")

--- a/tests/src/com.sun.jersey/jersey-json/1.9/src/test/java/com_sun_jersey/jersey_json/Jersey_jsonTest.java
+++ b/tests/src/com.sun.jersey/jersey-json/1.9/src/test/java/com_sun_jersey/jersey_json/Jersey_jsonTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_sun_jersey.jersey_json;
+
+import org.junit.jupiter.api.Test;
+
+class Jersey_jsonTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/com.sun.jersey/jersey-json/1.9/src/test/java/com_sun_jersey/jersey_json/Jersey_jsonTest.java
+++ b/tests/src/com.sun.jersey/jersey-json/1.9/src/test/java/com_sun_jersey/jersey_json/Jersey_jsonTest.java
@@ -6,11 +6,218 @@
  */
 package com_sun_jersey.jersey_json;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sun.jersey.api.json.JSONConfiguration;
+import com.sun.jersey.api.json.JSONJAXBContext;
+import com.sun.jersey.api.json.JSONMarshaller;
+import com.sun.jersey.api.json.JSONUnmarshaller;
+import com.sun.jersey.api.json.JSONWithPadding;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-class Jersey_jsonTest {
+public class Jersey_jsonTest {
+
+    @BeforeAll
+    static void disableJaxbRuntimeBytecodeGeneration() {
+        System.setProperty("com.sun.xml.bind.v2.bytecode.ClassTailor.noOptimize", "true");
+    }
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void configurationBuildersExposeSelectedNotationOptions() {
+        Map<String, String> namespaces = new LinkedHashMap<>();
+        namespaces.put("http://example.test/books", "bk");
+        namespaces.put("http://example.test/meta", "meta");
+
+        JSONConfiguration mapped = JSONConfiguration.mapped()
+                .arrays("tag", "author")
+                .attributeAsElement("isbn")
+                .nonStrings("pages", "available")
+                .xml2JsonNs(namespaces)
+                .nsSeparator('_')
+                .rootUnwrapping(true)
+                .build();
+
+        assertThat(mapped.getNotation()).isEqualTo(JSONConfiguration.Notation.MAPPED);
+        assertThat(mapped.getArrays()).containsExactlyInAnyOrder("tag", "author");
+        assertThat(mapped.getAttributeAsElements()).containsExactly("isbn");
+        assertThat(mapped.getNonStrings()).containsExactlyInAnyOrder("pages", "available");
+        assertThat(mapped.getXml2JsonNs()).containsEntry("http://example.test/books", "bk");
+        assertThat(mapped.getNsSeparator()).isEqualTo('_');
+        assertThat(mapped.isRootUnwrapping()).isTrue();
+        assertThat(mapped.toString()).contains("MAPPED");
+
+        JSONConfiguration mappedJettison = JSONConfiguration.mappedJettison()
+                .xml2JsonNs(namespaces)
+                .build();
+        assertThat(mappedJettison.getNotation()).isEqualTo(JSONConfiguration.Notation.MAPPED_JETTISON);
+        assertThat(mappedJettison.getXml2JsonNs()).containsEntry("http://example.test/meta", "meta");
+
+        JSONConfiguration badgerFish = JSONConfiguration.badgerFish().build();
+        assertThat(badgerFish.getNotation()).isEqualTo(JSONConfiguration.Notation.BADGERFISH);
+    }
+
+    @Test
+    void configurationCopyAndFactoryMethodsPreserveIndependentSettings() {
+        JSONConfiguration natural = JSONConfiguration.natural()
+                .humanReadableFormatting(true)
+                .rootUnwrapping(false)
+                .usePrefixesAtNaturalAttributes()
+                .build();
+
+        JSONConfiguration compact = JSONConfiguration.createJSONConfigurationWithFormatted(natural, false);
+        JSONConfiguration unwrapped = JSONConfiguration.createJSONConfigurationWithRootUnwrapping(compact, true);
+        JSONConfiguration copy = JSONConfiguration.copyBuilder(unwrapped).build();
+
+        assertThat(natural.getNotation()).isEqualTo(JSONConfiguration.Notation.NATURAL);
+        assertThat(natural.isHumanReadableFormatting()).isTrue();
+        assertThat(natural.isRootUnwrapping()).isFalse();
+        assertThat(natural.isUsingPrefixesAtNaturalAttributes()).isTrue();
+        assertThat(compact.isHumanReadableFormatting()).isFalse();
+        assertThat(compact.isRootUnwrapping()).isFalse();
+        assertThat(unwrapped.isRootUnwrapping()).isTrue();
+        assertThat(copy.getNotation()).isEqualTo(JSONConfiguration.Notation.NATURAL);
+        assertThat(copy.isHumanReadableFormatting()).isFalse();
+        assertThat(copy.isRootUnwrapping()).isTrue();
+        assertThat(copy.isUsingPrefixesAtNaturalAttributes()).isTrue();
+
+        assertThatThrownBy(() -> JSONConfiguration.createJSONConfigurationWithFormatted(null, true))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void naturalJsonContextMarshalsAndUnmarshalsBeanWithWriterAndReader() throws JAXBException {
+        Book book = new Book("978-0134685991", "Effective Java", 416, true, Arrays.asList("java", "api"));
+        JSONConfiguration configuration = JSONConfiguration.natural()
+                .humanReadableFormatting(true)
+                .rootUnwrapping(false)
+                .build();
+        JSONJAXBContext context = new JSONJAXBContext(configuration, Book.class);
+
+        StringWriter json = new StringWriter();
+        context.createJSONMarshaller().marshallToJSON(book, json);
+
+        assertThat(context.getJSONConfiguration()).isSameAs(configuration);
+        assertThat(json.toString()).contains("book", "isbn", "Effective Java", "tag");
+
+        Book restored = context.createJSONUnmarshaller().unmarshalFromJSON(new StringReader(json.toString()), Book.class);
+        assertThat(restored).isEqualTo(book);
+    }
+
+    @Test
+    void jsonMarshallerAndUnmarshallerAdaptersSupportStreamRoundTrip() throws JAXBException {
+        Book book = new Book("978-0321356680", "Java Concurrency in Practice", 384, false,
+                Arrays.asList("threads", "testing"));
+        JSONJAXBContext context = new JSONJAXBContext(JSONConfiguration.natural().rootUnwrapping(true).build(), Book.class);
+
+        Marshaller marshaller = context.createMarshaller();
+        JSONMarshaller jsonMarshaller = JSONJAXBContext.getJSONMarshaller(marshaller);
+        jsonMarshaller.setProperty(JSONMarshaller.FORMATTED, Boolean.TRUE);
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        jsonMarshaller.marshallToJSON(book, output);
+
+        String json = output.toString(StandardCharsets.UTF_8);
+        assertThat(json).contains("Java Concurrency in Practice");
+        assertThat(json).doesNotContain("\"book\"");
+
+        Unmarshaller unmarshaller = context.createUnmarshaller();
+        JSONUnmarshaller jsonUnmarshaller = JSONJAXBContext.getJSONUnmarshaller(unmarshaller);
+        ByteArrayInputStream input = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
+        Book restored = jsonUnmarshaller.unmarshalFromJSON(input, Book.class);
+
+        assertThat(jsonMarshaller).isSameAs(marshaller);
+        assertThat(jsonUnmarshaller).isSameAs(unmarshaller);
+        assertThat(restored).isEqualTo(book);
+    }
+
+    @Test
+    void jsonWithPaddingStoresCallbackAndDelegatesSourceSerialization() throws Exception {
+        Map<String, Object> source = new LinkedHashMap<>();
+        source.put("status", "ok");
+        source.put("count", 2);
+
+        JSONWithPadding explicitCallback = new JSONWithPadding(source, "handleBooks");
+        JSONWithPadding defaultCallback = new JSONWithPadding(source, null);
+
+        assertThat(explicitCallback.getCallbackName()).isEqualTo("handleBooks");
+        assertThat(explicitCallback.getJsonSource()).isSameAs(source);
+        assertThat(defaultCallback.getCallbackName()).isEqualTo(JSONWithPadding.DEFAULT_CALLBACK_NAME);
+        assertThat(new ObjectMapper().writeValueAsString(explicitCallback))
+                .isEqualTo("{\"status\":\"ok\",\"count\":2}");
+        assertThatThrownBy(() -> new JSONWithPadding(null, "callback"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @XmlRootElement(name = "book")
+    @XmlAccessorType(XmlAccessType.FIELD)
+    public static class Book {
+        @XmlAttribute
+        public String isbn;
+
+        @XmlElement
+        public String title;
+
+        @XmlElement
+        public int pages;
+
+        @XmlElement
+        public boolean available;
+
+        @XmlElement(name = "tag")
+        public List<String> tags = new ArrayList<>();
+
+        public Book() {
+        }
+
+        Book(String isbn, String title, int pages, boolean available, List<String> tags) {
+            this.isbn = isbn;
+            this.title = title;
+            this.pages = pages;
+            this.available = available;
+            this.tags = new ArrayList<>(tags);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (!(other instanceof Book)) {
+                return false;
+            }
+            Book book = (Book) other;
+            return pages == book.pages
+                    && available == book.available
+                    && Objects.equals(isbn, book.isbn)
+                    && Objects.equals(title, book.title)
+                    && Objects.equals(tags, book.tags);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(isbn, title, pages, available, tags);
+        }
     }
 }

--- a/tests/src/com.sun.jersey/jersey-json/1.9/src/test/java/com_sun_jersey/jersey_json/Jersey_jsonTest.java
+++ b/tests/src/com.sun.jersey/jersey-json/1.9/src/test/java/com_sun_jersey/jersey_json/Jersey_jsonTest.java
@@ -126,6 +126,36 @@ public class Jersey_jsonTest {
     }
 
     @Test
+    void mappedJsonContextHonorsArrayNonStringAndAttributeElementMappings() throws Exception {
+        Book book = new Book("978-1491950357", "Building Microservices", 280, true, Arrays.asList("architecture"));
+        JSONConfiguration configuration = JSONConfiguration.mapped()
+                .arrays("tag")
+                .attributeAsElement("isbn")
+                .nonStrings("pages", "available")
+                .rootUnwrapping(false)
+                .build();
+        JSONJAXBContext context = new JSONJAXBContext(configuration, Book.class);
+
+        StringWriter json = new StringWriter();
+        context.createJSONMarshaller().marshallToJSON(book, json);
+
+        Map<?, ?> document = new ObjectMapper().readValue(json.toString(), Map.class);
+        assertThat(document).hasSize(1);
+        assertThat(document.containsKey("book")).isTrue();
+        assertThat(document.get("book")).isInstanceOf(Map.class);
+        Map<?, ?> bookJson = (Map<?, ?>) document.get("book");
+        assertThat(bookJson.get("isbn")).isEqualTo(book.isbn);
+        assertThat(bookJson.containsKey("@isbn")).isFalse();
+        assertThat(bookJson.get("title")).isEqualTo(book.title);
+        assertThat(bookJson.get("pages")).isEqualTo(book.pages);
+        assertThat(bookJson.get("available")).isEqualTo(book.available);
+        assertThat(bookJson.get("tag")).isEqualTo(Arrays.asList("architecture"));
+
+        Book restored = context.createJSONUnmarshaller().unmarshalFromJSON(new StringReader(json.toString()), Book.class);
+        assertThat(restored).isEqualTo(book);
+    }
+
+    @Test
     void jsonMarshallerAndUnmarshallerAdaptersSupportStreamRoundTrip() throws JAXBException {
         Book book = new Book("978-0321356680", "Java Concurrency in Practice", 384, false,
                 Arrays.asList("threads", "testing"));

--- a/tests/src/com.sun.jersey/jersey-json/1.9/user-code-filter.json
+++ b/tests/src/com.sun.jersey/jersey-json/1.9/user-code-filter.json
@@ -1,13 +1,16 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.sun.jersey.api.json.**"
+      "includeClasses" : "com.sun.jersey.api.json.**"
     },
     {
-      "includeClasses": "com.sun.jersey.json.impl.**"
+      "includeClasses" : "com.sun.jersey.json.impl.**"
+    },
+    {
+      "includeClasses" : "com_sun_jersey.jersey_json.**"
     }
   ]
 }

--- a/tests/src/com.sun.jersey/jersey-json/1.9/user-code-filter.json
+++ b/tests/src/com.sun.jersey/jersey-json/1.9/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.sun.jersey.api.json.**"
+    },
+    {
+      "includeClasses": "com.sun.jersey.json.impl.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #2898

This PR introduces tests and metadata for com.sun.jersey:jersey-json:1.9, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 243855
- Cached input tokens: 2191360
- Output tokens: 25430
- Metadata entries: 3
- Iterations: 8
- Library coverage percentage: 44.19
- Generated lines of code: 239
- Tested library lines of code: 1220

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `57c8029a07c2b0bb34629ddae606dc50af336be3`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Library coverage:
- Instruction: 6020/12966 (46.43%)
- Line: 1220/2761 (44.19%)
- Method: 287/819 (35.04%)

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
