### PR TITLE
[GenAI] Add support for org.sonatype.plexus:plexus-cipher:1.4 using gpt-5.5

### DIFF
--- a/metadata/org.sonatype.plexus/plexus-cipher/1.4/reachability-metadata.json
+++ b/metadata/org.sonatype.plexus/plexus-cipher/1.4/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.sonatype.plexus.components.cipher.PlexusCipher$1"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.sonatype.plexus.components.cipher.PlexusCipher$1"
+      },
+      "type": "org.sonatype.plexus.components.cipher.PlexusCipher"
+    }
+  ]
+}

--- a/metadata/org.sonatype.plexus/plexus-cipher/index.json
+++ b/metadata/org.sonatype.plexus/plexus-cipher/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.4",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/$version$/plexus-cipher-$version$-sources.jar",
+    "repository-url" : "https://github.com/codehaus-plexus/plexus-cipher",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/$version$/plexus-cipher-$version$-javadoc.jar",
+    "description" : "Plexus Cipher is a Java component for encrypting and decrypting strings with passphrases and Base64-encoded output. It also supports Maven/Plexus-style decorated encrypted values wrapped in braces so callers can detect, decorate, and undecorate stored secrets.",
+    "tested-versions" : [
+      "1.4"
+    ],
+    "allowed-packages" : [
+      "org.sonatype.plexus.components.cipher"
+    ]
+  }
+]

--- a/stats/org.sonatype.plexus/plexus-cipher/1.4/execution-metrics.json
+++ b/stats/org.sonatype.plexus/plexus-cipher/1.4/execution-metrics.json
@@ -1,0 +1,62 @@
+{
+  "add_new_library_support:2026-05-12": {
+    "timestamp": "2026-05-12T23:46:31.195213Z",
+    "library": "org.sonatype.plexus:plexus-cipher:1.4",
+    "starting_commit": "816828bf737b7accf6f994ea13fdce4544042c38",
+    "ending_commit": "f1d7bcce6e9a26acf573b434b5a497a5e3d2cb09",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.4",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 10,
+          "missed": 1542,
+          "ratio": 0.006443,
+          "total": 1552
+        },
+        "line": {
+          "covered": 1,
+          "missed": 295,
+          "ratio": 0.003378,
+          "total": 296
+        },
+        "method": {
+          "covered": 1,
+          "missed": 36,
+          "ratio": 0.027027,
+          "total": 37
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 25454,
+      "cached_input_tokens_used": 237568,
+      "output_tokens_used": 2818,
+      "iterations": 1,
+      "cost_usd": 0.2033,
+      "generated_loc": 16,
+      "tested_library_loc": 1,
+      "metadata_entries": 2,
+      "code_coverage_percent": 0.34
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.sonatype.plexus/plexus-cipher/1.4/src/test/java/org_sonatype_plexus/plexus_cipher/PlexusCipherAnonymous1Test.java",
+      "metadata_file": "metadata/org.sonatype.plexus/plexus-cipher/1.4/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.sonatype.plexus/plexus-cipher/1.4/stats.json
+++ b/stats/org.sonatype.plexus/plexus-cipher/1.4/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "1.4",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 1,
+      "totalCalls" : 1
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 10,
+        "missed" : 1542,
+        "ratio" : 0.006443,
+        "total" : 1552
+      },
+      "line" : {
+        "covered" : 1,
+        "missed" : 295,
+        "ratio" : 0.003378,
+        "total" : 296
+      },
+      "method" : {
+        "covered" : 1,
+        "missed" : 36,
+        "ratio" : 0.027027,
+        "total" : 37
+      }
+    }
+  } ]
+}

--- a/tests/src/org.sonatype.plexus/plexus-cipher/1.4/.gitignore
+++ b/tests/src/org.sonatype.plexus/plexus-cipher/1.4/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.sonatype.plexus/plexus-cipher/1.4/build.gradle
+++ b/tests/src/org.sonatype.plexus/plexus-cipher/1.4/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.sonatype.plexus:plexus-cipher:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.sonatype.plexus/plexus-cipher/1.4/gradle.properties
+++ b/tests/src/org.sonatype.plexus/plexus-cipher/1.4/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.sonatype.plexus:plexus-cipher:1.4
+library.version = 1.4
+metadata.dir = org.sonatype.plexus/plexus-cipher/1.4/

--- a/tests/src/org.sonatype.plexus/plexus-cipher/1.4/settings.gradle
+++ b/tests/src/org.sonatype.plexus/plexus-cipher/1.4/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.sonatype.plexus.plexus-cipher_tests'

--- a/tests/src/org.sonatype.plexus/plexus-cipher/1.4/src/test/java/org_sonatype_plexus/plexus_cipher/PlexusCipherAnonymous1Test.java
+++ b/tests/src/org.sonatype.plexus/plexus-cipher/1.4/src/test/java/org_sonatype_plexus/plexus_cipher/PlexusCipherAnonymous1Test.java
@@ -6,11 +6,14 @@
  */
 package org_sonatype_plexus.plexus_cipher;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
-class Plexus_cipherTest {
+import org.junit.jupiter.api.Test;
+import org.sonatype.plexus.components.cipher.PlexusCipher;
+
+public class PlexusCipherAnonymous1Test {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void roleConstantInitializesPlexusCipherInterface() {
+        assertThat(PlexusCipher.ROLE).isEqualTo(PlexusCipher.class.getName());
     }
 }

--- a/tests/src/org.sonatype.plexus/plexus-cipher/1.4/src/test/java/org_sonatype_plexus/plexus_cipher/Plexus_cipherTest.java
+++ b/tests/src/org.sonatype.plexus/plexus-cipher/1.4/src/test/java/org_sonatype_plexus/plexus_cipher/Plexus_cipherTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_sonatype_plexus.plexus_cipher;
+
+import org.junit.jupiter.api.Test;
+
+class Plexus_cipherTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.sonatype.plexus/plexus-cipher/1.4/user-code-filter.json
+++ b/tests/src/org.sonatype.plexus/plexus-cipher/1.4/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.sonatype.plexus.components.cipher.**"
+    }
+  ]
+}

--- a/tests/src/org.sonatype.plexus/plexus-cipher/1.4/user-code-filter.json
+++ b/tests/src/org.sonatype.plexus/plexus-cipher/1.4/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.sonatype.plexus.components.cipher.**"
+      "includeClasses" : "org.sonatype.plexus.components.cipher.**"
+    },
+    {
+      "includeClasses" : "org_sonatype_plexus.plexus_cipher.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #2347

This PR introduces tests and metadata for org.sonatype.plexus:plexus-cipher:1.4, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 25454
- Cached input tokens: 237568
- Output tokens: 2818
- Metadata entries: 2
- Iterations: 1
- Library coverage percentage: 0.34
- Generated lines of code: 16
- Tested library lines of code: 1

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `907319e0f677986d3093c79e99b4badbfd2f50bf`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 1/1 covered calls (100.00%)
- Reflection: 1/1 covered calls (100.00%)

Library coverage:
- Instruction: 10/1552 (0.64%)
- Line: 1/296 (0.34%)
- Method: 1/37 (2.70%)

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
