### PR TITLE
[GenAI] Mark org.jetbrains.kotlinx:kotlinx-serialization-json as not for Native Image

### DIFF
--- a/metadata/org.jetbrains.kotlinx/kotlinx-serialization-json/index.json
+++ b/metadata/org.jetbrains.kotlinx/kotlinx-serialization-json/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published root JAR contains Kotlin Multiplatform metadata/linkdata and no JVM class files; Gradle module metadata redirects standard JVM variants to org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.9.0.",
+    "replacement": "org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.9.0"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #2610

This PR records `org.jetbrains.kotlinx:kotlinx-serialization-json` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published root JAR contains Kotlin Multiplatform metadata/linkdata and no JVM class files; Gradle module metadata redirects standard JVM variants to org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.9.0.

Replacement guidance:
- org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.9.0

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `2fb9ecc661ec3dbde373d2ca3466a404158734f1`

### Local CI Verification

- Status: `success`
- Commands run: 6
- Fixup attempts: 0
