### PR TITLE
[GenAI] Test fix for org.springframework:spring-aop:5.3.35 using gpt-5.5

### DIFF
--- a/metadata/org.springframework/spring-aop/5.3.35/reachability-metadata.json
+++ b/metadata/org.springframework/spring-aop/5.3.35/reachability-metadata.json
@@ -1,0 +1,347 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.AbstractAspectJAdvisorFactory"
+      },
+      "type" : "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.AbstractAspectJAdvisorFactory"
+      },
+      "type" : "org.slf4j.Logger"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.InstantiationModelAwarePointcutAdvisorImpl"
+      },
+      "type" : "org.springframework.aop.aspectj.annotation.InstantiationModelAwarePointcutAdvisorImpl",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.LazySingletonAspectInstanceFactoryDecorator"
+      },
+      "type" : "org.springframework.aop.aspectj.annotation.LazySingletonAspectInstanceFactoryDecorator",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.SingletonMetadataAwareAspectInstanceFactory"
+      },
+      "type" : "org.springframework.aop.aspectj.annotation.SingletonMetadataAwareAspectInstanceFactory",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.SingletonAspectInstanceFactory"
+      },
+      "type" : "org.springframework.aop.aspectj.SingletonAspectInstanceFactory",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.AspectMetadata"
+      },
+      "type" : "org.springframework.aop.aspectj.annotation.AspectMetadata",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.AspectMetadata"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.AspectMetadata"
+      },
+      "type" : {
+        "proxy" : [
+          "org.aspectj.lang.annotation.Aspect"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.AspectMetadata"
+      },
+      "type" : {
+        "proxy" : [
+          "org.aspectj.lang.annotation.Before"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.ReflectiveAspectJAdvisorFactory"
+      },
+      "type" : "org.springframework.aop.aspectj.annotation.ReflectiveAspectJAdvisorFactory",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.AbstractAspectJAdvisorFactory"
+      },
+      "type" : "org.aspectj.lang.annotation.Before"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.AbstractAspectJAdvisorFactory"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.Deprecated"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.AbstractAspectJAdvisorFactory"
+      },
+      "type" : {
+        "proxy" : [
+          "jdk.internal.vm.annotation.IntrinsicCandidate"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.AbstractAspectJAdvisorFactory"
+      },
+      "type" : "java.lang.annotation.ElementType[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.AbstractAspectJAdvisorFactory"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.AbstractAspectJAdvisorFactory"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Target"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.AbstractAspectJAdvisorFactory"
+      },
+      "type" : {
+        "proxy" : [
+          "org.aspectj.lang.annotation.Aspect"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.InstantiationModelAwarePointcutAdvisorImpl"
+      },
+      "type" : "org.springframework.aop.aspectj.AbstractAspectJAdvice",
+      "serializable" : true,
+      "methods" : [
+        {
+          "name" : "readObject",
+          "parameterTypes" : [
+            "java.io.ObjectInputStream"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.InstantiationModelAwarePointcutAdvisorImpl"
+      },
+      "type" : "org.springframework.aop.aspectj.AbstractAspectJAdvice"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.InstantiationModelAwarePointcutAdvisorImpl"
+      },
+      "type" : "org.springframework.aop.aspectj.AspectJMethodBeforeAdvice"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.InstantiationModelAwarePointcutAdvisorImpl"
+      },
+      "type" : "org.springframework.aop.TruePointcut",
+      "methods" : [
+        {
+          "name" : "readResolve",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.InstantiationModelAwarePointcutAdvisorImpl"
+      },
+      "type" : "java.lang.Object",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.AspectJExpressionPointcut"
+      },
+      "type" : "java.lang.Object",
+      "allPublicConstructors" : true,
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.AspectJExpressionPointcut"
+      },
+      "type" : "org.springframework.aop.support.AbstractExpressionPointcut",
+      "serializable" : true,
+      "fields" : [
+        {
+          "name" : "expression"
+        },
+        {
+          "name" : "location"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.AspectJExpressionPointcut"
+      },
+      "type" : "org.springframework.aop.aspectj.AspectJExpressionPointcut",
+      "fields" : [
+        {
+          "name" : "beanFactory"
+        },
+        {
+          "name" : "pointcutDeclarationScope"
+        },
+        {
+          "name" : "pointcutParameterNames"
+        },
+        {
+          "name" : "pointcutParameterTypes"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.AspectJExpressionPointcut"
+      },
+      "type" : "org.springframework.util.ConcurrentReferenceHashMap$Segment[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.framework.JdkDynamicAopProxy"
+      },
+      "type" : {
+        "proxy" : [
+          "org.springframework.aop.SpringProxy",
+          "org.springframework.aop.framework.Advised",
+          "org.springframework.core.DecoratingProxy"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.ReflectiveAspectJAdvisorFactory"
+      },
+      "type" : "java.io.Serializable"
+    }
+  ],
+  "serialization" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.InstantiationModelAwarePointcutAdvisorImpl"
+      },
+      "type" : "org.springframework.aop.aspectj.AspectJMethodBeforeAdvice"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.InstantiationModelAwarePointcutAdvisorImpl"
+      },
+      "type" : "org.springframework.aop.TruePointcut"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.InstantiationModelAwarePointcutAdvisorImpl"
+      },
+      "type" : "org.springframework.aop.aspectj.annotation.InstantiationModelAwarePointcutAdvisorImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.AspectJExpressionPointcut"
+      },
+      "type" : "org.springframework.aop.support.AbstractExpressionPointcut"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.AspectJExpressionPointcut"
+      },
+      "type" : "org.springframework.aop.aspectj.AspectJExpressionPointcut"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.LazySingletonAspectInstanceFactoryDecorator"
+      },
+      "type" : "org.springframework.aop.aspectj.annotation.LazySingletonAspectInstanceFactoryDecorator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.SingletonMetadataAwareAspectInstanceFactory"
+      },
+      "type" : "org.springframework.aop.aspectj.annotation.SingletonMetadataAwareAspectInstanceFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.SingletonAspectInstanceFactory"
+      },
+      "type" : "org.springframework.aop.aspectj.SingletonAspectInstanceFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.AspectMetadata"
+      },
+      "type" : "org.springframework.aop.aspectj.annotation.AspectMetadata"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.ReflectiveAspectJAdvisorFactory"
+      },
+      "type" : "org.springframework.aop.aspectj.annotation.ReflectiveAspectJAdvisorFactory"
+    }
+  ]
+}

--- a/metadata/org.springframework/spring-aop/index.json
+++ b/metadata/org.springframework/spring-aop/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "5.3.35",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/spring-aop/$version$/spring-aop-$version$-sources.jar",
+    "repository-url" : "https://github.com/spring-projects/spring-framework",
+    "test-code-url" : "https://github.com/spring-projects/spring-framework/tree/v$version$/spring-aop/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/springframework/spring-aop/$version$/spring-aop-$version$-javadoc.jar",
+    "description" : "Spring AOP provides Spring Framework's proxy-based aspect-oriented programming support for applying advice to Spring bean method executions. It integrates AOP with the Spring IoC container and supports @AspectJ-style or schema-based configuration for cross-cutting concerns such as transactions, logging, caching, and security.",
     "tested-versions" : [
       "5.3.35"
     ],

--- a/metadata/org.springframework/spring-aop/index.json
+++ b/metadata/org.springframework/spring-aop/index.json
@@ -1,6 +1,16 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "5.3.35",
+    "tested-versions" : [
+      "5.3.35"
+    ],
+    "allowed-packages" : [
+      "org.aopalliance",
+      "org.springframework.aop"
+    ]
+  },
+  {
     "metadata-version" : "5.3.15",
     "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/spring-aop/$version$/spring-aop-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-framework",

--- a/stats/org.springframework/spring-aop/5.3.35/execution-metrics.json
+++ b/stats/org.springframework/spring-aop/5.3.35/execution-metrics.json
@@ -1,0 +1,101 @@
+{
+  "fix_java_run_fail:2026-05-10": {
+    "timestamp": "2026-05-10T17:01:50.747694Z",
+    "library": "org.springframework:spring-aop:5.3.35",
+    "starting_commit": "9d974c3441068f116f6ba585c2f2a4c84583795c",
+    "ending_commit": "f6e8fc6ab53034f5ec5e1847d5c83addb4862eb2",
+    "previous_library": "org.springframework:spring-aop:5.3.15",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "5.3.35",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 21,
+            "totalCalls": 21
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 21,
+        "totalCalls": 21
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4458,
+          "missed": 19019,
+          "ratio": 0.189888,
+          "total": 23477
+        },
+        "line": {
+          "covered": 1109,
+          "missed": 4282,
+          "ratio": 0.205713,
+          "total": 5391
+        },
+        "method": {
+          "covered": 296,
+          "missed": 1092,
+          "ratio": 0.213256,
+          "total": 1388
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "5.3.15",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.863636,
+            "coveredCalls": 19,
+            "totalCalls": 22
+          }
+        },
+        "coverageRatio": 0.863636,
+        "coveredCalls": 19,
+        "totalCalls": 22
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4502,
+          "missed": 18968,
+          "ratio": 0.191819,
+          "total": 23470
+        },
+        "line": {
+          "covered": 1111,
+          "missed": 4274,
+          "ratio": 0.206314,
+          "total": 5385
+        },
+        "method": {
+          "covered": 295,
+          "missed": 1089,
+          "ratio": 0.21315,
+          "total": 1384
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 50952,
+      "cached_input_tokens_used": 768000,
+      "output_tokens_used": 9551,
+      "iterations": 2,
+      "cost_usd": 0.6705,
+      "tested_library_loc": 1109,
+      "metadata_entries": 50,
+      "test_only_metadata_entries": 15,
+      "previous_library_metadata_entries": 50,
+      "previous_library_test_only_metadata_entries": 15,
+      "code_coverage_percent": 20.57,
+      "previous_library_coverage_percent": 20.63
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/ThrowsAdviceInterceptorTest.java",
+      "metadata_file": "metadata/org.springframework/spring-aop/5.3.35/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.springframework/spring-aop/5.3.35/stats.json
+++ b/stats/org.springframework/spring-aop/5.3.35/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "5.3.35",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 21,
+          "totalCalls" : 21
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 21,
+      "totalCalls" : 21
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 4458,
+        "missed" : 19019,
+        "ratio" : 0.189888,
+        "total" : 23477
+      },
+      "line" : {
+        "covered" : 1109,
+        "missed" : 4282,
+        "ratio" : 0.205713,
+        "total" : 5391
+      },
+      "method" : {
+        "covered" : 296,
+        "missed" : 1092,
+        "ratio" : 0.213256,
+        "total" : 1388
+      }
+    }
+  } ]
+}

--- a/tests/src/org.springframework/spring-aop/5.3.35/.gitignore
+++ b/tests/src/org.springframework/spring-aop/5.3.35/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.springframework/spring-aop/5.3.35/build.gradle
+++ b/tests/src/org.springframework/spring-aop/5.3.35/build.gradle
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.springframework:spring-aop:$libraryVersion"
+    testImplementation 'org.aspectj:aspectjrt:1.9.6'
+    testImplementation 'org.aspectj:aspectjweaver:1.9.6'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-aop/5.3.35/build.gradle
+++ b/tests/src/org.springframework/spring-aop/5.3.35/build.gradle
@@ -17,7 +17,21 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
+tasks.withType(Test).configureEach {
+    systemProperty "spring.objenesis.ignore", "true"
+}
+
+tasks.named("nativeTest") {
+    runtimeArgs.add("-Dspring.objenesis.ignore=true")
+}
+
 graalvmNative {
+    binaries {
+        test {
+            buildArgs.add("-Dspring.objenesis.ignore=true")
+        }
+    }
+
     agent {
         defaultMode = "conditional"
         modes {

--- a/tests/src/org.springframework/spring-aop/5.3.35/gradle.properties
+++ b/tests/src/org.springframework/spring-aop/5.3.35/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.springframework:spring-aop:5.3.35
+library.version = 5.3.35
+metadata.dir = org.springframework/spring-aop/5.3.35/

--- a/tests/src/org.springframework/spring-aop/5.3.35/settings.gradle
+++ b/tests/src/org.springframework/spring-aop/5.3.35/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.springframework.spring-aop_tests'

--- a/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/AbstractAspectJAdviceTest.java
+++ b/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/AbstractAspectJAdviceTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aop.Advisor;
+import org.springframework.aop.aspectj.annotation.ReflectiveAspectJAdvisorFactory;
+import org.springframework.aop.aspectj.annotation.SingletonMetadataAwareAspectInstanceFactory;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.aop.interceptor.ExposeInvocationInterceptor;
+
+public class AbstractAspectJAdviceTest {
+
+    @Test
+    void invokesAspectJAdviceMethodThroughSpringProxy() {
+        CountingAspect aspect = new CountingAspect();
+        GreetingService proxy = createProxy(new DefaultGreetingService(), aspect);
+
+        String greeting = proxy.greet("GraalVM");
+
+        assertThat(greeting).isEqualTo("Hello GraalVM");
+        assertThat(aspect.invocations()).isEqualTo(1);
+    }
+
+    private static GreetingService createProxy(GreetingService target, CountingAspect aspect) {
+        ReflectiveAspectJAdvisorFactory advisorFactory = new ReflectiveAspectJAdvisorFactory();
+        SingletonMetadataAwareAspectInstanceFactory aspectInstanceFactory =
+                new SingletonMetadataAwareAspectInstanceFactory(aspect, "countingAspect");
+        List<Advisor> advisors = advisorFactory.getAdvisors(aspectInstanceFactory);
+        assertThat(advisors).hasSize(1);
+
+        ProxyFactory proxyFactory = new ProxyFactory(target);
+        proxyFactory.addAdvisor(ExposeInvocationInterceptor.ADVISOR);
+        advisors.forEach(proxyFactory::addAdvisor);
+        return (GreetingService) proxyFactory.getProxy();
+    }
+
+    public interface GreetingService {
+        String greet(String name);
+    }
+
+    public static class DefaultGreetingService implements GreetingService {
+        @Override
+        public String greet(String name) {
+            return "Hello " + name;
+        }
+    }
+
+    @Aspect
+    public static class CountingAspect {
+        private final AtomicInteger invocations = new AtomicInteger();
+
+        @Before("execution(* greet(..))")
+        public void beforeInvocation() {
+            this.invocations.incrementAndGet();
+        }
+
+        int invocations() {
+            return this.invocations.get();
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/AbstractAspectJAdvisorFactoryTest.java
+++ b/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/AbstractAspectJAdvisorFactoryTest.java
@@ -16,10 +16,19 @@ import org.springframework.aop.aspectj.annotation.ReflectiveAspectJAdvisorFactor
 public class AbstractAspectJAdvisorFactoryTest {
 
     @Test
-    void rejectsAspectWithAjcCompiledMarkerField() {
+    void acceptsAnnotationStyleAspectWithAjcCompiledMarkerField() {
         ReflectiveAspectJAdvisorFactory factory = new ReflectiveAspectJAdvisorFactory();
 
         boolean aspect = factory.isAspect(AjcCompiledMarkerAspect.class);
+
+        assertThat(aspect).isTrue();
+    }
+
+    @Test
+    void rejectsClassWithoutAspectAnnotation() {
+        ReflectiveAspectJAdvisorFactory factory = new ReflectiveAspectJAdvisorFactory();
+
+        boolean aspect = factory.isAspect(NonAspect.class);
 
         assertThat(aspect).isFalse();
     }
@@ -40,5 +49,8 @@ public class AbstractAspectJAdvisorFactoryTest {
 
     @Aspect
     public static class AnnotationStyleAspect {
+    }
+
+    public static class NonAspect {
     }
 }

--- a/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/AbstractAspectJAdvisorFactoryTest.java
+++ b/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/AbstractAspectJAdvisorFactoryTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.aspectj.lang.annotation.Aspect;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aop.aspectj.annotation.ReflectiveAspectJAdvisorFactory;
+
+public class AbstractAspectJAdvisorFactoryTest {
+
+    @Test
+    void rejectsAspectWithAjcCompiledMarkerField() {
+        ReflectiveAspectJAdvisorFactory factory = new ReflectiveAspectJAdvisorFactory();
+
+        boolean aspect = factory.isAspect(AjcCompiledMarkerAspect.class);
+
+        assertThat(aspect).isFalse();
+    }
+
+    @Test
+    void acceptsAnnotationStyleAspectWithoutAjcCompiledMarkerField() {
+        ReflectiveAspectJAdvisorFactory factory = new ReflectiveAspectJAdvisorFactory();
+
+        boolean aspect = factory.isAspect(AnnotationStyleAspect.class);
+
+        assertThat(aspect).isTrue();
+    }
+
+    @Aspect
+    public static class AjcCompiledMarkerAspect {
+        private Object ajc$perSingletonInstance;
+    }
+
+    @Aspect
+    public static class AnnotationStyleAspect {
+    }
+}

--- a/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/AopProxyUtilsTest.java
+++ b/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/AopProxyUtilsTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aop.framework.ProxyFactory;
+
+public class AopProxyUtilsTest {
+    @Test
+    void jdkProxyAdaptsObjectArrayVarargsToDeclaredArrayType() throws Throwable {
+        RecordingVarargsService target = new RecordingVarargsService();
+        VarargsService proxy = createJdkProxy(target);
+        Method method = VarargsService.class.getMethod("join", String.class, String[].class);
+        InvocationHandler invocationHandler = Proxy.getInvocationHandler(proxy);
+
+        Object result = invocationHandler.invoke(proxy, method, new Object[] {", ", new Object[] {"spring", "aop"}});
+
+        assertThat(result).isEqualTo("spring, aop");
+        assertThat(target.lastValuesType).isEqualTo(String[].class);
+    }
+
+    private static VarargsService createJdkProxy(VarargsService target) {
+        ProxyFactory proxyFactory = new ProxyFactory(target);
+        proxyFactory.setInterfaces(VarargsService.class);
+        return (VarargsService) proxyFactory.getProxy();
+    }
+
+    public interface VarargsService {
+        String join(String delimiter, String... values);
+    }
+
+    public static class RecordingVarargsService implements VarargsService {
+        private Class<?> lastValuesType;
+
+        @Override
+        public String join(String delimiter, String... values) {
+            this.lastValuesType = values.getClass();
+            return String.join(delimiter, values);
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/CglibAopProxyTest.java
+++ b/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/CglibAopProxyTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aop.framework.ProxyFactory;
+
+public class CglibAopProxyTest {
+    @Test
+    void frozenStaticCglibProxyUsesFixedCallbackChain() {
+        AtomicInteger invocationCount = new AtomicInteger();
+        ProxyFactory proxyFactory = new ProxyFactory(new GreetingTarget());
+        proxyFactory.setProxyTargetClass(true);
+        proxyFactory.addAdvice(countingInterceptor(invocationCount));
+        proxyFactory.setFrozen(true);
+
+        GreetingService proxy = (GreetingService) proxyFactory.getProxy();
+
+        assertThat(proxy.greet("Spring")).isEqualTo("Hello Spring");
+        assertThat(invocationCount).hasValue(1);
+    }
+
+    private static MethodInterceptor countingInterceptor(AtomicInteger invocationCount) {
+        return invocation -> {
+            invocationCount.incrementAndGet();
+            return invocation.proceed();
+        };
+    }
+
+    public interface GreetingService {
+        String greet(String name);
+    }
+
+    public static class GreetingTarget implements GreetingService {
+        @Override
+        public String greet(String name) {
+            return "Hello " + name;
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/DelegatePerTargetObjectIntroductionInterceptorTest.java
+++ b/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/DelegatePerTargetObjectIntroductionInterceptorTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.aop.support.DefaultIntroductionAdvisor;
+import org.springframework.aop.support.DelegatePerTargetObjectIntroductionInterceptor;
+
+public class DelegatePerTargetObjectIntroductionInterceptorTest {
+    @Test
+    void createsSeparateDelegateForEachTargetObject() {
+        DelegatePerTargetObjectIntroductionInterceptor interceptor =
+                new DelegatePerTargetObjectIntroductionInterceptor(CountingMixin.class, CountingOperations.class);
+        DefaultIntroductionAdvisor advisor = new DefaultIntroductionAdvisor(interceptor, CountingOperations.class);
+
+        CountingOperations firstProxy = createProxy(new NamedServiceImpl("first"), advisor);
+        CountingOperations secondProxy = createProxy(new NamedServiceImpl("second"), advisor);
+
+        assertThat(firstProxy.incrementAndGet()).isEqualTo(1);
+        assertThat(firstProxy.incrementAndGet()).isEqualTo(2);
+        assertThat(secondProxy.incrementAndGet()).isEqualTo(1);
+        assertThat(firstProxy.currentValue()).isEqualTo(2);
+        assertThat(secondProxy.currentValue()).isEqualTo(1);
+    }
+
+    @Test
+    void returnsProxyWhenIntroducedMethodReturnsDelegateItself() {
+        DelegatePerTargetObjectIntroductionInterceptor interceptor =
+                new DelegatePerTargetObjectIntroductionInterceptor(CountingMixin.class, CountingOperations.class);
+        DefaultIntroductionAdvisor advisor = new DefaultIntroductionAdvisor(interceptor, CountingOperations.class);
+
+        CountingOperations proxy = createProxy(new NamedServiceImpl("self"), advisor);
+
+        assertThat(proxy.self()).isSameAs(proxy);
+    }
+
+    private static CountingOperations createProxy(NamedService target, DefaultIntroductionAdvisor advisor) {
+        ProxyFactory proxyFactory = new ProxyFactory(target);
+        proxyFactory.addAdvisor(advisor);
+        Object proxy = proxyFactory.getProxy();
+        assertThat(proxy).isInstanceOf(NamedService.class);
+        assertThat(((NamedService) proxy).name()).isEqualTo(target.name());
+        return (CountingOperations) proxy;
+    }
+
+    public interface NamedService {
+        String name();
+    }
+
+    public interface CountingOperations {
+        int incrementAndGet();
+
+        int currentValue();
+
+        CountingOperations self();
+    }
+
+    public static class NamedServiceImpl implements NamedService {
+        private final String name;
+
+        NamedServiceImpl(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String name() {
+            return this.name;
+        }
+    }
+
+    public static class CountingMixin implements CountingOperations {
+        private int value;
+
+        @Override
+        public int incrementAndGet() {
+            this.value++;
+            return this.value;
+        }
+
+        @Override
+        public int currentValue() {
+            return this.value;
+        }
+
+        @Override
+        public CountingOperations self() {
+            return this;
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/InstantiationModelAwarePointcutAdvisorImplTest.java
+++ b/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/InstantiationModelAwarePointcutAdvisorImplTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.List;
+
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aop.Advisor;
+import org.springframework.aop.aspectj.annotation.ReflectiveAspectJAdvisorFactory;
+import org.springframework.aop.aspectj.annotation.SingletonMetadataAwareAspectInstanceFactory;
+
+public class InstantiationModelAwarePointcutAdvisorImplTest {
+
+    @Test
+    void deserializesAdvisorAndRestoresAdviceMethod() throws Exception {
+        Advisor advisor = createAdvisor(new SerializableAspect());
+
+        Advisor deserializedAdvisor = serializeAndDeserialize(advisor);
+
+        assertThat(deserializedAdvisor).isNotSameAs(advisor);
+        assertThat(deserializedAdvisor.getAdvice()).isNotNull();
+        assertThat(deserializedAdvisor.toString()).contains("beforeInvocation");
+    }
+
+    private static Advisor createAdvisor(SerializableAspect aspect) {
+        ReflectiveAspectJAdvisorFactory advisorFactory = new ReflectiveAspectJAdvisorFactory();
+        SingletonMetadataAwareAspectInstanceFactory aspectInstanceFactory =
+                new SingletonMetadataAwareAspectInstanceFactory(aspect, "serializableAspect");
+        List<Advisor> advisors = advisorFactory.getAdvisors(aspectInstanceFactory);
+
+        assertThat(advisors).hasSize(1);
+        return advisors.get(0);
+    }
+
+    private static Advisor serializeAndDeserialize(Advisor advisor) throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (ObjectOutputStream objectOutput = new ObjectOutputStream(output)) {
+            objectOutput.writeObject(advisor);
+        }
+
+        ByteArrayInputStream input = new ByteArrayInputStream(output.toByteArray());
+        try (ObjectInputStream objectInput = new ObjectInputStream(input)) {
+            return (Advisor) objectInput.readObject();
+        }
+    }
+
+    @Aspect
+    public static class SerializableAspect implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        @Before("execution(* *(..))")
+        public void beforeInvocation() {
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/ObjenesisCglibAopProxyTest.java
+++ b/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/ObjenesisCglibAopProxyTest.java
@@ -31,10 +31,12 @@ public class ObjenesisCglibAopProxyTest {
         DefaultGreetingService target = new DefaultGreetingService();
         DefaultGreetingService.constructorInvocations.set(0);
 
-        GreetingService proxy = createProxy(DefaultGreetingService.class, target);
+        AopProxy aopProxy = createAopProxy(DefaultGreetingService.class, target);
+        GreetingService proxy = (GreetingService) aopProxy.getProxy();
 
         assertThat(proxy.greet("Spring")).isEqualTo("Hello Spring");
-        assertThat(DefaultGreetingService.constructorInvocations).hasValue(1);
+        assertThat(DefaultGreetingService.constructorInvocations)
+                .hasValue(isObjenesisCglibProxy(aopProxy) ? 1 : 0);
     }
 
     @Test
@@ -47,7 +49,8 @@ public class ObjenesisCglibAopProxyTest {
         GreetingService proxy = (GreetingService) aopProxy.getProxy();
 
         assertThat(proxy.greet("Spring")).isEqualTo("Hello Spring");
-        assertThat(ConstructorGreetingService.lastConstructedGreeting).isEqualTo("Proxy");
+        assertThat(ConstructorGreetingService.lastConstructedGreeting)
+                .isEqualTo(isObjenesisCglibProxy(aopProxy) ? "Proxy" : null);
     }
 
     private static GreetingService createProxy(Class<? extends GreetingService> targetClass, GreetingService target) {
@@ -73,7 +76,7 @@ public class ObjenesisCglibAopProxyTest {
     private static void configureConstructorArgumentsIfCglibProxy(
             AopProxy aopProxy, Object[] constructorArgs, Class<?>[] constructorArgTypes) {
         Class<?> proxyClass = aopProxy.getClass();
-        if (!proxyClass.getName().endsWith("ObjenesisCglibAopProxy")) {
+        if (!isObjenesisCglibProxy(aopProxy)) {
             return;
         }
         try {
@@ -95,6 +98,10 @@ public class ObjenesisCglibAopProxyTest {
             }
         }
         throw new NoSuchMethodException("setConstructorArguments");
+    }
+
+    private static boolean isObjenesisCglibProxy(AopProxy aopProxy) {
+        return aopProxy.getClass().getName().endsWith("ObjenesisCglibAopProxy");
     }
 
     public interface GreetingService {

--- a/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/ObjenesisCglibAopProxyTest.java
+++ b/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/ObjenesisCglibAopProxyTest.java
@@ -9,8 +9,8 @@ package org_springframework.spring_aop;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -26,27 +26,28 @@ public class ObjenesisCglibAopProxyTest {
         recordJdkProxyMetadataForNativeImageFallback();
     }
 
-    @AfterAll
-    static void restoreObjenesisProperty() {
-        System.clearProperty(SpringObjenesis.IGNORE_OBJENESIS_PROPERTY_NAME);
-    }
-
     @Test
     void cglibProxyFallsBackToDefaultConstructorWhenObjenesisIsIgnored() {
-        GreetingService proxy = createProxy(DefaultGreetingService.class, new DefaultGreetingService());
+        DefaultGreetingService target = new DefaultGreetingService();
+        DefaultGreetingService.constructorInvocations.set(0);
+
+        GreetingService proxy = createProxy(DefaultGreetingService.class, target);
 
         assertThat(proxy.greet("Spring")).isEqualTo("Hello Spring");
+        assertThat(DefaultGreetingService.constructorInvocations).hasValue(1);
     }
 
     @Test
     void cglibProxyFallsBackToMatchingConstructorWhenConstructorArgumentsAreConfigured() {
-        AopProxy aopProxy = createAopProxy(ConstructorGreetingService.class,
-                new ConstructorGreetingService("Hello"));
+        ConstructorGreetingService target = new ConstructorGreetingService("Hello");
+        ConstructorGreetingService.lastConstructedGreeting = null;
+        AopProxy aopProxy = createAopProxy(ConstructorGreetingService.class, target);
         configureConstructorArgumentsIfCglibProxy(aopProxy, new Object[] {"Proxy"}, new Class<?>[] {String.class});
 
         GreetingService proxy = (GreetingService) aopProxy.getProxy();
 
         assertThat(proxy.greet("Spring")).isEqualTo("Hello Spring");
+        assertThat(ConstructorGreetingService.lastConstructedGreeting).isEqualTo("Proxy");
     }
 
     private static GreetingService createProxy(Class<? extends GreetingService> targetClass, GreetingService target) {
@@ -101,7 +102,10 @@ public class ObjenesisCglibAopProxyTest {
     }
 
     public static class DefaultGreetingService implements GreetingService {
+        private static final AtomicInteger constructorInvocations = new AtomicInteger();
+
         public DefaultGreetingService() {
+            constructorInvocations.incrementAndGet();
         }
 
         @Override
@@ -111,9 +115,12 @@ public class ObjenesisCglibAopProxyTest {
     }
 
     public static class ConstructorGreetingService implements GreetingService {
+        private static String lastConstructedGreeting;
+
         private final String greeting;
 
         public ConstructorGreetingService(String greeting) {
+            lastConstructedGreeting = greeting;
             this.greeting = greeting;
         }
 

--- a/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/ObjenesisCglibAopProxyTest.java
+++ b/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/ObjenesisCglibAopProxyTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aop.framework.AdvisedSupport;
+import org.springframework.aop.framework.AopProxy;
+import org.springframework.aop.framework.DefaultAopProxyFactory;
+import org.springframework.objenesis.SpringObjenesis;
+
+public class ObjenesisCglibAopProxyTest {
+    @BeforeAll
+    static void prepareProxyCreationModes() {
+        System.setProperty(SpringObjenesis.IGNORE_OBJENESIS_PROPERTY_NAME, "true");
+        recordJdkProxyMetadataForNativeImageFallback();
+    }
+
+    @AfterAll
+    static void restoreObjenesisProperty() {
+        System.clearProperty(SpringObjenesis.IGNORE_OBJENESIS_PROPERTY_NAME);
+    }
+
+    @Test
+    void cglibProxyFallsBackToDefaultConstructorWhenObjenesisIsIgnored() {
+        GreetingService proxy = createProxy(DefaultGreetingService.class, new DefaultGreetingService());
+
+        assertThat(proxy.greet("Spring")).isEqualTo("Hello Spring");
+    }
+
+    @Test
+    void cglibProxyFallsBackToMatchingConstructorWhenConstructorArgumentsAreConfigured() {
+        AopProxy aopProxy = createAopProxy(ConstructorGreetingService.class,
+                new ConstructorGreetingService("Hello"));
+        configureConstructorArgumentsIfCglibProxy(aopProxy, new Object[] {"Proxy"}, new Class<?>[] {String.class});
+
+        GreetingService proxy = (GreetingService) aopProxy.getProxy();
+
+        assertThat(proxy.greet("Spring")).isEqualTo("Hello Spring");
+    }
+
+    private static GreetingService createProxy(Class<? extends GreetingService> targetClass, GreetingService target) {
+        return (GreetingService) createAopProxy(targetClass, target).getProxy();
+    }
+
+    private static AopProxy createAopProxy(Class<? extends GreetingService> targetClass, GreetingService target) {
+        AdvisedSupport config = new AdvisedSupport(GreetingService.class);
+        config.setTargetClass(targetClass);
+        config.setTarget(target);
+        config.setProxyTargetClass(true);
+        return new DefaultAopProxyFactory().createAopProxy(config);
+    }
+
+    private static void recordJdkProxyMetadataForNativeImageFallback() {
+        AdvisedSupport config = new AdvisedSupport(GreetingService.class);
+        config.setTarget(new DefaultGreetingService());
+        GreetingService proxy = (GreetingService) new DefaultAopProxyFactory().createAopProxy(config).getProxy();
+
+        assertThat(proxy.greet("Spring")).isEqualTo("Hello Spring");
+    }
+
+    private static void configureConstructorArgumentsIfCglibProxy(
+            AopProxy aopProxy, Object[] constructorArgs, Class<?>[] constructorArgTypes) {
+        Class<?> proxyClass = aopProxy.getClass();
+        if (!proxyClass.getName().endsWith("ObjenesisCglibAopProxy")) {
+            return;
+        }
+        try {
+            Method method = findSetConstructorArgumentsMethod(proxyClass);
+            method.setAccessible(true);
+            method.invoke(aopProxy, constructorArgs, constructorArgTypes);
+        } catch (ReflectiveOperationException ex) {
+            throw new IllegalStateException("Failed to configure CGLIB proxy constructor arguments", ex);
+        }
+    }
+
+    private static Method findSetConstructorArgumentsMethod(Class<?> proxyClass) throws NoSuchMethodException {
+        Class<?> currentClass = proxyClass;
+        while (currentClass != null) {
+            try {
+                return currentClass.getDeclaredMethod("setConstructorArguments", Object[].class, Class[].class);
+            } catch (NoSuchMethodException ex) {
+                currentClass = currentClass.getSuperclass();
+            }
+        }
+        throw new NoSuchMethodException("setConstructorArguments");
+    }
+
+    public interface GreetingService {
+        String greet(String name);
+    }
+
+    public static class DefaultGreetingService implements GreetingService {
+        public DefaultGreetingService() {
+        }
+
+        @Override
+        public String greet(String name) {
+            return "Hello " + name;
+        }
+    }
+
+    public static class ConstructorGreetingService implements GreetingService {
+        private final String greeting;
+
+        public ConstructorGreetingService(String greeting) {
+            this.greeting = greeting;
+        }
+
+        @Override
+        public String greet(String name) {
+            return this.greeting + " " + name;
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/ProxyProcessorSupportTest.java
+++ b/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/ProxyProcessorSupportTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.aop.framework.ProxyProcessorSupport;
+
+public class ProxyProcessorSupportTest {
+    @Test
+    void evaluateProxyInterfacesAddsReasonableInterfaceWithMethods() {
+        TestProxyProcessorSupport support = new TestProxyProcessorSupport();
+        ProxyFactory proxyFactory = new ProxyFactory();
+
+        support.evaluate(ServiceBean.class, proxyFactory);
+
+        assertThat(proxyFactory.isProxyTargetClass()).isFalse();
+        assertThat(proxyFactory.getProxiedInterfaces()).contains(ServiceContract.class);
+    }
+
+    private static final class TestProxyProcessorSupport extends ProxyProcessorSupport {
+        void evaluate(Class<?> beanClass, ProxyFactory proxyFactory) {
+            evaluateProxyInterfaces(beanClass, proxyFactory);
+        }
+    }
+
+    public interface ServiceContract {
+        String message();
+    }
+
+    public static final class ServiceBean implements ServiceContract {
+        @Override
+        public String message() {
+            return "spring-aop";
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/RuntimeTestWalkerInnerInstanceOfResidueTestVisitorTest.java
+++ b/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/RuntimeTestWalkerInnerInstanceOfResidueTestVisitorTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aop.aspectj.AspectJExpressionPointcut;
+
+public class RuntimeTestWalkerInnerInstanceOfResidueTestVisitorTest {
+
+    @Test
+    void targetResidueComparesAspectJReferenceTypeWithConcreteTargetClass() throws Exception {
+        AspectJExpressionPointcut pointcut = new AspectJExpressionPointcut();
+        pointcut.setExpression("execution(* *(..)) && target(" + RuntimeWalkerMarker.class.getName() + ")");
+        Method method = RuntimeWalkerService.class.getMethod("process");
+
+        boolean matches = pointcut.matches(method, RuntimeWalkerService.class, false);
+
+        assertThat(matches).isFalse();
+    }
+}
+
+interface RuntimeWalkerMarker {
+}
+
+class RuntimeWalkerService {
+
+    public void process() {
+    }
+}

--- a/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/RuntimeTestWalkerTest.java
+++ b/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/RuntimeTestWalkerTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aop.aspectj.AspectJExpressionPointcut;
+
+public class RuntimeTestWalkerTest {
+
+    @Test
+    void staticPointcutMatchInspectsRuntimeResidueForArgumentTypeTest() throws Exception {
+        AspectJExpressionPointcut pointcut = new AspectJExpressionPointcut();
+        pointcut.setExpression("execution(* *(..)) && args(java.lang.String)");
+        Method method = RuntimeArgumentService.class.getMethod("process", Object.class);
+
+        boolean matches = pointcut.matches(method, RuntimeArgumentService.class, false);
+
+        assertThat(matches).isTrue();
+        assertThat(pointcut.isRuntime()).isTrue();
+    }
+
+    public static class RuntimeArgumentService {
+
+        public void process(Object value) {
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/SimpleAspectInstanceFactoryTest.java
+++ b/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/SimpleAspectInstanceFactoryTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aop.aspectj.SimpleAspectInstanceFactory;
+import org.springframework.core.Ordered;
+
+public class SimpleAspectInstanceFactoryTest {
+
+    @Test
+    void createsNewAspectInstanceUsingDefaultConstructor() {
+        SimpleAspectInstanceFactory factory = new SimpleAspectInstanceFactory(CountingAspect.class);
+
+        Object firstAspect = factory.getAspectInstance();
+        Object secondAspect = factory.getAspectInstance();
+
+        assertThat(firstAspect).isInstanceOf(CountingAspect.class);
+        assertThat(secondAspect).isInstanceOf(CountingAspect.class);
+        assertThat(secondAspect).isNotSameAs(firstAspect);
+        assertThat(((CountingAspect) firstAspect).instanceNumber()).isEqualTo(1);
+        assertThat(((CountingAspect) secondAspect).instanceNumber()).isEqualTo(2);
+    }
+
+    @Test
+    void exposesConfiguredAspectClassMetadata() {
+        SimpleAspectInstanceFactory factory = new SimpleAspectInstanceFactory(CountingAspect.class);
+
+        assertThat(factory.getAspectClass()).isSameAs(CountingAspect.class);
+        assertThat(factory.getAspectClassLoader()).isSameAs(CountingAspect.class.getClassLoader());
+        assertThat(factory.getOrder()).isEqualTo(Ordered.LOWEST_PRECEDENCE);
+    }
+
+    public static class CountingAspect {
+        private static int instanceCount;
+
+        private final int instanceNumber;
+
+        public CountingAspect() {
+            instanceCount++;
+            this.instanceNumber = instanceCount;
+        }
+
+        int instanceNumber() {
+            return this.instanceNumber;
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/ThrowsAdviceInterceptorTest.java
+++ b/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/ThrowsAdviceInterceptorTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Method;
+
+import org.aopalliance.intercept.MethodInvocation;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aop.ThrowsAdvice;
+import org.springframework.aop.framework.adapter.ThrowsAdviceInterceptor;
+
+public class ThrowsAdviceInterceptorTest {
+
+    @Test
+    void invokesMatchingThrowsAdviceHandlerWhenInvocationThrows() throws Throwable {
+        IllegalStateException failure = new IllegalStateException("expected failure");
+        RecordingThrowsAdvice advice = new RecordingThrowsAdvice();
+        ThrowsAdviceInterceptor interceptor = new ThrowsAdviceInterceptor(advice);
+
+        Throwable thrown = catchThrowable(() -> interceptor.invoke(new FailingMethodInvocation(failure)));
+
+        assertThat(thrown).isSameAs(failure);
+        assertThat(interceptor.getHandlerMethodCount()).isEqualTo(1);
+        assertThat(advice.handledException()).isSameAs(failure);
+    }
+
+    public static class RecordingThrowsAdvice implements ThrowsAdvice {
+        private IllegalStateException handledException;
+
+        public void afterThrowing(IllegalStateException ex) {
+            this.handledException = ex;
+        }
+
+        IllegalStateException handledException() {
+            return this.handledException;
+        }
+    }
+
+    private static class FailingMethodInvocation implements MethodInvocation {
+        private final Throwable failure;
+
+        FailingMethodInvocation(Throwable failure) {
+            this.failure = failure;
+        }
+
+        @Override
+        public Method getMethod() {
+            throw new UnsupportedOperationException("Single-argument throws advice does not need the invoked method");
+        }
+
+        @Override
+        public Object[] getArguments() {
+            throw new UnsupportedOperationException("Single-argument throws advice does not need invocation arguments");
+        }
+
+        @Override
+        public Object proceed() throws Throwable {
+            throw this.failure;
+        }
+
+        @Override
+        public Object getThis() {
+            throw new UnsupportedOperationException("Single-argument throws advice does not need the invocation target");
+        }
+
+        @Override
+        public AccessibleObject getStaticPart() {
+            throw new UnsupportedOperationException("Single-argument throws advice does not need the static part");
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-aop/5.3.35/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.springframework/spring-aop/5.3.35/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,136 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org_springframework.spring_aop.InstantiationModelAwarePointcutAdvisorImplTest$SerializableAspect"
+      },
+      "type" : "org_springframework.spring_aop.InstantiationModelAwarePointcutAdvisorImplTest$SerializableAspect",
+      "serializable" : true,
+      "fields" : [
+        {
+          "name" : "serialVersionUID"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework.spring_aop.InstantiationModelAwarePointcutAdvisorImplTest$SerializableAspect"
+      },
+      "type" : "java.lang.String",
+      "serializable" : true,
+      "fields" : [
+        {
+          "name" : "serialPersistentFields"
+        },
+        {
+          "name" : "serialVersionUID"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework.spring_aop.ObjenesisCglibAopProxyTest$GreetingService"
+      },
+      "type" : {
+        "proxy" : [
+          "org_springframework.spring_aop.ObjenesisCglibAopProxyTest$GreetingService",
+          "org.springframework.aop.SpringProxy",
+          "org.springframework.aop.framework.Advised",
+          "org.springframework.core.DecoratingProxy"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework.spring_aop.CglibAopProxyTest$GreetingService"
+      },
+      "type" : {
+        "proxy" : [
+          "org_springframework.spring_aop.CglibAopProxyTest$GreetingService",
+          "org.springframework.aop.SpringProxy",
+          "org.springframework.aop.framework.Advised",
+          "org.springframework.core.DecoratingProxy"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework.spring_aop.RuntimeTestWalkerInnerInstanceOfResidueTestVisitorTest"
+      },
+      "type" : "org_springframework.spring_aop.RuntimeWalkerMarker"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework.spring_aop.RuntimeTestWalkerInnerInstanceOfResidueTestVisitorTest"
+      },
+      "type" : "org_springframework.spring_aop.RuntimeWalkerService"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.framework.JdkDynamicAopProxy"
+      },
+      "type" : {
+        "proxy" : [
+          "org_springframework.spring_aop.AbstractAspectJAdviceTest$GreetingService",
+          "org.springframework.aop.SpringProxy",
+          "org.springframework.aop.framework.Advised",
+          "org.springframework.core.DecoratingProxy"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.framework.JdkDynamicAopProxy"
+      },
+      "type" : {
+        "proxy" : [
+          "org_springframework.spring_aop.AopProxyUtilsTest$VarargsService",
+          "org.springframework.aop.SpringProxy",
+          "org.springframework.aop.framework.Advised",
+          "org.springframework.core.DecoratingProxy"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.framework.JdkDynamicAopProxy"
+      },
+      "type" : {
+        "proxy" : [
+          "org_springframework.spring_aop.DelegatePerTargetObjectIntroductionInterceptorTest$NamedService",
+          "org_springframework.spring_aop.DelegatePerTargetObjectIntroductionInterceptorTest$CountingOperations",
+          "org.springframework.aop.SpringProxy",
+          "org.springframework.aop.framework.Advised",
+          "org.springframework.core.DecoratingProxy"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.framework.JdkDynamicAopProxy"
+      },
+      "type" : {
+        "proxy" : [
+          "org_springframework.spring_aop.ObjenesisCglibAopProxyTest$GreetingService",
+          "org.springframework.aop.SpringProxy",
+          "org.springframework.aop.framework.Advised",
+          "org.springframework.core.DecoratingProxy"
+        ]
+      }
+    }
+  ],
+  "serialization" : [
+    {
+      "condition" : {
+        "typeReached" : "org_springframework.spring_aop.InstantiationModelAwarePointcutAdvisorImplTest$SerializableAspect"
+      },
+      "type" : "org_springframework.spring_aop.InstantiationModelAwarePointcutAdvisorImplTest$SerializableAspect"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework.spring_aop.InstantiationModelAwarePointcutAdvisorImplTest$SerializableAspect"
+      },
+      "type" : "java.lang.String"
+    }
+  ]
+}

--- a/tests/src/org.springframework/spring-aop/5.3.35/user-code-filter.json
+++ b/tests/src/org.springframework/spring-aop/5.3.35/user-code-filter.json
@@ -1,0 +1,16 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.aopalliance.**"
+    },
+    {
+      "includeClasses" : "org.springframework.aop.**"
+    },
+    {
+      "includeClasses" : "org_springframework.spring_aop.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6762

This PR provides test fixes and new metadata for org.springframework:spring-aop:5.3.35, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 50952
- Cached input tokens: 768000
- Output tokens: 9551
- Metadata entries: 50
- Test-only metadata entries: 15
- Iterations: 2
- Library coverage percentage: 20.57
- Previous library version metadata entries: 50
- Previous library version test-only metadata entries: 15
- Previous library version coverage percentage: 20.63

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `2fb9ecc661ec3dbde373d2ca3466a404158734f1`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.springframework:spring-aop:5.3.15: 19/22 covered calls (86.36%)
- org.springframework:spring-aop:5.3.35: 21/21 covered calls (100.00%)

**Reflection:**
- org.springframework:spring-aop:5.3.15: 19/22 covered calls (86.36%)
- org.springframework:spring-aop:5.3.35: 21/21 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.springframework:spring-aop:5.3.15: 4502/23470 (19.18%)
- org.springframework:spring-aop:5.3.35: 4458/23477 (18.99%)

**Line:**
- org.springframework:spring-aop:5.3.15: 1111/5385 (20.63%)
- org.springframework:spring-aop:5.3.35: 1109/5391 (20.57%)

**Method:**
- org.springframework:spring-aop:5.3.15: 295/1384 (21.32%)
- org.springframework:spring-aop:5.3.35: 296/1388 (21.33%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.springframework/spring-aop/5.3.15/build.gradle 2/tests/src/org.springframework/spring-aop/5.3.35/build.gradle
index 6f404175ba..256f664728 100644
--- 1/tests/src/org.springframework/spring-aop/5.3.15/build.gradle
+++ 2/tests/src/org.springframework/spring-aop/5.3.35/build.gradle
@@ -17,7 +17,21 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
+tasks.withType(Test).configureEach {
+    systemProperty "spring.objenesis.ignore", "true"
+}
+
+tasks.named("nativeTest") {
+    runtimeArgs.add("-Dspring.objenesis.ignore=true")
+}
+
 graalvmNative {
+    binaries {
+        test {
+            buildArgs.add("-Dspring.objenesis.ignore=true")
+        }
+    }
+
     agent {
         defaultMode = "conditional"
         modes {
diff --git 1/tests/src/org.springframework/spring-aop/5.3.15/src/test/java/org_springframework/spring_aop/AbstractAspectJAdvisorFactoryTest.java 2/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/AbstractAspectJAdvisorFactoryTest.java
index 62e4066115..e486d864d3 100644
--- 1/tests/src/org.springframework/spring-aop/5.3.15/src/test/java/org_springframework/spring_aop/AbstractAspectJAdvisorFactoryTest.java
+++ 2/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/AbstractAspectJAdvisorFactoryTest.java
@@ -16,11 +16,20 @@ import org.springframework.aop.aspectj.annotation.ReflectiveAspectJAdvisorFactor
 public class AbstractAspectJAdvisorFactoryTest {
 
     @Test
-    void rejectsAspectWithAjcCompiledMarkerField() {
+    void acceptsAnnotationStyleAspectWithAjcCompiledMarkerField() {
         ReflectiveAspectJAdvisorFactory factory = new ReflectiveAspectJAdvisorFactory();
 
         boolean aspect = factory.isAspect(AjcCompiledMarkerAspect.class);
 
+        assertThat(aspect).isTrue();
+    }
+
+    @Test
+    void rejectsClassWithoutAspectAnnotation() {
+        ReflectiveAspectJAdvisorFactory factory = new ReflectiveAspectJAdvisorFactory();
+
+        boolean aspect = factory.isAspect(NonAspect.class);
+
         assertThat(aspect).isFalse();
     }
 
@@ -41,4 +50,7 @@ public class AbstractAspectJAdvisorFactoryTest {
     @Aspect
     public static class AnnotationStyleAspect {
     }
+
+    public static class NonAspect {
+    }
 }
diff --git 1/tests/src/org.springframework/spring-aop/5.3.15/src/test/java/org_springframework/spring_aop/ObjenesisCglibAopProxyTest.java 2/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/ObjenesisCglibAopProxyTest.java
index c9b137a86b..8918301749 100644
--- 1/tests/src/org.springframework/spring-aop/5.3.15/src/test/java/org_springframework/spring_aop/ObjenesisCglibAopProxyTest.java
+++ 2/tests/src/org.springframework/spring-aop/5.3.35/src/test/java/org_springframework/spring_aop/ObjenesisCglibAopProxyTest.java
@@ -9,8 +9,8 @@ package org_springframework.spring_aop;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -26,27 +26,31 @@ public class ObjenesisCglibAopProxyTest {
         recordJdkProxyMetadataForNativeImageFallback();
     }
 
-    @AfterAll
-    static void restoreObjenesisProperty() {
-        System.clearProperty(SpringObjenesis.IGNORE_OBJENESIS_PROPERTY_NAME);
-    }
-
     @Test
     void cglibProxyFallsBackToDefaultConstructorWhenObjenesisIsIgnored() {
-        GreetingService proxy = createProxy(DefaultGreetingService.class, new DefaultGreetingService());
+        DefaultGreetingService target = new DefaultGreetingService();
+        DefaultGreetingService.constructorInvocations.set(0);
+
+        AopProxy aopProxy = createAopProxy(DefaultGreetingService.class, target);
+        GreetingService proxy = (GreetingService) aopProxy.getProxy();
 
         assertThat(proxy.greet("Spring")).isEqualTo("Hello Spring");
+        assertThat(DefaultGreetingService.constructorInvocations)
+                .hasValue(isObjenesisCglibProxy(aopProxy) ? 1 : 0);
     }
 
     @Test
     void cglibProxyFallsBackToMatchingConstructorWhenConstructorArgumentsAreConfigured() {
-        AopProxy aopProxy = createAopProxy(ConstructorGreetingService.class,
-                new ConstructorGreetingService("Hello"));
+        ConstructorGreetingService target = new ConstructorGreetingService("Hello");
+        ConstructorGreetingService.lastConstructedGreeting = null;
+        AopProxy aopProxy = createAopProxy(ConstructorGreetingService.class, target);
         configureConstructorArgumentsIfCglibProxy(aopProxy, new Object[] {"Proxy"}, new Class<?>[] {String.class});
 
         GreetingService proxy = (GreetingService) aopProxy.getProxy();
 
         assertThat(proxy.greet("Spring")).isEqualTo("Hello Spring");
+        assertThat(ConstructorGreetingService.lastConstructedGreeting)
+                .isEqualTo(isObjenesisCglibProxy(aopProxy) ? "Proxy" : null);
     }
 
     private static GreetingService createProxy(Class<? extends GreetingService> targetClass, GreetingService target) {
@@ -72,7 +76,7 @@ public class ObjenesisCglibAopProxyTest {
     private static void configureConstructorArgumentsIfCglibProxy(
             AopProxy aopProxy, Object[] constructorArgs, Class<?>[] constructorArgTypes) {
         Class<?> proxyClass = aopProxy.getClass();
-        if (!proxyClass.getName().endsWith("ObjenesisCglibAopProxy")) {
+        if (!isObjenesisCglibProxy(aopProxy)) {
             return;
         }
         try {
@@ -96,12 +100,19 @@ public class ObjenesisCglibAopProxyTest {
         throw new NoSuchMethodException("setConstructorArguments");
     }
 
+    private static boolean isObjenesisCglibProxy(AopProxy aopProxy) {
+        return aopProxy.getClass().getName().endsWith("ObjenesisCglibAopProxy");
+    }
+
     public interface GreetingService {
         String greet(String name);
     }
 
     public static class DefaultGreetingService implements GreetingService {
+        private static final AtomicInteger constructorInvocations = new AtomicInteger();
+
         public DefaultGreetingService() {
+            constructorInvocations.incrementAndGet();
         }
 
         @Override
@@ -111,9 +122,12 @@ public class ObjenesisCglibAopProxyTest {
     }
 
     public static class ConstructorGreetingService implements GreetingService {
+        private static String lastConstructedGreeting;
+
         private final String greeting;
 
         public ConstructorGreetingService(String greeting) {
+            lastConstructedGreeting = greeting;
             this.greeting = greeting;
         }
 

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
