### PR TITLE
[GenAI] Test fix for org.codehaus.plexus:plexus-utils:2.0.3 using gpt-5.5

### DIFF
--- a/metadata/org.codehaus.plexus/plexus-utils/2.0.3/reachability-metadata.json
+++ b/metadata/org.codehaus.plexus/plexus-utils/2.0.3/reachability-metadata.json
@@ -1,0 +1,198 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.introspection.ClassMap"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.introspection.ClassMap$MethodInfo"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.cli.CommandLineUtils"
+      },
+      "type" : "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.cli.CommandLineUtils"
+      },
+      "type" : "java.lang.System",
+      "methods" : [
+        {
+          "name" : "getenv",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ExceptionUtils"
+      },
+      "type" : "java.lang.reflect.Method[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.introspection.ClassMap"
+      },
+      "type" : "java.lang.reflect.Method[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.introspection.ClassMap$MethodInfo"
+      },
+      "type" : "java.lang.reflect.Method[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.FastMap"
+      },
+      "type" : "java.lang.Integer",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.FastMap"
+      },
+      "type" : "java.lang.Number",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.FastMap"
+      },
+      "type" : "java.lang.String",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.FastMap"
+      },
+      "type" : "org.codehaus.plexus.util.FastMap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.FastMap"
+      },
+      "type" : "java.lang.Integer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.FastMap"
+      },
+      "type" : "java.lang.Number"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.FastMap"
+      },
+      "type" : "java.lang.Object",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.introspection.ClassMap"
+      },
+      "type" : "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.FastMap"
+      },
+      "type" : "java.lang.String"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.introspection.ReflectionValueExtractor"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.FastMap"
+      },
+      "type" : "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.FastMap"
+      },
+      "type" : "java.lang.reflect.Field[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "java.lang.reflect.Field[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.introspection.ClassMap$MethodInfo"
+      },
+      "type" : "java.util.AbstractList"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.introspection.ReflectionValueExtractor"
+      },
+      "type" : "java.util.AbstractList",
+      "methods" : [
+        {
+          "name" : "get",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.introspection.ClassMap"
+      },
+      "type" : "java.util.Arrays$ArrayList"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.introspection.ClassMap"
+      },
+      "type" : "java.util.LinkedHashMap"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.introspection.ReflectionValueExtractor"
+      },
+      "type" : "java.util.LinkedHashMap",
+      "methods" : [
+        {
+          "name" : "get",
+          "parameterTypes" : [
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.reflection.Reflector"
+      },
+      "type" : "java.lang.Object"
+    }
+  ]
+}

--- a/metadata/org.codehaus.plexus/plexus-utils/index.json
+++ b/metadata/org.codehaus.plexus/plexus-utils/index.json
@@ -16,6 +16,11 @@
   },
   {
     "metadata-version" : "2.0.3",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/$version$/plexus-utils-$version$-sources.jar",
+    "repository-url" : "https://github.com/codehaus-plexus/plexus-utils",
+    "test-code-url" : "https://github.com/codehaus-plexus/plexus-utils/tree/plexus-utils-$version$/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/$version$/plexus-utils-$version$-javadoc.jar",
+    "description" : "Plexus Utils provides common Java utility classes for working with strings, files, command lines, XML, and related tasks. It is used by Maven and Plexus-based projects to share reusable helpers for IO, reflection, collections, and process execution.",
     "tested-versions" : [
       "2.0.3"
     ],

--- a/metadata/org.codehaus.plexus/plexus-utils/index.json
+++ b/metadata/org.codehaus.plexus/plexus-utils/index.json
@@ -15,6 +15,15 @@
     ]
   },
   {
+    "metadata-version" : "2.0.3",
+    "tested-versions" : [
+      "2.0.3"
+    ],
+    "allowed-packages" : [
+      "org.codehaus.plexus.util"
+    ]
+  },
+  {
     "metadata-version" : "2.0.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/$version$/plexus-utils-$version$-sources.jar",
     "repository-url" : "https://github.com/codehaus-plexus/plexus-utils",

--- a/stats/org.codehaus.plexus/plexus-utils/2.0.3/execution-metrics.json
+++ b/stats/org.codehaus.plexus/plexus-utils/2.0.3/execution-metrics.json
@@ -1,0 +1,101 @@
+{
+  "fix_javac_fail:2026-05-12": {
+    "timestamp": "2026-05-12T10:22:43.429119Z",
+    "library": "org.codehaus.plexus:plexus-utils:2.0.3",
+    "starting_commit": "a319dfb87d9d641a153d303bf124f73a34c0ba2d",
+    "ending_commit": "fc5d1554b896575c1bfa2bfa95e1438c8a7f25cd",
+    "previous_library": "org.codehaus.plexus:plexus-utils:1.5.7",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.0.3",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 43,
+            "totalCalls": 43
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 43,
+        "totalCalls": 43
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2321,
+          "missed": 35835,
+          "ratio": 0.060829,
+          "total": 38156
+        },
+        "line": {
+          "covered": 550,
+          "missed": 7178,
+          "ratio": 0.07117,
+          "total": 7728
+        },
+        "method": {
+          "covered": 84,
+          "missed": 1044,
+          "ratio": 0.074468,
+          "total": 1128
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.5.7",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 45,
+            "totalCalls": 45
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 45,
+        "totalCalls": 45
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2970,
+          "missed": 38215,
+          "ratio": 0.072114,
+          "total": 41185
+        },
+        "line": {
+          "covered": 704,
+          "missed": 7746,
+          "ratio": 0.083314,
+          "total": 8450
+        },
+        "method": {
+          "covered": 102,
+          "missed": 1165,
+          "ratio": 0.080505,
+          "total": 1267
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 47973,
+      "cached_input_tokens_used": 326656,
+      "output_tokens_used": 5084,
+      "iterations": 2,
+      "cost_usd": 0.3158,
+      "tested_library_loc": 550,
+      "metadata_entries": 35,
+      "test_only_metadata_entries": 7,
+      "previous_library_metadata_entries": 31,
+      "previous_library_test_only_metadata_entries": 7,
+      "code_coverage_percent": 7.12,
+      "previous_library_coverage_percent": 8.33
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/ReflectionUtilsTest.java",
+      "metadata_file": "metadata/org.codehaus.plexus/plexus-utils/2.0.3/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.codehaus.plexus/plexus-utils/2.0.3/stats.json
+++ b/stats/org.codehaus.plexus/plexus-utils/2.0.3/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "2.0.3",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 43,
+          "totalCalls" : 43
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 43,
+      "totalCalls" : 43
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2321,
+        "missed" : 35835,
+        "ratio" : 0.060829,
+        "total" : 38156
+      },
+      "line" : {
+        "covered" : 550,
+        "missed" : 7178,
+        "ratio" : 0.07117,
+        "total" : 7728
+      },
+      "method" : {
+        "covered" : 84,
+        "missed" : 1044,
+        "ratio" : 0.074468,
+        "total" : 1128
+      }
+    }
+  } ]
+}

--- a/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/.gitignore
+++ b/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/build.gradle
+++ b/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.codehaus.plexus:plexus-utils:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/gradle.properties
+++ b/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.codehaus.plexus:plexus-utils:2.0.3
+library.version = 2.0.3
+metadata.dir = org.codehaus.plexus/plexus-utils/2.0.3/

--- a/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/settings.gradle
+++ b/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.codehaus.plexus.plexus-utils_tests'

--- a/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/ClassMapInnerMethodInfoTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/ClassMapInnerMethodInfoTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_utils;
+
+import java.lang.reflect.Method;
+
+import org.codehaus.plexus.util.introspection.ClassMap;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ClassMapInnerMethodInfoTest {
+    @Test
+    void upcastsPublicMethodsFromNonPublicClassToPublicInterfaceMethods() throws Exception {
+        ClassMap classMap = new ClassMap(HiddenWorker.class);
+
+        Method method = classMap.findMethod("work", new Object[] {"input"});
+
+        assertThat(method).isNotNull();
+        assertThat(method.getDeclaringClass()).isEqualTo(Worker.class);
+        assertThat(method.getParameterTypes()).containsExactly(String.class);
+    }
+
+    public interface Worker {
+        String work(String value);
+    }
+
+    private static class HiddenWorker implements Worker {
+        public String work(String value) {
+            return "processed " + value;
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/ClassMapTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/ClassMapTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_utils;
+
+import java.lang.reflect.Method;
+
+import org.codehaus.plexus.util.introspection.ClassMap;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ClassMapTest {
+    @Test
+    void buildsCacheFromPublicMethodsAndFindsMatchingMethod() throws Exception {
+        ClassMap classMap = new ClassMap(PublicGreeter.class);
+
+        Method method = classMap.findMethod("greet", new Object[] {"Ada"});
+
+        assertThat(method).isNotNull();
+        assertThat(method.getName()).isEqualTo("greet");
+        assertThat(method.getDeclaringClass()).isEqualTo(PublicGreeter.class);
+        assertThat(method.getParameterTypes()).containsExactly(String.class);
+    }
+
+    @Test
+    void resolvesNonPublicImplementationMethodToPublicInterfaceMethod() throws Exception {
+        Method implementationMethod = HiddenGreeter.class.getDeclaredMethod("greet", String.class);
+
+        Method publicMethod = ClassMap.getPublicMethod(implementationMethod);
+
+        assertThat(publicMethod).isNotNull();
+        assertThat(publicMethod.getDeclaringClass()).isEqualTo(Greeting.class);
+        assertThat(publicMethod.getParameterTypes()).containsExactly(String.class);
+    }
+
+    public interface Greeting {
+        String greet(String name);
+    }
+
+    public static class PublicGreeter {
+        public String greet(String name) {
+            return "Hello " + name;
+        }
+    }
+
+    private static class HiddenGreeter implements Greeting {
+        public String greet(String name) {
+            return "Hello " + name;
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/CommandLineUtilsTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/CommandLineUtilsTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_utils;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+
+import org.codehaus.plexus.util.cli.CommandLineUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CommandLineUtilsTest {
+    @Test
+    void readsSystemEnvironmentVariablesThroughCommandLineUtils() throws IOException {
+        Properties envVars = CommandLineUtils.getSystemEnvVars(true);
+
+        assertThat(envVars).isNotNull();
+        assertThat(envVars).containsAllEntriesOf(System.getenv());
+    }
+
+    @Test
+    void normalizesSystemEnvironmentVariableNamesWhenCaseInsensitive() throws IOException {
+        Properties expectedEnvVars = new Properties();
+        for (Map.Entry<String, String> entry : System.getenv().entrySet()) {
+            expectedEnvVars.put(entry.getKey().toUpperCase(Locale.ENGLISH), entry.getValue());
+        }
+
+        Properties envVars = CommandLineUtils.getSystemEnvVars(false);
+
+        assertThat(envVars).isNotNull();
+        assertThat(envVars).containsAllEntriesOf(expectedEnvVars);
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/ExceptionUtilsTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/ExceptionUtilsTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_utils;
+
+import org.codehaus.plexus.util.ExceptionUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExceptionUtilsTest {
+    @Test
+    void resolvesCauseFromConfiguredPublicMethod() {
+        Throwable cause = new IllegalStateException("method cause");
+        MethodBackedException wrapper = new MethodBackedException(cause);
+
+        Throwable resolved = ExceptionUtils.getCause(wrapper, new String[] {"getLegacyCause"});
+
+        assertThat(resolved).isSameAs(cause);
+    }
+
+    @Test
+    void resolvesCauseFromPublicDetailFieldWhenConfiguredMethodsDoNotMatch() {
+        Throwable cause = new IllegalArgumentException("field cause");
+        FieldBackedException wrapper = new FieldBackedException(cause);
+
+        Throwable resolved = ExceptionUtils.getCause(wrapper, new String[] {"missingCause"});
+
+        assertThat(resolved).isSameAs(cause);
+    }
+
+    @Test
+    void detectsNestedThrowableFromConfiguredCauseMethod() {
+        Throwable cause = new IllegalStateException("nested method cause");
+        MethodBackedException wrapper = new MethodBackedException(cause);
+
+        assertThat(ExceptionUtils.isNestedThrowable(wrapper)).isTrue();
+    }
+
+    @Test
+    void detectsNestedThrowableFromPublicDetailFieldWhenNoCauseMethodsAreConfigured() {
+        Throwable cause = new IllegalArgumentException("nested field cause");
+        FieldBackedException wrapper = new FieldBackedException(cause);
+
+        ExceptionUtilsAccess.withCauseMethodNames(new String[] {"missingCause"}, () ->
+                assertThat(ExceptionUtils.isNestedThrowable(wrapper)).isTrue());
+    }
+
+    public static class MethodBackedException extends Exception {
+        private final Throwable legacyCause;
+
+        MethodBackedException(Throwable legacyCause) {
+            this.legacyCause = legacyCause;
+        }
+
+        public Throwable getLegacyCause() {
+            return legacyCause;
+        }
+    }
+
+    public static class FieldBackedException extends Exception {
+        public final Throwable detail;
+
+        FieldBackedException(Throwable detail) {
+            this.detail = detail;
+        }
+    }
+
+    private static final class ExceptionUtilsAccess extends ExceptionUtils {
+        static void withCauseMethodNames(String[] methodNames, Runnable action) {
+            String[] previousMethodNames = CAUSE_METHOD_NAMES;
+            CAUSE_METHOD_NAMES = methodNames;
+            try {
+                action.run();
+            } finally {
+                CAUSE_METHOD_NAMES = previousMethodNames;
+            }
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/FastMapTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/FastMapTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_utils;
+
+import org.codehaus.plexus.util.FastMap;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FastMapTest {
+    @Test
+    void roundTripsEntriesThroughJavaSerialization() throws Exception {
+        FastMap original = new FastMap(4);
+        original.put("alpha", "one");
+        original.put("beta", Integer.valueOf(2));
+        original.put("gamma", "three");
+
+        byte[] serialized = serialize(original);
+        FastMap copy = deserialize(serialized);
+
+        assertThat(copy).isNotSameAs(original);
+        assertThat(copy.capacity()).isEqualTo(original.capacity());
+        assertThat(copy).hasSize(3);
+        assertThat(copy.get("alpha")).isEqualTo("one");
+        assertThat(copy.get("beta")).isEqualTo(Integer.valueOf(2));
+        assertThat(copy.get("gamma")).isEqualTo("three");
+        assertThat(copy.entrySet())
+                .extracting(entry -> ((Map.Entry) entry).getKey())
+                .containsExactly("alpha", "beta", "gamma");
+
+        copy.put("delta", "four");
+
+        assertThat(copy.get("delta")).isEqualTo("four");
+    }
+
+    private static byte[] serialize(FastMap map) throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream stream = new ObjectOutputStream(bytes)) {
+            stream.writeObject(map);
+        }
+        return bytes.toByteArray();
+    }
+
+    private static FastMap deserialize(byte[] bytes) throws IOException, ClassNotFoundException {
+        try (ObjectInputStream stream = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+            Object object = stream.readObject();
+            assertThat(object).isInstanceOf(FastMap.class);
+            return (FastMap) object;
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/HiddenClassMapTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/HiddenClassMapTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_utils;
+
+import java.lang.reflect.Method;
+
+import hidden.org.codehaus.plexus.interpolation.reflection.ClassMap;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HiddenClassMapTest {
+    @Test
+    void buildsMethodCacheFromAccessibleMethods() throws Exception {
+        ClassMap classMap = new ClassMap(HiddenTask.class);
+
+        Method method = classMap.findMethod("describe", new Object[] {"compile"});
+
+        assertThat(method).isNotNull();
+        assertThat(method.getDeclaringClass()).isEqualTo(Task.class);
+        assertThat(method.getParameterTypes()).containsExactly(String.class);
+    }
+
+    @Test
+    void resolvesNonPublicImplementationMethodToPublicInterfaceMethod() throws Exception {
+        Method implementationMethod = HiddenTask.class.getDeclaredMethod("describe", String.class);
+
+        Method publicMethod = ClassMap.getPublicMethod(implementationMethod);
+
+        assertThat(publicMethod).isNotNull();
+        assertThat(publicMethod.getDeclaringClass()).isEqualTo(Task.class);
+        assertThat(publicMethod.getParameterTypes()).containsExactly(String.class);
+    }
+
+    public interface Task {
+        String describe(String name);
+    }
+
+    private static final class HiddenTask implements Task {
+        public String describe(String name) {
+            return "task " + name;
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/HiddenClassMapTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/HiddenClassMapTest.java
@@ -8,7 +8,7 @@ package org_codehaus_plexus.plexus_utils;
 
 import java.lang.reflect.Method;
 
-import hidden.org.codehaus.plexus.interpolation.reflection.ClassMap;
+import org.codehaus.plexus.util.introspection.ClassMap;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/HiddenMethodMapTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/HiddenMethodMapTest.java
@@ -8,7 +8,7 @@ package org_codehaus_plexus.plexus_utils;
 
 import java.lang.reflect.Method;
 
-import hidden.org.codehaus.plexus.interpolation.reflection.MethodMap;
+import org.codehaus.plexus.util.introspection.MethodMap;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/HiddenMethodMapTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/HiddenMethodMapTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_utils;
+
+import java.lang.reflect.Method;
+
+import hidden.org.codehaus.plexus.interpolation.reflection.MethodMap;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HiddenMethodMapTest {
+    @Test
+    void findsPrimitiveFormalMethodForBoxedBooleanArgument() throws Exception {
+        MethodMap methodMap = new MethodMap();
+        methodMap.add(PrimitiveTarget.class.getMethod("accept", Boolean.TYPE));
+
+        Method method = methodMap.find("accept", new Object[] {Boolean.TRUE});
+
+        assertThat(method).isNotNull();
+        assertThat(method.getName()).isEqualTo("accept");
+        assertThat(method.getDeclaringClass()).isEqualTo(PrimitiveTarget.class);
+        assertThat(method.getParameterTypes()).containsExactly(Boolean.TYPE);
+    }
+
+    public static class PrimitiveTarget {
+        public void accept(boolean value) {
+            // MethodMap only needs the signature for overload resolution.
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/HiddenReflectionValueExtractorTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/HiddenReflectionValueExtractorTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_utils;
+
+import hidden.org.codehaus.plexus.interpolation.reflection.ReflectionValueExtractor;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HiddenReflectionValueExtractorTest {
+    @Test
+    void evaluatesNestedGetterExpression() throws Exception {
+        Project project = new Project(new Build("target/classes"));
+
+        Object value = ReflectionValueExtractor.evaluate("project.build.outputDirectory", project);
+
+        assertThat(value).isEqualTo("target/classes");
+    }
+
+    @Test
+    void evaluatesBooleanIsAccessorExpression() throws Exception {
+        Project project = new Project(new Build("target/classes"));
+
+        Object value = ReflectionValueExtractor.evaluate("project.build.active", project);
+
+        assertThat(value).isEqualTo(Boolean.TRUE);
+    }
+
+    public static class Project {
+        private final Build build;
+
+        public Project(Build build) {
+            this.build = build;
+        }
+
+        public Build getBuild() {
+            return build;
+        }
+    }
+
+    public static class Build {
+        private final String outputDirectory;
+
+        public Build(String outputDirectory) {
+            this.outputDirectory = outputDirectory;
+        }
+
+        public String getOutputDirectory() {
+            return outputDirectory;
+        }
+
+        public boolean isActive() {
+            return true;
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/HiddenReflectionValueExtractorTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/HiddenReflectionValueExtractorTest.java
@@ -6,7 +6,7 @@
  */
 package org_codehaus_plexus.plexus_utils;
 
-import hidden.org.codehaus.plexus.interpolation.reflection.ReflectionValueExtractor;
+import org.codehaus.plexus.util.introspection.ReflectionValueExtractor;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/MethodMapTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/MethodMapTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_utils;
+
+import java.lang.reflect.Method;
+
+import org.codehaus.plexus.util.introspection.MethodMap;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MethodMapTest {
+    @Test
+    void findsPrimitiveFormalMethodForBoxedBooleanArgument() throws Exception {
+        MethodMap methodMap = new MethodMap();
+        methodMap.add(PrimitiveTarget.class.getMethod("accept", Boolean.TYPE));
+
+        Method method = methodMap.find("accept", new Object[] {Boolean.TRUE});
+
+        assertThat(method).isNotNull();
+        assertThat(method.getName()).isEqualTo("accept");
+        assertThat(method.getDeclaringClass()).isEqualTo(PrimitiveTarget.class);
+        assertThat(method.getParameterTypes()).containsExactly(Boolean.TYPE);
+    }
+
+    public static class PrimitiveTarget {
+        public void accept(boolean value) {
+            // MethodMap only needs the signature for overload resolution.
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/ReflectionUtilsTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/ReflectionUtilsTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_utils;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+
+import org.codehaus.plexus.util.ReflectionUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReflectionUtilsTest {
+    @Test
+    void findsDeclaredFieldInSuperclass() {
+        Field field = ReflectionUtils.getFieldByNameIncludingSuperclasses("parentValue", ChildBean.class);
+
+        assertThat(field).isNotNull();
+        assertThat(field.getName()).isEqualTo("parentValue");
+        assertThat(field.getDeclaringClass()).isEqualTo(ParentBean.class);
+    }
+
+    @Test
+    void returnsNullWhenFieldDoesNotExistInHierarchy() {
+        Field field = ReflectionUtils.getFieldByNameIncludingSuperclasses("missingValue", ChildBean.class);
+
+        assertThat(field).isNull();
+    }
+
+    @Test
+    void findsPublicInstanceSetter() {
+        Method setter = ReflectionUtils.getSetter("name", ChildBean.class);
+
+        assertThat(setter).isNotNull();
+        assertThat(setter.getName()).isEqualTo("setName");
+        assertThat(setter.getDeclaringClass()).isEqualTo(ParentBean.class);
+        assertThat(setter.getParameterTypes()).containsExactly(String.class);
+    }
+
+    @Test
+    void ignoresStaticAndNonVoidSetterCandidates() {
+        assertThat(ReflectionUtils.getSetter("status", ChildBean.class)).isNull();
+        assertThat(ReflectionUtils.getSetter("count", ChildBean.class)).isNull();
+    }
+
+    @Test
+    void listsDeclaredFieldsFromClassHierarchy() {
+        List<?> fields = ReflectionUtils.getFieldsIncludingSuperclasses(ChildBean.class);
+
+        assertThat(fields)
+                .extracting(field -> ((Field) field).getName())
+                .contains("childValue", "parentValue", "statusValue");
+    }
+
+    @Test
+    void listsOnlyPublicInstanceSetters() {
+        List<?> setters = ReflectionUtils.getSetters(ChildBean.class);
+
+        assertThat(setters)
+                .extracting(setter -> ((Method) setter).getName())
+                .contains("setName")
+                .doesNotContain("setStatus", "setCount");
+    }
+
+    @Test
+    void setsAndReadsPrivateFieldInSuperclass() throws Exception {
+        ChildBean bean = new ChildBean();
+
+        ReflectionUtils.setVariableValueInObject(bean, "parentValue", "configured");
+        Object value = ReflectionUtils.getValueIncludingSuperclasses("parentValue", bean);
+
+        assertThat(value).isEqualTo("configured");
+    }
+
+    @Test
+    void gathersDeclaredFieldValuesFromObject() throws Exception {
+        ValueBean bean = new ValueBean("alpha", 7);
+
+        Map<?, ?> values = ReflectionUtils.getVariablesAndValuesIncludingSuperclasses(bean);
+
+        assertThat(values.get("item")).isEqualTo("alpha");
+        assertThat(values.get("priority")).isEqualTo(7);
+    }
+
+    public static class ParentBean {
+        private static String statusValue;
+
+        private String parentValue;
+
+        public void setName(String name) {
+            this.parentValue = name;
+        }
+
+        public static void setStatus(String status) {
+            statusValue = status;
+        }
+    }
+
+    public static class ChildBean extends ParentBean {
+        private String childValue;
+
+        public String setCount(Integer count) {
+            childValue = String.valueOf(count);
+            return childValue;
+        }
+    }
+
+    public static class ValueBean {
+        private final String item;
+
+        private final int priority;
+
+        ValueBean(String item, int priority) {
+            this.item = item;
+            this.priority = priority;
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/ReflectionValueExtractorTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/ReflectionValueExtractorTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_utils;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.codehaus.plexus.util.introspection.ReflectionValueExtractor;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReflectionValueExtractorTest {
+    @Test
+    void evaluatesNestedGetterExpression() throws Exception {
+        Project project = new Project(new Build("target/classes"));
+
+        Object value = ReflectionValueExtractor.evaluate("project.build.outputDirectory", project);
+
+        assertThat(value).isEqualTo("target/classes");
+    }
+
+    @Test
+    void evaluatesBooleanIsAccessorExpression() throws Exception {
+        Project project = new Project(new Build("target/classes"));
+
+        Object value = ReflectionValueExtractor.evaluate("project.build.active", project);
+
+        assertThat(value).isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    void evaluatesIndexedListPropertyExpression() throws Exception {
+        Project project = new Project(new Build("target/classes"));
+
+        Object value = ReflectionValueExtractor.evaluate("project.build.sourceRoots[1].directory", project);
+
+        assertThat(value).isEqualTo("src/integration-test/java");
+    }
+
+    @Test
+    void evaluatesMappedPropertyExpression() throws Exception {
+        Project project = new Project(new Build("target/classes"));
+
+        Object value = ReflectionValueExtractor.evaluate("project.build.sourceRootsById(main).directory", project);
+
+        assertThat(value).isEqualTo("src/main/java");
+    }
+
+    public static class Project {
+        private final Build build;
+
+        public Project(Build build) {
+            this.build = build;
+        }
+
+        public Build getBuild() {
+            return build;
+        }
+    }
+
+    public static class Build {
+        private final String outputDirectory;
+        private final List<SourceRoot> sourceRoots;
+        private final Map<String, SourceRoot> sourceRootsById;
+
+        public Build(String outputDirectory) {
+            this.outputDirectory = outputDirectory;
+            this.sourceRoots = Arrays.asList(
+                    new SourceRoot("src/main/java"),
+                    new SourceRoot("src/integration-test/java")
+            );
+            this.sourceRootsById = new LinkedHashMap<>();
+            this.sourceRootsById.put("main", sourceRoots.get(0));
+            this.sourceRootsById.put("integration-test", sourceRoots.get(1));
+        }
+
+        public String getOutputDirectory() {
+            return outputDirectory;
+        }
+
+        public boolean isActive() {
+            return true;
+        }
+
+        public List<SourceRoot> getSourceRoots() {
+            return sourceRoots;
+        }
+
+        public Map<String, SourceRoot> getSourceRootsById() {
+            return sourceRootsById;
+        }
+    }
+
+    public static class SourceRoot {
+        private final String directory;
+
+        public SourceRoot(String directory) {
+            this.directory = directory;
+        }
+
+        public String getDirectory() {
+            return directory;
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/ReflectorTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/ReflectorTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_utils;
+
+import org.codehaus.plexus.util.reflection.Reflector;
+import org.codehaus.plexus.util.reflection.ReflectorException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ReflectorTest {
+    @Test
+    void createsObjectsUsingMatchingPublicConstructors() throws Exception {
+        Reflector reflector = new Reflector();
+
+        Object instance = reflector.newInstance(ReflectorFixture.class, new Object[] {"created"});
+
+        assertThat(instance).isInstanceOf(ReflectorFixture.class);
+        assertThat(((ReflectorFixture) instance).value).isEqualTo("created");
+    }
+
+    @Test
+    void readsPublicStaticAndInstanceFields() throws Exception {
+        Reflector reflector = new Reflector();
+        ReflectorFixture fixture = new ReflectorFixture("field-value");
+
+        assertThat(reflector.getStaticField(ReflectorFixture.class, "STATIC_VALUE")).isEqualTo("static-value");
+        assertThat(reflector.getField(fixture, "value")).isEqualTo("field-value");
+    }
+
+    @Test
+    void invokesPublicInstanceStaticAndSingletonMethods() throws Exception {
+        Reflector reflector = new Reflector();
+        ReflectorFixture fixture = new ReflectorFixture("call");
+
+        assertThat(reflector.invoke(fixture, "append", new Object[] {"-suffix"})).isEqualTo("call-suffix");
+        assertThat(reflector.invokeStatic(ReflectorFixture.class, "join", new Object[] {"left", "right"}))
+                .isEqualTo("left:right");
+
+        Object singleton = reflector.getSingleton(ReflectorFixture.class, new Object[] {"singleton"});
+
+        assertThat(singleton).isInstanceOf(ReflectorFixture.class);
+        assertThat(((ReflectorFixture) singleton).value).isEqualTo("singleton");
+    }
+
+    @Test
+    void readsObjectPropertyThroughBeanAccessor() throws Exception {
+        Reflector reflector = new Reflector();
+        ReflectorFixture fixture = new ReflectorFixture("property-value");
+
+        assertThat(reflector.getObjectProperty(fixture, "value")).isEqualTo("property-value");
+    }
+
+    @Test
+    void reportsMissingFieldAfterSearchingThroughObjectClass() {
+        Reflector reflector = new Reflector();
+        ReflectorFixture fixture = new ReflectorFixture("field-value");
+
+        assertThatThrownBy(() -> reflector.getField(fixture, "missingField"))
+                .isInstanceOf(ReflectorException.class)
+                .hasCauseInstanceOf(NoSuchFieldException.class);
+    }
+
+    public static class ReflectorFixture {
+        public static final String STATIC_VALUE = "static-value";
+
+        public String value;
+
+        public ReflectorFixture() {
+            this("default");
+        }
+
+        public ReflectorFixture(String value) {
+            this.value = value;
+        }
+
+        public static ReflectorFixture getInstance(String value) {
+            return new ReflectorFixture(value);
+        }
+
+        public static String join(String left, String right) {
+            return left + ":" + right;
+        }
+
+        public String append(String suffix) {
+            return value + suffix;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,46 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.introspection.ClassMap$MethodInfo"
+      },
+      "type" : "org_codehaus_plexus.plexus_utils.ClassMapInnerMethodInfoTest$Worker"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.introspection.ClassMap"
+      },
+      "type" : "org_codehaus_plexus.plexus_utils.ClassMapTest$Greeting"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ExceptionUtils"
+      },
+      "type" : "org_codehaus_plexus.plexus_utils.ExceptionUtilsTest$FieldBackedException"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ExceptionUtils"
+      },
+      "type" : "org_codehaus_plexus.plexus_utils.ExceptionUtilsTest$MethodBackedException"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org_codehaus_plexus.plexus_utils.ReflectionUtilsTest$ChildBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org_codehaus_plexus.plexus_utils.ReflectionUtilsTest$ParentBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.reflection.Reflector"
+      },
+      "type" : "org_codehaus_plexus.plexus_utils.ReflectorTest$ReflectorFixture"
+    }
+  ]
+}

--- a/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/user-code-filter.json
+++ b/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/user-code-filter.json
@@ -1,0 +1,16 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "hidden.org.codehaus.plexus.interpolation.**"
+    },
+    {
+      "includeClasses" : "org.codehaus.plexus.util.**"
+    },
+    {
+      "includeClasses" : "org_codehaus_plexus.plexus_utils.**"
+    }
+  ]
+}

--- a/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/user-code-filter.json
+++ b/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/user-code-filter.json
@@ -4,9 +4,6 @@
       "excludeClasses" : "**"
     },
     {
-      "includeClasses" : "hidden.org.codehaus.plexus.interpolation.**"
-    },
-    {
       "includeClasses" : "org.codehaus.plexus.util.**"
     },
     {


### PR DESCRIPTION
## What does this PR do?

Fixes: #6757

This PR provides test fixes and new metadata for org.codehaus.plexus:plexus-utils:2.0.3, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 47973
- Cached input tokens: 326656
- Output tokens: 5084
- Metadata entries: 35
- Test-only metadata entries: 7
- Iterations: 2
- Library coverage percentage: 7.12
- Previous library version metadata entries: 31
- Previous library version test-only metadata entries: 7
- Previous library version coverage percentage: 8.33

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `835d1946fe0ca1a3c738fcd0552647bf0f299876`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.codehaus.plexus:plexus-utils:1.5.7: 45/45 covered calls (100.00%)
- org.codehaus.plexus:plexus-utils:2.0.3: 43/43 covered calls (100.00%)

**Reflection:**
- org.codehaus.plexus:plexus-utils:1.5.7: 45/45 covered calls (100.00%)
- org.codehaus.plexus:plexus-utils:2.0.3: 43/43 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.codehaus.plexus:plexus-utils:1.5.7: 2970/41185 (7.21%)
- org.codehaus.plexus:plexus-utils:2.0.3: 2321/38156 (6.08%)

**Line:**
- org.codehaus.plexus:plexus-utils:1.5.7: 704/8450 (8.33%)
- org.codehaus.plexus:plexus-utils:2.0.3: 550/7728 (7.12%)

**Method:**
- org.codehaus.plexus:plexus-utils:1.5.7: 102/1267 (8.05%)
- org.codehaus.plexus:plexus-utils:2.0.3: 84/1128 (7.45%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/CommandLineUtilsTest.java 2/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/CommandLineUtilsTest.java
new file mode 100644
index 0000000000..ccb3406fc8
--- /dev/null
+++ 2/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/CommandLineUtilsTest.java
@@ -0,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_utils;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+
+import org.codehaus.plexus.util.cli.CommandLineUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CommandLineUtilsTest {
+    @Test
+    void readsSystemEnvironmentVariablesThroughCommandLineUtils() throws IOException {
+        Properties envVars = CommandLineUtils.getSystemEnvVars(true);
+
+        assertThat(envVars).isNotNull();
+        assertThat(envVars).containsAllEntriesOf(System.getenv());
+    }
+
+    @Test
+    void normalizesSystemEnvironmentVariableNamesWhenCaseInsensitive() throws IOException {
+        Properties expectedEnvVars = new Properties();
+        for (Map.Entry<String, String> entry : System.getenv().entrySet()) {
+            expectedEnvVars.put(entry.getKey().toUpperCase(Locale.ENGLISH), entry.getValue());
+        }
+
+        Properties envVars = CommandLineUtils.getSystemEnvVars(false);
+
+        assertThat(envVars).isNotNull();
+        assertThat(envVars).containsAllEntriesOf(expectedEnvVars);
+    }
+}
diff --git 1/tests/src/org.codehaus.plexus/plexus-utils/1.5.7/src/test/java/org_codehaus_plexus/plexus_utils/HiddenClassMapTest.java 2/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/HiddenClassMapTest.java
index 1f14069dc9..8421886dd7 100644
--- 1/tests/src/org.codehaus.plexus/plexus-utils/1.5.7/src/test/java/org_codehaus_plexus/plexus_utils/HiddenClassMapTest.java
+++ 2/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/HiddenClassMapTest.java
@@ -8,7 +8,7 @@ package org_codehaus_plexus.plexus_utils;
 
 import java.lang.reflect.Method;
 
-import hidden.org.codehaus.plexus.interpolation.reflection.ClassMap;
+import org.codehaus.plexus.util.introspection.ClassMap;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
diff --git 1/tests/src/org.codehaus.plexus/plexus-utils/1.5.7/src/test/java/org_codehaus_plexus/plexus_utils/HiddenMethodMapTest.java 2/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/HiddenMethodMapTest.java
index 01e1a6e2df..716ecddf85 100644
--- 1/tests/src/org.codehaus.plexus/plexus-utils/1.5.7/src/test/java/org_codehaus_plexus/plexus_utils/HiddenMethodMapTest.java
+++ 2/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/HiddenMethodMapTest.java
@@ -8,7 +8,7 @@ package org_codehaus_plexus.plexus_utils;
 
 import java.lang.reflect.Method;
 
-import hidden.org.codehaus.plexus.interpolation.reflection.MethodMap;
+import org.codehaus.plexus.util.introspection.MethodMap;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
diff --git 1/tests/src/org.codehaus.plexus/plexus-utils/1.5.7/src/test/java/org_codehaus_plexus/plexus_utils/HiddenReflectionValueExtractorTest.java 2/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/HiddenReflectionValueExtractorTest.java
index dfa8005df9..db28c63dbe 100644
--- 1/tests/src/org.codehaus.plexus/plexus-utils/1.5.7/src/test/java/org_codehaus_plexus/plexus_utils/HiddenReflectionValueExtractorTest.java
+++ 2/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/src/test/java/org_codehaus_plexus/plexus_utils/HiddenReflectionValueExtractorTest.java
@@ -6,7 +6,7 @@
  */
 package org_codehaus_plexus.plexus_utils;
 
-import hidden.org.codehaus.plexus.interpolation.reflection.ReflectionValueExtractor;
+import org.codehaus.plexus.util.introspection.ReflectionValueExtractor;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
diff --git 1/tests/src/org.codehaus.plexus/plexus-utils/1.5.7/user-code-filter.json 2/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/user-code-filter.json
index 0c3c61c8b2..9777cfff02 100644
--- 1/tests/src/org.codehaus.plexus/plexus-utils/1.5.7/user-code-filter.json
+++ 2/tests/src/org.codehaus.plexus/plexus-utils/2.0.3/user-code-filter.json
@@ -3,9 +3,6 @@
     {
       "excludeClasses" : "**"
     },
-    {
-      "includeClasses" : "hidden.org.codehaus.plexus.interpolation.**"
-    },
     {
       "includeClasses" : "org.codehaus.plexus.util.**"
     },

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
