### PR TITLE
[GenAI] Add support for org.apache.logging.log4j:log4j-slf4j-impl:2.17.1 using gpt-5.5

### DIFF
--- a/metadata/org.apache.logging.log4j/log4j-slf4j-impl/2.17.1/reachability-metadata.json
+++ b/metadata/org.apache.logging.log4j/log4j-slf4j-impl/2.17.1/reachability-metadata.json
@@ -1,0 +1,248 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.spi.AbstractLogger"
+      },
+      "type" : "org.apache.logging.log4j.message.DefaultFlowMessageFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.spi.AbstractLogger"
+      },
+      "type" : "org.apache.logging.log4j.message.ParameterizedMessageFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.LogManager"
+      },
+      "type" : "org.apache.logging.log4j.core.impl.Log4jContextFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.LoggerContext"
+      },
+      "type" : "org.apache.logging.log4j.core.util.ExecutorServices"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.util.LoaderUtil"
+      },
+      "type" : "org.apache.logging.log4j.message.DefaultFlowMessageFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.util.LoaderUtil"
+      },
+      "type" : "org.apache.logging.log4j.message.ReusableMessageFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.spi.AbstractLogger"
+      },
+      "type" : "org.apache.logging.log4j.message.ReusableMessageFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.util.PropertiesUtil$Environment"
+      },
+      "type" : "org.apache.logging.log4j.util.EnvironmentPropertySource"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.util.PropertiesUtil$Environment"
+      },
+      "type" : "org.apache.logging.log4j.util.SystemPropertiesPropertySource"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.DatePatternConverter",
+      "methods" : [
+        {
+          "name" : "newInstance",
+          "parameterTypes" : [
+            "java.lang.String[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.ThreadNamePatternConverter",
+      "methods" : [
+        {
+          "name" : "newInstance",
+          "parameterTypes" : [
+            "java.lang.String[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.LevelPatternConverter",
+      "methods" : [
+        {
+          "name" : "newInstance",
+          "parameterTypes" : [
+            "java.lang.String[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.LoggerPatternConverter",
+      "methods" : [
+        {
+          "name" : "newInstance",
+          "parameterTypes" : [
+            "java.lang.String[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.MessagePatternConverter",
+      "methods" : [
+        {
+          "name" : "newInstance",
+          "parameterTypes" : [
+            "org.apache.logging.log4j.core.config.Configuration",
+            "java.lang.String[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.LineSeparatorPatternConverter",
+      "methods" : [
+        {
+          "name" : "newInstance",
+          "parameterTypes" : [
+            "java.lang.String[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.MarkerPatternConverter",
+      "methods" : [
+        {
+          "name" : "newInstance",
+          "parameterTypes" : [
+            "java.lang.String[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.MdcPatternConverter",
+      "methods" : [
+        {
+          "name" : "newInstance",
+          "parameterTypes" : [
+            "java.lang.String[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.ThrowablePatternConverter",
+      "methods" : [
+        {
+          "name" : "newInstance",
+          "parameterTypes" : [
+            "org.apache.logging.log4j.core.config.Configuration",
+            "java.lang.String[]"
+          ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.LogManager"
+      },
+      "glob" : "META-INF/services/org.apache.logging.log4j.spi.Provider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.util.LoaderUtil"
+      },
+      "glob" : "META-INF/services/org.apache.logging.log4j.util.PropertySource"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "glob" : "META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.util.LoaderUtil"
+      },
+      "glob" : "log4j2.StatusLogger.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.util.LoaderUtil"
+      },
+      "glob" : "log4j2.component.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.util.LoaderUtil"
+      },
+      "glob" : "log4j2.system.properties"
+    }
+  ]
+}

--- a/metadata/org.apache.logging.log4j/log4j-slf4j-impl/index.json
+++ b/metadata/org.apache.logging.log4j/log4j-slf4j-impl/index.json
@@ -1,18 +1,23 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "2.17.1",
-    "source-code-url" : "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-slf4j-impl/$version$/log4j-slf4j-impl-$version$-sources.jar",
-    "repository-url" : "https://github.com/apache/logging-log4j2",
-    "test-code-url" : "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-slf4j-impl/$version$/log4j-slf4j-impl-$version$-test-sources.jar",
-    "documentation-url" : "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-slf4j-impl/$version$/log4j-slf4j-impl-$version$-javadoc.jar",
-    "description" : "Apache Log4j SLF4J Binding connects the SLF4J 1.x API to Log4j 2, providing the SLF4J binder classes that route logging calls into Log4j Core. It lets applications and libraries written against SLF4J use Log4j 2 as the underlying logging implementation without changing their SLF4J logging code.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "2.17.1",
+    "source-code-url": "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-slf4j-impl/$version$/log4j-slf4j-impl-$version$-sources.jar",
+    "repository-url": "https://github.com/apache/logging-log4j2",
+    "test-code-url": "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-slf4j-impl/$version$/log4j-slf4j-impl-$version$-test-sources.jar",
+    "documentation-url": "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-slf4j-impl/$version$/log4j-slf4j-impl-$version$-javadoc.jar",
+    "description": "Apache Log4j SLF4J Binding connects the SLF4J 1.x API to Log4j 2, providing the SLF4J binder classes that route logging calls into Log4j Core. It lets applications and libraries written against SLF4J use Log4j 2 as the underlying logging implementation without changing their SLF4J logging code.",
+    "tested-versions": [
       "2.17.1"
     ],
-    "allowed-packages" : [
+    "allowed-packages": [
       "org.apache.logging.slf4j",
-      "org.slf4j.impl"
+      "org.slf4j.impl",
+      "org.apache.logging.log4j",
+      "org.apache.logging.log4j.core",
+      "org.apache.logging.log4j.core.config.plugins.util",
+      "org.apache.logging.log4j.spi",
+      "org.apache.logging.log4j.util"
     ]
   }
 ]

--- a/metadata/org.apache.logging.log4j/log4j-slf4j-impl/index.json
+++ b/metadata/org.apache.logging.log4j/log4j-slf4j-impl/index.json
@@ -1,0 +1,18 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.17.1",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-slf4j-impl/$version$/log4j-slf4j-impl-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/logging-log4j2",
+    "test-code-url" : "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-slf4j-impl/$version$/log4j-slf4j-impl-$version$-test-sources.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-slf4j-impl/$version$/log4j-slf4j-impl-$version$-javadoc.jar",
+    "description" : "Apache Log4j SLF4J Binding connects the SLF4J 1.x API to Log4j 2, providing the SLF4J binder classes that route logging calls into Log4j Core. It lets applications and libraries written against SLF4J use Log4j 2 as the underlying logging implementation without changing their SLF4J logging code.",
+    "tested-versions" : [
+      "2.17.1"
+    ],
+    "allowed-packages" : [
+      "org.apache.logging.slf4j",
+      "org.slf4j.impl"
+    ]
+  }
+]

--- a/stats/org.apache.logging.log4j/log4j-slf4j-impl/2.17.1/execution-metrics.json
+++ b/stats/org.apache.logging.log4j/log4j-slf4j-impl/2.17.1/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-11": {
+    "timestamp": "2026-05-11T21:31:08.831357Z",
+    "library": "org.apache.logging.log4j:log4j-slf4j-impl:2.17.1",
+    "starting_commit": "180103f987956d132078e847fdba5a1f5e681f35",
+    "ending_commit": "f411067f8bb0d5c1c84d14cc0e225d9afbbac378",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.17.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 503,
+          "missed": 740,
+          "ratio": 0.404666,
+          "total": 1243
+        },
+        "line": {
+          "covered": 132,
+          "missed": 159,
+          "ratio": 0.453608,
+          "total": 291
+        },
+        "method": {
+          "covered": 58,
+          "missed": 65,
+          "ratio": 0.471545,
+          "total": 123
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 104641,
+      "cached_input_tokens_used": 1121280,
+      "output_tokens_used": 22065,
+      "iterations": 3,
+      "cost_usd": 1.2226,
+      "generated_loc": 236,
+      "tested_library_loc": 132,
+      "metadata_entries": 37,
+      "code_coverage_percent": 45.36
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.logging.log4j/log4j-slf4j-impl/2.17.1/src/test/java/org_apache_logging_log4j/log4j_slf4j_impl/Log4j_slf4j_implTest.java",
+      "metadata_file": "metadata/org.apache.logging.log4j/log4j-slf4j-impl/2.17.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.logging.log4j/log4j-slf4j-impl/2.17.1/stats.json
+++ b/stats/org.apache.logging.log4j/log4j-slf4j-impl/2.17.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.17.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 503,
+        "missed" : 740,
+        "ratio" : 0.404666,
+        "total" : 1243
+      },
+      "line" : {
+        "covered" : 132,
+        "missed" : 159,
+        "ratio" : 0.453608,
+        "total" : 291
+      },
+      "method" : {
+        "covered" : 58,
+        "missed" : 65,
+        "ratio" : 0.471545,
+        "total" : 123
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.logging.log4j/log4j-slf4j-impl/2.17.1/.gitignore
+++ b/tests/src/org.apache.logging.log4j/log4j-slf4j-impl/2.17.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.logging.log4j/log4j-slf4j-impl/2.17.1/build.gradle
+++ b/tests/src/org.apache.logging.log4j/log4j-slf4j-impl/2.17.1/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.apache.logging.log4j:log4j-slf4j-impl:$libraryVersion"
+    testImplementation "org.apache.logging.log4j:log4j-core:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.apache.logging.log4j/log4j-slf4j-impl/2.17.1/build.gradle
+++ b/tests/src/org.apache.logging.log4j/log4j-slf4j-impl/2.17.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.logging.log4j:log4j-slf4j-impl:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.logging.log4j/log4j-slf4j-impl/2.17.1/gradle.properties
+++ b/tests/src/org.apache.logging.log4j/log4j-slf4j-impl/2.17.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
+library.version = 2.17.1
+metadata.dir = org.apache.logging.log4j/log4j-slf4j-impl/2.17.1/

--- a/tests/src/org.apache.logging.log4j/log4j-slf4j-impl/2.17.1/settings.gradle
+++ b/tests/src/org.apache.logging.log4j/log4j-slf4j-impl/2.17.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.logging.log4j.log4j-slf4j-impl_tests'

--- a/tests/src/org.apache.logging.log4j/log4j-slf4j-impl/2.17.1/src/test/java/org_apache_logging_log4j/log4j_slf4j_impl/Log4j_slf4j_implTest.java
+++ b/tests/src/org.apache.logging.log4j/log4j-slf4j-impl/2.17.1/src/test/java/org_apache_logging_log4j/log4j_slf4j_impl/Log4j_slf4j_implTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_logging_log4j.log4j_slf4j_impl;
+
+import org.junit.jupiter.api.Test;
+
+class Log4j_slf4j_implTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.apache.logging.log4j/log4j-slf4j-impl/2.17.1/src/test/java/org_apache_logging_log4j/log4j_slf4j_impl/Log4j_slf4j_implTest.java
+++ b/tests/src/org.apache.logging.log4j/log4j-slf4j-impl/2.17.1/src/test/java/org_apache_logging_log4j/log4j_slf4j_impl/Log4j_slf4j_implTest.java
@@ -6,11 +6,214 @@
  */
 package org_apache_logging_log4j.log4j_slf4j_impl;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
-class Log4j_slf4j_implTest {
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.ThreadContext;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.WriterAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.apache.logging.slf4j.Log4jLoggerFactory;
+import org.apache.logging.slf4j.Log4jMDCAdapter;
+import org.apache.logging.slf4j.Log4jMarkerFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
+import org.slf4j.impl.StaticLoggerBinder;
+import org.slf4j.spi.LocationAwareLogger;
+
+public class Log4j_slf4j_implTest {
+
+    @AfterEach
+    void clearThreadLocalLoggingState() {
+        MDC.clear();
+        ThreadContext.clearAll();
+    }
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void exposesLog4jBackedSlf4jServices() {
+        ILoggerFactory loggerFactory = LoggerFactory.getILoggerFactory();
+
+        assertThat(loggerFactory).isInstanceOf(Log4jLoggerFactory.class);
+        assertThat(StaticLoggerBinder.getSingleton().getLoggerFactory()).isSameAs(loggerFactory);
+        assertThat(StaticLoggerBinder.getSingleton().getLoggerFactoryClassStr())
+                .isEqualTo(Log4jLoggerFactory.class.getName());
+        assertThat(MarkerFactory.getIMarkerFactory()).isInstanceOf(Log4jMarkerFactory.class);
+        assertThat(MDC.getMDCAdapter()).isInstanceOf(Log4jMDCAdapter.class);
+    }
+
+    @Test
+    void routesFormattedSlf4jMessagesMarkersMdcAndThrowablesToLog4j() {
+        try (CapturedLogger capturedLogger = CapturedLogger.create(
+                "routesFormattedSlf4jMessagesMarkersMdcAndThrowablesToLog4j",
+                Level.TRACE,
+                "%level|%logger|%marker|%X{requestId}|%message|%throwable{short.message}%n")) {
+            Logger logger = LoggerFactory.getLogger(capturedLogger.getLoggerName());
+            Marker marker = MarkerFactory.getMarker("AUDIT");
+
+            try (MDC.MDCCloseable ignored = MDC.putCloseable("requestId", "request-42")) {
+                logger.info(marker, "processed {} records for {}", 7, "alice");
+                logger.error(marker, "operation failed", new IllegalStateException("database unavailable"));
+            }
+
+            String output = capturedLogger.getOutput();
+            assertThat(output).contains("INFO|" + capturedLogger.getLoggerName()
+                    + "|AUDIT|request-42|processed 7 records for alice|");
+            assertThat(output).contains("ERROR|" + capturedLogger.getLoggerName()
+                    + "|AUDIT|request-42|operation failed|");
+            assertThat(output).contains("database unavailable");
+            assertThat(MDC.get("requestId")).isNull();
+        }
+    }
+
+    @Test
+    void honorsLog4jLevelConfigurationForSlf4jLevelChecksAndLogging() {
+        try (CapturedLogger capturedLogger = CapturedLogger.create(
+                "honorsLog4jLevelConfigurationForSlf4jLevelChecksAndLogging",
+                Level.WARN,
+                "%level|%message%n")) {
+            Logger logger = LoggerFactory.getLogger(capturedLogger.getLoggerName());
+            Marker marker = MarkerFactory.getMarker("SECURITY");
+
+            assertThat(logger.isTraceEnabled()).isFalse();
+            assertThat(logger.isDebugEnabled()).isFalse();
+            assertThat(logger.isInfoEnabled()).isFalse();
+            assertThat(logger.isWarnEnabled()).isTrue();
+            assertThat(logger.isErrorEnabled()).isTrue();
+            assertThat(logger.isInfoEnabled(marker)).isFalse();
+            assertThat(logger.isWarnEnabled(marker)).isTrue();
+
+            logger.trace("suppressed trace");
+            logger.debug("suppressed debug");
+            logger.info(marker, "suppressed info");
+            logger.warn("visible warning");
+            logger.error("visible error");
+
+            assertThat(capturedLogger.getOutput())
+                    .doesNotContain("suppressed")
+                    .contains("WARN|visible warning")
+                    .contains("ERROR|visible error");
+        }
+    }
+
+    @Test
+    void supportsSlf4jLocationAwareLoggerCalls() {
+        try (CapturedLogger capturedLogger = CapturedLogger.create(
+                "supportsSlf4jLocationAwareLoggerCalls",
+                Level.TRACE,
+                "%level|%marker|%message%n")) {
+            Logger logger = LoggerFactory.getLogger(capturedLogger.getLoggerName());
+            Marker marker = MarkerFactory.getMarker("LOCATION");
+
+            assertThat(logger).isInstanceOf(LocationAwareLogger.class);
+            LocationAwareLogger locationAwareLogger = (LocationAwareLogger) logger;
+            locationAwareLogger.log(
+                    marker,
+                    Log4j_slf4j_implTest.class.getName(),
+                    LocationAwareLogger.INFO_INT,
+                    "location {} message",
+                    new Object[] {"aware"},
+                    null);
+
+            assertThat(capturedLogger.getOutput()).contains("INFO|LOCATION|location aware message");
+        }
+    }
+
+    @Test
+    void synchronizesSlf4jMdcOperationsWithLog4jThreadContext() {
+        Map<String, String> contextMap = new HashMap<>();
+        contextMap.put("tenant", "acme");
+        contextMap.put("traceId", "trace-123");
+
+        MDC.setContextMap(contextMap);
+
+        assertThat(MDC.get("tenant")).isEqualTo("acme");
+        assertThat(ThreadContext.get("tenant")).isEqualTo("acme");
+        assertThat(MDC.getCopyOfContextMap())
+                .containsEntry("tenant", "acme")
+                .containsEntry("traceId", "trace-123");
+
+        MDC.put("requestId", "request-7");
+        assertThat(ThreadContext.getImmutableContext()).containsEntry("requestId", "request-7");
+
+        MDC.remove("tenant");
+        assertThat(MDC.get("tenant")).isNull();
+        assertThat(ThreadContext.get("tenant")).isNull();
+
+        MDC.clear();
+        assertThat(ThreadContext.getImmutableContext()).isEmpty();
+    }
+
+    private static final class CapturedLogger implements AutoCloseable {
+
+        private final LoggerContext context;
+        private final Configuration configuration;
+        private final String loggerName;
+        private final StringWriter writer;
+        private final WriterAppender appender;
+
+        private CapturedLogger(
+                LoggerContext context,
+                Configuration configuration,
+                String loggerName,
+                StringWriter writer,
+                WriterAppender appender) {
+            this.context = context;
+            this.configuration = configuration;
+            this.loggerName = loggerName;
+            this.writer = writer;
+            this.appender = appender;
+        }
+
+        static CapturedLogger create(String testName, Level level, String pattern) {
+            LoggerContext context = (LoggerContext) LogManager.getContext(false);
+            Configuration configuration = context.getConfiguration();
+            String loggerName = Log4j_slf4j_implTest.class.getName() + "." + testName;
+            StringWriter writer = new StringWriter();
+            PatternLayout layout = PatternLayout.newBuilder()
+                    .withPattern(pattern)
+                    .withConfiguration(configuration)
+                    .build();
+            WriterAppender appender = WriterAppender.newBuilder()
+                    .setName(testName + "Appender")
+                    .setTarget(writer)
+                    .setLayout(layout)
+                    .setIgnoreExceptions(false)
+                    .build();
+            appender.start();
+
+            LoggerConfig loggerConfig = new LoggerConfig(loggerName, level, false);
+            loggerConfig.addAppender(appender, level, null);
+            configuration.addLogger(loggerName, loggerConfig);
+            context.updateLoggers();
+
+            return new CapturedLogger(context, configuration, loggerName, writer, appender);
+        }
+
+        String getLoggerName() {
+            return loggerName;
+        }
+
+        String getOutput() {
+            return writer.toString();
+        }
+
+        @Override
+        public void close() {
+            configuration.removeLogger(loggerName);
+            context.updateLoggers();
+            appender.stop();
+        }
     }
 }

--- a/tests/src/org.apache.logging.log4j/log4j-slf4j-impl/2.17.1/src/test/java/org_apache_logging_log4j/log4j_slf4j_impl/Log4j_slf4j_implTest.java
+++ b/tests/src/org.apache.logging.log4j/log4j-slf4j-impl/2.17.1/src/test/java/org_apache_logging_log4j/log4j_slf4j_impl/Log4j_slf4j_implTest.java
@@ -27,11 +27,13 @@ import org.apache.logging.slf4j.Log4jMarkerFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.ILoggerFactory;
+import org.slf4j.IMarkerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.slf4j.Marker;
 import org.slf4j.MarkerFactory;
+import org.slf4j.helpers.BasicMarkerFactory;
 import org.slf4j.impl.StaticLoggerBinder;
 import org.slf4j.spi.LocationAwareLogger;
 
@@ -131,6 +133,28 @@ public class Log4j_slf4j_implTest {
                     .contains("accepted parent marker")
                     .doesNotContain("rejected unrelated marker")
                     .doesNotContain("rejected unmarked message");
+        }
+    }
+
+    @Test
+    void convertsForeignSlf4jMarkersForLog4jMarkerFilters() {
+        try (CapturedLogger capturedLogger = CapturedLogger.create(
+                "convertsForeignSlf4jMarkersForLog4jMarkerFilters",
+                Level.TRACE,
+                "%message%n",
+                MarkerFilter.createFilter("FOREIGN_PARENT", Filter.Result.ACCEPT, Filter.Result.DENY))) {
+            Logger logger = LoggerFactory.getLogger(capturedLogger.getLoggerName());
+            IMarkerFactory markerFactory = new BasicMarkerFactory();
+            Marker parentMarker = markerFactory.getMarker("FOREIGN_PARENT");
+            Marker childMarker = markerFactory.getMarker("FOREIGN_CHILD");
+            childMarker.add(parentMarker);
+
+            logger.info(childMarker, "accepted converted child marker");
+            logger.info(markerFactory.getMarker("FOREIGN_OTHER"), "rejected converted unrelated marker");
+
+            assertThat(capturedLogger.getOutput())
+                    .contains("accepted converted child marker")
+                    .doesNotContain("rejected converted unrelated marker");
         }
     }
 

--- a/tests/src/org.apache.logging.log4j/log4j-slf4j-impl/2.17.1/src/test/java/org_apache_logging_log4j/log4j_slf4j_impl/Log4j_slf4j_implTest.java
+++ b/tests/src/org.apache.logging.log4j/log4j-slf4j-impl/2.17.1/src/test/java/org_apache_logging_log4j/log4j_slf4j_impl/Log4j_slf4j_implTest.java
@@ -14,10 +14,12 @@ import java.util.Map;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.ThreadContext;
+import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.WriterAppender;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.filter.MarkerFilter;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.apache.logging.slf4j.Log4jLoggerFactory;
 import org.apache.logging.slf4j.Log4jMDCAdapter;
@@ -108,6 +110,31 @@ public class Log4j_slf4j_implTest {
     }
 
     @Test
+    void routesSlf4jMarkerHierarchyToLog4jMarkerFilters() {
+        try (CapturedLogger capturedLogger = CapturedLogger.create(
+                "routesSlf4jMarkerHierarchyToLog4jMarkerFilters",
+                Level.TRACE,
+                "%message%n",
+                MarkerFilter.createFilter("SECURITY", Filter.Result.ACCEPT, Filter.Result.DENY))) {
+            Logger logger = LoggerFactory.getLogger(capturedLogger.getLoggerName());
+            Marker securityMarker = MarkerFactory.getDetachedMarker("SECURITY");
+            Marker loginMarker = MarkerFactory.getDetachedMarker("LOGIN");
+            loginMarker.add(securityMarker);
+
+            logger.info(loginMarker, "accepted child marker");
+            logger.info(securityMarker, "accepted parent marker");
+            logger.info(MarkerFactory.getDetachedMarker("AUDIT"), "rejected unrelated marker");
+            logger.info("rejected unmarked message");
+
+            assertThat(capturedLogger.getOutput())
+                    .contains("accepted child marker")
+                    .contains("accepted parent marker")
+                    .doesNotContain("rejected unrelated marker")
+                    .doesNotContain("rejected unmarked message");
+        }
+    }
+
+    @Test
     void supportsSlf4jLocationAwareLoggerCalls() {
         try (CapturedLogger capturedLogger = CapturedLogger.create(
                 "supportsSlf4jLocationAwareLoggerCalls",
@@ -177,6 +204,10 @@ public class Log4j_slf4j_implTest {
         }
 
         static CapturedLogger create(String testName, Level level, String pattern) {
+            return create(testName, level, pattern, null);
+        }
+
+        static CapturedLogger create(String testName, Level level, String pattern, Filter filter) {
             LoggerContext context = (LoggerContext) LogManager.getContext(false);
             Configuration configuration = context.getConfiguration();
             String loggerName = Log4j_slf4j_implTest.class.getName() + "." + testName;
@@ -194,7 +225,7 @@ public class Log4j_slf4j_implTest {
             appender.start();
 
             LoggerConfig loggerConfig = new LoggerConfig(loggerName, level, false);
-            loggerConfig.addAppender(appender, level, null);
+            loggerConfig.addAppender(appender, level, filter);
             configuration.addLogger(loggerName, loggerConfig);
             context.updateLoggers();
 

--- a/tests/src/org.apache.logging.log4j/log4j-slf4j-impl/2.17.1/user-code-filter.json
+++ b/tests/src/org.apache.logging.log4j/log4j-slf4j-impl/2.17.1/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.apache.logging.slf4j.**"
+    },
+    {
+      "includeClasses": "org.slf4j.impl.**"
+    }
+  ]
+}

--- a/tests/src/org.apache.logging.log4j/log4j-slf4j-impl/2.17.1/user-code-filter.json
+++ b/tests/src/org.apache.logging.log4j/log4j-slf4j-impl/2.17.1/user-code-filter.json
@@ -1,13 +1,16 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.apache.logging.slf4j.**"
+      "includeClasses" : "org.apache.logging.slf4j.**"
     },
     {
-      "includeClasses": "org.slf4j.impl.**"
+      "includeClasses" : "org.slf4j.impl.**"
+    },
+    {
+      "includeClasses" : "org_apache_logging_log4j.log4j_slf4j_impl.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #2612

This PR introduces tests and metadata for org.apache.logging.log4j:log4j-slf4j-impl:2.17.1, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 104641
- Cached input tokens: 1121280
- Output tokens: 22065
- Metadata entries: 37
- Iterations: 3
- Library coverage percentage: 45.36
- Generated lines of code: 236
- Tested library lines of code: 132

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `12ab11bafb4a799143877fe32c276376f73e937a`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 503/1243 (40.47%)
- Line: 132/291 (45.36%)
- Method: 58/123 (47.15%)

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
