### PR TITLE
[Automation] Generated metadata for backport-util-concurrent:backport-util-concurrent:3.1

### DIFF
--- a/stats/backport-util-concurrent/backport-util-concurrent/3.1/stats.json
+++ b/stats/backport-util-concurrent/backport-util-concurrent/3.1/stats.json
@@ -15,21 +15,21 @@
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 7859,
-        "missed" : 29581,
-        "ratio" : 0.209909,
+        "covered" : 7812,
+        "missed" : 29628,
+        "ratio" : 0.208654,
         "total" : 37440
       },
       "line" : {
-        "covered" : 1961,
-        "missed" : 6662,
-        "ratio" : 0.227415,
+        "covered" : 1960,
+        "missed" : 6663,
+        "ratio" : 0.227299,
         "total" : 8623
       },
       "method" : {
-        "covered" : 461,
-        "missed" : 1763,
-        "ratio" : 0.207284,
+        "covered" : 460,
+        "missed" : 1764,
+        "ratio" : 0.206835,
         "total" : 2224
       }
     }

--- a/tests/src/backport-util-concurrent/backport-util-concurrent/3.1/build.gradle
+++ b/tests/src/backport-util-concurrent/backport-util-concurrent/3.1/build.gradle
@@ -16,17 +16,16 @@ tasks.withType(Test).configureEach {
     systemProperty nanoTimerProviderProperty, nanoTimerProviderClass
 }
 
+tasks.named("nativeTest") {
+    runtimeArgs.add("-D${nanoTimerProviderProperty}=${nanoTimerProviderClass}")
+}
+
 dependencies {
     testImplementation "backport-util-concurrent:backport-util-concurrent:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
 graalvmNative {
-    binaries {
-        test {
-            runtimeArgs("-D${nanoTimerProviderProperty}=${nanoTimerProviderClass}")
-        }
-    }
     agent {
         defaultMode = "conditional"
         modes {


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#6832

This PR provides new metadata needed for the backport-util-concurrent:backport-util-concurrent:3.1, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `backport-util-concurrent:backport-util-concurrent:3.1`): 139
- Test-only metadata entries (previous `backport-util-concurrent:backport-util-concurrent:3.1`): 2
- Metadata entries (new `backport-util-concurrent:backport-util-concurrent:3.1`): 139
- Test-only metadata entries (new `backport-util-concurrent:backport-util-concurrent:3.1`): 2
- Library coverage (previous): 22.73%
- Library coverage (new): 22.73%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `907319e0f677986d3093c79e99b4badbfd2f50bf`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `backport-util-concurrent:backport-util-concurrent:3.1` and `backport-util-concurrent:backport-util-concurrent:3.1`.

### Local CI Verification

- Status: `success`
- Commands run: 12
- Fixup attempts: 0
