### PR TITLE
[GenAI] Add support for org.apache.maven.doxia:doxia-sink-api:1.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.maven.doxia/doxia-sink-api/1.0/reachability-metadata.json
+++ b/metadata/org.apache.maven.doxia/doxia-sink-api/1.0/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.doxia.sink.Sink$1"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.doxia.sink.Sink$1"
+      },
+      "type": "org.apache.maven.doxia.sink.Sink"
+    }
+  ]
+}

--- a/metadata/org.apache.maven.doxia/doxia-sink-api/index.json
+++ b/metadata/org.apache.maven.doxia/doxia-sink-api/index.json
@@ -1,0 +1,18 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-sink-api/$version$/doxia-sink-api-$version$-sources.jar",
+    "repository-url" : "https://svn.apache.org/repos/asf/maven/doxia/doxia",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-sink-api/$version$/doxia-sink-api-$version$-javadoc.jar",
+    "description" : "Doxia Sink API defines Java interfaces for emitting document structure and content events into Apache Maven Doxia sinks. It lets parsers and generators write documents independently of a specific output format so Doxia modules can render markup into target formats.",
+    "tested-versions" : [
+      "1.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.maven.doxia.sink",
+      "org.codehaus.doxia.sink"
+    ]
+  }
+]

--- a/stats/org.apache.maven.doxia/doxia-sink-api/1.0/execution-metrics.json
+++ b/stats/org.apache.maven.doxia/doxia-sink-api/1.0/execution-metrics.json
@@ -1,0 +1,62 @@
+{
+  "add_new_library_support:2026-05-09": {
+    "timestamp": "2026-05-09T16:37:12.942804Z",
+    "library": "org.apache.maven.doxia:doxia-sink-api:1.0",
+    "starting_commit": "09ff5d48a1b3089472e3396589fa95014568667e",
+    "ending_commit": "cffaeee971c74e3409a58b915023154b47dda67a",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 10,
+          "missed": 1,
+          "ratio": 0.909091,
+          "total": 11
+        },
+        "line": {
+          "covered": 1,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 1
+        },
+        "method": {
+          "covered": 1,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 1
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 16973,
+      "cached_input_tokens_used": 175616,
+      "output_tokens_used": 2376,
+      "iterations": 1,
+      "cost_usd": 0.1591,
+      "generated_loc": 16,
+      "tested_library_loc": 1,
+      "metadata_entries": 2,
+      "code_coverage_percent": 100.0
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.maven.doxia/doxia-sink-api/1.0/src/test/java/org_apache_maven_doxia/doxia_sink_api/SinkAnonymous1Test.java",
+      "metadata_file": "metadata/org.apache.maven.doxia/doxia-sink-api/1.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.maven.doxia/doxia-sink-api/1.0/stats.json
+++ b/stats/org.apache.maven.doxia/doxia-sink-api/1.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "1.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 1,
+      "totalCalls" : 1
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 10,
+        "missed" : 1,
+        "ratio" : 0.909091,
+        "total" : 11
+      },
+      "line" : {
+        "covered" : 1,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 1
+      },
+      "method" : {
+        "covered" : 1,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 1
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.maven.doxia/doxia-sink-api/1.0/.gitignore
+++ b/tests/src/org.apache.maven.doxia/doxia-sink-api/1.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.maven.doxia/doxia-sink-api/1.0/build.gradle
+++ b/tests/src/org.apache.maven.doxia/doxia-sink-api/1.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.maven.doxia:doxia-sink-api:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.maven.doxia/doxia-sink-api/1.0/gradle.properties
+++ b/tests/src/org.apache.maven.doxia/doxia-sink-api/1.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.maven.doxia:doxia-sink-api:1.0
+library.version = 1.0
+metadata.dir = org.apache.maven.doxia/doxia-sink-api/1.0/

--- a/tests/src/org.apache.maven.doxia/doxia-sink-api/1.0/settings.gradle
+++ b/tests/src/org.apache.maven.doxia/doxia-sink-api/1.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.maven.doxia.doxia-sink-api_tests'

--- a/tests/src/org.apache.maven.doxia/doxia-sink-api/1.0/src/test/java/org_apache_maven_doxia/doxia_sink_api/Doxia_sink_apiTest.java
+++ b/tests/src/org.apache.maven.doxia/doxia-sink-api/1.0/src/test/java/org_apache_maven_doxia/doxia_sink_api/Doxia_sink_apiTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_doxia.doxia_sink_api;
+
+import org.junit.jupiter.api.Test;
+
+class Doxia_sink_apiTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.apache.maven.doxia/doxia-sink-api/1.0/src/test/java/org_apache_maven_doxia/doxia_sink_api/SinkAnonymous1Test.java
+++ b/tests/src/org.apache.maven.doxia/doxia-sink-api/1.0/src/test/java/org_apache_maven_doxia/doxia_sink_api/SinkAnonymous1Test.java
@@ -6,11 +6,14 @@
  */
 package org_apache_maven_doxia.doxia_sink_api;
 
+import org.apache.maven.doxia.sink.Sink;
 import org.junit.jupiter.api.Test;
 
-class Doxia_sink_apiTest {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SinkAnonymous1Test {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void roleUsesSinkClassName() {
+        assertEquals("org.apache.maven.doxia.sink.Sink", Sink.ROLE);
     }
 }

--- a/tests/src/org.apache.maven.doxia/doxia-sink-api/1.0/user-code-filter.json
+++ b/tests/src/org.apache.maven.doxia/doxia-sink-api/1.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.apache.maven.doxia.sink.**"
+    },
+    {
+      "includeClasses": "org.codehaus.doxia.sink.**"
+    }
+  ]
+}

--- a/tests/src/org.apache.maven.doxia/doxia-sink-api/1.0/user-code-filter.json
+++ b/tests/src/org.apache.maven.doxia/doxia-sink-api/1.0/user-code-filter.json
@@ -1,13 +1,16 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.apache.maven.doxia.sink.**"
+      "includeClasses" : "org.apache.maven.doxia.sink.**"
     },
     {
-      "includeClasses": "org.codehaus.doxia.sink.**"
+      "includeClasses" : "org.codehaus.doxia.sink.**"
+    },
+    {
+      "includeClasses" : "org_apache_maven_doxia.doxia_sink_api.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #2291

This PR introduces tests and metadata for org.apache.maven.doxia:doxia-sink-api:1.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 16973
- Cached input tokens: 175616
- Output tokens: 2376
- Metadata entries: 2
- Iterations: 1
- Library coverage percentage: 100.0
- Generated lines of code: 16
- Tested library lines of code: 1

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `e95accdd2a07daabe521cd7ad09ff414ef3db458`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 1/1 covered calls (100.00%)
- Reflection: 1/1 covered calls (100.00%)

Library coverage:
- Instruction: 10/11 (90.91%)
- Line: 1/1 (100.00%)
- Method: 1/1 (100.00%)

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
