### PR TITLE
[GenAI] Mark org.springframework.boot:spring-boot-starter-validation as not for Native Image

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-starter-validation/index.json
+++ b/metadata/org.springframework.boot/spring-boot-starter-validation/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published JAR for org.springframework.boot:spring-boot-starter-validation:3.4.3 contains only META-INF files and no JVM class files; it is a dependency starter whose runtime classes are supplied by its dependencies.",
+    "replacement": "Use class-bearing dependencies such as org.hibernate.validator:hibernate-validator:8.0.2.Final, org.apache.tomcat.embed:tomcat-embed-el:10.1.36, org.springframework.boot:spring-boot:3.4.3, and org.springframework.boot:spring-boot-autoconfigure:3.4.3."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #2630

This PR records `org.springframework.boot:spring-boot-starter-validation` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published JAR for org.springframework.boot:spring-boot-starter-validation:3.4.3 contains only META-INF files and no JVM class files; it is a dependency starter whose runtime classes are supplied by its dependencies.

Replacement guidance:
- Use class-bearing dependencies such as org.hibernate.validator:hibernate-validator:8.0.2.Final, org.apache.tomcat.embed:tomcat-embed-el:10.1.36, org.springframework.boot:spring-boot:3.4.3, and org.springframework.boot:spring-boot-autoconfigure:3.4.3.

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `f560fe5beb95859a6baa0851b0bc794624f3ac2c`

### Local CI Verification

- Status: `success`
- Commands run: 6
- Fixup attempts: 0
