### PR TITLE
[GenAI] Mark com.cognitect:transit-clj as not for Native Image

### DIFF
--- a/metadata/com.cognitect/transit-clj/index.json
+++ b/metadata/com.cognitect/transit-clj/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published JAR for 0.8.285 contains Clojure source and Maven metadata but no JVM .class files, so there is no class-bearing artifact for Native Image reachability metadata.",
+    "replacement": "com.cognitect:transit-java:0.8.311"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #2812

This PR records `com.cognitect:transit-clj` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published JAR for 0.8.285 contains Clojure source and Maven metadata but no JVM .class files, so there is no class-bearing artifact for Native Image reachability metadata.

Replacement guidance:
- com.cognitect:transit-java:0.8.311

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `12ab11bafb4a799143877fe32c276376f73e937a`

### Local CI Verification

- Status: `success`
- Commands run: 6
- Fixup attempts: 0
