### PR TITLE
[GenAI] Mark org.springframework.boot:spring-boot-starter-data-jpa as not for Native Image

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-starter-data-jpa/index.json
+++ b/metadata/org.springframework.boot/spring-boot-starter-data-jpa/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published JAR for org.springframework.boot:spring-boot-starter-data-jpa:2.7.18 contains only META-INF files and no JVM class files; it is a dependency starter whose runtime classes are supplied by its dependencies.",
+    "replacement": "Use class-bearing dependencies such as org.springframework.data:spring-data-jpa:2.7.18, org.hibernate:hibernate-core:5.6.15.Final, and org.springframework.boot:spring-boot-autoconfigure:2.7.18."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #2645

This PR records `org.springframework.boot:spring-boot-starter-data-jpa` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published JAR for org.springframework.boot:spring-boot-starter-data-jpa:2.7.18 contains only META-INF files and no JVM class files; it is a dependency starter whose runtime classes are supplied by its dependencies.

Replacement guidance:
- Use class-bearing dependencies such as org.springframework.data:spring-data-jpa:2.7.18, org.hibernate:hibernate-core:5.6.15.Final, and org.springframework.boot:spring-boot-autoconfigure:2.7.18.

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `e95accdd2a07daabe521cd7ad09ff414ef3db458`

### Local CI Verification

- Status: `success`
- Commands run: 6
- Fixup attempts: 0
