### PR TITLE
[GenAI] Mark org.springframework.boot:spring-boot-starter-aop as not for Native Image

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-starter-aop/index.json
+++ b/metadata/org.springframework.boot/spring-boot-starter-aop/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published JAR for org.springframework.boot:spring-boot-starter-aop:2.7.18 contains only META-INF files and no JVM class files; it is a dependency starter whose runtime classes are supplied by its dependencies.",
+    "replacement": "Use class-bearing dependencies such as org.springframework:spring-aop:5.3.31, org.aspectj:aspectjweaver:1.9.7, and org.springframework.boot:spring-boot-autoconfigure:2.7.18."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #2618

This PR records `org.springframework.boot:spring-boot-starter-aop` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published JAR for org.springframework.boot:spring-boot-starter-aop:2.7.18 contains only META-INF files and no JVM class files; it is a dependency starter whose runtime classes are supplied by its dependencies.

Replacement guidance:
- Use class-bearing dependencies such as org.springframework:spring-aop:5.3.31, org.aspectj:aspectjweaver:1.9.7, and org.springframework.boot:spring-boot-autoconfigure:2.7.18.

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `f75f39a2b9bae57965c41f3161f74f0f43597ae9`

### Local CI Verification

- Status: `success`
- Commands run: 6
- Fixup attempts: 0
