### PR TITLE
[GenAI] Test fix for org.apache.hadoop:hadoop-yarn-api:2.3.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.hadoop/hadoop-yarn-api/2.3.0/reachability-metadata.json
+++ b/metadata/org.apache.hadoop/hadoop-yarn-api/2.3.0/reachability-metadata.json
@@ -1,0 +1,892 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider"
+      },
+      "type": "java.lang.Thread",
+      "methods": [
+        {
+          "name": "getContextClassLoader",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider"
+      },
+      "type": "org.apache.commons.logging.LogFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider"
+      },
+      "type": "org.apache.commons.logging.impl.Jdk14Logger",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider"
+      },
+      "type": "org.apache.commons.logging.impl.LogFactoryImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider"
+      },
+      "type": "org.apache.commons.logging.impl.SimpleLog",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider"
+      },
+      "type": "org.apache.commons.logging.impl.WeakHashtable",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider"
+      },
+      "type": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl",
+      "methods": [
+        {
+          "name": "get",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.AllocateRequestPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.AllocateResponsePBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.CancelDelegationTokenRequestPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.CancelDelegationTokenResponsePBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.FinishApplicationMasterRequestPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.FinishApplicationMasterResponsePBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.GetApplicationReportRequestPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.GetApplicationReportResponsePBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.GetApplicationsRequestPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.GetApplicationsResponsePBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.GetClusterMetricsRequestPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.GetClusterMetricsResponsePBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.GetClusterNodesRequestPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.GetClusterNodesResponsePBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.GetContainerStatusesRequestPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.GetContainerStatusesResponsePBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.GetDelegationTokenRequestPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.GetDelegationTokenResponsePBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.GetNewApplicationRequestPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.GetNewApplicationResponsePBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.GetQueueInfoRequestPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.GetQueueInfoResponsePBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.GetQueueUserAclsInfoRequestPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.GetQueueUserAclsInfoResponsePBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.KillApplicationRequestPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.KillApplicationResponsePBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.RegisterApplicationMasterRequestPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.RegisterApplicationMasterResponsePBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.RenewDelegationTokenRequestPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.RenewDelegationTokenResponsePBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.StartContainerRequestPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.StartContainersRequestPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.StartContainersResponsePBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.StopContainersRequestPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.StopContainersResponsePBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.SubmitApplicationRequestPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.protocolrecords.impl.pb.SubmitApplicationResponsePBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.records.impl.pb.ApplicationAttemptIdPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.records.impl.pb.ApplicationIdPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.records.impl.pb.ApplicationReportPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.records.impl.pb.ApplicationResourceUsageReportPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.records.impl.pb.ApplicationSubmissionContextPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.records.impl.pb.ContainerIdPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.records.impl.pb.ContainerLaunchContextPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.records.impl.pb.ContainerPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.records.impl.pb.ContainerStatusPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.records.impl.pb.LocalResourcePBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.records.impl.pb.NMTokenPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.records.impl.pb.NodeIdPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.records.impl.pb.NodeReportPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.records.impl.pb.PreemptionContainerPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.records.impl.pb.PreemptionContractPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.records.impl.pb.PreemptionMessagePBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.records.impl.pb.PreemptionResourceRequestPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.records.impl.pb.PriorityPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.records.impl.pb.QueueInfoPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.records.impl.pb.QueueUserACLInfoPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.records.impl.pb.ResourceBlacklistRequestPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.records.impl.pb.ResourcePBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.records.impl.pb.ResourceRequestPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.records.impl.pb.SerializedExceptionPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.records.impl.pb.StrictPreemptionContractPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.records.impl.pb.TokenPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.records.impl.pb.URLPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factories.impl.pb.RecordFactoryPBImpl"
+      },
+      "type": "org.apache.hadoop.yarn.api.records.impl.pb.YarnClusterMetricsPBImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider"
+      },
+      "glob": "META-INF/services/org.apache.commons.logging.LogFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider"
+      },
+      "glob": "commons-logging.properties"
+    }
+  ]
+}

--- a/metadata/org.apache.hadoop/hadoop-yarn-api/index.json
+++ b/metadata/org.apache.hadoop/hadoop-yarn-api/index.json
@@ -13,5 +13,14 @@
     "allowed-packages" : [
       "org.apache.hadoop.yarn"
     ]
+  },
+  {
+    "metadata-version" : "2.3.0",
+    "tested-versions" : [
+      "2.3.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.hadoop.yarn"
+    ]
   }
 ]

--- a/metadata/org.apache.hadoop/hadoop-yarn-api/index.json
+++ b/metadata/org.apache.hadoop/hadoop-yarn-api/index.json
@@ -16,6 +16,11 @@
   },
   {
     "metadata-version" : "2.3.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/hadoop/hadoop-yarn-api/$version$/hadoop-yarn-api-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/hadoop",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/hadoop/hadoop-yarn-api/$version$/hadoop-yarn-api-$version$-javadoc.jar",
+    "description" : "Apache Hadoop YARN API provides Java interfaces, protocol records, and generated protocol buffer classes for interacting with YARN resource management services. It is used by Hadoop clients and services to describe applications, containers, resources, queues, and administrative operations in a YARN cluster.",
     "tested-versions" : [
       "2.3.0"
     ],

--- a/stats/org.apache.hadoop/hadoop-yarn-api/2.3.0/execution-metrics.json
+++ b/stats/org.apache.hadoop/hadoop-yarn-api/2.3.0/execution-metrics.json
@@ -1,0 +1,99 @@
+{
+  "fix_javac_fail:2026-05-09": {
+    "timestamp": "2026-05-09T13:11:25.304400Z",
+    "library": "org.apache.hadoop:hadoop-yarn-api:2.3.0",
+    "starting_commit": "78aad2ddb2fb9579d5cd6fe62a4d7da68eea946c",
+    "ending_commit": "3440560778669b1e80753d720b52d01252f63798",
+    "previous_library": "org.apache.hadoop:hadoop-yarn-api:2.2.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.3.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 3,
+        "totalCalls": 3
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 18324,
+          "missed": 104544,
+          "ratio": 0.149136,
+          "total": 122868
+        },
+        "line": {
+          "covered": 4916,
+          "missed": 25000,
+          "ratio": 0.164327,
+          "total": 29916
+        },
+        "method": {
+          "covered": 1394,
+          "missed": 6505,
+          "ratio": 0.176478,
+          "total": 7899
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.2.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 3,
+        "totalCalls": 3
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 18204,
+          "missed": 88364,
+          "ratio": 0.170821,
+          "total": 106568
+        },
+        "line": {
+          "covered": 4880,
+          "missed": 21223,
+          "ratio": 0.186952,
+          "total": 26103
+        },
+        "method": {
+          "covered": 1388,
+          "missed": 5602,
+          "ratio": 0.198569,
+          "total": 6990
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 12334,
+      "cached_input_tokens_used": 58368,
+      "output_tokens_used": 1254,
+      "iterations": 1,
+      "cost_usd": 0.0668,
+      "tested_library_loc": 4916,
+      "metadata_entries": 147,
+      "previous_library_metadata_entries": 147,
+      "code_coverage_percent": 16.43,
+      "previous_library_coverage_percent": 18.7
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.hadoop/hadoop-yarn-api/2.3.0/src/test/java/org_apache_hadoop/hadoop_yarn_api/Hadoop_yarn_apiTest.java",
+      "metadata_file": "metadata/org.apache.hadoop/hadoop-yarn-api/2.3.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.hadoop/hadoop-yarn-api/2.3.0/stats.json
+++ b/stats/org.apache.hadoop/hadoop-yarn-api/2.3.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "2.3.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 3,
+          "totalCalls" : 3
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 3,
+      "totalCalls" : 3
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 18324,
+        "missed" : 104544,
+        "ratio" : 0.149136,
+        "total" : 122868
+      },
+      "line" : {
+        "covered" : 4916,
+        "missed" : 25000,
+        "ratio" : 0.164327,
+        "total" : 29916
+      },
+      "method" : {
+        "covered" : 1394,
+        "missed" : 6505,
+        "ratio" : 0.176478,
+        "total" : 7899
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.hadoop/hadoop-yarn-api/2.3.0/.gitignore
+++ b/tests/src/org.apache.hadoop/hadoop-yarn-api/2.3.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.hadoop/hadoop-yarn-api/2.3.0/build.gradle
+++ b/tests/src/org.apache.hadoop/hadoop-yarn-api/2.3.0/build.gradle
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.hadoop:hadoop-yarn-api:$libraryVersion"
+    testImplementation "org.apache.hadoop:hadoop-yarn-common:$libraryVersion"
+    testImplementation "org.apache.hadoop:hadoop-common:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.hadoop/hadoop-yarn-api/2.3.0/gradle.properties
+++ b/tests/src/org.apache.hadoop/hadoop-yarn-api/2.3.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.hadoop:hadoop-yarn-api:2.3.0
+library.version = 2.3.0
+metadata.dir = org.apache.hadoop/hadoop-yarn-api/2.3.0/

--- a/tests/src/org.apache.hadoop/hadoop-yarn-api/2.3.0/settings.gradle
+++ b/tests/src/org.apache.hadoop/hadoop-yarn-api/2.3.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.hadoop.hadoop-yarn-api_tests'

--- a/tests/src/org.apache.hadoop/hadoop-yarn-api/2.3.0/src/test/java/org_apache_hadoop/hadoop_yarn_api/Hadoop_yarn_apiTest.java
+++ b/tests/src/org.apache.hadoop/hadoop-yarn-api/2.3.0/src/test/java/org_apache_hadoop/hadoop_yarn_api/Hadoop_yarn_apiTest.java
@@ -387,7 +387,7 @@ public class Hadoop_yarn_apiTest {
         GetQueueUserAclsInfoResponse aclsResponse = GetQueueUserAclsInfoResponse.newInstance(Collections.singletonList(
                 QueueUserACLInfo.newInstance("default", Collections.singletonList(QueueACL.SUBMIT_APPLICATIONS))));
         KillApplicationRequest killRequest = KillApplicationRequest.newInstance(applicationId);
-        KillApplicationResponse killResponse = KillApplicationResponse.newInstance();
+        KillApplicationResponse killResponse = KillApplicationResponse.newInstance(true);
 
         assertThat(submitRequest.getApplicationSubmissionContext()).isEqualTo(submission);
         assertThat(submitResponse).isNotNull();
@@ -410,7 +410,7 @@ public class Hadoop_yarn_apiTest {
         assertThat(aclsRequest).isNotNull();
         assertThat(aclsResponse.getUserAclsInfoList()).hasSize(1);
         assertThat(killRequest.getApplicationId()).isEqualTo(applicationId);
-        assertThat(killResponse).isNotNull();
+        assertThat(killResponse.getIsKillCompleted()).isTrue();
     }
 
     @Test
@@ -470,7 +470,8 @@ public class Hadoop_yarn_apiTest {
                 Resource.newInstance(128, 1),
                 Resource.newInstance(8192, 8),
                 acls,
-                byteBuffer(3, 4));
+                byteBuffer(3, 4),
+                "default");
         AllocateRequest allocateRequest = AllocateRequest.newInstance(
                 3,
                 0.5f,
@@ -510,6 +511,7 @@ public class Hadoop_yarn_apiTest {
         assertThat(registerResponse.getMaximumResourceCapability().getVirtualCores()).isEqualTo(8);
         assertThat(registerResponse.getApplicationACLs()).containsEntry(ApplicationAccessType.MODIFY_APP, "admin");
         assertThat(byteBufferToBytes(registerResponse.getClientToAMTokenMasterKey())).containsExactly(3, 4);
+        assertThat(registerResponse.getQueue()).isEqualTo("default");
         assertThat(allocateRequest.getResponseId()).isEqualTo(3);
         assertThat(allocateRequest.getAskList()).containsExactly(ask);
         assertThat(allocateRequest.getReleaseList()).containsExactly(containerId);

--- a/tests/src/org.apache.hadoop/hadoop-yarn-api/2.3.0/src/test/java/org_apache_hadoop/hadoop_yarn_api/Hadoop_yarn_apiTest.java
+++ b/tests/src/org.apache.hadoop/hadoop-yarn-api/2.3.0/src/test/java/org_apache_hadoop/hadoop_yarn_api/Hadoop_yarn_apiTest.java
@@ -1,0 +1,655 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_hadoop.hadoop_yarn_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.apache.hadoop.yarn.api.protocolrecords.AllocateRequest;
+import org.apache.hadoop.yarn.api.protocolrecords.AllocateResponse;
+import org.apache.hadoop.yarn.api.protocolrecords.CancelDelegationTokenRequest;
+import org.apache.hadoop.yarn.api.protocolrecords.CancelDelegationTokenResponse;
+import org.apache.hadoop.yarn.api.protocolrecords.FinishApplicationMasterRequest;
+import org.apache.hadoop.yarn.api.protocolrecords.FinishApplicationMasterResponse;
+import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationReportRequest;
+import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationReportResponse;
+import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationsRequest;
+import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationsResponse;
+import org.apache.hadoop.yarn.api.protocolrecords.GetClusterMetricsRequest;
+import org.apache.hadoop.yarn.api.protocolrecords.GetClusterMetricsResponse;
+import org.apache.hadoop.yarn.api.protocolrecords.GetClusterNodesRequest;
+import org.apache.hadoop.yarn.api.protocolrecords.GetClusterNodesResponse;
+import org.apache.hadoop.yarn.api.protocolrecords.GetContainerStatusesRequest;
+import org.apache.hadoop.yarn.api.protocolrecords.GetContainerStatusesResponse;
+import org.apache.hadoop.yarn.api.protocolrecords.GetDelegationTokenRequest;
+import org.apache.hadoop.yarn.api.protocolrecords.GetDelegationTokenResponse;
+import org.apache.hadoop.yarn.api.protocolrecords.GetNewApplicationRequest;
+import org.apache.hadoop.yarn.api.protocolrecords.GetNewApplicationResponse;
+import org.apache.hadoop.yarn.api.protocolrecords.GetQueueInfoRequest;
+import org.apache.hadoop.yarn.api.protocolrecords.GetQueueInfoResponse;
+import org.apache.hadoop.yarn.api.protocolrecords.GetQueueUserAclsInfoRequest;
+import org.apache.hadoop.yarn.api.protocolrecords.GetQueueUserAclsInfoResponse;
+import org.apache.hadoop.yarn.api.protocolrecords.KillApplicationRequest;
+import org.apache.hadoop.yarn.api.protocolrecords.KillApplicationResponse;
+import org.apache.hadoop.yarn.api.protocolrecords.RegisterApplicationMasterRequest;
+import org.apache.hadoop.yarn.api.protocolrecords.RegisterApplicationMasterResponse;
+import org.apache.hadoop.yarn.api.protocolrecords.RenewDelegationTokenRequest;
+import org.apache.hadoop.yarn.api.protocolrecords.RenewDelegationTokenResponse;
+import org.apache.hadoop.yarn.api.protocolrecords.StartContainerRequest;
+import org.apache.hadoop.yarn.api.protocolrecords.StartContainersRequest;
+import org.apache.hadoop.yarn.api.protocolrecords.StartContainersResponse;
+import org.apache.hadoop.yarn.api.protocolrecords.StopContainersRequest;
+import org.apache.hadoop.yarn.api.protocolrecords.StopContainersResponse;
+import org.apache.hadoop.yarn.api.protocolrecords.SubmitApplicationRequest;
+import org.apache.hadoop.yarn.api.protocolrecords.SubmitApplicationResponse;
+import org.apache.hadoop.yarn.api.records.AMCommand;
+import org.apache.hadoop.yarn.api.records.ApplicationAccessType;
+import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.api.records.ApplicationReport;
+import org.apache.hadoop.yarn.api.records.ApplicationResourceUsageReport;
+import org.apache.hadoop.yarn.api.records.ApplicationSubmissionContext;
+import org.apache.hadoop.yarn.api.records.Container;
+import org.apache.hadoop.yarn.api.records.ContainerExitStatus;
+import org.apache.hadoop.yarn.api.records.ContainerId;
+import org.apache.hadoop.yarn.api.records.ContainerLaunchContext;
+import org.apache.hadoop.yarn.api.records.ContainerState;
+import org.apache.hadoop.yarn.api.records.ContainerStatus;
+import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
+import org.apache.hadoop.yarn.api.records.LocalResource;
+import org.apache.hadoop.yarn.api.records.LocalResourceType;
+import org.apache.hadoop.yarn.api.records.LocalResourceVisibility;
+import org.apache.hadoop.yarn.api.records.NMToken;
+import org.apache.hadoop.yarn.api.records.NodeId;
+import org.apache.hadoop.yarn.api.records.NodeReport;
+import org.apache.hadoop.yarn.api.records.NodeState;
+import org.apache.hadoop.yarn.api.records.PreemptionContainer;
+import org.apache.hadoop.yarn.api.records.PreemptionContract;
+import org.apache.hadoop.yarn.api.records.PreemptionMessage;
+import org.apache.hadoop.yarn.api.records.PreemptionResourceRequest;
+import org.apache.hadoop.yarn.api.records.Priority;
+import org.apache.hadoop.yarn.api.records.QueueACL;
+import org.apache.hadoop.yarn.api.records.QueueInfo;
+import org.apache.hadoop.yarn.api.records.QueueState;
+import org.apache.hadoop.yarn.api.records.QueueUserACLInfo;
+import org.apache.hadoop.yarn.api.records.Resource;
+import org.apache.hadoop.yarn.api.records.ResourceBlacklistRequest;
+import org.apache.hadoop.yarn.api.records.ResourceRequest;
+import org.apache.hadoop.yarn.api.records.SerializedException;
+import org.apache.hadoop.yarn.api.records.StrictPreemptionContract;
+import org.apache.hadoop.yarn.api.records.Token;
+import org.apache.hadoop.yarn.api.records.URL;
+import org.apache.hadoop.yarn.api.records.YarnApplicationState;
+import org.apache.hadoop.yarn.api.records.YarnClusterMetrics;
+import org.junit.jupiter.api.Test;
+
+public class Hadoop_yarn_apiTest {
+    @Test
+    void createsApplicationSubmissionRecords() {
+        ApplicationId applicationId = ApplicationId.newInstance(123456789L, 42);
+        ApplicationAttemptId attemptId = ApplicationAttemptId.newInstance(applicationId, 3);
+        ContainerId containerId = ContainerId.newInstance(attemptId, 7);
+        NodeId nodeId = NodeId.newInstance("worker.example.test", 8042);
+        Priority priority = Priority.newInstance(5);
+        Resource capability = Resource.newInstance(2048, 2);
+        Token token = Token.newInstance(bytes(1, 2, 3), "container-kind", bytes(4, 5), "node-service");
+
+        URL resourceUrl = URL.newInstance("hdfs", "yarn", 8020, "/apps/app.jar");
+        LocalResource localResource = LocalResource.newInstance(
+                resourceUrl,
+                LocalResourceType.FILE,
+                LocalResourceVisibility.APPLICATION,
+                4096L,
+                111L,
+                "*.jar");
+        Map<String, LocalResource> localResources = new LinkedHashMap<>();
+        localResources.put("app.jar", localResource);
+        Map<String, String> environment = new LinkedHashMap<>();
+        environment.put("JAVA_HOME", "/opt/jdk");
+        Map<String, ByteBuffer> serviceData = new LinkedHashMap<>();
+        serviceData.put("shuffle", byteBuffer(9, 8, 7));
+        Map<ApplicationAccessType, String> acls = new LinkedHashMap<>();
+        acls.put(ApplicationAccessType.VIEW_APP, "alice,bob");
+
+        ContainerLaunchContext launchContext = ContainerLaunchContext.newInstance(
+                localResources,
+                environment,
+                Arrays.asList("echo starting", "java -jar app.jar"),
+                serviceData,
+                byteBuffer(6, 6, 6),
+                acls);
+        ApplicationSubmissionContext submission = ApplicationSubmissionContext.newInstance(
+                applicationId,
+                "demo-application",
+                "default",
+                priority,
+                launchContext,
+                false,
+                true,
+                2,
+                capability,
+                "MAPREDUCE");
+
+        assertThat(applicationId.getClusterTimestamp()).isEqualTo(123456789L);
+        assertThat(applicationId.getId()).isEqualTo(42);
+        assertThat(applicationId).isEqualTo(ApplicationId.newInstance(123456789L, 42));
+        assertThat(attemptId.getApplicationId()).isEqualTo(applicationId);
+        assertThat(containerId.getApplicationAttemptId()).isEqualTo(attemptId);
+        assertThat(nodeId.toString()).isEqualTo("worker.example.test:8042");
+        assertThat(priority.getPriority()).isEqualTo(5);
+        assertThat(capability.getMemory()).isEqualTo(2048);
+        assertThat(capability.getVirtualCores()).isEqualTo(2);
+        assertThat(byteBufferToBytes(token.getIdentifier())).containsExactly(1, 2, 3);
+        assertThat(token.getKind()).isEqualTo("container-kind");
+        assertThat(localResource.getResource().getFile()).isEqualTo("/apps/app.jar");
+        assertThat(localResource.getPattern()).isEqualTo("*.jar");
+        assertThat(launchContext.getLocalResources()).containsEntry("app.jar", localResource);
+        assertThat(launchContext.getEnvironment()).containsEntry("JAVA_HOME", "/opt/jdk");
+        assertThat(launchContext.getCommands()).containsExactly("echo starting", "java -jar app.jar");
+        assertThat(byteBufferToBytes(launchContext.getServiceData().get("shuffle"))).containsExactly(9, 8, 7);
+        assertThat(launchContext.getApplicationACLs()).containsEntry(ApplicationAccessType.VIEW_APP, "alice,bob");
+        assertThat(submission.getApplicationId()).isEqualTo(applicationId);
+        assertThat(submission.getApplicationName()).isEqualTo("demo-application");
+        assertThat(submission.getAMContainerSpec()).isEqualTo(launchContext);
+        assertThat(submission.getApplicationType()).isEqualTo("MAPREDUCE");
+    }
+
+    @Test
+    void createsResourceRequestsContainersAndPreemptionRecords() {
+        ApplicationId applicationId = ApplicationId.newInstance(2000L, 1);
+        ApplicationAttemptId attemptId = ApplicationAttemptId.newInstance(applicationId, 1);
+        ContainerId containerId = ContainerId.newInstance(attemptId, 1);
+        Priority priority = Priority.newInstance(1);
+        Resource resource = Resource.newInstance(1024, 1);
+        ResourceRequest anyRequest = ResourceRequest.newInstance(priority, ResourceRequest.ANY, resource, 3, true);
+        ResourceRequest rackRequest = ResourceRequest.newInstance(priority, "/rack1", resource, 1, false);
+        Token token = Token.newInstance(bytes(10), "container", bytes(11), "nm");
+        Container container = Container.newInstance(
+                containerId,
+                NodeId.newInstance("worker", 1234),
+                "worker:8042",
+                resource,
+                priority,
+                token);
+        ContainerStatus status = ContainerStatus.newInstance(
+                containerId,
+                ContainerState.COMPLETE,
+                "finished",
+                0);
+        PreemptionContainer preemptedContainer = PreemptionContainer.newInstance(containerId);
+        PreemptionResourceRequest preemptionRequest = PreemptionResourceRequest.newInstance(anyRequest);
+        StrictPreemptionContract strictContract = StrictPreemptionContract.newInstance(
+                Collections.singleton(preemptedContainer));
+        PreemptionContract contract = PreemptionContract.newInstance(
+                Collections.singletonList(preemptionRequest),
+                Collections.singleton(preemptedContainer));
+        PreemptionMessage message = PreemptionMessage.newInstance(strictContract, contract);
+        ResourceBlacklistRequest blacklist = ResourceBlacklistRequest.newInstance(
+                Collections.singletonList("bad-node"),
+                Collections.singletonList("recovered-node"));
+        NMToken nmToken = NMToken.newInstance(container.getNodeId(), token);
+
+        assertThat(ResourceRequest.isAnyLocation(ResourceRequest.ANY)).isTrue();
+        assertThat(ResourceRequest.isAnyLocation("worker")).isFalse();
+        assertThat(anyRequest.getCapability()).isEqualTo(resource);
+        assertThat(anyRequest.getNumContainers()).isEqualTo(3);
+        assertThat(anyRequest.getRelaxLocality()).isTrue();
+        assertThat(rackRequest.getRelaxLocality()).isFalse();
+        assertThat(container.getId()).isEqualTo(containerId);
+        assertThat(container.getNodeHttpAddress()).isEqualTo("worker:8042");
+        assertThat(status.getState()).isEqualTo(ContainerState.COMPLETE);
+        assertThat(status.getDiagnostics()).isEqualTo("finished");
+        assertThat(message.getStrictContract().getContainers()).containsExactly(preemptedContainer);
+        assertThat(message.getContract().getResourceRequest()).containsExactly(preemptionRequest);
+        assertThat(blacklist.getBlacklistAdditions()).containsExactly("bad-node");
+        assertThat(blacklist.getBlacklistRemovals()).containsExactly("recovered-node");
+        assertThat(nmToken.getNodeId()).isEqualTo(container.getNodeId());
+        assertThat(nmToken.getToken()).isEqualTo(token);
+    }
+
+    @Test
+    void createsReportsQueuesMetricsAndSerializedExceptions() {
+        ApplicationId applicationId = ApplicationId.newInstance(3000L, 2);
+        ApplicationAttemptId attemptId = ApplicationAttemptId.newInstance(applicationId, 4);
+        Token clientToken = Token.newInstance(bytes(1), "client", bytes(2), "am");
+        Token amRmToken = Token.newInstance(bytes(3), "amrm", bytes(4), "rm");
+        ApplicationResourceUsageReport usage = ApplicationResourceUsageReport.newInstance(
+                2,
+                1,
+                Resource.newInstance(2048, 2),
+                Resource.newInstance(1024, 1),
+                Resource.newInstance(4096, 4));
+        ApplicationReport report = ApplicationReport.newInstance(
+                applicationId,
+                attemptId,
+                "alice",
+                "default",
+                "demo",
+                "am-host",
+                10000,
+                clientToken,
+                YarnApplicationState.RUNNING,
+                "healthy",
+                "http://tracking",
+                10L,
+                20L,
+                FinalApplicationStatus.SUCCEEDED,
+                usage,
+                "http://original-tracking",
+                0.75f,
+                "YARN",
+                amRmToken);
+        NodeReport nodeReport = NodeReport.newInstance(
+                NodeId.newInstance("node1", 8041),
+                NodeState.RUNNING,
+                "node1:8042",
+                "/rack1",
+                Resource.newInstance(512, 1),
+                Resource.newInstance(8192, 8),
+                2,
+                "healthy",
+                123L);
+        QueueInfo childQueue = QueueInfo.newInstance(
+                "child",
+                0.25f,
+                0.50f,
+                0.10f,
+                Collections.<QueueInfo>emptyList(),
+                Collections.<ApplicationReport>emptyList(),
+                QueueState.RUNNING);
+        QueueInfo queueInfo = QueueInfo.newInstance(
+                "root",
+                1.0f,
+                1.0f,
+                0.25f,
+                Collections.singletonList(childQueue),
+                Collections.singletonList(report),
+                QueueState.RUNNING);
+        QueueUserACLInfo aclInfo = QueueUserACLInfo.newInstance(
+                "root",
+                Arrays.asList(QueueACL.SUBMIT_APPLICATIONS, QueueACL.ADMINISTER_QUEUE));
+        YarnClusterMetrics metrics = YarnClusterMetrics.newInstance(5);
+        SerializedException serialized = SerializedException.newInstance(
+                new RuntimeException("top", new IllegalStateException("nested")));
+
+        assertThat(usage.getNumUsedContainers()).isEqualTo(2);
+        assertThat(usage.getNeededResources().getVirtualCores()).isEqualTo(4);
+        assertThat(report.getApplicationId()).isEqualTo(applicationId);
+        assertThat(report.getYarnApplicationState()).isEqualTo(YarnApplicationState.RUNNING);
+        assertThat(report.getProgress()).isEqualTo(0.75f);
+        assertThat(report.getAMRMToken()).isEqualTo(amRmToken);
+        assertThat(nodeReport.getRackName()).isEqualTo("/rack1");
+        assertThat(nodeReport.getCapability().getMemory()).isEqualTo(8192);
+        assertThat(queueInfo.getChildQueues()).containsExactly(childQueue);
+        assertThat(queueInfo.getApplications()).containsExactly(report);
+        assertThat(aclInfo.getUserAcls()).containsExactly(QueueACL.SUBMIT_APPLICATIONS, QueueACL.ADMINISTER_QUEUE);
+        assertThat(metrics.getNumNodeManagers()).isEqualTo(5);
+        assertThat(serialized.getMessage()).contains("top");
+        assertThat(serialized.getCause().getMessage()).contains("nested");
+    }
+
+    @Test
+    void createsApplicationClientProtocolRecords() {
+        ApplicationId applicationId = ApplicationId.newInstance(4000L, 1);
+        ApplicationSubmissionContext submission = ApplicationSubmissionContext.newInstance(
+                applicationId,
+                "client-app",
+                "default",
+                Priority.newInstance(0),
+                ContainerLaunchContext.newInstance(
+                        Collections.<String, LocalResource>emptyMap(),
+                        Collections.<String, String>emptyMap(),
+                        Collections.singletonList("true"),
+                        Collections.<String, ByteBuffer>emptyMap(),
+                        byteBuffer(1),
+                        Collections.<ApplicationAccessType, String>emptyMap()),
+                false,
+                true,
+                1,
+                Resource.newInstance(256, 1));
+        ApplicationReport report = ApplicationReport.newInstance(
+                applicationId,
+                ApplicationAttemptId.newInstance(applicationId, 1),
+                "alice",
+                "default",
+                "client-app",
+                "host",
+                1,
+                Token.newInstance(bytes(2), "client", bytes(3), "am"),
+                YarnApplicationState.ACCEPTED,
+                "",
+                "N/A",
+                1L,
+                0L,
+                FinalApplicationStatus.UNDEFINED,
+                ApplicationResourceUsageReport.newInstance(
+                        0,
+                        0,
+                        Resource.newInstance(0, 0),
+                        Resource.newInstance(0, 0),
+                        Resource.newInstance(0, 0)),
+                "N/A",
+                0.0f,
+                "YARN",
+                Token.newInstance(bytes(4), "amrm", bytes(5), "rm"));
+        QueueInfo queueInfo = QueueInfo.newInstance(
+                "default",
+                1.0f,
+                1.0f,
+                0.0f,
+                Collections.<QueueInfo>emptyList(),
+                Collections.singletonList(report),
+                QueueState.RUNNING);
+        NodeReport nodeReport = NodeReport.newInstance(
+                NodeId.newInstance("node", 8041),
+                NodeState.RUNNING,
+                "node:8042",
+                "/default-rack",
+                Resource.newInstance(0, 0),
+                Resource.newInstance(4096, 4),
+                0,
+                "healthy",
+                1L);
+
+        SubmitApplicationRequest submitRequest = SubmitApplicationRequest.newInstance(submission);
+        SubmitApplicationResponse submitResponse = SubmitApplicationResponse.newInstance();
+        GetNewApplicationRequest newApplicationRequest = GetNewApplicationRequest.newInstance();
+        GetNewApplicationResponse newApplicationResponse = GetNewApplicationResponse.newInstance(
+                applicationId,
+                Resource.newInstance(128, 1),
+                Resource.newInstance(8192, 8));
+        GetApplicationReportRequest reportRequest = GetApplicationReportRequest.newInstance(applicationId);
+        GetApplicationReportResponse reportResponse = GetApplicationReportResponse.newInstance(report);
+        GetApplicationsRequest applicationsRequest = GetApplicationsRequest.newInstance(
+                Collections.singleton("YARN"),
+                EnumSet.of(YarnApplicationState.ACCEPTED, YarnApplicationState.RUNNING));
+        GetApplicationsResponse applicationsResponse = GetApplicationsResponse.newInstance(
+                Collections.singletonList(report));
+        GetClusterMetricsRequest metricsRequest = GetClusterMetricsRequest.newInstance();
+        GetClusterMetricsResponse metricsResponse = GetClusterMetricsResponse.newInstance(
+                YarnClusterMetrics.newInstance(1));
+        GetClusterNodesRequest nodesRequest = GetClusterNodesRequest.newInstance(EnumSet.of(NodeState.RUNNING));
+        GetClusterNodesResponse nodesResponse = GetClusterNodesResponse.newInstance(
+                Collections.singletonList(nodeReport));
+        GetQueueInfoRequest queueInfoRequest = GetQueueInfoRequest.newInstance("default", true, true, false);
+        GetQueueInfoResponse queueInfoResponse = GetQueueInfoResponse.newInstance(queueInfo);
+        GetQueueUserAclsInfoRequest aclsRequest = GetQueueUserAclsInfoRequest.newInstance();
+        GetQueueUserAclsInfoResponse aclsResponse = GetQueueUserAclsInfoResponse.newInstance(Collections.singletonList(
+                QueueUserACLInfo.newInstance("default", Collections.singletonList(QueueACL.SUBMIT_APPLICATIONS))));
+        KillApplicationRequest killRequest = KillApplicationRequest.newInstance(applicationId);
+        KillApplicationResponse killResponse = KillApplicationResponse.newInstance();
+
+        assertThat(submitRequest.getApplicationSubmissionContext()).isEqualTo(submission);
+        assertThat(submitResponse).isNotNull();
+        assertThat(newApplicationRequest).isNotNull();
+        assertThat(newApplicationResponse.getApplicationId()).isEqualTo(applicationId);
+        assertThat(newApplicationResponse.getMaximumResourceCapability().getMemory()).isEqualTo(8192);
+        assertThat(reportRequest.getApplicationId()).isEqualTo(applicationId);
+        assertThat(reportResponse.getApplicationReport()).isEqualTo(report);
+        assertThat(applicationsRequest.getApplicationTypes()).containsExactly("YARN");
+        assertThat(applicationsRequest.getApplicationStates())
+                .contains(YarnApplicationState.ACCEPTED, YarnApplicationState.RUNNING);
+        assertThat(applicationsResponse.getApplicationList()).containsExactly(report);
+        assertThat(metricsRequest).isNotNull();
+        assertThat(metricsResponse.getClusterMetrics().getNumNodeManagers()).isEqualTo(1);
+        assertThat(nodesRequest.getNodeStates()).isEqualTo(EnumSet.of(NodeState.RUNNING));
+        assertThat(nodesResponse.getNodeReports()).containsExactly(nodeReport);
+        assertThat(queueInfoRequest.getQueueName()).isEqualTo("default");
+        assertThat(queueInfoRequest.getIncludeApplications()).isTrue();
+        assertThat(queueInfoResponse.getQueueInfo()).isEqualTo(queueInfo);
+        assertThat(aclsRequest).isNotNull();
+        assertThat(aclsResponse.getUserAclsInfoList()).hasSize(1);
+        assertThat(killRequest.getApplicationId()).isEqualTo(applicationId);
+        assertThat(killResponse).isNotNull();
+    }
+
+    @Test
+    void createsApplicationMasterAndContainerManagerProtocolRecords() {
+        ApplicationId applicationId = ApplicationId.newInstance(5000L, 9);
+        ApplicationAttemptId attemptId = ApplicationAttemptId.newInstance(applicationId, 2);
+        ContainerId containerId = ContainerId.newInstance(attemptId, 12);
+        Priority priority = Priority.newInstance(2);
+        Resource resource = Resource.newInstance(512, 1);
+        ResourceRequest ask = ResourceRequest.newInstance(priority, ResourceRequest.ANY, resource, 2);
+        Token containerToken = Token.newInstance(bytes(12), "container", bytes(13), "node");
+        Container container = Container.newInstance(
+                containerId,
+                NodeId.newInstance("node", 8041),
+                "node:8042",
+                resource,
+                priority,
+                containerToken);
+        ContainerStatus status = ContainerStatus.newInstance(containerId, ContainerState.RUNNING, "running", -1000);
+        ResourceBlacklistRequest blacklist = ResourceBlacklistRequest.newInstance(
+                Collections.singletonList("bad"),
+                Collections.<String>emptyList());
+        PreemptionContainer preemptionContainer = PreemptionContainer.newInstance(containerId);
+        PreemptionMessage preemptionMessage = PreemptionMessage.newInstance(
+                StrictPreemptionContract.newInstance(Collections.singleton(preemptionContainer)),
+                PreemptionContract.newInstance(
+                        Collections.singletonList(PreemptionResourceRequest.newInstance(ask)),
+                        Collections.singleton(preemptionContainer)));
+        NMToken nmToken = NMToken.newInstance(container.getNodeId(), containerToken);
+        NodeReport nodeReport = NodeReport.newInstance(
+                container.getNodeId(),
+                NodeState.RUNNING,
+                "node:8042",
+                "/rack",
+                resource,
+                Resource.newInstance(4096, 4),
+                1,
+                "ok",
+                5L);
+        Map<ApplicationAccessType, String> acls = Collections.singletonMap(ApplicationAccessType.MODIFY_APP, "admin");
+        ContainerLaunchContext launchContext = ContainerLaunchContext.newInstance(
+                Collections.<String, LocalResource>emptyMap(),
+                Collections.singletonMap("A", "B"),
+                Collections.singletonList("sleep 1"),
+                Collections.<String, ByteBuffer>emptyMap(),
+                byteBuffer(1, 2),
+                acls);
+        Map<String, ByteBuffer> serviceMetadata = Collections.singletonMap("aux", byteBuffer(7));
+        SerializedException failure = SerializedException.newInstance(new IllegalArgumentException("container failed"));
+        Map<ContainerId, SerializedException> failedRequests = Collections.singletonMap(containerId, failure);
+
+        RegisterApplicationMasterRequest registerRequest = RegisterApplicationMasterRequest.newInstance(
+                "am-host",
+                12000,
+                "http://am");
+        RegisterApplicationMasterResponse registerResponse = RegisterApplicationMasterResponse.newInstance(
+                Resource.newInstance(128, 1),
+                Resource.newInstance(8192, 8),
+                acls,
+                byteBuffer(3, 4));
+        AllocateRequest allocateRequest = AllocateRequest.newInstance(
+                3,
+                0.5f,
+                Collections.singletonList(ask),
+                Collections.singletonList(containerId),
+                blacklist);
+        AllocateResponse allocateResponse = AllocateResponse.newInstance(
+                4,
+                Collections.singletonList(status),
+                Collections.singletonList(container),
+                Collections.singletonList(nodeReport),
+                Resource.newInstance(16384, 16),
+                AMCommand.AM_RESYNC,
+                6,
+                preemptionMessage,
+                Collections.singletonList(nmToken));
+        FinishApplicationMasterRequest finishRequest = FinishApplicationMasterRequest.newInstance(
+                FinalApplicationStatus.SUCCEEDED,
+                "done",
+                "http://done");
+        FinishApplicationMasterResponse finishResponse = FinishApplicationMasterResponse.newInstance(true);
+        StartContainerRequest startContainerRequest = StartContainerRequest.newInstance(launchContext, containerToken);
+        StartContainersRequest startContainersRequest = StartContainersRequest.newInstance(
+                Collections.singletonList(startContainerRequest));
+        StartContainersResponse startContainersResponse = StartContainersResponse.newInstance(
+                serviceMetadata,
+                Collections.singletonList(containerId),
+                failedRequests);
+        StopContainersRequest stopContainersRequest = StopContainersRequest.newInstance(
+                Collections.singletonList(containerId));
+        StopContainersResponse stopContainersResponse = StopContainersResponse.newInstance(
+                Collections.singletonList(containerId),
+                failedRequests);
+
+        assertThat(registerRequest.getHost()).isEqualTo("am-host");
+        assertThat(registerRequest.getRpcPort()).isEqualTo(12000);
+        assertThat(registerResponse.getMaximumResourceCapability().getVirtualCores()).isEqualTo(8);
+        assertThat(registerResponse.getApplicationACLs()).containsEntry(ApplicationAccessType.MODIFY_APP, "admin");
+        assertThat(byteBufferToBytes(registerResponse.getClientToAMTokenMasterKey())).containsExactly(3, 4);
+        assertThat(allocateRequest.getResponseId()).isEqualTo(3);
+        assertThat(allocateRequest.getAskList()).containsExactly(ask);
+        assertThat(allocateRequest.getReleaseList()).containsExactly(containerId);
+        assertThat(allocateRequest.getResourceBlacklistRequest()).isEqualTo(blacklist);
+        assertThat(allocateResponse.getResponseId()).isEqualTo(4);
+        assertThat(allocateResponse.getCompletedContainersStatuses()).containsExactly(status);
+        assertThat(allocateResponse.getAllocatedContainers()).containsExactly(container);
+        assertThat(allocateResponse.getUpdatedNodes()).containsExactly(nodeReport);
+        assertThat(allocateResponse.getAMCommand()).isEqualTo(AMCommand.AM_RESYNC);
+        assertThat(allocateResponse.getNumClusterNodes()).isEqualTo(6);
+        assertThat(allocateResponse.getPreemptionMessage()).isEqualTo(preemptionMessage);
+        assertThat(allocateResponse.getNMTokens()).containsExactly(nmToken);
+        assertThat(finishRequest.getFinalApplicationStatus()).isEqualTo(FinalApplicationStatus.SUCCEEDED);
+        assertThat(finishResponse.getIsUnregistered()).isTrue();
+        assertThat(startContainerRequest.getContainerLaunchContext()).isEqualTo(launchContext);
+        assertThat(startContainersRequest.getStartContainerRequests()).containsExactly(startContainerRequest);
+        assertThat(startContainersResponse.getSuccessfullyStartedContainers()).containsExactly(containerId);
+        assertThat(byteBufferToBytes(startContainersResponse.getAllServicesMetaData().get("aux"))).containsExactly(7);
+        assertThat(startContainersResponse.getFailedRequests()).containsEntry(containerId, failure);
+        assertThat(stopContainersRequest.getContainerIds()).containsExactly(containerId);
+        assertThat(stopContainersResponse.getSuccessfullyStoppedContainers()).containsExactly(containerId);
+        assertThat(stopContainersResponse.getFailedRequests()).containsEntry(containerId, failure);
+    }
+
+    @Test
+    void createsContainerStatusLookupProtocolRecords() {
+        ApplicationId applicationId = ApplicationId.newInstance(6000L, 3);
+        ApplicationAttemptId attemptId = ApplicationAttemptId.newInstance(applicationId, 1);
+        ContainerId completedContainerId = ContainerId.newInstance(attemptId, 1);
+        ContainerId failedContainerId = ContainerId.newInstance(attemptId, 2);
+        ContainerStatus completedStatus = ContainerStatus.newInstance(
+                completedContainerId,
+                ContainerState.COMPLETE,
+                "finished successfully",
+                ContainerExitStatus.SUCCESS);
+        SerializedException failure = SerializedException.newInstance(
+                new IllegalArgumentException("container status unavailable"));
+
+        GetContainerStatusesRequest request = GetContainerStatusesRequest.newInstance(
+                Arrays.asList(completedContainerId, failedContainerId));
+        GetContainerStatusesResponse response = GetContainerStatusesResponse.newInstance(
+                Collections.singletonList(completedStatus),
+                Collections.singletonMap(failedContainerId, failure));
+
+        assertThat(request.getContainerIds()).containsExactly(completedContainerId, failedContainerId);
+        assertThat(response.getContainerStatuses()).containsExactly(completedStatus);
+        assertThat(completedStatus.getExitStatus()).isEqualTo(ContainerExitStatus.SUCCESS);
+        assertThat(response.getFailedRequests()).containsEntry(failedContainerId, failure);
+    }
+
+    @Test
+    void createsDelegationTokenProtocolRecords() {
+        Token delegationToken = Token.newInstance(
+                bytes(21, 22, 23),
+                "RM_DELEGATION_TOKEN",
+                bytes(24, 25),
+                "resource-manager");
+        GetDelegationTokenRequest getRequest = GetDelegationTokenRequest.newInstance("history-server");
+        GetDelegationTokenResponse getResponse = GetDelegationTokenResponse.newInstance(delegationToken);
+        RenewDelegationTokenRequest renewRequest = RenewDelegationTokenRequest.newInstance(delegationToken);
+        RenewDelegationTokenResponse renewResponse = RenewDelegationTokenResponse.newInstance(123456789L);
+        CancelDelegationTokenRequest cancelRequest = CancelDelegationTokenRequest.newInstance(delegationToken);
+        CancelDelegationTokenResponse cancelResponse = CancelDelegationTokenResponse.newInstance();
+
+        assertThat(getRequest.getRenewer()).isEqualTo("history-server");
+        assertThat(getResponse.getRMDelegationToken()).isEqualTo(delegationToken);
+        assertThat(renewRequest.getDelegationToken()).isEqualTo(delegationToken);
+        assertThat(renewResponse.getNextExpirationTime()).isEqualTo(123456789L);
+        assertThat(cancelRequest.getDelegationToken()).isEqualTo(delegationToken);
+        assertThat(cancelResponse).isNotNull();
+    }
+
+    @Test
+    void mutatesRecordsThroughSetters() {
+        Resource resource = Resource.newInstance(1, 1);
+        resource.setMemory(4096);
+        resource.setVirtualCores(4);
+        Priority priority = Priority.newInstance(1);
+        priority.setPriority(9);
+        ResourceRequest request = ResourceRequest.newInstance(priority, "old", resource, 1);
+        request.setResourceName("new");
+        request.setNumContainers(5);
+        request.setRelaxLocality(false);
+        URL url = URL.newInstance("file", null, 0, "/tmp/a");
+        url.setScheme("hdfs");
+        url.setUserInfo("user");
+        url.setHost("namenode");
+        url.setPort(8020);
+        url.setFile("/tmp/b");
+        LocalResource localResource = LocalResource.newInstance(
+                url,
+                LocalResourceType.FILE,
+                LocalResourceVisibility.PRIVATE,
+                1L,
+                2L);
+        localResource.setSize(3L);
+        localResource.setTimestamp(4L);
+        localResource.setPattern("*.txt");
+        Token token = Token.newInstance(bytes(1), "kind", bytes(2), "service");
+        token.setKind("updated-kind");
+        token.setService("updated-service");
+        token.setIdentifier(byteBuffer(3, 4));
+        token.setPassword(byteBuffer(5, 6));
+
+        assertThat(resource.getMemory()).isEqualTo(4096);
+        assertThat(resource.getVirtualCores()).isEqualTo(4);
+        assertThat(priority.getPriority()).isEqualTo(9);
+        assertThat(request.getResourceName()).isEqualTo("new");
+        assertThat(request.getNumContainers()).isEqualTo(5);
+        assertThat(request.getRelaxLocality()).isFalse();
+        assertThat(url.getScheme()).isEqualTo("hdfs");
+        assertThat(url.getUserInfo()).isEqualTo("user");
+        assertThat(url.getHost()).isEqualTo("namenode");
+        assertThat(url.getPort()).isEqualTo(8020);
+        assertThat(url.getFile()).isEqualTo("/tmp/b");
+        assertThat(localResource.getSize()).isEqualTo(3L);
+        assertThat(localResource.getTimestamp()).isEqualTo(4L);
+        assertThat(localResource.getPattern()).isEqualTo("*.txt");
+        assertThat(token.getKind()).isEqualTo("updated-kind");
+        assertThat(token.getService()).isEqualTo("updated-service");
+        assertThat(byteBufferToBytes(token.getIdentifier())).containsExactly(3, 4);
+        assertThat(byteBufferToBytes(token.getPassword())).containsExactly(5, 6);
+    }
+
+    private static byte[] bytes(int... values) {
+        byte[] bytes = new byte[values.length];
+        for (int index = 0; index < values.length; index++) {
+            bytes[index] = (byte) values[index];
+        }
+        return bytes;
+    }
+
+    private static ByteBuffer byteBuffer(int... values) {
+        return ByteBuffer.wrap(bytes(values));
+    }
+
+    private static byte[] byteBufferToBytes(ByteBuffer buffer) {
+        ByteBuffer duplicate = buffer.duplicate();
+        byte[] bytes = new byte[duplicate.remaining()];
+        duplicate.get(bytes);
+        return bytes;
+    }
+}

--- a/tests/src/org.apache.hadoop/hadoop-yarn-api/2.3.0/user-code-filter.json
+++ b/tests/src/org.apache.hadoop/hadoop-yarn-api/2.3.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.hadoop.yarn.**"
+    },
+    {
+      "includeClasses" : "org_apache_hadoop.hadoop_yarn_api.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6666

This PR provides test fixes and new metadata for org.apache.hadoop:hadoop-yarn-api:2.3.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 12334
- Cached input tokens: 58368
- Output tokens: 1254
- Metadata entries: 147
- Iterations: 1
- Library coverage percentage: 16.43
- Previous library version metadata entries: 147
- Previous library version coverage percentage: 18.7

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `b524ec97a3b1611609f0fe9c5c6b9dbfcd54b6ce`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.hadoop:hadoop-yarn-api:2.2.0: 3/3 covered calls (100.00%)
- org.apache.hadoop:hadoop-yarn-api:2.3.0: 3/3 covered calls (100.00%)

**Reflection:**
- org.apache.hadoop:hadoop-yarn-api:2.2.0: 3/3 covered calls (100.00%)
- org.apache.hadoop:hadoop-yarn-api:2.3.0: 3/3 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.hadoop:hadoop-yarn-api:2.2.0: 18204/106568 (17.08%)
- org.apache.hadoop:hadoop-yarn-api:2.3.0: 18324/122868 (14.91%)

**Line:**
- org.apache.hadoop:hadoop-yarn-api:2.2.0: 4880/26103 (18.70%)
- org.apache.hadoop:hadoop-yarn-api:2.3.0: 4916/29916 (16.43%)

**Method:**
- org.apache.hadoop:hadoop-yarn-api:2.2.0: 1388/6990 (19.86%)
- org.apache.hadoop:hadoop-yarn-api:2.3.0: 1394/7899 (17.65%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.hadoop/hadoop-yarn-api/2.2.0/src/test/java/org_apache_hadoop/hadoop_yarn_api/Hadoop_yarn_apiTest.java 2/tests/src/org.apache.hadoop/hadoop-yarn-api/2.3.0/src/test/java/org_apache_hadoop/hadoop_yarn_api/Hadoop_yarn_apiTest.java
index 6133b4427e..0b69f87b82 100644
--- 1/tests/src/org.apache.hadoop/hadoop-yarn-api/2.2.0/src/test/java/org_apache_hadoop/hadoop_yarn_api/Hadoop_yarn_apiTest.java
+++ 2/tests/src/org.apache.hadoop/hadoop-yarn-api/2.3.0/src/test/java/org_apache_hadoop/hadoop_yarn_api/Hadoop_yarn_apiTest.java
@@ -387,7 +387,7 @@ public class Hadoop_yarn_apiTest {
         GetQueueUserAclsInfoResponse aclsResponse = GetQueueUserAclsInfoResponse.newInstance(Collections.singletonList(
                 QueueUserACLInfo.newInstance("default", Collections.singletonList(QueueACL.SUBMIT_APPLICATIONS))));
         KillApplicationRequest killRequest = KillApplicationRequest.newInstance(applicationId);
-        KillApplicationResponse killResponse = KillApplicationResponse.newInstance();
+        KillApplicationResponse killResponse = KillApplicationResponse.newInstance(true);
 
         assertThat(submitRequest.getApplicationSubmissionContext()).isEqualTo(submission);
         assertThat(submitResponse).isNotNull();
@@ -410,7 +410,7 @@ public class Hadoop_yarn_apiTest {
         assertThat(aclsRequest).isNotNull();
         assertThat(aclsResponse.getUserAclsInfoList()).hasSize(1);
         assertThat(killRequest.getApplicationId()).isEqualTo(applicationId);
-        assertThat(killResponse).isNotNull();
+        assertThat(killResponse.getIsKillCompleted()).isTrue();
     }
 
     @Test
@@ -470,7 +470,8 @@ public class Hadoop_yarn_apiTest {
                 Resource.newInstance(128, 1),
                 Resource.newInstance(8192, 8),
                 acls,
-                byteBuffer(3, 4));
+                byteBuffer(3, 4),
+                "default");
         AllocateRequest allocateRequest = AllocateRequest.newInstance(
                 3,
                 0.5f,
@@ -510,6 +511,7 @@ public class Hadoop_yarn_apiTest {
         assertThat(registerResponse.getMaximumResourceCapability().getVirtualCores()).isEqualTo(8);
         assertThat(registerResponse.getApplicationACLs()).containsEntry(ApplicationAccessType.MODIFY_APP, "admin");
         assertThat(byteBufferToBytes(registerResponse.getClientToAMTokenMasterKey())).containsExactly(3, 4);
+        assertThat(registerResponse.getQueue()).isEqualTo("default");
         assertThat(allocateRequest.getResponseId()).isEqualTo(3);
         assertThat(allocateRequest.getAskList()).containsExactly(ask);
         assertThat(allocateRequest.getReleaseList()).containsExactly(containerId);

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
