### PR TITLE
[Automation] Generated metadata for org.apache.activemq:activemq-broker:6.0.0

### DIFF
--- a/metadata/org.apache.activemq/activemq-broker/6.0.0/reachability-metadata.json
+++ b/metadata/org.apache.activemq/activemq-broker/6.0.0/reachability-metadata.json
@@ -2,6 +2,280 @@
   "reflection": [
     {
       "condition": {
+        "typeReached": "org.apache.activemq.broker.BrokerService"
+      },
+      "type": "boolean[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.BrokerService"
+      },
+      "type": "byte[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.BrokerService"
+      },
+      "type": "char[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.BrokerService"
+      },
+      "type": "double[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.jmx.ManagementContext"
+      },
+      "type": "com.oracle.svm.core.genscavenge.IncrementalGarbageCollectorMXBean"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.jmx.ManagementContext"
+      },
+      "type": "com.oracle.svm.core.jdk.management.SubstrateClassLoadingMXBean"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.jmx.ManagementContext"
+      },
+      "type": "com.oracle.svm.core.jdk.management.SubstrateCompilationMXBean"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.jmx.ManagementContext"
+      },
+      "type": "com.oracle.svm.core.jdk.management.SubstrateRuntimeMXBean"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.jmx.ManagementContext"
+      },
+      "type": "com.oracle.svm.core.jdk.management.SubstrateThreadMXBean"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.jmx.ManagementContext"
+      },
+      "type": "com.sun.jmx.mbeanserver.ClassLoaderRepositorySupport$LoaderEntry[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.jmx.ManagementContext"
+      },
+      "type": "com.sun.management.GarbageCollectorMXBean"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.jmx.ManagementContext"
+      },
+      "type": "com.sun.management.GcInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.jmx.ManagementContext"
+      },
+      "type": "com.sun.management.HotSpotDiagnosticMXBean"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.jmx.ManagementContext"
+      },
+      "type": "com.sun.management.OperatingSystemMXBean"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.jmx.ManagementContext"
+      },
+      "type": "com.sun.management.ThreadMXBean"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.jmx.ManagementContext"
+      },
+      "type": "com.sun.management.UnixOperatingSystemMXBean"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.jmx.ManagementContext"
+      },
+      "type": "com.sun.management.VMOption"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.jmx.ManagementContext"
+      },
+      "type": "com.sun.management.internal.DiagnosticCommandArgumentInfo",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String",
+            "java.lang.String",
+            "java.lang.String",
+            "java.lang.String",
+            "boolean",
+            "boolean",
+            "boolean",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.jmx.ManagementContext"
+      },
+      "type": "com.sun.management.internal.DiagnosticCommandArgumentInfo[]",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.jmx.ManagementContext"
+      },
+      "type": "com.sun.management.internal.DiagnosticCommandInfo",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String",
+            "java.lang.String",
+            "java.lang.String",
+            "java.lang.String",
+            "java.lang.String",
+            "java.lang.String",
+            "boolean",
+            "java.util.List"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.jmx.ManagementContext"
+      },
+      "type": "com.sun.management.internal.DiagnosticCommandInfo[]",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.jmx.ManagementContext"
+      },
+      "type": "com.sun.management.internal.GarbageCollectorExtImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.jmx.ManagementContext"
+      },
+      "type": "com.sun.management.internal.HotSpotDiagnostic"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.jmx.ManagementContext"
+      },
+      "type": "com.sun.management.internal.HotSpotThreadImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.jmx.ManagementContext"
+      },
+      "type": "com.sun.management.internal.OperatingSystemImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.BrokerService"
+      },
+      "type": "float[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.BrokerService"
+      },
+      "type": "int[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.BrokerService"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.jmx.ManagementContext"
+      },
+      "type": "java.lang.management.ManagementFactory",
+      "methods": [
+        {
+          "name": "getPlatformMBeanServer",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.jmx.ManagementContext"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.jmx.ManagementContext"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.util.IntrospectionSupport"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.jmx.ManagementContext"
+      },
+      "type": "java.util.Map"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.BrokerService"
+      },
+      "type": "org.bouncycastle.jce.provider.BouncyCastleProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.BrokerService"
+      },
+      "type": "javax.management.openmbean.CompositeData[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.BrokerService"
+      },
+      "type": "long[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.BrokerService"
+      },
+      "type": "org.apache.activemq.Service",
+      "methods": [
+        {
+          "name": "start",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.BrokerService"
+      },
+      "type": "org.apache.activemq.command.ActiveMQDestination[]"
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.activemq.util.IntrospectionSupport"
       },
       "type": "org.apache.activemq.broker.BrokerService",
@@ -48,6 +322,30 @@
           "name": "lastSequenceId"
         }
       ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.util.IdGenerator"
+      },
+      "type": "jdk.net.LinuxSocketOptions"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.jmx.ManagementContext"
+      },
+      "type": "javax.management.MBeanAttributeInfo[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.jmx.ManagementContext"
+      },
+      "type": "javax.management.MBeanServerBuilder"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.BrokerService"
+      },
+      "type": "short[]"
     }
   ],
   "resources": [
@@ -62,6 +360,12 @@
         "typeReached": "org.apache.activemq.transport.TransportFactory"
       },
       "glob": "META-INF/services/org/apache/activemq/transport/vm"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.activemq.broker.BrokerService"
+      },
+      "glob": "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
     },
     {
       "condition": {

--- a/stats/org.apache.activemq/activemq-broker/6.0.0/stats.json
+++ b/stats/org.apache.activemq/activemq-broker/6.0.0/stats.json
@@ -20,21 +20,21 @@
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 8855,
-        "missed" : 95875,
-        "ratio" : 0.084551,
+        "covered" : 8892,
+        "missed" : 95838,
+        "ratio" : 0.084904,
         "total" : 104730
       },
       "line" : {
-        "covered" : 2309,
-        "missed" : 23927,
-        "ratio" : 0.088009,
+        "covered" : 2316,
+        "missed" : 23920,
+        "ratio" : 0.088276,
         "total" : 26236
       },
       "method" : {
-        "covered" : 533,
-        "missed" : 5599,
-        "ratio" : 0.086921,
+        "covered" : 534,
+        "missed" : 5598,
+        "ratio" : 0.087084,
         "total" : 6132
       }
     }


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#6841

This PR provides new metadata needed for the org.apache.activemq:activemq-broker:6.0.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.apache.activemq:activemq-broker:6.0.0`): 62
- Metadata entries (new `org.apache.activemq:activemq-broker:6.0.0`): 62
- Library coverage (previous): 8.83%
- Library coverage (new): 8.83%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `907319e0f677986d3093c79e99b4badbfd2f50bf`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `org.apache.activemq:activemq-broker:6.0.0` and `org.apache.activemq:activemq-broker:6.0.0`.

### Local CI Verification

- Status: `success`
- Commands run: 12
- Fixup attempts: 0
