### PR TITLE
[GenAI] Mark org.clojure:data.json as not for Native Image

### DIFF
--- a/metadata/org.clojure/data.json/index.json
+++ b/metadata/org.clojure/data.json/index.json
@@ -1,0 +1,6 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "Artifact JAR contains only Clojure source files and no JVM class files, so there is no library bytecode for native-image reachability metadata."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #2793

This PR records `org.clojure:data.json` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- Artifact JAR contains only Clojure source files and no JVM class files, so there is no library bytecode for native-image reachability metadata.

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `12ab11bafb4a799143877fe32c276376f73e937a`

### Local CI Verification

- Status: `success`
- Commands run: 6
- Fixup attempts: 0
