### PR TITLE
[Automation] Generated metadata for io.grpc:grpc-opentelemetry:1.80.0

### DIFF
--- a/tests/src/io.grpc/grpc-opentelemetry/1.80.0/src/test/java/io_grpc/grpc_opentelemetry/Grpc_opentelemetryTest.java
+++ b/tests/src/io.grpc/grpc-opentelemetry/1.80.0/src/test/java/io_grpc/grpc_opentelemetry/Grpc_opentelemetryTest.java
@@ -93,7 +93,7 @@ public class Grpc_opentelemetryTest {
 
         propagator.inject(originalContext, carrier, MAP_SETTER);
 
-        assertThat(carrier).containsOnlyKeys(GrpcTraceBinContextPropagator.GRPC_TRACE_BIN_HEADER);
+        assertThat(carrier.keySet()).containsExactly(GrpcTraceBinContextPropagator.GRPC_TRACE_BIN_HEADER);
         assertThat(carrier.get(GrpcTraceBinContextPropagator.GRPC_TRACE_BIN_HEADER))
                 .isNotBlank()
                 .doesNotContain("=");
@@ -132,7 +132,7 @@ public class Grpc_opentelemetryTest {
         propagator.inject(null, carrier, MAP_SETTER);
         propagator.inject(Context.root().with(Span.wrap(SpanContext.getInvalid())), carrier, MAP_SETTER);
 
-        assertThat(carrier).isEmpty();
+        assertThat(carrier.keySet()).isEmpty();
         assertThat(propagator.extract(null, carrier, MAP_GETTER)).isSameAs(Context.root());
 
         Context existingContext = Context.root().with(Span.wrap(sampledSpanContext()));


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#6837

This PR provides new metadata needed for the io.grpc:grpc-opentelemetry:1.80.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `io.grpc:grpc-opentelemetry:1.80.0`): 0
- Metadata entries (new `io.grpc:grpc-opentelemetry:1.80.0`): 0
- Library coverage (previous): 49.25%
- Library coverage (new): 49.25%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `907319e0f677986d3093c79e99b4badbfd2f50bf`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `io.grpc:grpc-opentelemetry:1.80.0` and `io.grpc:grpc-opentelemetry:1.80.0`.

### Local CI Verification

- Status: `success`
- Commands run: 11
- Fixup attempts: 0
