### PR TITLE
[Automation] Generated metadata for info.picocli:picocli:4.7.6

### DIFF
--- a/tests/src/info.picocli/picocli/4.7.6/build.gradle
+++ b/tests/src/info.picocli/picocli/4.7.6/build.gradle
@@ -4,15 +4,40 @@
  * You should have received a copy of the CC0 legalcode along with this
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
+import java.io.OutputStream
+
 plugins {
     id "org.graalvm.internal.tck"
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+Provider<Directory> generatedTestRuntimePropertiesDir = layout.buildDirectory.dir("generated/test-runtime-properties")
 
 dependencies {
     testImplementation "info.picocli:picocli:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+tasks.register("generateNativeRuntimeProperties") {
+    outputs.dir(generatedTestRuntimePropertiesDir)
+    doLast {
+        File outputDir = generatedTestRuntimePropertiesDir.get().asFile
+        outputDir.mkdirs()
+
+        Properties properties = new Properties()
+        properties.setProperty("java.home", System.getenv("JAVA_HOME") ?: "")
+        properties.setProperty("java.class.path", sourceSets.test.runtimeClasspath.asPath)
+
+        File outputFile = new File(outputDir, "native-runtime.properties")
+        outputFile.withOutputStream { OutputStream outputStream ->
+            properties.store(outputStream, "Generated runtime properties for picocli native tests")
+        }
+    }
+}
+
+processTestResources {
+    dependsOn(tasks.named("generateNativeRuntimeProperties"))
+    from(generatedTestRuntimePropertiesDir)
 }
 
 graalvmNative {

--- a/tests/src/info.picocli/picocli/4.7.6/src/test/java/info_picocli/picocli/CommandLineInnerHelpInnerAnsiTest.java
+++ b/tests/src/info.picocli/picocli/4.7.6/src/test/java/info_picocli/picocli/CommandLineInnerHelpInnerAnsiTest.java
@@ -74,6 +74,7 @@ public class CommandLineInnerHelpInnerAnsiTest {
     }
 
     private static ProcessResult runChildProcessInPseudoTerminal() throws IOException, InterruptedException {
+        NativeRuntimePropertiesSupport.restoreMissingRuntimeProperties();
         Path javaExecutable = Paths.get(System.getProperty("java.home"), "bin", javaExecutableName());
         Path scriptExecutable = Paths.get("/usr/bin/script");
         Path typescript = Files.createTempFile("picocli-ansi-pty", ".log");
@@ -100,10 +101,14 @@ public class CommandLineInnerHelpInnerAnsiTest {
 
     private static List<String> childJavaCommand(Path javaExecutable) {
         List<String> command = new ArrayList<>();
+        String classPath = System.getProperty("java.class.path", "");
+        if (classPath.isBlank()) {
+            throw new IllegalStateException("Could not locate child Java classpath");
+        }
         command.add(javaExecutable.toString());
         command.addAll(jacocoAgentArguments());
         command.add("-cp");
-        command.add(System.getProperty("java.class.path"));
+        command.add(classPath);
         command.add(CommandLineInnerHelpInnerAnsiTest.class.getName());
         command.add(CHILD_PROCESS_ARGUMENT);
         return command;

--- a/tests/src/info.picocli/picocli/4.7.6/src/test/java/info_picocli/picocli/CommandLineInnerModelInnerUsageMessageSpecAnonymous1Test.java
+++ b/tests/src/info.picocli/picocli/4.7.6/src/test/java/info_picocli/picocli/CommandLineInnerModelInnerUsageMessageSpecAnonymous1Test.java
@@ -60,6 +60,7 @@ public class CommandLineInnerModelInnerUsageMessageSpecAnonymous1Test {
     }
 
     private static ProcessResult runChildProcessInPseudoTerminal() throws IOException, InterruptedException {
+        NativeRuntimePropertiesSupport.restoreMissingRuntimeProperties();
         Path javaExecutable = Paths.get(System.getProperty("java.home"), "bin", javaExecutableName());
         Path scriptExecutable = Paths.get("/usr/bin/script");
         Path typescript = Files.createTempFile("picocli-usage-width-pty", ".log");
@@ -86,10 +87,14 @@ public class CommandLineInnerModelInnerUsageMessageSpecAnonymous1Test {
 
     private static List<String> childJavaCommand(Path javaExecutable) {
         List<String> command = new ArrayList<>();
+        String classPath = System.getProperty("java.class.path", "");
+        if (classPath.isBlank()) {
+            throw new IllegalStateException("Could not locate child Java classpath");
+        }
         command.add(javaExecutable.toString());
         command.addAll(jacocoAgentArguments());
         command.add("-cp");
-        command.add(System.getProperty("java.class.path"));
+        command.add(classPath);
         command.add(CommandLineInnerModelInnerUsageMessageSpecAnonymous1Test.class.getName());
         command.add(CHILD_PROCESS_ARGUMENT);
         return command;

--- a/tests/src/info.picocli/picocli/4.7.6/src/test/java/info_picocli/picocli/NativeRuntimePropertiesSupport.java
+++ b/tests/src/info.picocli/picocli/4.7.6/src/test/java/info_picocli/picocli/NativeRuntimePropertiesSupport.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package info_picocli.picocli;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+final class NativeRuntimePropertiesSupport {
+    private NativeRuntimePropertiesSupport() {
+    }
+
+    static void restoreMissingRuntimeProperties() {
+        Properties embeddedRuntimeProperties = loadEmbeddedRuntimeProperties();
+
+        if (System.getProperty("java.home") == null || System.getProperty("java.home").isBlank()) {
+            String javaHome = firstNonBlank(
+                    embeddedRuntimeProperties.getProperty("java.home"),
+                    System.getenv("JAVA_HOME"),
+                    System.getenv("GRAALVM_HOME"));
+            if (!javaHome.isBlank()) {
+                System.setProperty("java.home", javaHome);
+            }
+        }
+
+        String currentClassPath = System.getProperty("java.class.path", "");
+        if (currentClassPath.isBlank()) {
+            String classPath = embeddedRuntimeProperties.getProperty("java.class.path", "");
+            if (!classPath.isBlank()) {
+                System.setProperty("java.class.path", classPath);
+            }
+        }
+    }
+
+    private static Properties loadEmbeddedRuntimeProperties() {
+        Properties properties = new Properties();
+        try (InputStream inputStream = NativeRuntimePropertiesSupport.class.getResourceAsStream("/native-runtime.properties")) {
+            if (inputStream != null) {
+                properties.load(inputStream);
+            }
+        } catch (IOException exception) {
+            throw new IllegalStateException("Could not load embedded native runtime properties", exception);
+        }
+        return properties;
+    }
+
+    private static String firstNonBlank(String... candidates) {
+        for (String candidate : candidates) {
+            if (candidate != null && !candidate.isBlank()) {
+                return candidate;
+            }
+        }
+        return "";
+    }
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#6835

This PR provides new metadata needed for the info.picocli:picocli:4.7.6, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `info.picocli:picocli:4.7.6`): 10
- Metadata entries (new `info.picocli:picocli:4.7.6`): 10
- Library coverage (previous): 44.95%
- Library coverage (new): 44.95%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `907319e0f677986d3093c79e99b4badbfd2f50bf`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `info.picocli:picocli:4.7.6` and `info.picocli:picocli:4.7.6`.

### Local CI Verification

- Status: `success`
- Commands run: 11
- Fixup attempts: 0
