### PR TITLE
[Automation] Generated metadata for org.apache-extras.beanshell:bsh:2.0b6

### DIFF
--- a/metadata/org.apache-extras.beanshell/bsh/2.0b6/reachability-metadata.json
+++ b/metadata/org.apache-extras.beanshell/bsh/2.0b6/reachability-metadata.json
@@ -1959,6 +1959,50 @@
       "condition" : {
         "typeReached" : "bsh.util.ClassBrowser"
       },
+      "type" : "java.awt.image.BufferedImage",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "colorModel"
+        },
+        {
+          "name" : "imageType"
+        },
+        {
+          "name" : "raster"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "getRGB",
+          "parameterTypes" : [
+            "int",
+            "int",
+            "int",
+            "int",
+            "int[]",
+            "int",
+            "int"
+          ]
+        },
+        {
+          "name" : "setRGB",
+          "parameterTypes" : [
+            "int",
+            "int",
+            "int",
+            "int",
+            "int[]",
+            "int",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "bsh.util.ClassBrowser"
+      },
       "type" : "sun.java2d.Disposer",
       "jniAccessible" : true,
       "methods" : [

--- a/tests/src/org.apache-extras.beanshell/bsh/2.0b6/build.gradle
+++ b/tests/src/org.apache-extras.beanshell/bsh/2.0b6/build.gradle
@@ -15,6 +15,11 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
+tasks.named("nativeTest") {
+    runtimeArgs.add("-Djava.home=${System.getenv('JAVA_HOME')}")
+    runtimeArgs.add("-Djava.class.path=${sourceSets.test.runtimeClasspath.asPath}")
+}
+
 graalvmNative {
     binaries {
         test {


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#6839

This PR provides new metadata needed for the org.apache-extras.beanshell:bsh:2.0b6, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.apache-extras.beanshell:bsh:2.0b6`): 599
- Test-only metadata entries (previous `org.apache-extras.beanshell:bsh:2.0b6`): 18
- Metadata entries (new `org.apache-extras.beanshell:bsh:2.0b6`): 599
- Test-only metadata entries (new `org.apache-extras.beanshell:bsh:2.0b6`): 18
- Library coverage (previous): 41.70%
- Library coverage (new): 41.70%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `907319e0f677986d3093c79e99b4badbfd2f50bf`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `org.apache-extras.beanshell:bsh:2.0b6` and `org.apache-extras.beanshell:bsh:2.0b6`.

### Local CI Verification

- Status: `success`
- Commands run: 12
- Fixup attempts: 0
