### PR TITLE
[Automation] Generated metadata for org.apache.activemq:activemq-broker:5.18.1

### DIFF
--- a/metadata/org.apache.activemq/activemq-broker/5.18.1/reachability-metadata.json
+++ b/metadata/org.apache.activemq/activemq-broker/5.18.1/reachability-metadata.json
@@ -106,6 +106,18 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.activemq.broker.jmx.ManagementContext"
+      },
+      "type": "java.lang.management.ManagementFactory",
+      "methods": [
+        {
+          "name": "getPlatformMBeanServer",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.activemq.broker.BrokerService"
       },
       "type": "short[]"


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#6840

This PR provides new metadata needed for the org.apache.activemq:activemq-broker:5.18.1, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.apache.activemq:activemq-broker:6.0.0`): 11
- Metadata entries (new `org.apache.activemq:activemq-broker:5.18.1`): 22
- Library coverage (previous): 8.80%
- Library coverage (new): 8.85%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `907319e0f677986d3093c79e99b4badbfd2f50bf`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.activemq:activemq-broker:6.0.0: 5/80 covered calls (6.25%)
- org.apache.activemq:activemq-broker:5.18.1: 5/80 covered calls (6.25%)

**Reflection:**
- org.apache.activemq:activemq-broker:6.0.0: 5/73 covered calls (6.85%)
- org.apache.activemq:activemq-broker:5.18.1: 5/73 covered calls (6.85%)

**Resources:**
- org.apache.activemq:activemq-broker:6.0.0: 0/7 covered calls (0.00%)
- org.apache.activemq:activemq-broker:5.18.1: 0/7 covered calls (0.00%)

#### Library coverage

**Instruction:**
- org.apache.activemq:activemq-broker:6.0.0: 8855/104730 (8.46%)
- org.apache.activemq:activemq-broker:5.18.1: 8906/104523 (8.52%)

**Line:**
- org.apache.activemq:activemq-broker:6.0.0: 2309/26236 (8.80%)
- org.apache.activemq:activemq-broker:5.18.1: 2315/26172 (8.85%)

**Method:**
- org.apache.activemq:activemq-broker:6.0.0: 533/6132 (8.69%)
- org.apache.activemq:activemq-broker:5.18.1: 534/6121 (8.72%)

### Local CI Verification

- Status: `success`
- Commands run: 12
- Fixup attempts: 0
