### PR TITLE
[Automation] Generated metadata for org.junit.platform:junit-platform-commons:1.8.2

### DIFF
--- a/tests/src/org.junit.platform/junit-platform-commons/1.8.2/build.gradle
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.8.2/build.gradle
@@ -15,6 +15,11 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
+tasks.named("nativeTest") {
+    runtimeArgs.add("-Djava.home=${System.getenv('JAVA_HOME')}")
+    runtimeArgs.add("-Djava.class.path=${sourceSets.test.runtimeClasspath.asPath}")
+}
+
 graalvmNative {
     binaries {
         test {


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#6843

This PR provides new metadata needed for the org.junit.platform:junit-platform-commons:1.8.2, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.junit.platform:junit-platform-commons:1.8.2`): 25
- Test-only metadata entries (previous `org.junit.platform:junit-platform-commons:1.8.2`): 47
- Metadata entries (new `org.junit.platform:junit-platform-commons:1.8.2`): 25
- Test-only metadata entries (new `org.junit.platform:junit-platform-commons:1.8.2`): 47
- Library coverage (previous): 45.29%
- Library coverage (new): 45.29%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `076fb220eb5464534b54cc7e2b6fb3efacad85cd`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `org.junit.platform:junit-platform-commons:1.8.2` and `org.junit.platform:junit-platform-commons:1.8.2`.

### Local CI Verification

- Status: `success`
- Commands run: 11
- Fixup attempts: 0
