### PR TITLE
[GenAI] Test fix for io.grpc:grpc-xds:1.80.0 using gpt-5.5

### DIFF
--- a/metadata/io.grpc/grpc-xds/1.80.0/reachability-metadata.json
+++ b/metadata/io.grpc/grpc-xds/1.80.0/reachability-metadata.json
@@ -1,0 +1,254 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.TlsParameters",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.TlsParameters$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.TlsCertificate",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.TlsCertificate$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.SdsSecretConfig",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.SdsSecretConfig$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CertificateProviderPluginInstance",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CertificateProviderPluginInstance$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext$CertificateProvider",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext$CertificateProvider$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext$CertificateProviderInstance",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext$CertificateProviderInstance$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CertificateValidationContext",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CertificateValidationContext$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext$CombinedCertificateValidationContext",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext$CombinedCertificateValidationContext$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.config.core.v3.TypedExtensionConfig",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.config.core.v3.TypedExtensionConfig$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.TlsKeyLog",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.TlsKeyLog$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.com.github.xds.data.orca.v3.OrcaLoadReport"
+      },
+      "type": "com.google.protobuf.ExtensionRegistry",
+      "methods": [
+        {
+          "name": "getEmptyRegistry",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.com.github.xds.service.orca.v3.OrcaLoadReportRequest"
+      },
+      "type": "com.google.protobuf.ExtensionRegistry",
+      "methods": [
+        {
+          "name": "getEmptyRegistry",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.config.core.v3.Node"
+      },
+      "type": "com.google.protobuf.ExtensionRegistry",
+      "methods": [
+        {
+          "name": "getEmptyRegistry",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "com.google.protobuf.ExtensionRegistry",
+      "methods": [
+        {
+          "name": "getEmptyRegistry",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.service.rate_limit_quota.v3.BucketId"
+      },
+      "type": "com.google.protobuf.ExtensionRegistry",
+      "methods": [
+        {
+          "name": "getEmptyRegistry",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.service.status.v3.ClientStatusRequest"
+      },
+      "type": "com.google.protobuf.ExtensionRegistry",
+      "methods": [
+        {
+          "name": "getEmptyRegistry",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.XdsChannelCredentials"
+      },
+      "type": "java.util.concurrent.atomic.LongAdder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.XdsServerBuilder"
+      },
+      "type": "java.util.concurrent.atomic.LongAdder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/io.grpc/grpc-xds/index.json
+++ b/metadata/io.grpc/grpc-xds/index.json
@@ -40,6 +40,15 @@
     ]
   },
   {
+    "metadata-version" : "1.80.0",
+    "tested-versions" : [
+      "1.80.0"
+    ],
+    "allowed-packages" : [
+      "io.grpc.xds"
+    ]
+  },
+  {
     "metadata-version" : "1.79.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/grpc/grpc-xds/$version$/grpc-xds-$version$-sources.jar",
     "repository-url" : "https://github.com/grpc/grpc-java",

--- a/metadata/io.grpc/grpc-xds/index.json
+++ b/metadata/io.grpc/grpc-xds/index.json
@@ -41,6 +41,11 @@
   },
   {
     "metadata-version" : "1.80.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/grpc/grpc-xds/$version$/grpc-xds-$version$-sources.jar",
+    "repository-url" : "https://github.com/grpc/grpc-java",
+    "test-code-url" : "https://github.com/grpc/grpc-java/tree/v$version$/xds/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/grpc/grpc-xds/$version$/grpc-xds-$version$-javadoc.jar",
+    "description" : "grpc-xds provides the Java gRPC xDS plugin, adding xDS-based name resolution, load balancing, control-plane discovery, and related security/filter support for gRPC clients and servers. It lets JVM applications participate in service-mesh style traffic management by consuming xDS configuration and Envoy-compatible protocol resources.",
     "tested-versions" : [
       "1.80.0"
     ],

--- a/stats/io.grpc/grpc-xds/1.80.0/execution-metrics.json
+++ b/stats/io.grpc/grpc-xds/1.80.0/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_javac_fail:2026-05-12": {
+    "timestamp": "2026-05-12T03:59:39.647453Z",
+    "library": "io.grpc:grpc-xds:1.80.0",
+    "starting_commit": "27cbeb847ce0444fbc613c49a3745216db4001ab",
+    "ending_commit": "8ee26ce8471dc872336a1e7b4ce86033643a8ec7",
+    "previous_library": "io.grpc:grpc-xds:1.71.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.80.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 18228,
+          "missed": 1148765,
+          "ratio": 0.01562,
+          "total": 1166993
+        },
+        "line": {
+          "covered": 4361,
+          "missed": 303330,
+          "ratio": 0.014173,
+          "total": 307691
+        },
+        "method": {
+          "covered": 942,
+          "missed": 70648,
+          "ratio": 0.013158,
+          "total": 71590
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.71.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 18076,
+          "missed": 1034646,
+          "ratio": 0.017171,
+          "total": 1052722
+        },
+        "line": {
+          "covered": 4341,
+          "missed": 273055,
+          "ratio": 0.015649,
+          "total": 277396
+        },
+        "method": {
+          "covered": 947,
+          "missed": 63748,
+          "ratio": 0.014638,
+          "total": 64695
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 19428,
+      "cached_input_tokens_used": 139264,
+      "output_tokens_used": 1444,
+      "iterations": 1,
+      "cost_usd": 0.1129,
+      "tested_library_loc": 4361,
+      "metadata_entries": 60,
+      "previous_library_metadata_entries": 60,
+      "code_coverage_percent": 1.42,
+      "previous_library_coverage_percent": 1.56
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.grpc/grpc-xds/1.80.0/src/test/java/io_grpc/grpc_xds/Grpc_xdsTest.java",
+      "metadata_file": "metadata/io.grpc/grpc-xds/1.80.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.grpc/grpc-xds/1.80.0/stats.json
+++ b/stats/io.grpc/grpc-xds/1.80.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.80.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 18228,
+        "missed" : 1148765,
+        "ratio" : 0.01562,
+        "total" : 1166993
+      },
+      "line" : {
+        "covered" : 4361,
+        "missed" : 303330,
+        "ratio" : 0.014173,
+        "total" : 307691
+      },
+      "method" : {
+        "covered" : 942,
+        "missed" : 70648,
+        "ratio" : 0.013158,
+        "total" : 71590
+      }
+    }
+  } ]
+}

--- a/tests/src/io.grpc/grpc-xds/1.80.0/.gitignore
+++ b/tests/src/io.grpc/grpc-xds/1.80.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.grpc/grpc-xds/1.80.0/build.gradle
+++ b/tests/src/io.grpc/grpc-xds/1.80.0/build.gradle
@@ -1,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.grpc:grpc-xds:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    binaries {
+        all {
+            buildArgs.add('--initialize-at-run-time=io.grpc.netty.shaded.io.netty.handler.ssl')
+            buildArgs.add('--initialize-at-run-time=io.grpc.netty.shaded.io.netty.internal.tcnative')
+        }
+    }
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.grpc/grpc-xds/1.80.0/gradle.properties
+++ b/tests/src/io.grpc/grpc-xds/1.80.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.grpc:grpc-xds:1.80.0
+library.version = 1.80.0
+metadata.dir = io.grpc/grpc-xds/1.80.0/

--- a/tests/src/io.grpc/grpc-xds/1.80.0/settings.gradle
+++ b/tests/src/io.grpc/grpc-xds/1.80.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.grpc.grpc-xds_tests'

--- a/tests/src/io.grpc/grpc-xds/1.80.0/src/test/java/io_grpc/grpc_xds/Grpc_xdsTest.java
+++ b/tests/src/io.grpc/grpc-xds/1.80.0/src/test/java/io_grpc/grpc_xds/Grpc_xdsTest.java
@@ -38,7 +38,6 @@ import io.grpc.SynchronizationContext;
 import io.grpc.xds.CdsLoadBalancerProvider;
 import io.grpc.xds.ClusterImplLoadBalancerProvider;
 import io.grpc.xds.ClusterManagerLoadBalancerProvider;
-import io.grpc.xds.ClusterResolverLoadBalancerProvider;
 import io.grpc.xds.CsdsService;
 import io.grpc.xds.EnvoyServerProtoData;
 import io.grpc.xds.LeastRequestLoadBalancerProvider;
@@ -115,7 +114,6 @@ public class Grpc_xdsTest {
         assertRegisteredProvider(loadBalancerRegistry, new LeastRequestLoadBalancerProvider());
         assertRegisteredProvider(loadBalancerRegistry, new WeightedRoundRobinLoadBalancerProvider());
         assertRegisteredProvider(loadBalancerRegistry, new CdsLoadBalancerProvider());
-        assertRegisteredProvider(loadBalancerRegistry, new ClusterResolverLoadBalancerProvider());
         assertRegisteredProvider(loadBalancerRegistry, new ClusterImplLoadBalancerProvider());
         assertRegisteredProvider(loadBalancerRegistry, new PriorityLoadBalancerProvider());
         assertRegisteredProvider(loadBalancerRegistry, new WeightedTargetLoadBalancerProvider());
@@ -186,7 +184,6 @@ public class Grpc_xdsTest {
         assertConfigRejected(new WeightedTargetLoadBalancerProvider(), Map.of("targets", Map.of()));
         assertConfigRejected(new WrrLocalityLoadBalancerProvider(), Map.of("childPolicy", List.of()));
         assertConfigRejected(new PriorityLoadBalancerProvider(), Map.of());
-        assertConfigRejected(new ClusterResolverLoadBalancerProvider(), Map.of());
         assertConfigRejected(new ClusterImplLoadBalancerProvider(), Map.of());
     }
 

--- a/tests/src/io.grpc/grpc-xds/1.80.0/src/test/java/io_grpc/grpc_xds/Grpc_xdsTest.java
+++ b/tests/src/io.grpc/grpc-xds/1.80.0/src/test/java/io_grpc/grpc_xds/Grpc_xdsTest.java
@@ -1,0 +1,685 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_grpc.grpc_xds;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import com.google.protobuf.BoolValue;
+import com.google.protobuf.Duration;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ChannelCredentials;
+import io.grpc.ChannelLogger;
+import io.grpc.ClientCall;
+import io.grpc.ClientStreamTracer;
+import io.grpc.Grpc;
+import io.grpc.InsecureChannelCredentials;
+import io.grpc.InsecureServerCredentials;
+import io.grpc.LoadBalancerProvider;
+import io.grpc.LoadBalancerRegistry;
+import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.NameResolver;
+import io.grpc.NameResolverProvider;
+import io.grpc.NameResolverRegistry;
+import io.grpc.Server;
+import io.grpc.ServerCredentials;
+import io.grpc.ServerMethodDefinition;
+import io.grpc.ServerServiceDefinition;
+import io.grpc.Status;
+import io.grpc.SynchronizationContext;
+import io.grpc.xds.CdsLoadBalancerProvider;
+import io.grpc.xds.ClusterImplLoadBalancerProvider;
+import io.grpc.xds.ClusterManagerLoadBalancerProvider;
+import io.grpc.xds.ClusterResolverLoadBalancerProvider;
+import io.grpc.xds.CsdsService;
+import io.grpc.xds.EnvoyServerProtoData;
+import io.grpc.xds.LeastRequestLoadBalancerProvider;
+import io.grpc.xds.PriorityLoadBalancerProvider;
+import io.grpc.xds.RingHashLoadBalancerProvider;
+import io.grpc.xds.RingHashOptions;
+import io.grpc.xds.WeightedRoundRobinLoadBalancerProvider;
+import io.grpc.xds.WeightedTargetLoadBalancerProvider;
+import io.grpc.xds.WrrLocalityLoadBalancerProvider;
+import io.grpc.xds.XdsChannelCredentials;
+import io.grpc.xds.XdsNameResolverProvider;
+import io.grpc.xds.XdsServerBuilder;
+import io.grpc.xds.XdsServerCredentials;
+import io.grpc.xds.client.Bootstrapper;
+import io.grpc.xds.client.BootstrapperImpl;
+import io.grpc.xds.client.EnvoyProtoData;
+import io.grpc.xds.client.XdsInitializationException;
+import io.grpc.xds.orca.OrcaOobUtil;
+import io.grpc.xds.orca.OrcaPerRequestUtil;
+import io.grpc.xds.shaded.com.github.xds.data.orca.v3.OrcaLoadReport;
+import io.grpc.xds.shaded.com.github.xds.service.orca.v3.OpenRcaServiceGrpc;
+import io.grpc.xds.shaded.com.github.xds.service.orca.v3.OrcaLoadReportRequest;
+import io.grpc.xds.shaded.io.envoyproxy.envoy.config.core.v3.Node;
+import io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext;
+import io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext;
+import io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext;
+import io.grpc.xds.shaded.io.envoyproxy.envoy.service.rate_limit_quota.v3.BucketId;
+import io.grpc.xds.shaded.io.envoyproxy.envoy.service.rate_limit_quota.v3.RateLimitQuotaResponse;
+import io.grpc.xds.shaded.io.envoyproxy.envoy.service.rate_limit_quota.v3.RateLimitQuotaResponse.BucketAction;
+import io.grpc.xds.shaded.io.envoyproxy.envoy.service.rate_limit_quota.v3.RateLimitQuotaServiceGrpc;
+import io.grpc.xds.shaded.io.envoyproxy.envoy.service.rate_limit_quota.v3.RateLimitQuotaUsageReports;
+import io.grpc.xds.shaded.io.envoyproxy.envoy.service.rate_limit_quota.v3.RateLimitQuotaUsageReports.BucketQuotaUsage;
+import io.grpc.xds.shaded.io.envoyproxy.envoy.service.status.v3.ClientStatusDiscoveryServiceGrpc;
+import io.grpc.xds.shaded.io.envoyproxy.envoy.service.status.v3.ClientStatusRequest;
+import io.grpc.xds.shaded.io.envoyproxy.envoy.type.v3.RateLimitStrategy;
+import io.grpc.xds.shaded.io.envoyproxy.envoy.type.v3.RateLimitStrategy.RequestsPerTimeUnit;
+import io.grpc.xds.shaded.io.envoyproxy.envoy.type.v3.RateLimitUnit;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+public class Grpc_xdsTest {
+    @Test
+    void xdsCredentialsWrapFallbackCredentialsAndValidateNulls() {
+        ChannelCredentials fallbackChannelCredentials = InsecureChannelCredentials.create();
+        ChannelCredentials xdsChannelCredentials = XdsChannelCredentials.create(fallbackChannelCredentials);
+
+        assertThat(xdsChannelCredentials).isNotNull();
+        assertThat(xdsChannelCredentials.withoutBearerTokens()).isNotNull();
+        assertThatNullPointerException().isThrownBy(() -> XdsChannelCredentials.create(null));
+
+        ServerCredentials fallbackServerCredentials = InsecureServerCredentials.create();
+        ServerCredentials xdsServerCredentials = XdsServerCredentials.create(fallbackServerCredentials);
+
+        assertThat(xdsServerCredentials).isNotNull();
+        assertThatNullPointerException().isThrownBy(() -> XdsServerCredentials.create(null));
+    }
+
+    @Test
+    void xdsProvidersAreDiscoverableFromGrpcRegistries() {
+        LoadBalancerRegistry loadBalancerRegistry = LoadBalancerRegistry.getDefaultRegistry();
+
+        assertRegisteredProvider(loadBalancerRegistry, new RingHashLoadBalancerProvider());
+        assertRegisteredProvider(loadBalancerRegistry, new LeastRequestLoadBalancerProvider());
+        assertRegisteredProvider(loadBalancerRegistry, new WeightedRoundRobinLoadBalancerProvider());
+        assertRegisteredProvider(loadBalancerRegistry, new CdsLoadBalancerProvider());
+        assertRegisteredProvider(loadBalancerRegistry, new ClusterResolverLoadBalancerProvider());
+        assertRegisteredProvider(loadBalancerRegistry, new ClusterImplLoadBalancerProvider());
+        assertRegisteredProvider(loadBalancerRegistry, new PriorityLoadBalancerProvider());
+        assertRegisteredProvider(loadBalancerRegistry, new WeightedTargetLoadBalancerProvider());
+        assertRegisteredProvider(loadBalancerRegistry, new WrrLocalityLoadBalancerProvider());
+
+        NameResolverProvider xdsProvider = NameResolverRegistry.getDefaultRegistry().getProviderForScheme("xds");
+        assertThat(xdsProvider).isInstanceOf(XdsNameResolverProvider.class);
+        assertThat(xdsProvider.getDefaultScheme()).isEqualTo("xds");
+    }
+
+    @Test
+    void xdsNameResolverProviderCreatesResolversForMatchingSchemeOnly() throws Exception {
+        NameResolverProvider provider = XdsNameResolverProvider.createForTest("xdstest", bootstrapOverride());
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+
+        try {
+            NameResolver resolver = provider.newNameResolver(
+                    URI.create("xdstest:///orders.googleapis.com:443"), resolverArgs(scheduler));
+
+            assertThat(provider.getDefaultScheme()).isEqualTo("xdstest");
+            assertThat(provider.getProducedSocketAddressTypes()).containsExactly(InetSocketAddress.class);
+            assertThat(resolver).isNotNull();
+            assertThat(resolver.getServiceAuthority()).isEqualTo("orders.googleapis.com:443");
+            assertThat(provider.newNameResolver(URI.create("dns:///orders.googleapis.com"), resolverArgs(scheduler)))
+                    .isNull();
+            resolver.shutdown();
+        } finally {
+            scheduler.shutdownNow();
+            scheduler.awaitTermination(5, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void ringHashOptionsClampConfiguredRingSizeCap() {
+        long originalRingSizeCap = RingHashOptions.getRingSizeCap();
+
+        try {
+            RingHashOptions.setRingSizeCap(-5);
+            assertThat(RingHashOptions.getRingSizeCap()).isEqualTo(1);
+
+            RingHashOptions.setRingSizeCap(65_536);
+            assertThat(RingHashOptions.getRingSizeCap()).isEqualTo(65_536);
+
+            RingHashOptions.setRingSizeCap(Long.MAX_VALUE);
+            assertThat(RingHashOptions.getRingSizeCap()).isEqualTo(8_388_608);
+        } finally {
+            RingHashOptions.setRingSizeCap(originalRingSizeCap);
+        }
+    }
+
+    @Test
+    void loadBalancerProvidersParsePublicServiceConfigShapes() {
+        assertConfigAccepted(new RingHashLoadBalancerProvider(), Map.of("minRingSize", 128.0, "maxRingSize", 4096.0));
+        assertConfigAccepted(new LeastRequestLoadBalancerProvider(), Map.of("choiceCount", 3.0));
+        assertConfigAccepted(
+                new WeightedRoundRobinLoadBalancerProvider(),
+                Map.of(
+                        "blackoutPeriod", "1s",
+                        "weightExpirationPeriod", "3s",
+                        "enableOobLoadReport", true,
+                        "oobReportingPeriod", "2s",
+                        "weightUpdatePeriod", "0.250s",
+                        "errorUtilizationPenalty", 1.5f));
+        assertConfigAccepted(new CdsLoadBalancerProvider(), Map.of("cluster", "payments-cluster"));
+
+        assertConfigRejected(new RingHashLoadBalancerProvider(), Map.of("minRingSize", 8.0, "maxRingSize", 4.0));
+        assertConfigRejected(new LeastRequestLoadBalancerProvider(), Map.of("choiceCount", 1.0));
+        assertConfigRejected(new WeightedTargetLoadBalancerProvider(), Map.of("targets", Map.of()));
+        assertConfigRejected(new WrrLocalityLoadBalancerProvider(), Map.of("childPolicy", List.of()));
+        assertConfigRejected(new PriorityLoadBalancerProvider(), Map.of());
+        assertConfigRejected(new ClusterResolverLoadBalancerProvider(), Map.of());
+        assertConfigRejected(new ClusterImplLoadBalancerProvider(), Map.of());
+    }
+
+    @Test
+    void clusterManagerLoadBalancerProviderParsesNamedChildPolicies() {
+        ClusterManagerLoadBalancerProvider provider = new ClusterManagerLoadBalancerProvider();
+        RingHashLoadBalancerProvider ringHashProvider = new RingHashLoadBalancerProvider();
+        LeastRequestLoadBalancerProvider leastRequestProvider = new LeastRequestLoadBalancerProvider();
+
+        assertRegisteredProvider(LoadBalancerRegistry.getDefaultRegistry(), provider);
+
+        NameResolver.ConfigOrError result = provider.parseLoadBalancingPolicyConfig(Map.of(
+                "childPolicy",
+                Map.of(
+                        "payments-child",
+                        Map.of(
+                                "lbPolicy",
+                                List.of(Map.of(
+                                        ringHashProvider.getPolicyName(),
+                                        Map.of("minRingSize", 128.0, "maxRingSize", 1024.0)))),
+                        "orders-child",
+                        Map.of(
+                                "lbPolicy",
+                                List.of(Map.of(
+                                        leastRequestProvider.getPolicyName(),
+                                        Map.of("choiceCount", 2.0)))))));
+
+        assertThat(result.getError()).isNull();
+        assertThat(result.getConfig()).isNotNull();
+        assertThat(result.getConfig().toString()).contains("payments-child", "orders-child");
+
+        assertConfigRejected(provider, Map.of());
+        assertConfigRejected(provider, Map.of("childPolicy", Map.of()));
+        assertConfigRejected(provider, Map.of(
+                "childPolicy",
+                Map.of("broken-child", Map.of("lbPolicy", List.of(Map.of("unknown_policy", Map.of()))))));
+    }
+
+    @Test
+    void csdsServiceBindsExpectedXdsStatusMethods() {
+        CsdsService service = CsdsService.newInstance();
+        ServerServiceDefinition definition = service.bindService();
+
+        assertThat(definition.getServiceDescriptor().getName())
+                .isEqualTo(ClientStatusDiscoveryServiceGrpc.SERVICE_NAME);
+        assertThat(methodFullNames(definition.getMethods()))
+                .containsExactlyInAnyOrder(
+                        ClientStatusDiscoveryServiceGrpc.getFetchClientStatusMethod().getFullMethodName(),
+                        ClientStatusDiscoveryServiceGrpc.getStreamClientStatusMethod().getFullMethodName());
+
+        ClientStatusRequest request = ClientStatusRequest.newBuilder()
+                .setNode(Node.newBuilder().setId("test-node").setCluster("test-cluster"))
+                .setExcludeResourceContents(true)
+                .build();
+        ClientStatusRequest parsed = request.toBuilder().build();
+
+        assertThat(parsed.getNode().getId()).isEqualTo("test-node");
+        assertThat(parsed.getNode().getCluster()).isEqualTo("test-cluster");
+        assertThat(parsed.getExcludeResourceContents()).isTrue();
+    }
+
+    @Test
+    void xdsServerBuilderAcceptsPublicCsdsServiceAndBootstrapOverride() throws Exception {
+        ServerCredentials credentials = XdsServerCredentials.create(InsecureServerCredentials.create());
+        Server server = XdsServerBuilder.forPort(0, credentials)
+                .addService(CsdsService.newInstance())
+                .xdsServingStatusListener(new RecordingServingStatusListener())
+                .drainGraceTime(1, TimeUnit.SECONDS)
+                .overrideBootstrapForTest(bootstrapOverride())
+                .build();
+
+        try {
+            assertThat(server).isNotNull();
+        } finally {
+            server.shutdownNow();
+            server.awaitTermination(5, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void orcaProtosDescriptorsAndStubFactoriesAreUsable() {
+        OrcaLoadReportRequest request = OrcaLoadReportRequest.newBuilder()
+                .setReportInterval(Duration.newBuilder().setSeconds(1).build())
+                .addRequestCostNames("cpu-cost")
+                .addRequestCostNames("memory-cost")
+                .build();
+        OrcaLoadReportRequest parsedRequest = request.toBuilder().build();
+
+        assertThat(parsedRequest.getReportInterval().getSeconds()).isEqualTo(1);
+        assertThat(parsedRequest.getRequestCostNamesList()).containsExactly("cpu-cost", "memory-cost");
+
+        OrcaLoadReport report = OrcaLoadReport.newBuilder()
+                .setCpuUtilization(0.25)
+                .setMemUtilization(0.50)
+                .setRps(42)
+                .setRpsFractional(42.5)
+                .setEps(1.5)
+                .setApplicationUtilization(0.75)
+                .putRequestCost("cpu-cost", 2.0)
+                .putUtilization("gpu", 0.60)
+                .putNamedMetrics("queue-depth", 7.0)
+                .build();
+        OrcaLoadReport parsedReport = report.toBuilder().build();
+
+        assertThat(parsedReport.getCpuUtilization()).isEqualTo(0.25);
+        assertThat(parsedReport.getMemUtilization()).isEqualTo(0.50);
+        assertThat(parsedReport.getRps()).isEqualTo(42);
+        assertThat(parsedReport.getRpsFractional()).isEqualTo(42.5);
+        assertThat(parsedReport.getEps()).isEqualTo(1.5);
+        assertThat(parsedReport.getApplicationUtilization()).isEqualTo(0.75);
+        assertThat(parsedReport.getRequestCostOrThrow("cpu-cost")).isEqualTo(2.0);
+        assertThat(parsedReport.getUtilizationOrThrow("gpu")).isEqualTo(0.60);
+        assertThat(parsedReport.getNamedMetricsOrThrow("queue-depth")).isEqualTo(7.0);
+
+        assertThat(OpenRcaServiceGrpc.SERVICE_NAME).isEqualTo("xds.service.orca.v3.OpenRcaService");
+        assertThat(OpenRcaServiceGrpc.getStreamCoreMetricsMethod().getType())
+                .isEqualTo(MethodDescriptor.MethodType.SERVER_STREAMING);
+        assertThat(OpenRcaServiceGrpc.getServiceDescriptor().getMethods())
+                .contains(OpenRcaServiceGrpc.getStreamCoreMetricsMethod());
+
+        Channel channel = new NoopChannel();
+        assertThat(OpenRcaServiceGrpc.newStub(channel)).isNotNull();
+        assertThat(OpenRcaServiceGrpc.newBlockingStub(channel)).isNotNull();
+        assertThat(OpenRcaServiceGrpc.newFutureStub(channel)).isNotNull();
+    }
+
+    @Test
+    void rateLimitQuotaServiceProtosDescriptorsAndStubsAreUsable() {
+        BucketId bucketId = BucketId.newBuilder()
+                .putBucket("route", "checkout")
+                .putBucket("tenant", "test-tenant")
+                .build();
+        RateLimitQuotaUsageReports usageReports = RateLimitQuotaUsageReports.newBuilder()
+                .setDomain("payments")
+                .addBucketQuotaUsages(BucketQuotaUsage.newBuilder()
+                        .setBucketId(bucketId)
+                        .setTimeElapsed(Duration.newBuilder().setSeconds(5))
+                        .setNumRequestsAllowed(12)
+                        .setNumRequestsDenied(3))
+                .build();
+        RateLimitQuotaUsageReports parsedUsageReports = usageReports.toBuilder().build();
+
+        assertThat(parsedUsageReports.getDomain()).isEqualTo("payments");
+        assertThat(parsedUsageReports.getBucketQuotaUsagesCount()).isEqualTo(1);
+        assertThat(parsedUsageReports.getBucketQuotaUsages(0).getBucketId().getBucketOrThrow("route"))
+                .isEqualTo("checkout");
+        assertThat(parsedUsageReports.getBucketQuotaUsages(0).getTimeElapsed().getSeconds()).isEqualTo(5);
+        assertThat(parsedUsageReports.getBucketQuotaUsages(0).getNumRequestsAllowed()).isEqualTo(12);
+        assertThat(parsedUsageReports.getBucketQuotaUsages(0).getNumRequestsDenied()).isEqualTo(3);
+
+        RateLimitStrategy strategy = RateLimitStrategy.newBuilder()
+                .setRequestsPerTimeUnit(RequestsPerTimeUnit.newBuilder()
+                        .setRequestsPerTimeUnit(100)
+                        .setTimeUnit(RateLimitUnit.MINUTE))
+                .build();
+        RateLimitQuotaResponse response = RateLimitQuotaResponse.newBuilder()
+                .addBucketAction(BucketAction.newBuilder()
+                        .setBucketId(bucketId)
+                        .setQuotaAssignmentAction(BucketAction.QuotaAssignmentAction.newBuilder()
+                                .setAssignmentTimeToLive(Duration.newBuilder().setSeconds(30))
+                                .setRateLimitStrategy(strategy)))
+                .build();
+        RateLimitQuotaResponse parsedResponse = response.toBuilder().build();
+
+        assertThat(parsedResponse.getBucketActionCount()).isEqualTo(1);
+        assertThat(parsedResponse.getBucketAction(0).getBucketActionCase())
+                .isEqualTo(BucketAction.BucketActionCase.QUOTA_ASSIGNMENT_ACTION);
+        assertThat(parsedResponse.getBucketAction(0)
+                .getQuotaAssignmentAction()
+                .getAssignmentTimeToLive()
+                .getSeconds())
+                .isEqualTo(30);
+        assertThat(parsedResponse.getBucketAction(0)
+                .getQuotaAssignmentAction()
+                .getRateLimitStrategy()
+                .getRequestsPerTimeUnit()
+                .getTimeUnit())
+                .isEqualTo(RateLimitUnit.MINUTE);
+
+        assertThat(RateLimitQuotaServiceGrpc.SERVICE_NAME)
+                .isEqualTo("envoy.service.rate_limit_quota.v3.RateLimitQuotaService");
+        assertThat(RateLimitQuotaServiceGrpc.getStreamRateLimitQuotasMethod().getType())
+                .isEqualTo(MethodDescriptor.MethodType.BIDI_STREAMING);
+        assertThat(RateLimitQuotaServiceGrpc.getServiceDescriptor().getMethods())
+                .contains(RateLimitQuotaServiceGrpc.getStreamRateLimitQuotasMethod());
+        assertThat(RateLimitQuotaServiceGrpc.bindService(new RateLimitQuotaServiceGrpc.AsyncService() {})
+                .getServiceDescriptor()
+                .getName())
+                .isEqualTo(RateLimitQuotaServiceGrpc.SERVICE_NAME);
+
+        Channel channel = new NoopChannel();
+        assertThat(RateLimitQuotaServiceGrpc.newStub(channel)).isNotNull();
+        assertThat(RateLimitQuotaServiceGrpc.newBlockingV2Stub(channel)).isNotNull();
+        assertThat(RateLimitQuotaServiceGrpc.newBlockingStub(channel)).isNotNull();
+        assertThat(RateLimitQuotaServiceGrpc.newFutureStub(channel)).isNotNull();
+    }
+
+    @Test
+    void orcaUtilitiesCreateReportingConfigurationAndPerRequestTracers() {
+        OrcaOobUtil.OrcaReportingConfig config = OrcaOobUtil.OrcaReportingConfig.newBuilder()
+                .setReportInterval(250, TimeUnit.MILLISECONDS)
+                .build();
+
+        assertThat(config.getReportIntervalNanos()).isEqualTo(TimeUnit.MILLISECONDS.toNanos(250));
+        assertThat(config.toBuilder().build().getReportIntervalNanos()).isEqualTo(config.getReportIntervalNanos());
+        assertThat(config.toString()).contains("reportIntervalNanos");
+
+        AtomicInteger delegateCalls = new AtomicInteger();
+        ClientStreamTracer.Factory delegateFactory = new ClientStreamTracer.Factory() {
+            @Override
+            public ClientStreamTracer newClientStreamTracer(ClientStreamTracer.StreamInfo info, Metadata headers) {
+                delegateCalls.incrementAndGet();
+                return new ClientStreamTracer() {};
+            }
+        };
+        OrcaPerRequestUtil perRequestUtil = OrcaPerRequestUtil.getInstance();
+        ClientStreamTracer.Factory factory = perRequestUtil.newOrcaClientStreamTracerFactory(
+                delegateFactory,
+                report -> assertThat(report).isNotNull());
+
+        ClientStreamTracer tracer = factory.newClientStreamTracer(
+                ClientStreamTracer.StreamInfo.newBuilder().setCallOptions(CallOptions.DEFAULT).build(),
+                new Metadata());
+
+        assertThat(tracer).isNotNull();
+        assertThat(delegateCalls).hasValue(1);
+        assertThat(perRequestUtil.newOrcaClientStreamTracerFactory(report -> assertThat(report).isNotNull()))
+                .isNotNull();
+    }
+
+    @Test
+    void envoyTlsContextsConvertFromXdsProtosAndPreserveCommonSettings() {
+        CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
+                .addAlpnProtocols("h2")
+                .addAlpnProtocols("grpc-exp")
+                .build();
+        DownstreamTlsContext downstreamTlsContext = DownstreamTlsContext.newBuilder()
+                .setCommonTlsContext(commonTlsContext)
+                .setRequireClientCertificate(BoolValue.of(true))
+                .build();
+
+        EnvoyServerProtoData.DownstreamTlsContext convertedDownstreamTlsContext =
+                EnvoyServerProtoData.DownstreamTlsContext.fromEnvoyProtoDownstreamTlsContext(downstreamTlsContext);
+
+        assertThat(convertedDownstreamTlsContext.getCommonTlsContext().getAlpnProtocolsList())
+                .containsExactly("h2", "grpc-exp");
+        assertThat(convertedDownstreamTlsContext.isRequireClientCertificate()).isTrue();
+        assertThat(convertedDownstreamTlsContext)
+                .isEqualTo(new EnvoyServerProtoData.DownstreamTlsContext(commonTlsContext, true));
+
+        UpstreamTlsContext upstreamTlsContext = UpstreamTlsContext.newBuilder()
+                .setCommonTlsContext(commonTlsContext)
+                .setSni("backend.example.com")
+                .build();
+
+        EnvoyServerProtoData.UpstreamTlsContext convertedUpstreamTlsContext =
+                EnvoyServerProtoData.UpstreamTlsContext.fromEnvoyProtoUpstreamTlsContext(upstreamTlsContext);
+
+        assertThat(convertedUpstreamTlsContext.getCommonTlsContext()).isEqualTo(commonTlsContext);
+        assertThat(convertedUpstreamTlsContext.toString()).contains("commonTlsContext");
+    }
+
+    @Test
+    void managedChannelBuilderAcceptsXdsChannelCredentials() {
+        ChannelCredentials credentials = XdsChannelCredentials.create(InsecureChannelCredentials.create());
+
+        assertThatCode(() -> {
+            ManagedChannel channel = Grpc.newChannelBuilderForAddress("localhost", 8080, credentials).build();
+            try {
+                assertThat(channel).isNotNull();
+            } finally {
+                channel.shutdownNow();
+                channel.awaitTermination(5, TimeUnit.SECONDS);
+            }
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    void bootstrapperParsesXdsBootstrapNodeSecurityAndAuthorityConfiguration() throws Exception {
+        Bootstrapper.BootstrapInfo bootstrapInfo = new TestingBootstrapper().bootstrap(Map.of(
+                "xds_servers",
+                List.of(serverConfig("xds-primary.example.com:443", true)),
+                "node",
+                Map.of(
+                        "id",
+                        "bootstrap-node",
+                        "cluster",
+                        "bootstrap-cluster",
+                        "metadata",
+                        Map.of("environment", "test", "debug", true),
+                        "locality",
+                        Map.of("region", "us-central1", "zone", "us-central1-a", "sub_zone", "blue")),
+                "certificate_providers",
+                Map.of("file-provider", Map.of(
+                        "plugin_name",
+                        "file_watcher",
+                        "config",
+                        Map.of("certificate_file", "/tmp/cert.pem", "private_key_file", "/tmp/key.pem"))),
+                "server_listener_resource_name_template",
+                "grpc/server/%s",
+                "client_default_listener_resource_name_template",
+                "xdstp://traffic-director/global/envoy.config.listener.v3.Listener/%s",
+                "authorities",
+                Map.of("traffic-director", Map.of(
+                        "client_listener_resource_name_template",
+                        "xdstp://traffic-director/envoy.config.listener.v3.Listener/%s",
+                        "xds_servers",
+                        List.of(serverConfig("authority-xds.example.com:443", false))))));
+
+        Bootstrapper.ServerInfo primaryServer = bootstrapInfo.servers().get(0);
+        assertThat(primaryServer.target()).isEqualTo("xds-primary.example.com:443");
+        assertThat(primaryServer.ignoreResourceDeletion()).isTrue();
+        assertThat(primaryServer.implSpecificConfig())
+                .isEqualTo(Map.copyOf(serverConfig("xds-primary.example.com:443", true)));
+
+        EnvoyProtoData.Node xdsNode = bootstrapInfo.node();
+        Node envoyNode = xdsNode.toEnvoyProtoNode();
+        assertThat(xdsNode.getId()).isEqualTo("bootstrap-node");
+        assertThat(envoyNode.getCluster()).isEqualTo("bootstrap-cluster");
+        assertThat(envoyNode.getMetadata().getFieldsOrThrow("environment").getStringValue()).isEqualTo("test");
+        assertThat(envoyNode.getMetadata().getFieldsOrThrow("debug").getBoolValue()).isTrue();
+        assertThat(envoyNode.getLocality().getRegion()).isEqualTo("us-central1");
+        assertThat(envoyNode.getLocality().getZone()).isEqualTo("us-central1-a");
+        assertThat(envoyNode.getLocality().getSubZone()).isEqualTo("blue");
+        assertThat(envoyNode.getClientFeaturesList())
+                .contains(
+                        BootstrapperImpl.CLIENT_FEATURE_DISABLE_OVERPROVISIONING,
+                        BootstrapperImpl.CLIENT_FEATURE_RESOURCE_IN_SOTW);
+
+        Bootstrapper.CertificateProviderInfo certificateProvider = bootstrapInfo.certProviders().get("file-provider");
+        assertThat(certificateProvider.pluginName()).isEqualTo("file_watcher");
+        assertThat(certificateProvider.config().get("certificate_file")).isEqualTo("/tmp/cert.pem");
+
+        assertThat(bootstrapInfo.serverListenerResourceNameTemplate()).isEqualTo("grpc/server/%s");
+        assertThat(bootstrapInfo.clientDefaultListenerResourceNameTemplate())
+                .isEqualTo("xdstp://traffic-director/global/envoy.config.listener.v3.Listener/%s");
+
+        Bootstrapper.AuthorityInfo authority = bootstrapInfo.authorities().get("traffic-director");
+        assertThat(authority.clientListenerResourceNameTemplate())
+                .isEqualTo("xdstp://traffic-director/envoy.config.listener.v3.Listener/%s");
+        assertThat(authority.xdsServers()).hasSize(1);
+        assertThat(authority.xdsServers().get(0).target()).isEqualTo("authority-xds.example.com:443");
+        assertThat(authority.xdsServers().get(0).ignoreResourceDeletion()).isFalse();
+    }
+
+    private static void assertRegisteredProvider(LoadBalancerRegistry registry, LoadBalancerProvider provider) {
+        LoadBalancerProvider registeredProvider = registry.getProvider(provider.getPolicyName());
+
+        assertThat(registeredProvider).isNotNull();
+        assertThat(registeredProvider.isAvailable()).isTrue();
+        assertThat(registeredProvider.getPolicyName()).isEqualTo(provider.getPolicyName());
+    }
+
+    private static void assertConfigAccepted(LoadBalancerProvider provider, Map<String, ?> config) {
+        NameResolver.ConfigOrError result = provider.parseLoadBalancingPolicyConfig(config);
+
+        assertThat(result.getError()).isNull();
+        assertThat(result.getConfig()).isNotNull();
+    }
+
+    private static void assertConfigRejected(LoadBalancerProvider provider, Map<String, ?> config) {
+        NameResolver.ConfigOrError result = provider.parseLoadBalancingPolicyConfig(config);
+
+        assertThat(result.getError()).isNotNull();
+        assertThat(result.getError().getCode()).isNotEqualTo(Status.Code.OK);
+    }
+
+    private static NameResolver.Args resolverArgs(ScheduledExecutorService scheduler) {
+        return NameResolver.Args.newBuilder()
+                .setDefaultPort(443)
+                .setProxyDetector(targetServerAddress -> null)
+                .setSynchronizationContext(new SynchronizationContext((thread, exception) -> {
+                    throw new AssertionError(exception);
+                }))
+                .setScheduledExecutorService(scheduler)
+                .setServiceConfigParser(new NameResolver.ServiceConfigParser() {
+                    @Override
+                    public NameResolver.ConfigOrError parseServiceConfig(Map<String, ?> rawServiceConfig) {
+                        return NameResolver.ConfigOrError.fromConfig(rawServiceConfig);
+                    }
+                })
+                .setChannelLogger(new ChannelLogger() {
+                    @Override
+                    public void log(ChannelLogger.ChannelLogLevel level, String message) {
+                        assertThat(level).isNotNull();
+                        assertThat(message).isNotNull();
+                    }
+
+                    @Override
+                    public void log(ChannelLogger.ChannelLogLevel level, String message, Object... args) {
+                        assertThat(level).isNotNull();
+                        assertThat(message).isNotNull();
+                        assertThat(args).isNotNull();
+                    }
+                })
+                .build();
+    }
+
+    private static Set<String> methodFullNames(Collection<ServerMethodDefinition<?, ?>> methods) {
+        Map<String, Boolean> fullNames = new HashMap<>();
+        for (ServerMethodDefinition<?, ?> method : methods) {
+            fullNames.put(method.getMethodDescriptor().getFullMethodName(), true);
+        }
+        return fullNames.keySet();
+    }
+
+    private static Map<String, ?> bootstrapOverride() {
+        return Map.of(
+                "xds_servers",
+                List.of(Map.of(
+                        "server_uri", "trafficdirector.googleapis.com:443",
+                        "channel_creds", List.of(Map.of("type", "insecure")))),
+                "node",
+                Map.of("id", "test-node", "cluster", "test-cluster"));
+    }
+
+    private static Map<String, ?> serverConfig(String serverUri, boolean ignoreResourceDeletion) {
+        return Map.of(
+                "server_uri",
+                serverUri,
+                "channel_creds",
+                List.of(Map.of("type", "insecure")),
+                "server_features",
+                ignoreResourceDeletion ? List.of("ignore_resource_deletion") : List.of());
+    }
+
+    private static final class TestingBootstrapper extends BootstrapperImpl {
+        @Override
+        protected String getJsonContent() throws IOException, XdsInitializationException {
+            throw new UnsupportedOperationException("bootstrap(Map) supplies configuration directly");
+        }
+
+        @Override
+        protected Object getImplSpecificConfig(Map<String, ?> rawServerConfig, String serverUri)
+                throws XdsInitializationException {
+            assertThat(rawServerConfig.get("server_uri")).isEqualTo(serverUri);
+            return Map.copyOf(rawServerConfig);
+        }
+    }
+
+    private static final class RecordingServingStatusListener implements XdsServerBuilder.XdsServingStatusListener {
+        private final AtomicInteger statusChanges = new AtomicInteger();
+
+        @Override
+        public void onServing() {
+            statusChanges.incrementAndGet();
+        }
+
+        @Override
+        public void onNotServing(Throwable throwable) {
+            statusChanges.incrementAndGet();
+            assertThat(throwable).isNotNull();
+        }
+    }
+
+    private static final class NoopChannel extends Channel {
+        @Override
+        public <RequestT, ResponseT> ClientCall<RequestT, ResponseT> newCall(
+                MethodDescriptor<RequestT, ResponseT> methodDescriptor, CallOptions callOptions) {
+            return new ClientCall<>() {
+                private boolean halfClosed;
+
+                @Override
+                public void start(Listener<ResponseT> responseListener, Metadata headers) {
+                    assertThat(responseListener).isNotNull();
+                    assertThat(headers).isNotNull();
+                }
+
+                @Override
+                public void request(int numberOfMessages) {
+                    assertThat(numberOfMessages).isPositive();
+                }
+
+                @Override
+                public void cancel(String message, Throwable cause) {
+                    assertThat(halfClosed).isFalse();
+                }
+
+                @Override
+                public void halfClose() {
+                    halfClosed = true;
+                }
+
+                @Override
+                public void sendMessage(RequestT message) {
+                    assertThat(message).isNotNull();
+                }
+            };
+        }
+
+        @Override
+        public String authority() {
+            return "noop-authority";
+        }
+    }
+}

--- a/tests/src/io.grpc/grpc-xds/1.80.0/user-code-filter.json
+++ b/tests/src/io.grpc/grpc-xds/1.80.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "io.grpc.xds.**"
+    },
+    {
+      "includeClasses" : "io_grpc.grpc_xds.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6800

This PR provides test fixes and new metadata for io.grpc:grpc-xds:1.80.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 19428
- Cached input tokens: 139264
- Output tokens: 1444
- Metadata entries: 60
- Iterations: 1
- Library coverage percentage: 1.42
- Previous library version metadata entries: 60
- Previous library version coverage percentage: 1.56

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `12ab11bafb4a799143877fe32c276376f73e937a`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.grpc:grpc-xds:1.71.0: 0/0 covered calls (100.00%)
- io.grpc:grpc-xds:1.80.0: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.grpc:grpc-xds:1.71.0: 18076/1052722 (1.72%)
- io.grpc:grpc-xds:1.80.0: 18228/1166993 (1.56%)

**Line:**
- io.grpc:grpc-xds:1.71.0: 4341/277396 (1.56%)
- io.grpc:grpc-xds:1.80.0: 4361/307691 (1.42%)

**Method:**
- io.grpc:grpc-xds:1.71.0: 947/64695 (1.46%)
- io.grpc:grpc-xds:1.80.0: 942/71590 (1.32%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/io.grpc/grpc-xds/1.71.0/src/test/java/io_grpc/grpc_xds/Grpc_xdsTest.java 2/tests/src/io.grpc/grpc-xds/1.80.0/src/test/java/io_grpc/grpc_xds/Grpc_xdsTest.java
index 20bcc18828..9403be4cab 100644
--- 1/tests/src/io.grpc/grpc-xds/1.71.0/src/test/java/io_grpc/grpc_xds/Grpc_xdsTest.java
+++ 2/tests/src/io.grpc/grpc-xds/1.80.0/src/test/java/io_grpc/grpc_xds/Grpc_xdsTest.java
@@ -38,7 +38,6 @@ import io.grpc.SynchronizationContext;
 import io.grpc.xds.CdsLoadBalancerProvider;
 import io.grpc.xds.ClusterImplLoadBalancerProvider;
 import io.grpc.xds.ClusterManagerLoadBalancerProvider;
-import io.grpc.xds.ClusterResolverLoadBalancerProvider;
 import io.grpc.xds.CsdsService;
 import io.grpc.xds.EnvoyServerProtoData;
 import io.grpc.xds.LeastRequestLoadBalancerProvider;
@@ -115,7 +114,6 @@ public class Grpc_xdsTest {
         assertRegisteredProvider(loadBalancerRegistry, new LeastRequestLoadBalancerProvider());
         assertRegisteredProvider(loadBalancerRegistry, new WeightedRoundRobinLoadBalancerProvider());
         assertRegisteredProvider(loadBalancerRegistry, new CdsLoadBalancerProvider());
-        assertRegisteredProvider(loadBalancerRegistry, new ClusterResolverLoadBalancerProvider());
         assertRegisteredProvider(loadBalancerRegistry, new ClusterImplLoadBalancerProvider());
         assertRegisteredProvider(loadBalancerRegistry, new PriorityLoadBalancerProvider());
         assertRegisteredProvider(loadBalancerRegistry, new WeightedTargetLoadBalancerProvider());
@@ -186,7 +184,6 @@ public class Grpc_xdsTest {
         assertConfigRejected(new WeightedTargetLoadBalancerProvider(), Map.of("targets", Map.of()));
         assertConfigRejected(new WrrLocalityLoadBalancerProvider(), Map.of("childPolicy", List.of()));
         assertConfigRejected(new PriorityLoadBalancerProvider(), Map.of());
-        assertConfigRejected(new ClusterResolverLoadBalancerProvider(), Map.of());
         assertConfigRejected(new ClusterImplLoadBalancerProvider(), Map.of());
     }
 

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
