### PR TITLE
[Automation] Generated metadata for org.springframework.boot:spring-boot-configuration-processor:2.7.18

### DIFF
--- a/tests/src/org.springframework.boot/spring-boot-configuration-processor/2.7.18/build.gradle
+++ b/tests/src/org.springframework.boot/spring-boot-configuration-processor/2.7.18/build.gradle
@@ -4,11 +4,18 @@
  * You should have received a copy of the CC0 legalcode along with this
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
+import org.graalvm.buildtools.gradle.tasks.NativeRunTask
+
 plugins {
     id "org.graalvm.internal.tck"
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+String javaHome = System.getenv('JAVA_HOME')
+List<String> javacRuntimeArgs = [
+        "-Djava.home=${javaHome}",
+        "-Djava.class.path=${-> sourceSets.test.runtimeClasspath.asPath}"
+]
 
 dependencies {
     testImplementation "org.springframework.boot:spring-boot-configuration-processor:$libraryVersion"
@@ -19,8 +26,7 @@ graalvmNative {
     binaries {
         test {
             buildArgs("-H:+AllowJRTFileSystem")
-            runtimeArgs("-Djava.home=${System.getenv('JAVA_HOME')}")
-            runtimeArgs("-Djava.class.path=${sourceSets.test.runtimeClasspath.asPath}")
+            runtimeArgs.addAll(javacRuntimeArgs)
         }
     }
     agent {
@@ -31,4 +37,8 @@ graalvmNative {
             }
         }
     }
+}
+
+tasks.named("nativeTest", NativeRunTask) {
+    runtimeArgs.addAll(javacRuntimeArgs)
 }


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#6844

This PR provides new metadata needed for the org.springframework.boot:spring-boot-configuration-processor:2.7.18, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.springframework.boot:spring-boot-configuration-processor:2.7.18`): 29
- Metadata entries (new `org.springframework.boot:spring-boot-configuration-processor:2.7.18`): 29
- Library coverage (previous): 8.47%
- Library coverage (new): 8.47%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `076fb220eb5464534b54cc7e2b6fb3efacad85cd`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `org.springframework.boot:spring-boot-configuration-processor:2.7.18` and `org.springframework.boot:spring-boot-configuration-processor:2.7.18`.

### Local CI Verification

- Status: `success`
- Commands run: 17
- Fixup attempts: 0
