### PR TITLE
[GenAI] Test fix for com.diffplug.spotless:spotless-lib-extra:4.3.0 using gpt-5.5

### DIFF
--- a/metadata/com.diffplug.spotless/spotless-lib-extra/4.3.0/reachability-metadata.json
+++ b/metadata/com.diffplug.spotless/spotless-lib-extra/4.3.0/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com.diffplug.spotless.extra.EclipseBasedStepBuilder"
+      },
+      "glob" : "com/diffplug/spotless/extra/eclipse_wtp_formatter/v4.21.0.lockfile"
+    }
+  ]
+}

--- a/metadata/com.diffplug.spotless/spotless-lib-extra/index.json
+++ b/metadata/com.diffplug.spotless/spotless-lib-extra/index.json
@@ -17,6 +17,11 @@
   },
   {
     "metadata-version" : "4.3.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/diffplug/spotless/spotless-lib-extra/$version$/spotless-lib-extra-$version$-sources.jar",
+    "repository-url" : "https://github.com/diffplug/spotless",
+    "test-code-url" : "https://github.com/diffplug/spotless/tree/lib/$version$/lib-extra/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/diffplug/spotless/spotless-lib-extra/$version$/spotless-lib-extra-$version$-javadoc.jar",
+    "description" : "Spotless Lib Extra provides optional formatter steps and support classes for Spotless, including Eclipse-based Java, C/C++, Groovy, WTP formatting, git ratcheting, and diff integration helpers. Spotless integrations use it to apply those additional formatter capabilities while keeping the core spotless-lib artifact smaller.",
     "tested-versions" : [
       "4.3.0"
     ],

--- a/metadata/com.diffplug.spotless/spotless-lib-extra/index.json
+++ b/metadata/com.diffplug.spotless/spotless-lib-extra/index.json
@@ -16,6 +16,16 @@
     ]
   },
   {
+    "metadata-version" : "4.3.0",
+    "tested-versions" : [
+      "4.3.0"
+    ],
+    "allowed-packages" : [
+      "com.diffplug.spotless.extra",
+      "com.diffplug.spotless"
+    ]
+  },
+  {
     "metadata-version" : "2.45.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/com/diffplug/spotless/spotless-lib-extra/$version$/spotless-lib-extra-$version$-sources.jar",
     "repository-url" : "https://github.com/diffplug/spotless",

--- a/stats/com.diffplug.spotless/spotless-lib-extra/4.3.0/execution-metrics.json
+++ b/stats/com.diffplug.spotless/spotless-lib-extra/4.3.0/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_javac_fail:2026-05-09": {
+    "timestamp": "2026-05-09T15:20:11.496539Z",
+    "library": "com.diffplug.spotless:spotless-lib-extra:4.3.0",
+    "starting_commit": "d60e4a02004acbf38d9e06a7a6a1ffacab30d342",
+    "ending_commit": "0ee576b05098df98fd256db9ab16cbdf427479b2",
+    "previous_library": "com.diffplug.spotless:spotless-lib-extra:3.0.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.3.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 24,
+            "totalCalls": 24
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 25,
+        "totalCalls": 25
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1163,
+          "missed": 3626,
+          "ratio": 0.242848,
+          "total": 4789
+        },
+        "line": {
+          "covered": 206,
+          "missed": 862,
+          "ratio": 0.192884,
+          "total": 1068
+        },
+        "method": {
+          "covered": 64,
+          "missed": 174,
+          "ratio": 0.268908,
+          "total": 238
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.0.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 24,
+            "totalCalls": 24
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 25,
+        "totalCalls": 25
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1185,
+          "missed": 3464,
+          "ratio": 0.254894,
+          "total": 4649
+        },
+        "line": {
+          "covered": 208,
+          "missed": 824,
+          "ratio": 0.20155,
+          "total": 1032
+        },
+        "method": {
+          "covered": 64,
+          "missed": 161,
+          "ratio": 0.284444,
+          "total": 225
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 30349,
+      "cached_input_tokens_used": 216064,
+      "output_tokens_used": 4048,
+      "iterations": 1,
+      "cost_usd": 0.2294,
+      "tested_library_loc": 206,
+      "metadata_entries": 1,
+      "test_only_metadata_entries": 3,
+      "previous_library_metadata_entries": 47,
+      "previous_library_test_only_metadata_entries": 3,
+      "code_coverage_percent": 19.29,
+      "previous_library_coverage_percent": 20.16
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/src/test/java/com_diffplug_spotless/spotless_lib_extra/EclipseCdtFormatterStepTest.java",
+      "metadata_file": "metadata/com.diffplug.spotless/spotless-lib-extra/4.3.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.diffplug.spotless/spotless-lib-extra/4.3.0/stats.json
+++ b/stats/com.diffplug.spotless/spotless-lib-extra/4.3.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "4.3.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 24,
+          "totalCalls" : 24
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 25,
+      "totalCalls" : 25
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1163,
+        "missed" : 3626,
+        "ratio" : 0.242848,
+        "total" : 4789
+      },
+      "line" : {
+        "covered" : 206,
+        "missed" : 862,
+        "ratio" : 0.192884,
+        "total" : 1068
+      },
+      "method" : {
+        "covered" : 64,
+        "missed" : 174,
+        "ratio" : 0.268908,
+        "total" : 238
+      }
+    }
+  } ]
+}

--- a/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/.gitignore
+++ b/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/build.gradle
+++ b/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/build.gradle
@@ -1,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.diffplug.spotless:spotless-lib-extra:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+    binaries {
+        test {
+            buildArgs.add('--enable-url-protocols=jar')
+        }
+    }
+}

--- a/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/gradle.properties
+++ b/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.diffplug.spotless:spotless-lib-extra:4.3.0
+library.version = 4.3.0
+metadata.dir = com.diffplug.spotless/spotless-lib-extra/4.3.0/

--- a/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/settings.gradle
+++ b/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.diffplug.spotless.spotless-lib-extra_tests'

--- a/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/src/test/java/com_diffplug_spotless/spotless_lib_extra/EclipseCdtFormatterStepTest.java
+++ b/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/src/test/java/com_diffplug_spotless/spotless_lib_extra/EclipseCdtFormatterStepTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_diffplug_spotless.spotless_lib_extra;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.Provisioner;
+import com.diffplug.spotless.extra.EquoBasedStepBuilder;
+import com.diffplug.spotless.extra.cpp.EclipseCdtFormatterStep;
+
+public class EclipseCdtFormatterStepTest {
+    private static final String CDT_FORMATTER_CLASS = "com/diffplug/spotless/extra/glue/cdt/"
+            + "EclipseCdtFormatterStepImpl.class";
+    private static final String STUB_CDT_FORMATTER_CLASS = """
+            yv66vgAAADQAGgoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+AQADKClW
+            CAAIAQAVaW50IG1haW4oKXtyZXR1cm4gMDt9CAAKAQAcaW50IG1haW4oKSB7CiAgICByZXR1cm4g
+            MDsKfQoADAANBwAODAAPABABABBqYXZhL2xhbmcvU3RyaW5nAQAHcmVwbGFjZQEARChMamF2YS9s
+            YW5nL0NoYXJTZXF1ZW5jZTtMamF2YS9sYW5nL0NoYXJTZXF1ZW5jZTspTGphdmEvbGFuZy9TdHJp
+            bmc7BwASAQBAY29tL2RpZmZwbHVnL3Nwb3RsZXNzL2V4dHJhL2dsdWUvY2R0L0VjbGlwc2VDZHRG
+            b3JtYXR0ZXJTdGVwSW1wbAEAGShMamF2YS91dGlsL1Byb3BlcnRpZXM7KVYBAARDb2RlAQAPTGlu
+            ZU51bWJlclRhYmxlAQAGZm9ybWF0AQAmKExqYXZhL2xhbmcvU3RyaW5nOylMamF2YS9sYW5nL1N0
+            cmluZzsBAApTb3VyY2VGaWxlAQAgRWNsaXBzZUNkdEZvcm1hdHRlclN0ZXBJbXBsLmphdmEAIQAR
+            AAIAAAAAAAIAAQAFABMAAQAUAAAAIQABAAIAAAAFKrcAAbEAAAABABUAAAAKAAIAAAAGAAQABwAB
+            ABYAFwABABQAAAAhAAMAAgAAAAkrEgcSCbYAC7AAAAABABUAAAAGAAEAAAAKAAEAGAAAAAIAGQ==
+            """;
+    private static final String ECLIPSE_DOWNLOADS = "https://download.eclipse.org/";
+
+    @TempDir
+    private Path tempDir;
+
+    @Test
+    void cdtFormatterUsesReflectiveConstructorAndFormatMethod() throws Exception {
+        try {
+            final String cdtVersion = EclipseCdtFormatterStep.defaultVersion();
+            final Path p2Repository = tempDir.resolve("p2");
+            createMinimalP2Repository(p2Repository, cdtVersion);
+
+            try (LocalP2Server p2Server = new LocalP2Server(p2Repository)) {
+                final EquoBasedStepBuilder builder = EclipseCdtFormatterStep.createBuilder(
+                        new StubFormatterProvisioner(tempDir));
+                builder.setVersion(cdtVersion);
+                builder.setP2Mirrors(Map.of(ECLIPSE_DOWNLOADS, p2Server.url()));
+                final FormatterStep formatter = builder.build();
+
+                final String formatted = formatter.format(
+                        "int main(){return 0;}", tempDir.resolve("main.cpp").toFile());
+
+                assertTrue(formatted.contains("int main() {"), formatted);
+                assertTrue(formatted.contains("return 0;"), formatted);
+            }
+        } catch (Throwable throwable) {
+            rethrowIfNotNativeImageDynamicClassLoadingError(throwable);
+        }
+    }
+
+    private static void createMinimalP2Repository(Path p2Repository, String cdtVersion) throws IOException {
+        writeContentXml(p2Repository.resolve("eclipse/updates/4.26/content.xml"));
+        writeContentXml(p2Repository.resolve("tools/cdt/releases/" + cdtVersion + "/content.xml"));
+    }
+
+    private static void writeContentXml(Path contentXml) throws IOException {
+        Files.createDirectories(contentXml.getParent());
+        Files.writeString(contentXml, """
+                <repository>
+                  <units size="5">
+                    <unit id="org.apache.felix.scr" version="1.0.0"/>
+                    <unit id="org.eclipse.equinox.event" version="1.0.0"/>
+                    <unit id="org.osgi.service.cm" version="1.0.0"/>
+                    <unit id="org.osgi.service.metatype" version="1.0.0"/>
+                    <unit id="org.eclipse.cdt.core" version="1.0.0"/>
+                  </units>
+                </repository>
+                """);
+    }
+
+    private static void rethrowIfNotNativeImageDynamicClassLoadingError(Throwable throwable) {
+        NativeImageDynamicClassLoadingSupport.rethrowIfNotNativeImageDynamicClassLoadingError(throwable);
+    }
+
+    private static final class LocalP2Server implements AutoCloseable {
+        private final Path root;
+        private final HttpServer server;
+        private final ExecutorService executor;
+
+        private LocalP2Server(Path root) throws IOException {
+            this.root = root;
+            this.server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            this.executor = Executors.newSingleThreadExecutor();
+            server.createContext("/", this::serve);
+            server.setExecutor(executor);
+            server.start();
+        }
+
+        private String url() {
+            return "http://127.0.0.1:" + server.getAddress().getPort() + "/";
+        }
+
+        private void serve(HttpExchange exchange) throws IOException {
+            final Path requested = root.resolve(exchange.getRequestURI().getPath().substring(1)).normalize();
+            if (!requested.startsWith(root) || !Files.isRegularFile(requested)) {
+                exchange.sendResponseHeaders(404, -1);
+                exchange.close();
+                return;
+            }
+
+            final byte[] content = Files.readAllBytes(requested);
+            exchange.sendResponseHeaders(200, content.length);
+            exchange.getResponseBody().write(content);
+            exchange.close();
+        }
+
+        @Override
+        public void close() {
+            server.stop(0);
+            executor.shutdownNow();
+        }
+    }
+
+    private static final class StubFormatterProvisioner implements Provisioner {
+        private final Path outputDirectory;
+
+        private StubFormatterProvisioner(Path outputDirectory) {
+            this.outputDirectory = outputDirectory;
+        }
+
+        @Override
+        public Set<File> provisionWithTransitives(boolean withTransitives, Collection<String> mavenCoordinates) {
+            return Collections.singleton(createStubFormatterJar());
+        }
+
+        private File createStubFormatterJar() {
+            final Path jar = outputDirectory.resolve("stub-eclipse-cdt-formatter.jar");
+            if (Files.isRegularFile(jar)) {
+                return jar.toFile();
+            }
+            try (JarOutputStream output = new JarOutputStream(Files.newOutputStream(jar))) {
+                output.putNextEntry(new JarEntry(CDT_FORMATTER_CLASS));
+                output.write(Base64.getMimeDecoder().decode(STUB_CDT_FORMATTER_CLASS));
+                output.closeEntry();
+            } catch (IOException exception) {
+                throw new UncheckedIOException("Unable to create Eclipse CDT formatter test JAR", exception);
+            }
+            return jar.toFile();
+        }
+    }
+}

--- a/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/src/test/java/com_diffplug_spotless/spotless_lib_extra/EclipseCdtFormatterStepTest.java
+++ b/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/src/test/java/com_diffplug_spotless/spotless_lib_extra/EclipseCdtFormatterStepTest.java
@@ -17,6 +17,7 @@ import java.nio.file.Path;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -63,8 +64,11 @@ public class EclipseCdtFormatterStepTest {
             createMinimalP2Repository(p2Repository, cdtVersion);
 
             try (LocalP2Server p2Server = new LocalP2Server(p2Repository)) {
+                final Provisioner provisioner = new StubFormatterProvisioner(tempDir);
                 final EquoBasedStepBuilder builder = EclipseCdtFormatterStep.createBuilder(
-                        new StubFormatterProvisioner(tempDir));
+                        provisioner,
+                        (modelWrapper, mavenProvisioner, cacheDirectory) -> List.copyOf(
+                                mavenProvisioner.provisionWithTransitives(false, Collections.emptyList())));
                 builder.setVersion(cdtVersion);
                 builder.setP2Mirrors(Map.of(ECLIPSE_DOWNLOADS, p2Server.url()));
                 final FormatterStep formatter = builder.build();

--- a/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/src/test/java/com_diffplug_spotless/spotless_lib_extra/EclipseJdtFormatterStepTest.java
+++ b/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/src/test/java/com_diffplug_spotless/spotless_lib_extra/EclipseJdtFormatterStepTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_diffplug_spotless.spotless_lib_extra;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.Provisioner;
+import com.diffplug.spotless.extra.EquoBasedStepBuilder;
+import com.diffplug.spotless.extra.java.EclipseJdtFormatterStep;
+
+public class EclipseJdtFormatterStepTest {
+    private static final String JDT_FORMATTER_CLASS = "com/diffplug/spotless/extra/glue/jdt/"
+            + "EclipseJdtFormatterStepImpl.class";
+    private static final String STUB_JDT_FORMATTER_CLASS = """
+            yv66vgAAADQAHAoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+AQADKClW
+            CAAIAQAuY2xhc3MgRGVtb3t2b2lkIHJ1bigpe1N5c3RlbS5vdXQucHJpbnRsbigxKTt9fQgACgEA
+            RWNsYXNzIERlbW8gewogICAgdm9pZCBydW4oKSB7CiAgICAgICAgU3lzdGVtLm91dC5wcmludGxu
+            KDEpOwogICAgfQp9CgoADAANBwAODAAPABABABBqYXZhL2xhbmcvU3RyaW5nAQAHcmVwbGFjZQEA
+            RChMamF2YS9sYW5nL0NoYXJTZXF1ZW5jZTtMamF2YS9sYW5nL0NoYXJTZXF1ZW5jZTspTGphdmEv
+            bGFuZy9TdHJpbmc7BwASAQBAY29tL2RpZmZwbHVnL3Nwb3RsZXNzL2V4dHJhL2dsdWUvamR0L0Vj
+            bGlwc2VKZHRGb3JtYXR0ZXJTdGVwSW1wbAEAKChMamF2YS91dGlsL1Byb3BlcnRpZXM7TGphdmEv
+            dXRpbC9NYXA7KVYBAARDb2RlAQAPTGluZU51bWJlclRhYmxlAQAJU2lnbmF0dXJlAQBOKExqYXZh
+            L3V0aWwvUHJvcGVydGllcztMamF2YS91dGlsL01hcDxMamF2YS9sYW5nL1N0cmluZztMamF2YS9s
+            YW5nL1N0cmluZzs+OylWAQAGZm9ybWF0AQA0KExqYXZhL2xhbmcvU3RyaW5nO0xqYXZhL2lvL0Zp
+            bGU7KUxqYXZhL2xhbmcvU3RyaW5nOwEAClNvdXJjZUZpbGUBACBFY2xpcHNlSmR0Rm9ybWF0dGVy
+            U3RlcEltcGwuamF2YQAhABEAAgAAAAAAAgABAAUAEwACABQAAAAdAAEAAwAAAAUqtwABsQAAAAEA
+            FQAAAAYAAQAAAAgAFgAAAAIAFwABABgAGQABABQAAAAhAAMAAwAAAAkrEgcSCbYAC7AAAAABABUA
+            AAAGAAEAAAALAAEAGgAAAAIAGw==
+            """;
+    private static final String ECLIPSE_DOWNLOADS = "https://download.eclipse.org/";
+
+    @TempDir
+    private Path tempDir;
+
+    @Test
+    void jdtFormatterUsesReflectiveConstructorAndFileAwareFormatMethod() throws Exception {
+        try {
+            final String jdtVersion = EclipseJdtFormatterStep.defaultVersion();
+            final Path p2Repository = tempDir.resolve("p2");
+            createMinimalP2Repository(p2Repository, jdtVersion);
+
+            try (LocalP2Server p2Server = new LocalP2Server(p2Repository)) {
+                final EquoBasedStepBuilder builder = EclipseJdtFormatterStep.createBuilder(
+                        new StubFormatterProvisioner(tempDir));
+                builder.setVersion(jdtVersion);
+                builder.setP2Mirrors(Map.of(ECLIPSE_DOWNLOADS, p2Server.url()));
+                final FormatterStep formatter = builder.build();
+
+                final String formatted = formatter.format(
+                        "class Demo{void run(){System.out.println(1);}}",
+                        tempDir.resolve("Demo.java").toFile());
+
+                assertTrue(formatted.contains("class Demo {"), formatted);
+                assertTrue(formatted.contains("System.out.println(1);"), formatted);
+            }
+        } catch (Throwable throwable) {
+            rethrowIfNotNativeImageDynamicClassLoadingError(throwable);
+        }
+    }
+
+    private static void createMinimalP2Repository(Path p2Repository, String jdtVersion) throws IOException {
+        writeContentXml(p2Repository.resolve("eclipse/updates/" + jdtVersion + "/content.xml"));
+    }
+
+    private static void writeContentXml(Path contentXml) throws IOException {
+        Files.createDirectories(contentXml.getParent());
+        Files.writeString(contentXml, """
+                <repository>
+                  <units size="5">
+                    <unit id="org.apache.felix.scr" version="1.0.0"/>
+                    <unit id="org.eclipse.equinox.event" version="1.0.0"/>
+                    <unit id="org.osgi.service.cm" version="1.0.0"/>
+                    <unit id="org.osgi.service.metatype" version="1.0.0"/>
+                    <unit id="org.eclipse.jdt.core" version="1.0.0"/>
+                  </units>
+                </repository>
+                """);
+    }
+
+    private static void rethrowIfNotNativeImageDynamicClassLoadingError(Throwable throwable) {
+        NativeImageDynamicClassLoadingSupport.rethrowIfNotNativeImageDynamicClassLoadingError(throwable);
+    }
+
+    private static final class LocalP2Server implements AutoCloseable {
+        private final Path root;
+        private final HttpServer server;
+        private final ExecutorService executor;
+
+        private LocalP2Server(Path root) throws IOException {
+            this.root = root;
+            this.server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            this.executor = Executors.newSingleThreadExecutor();
+            server.createContext("/", this::serve);
+            server.setExecutor(executor);
+            server.start();
+        }
+
+        private String url() {
+            return "http://127.0.0.1:" + server.getAddress().getPort() + "/";
+        }
+
+        private void serve(HttpExchange exchange) throws IOException {
+            final Path requested = root.resolve(exchange.getRequestURI().getPath().substring(1)).normalize();
+            if (!requested.startsWith(root) || !Files.isRegularFile(requested)) {
+                exchange.sendResponseHeaders(404, -1);
+                exchange.close();
+                return;
+            }
+
+            final byte[] content = Files.readAllBytes(requested);
+            exchange.sendResponseHeaders(200, content.length);
+            exchange.getResponseBody().write(content);
+            exchange.close();
+        }
+
+        @Override
+        public void close() {
+            server.stop(0);
+            executor.shutdownNow();
+        }
+    }
+
+    private static final class StubFormatterProvisioner implements Provisioner {
+        private final Path outputDirectory;
+
+        private StubFormatterProvisioner(Path outputDirectory) {
+            this.outputDirectory = outputDirectory;
+        }
+
+        @Override
+        public Set<File> provisionWithTransitives(boolean withTransitives, Collection<String> mavenCoordinates) {
+            return Collections.singleton(createStubFormatterJar());
+        }
+
+        private File createStubFormatterJar() {
+            final Path jar = outputDirectory.resolve("stub-eclipse-jdt-formatter.jar");
+            if (Files.isRegularFile(jar)) {
+                return jar.toFile();
+            }
+            try (JarOutputStream output = new JarOutputStream(Files.newOutputStream(jar))) {
+                output.putNextEntry(new JarEntry(JDT_FORMATTER_CLASS));
+                output.write(Base64.getMimeDecoder().decode(STUB_JDT_FORMATTER_CLASS));
+                output.closeEntry();
+            } catch (IOException exception) {
+                throw new UncheckedIOException("Unable to create Eclipse JDT formatter test JAR", exception);
+            }
+            return jar.toFile();
+        }
+    }
+}

--- a/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/src/test/java/com_diffplug_spotless/spotless_lib_extra/EclipseJdtFormatterStepTest.java
+++ b/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/src/test/java/com_diffplug_spotless/spotless_lib_extra/EclipseJdtFormatterStepTest.java
@@ -17,6 +17,7 @@ import java.nio.file.Path;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -67,8 +68,11 @@ public class EclipseJdtFormatterStepTest {
             createMinimalP2Repository(p2Repository, jdtVersion);
 
             try (LocalP2Server p2Server = new LocalP2Server(p2Repository)) {
+                final Provisioner provisioner = new StubFormatterProvisioner(tempDir);
                 final EquoBasedStepBuilder builder = EclipseJdtFormatterStep.createBuilder(
-                        new StubFormatterProvisioner(tempDir));
+                        provisioner,
+                        (modelWrapper, mavenProvisioner, cacheDirectory) -> List.copyOf(
+                                mavenProvisioner.provisionWithTransitives(false, Collections.emptyList())));
                 builder.setVersion(jdtVersion);
                 builder.setP2Mirrors(Map.of(ECLIPSE_DOWNLOADS, p2Server.url()));
                 final FormatterStep formatter = builder.build();

--- a/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/src/test/java/com_diffplug_spotless/spotless_lib_extra/EclipseWtpFormatterStepTest.java
+++ b/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/src/test/java/com_diffplug_spotless/spotless_lib_extra/EclipseWtpFormatterStepTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_diffplug_spotless.spotless_lib_extra;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.Provisioner;
+import com.diffplug.spotless.extra.EclipseBasedStepBuilder;
+import com.diffplug.spotless.extra.wtp.EclipseWtpFormatterStep;
+
+public class EclipseWtpFormatterStepTest {
+    private static final String CSS_FORMATTER_CLASS = "com/diffplug/spotless/extra/eclipse/wtp/"
+            + "EclipseCssFormatterStepImpl.class";
+    private static final String XML_FORMATTER_CLASS = "com/diffplug/spotless/extra/eclipse/wtp/"
+            + "EclipseXmlFormatterStepImpl.class";
+    private static final Map<String, String> STUB_FORMATTER_CLASSES = Map.of(
+            CSS_FORMATTER_CLASS,
+            """
+                    yv66vgAAADQAEAoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+
+                    AQADKClWBwAIAQBDY29tL2RpZmZwbHVnL3Nwb3RsZXNzL2V4dHJhL2VjbGlwc2Uv
+                    d3RwL0VjbGlwc2VDc3NGb3JtYXR0ZXJTdGVwSW1wbAEAGShMamF2YS91dGlsL1By
+                    b3BlcnRpZXM7KVYBAARDb2RlAQAPTGluZU51bWJlclRhYmxlAQAGZm9ybWF0AQAm
+                    KExqYXZhL2xhbmcvU3RyaW5nOylMamF2YS9sYW5nL1N0cmluZzsBAApTb3VyY2VG
+                    aWxlAQAgRWNsaXBzZUNzc0Zvcm1hdHRlclN0ZXBJbXBsLmphdmEAIQAHAAIAAAAA
+                    AAIAAQAFAAkAAQAKAAAAIQABAAIAAAAFKrcAAbEAAAABAAsAAAAKAAIAAAAGAAQA
+                    BwABAAwADQABAAoAAAAaAAEAAgAAAAIrsAAAAAEACwAAAAYAAQAAAAoAAQAOAAAA
+                    AgAP
+                    """,
+            XML_FORMATTER_CLASS,
+            """
+                    yv66vgAAADQAEAoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+
+                    AQADKClWBwAIAQBDY29tL2RpZmZwbHVnL3Nwb3RsZXNzL2V4dHJhL2VjbGlwc2Uv
+                    d3RwL0VjbGlwc2VYbWxGb3JtYXR0ZXJTdGVwSW1wbAEAGShMamF2YS91dGlsL1By
+                    b3BlcnRpZXM7KVYBAARDb2RlAQAPTGluZU51bWJlclRhYmxlAQAGZm9ybWF0AQA4
+                    KExqYXZhL2xhbmcvU3RyaW5nO0xqYXZhL2xhbmcvU3RyaW5nOylMamF2YS9sYW5n
+                    L1N0cmluZzsBAApTb3VyY2VGaWxlAQAgRWNsaXBzZVhtbEZvcm1hdHRlclN0ZXBJ
+                    bXBsLmphdmEAIQAHAAIAAAAAAAIAAQAFAAkAAQAKAAAAIQABAAIAAAAFKrcAAbEA
+                    AAABAAsAAAAKAAIAAAAGAAQABwABAAwADQABAAoAAAAaAAEAAwAAAAIrsAAAAAEA
+                    CwAAAAYAAQAAAAoAAQAOAAAAAgAP
+                    """);
+
+    @TempDir
+    private Path tempDir;
+
+    @Test
+    void cssFormatterUsesReflectiveConstructorAndFormatMethod() throws Exception {
+        try {
+            final Path cssFile = tempDir.resolve("style.css");
+            Files.writeString(cssFile, "a { color: red; }");
+
+            final String formatted = formatter(EclipseWtpFormatterStep.CSS).format("a{color:red;}", cssFile.toFile());
+
+            assertTrue(formatted.contains("color"), formatted);
+            assertTrue(formatted.contains("red"), formatted);
+        } catch (Throwable throwable) {
+            rethrowIfNotNativeImageDynamicClassLoadingError(throwable);
+        }
+    }
+
+    @Test
+    void xmlFormatterUsesReflectiveConstructorAndFileAwareFormatMethod() throws Exception {
+        try {
+            final Path xmlFile = tempDir.resolve("document.xml");
+            Files.writeString(xmlFile, "<root><child/></root>");
+
+            final String formatted = formatter(EclipseWtpFormatterStep.XML)
+                    .format("<root><child/></root>", xmlFile.toFile());
+
+            assertTrue(formatted.contains("<root"), formatted);
+            assertTrue(formatted.contains("child"), formatted);
+        } catch (Throwable throwable) {
+            rethrowIfNotNativeImageDynamicClassLoadingError(throwable);
+        }
+    }
+
+    private FormatterStep formatter(EclipseWtpFormatterStep formatterStep) {
+        final EclipseBasedStepBuilder builder = formatterStep.createBuilder(new StubFormatterProvisioner(tempDir));
+        builder.setVersion(EclipseWtpFormatterStep.defaultVersion());
+        return builder.build();
+    }
+
+    private static void rethrowIfNotNativeImageDynamicClassLoadingError(Throwable throwable) {
+        NativeImageDynamicClassLoadingSupport.rethrowIfNotNativeImageDynamicClassLoadingError(throwable);
+    }
+
+    private static final class StubFormatterProvisioner implements Provisioner {
+        private final Path outputDirectory;
+
+        private StubFormatterProvisioner(Path outputDirectory) {
+            this.outputDirectory = outputDirectory;
+        }
+
+        @Override
+        public Set<File> provisionWithTransitives(boolean withTransitives, Collection<String> mavenCoordinates) {
+            return Collections.singleton(createStubFormatterJar());
+        }
+
+        private File createStubFormatterJar() {
+            final Path jar = outputDirectory.resolve("stub-eclipse-wtp-formatters.jar");
+            if (Files.isRegularFile(jar)) {
+                return jar.toFile();
+            }
+            try (JarOutputStream output = new JarOutputStream(Files.newOutputStream(jar))) {
+                for (Map.Entry<String, String> formatterClass : STUB_FORMATTER_CLASSES.entrySet()) {
+                    output.putNextEntry(new JarEntry(formatterClass.getKey()));
+                    output.write(Base64.getMimeDecoder().decode(formatterClass.getValue()));
+                    output.closeEntry();
+                }
+            } catch (IOException exception) {
+                throw new UncheckedIOException("Unable to create Eclipse WTP formatter test JAR", exception);
+            }
+            return jar.toFile();
+        }
+    }
+}

--- a/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/src/test/java/com_diffplug_spotless/spotless_lib_extra/GrEclipseFormatterStepTest.java
+++ b/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/src/test/java/com_diffplug_spotless/spotless_lib_extra/GrEclipseFormatterStepTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_diffplug_spotless.spotless_lib_extra;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.diffplug.spotless.FormatterStep;
+import com.diffplug.spotless.Provisioner;
+import com.diffplug.spotless.extra.EquoBasedStepBuilder;
+import com.diffplug.spotless.extra.groovy.GrEclipseFormatterStep;
+
+public class GrEclipseFormatterStepTest {
+    private static final String GROOVY_FORMATTER_CLASS = "com/diffplug/spotless/extra/glue/groovy/"
+            + "GrEclipseFormatterStepImpl.class";
+    private static final String STUB_GROOVY_FORMATTER_CLASS = """
+            yv66vgAAADQAGgoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+AQADKClW
+            CAAIAQAZZGVmIGdyZWV0KCl7cHJpbnRsbiAnaGknfQgACgEAIGRlZiBncmVldCgpIHsKICAgIHBy
+            aW50bG4gJ2hpJwp9CgAMAA0HAA4MAA8AEAEAEGphdmEvbGFuZy9TdHJpbmcBAAdyZXBsYWNlAQBE
+            KExqYXZhL2xhbmcvQ2hhclNlcXVlbmNlO0xqYXZhL2xhbmcvQ2hhclNlcXVlbmNlOylMamF2YS9s
+            YW5nL1N0cmluZzsHABIBAEJjb20vZGlmZnBsdWcvc3BvdGxlc3MvZXh0cmEvZ2x1ZS9ncm9vdnkv
+            R3JFY2xpcHNlRm9ybWF0dGVyU3RlcEltcGwBABkoTGphdmEvdXRpbC9Qcm9wZXJ0aWVzOylWAQAE
+            Q29kZQEAD0xpbmVOdW1iZXJUYWJsZQEABmZvcm1hdAEAJihMamF2YS9sYW5nL1N0cmluZzspTGph
+            dmEvbGFuZy9TdHJpbmc7AQAKU291cmNlRmlsZQEAH0dyRWNsaXBzZUZvcm1hdHRlclN0ZXBJbXBs
+            LmphdmEAIQARAAIAAAAAAAIAAQAFABMAAQAUAAAAIQABAAIAAAAFKrcAAbEAAAABABUAAAAKAAIA
+            AAAGAAQABwABABYAFwABABQAAAAhAAMAAgAAAAkrEgcSCbYAC7AAAAABABUAAAAGAAEAAAAKAAEA
+            GAAAAAIAGQ==
+            """;
+    private static final String ECLIPSE_DOWNLOADS = "https://download.eclipse.org/";
+    private static final String GROOVY_RELEASES = "https://groovy.jfrog.io/artifactory/plugins-release/";
+
+    @TempDir
+    private Path tempDir;
+
+    @Test
+    void groovyFormatterUsesReflectiveConstructorAndFormatMethod() throws Exception {
+        try {
+            final String eclipseVersion = GrEclipseFormatterStep.defaultVersion();
+            final Path p2Repository = tempDir.resolve("p2");
+            createMinimalP2Repository(p2Repository, eclipseVersion);
+
+            try (LocalP2Server p2Server = new LocalP2Server(p2Repository)) {
+                final EquoBasedStepBuilder builder = GrEclipseFormatterStep.createBuilder(
+                        new StubFormatterProvisioner(tempDir));
+                builder.setVersion(eclipseVersion);
+                builder.setP2Mirrors(Map.of(
+                        ECLIPSE_DOWNLOADS, p2Server.url(),
+                        GROOVY_RELEASES, p2Server.url()));
+                final FormatterStep formatter = builder.build();
+
+                final String formatted = formatter.format(
+                        "def greet(){println 'hi'}", tempDir.resolve("script.groovy").toFile());
+
+                assertTrue(formatted.contains("def greet() {"), formatted);
+                assertTrue(formatted.contains("println 'hi'"), formatted);
+            }
+        } catch (Throwable throwable) {
+            rethrowIfNotNativeImageDynamicClassLoadingError(throwable);
+        }
+    }
+
+    private static void createMinimalP2Repository(Path p2Repository, String eclipseVersion) throws IOException {
+        writeContentXml(p2Repository.resolve("eclipse/updates/" + eclipseVersion + "/content.xml"));
+        writeContentXml(p2Repository.resolve("org/codehaus/groovy/groovy-eclipse-integration/"
+                + groovyEclipseVersion(eclipseVersion) + "/e" + eclipseVersion + "/content.xml"));
+    }
+
+    private static String groovyEclipseVersion(String eclipseVersion) {
+        final int eclipseMinorVersion = Integer.parseInt(eclipseVersion.substring("4.".length()));
+        if (eclipseMinorVersion >= 28) {
+            return "5." + (eclipseMinorVersion - 28) + ".0";
+        }
+        if (eclipseMinorVersion >= 18) {
+            return "4." + (eclipseMinorVersion - 18) + ".0";
+        }
+        return "3." + (eclipseMinorVersion - 8) + ".0";
+    }
+
+    private static void writeContentXml(Path contentXml) throws IOException {
+        Files.createDirectories(contentXml.getParent());
+        Files.writeString(contentXml, """
+                <repository>
+                  <units size="8">
+                    <unit id="org.apache.felix.scr" version="1.0.0"/>
+                    <unit id="org.eclipse.equinox.event" version="1.0.0"/>
+                    <unit id="org.osgi.service.cm" version="1.0.0"/>
+                    <unit id="org.osgi.service.metatype" version="1.0.0"/>
+                    <unit id="org.codehaus.groovy.eclipse.refactoring" version="1.0.0"/>
+                    <unit id="org.codehaus.groovy.eclipse.core" version="1.0.0"/>
+                    <unit id="org.eclipse.jdt.groovy.core" version="1.0.0"/>
+                    <unit id="org.codehaus.groovy" version="1.0.0"/>
+                  </units>
+                </repository>
+                """);
+    }
+
+    private static void rethrowIfNotNativeImageDynamicClassLoadingError(Throwable throwable) {
+        NativeImageDynamicClassLoadingSupport.rethrowIfNotNativeImageDynamicClassLoadingError(throwable);
+    }
+
+    private static final class LocalP2Server implements AutoCloseable {
+        private final Path root;
+        private final HttpServer server;
+        private final ExecutorService executor;
+
+        private LocalP2Server(Path root) throws IOException {
+            this.root = root;
+            this.server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            this.executor = Executors.newSingleThreadExecutor();
+            server.createContext("/", this::serve);
+            server.setExecutor(executor);
+            server.start();
+        }
+
+        private String url() {
+            return "http://127.0.0.1:" + server.getAddress().getPort() + "/";
+        }
+
+        private void serve(HttpExchange exchange) throws IOException {
+            final Path requested = root.resolve(exchange.getRequestURI().getPath().substring(1)).normalize();
+            if (!requested.startsWith(root) || !Files.isRegularFile(requested)) {
+                exchange.sendResponseHeaders(404, -1);
+                exchange.close();
+                return;
+            }
+
+            final byte[] content = Files.readAllBytes(requested);
+            exchange.sendResponseHeaders(200, content.length);
+            exchange.getResponseBody().write(content);
+            exchange.close();
+        }
+
+        @Override
+        public void close() {
+            server.stop(0);
+            executor.shutdownNow();
+        }
+    }
+
+    private static final class StubFormatterProvisioner implements Provisioner {
+        private final Path outputDirectory;
+
+        private StubFormatterProvisioner(Path outputDirectory) {
+            this.outputDirectory = outputDirectory;
+        }
+
+        @Override
+        public Set<File> provisionWithTransitives(boolean withTransitives, Collection<String> mavenCoordinates) {
+            return Collections.singleton(createStubFormatterJar());
+        }
+
+        private File createStubFormatterJar() {
+            final Path jar = outputDirectory.resolve("stub-greclipse-formatter.jar");
+            if (Files.isRegularFile(jar)) {
+                return jar.toFile();
+            }
+            try (JarOutputStream output = new JarOutputStream(Files.newOutputStream(jar))) {
+                output.putNextEntry(new JarEntry(GROOVY_FORMATTER_CLASS));
+                output.write(Base64.getMimeDecoder().decode(STUB_GROOVY_FORMATTER_CLASS));
+                output.closeEntry();
+            } catch (IOException exception) {
+                throw new UncheckedIOException("Unable to create GrEclipse formatter test JAR", exception);
+            }
+            return jar.toFile();
+        }
+    }
+}

--- a/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/src/test/java/com_diffplug_spotless/spotless_lib_extra/GrEclipseFormatterStepTest.java
+++ b/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/src/test/java/com_diffplug_spotless/spotless_lib_extra/GrEclipseFormatterStepTest.java
@@ -17,6 +17,7 @@ import java.nio.file.Path;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -65,8 +66,11 @@ public class GrEclipseFormatterStepTest {
             createMinimalP2Repository(p2Repository, eclipseVersion);
 
             try (LocalP2Server p2Server = new LocalP2Server(p2Repository)) {
+                final Provisioner provisioner = new StubFormatterProvisioner(tempDir);
                 final EquoBasedStepBuilder builder = GrEclipseFormatterStep.createBuilder(
-                        new StubFormatterProvisioner(tempDir));
+                        provisioner,
+                        (modelWrapper, mavenProvisioner, cacheDirectory) -> List.copyOf(
+                                mavenProvisioner.provisionWithTransitives(false, Collections.emptyList())));
                 builder.setVersion(eclipseVersion);
                 builder.setP2Mirrors(Map.of(
                         ECLIPSE_DOWNLOADS, p2Server.url(),

--- a/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/src/test/java/com_diffplug_spotless/spotless_lib_extra/NativeImageDynamicClassLoadingSupport.java
+++ b/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/src/test/java/com_diffplug_spotless/spotless_lib_extra/NativeImageDynamicClassLoadingSupport.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_diffplug_spotless.spotless_lib_extra;
+
+import org.graalvm.internal.tck.NativeImageSupport;
+
+final class NativeImageDynamicClassLoadingSupport {
+    private NativeImageDynamicClassLoadingSupport() {
+    }
+
+    static void rethrowIfNotNativeImageDynamicClassLoadingError(Throwable throwable) {
+        if (!hasUnsupportedFeatureError(throwable) && !hasUnsupportedIsolatedClassLoadingFailure(throwable)) {
+            if (throwable instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            if (throwable instanceof Error error) {
+                throw error;
+            }
+            throw new AssertionError(throwable);
+        }
+    }
+
+    private static boolean hasUnsupportedFeatureError(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof Error error && NativeImageSupport.isUnsupportedFeatureError(error)) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private static boolean hasUnsupportedIsolatedClassLoadingFailure(Throwable throwable) {
+        if (!"runtime".equals(System.getProperty("org.graalvm.nativeimage.imagecode"))) {
+            return false;
+        }
+
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof ClassNotFoundException || current instanceof NoClassDefFoundError) {
+                String message = current.getMessage();
+                if (message != null && (message.startsWith("com.diffplug.spotless.extra.")
+                        || message.startsWith("org.eclipse.")
+                        || message.startsWith("org/eclipse/"))) {
+                    return true;
+                }
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+}

--- a/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,22 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com_diffplug_spotless.spotless_lib_extra.EclipseCdtFormatterStepTest"
+      },
+      "glob" : "META-INF/services/com.sun.net.httpserver.spi.HttpServerProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_diffplug_spotless.spotless_lib_extra.EclipseJdtFormatterStepTest"
+      },
+      "glob" : "META-INF/services/com.sun.net.httpserver.spi.HttpServerProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_diffplug_spotless.spotless_lib_extra.GrEclipseFormatterStepTest"
+      },
+      "glob" : "META-INF/services/com.sun.net.httpserver.spi.HttpServerProvider"
+    }
+  ]
+}

--- a/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/user-code-filter.json
+++ b/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.diffplug.spotless.extra.**"
+    },
+    {
+      "includeClasses" : "com_diffplug_spotless.spotless_lib_extra.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6661

This PR provides test fixes and new metadata for com.diffplug.spotless:spotless-lib-extra:4.3.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 30349
- Cached input tokens: 216064
- Output tokens: 4048
- Metadata entries: 1
- Test-only metadata entries: 3
- Iterations: 1
- Library coverage percentage: 19.29
- Previous library version metadata entries: 47
- Previous library version test-only metadata entries: 3
- Previous library version coverage percentage: 20.16

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `e95accdd2a07daabe521cd7ad09ff414ef3db458`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.diffplug.spotless:spotless-lib-extra:3.0.0: 25/25 covered calls (100.00%)
- com.diffplug.spotless:spotless-lib-extra:4.3.0: 25/25 covered calls (100.00%)

**Reflection:**
- com.diffplug.spotless:spotless-lib-extra:3.0.0: 24/24 covered calls (100.00%)
- com.diffplug.spotless:spotless-lib-extra:4.3.0: 24/24 covered calls (100.00%)

**Resources:**
- com.diffplug.spotless:spotless-lib-extra:3.0.0: 1/1 covered calls (100.00%)
- com.diffplug.spotless:spotless-lib-extra:4.3.0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.diffplug.spotless:spotless-lib-extra:3.0.0: 1185/4649 (25.49%)
- com.diffplug.spotless:spotless-lib-extra:4.3.0: 1163/4789 (24.28%)

**Line:**
- com.diffplug.spotless:spotless-lib-extra:3.0.0: 208/1032 (20.16%)
- com.diffplug.spotless:spotless-lib-extra:4.3.0: 206/1068 (19.29%)

**Method:**
- com.diffplug.spotless:spotless-lib-extra:3.0.0: 64/225 (28.44%)
- com.diffplug.spotless:spotless-lib-extra:4.3.0: 64/238 (26.89%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/com.diffplug.spotless/spotless-lib-extra/3.0.0/src/test/java/com_diffplug_spotless/spotless_lib_extra/EclipseCdtFormatterStepTest.java 2/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/src/test/java/com_diffplug_spotless/spotless_lib_extra/EclipseCdtFormatterStepTest.java
index 2ff7116c27..f219cfcaf8 100644
--- 1/tests/src/com.diffplug.spotless/spotless-lib-extra/3.0.0/src/test/java/com_diffplug_spotless/spotless_lib_extra/EclipseCdtFormatterStepTest.java
+++ 2/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/src/test/java/com_diffplug_spotless/spotless_lib_extra/EclipseCdtFormatterStepTest.java
@@ -17,6 +17,7 @@ import java.nio.file.Path;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -63,8 +64,11 @@ public class EclipseCdtFormatterStepTest {
             createMinimalP2Repository(p2Repository, cdtVersion);
 
             try (LocalP2Server p2Server = new LocalP2Server(p2Repository)) {
+                final Provisioner provisioner = new StubFormatterProvisioner(tempDir);
                 final EquoBasedStepBuilder builder = EclipseCdtFormatterStep.createBuilder(
-                        new StubFormatterProvisioner(tempDir));
+                        provisioner,
+                        (modelWrapper, mavenProvisioner, cacheDirectory) -> List.copyOf(
+                                mavenProvisioner.provisionWithTransitives(false, Collections.emptyList())));
                 builder.setVersion(cdtVersion);
                 builder.setP2Mirrors(Map.of(ECLIPSE_DOWNLOADS, p2Server.url()));
                 final FormatterStep formatter = builder.build();
diff --git 1/tests/src/com.diffplug.spotless/spotless-lib-extra/3.0.0/src/test/java/com_diffplug_spotless/spotless_lib_extra/EclipseJdtFormatterStepTest.java 2/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/src/test/java/com_diffplug_spotless/spotless_lib_extra/EclipseJdtFormatterStepTest.java
index 8eb7b21f67..bcb3cefc6f 100644
--- 1/tests/src/com.diffplug.spotless/spotless-lib-extra/3.0.0/src/test/java/com_diffplug_spotless/spotless_lib_extra/EclipseJdtFormatterStepTest.java
+++ 2/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/src/test/java/com_diffplug_spotless/spotless_lib_extra/EclipseJdtFormatterStepTest.java
@@ -17,6 +17,7 @@ import java.nio.file.Path;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -67,8 +68,11 @@ public class EclipseJdtFormatterStepTest {
             createMinimalP2Repository(p2Repository, jdtVersion);
 
             try (LocalP2Server p2Server = new LocalP2Server(p2Repository)) {
+                final Provisioner provisioner = new StubFormatterProvisioner(tempDir);
                 final EquoBasedStepBuilder builder = EclipseJdtFormatterStep.createBuilder(
-                        new StubFormatterProvisioner(tempDir));
+                        provisioner,
+                        (modelWrapper, mavenProvisioner, cacheDirectory) -> List.copyOf(
+                                mavenProvisioner.provisionWithTransitives(false, Collections.emptyList())));
                 builder.setVersion(jdtVersion);
                 builder.setP2Mirrors(Map.of(ECLIPSE_DOWNLOADS, p2Server.url()));
                 final FormatterStep formatter = builder.build();
diff --git 1/tests/src/com.diffplug.spotless/spotless-lib-extra/3.0.0/src/test/java/com_diffplug_spotless/spotless_lib_extra/GrEclipseFormatterStepTest.java 2/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/src/test/java/com_diffplug_spotless/spotless_lib_extra/GrEclipseFormatterStepTest.java
index 4f6fbeca8a..1e2dfe051f 100644
--- 1/tests/src/com.diffplug.spotless/spotless-lib-extra/3.0.0/src/test/java/com_diffplug_spotless/spotless_lib_extra/GrEclipseFormatterStepTest.java
+++ 2/tests/src/com.diffplug.spotless/spotless-lib-extra/4.3.0/src/test/java/com_diffplug_spotless/spotless_lib_extra/GrEclipseFormatterStepTest.java
@@ -17,6 +17,7 @@ import java.nio.file.Path;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -65,8 +66,11 @@ public class GrEclipseFormatterStepTest {
             createMinimalP2Repository(p2Repository, eclipseVersion);
 
             try (LocalP2Server p2Server = new LocalP2Server(p2Repository)) {
+                final Provisioner provisioner = new StubFormatterProvisioner(tempDir);
                 final EquoBasedStepBuilder builder = GrEclipseFormatterStep.createBuilder(
-                        new StubFormatterProvisioner(tempDir));
+                        provisioner,
+                        (modelWrapper, mavenProvisioner, cacheDirectory) -> List.copyOf(
+                                mavenProvisioner.provisionWithTransitives(false, Collections.emptyList())));
                 builder.setVersion(eclipseVersion);
                 builder.setP2Mirrors(Map.of(
                         ECLIPSE_DOWNLOADS, p2Server.url(),

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
