### PR TITLE
[GenAI] Test fix for org.apache.hadoop:hadoop-yarn-server-common:2.8.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.hadoop/hadoop-yarn-server-common/2.8.0/reachability-metadata.json
+++ b/metadata/org.apache.hadoop/hadoop-yarn-server-common/2.8.0/reachability-metadata.json
@@ -1,0 +1,254 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.conf.Configuration"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.conf.Configuration"
+      },
+      "type": "java.lang.Thread",
+      "methods": [
+        {
+          "name": "getContextClassLoader",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.conf.Configuration"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.conf.Configuration"
+      },
+      "type": "org.apache.commons.logging.LogFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.conf.Configuration"
+      },
+      "type": "org.apache.commons.logging.impl.Jdk14Logger",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.conf.Configuration"
+      },
+      "type": "org.apache.commons.logging.impl.LogFactoryImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.conf.Configuration"
+      },
+      "type": "org.apache.commons.logging.impl.SimpleLog",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.conf.Configuration"
+      },
+      "type": "org.apache.commons.logging.impl.WeakHashtable",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.records.impl.pb.ResourceUtilizationPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.server.api.protocolrecords.impl.pb.NMContainerStatusPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.server.api.protocolrecords.impl.pb.NodeHeartbeatRequestPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.server.api.protocolrecords.impl.pb.NodeHeartbeatResponsePBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.server.api.protocolrecords.impl.pb.RegisterNodeManagerRequestPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.server.api.protocolrecords.impl.pb.RegisterNodeManagerResponsePBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.server.api.protocolrecords.impl.pb.SCMUploaderCanUploadRequestPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.server.api.protocolrecords.impl.pb.SCMUploaderCanUploadResponsePBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.server.api.protocolrecords.impl.pb.SCMUploaderNotifyRequestPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.server.api.protocolrecords.impl.pb.SCMUploaderNotifyResponsePBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.server.api.records.impl.pb.MasterKeyPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.server.api.records.impl.pb.NodeHealthStatusPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.server.api.records.impl.pb.NodeStatusPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.server.records.impl.pb.VersionPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.apache.hadoop/hadoop-yarn-server-common/index.json
+++ b/metadata/org.apache.hadoop/hadoop-yarn-server-common/index.json
@@ -17,6 +17,11 @@
   },
   {
     "metadata-version" : "2.8.0",
+    "source-code-url" : "https://github.com/apache/hadoop/tree/rel/release-$version$/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common",
+    "repository-url" : "https://github.com/apache/hadoop",
+    "test-code-url" : "https://github.com/apache/hadoop/tree/rel/release-$version$/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java",
+    "documentation-url" : "https://hadoop.apache.org/docs/r$version$/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/apidocs/",
+    "description" : "Apache Hadoop YARN Server Common provides shared server-side classes, services, and protocol helpers used by YARN components such as the ResourceManager and NodeManager. It supports cluster resource-management infrastructure including node registration, container lifecycle handling, shared cache coordination, and server configuration within Hadoop YARN.",
     "tested-versions" : [
       "2.8.0"
     ],

--- a/metadata/org.apache.hadoop/hadoop-yarn-server-common/index.json
+++ b/metadata/org.apache.hadoop/hadoop-yarn-server-common/index.json
@@ -1,16 +1,26 @@
 [
   {
-    "latest": true,
-    "metadata-version": "2.7.3",
-    "source-code-url": "https://repo.maven.apache.org/maven2/org/apache/hadoop/hadoop-yarn-server-common/$version$/hadoop-yarn-server-common-$version$-sources.jar",
-    "repository-url": "https://github.com/apache/hadoop",
-    "test-code-url": "https://repo.maven.apache.org/maven2/org/apache/hadoop/hadoop-yarn-server-common/$version$/hadoop-yarn-server-common-$version$-test-sources.jar",
-    "documentation-url": "https://repo.maven.apache.org/maven2/org/apache/hadoop/hadoop-yarn-server-common/$version$/hadoop-yarn-server-common-$version$-javadoc.jar",
-    "description": "Apache Hadoop YARN Server Common contains shared server-side services, protocol helpers, and utility classes used by YARN ResourceManager, NodeManager, and related server components. It supports coordination of cluster resource management features such as node registration, container lifecycle handling, shared cache management, and server configuration within Hadoop YARN.",
-    "tested-versions": [
+    "latest" : true,
+    "metadata-version" : "2.7.3",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/hadoop/hadoop-yarn-server-common/$version$/hadoop-yarn-server-common-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/hadoop",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/hadoop/hadoop-yarn-server-common/$version$/hadoop-yarn-server-common-$version$-test-sources.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/hadoop/hadoop-yarn-server-common/$version$/hadoop-yarn-server-common-$version$-javadoc.jar",
+    "description" : "Apache Hadoop YARN Server Common contains shared server-side services, protocol helpers, and utility classes used by YARN ResourceManager, NodeManager, and related server components. It supports coordination of cluster resource management features such as node registration, container lifecycle handling, shared cache management, and server configuration within Hadoop YARN.",
+    "tested-versions" : [
       "2.7.3"
     ],
-    "allowed-packages": [
+    "allowed-packages" : [
+      "org.apache.hadoop.yarn",
+      "org.apache.hadoop.conf"
+    ]
+  },
+  {
+    "metadata-version" : "2.8.0",
+    "tested-versions" : [
+      "2.8.0"
+    ],
+    "allowed-packages" : [
       "org.apache.hadoop.yarn",
       "org.apache.hadoop.conf"
     ]

--- a/stats/org.apache.hadoop/hadoop-yarn-server-common/2.8.0/execution-metrics.json
+++ b/stats/org.apache.hadoop/hadoop-yarn-server-common/2.8.0/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_javac_fail:2026-05-09": {
+    "timestamp": "2026-05-09T12:51:05.150438Z",
+    "library": "org.apache.hadoop:hadoop-yarn-server-common:2.8.0",
+    "starting_commit": "a33721e36f868be7c25890204a11e25da9ff11fe",
+    "ending_commit": "18465d129691af4723f34988065ae06c0dba030f",
+    "previous_library": "org.apache.hadoop:hadoop-yarn-server-common:2.7.3",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.8.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4301,
+          "missed": 40814,
+          "ratio": 0.095334,
+          "total": 45115
+        },
+        "line": {
+          "covered": 1339,
+          "missed": 9707,
+          "ratio": 0.12122,
+          "total": 11046
+        },
+        "method": {
+          "covered": 415,
+          "missed": 2108,
+          "ratio": 0.164487,
+          "total": 2523
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.7.3",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3875,
+          "missed": 29073,
+          "ratio": 0.11761,
+          "total": 32948
+        },
+        "line": {
+          "covered": 1244,
+          "missed": 7202,
+          "ratio": 0.147289,
+          "total": 8446
+        },
+        "method": {
+          "covered": 386,
+          "missed": 1518,
+          "ratio": 0.202731,
+          "total": 1904
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 31732,
+      "cached_input_tokens_used": 320000,
+      "output_tokens_used": 6086,
+      "iterations": 1,
+      "cost_usd": 0.3426,
+      "tested_library_loc": 1339,
+      "metadata_entries": 41,
+      "previous_library_metadata_entries": 39,
+      "code_coverage_percent": 12.12,
+      "previous_library_coverage_percent": 14.73
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.8.0/src/test/java/org_apache_hadoop/hadoop_yarn_server_common/Hadoop_yarn_server_commonTest.java",
+      "metadata_file": "metadata/org.apache.hadoop/hadoop-yarn-server-common/2.8.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.hadoop/hadoop-yarn-server-common/2.8.0/stats.json
+++ b/stats/org.apache.hadoop/hadoop-yarn-server-common/2.8.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.8.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 4301,
+        "missed" : 40814,
+        "ratio" : 0.095334,
+        "total" : 45115
+      },
+      "line" : {
+        "covered" : 1339,
+        "missed" : 9707,
+        "ratio" : 0.12122,
+        "total" : 11046
+      },
+      "method" : {
+        "covered" : 415,
+        "missed" : 2108,
+        "ratio" : 0.164487,
+        "total" : 2523
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.8.0/.gitignore
+++ b/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.8.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.8.0/build.gradle
+++ b/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.8.0/build.gradle
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.hadoop:hadoop-yarn-server-common:$libraryVersion"
+    testImplementation "org.apache.hadoop:hadoop-common:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.8.0/gradle.properties
+++ b/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.8.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.hadoop:hadoop-yarn-server-common:2.8.0
+library.version = 2.8.0
+metadata.dir = org.apache.hadoop/hadoop-yarn-server-common/2.8.0/

--- a/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.8.0/settings.gradle
+++ b/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.8.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.hadoop.hadoop-yarn-server-common_tests'

--- a/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.8.0/src/test/java/org_apache_hadoop/hadoop_yarn_server_common/Hadoop_yarn_server_commonTest.java
+++ b/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.8.0/src/test/java/org_apache_hadoop/hadoop_yarn_server_common/Hadoop_yarn_server_commonTest.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.api.records.Priority;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.api.records.ResourceRequest;
+import org.apache.hadoop.yarn.api.records.ResourceUtilization;
 import org.apache.hadoop.yarn.api.records.Token;
 import org.apache.hadoop.yarn.api.records.URL;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
@@ -78,6 +79,7 @@ public class Hadoop_yarn_server_commonTest {
         Priority priority = Priority.newInstance(3);
         NMContainerStatus containerStatus = NMContainerStatus.newInstance(
                 containerId,
+                0,
                 ContainerState.RUNNING,
                 Resource.newInstance(1024, 1),
                 "healthy container",
@@ -95,7 +97,7 @@ public class Hadoop_yarn_server_commonTest {
 
         assertThat(request.getNodeId()).isEqualTo(nodeId);
         assertThat(request.getHttpPort()).isEqualTo(8042);
-        assertThat(request.getResource().getMemory()).isEqualTo(8192);
+        assertThat(request.getResource().getMemorySize()).isEqualTo(8192L);
         assertThat(request.getResource().getVirtualCores()).isEqualTo(4);
         assertThat(request.getNMVersion()).isEqualTo("test-nm-version");
         assertThat(request.getRunningApplications()).containsExactly(applicationId);
@@ -103,7 +105,7 @@ public class Hadoop_yarn_server_commonTest {
         NMContainerStatus roundTrippedStatus = request.getNMContainerStatuses().get(0);
         assertThat(roundTrippedStatus.getContainerId()).isEqualTo(containerId);
         assertThat(roundTrippedStatus.getContainerState()).isEqualTo(ContainerState.RUNNING);
-        assertThat(roundTrippedStatus.getAllocatedResource().getMemory()).isEqualTo(1024);
+        assertThat(roundTrippedStatus.getAllocatedResource().getMemorySize()).isEqualTo(1024L);
         assertThat(roundTrippedStatus.getDiagnostics()).isEqualTo("healthy container");
         assertThat(roundTrippedStatus.getPriority().getPriority()).isEqualTo(3);
         assertThat(roundTrippedStatus.getCreationTime()).isEqualTo(44L);
@@ -117,22 +119,39 @@ public class Hadoop_yarn_server_commonTest {
                 runningContainer,
                 ContainerState.COMPLETE,
                 "finished",
-                0);
+                0,
+                Resource.newInstance(1024, 1));
         NodeHealthStatus healthStatus = NodeHealthStatus.newInstance(true, "all disks healthy", 99L);
+        ResourceUtilization containersUtilization = ResourceUtilization.newInstance(1024, 2048, 1.0F);
+        ResourceUtilization nodeUtilization = ResourceUtilization.newInstance(2048, 4096, 2.0F);
         NodeStatus nodeStatus = NodeStatus.newInstance(
                 NodeId.newInstance("nm.example.test", 1234),
                 5,
                 Collections.singletonList(containerStatus),
                 Collections.singletonList(applicationId),
-                healthStatus);
+                healthStatus,
+                containersUtilization,
+                nodeUtilization,
+                Collections.<Container>emptyList());
         MasterKey containerTokenKey = masterKey(17, new byte[] {1, 2, 3, 4});
         MasterKey nmTokenKey = masterKey(23, new byte[] {5, 6, 7, 8});
 
-        NodeHeartbeatRequest request = NodeHeartbeatRequest.newInstance(nodeStatus, containerTokenKey, nmTokenKey);
+        NodeHeartbeatRequest request = NodeHeartbeatRequest.newInstance(
+                nodeStatus,
+                containerTokenKey,
+                nmTokenKey,
+                Collections.emptySet());
 
         assertThat(request.getNodeStatus().getResponseId()).isEqualTo(5);
         assertThat(request.getNodeStatus().getContainersStatuses()).hasSize(1);
         assertThat(request.getNodeStatus().getNodeHealthStatus().getHealthReport()).isEqualTo("all disks healthy");
+        assertThat(request.getNodeStatus().getContainersUtilization().getPhysicalMemory()).isEqualTo(1024);
+        assertThat(request.getNodeStatus().getContainersUtilization().getVirtualMemory()).isEqualTo(2048);
+        assertThat(request.getNodeStatus().getContainersUtilization().getCPU()).isEqualTo(1.0F);
+        assertThat(request.getNodeStatus().getNodeUtilization().getPhysicalMemory()).isEqualTo(2048);
+        assertThat(request.getNodeStatus().getNodeUtilization().getVirtualMemory()).isEqualTo(4096);
+        assertThat(request.getNodeStatus().getNodeUtilization().getCPU()).isEqualTo(2.0F);
+        assertThat(request.getNodeStatus().getIncreasedContainers()).isEmpty();
         assertThat(request.getLastKnownContainerTokenMasterKey().getKeyId()).isEqualTo(17);
         assertThat(bytes(request.getLastKnownNMTokenMasterKey().getBytes()))
                 .containsExactly((byte) 5, (byte) 6, (byte) 7, (byte) 8);
@@ -237,7 +256,7 @@ public class Hadoop_yarn_server_commonTest {
                 3);
         assertThat(request.getPriority().getPriority()).isEqualTo(9);
         assertThat(request.getResourceName()).isEqualTo(ResourceRequest.ANY);
-        assertThat(request.getCapability().getMemory()).isEqualTo(2048);
+        assertThat(request.getCapability().getMemorySize()).isEqualTo(2048L);
         assertThat(request.getCapability().getVirtualCores()).isEqualTo(2);
         assertThat(request.getNumContainers()).isEqualTo(3);
 
@@ -259,7 +278,7 @@ public class Hadoop_yarn_server_commonTest {
         assertThat(container.getId()).isEqualTo(containerId);
         assertThat(container.getNodeId()).isEqualTo(nodeId);
         assertThat(container.getNodeHttpAddress()).isEqualTo("worker.example.test:8042");
-        assertThat(container.getResource().getMemory()).isEqualTo(1024);
+        assertThat(container.getResource().getMemorySize()).isEqualTo(1024L);
         assertThat(container.getPriority().getPriority()).isEqualTo(1);
         assertThat(container.getContainerToken().getKind()).isEqualTo("kind");
     }
@@ -366,7 +385,7 @@ public class Hadoop_yarn_server_commonTest {
 
     private static ContainerId containerId(ApplicationId applicationId, int attemptId, long containerSequence) {
         ApplicationAttemptId applicationAttemptId = ApplicationAttemptId.newInstance(applicationId, attemptId);
-        return BuilderUtils.newContainerId(applicationAttemptId, containerSequence);
+        return ContainerId.newContainerId(applicationAttemptId, containerSequence);
     }
 
     private static MasterKey masterKey(int keyId, byte[] keyBytes) {

--- a/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.8.0/src/test/java/org_apache_hadoop/hadoop_yarn_server_common/Hadoop_yarn_server_commonTest.java
+++ b/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.8.0/src/test/java/org_apache_hadoop/hadoop_yarn_server_common/Hadoop_yarn_server_commonTest.java
@@ -1,0 +1,408 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_hadoop.hadoop_yarn_server_common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.http.FilterContainer;
+import org.apache.hadoop.security.KerberosInfo;
+import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.api.records.Container;
+import org.apache.hadoop.yarn.api.records.ContainerId;
+import org.apache.hadoop.yarn.api.records.ContainerState;
+import org.apache.hadoop.yarn.api.records.ContainerStatus;
+import org.apache.hadoop.yarn.api.records.LocalResource;
+import org.apache.hadoop.yarn.api.records.LocalResourceType;
+import org.apache.hadoop.yarn.api.records.LocalResourceVisibility;
+import org.apache.hadoop.yarn.api.records.NodeId;
+import org.apache.hadoop.yarn.api.records.Priority;
+import org.apache.hadoop.yarn.api.records.Resource;
+import org.apache.hadoop.yarn.api.records.ResourceRequest;
+import org.apache.hadoop.yarn.api.records.Token;
+import org.apache.hadoop.yarn.api.records.URL;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.security.client.RMDelegationTokenIdentifier;
+import org.apache.hadoop.yarn.server.RMNMSecurityInfoClass;
+import org.apache.hadoop.yarn.server.api.ResourceTrackerPB;
+import org.apache.hadoop.yarn.server.api.SCMUploaderProtocolPB;
+import org.apache.hadoop.yarn.server.api.protocolrecords.NMContainerStatus;
+import org.apache.hadoop.yarn.server.api.protocolrecords.NodeHeartbeatRequest;
+import org.apache.hadoop.yarn.server.api.protocolrecords.NodeHeartbeatResponse;
+import org.apache.hadoop.yarn.server.api.protocolrecords.RegisterNodeManagerRequest;
+import org.apache.hadoop.yarn.server.api.protocolrecords.RegisterNodeManagerResponse;
+import org.apache.hadoop.yarn.server.api.protocolrecords.SCMUploaderCanUploadRequest;
+import org.apache.hadoop.yarn.server.api.protocolrecords.SCMUploaderCanUploadResponse;
+import org.apache.hadoop.yarn.server.api.protocolrecords.SCMUploaderNotifyRequest;
+import org.apache.hadoop.yarn.server.api.protocolrecords.SCMUploaderNotifyResponse;
+import org.apache.hadoop.yarn.server.api.records.MasterKey;
+import org.apache.hadoop.yarn.server.api.records.NodeAction;
+import org.apache.hadoop.yarn.server.api.records.NodeHealthStatus;
+import org.apache.hadoop.yarn.server.api.records.NodeStatus;
+import org.apache.hadoop.yarn.server.records.Version;
+import org.apache.hadoop.yarn.server.security.MasterKeyData;
+import org.apache.hadoop.yarn.server.security.http.RMAuthenticationFilter;
+import org.apache.hadoop.yarn.server.security.http.RMAuthenticationFilterInitializer;
+import org.apache.hadoop.yarn.server.sharedcache.SharedCacheUtil;
+import org.apache.hadoop.yarn.server.utils.BuilderUtils;
+import org.apache.hadoop.yarn.server.utils.YarnServerBuilderUtils;
+import org.apache.hadoop.yarn.server.webapp.WebPageUtils;
+import org.apache.hadoop.yarn.server.webapp.dao.AppAttemptsInfo;
+import org.apache.hadoop.yarn.server.webapp.dao.AppsInfo;
+import org.apache.hadoop.yarn.server.webapp.dao.ContainersInfo;
+import org.apache.hadoop.yarn.util.Records;
+import org.junit.jupiter.api.Test;
+
+public class Hadoop_yarn_server_commonTest {
+    @Test
+    void nodeManagerRegistrationCarriesResourceContainersAndRunningApplications() {
+        NodeId nodeId = NodeId.newInstance("worker.example.test", 45454);
+        Resource nodeResource = Resource.newInstance(8192, 4);
+        ApplicationId applicationId = ApplicationId.newInstance(1234L, 7);
+        ContainerId containerId = containerId(applicationId, 1, 99L);
+        Priority priority = Priority.newInstance(3);
+        NMContainerStatus containerStatus = NMContainerStatus.newInstance(
+                containerId,
+                ContainerState.RUNNING,
+                Resource.newInstance(1024, 1),
+                "healthy container",
+                0,
+                priority,
+                44L);
+
+        RegisterNodeManagerRequest request = RegisterNodeManagerRequest.newInstance(
+                nodeId,
+                8042,
+                nodeResource,
+                "test-nm-version",
+                Collections.singletonList(containerStatus),
+                Collections.singletonList(applicationId));
+
+        assertThat(request.getNodeId()).isEqualTo(nodeId);
+        assertThat(request.getHttpPort()).isEqualTo(8042);
+        assertThat(request.getResource().getMemory()).isEqualTo(8192);
+        assertThat(request.getResource().getVirtualCores()).isEqualTo(4);
+        assertThat(request.getNMVersion()).isEqualTo("test-nm-version");
+        assertThat(request.getRunningApplications()).containsExactly(applicationId);
+
+        NMContainerStatus roundTrippedStatus = request.getNMContainerStatuses().get(0);
+        assertThat(roundTrippedStatus.getContainerId()).isEqualTo(containerId);
+        assertThat(roundTrippedStatus.getContainerState()).isEqualTo(ContainerState.RUNNING);
+        assertThat(roundTrippedStatus.getAllocatedResource().getMemory()).isEqualTo(1024);
+        assertThat(roundTrippedStatus.getDiagnostics()).isEqualTo("healthy container");
+        assertThat(roundTrippedStatus.getPriority().getPriority()).isEqualTo(3);
+        assertThat(roundTrippedStatus.getCreationTime()).isEqualTo(44L);
+    }
+
+    @Test
+    void heartbeatRequestAndResponseRoundTripNodeStatusCleanupListsAndCredentials() {
+        ApplicationId applicationId = ApplicationId.newInstance(5678L, 11);
+        ContainerId runningContainer = containerId(applicationId, 2, 3L);
+        ContainerStatus containerStatus = BuilderUtils.newContainerStatus(
+                runningContainer,
+                ContainerState.COMPLETE,
+                "finished",
+                0);
+        NodeHealthStatus healthStatus = NodeHealthStatus.newInstance(true, "all disks healthy", 99L);
+        NodeStatus nodeStatus = NodeStatus.newInstance(
+                NodeId.newInstance("nm.example.test", 1234),
+                5,
+                Collections.singletonList(containerStatus),
+                Collections.singletonList(applicationId),
+                healthStatus);
+        MasterKey containerTokenKey = masterKey(17, new byte[] {1, 2, 3, 4});
+        MasterKey nmTokenKey = masterKey(23, new byte[] {5, 6, 7, 8});
+
+        NodeHeartbeatRequest request = NodeHeartbeatRequest.newInstance(nodeStatus, containerTokenKey, nmTokenKey);
+
+        assertThat(request.getNodeStatus().getResponseId()).isEqualTo(5);
+        assertThat(request.getNodeStatus().getContainersStatuses()).hasSize(1);
+        assertThat(request.getNodeStatus().getNodeHealthStatus().getHealthReport()).isEqualTo("all disks healthy");
+        assertThat(request.getLastKnownContainerTokenMasterKey().getKeyId()).isEqualTo(17);
+        assertThat(bytes(request.getLastKnownNMTokenMasterKey().getBytes()))
+                .containsExactly((byte) 5, (byte) 6, (byte) 7, (byte) 8);
+
+        NodeHeartbeatResponse response = YarnServerBuilderUtils.newNodeHeartbeatResponse(
+                6,
+                NodeAction.NORMAL,
+                Collections.singletonList(runningContainer),
+                Collections.singletonList(applicationId),
+                containerTokenKey,
+                nmTokenKey,
+                1000L);
+        ContainerId removedContainer = containerId(applicationId, 2, 4L);
+        Map<ApplicationId, ByteBuffer> credentials = new HashMap<ApplicationId, ByteBuffer>();
+        credentials.put(applicationId, ByteBuffer.wrap(new byte[] {9, 10, 11}));
+
+        response.addContainersToBeRemovedFromNM(Collections.singletonList(removedContainer));
+        response.setDiagnosticsMessage("continue processing");
+        response.setSystemCredentialsForApps(credentials);
+
+        assertThat(response.getResponseId()).isEqualTo(6);
+        assertThat(response.getNodeAction()).isEqualTo(NodeAction.NORMAL);
+        assertThat(response.getContainersToCleanup()).containsExactly(runningContainer);
+        assertThat(response.getContainersToBeRemovedFromNM()).containsExactly(removedContainer);
+        assertThat(response.getApplicationsToCleanup()).containsExactly(applicationId);
+        assertThat(response.getNextHeartBeatInterval()).isEqualTo(1000L);
+        assertThat(response.getDiagnosticsMessage()).isEqualTo("continue processing");
+        assertThat(response.getContainerTokenMasterKey().getKeyId()).isEqualTo(17);
+        assertThat(response.getNMTokenMasterKey().getKeyId()).isEqualTo(23);
+        assertThat(bytes(response.getSystemCredentialsForApps().get(applicationId)))
+                .containsExactly((byte) 9, (byte) 10, (byte) 11);
+    }
+
+    @Test
+    void registerNodeManagerResponseExposesMasterKeysAndDiagnostics() {
+        RegisterNodeManagerResponse response = Records.newRecord(RegisterNodeManagerResponse.class);
+        MasterKey containerTokenKey = masterKey(101, new byte[] {12, 13});
+        MasterKey nmTokenKey = masterKey(102, new byte[] {14, 15});
+
+        response.setContainerTokenMasterKey(containerTokenKey);
+        response.setNMTokenMasterKey(nmTokenKey);
+        response.setNodeAction(NodeAction.RESYNC);
+        response.setRMIdentifier(987654321L);
+        response.setDiagnosticsMessage("resync requested");
+        response.setRMVersion("rm-test-version");
+
+        assertThat(response.getContainerTokenMasterKey().getKeyId()).isEqualTo(101);
+        assertThat(bytes(response.getNMTokenMasterKey().getBytes())).containsExactly((byte) 14, (byte) 15);
+        assertThat(response.getNodeAction()).isEqualTo(NodeAction.RESYNC);
+        assertThat(response.getRMIdentifier()).isEqualTo(987654321L);
+        assertThat(response.getDiagnosticsMessage()).isEqualTo("resync requested");
+        assertThat(response.getRMVersion()).isEqualTo("rm-test-version");
+    }
+
+    @Test
+    void sharedCacheUtilitiesBuildDepthAwarePathsAndGlobPatterns() {
+        assertThat(SharedCacheUtil.getCacheEntryPath(3, "/shared-cache", "abcdef"))
+                .isEqualTo("/shared-cache/a/b/c/abcdef");
+        assertThat(SharedCacheUtil.getCacheEntryGlobPattern(3)).isEqualTo("*/*/*/*");
+
+        assertThatThrownBy(() -> SharedCacheUtil.getCacheEntryPath(0, "/shared-cache", "abcdef"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("cache depth");
+        assertThatThrownBy(() -> SharedCacheUtil.getCacheEntryPath(4, "/shared-cache", "abc"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("checksum");
+    }
+
+    @Test
+    void builderUtilitiesCreateYarnRecordsWithExpectedValues() throws Exception {
+        URL resourceUrl = BuilderUtils.newURL("hdfs", "namenode.example.test", 8020, "/apps/app.jar");
+        LocalResource localResource = BuilderUtils.newLocalResource(
+                resourceUrl,
+                LocalResourceType.FILE,
+                LocalResourceVisibility.APPLICATION,
+                4096L,
+                12345L,
+                true);
+        LocalResource uriResource = BuilderUtils.newLocalResource(
+                new URI("hdfs://namenode.example.test:8020/apps/lib.jar"),
+                LocalResourceType.ARCHIVE,
+                LocalResourceVisibility.PUBLIC,
+                8192L,
+                54321L,
+                false);
+
+        assertThat(localResource.getResource().getHost()).isEqualTo("namenode.example.test");
+        assertThat(localResource.getResource().getPort()).isEqualTo(8020);
+        assertThat(localResource.getResource().getFile()).isEqualTo("/apps/app.jar");
+        assertThat(localResource.getType()).isEqualTo(LocalResourceType.FILE);
+        assertThat(localResource.getVisibility()).isEqualTo(LocalResourceVisibility.APPLICATION);
+        assertThat(localResource.getSize()).isEqualTo(4096L);
+        assertThat(localResource.getTimestamp()).isEqualTo(12345L);
+        assertThat(localResource.getShouldBeUploadedToSharedCache()).isTrue();
+        assertThat(uriResource.getType()).isEqualTo(LocalResourceType.ARCHIVE);
+        assertThat(uriResource.getShouldBeUploadedToSharedCache()).isFalse();
+
+        ResourceRequest request = BuilderUtils.newResourceRequest(
+                Priority.newInstance(9),
+                ResourceRequest.ANY,
+                Resource.newInstance(2048, 2),
+                3);
+        assertThat(request.getPriority().getPriority()).isEqualTo(9);
+        assertThat(request.getResourceName()).isEqualTo(ResourceRequest.ANY);
+        assertThat(request.getCapability().getMemory()).isEqualTo(2048);
+        assertThat(request.getCapability().getVirtualCores()).isEqualTo(2);
+        assertThat(request.getNumContainers()).isEqualTo(3);
+
+        Token token = BuilderUtils.newDelegationToken(
+                new byte[] {1, 2},
+                "kind",
+                new byte[] {3, 4},
+                "service");
+        NodeId nodeId = BuilderUtils.newNodeId("worker.example.test", 8041);
+        ContainerId containerId = containerId(ApplicationId.newInstance(2000L, 3), 4, 5L);
+        Container container = BuilderUtils.newContainer(
+                containerId,
+                nodeId,
+                "worker.example.test:8042",
+                Resource.newInstance(1024, 1),
+                Priority.newInstance(1),
+                token);
+
+        assertThat(container.getId()).isEqualTo(containerId);
+        assertThat(container.getNodeId()).isEqualTo(nodeId);
+        assertThat(container.getNodeHttpAddress()).isEqualTo("worker.example.test:8042");
+        assertThat(container.getResource().getMemory()).isEqualTo(1024);
+        assertThat(container.getPriority().getPriority()).isEqualTo(1);
+        assertThat(container.getContainerToken().getKind()).isEqualTo("kind");
+    }
+
+    @Test
+    void sharedCacheUploaderRecordsExposeRequestAndResponseState() {
+        SCMUploaderCanUploadRequest canUploadRequest = Records.newRecord(SCMUploaderCanUploadRequest.class);
+        SCMUploaderCanUploadResponse canUploadResponse = Records.newRecord(SCMUploaderCanUploadResponse.class);
+        SCMUploaderNotifyRequest notifyRequest = Records.newRecord(SCMUploaderNotifyRequest.class);
+        SCMUploaderNotifyResponse notifyResponse = Records.newRecord(SCMUploaderNotifyResponse.class);
+
+        canUploadRequest.setResourceKey("resource-checksum");
+        canUploadResponse.setUploadable(true);
+        notifyRequest.setResourceKey("resource-checksum");
+        notifyRequest.setFilename("archive.tar.gz");
+        notifyResponse.setAccepted(true);
+
+        assertThat(canUploadRequest.getResourceKey()).isEqualTo("resource-checksum");
+        assertThat(canUploadResponse.getUploadable()).isTrue();
+        assertThat(notifyRequest.getResourceKey()).isEqualTo("resource-checksum");
+        assertThat(notifyRequest.getFileName()).isEqualTo("archive.tar.gz");
+        assertThat(notifyResponse.getAccepted()).isTrue();
+    }
+
+    @Test
+    void resourceTrackerSecurityInfoPublishesResourceManagerAndNodeManagerPrincipals() {
+        RMNMSecurityInfoClass securityInfo = new RMNMSecurityInfoClass();
+        Configuration configuration = new Configuration(false);
+
+        KerberosInfo kerberosInfo = securityInfo.getKerberosInfo(ResourceTrackerPB.class, configuration);
+
+        assertThat(kerberosInfo).isNotNull();
+        assertThat(kerberosInfo.serverPrincipal()).isEqualTo(YarnConfiguration.RM_PRINCIPAL);
+        assertThat(kerberosInfo.clientPrincipal()).isEqualTo(YarnConfiguration.NM_PRINCIPAL);
+        assertThat(securityInfo.getTokenInfo(ResourceTrackerPB.class, configuration)).isNull();
+        assertThat(securityInfo.getKerberosInfo(SCMUploaderProtocolPB.class, configuration)).isNull();
+    }
+
+    @Test
+    void resourceManagerAuthenticationFilterInitializerInstallsFilterWithTokenAndProxySettings() {
+        Configuration configuration = new Configuration(false);
+        configuration.set("hadoop.http.authentication.type", "kerberos");
+        configuration.set("hadoop.http.authentication.kerberos.principal", "HTTP/rm.example.test@EXAMPLE.COM");
+        configuration.set("hadoop.http.authentication.signature.secret", "shared-secret");
+        configuration.set("hadoop.proxyuser.alice.hosts", "host-a.example.test,host-b.example.test");
+        configuration.set("hadoop.proxyuser.alice.groups", "analytics,operators");
+        RecordingFilterContainer container = new RecordingFilterContainer();
+
+        new RMAuthenticationFilterInitializer().initFilter(container, configuration);
+
+        assertThat(container.filterName).isEqualTo("RMAuthenticationFilter");
+        assertThat(container.filterClassName).isEqualTo(RMAuthenticationFilter.class.getName());
+        assertThat(container.globalFilter).isFalse();
+        assertThat(container.filterConfig)
+                .containsEntry("type", "kerberos")
+                .containsEntry("kerberos.principal", "HTTP/rm.example.test@EXAMPLE.COM")
+                .containsEntry("signature.secret", "shared-secret")
+                .containsEntry("cookie.path", "/")
+                .containsEntry("proxyuser.alice.hosts", "host-a.example.test,host-b.example.test")
+                .containsEntry("proxyuser.alice.groups", "analytics,operators")
+                .containsEntry("delegation-token.token-kind", RMDelegationTokenIdentifier.KIND_NAME.toString());
+    }
+
+    @Test
+    void versionsCompareCompatibilityAndMasterKeyDataPublishesEncodedSecret() {
+        Version version = Version.newInstance(2, 7);
+        Version sameMajorNewerMinor = Version.newInstance(2, 9);
+        Version differentMajor = Version.newInstance(3, 0);
+
+        assertThat(version.getMajorVersion()).isEqualTo(2);
+        assertThat(version.getMinorVersion()).isEqualTo(7);
+        assertThat(version.toString()).isEqualTo("2.7");
+        assertThat(version.isCompatibleTo(sameMajorNewerMinor)).isTrue();
+        assertThat(version.isCompatibleTo(differentMajor)).isFalse();
+        assertThat(version).isEqualTo(Version.newInstance(2, 7));
+
+        SecretKey secretKey = new SecretKeySpec(new byte[] {21, 22, 23, 24}, "HmacSHA1");
+        MasterKeyData keyData = new MasterKeyData(77, secretKey);
+
+        assertThat(keyData.getMasterKey().getKeyId()).isEqualTo(77);
+        assertThat(bytes(keyData.getMasterKey().getBytes()))
+                .containsExactly((byte) 21, (byte) 22, (byte) 23, (byte) 24);
+        assertThat(keyData.getSecretKey()).isSameAs(secretKey);
+    }
+
+    @Test
+    void webContainerDaoCollectionsAndTableInitializersAreUsableWithoutWebServer() {
+        AppsInfo appsInfo = new AppsInfo();
+        AppAttemptsInfo attemptsInfo = new AppAttemptsInfo();
+        ContainersInfo containersInfo = new ContainersInfo();
+
+        appsInfo.add(null);
+        attemptsInfo.add(null);
+        containersInfo.add(null);
+
+        assertThat(appsInfo.getApps()).hasSize(1).containsNull();
+        assertThat(attemptsInfo.getAttempts()).hasSize(1).containsNull();
+        assertThat(containersInfo.getContainers()).hasSize(1).containsNull();
+        assertThat(WebPageUtils.appsTableInit()).contains("natural").contains("renderHadoopDate");
+        assertThat(WebPageUtils.appsTableInit(true)).contains("'aaData'").contains("renderHadoopDate");
+        assertThat(WebPageUtils.attemptsTableInit()).contains("natural");
+        assertThat(WebPageUtils.containersTableInit()).contains("natural");
+    }
+
+    private static ContainerId containerId(ApplicationId applicationId, int attemptId, long containerSequence) {
+        ApplicationAttemptId applicationAttemptId = ApplicationAttemptId.newInstance(applicationId, attemptId);
+        return BuilderUtils.newContainerId(applicationAttemptId, containerSequence);
+    }
+
+    private static MasterKey masterKey(int keyId, byte[] keyBytes) {
+        MasterKey masterKey = Records.newRecord(MasterKey.class);
+        masterKey.setKeyId(keyId);
+        masterKey.setBytes(ByteBuffer.wrap(Arrays.copyOf(keyBytes, keyBytes.length)));
+        return masterKey;
+    }
+
+    private static byte[] bytes(ByteBuffer buffer) {
+        ByteBuffer duplicate = buffer.duplicate();
+        byte[] bytes = new byte[duplicate.remaining()];
+        duplicate.get(bytes);
+        return bytes;
+    }
+
+    private static final class RecordingFilterContainer implements FilterContainer {
+        private String filterName;
+        private String filterClassName;
+        private Map<String, String> filterConfig;
+        private boolean globalFilter;
+
+        @Override
+        public void addFilter(String name, String classname, Map<String, String> parameters) {
+            filterName = name;
+            filterClassName = classname;
+            filterConfig = new HashMap<String, String>(parameters);
+            globalFilter = false;
+        }
+
+        @Override
+        public void addGlobalFilter(String name, String classname, Map<String, String> parameters) {
+            filterName = name;
+            filterClassName = classname;
+            filterConfig = new HashMap<String, String>(parameters);
+            globalFilter = true;
+        }
+    }
+}

--- a/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.8.0/user-code-filter.json
+++ b/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.8.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.hadoop.yarn.**"
+    },
+    {
+      "includeClasses" : "org_apache_hadoop.hadoop_yarn_server_common.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6667

This PR provides test fixes and new metadata for org.apache.hadoop:hadoop-yarn-server-common:2.8.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 31732
- Cached input tokens: 320000
- Output tokens: 6086
- Metadata entries: 41
- Iterations: 1
- Library coverage percentage: 12.12
- Previous library version metadata entries: 39
- Previous library version coverage percentage: 14.73

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `b524ec97a3b1611609f0fe9c5c6b9dbfcd54b6ce`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.hadoop:hadoop-yarn-server-common:2.7.3: 0/0 covered calls (100.00%)
- org.apache.hadoop:hadoop-yarn-server-common:2.8.0: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.hadoop:hadoop-yarn-server-common:2.7.3: 3875/32948 (11.76%)
- org.apache.hadoop:hadoop-yarn-server-common:2.8.0: 4301/45115 (9.53%)

**Line:**
- org.apache.hadoop:hadoop-yarn-server-common:2.7.3: 1244/8446 (14.73%)
- org.apache.hadoop:hadoop-yarn-server-common:2.8.0: 1339/11046 (12.12%)

**Method:**
- org.apache.hadoop:hadoop-yarn-server-common:2.7.3: 386/1904 (20.27%)
- org.apache.hadoop:hadoop-yarn-server-common:2.8.0: 415/2523 (16.45%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.7.3/src/test/java/org_apache_hadoop/hadoop_yarn_server_common/Hadoop_yarn_server_commonTest.java 2/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.8.0/src/test/java/org_apache_hadoop/hadoop_yarn_server_common/Hadoop_yarn_server_commonTest.java
index b9561021e7..b7d3f82bb7 100644
--- 1/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.7.3/src/test/java/org_apache_hadoop/hadoop_yarn_server_common/Hadoop_yarn_server_commonTest.java
+++ 2/tests/src/org.apache.hadoop/hadoop-yarn-server-common/2.8.0/src/test/java/org_apache_hadoop/hadoop_yarn_server_common/Hadoop_yarn_server_commonTest.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.api.records.Priority;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.api.records.ResourceRequest;
+import org.apache.hadoop.yarn.api.records.ResourceUtilization;
 import org.apache.hadoop.yarn.api.records.Token;
 import org.apache.hadoop.yarn.api.records.URL;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
@@ -78,6 +79,7 @@ public class Hadoop_yarn_server_commonTest {
         Priority priority = Priority.newInstance(3);
         NMContainerStatus containerStatus = NMContainerStatus.newInstance(
                 containerId,
+                0,
                 ContainerState.RUNNING,
                 Resource.newInstance(1024, 1),
                 "healthy container",
@@ -95,7 +97,7 @@ public class Hadoop_yarn_server_commonTest {
 
         assertThat(request.getNodeId()).isEqualTo(nodeId);
         assertThat(request.getHttpPort()).isEqualTo(8042);
-        assertThat(request.getResource().getMemory()).isEqualTo(8192);
+        assertThat(request.getResource().getMemorySize()).isEqualTo(8192L);
         assertThat(request.getResource().getVirtualCores()).isEqualTo(4);
         assertThat(request.getNMVersion()).isEqualTo("test-nm-version");
         assertThat(request.getRunningApplications()).containsExactly(applicationId);
@@ -103,7 +105,7 @@ public class Hadoop_yarn_server_commonTest {
         NMContainerStatus roundTrippedStatus = request.getNMContainerStatuses().get(0);
         assertThat(roundTrippedStatus.getContainerId()).isEqualTo(containerId);
         assertThat(roundTrippedStatus.getContainerState()).isEqualTo(ContainerState.RUNNING);
-        assertThat(roundTrippedStatus.getAllocatedResource().getMemory()).isEqualTo(1024);
+        assertThat(roundTrippedStatus.getAllocatedResource().getMemorySize()).isEqualTo(1024L);
         assertThat(roundTrippedStatus.getDiagnostics()).isEqualTo("healthy container");
         assertThat(roundTrippedStatus.getPriority().getPriority()).isEqualTo(3);
         assertThat(roundTrippedStatus.getCreationTime()).isEqualTo(44L);
@@ -117,22 +119,39 @@ public class Hadoop_yarn_server_commonTest {
                 runningContainer,
                 ContainerState.COMPLETE,
                 "finished",
-                0);
+                0,
+                Resource.newInstance(1024, 1));
         NodeHealthStatus healthStatus = NodeHealthStatus.newInstance(true, "all disks healthy", 99L);
+        ResourceUtilization containersUtilization = ResourceUtilization.newInstance(1024, 2048, 1.0F);
+        ResourceUtilization nodeUtilization = ResourceUtilization.newInstance(2048, 4096, 2.0F);
         NodeStatus nodeStatus = NodeStatus.newInstance(
                 NodeId.newInstance("nm.example.test", 1234),
                 5,
                 Collections.singletonList(containerStatus),
                 Collections.singletonList(applicationId),
-                healthStatus);
+                healthStatus,
+                containersUtilization,
+                nodeUtilization,
+                Collections.<Container>emptyList());
         MasterKey containerTokenKey = masterKey(17, new byte[] {1, 2, 3, 4});
         MasterKey nmTokenKey = masterKey(23, new byte[] {5, 6, 7, 8});
 
-        NodeHeartbeatRequest request = NodeHeartbeatRequest.newInstance(nodeStatus, containerTokenKey, nmTokenKey);
+        NodeHeartbeatRequest request = NodeHeartbeatRequest.newInstance(
+                nodeStatus,
+                containerTokenKey,
+                nmTokenKey,
+                Collections.emptySet());
 
         assertThat(request.getNodeStatus().getResponseId()).isEqualTo(5);
         assertThat(request.getNodeStatus().getContainersStatuses()).hasSize(1);
         assertThat(request.getNodeStatus().getNodeHealthStatus().getHealthReport()).isEqualTo("all disks healthy");
+        assertThat(request.getNodeStatus().getContainersUtilization().getPhysicalMemory()).isEqualTo(1024);
+        assertThat(request.getNodeStatus().getContainersUtilization().getVirtualMemory()).isEqualTo(2048);
+        assertThat(request.getNodeStatus().getContainersUtilization().getCPU()).isEqualTo(1.0F);
+        assertThat(request.getNodeStatus().getNodeUtilization().getPhysicalMemory()).isEqualTo(2048);
+        assertThat(request.getNodeStatus().getNodeUtilization().getVirtualMemory()).isEqualTo(4096);
+        assertThat(request.getNodeStatus().getNodeUtilization().getCPU()).isEqualTo(2.0F);
+        assertThat(request.getNodeStatus().getIncreasedContainers()).isEmpty();
         assertThat(request.getLastKnownContainerTokenMasterKey().getKeyId()).isEqualTo(17);
         assertThat(bytes(request.getLastKnownNMTokenMasterKey().getBytes()))
                 .containsExactly((byte) 5, (byte) 6, (byte) 7, (byte) 8);
@@ -237,7 +256,7 @@ public class Hadoop_yarn_server_commonTest {
                 3);
         assertThat(request.getPriority().getPriority()).isEqualTo(9);
         assertThat(request.getResourceName()).isEqualTo(ResourceRequest.ANY);
-        assertThat(request.getCapability().getMemory()).isEqualTo(2048);
+        assertThat(request.getCapability().getMemorySize()).isEqualTo(2048L);
         assertThat(request.getCapability().getVirtualCores()).isEqualTo(2);
         assertThat(request.getNumContainers()).isEqualTo(3);
 
@@ -259,7 +278,7 @@ public class Hadoop_yarn_server_commonTest {
         assertThat(container.getId()).isEqualTo(containerId);
         assertThat(container.getNodeId()).isEqualTo(nodeId);
         assertThat(container.getNodeHttpAddress()).isEqualTo("worker.example.test:8042");
-        assertThat(container.getResource().getMemory()).isEqualTo(1024);
+        assertThat(container.getResource().getMemorySize()).isEqualTo(1024L);
         assertThat(container.getPriority().getPriority()).isEqualTo(1);
         assertThat(container.getContainerToken().getKind()).isEqualTo("kind");
     }
@@ -366,7 +385,7 @@ public class Hadoop_yarn_server_commonTest {
 
     private static ContainerId containerId(ApplicationId applicationId, int attemptId, long containerSequence) {
         ApplicationAttemptId applicationAttemptId = ApplicationAttemptId.newInstance(applicationId, attemptId);
-        return BuilderUtils.newContainerId(applicationAttemptId, containerSequence);
+        return ContainerId.newContainerId(applicationAttemptId, containerSequence);
     }
 
     private static MasterKey masterKey(int keyId, byte[] keyBytes) {

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
