### PR TITLE
[GenAI] Add support for org.apache.maven.wagon:wagon-http-shared:1.0-beta-2 using gpt-5.5

### DIFF
--- a/metadata/org.apache.maven.wagon/wagon-http-shared/1.0-beta-2/reachability-metadata.json
+++ b/metadata/org.apache.maven.wagon/wagon-http-shared/1.0-beta-2/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.wagon.shared.http.HtmlFileListParser"
+      },
+      "bundle": "org/w3c/tidy/TidyMessages"
+    }
+  ]
+}

--- a/metadata/org.apache.maven.wagon/wagon-http-shared/index.json
+++ b/metadata/org.apache.maven.wagon/wagon-http-shared/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.0-beta-2",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http-shared/$version$/wagon-http-shared-$version$-sources.jar",
+    "repository-url" : "https://svn.apache.org/repos/asf/maven/wagon",
+    "test-code-url" : "https://svn.apache.org/repos/asf/maven/wagon/tags/wagon-$version$/wagon-providers/wagon-http-shared/src/test/",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-http-shared/$version$/wagon-http-shared-$version$-javadoc.jar",
+    "description" : "Maven Wagon HTTP Shared Library provides common HTTP utilities used by the wagon-http and wagon-http-lightweight provider modules in Apache Maven Wagon. It supports Maven's transport layer by sharing HTTP-related parsing and stream helper code between those Wagon implementations.",
+    "tested-versions" : [
+      "1.0-beta-2"
+    ],
+    "allowed-packages" : [
+      "org.apache.maven.wagon.shared.http"
+    ]
+  }
+]

--- a/stats/org.apache.maven.wagon/wagon-http-shared/1.0-beta-2/execution-metrics.json
+++ b/stats/org.apache.maven.wagon/wagon-http-shared/1.0-beta-2/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-13": {
+    "timestamp": "2026-05-13T05:55:02.712745Z",
+    "library": "org.apache.maven.wagon:wagon-http-shared:1.0-beta-2",
+    "starting_commit": "9416b9a095f9908d480ad2c5bef80f612c1f0cd0",
+    "ending_commit": "2e3dd6bae975619454ac7fad17be994aa519b7da",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.0-beta-2",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 203,
+          "missed": 5,
+          "ratio": 0.975962,
+          "total": 208
+        },
+        "line": {
+          "covered": 55,
+          "missed": 2,
+          "ratio": 0.964912,
+          "total": 57
+        },
+        "method": {
+          "covered": 9,
+          "missed": 1,
+          "ratio": 0.9,
+          "total": 10
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 110511,
+      "cached_input_tokens_used": 622592,
+      "output_tokens_used": 12950,
+      "iterations": 4,
+      "cost_usd": 0.6998,
+      "generated_loc": 129,
+      "tested_library_loc": 55,
+      "metadata_entries": 1,
+      "code_coverage_percent": 96.49
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.maven.wagon/wagon-http-shared/1.0-beta-2/src/test/java/org_apache_maven_wagon/wagon_http_shared/Wagon_http_sharedTest.java",
+      "metadata_file": "metadata/org.apache.maven.wagon/wagon-http-shared/1.0-beta-2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.maven.wagon/wagon-http-shared/1.0-beta-2/stats.json
+++ b/stats/org.apache.maven.wagon/wagon-http-shared/1.0-beta-2/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.0-beta-2",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 203,
+        "missed" : 5,
+        "ratio" : 0.975962,
+        "total" : 208
+      },
+      "line" : {
+        "covered" : 55,
+        "missed" : 2,
+        "ratio" : 0.964912,
+        "total" : 57
+      },
+      "method" : {
+        "covered" : 9,
+        "missed" : 1,
+        "ratio" : 0.9,
+        "total" : 10
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.maven.wagon/wagon-http-shared/1.0-beta-2/.gitignore
+++ b/tests/src/org.apache.maven.wagon/wagon-http-shared/1.0-beta-2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.maven.wagon/wagon-http-shared/1.0-beta-2/build.gradle
+++ b/tests/src/org.apache.maven.wagon/wagon-http-shared/1.0-beta-2/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.maven.wagon:wagon-http-shared:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.maven.wagon/wagon-http-shared/1.0-beta-2/gradle.properties
+++ b/tests/src/org.apache.maven.wagon/wagon-http-shared/1.0-beta-2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.maven.wagon:wagon-http-shared:1.0-beta-2
+library.version = 1.0-beta-2
+metadata.dir = org.apache.maven.wagon/wagon-http-shared/1.0-beta-2/

--- a/tests/src/org.apache.maven.wagon/wagon-http-shared/1.0-beta-2/settings.gradle
+++ b/tests/src/org.apache.maven.wagon/wagon-http-shared/1.0-beta-2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.maven.wagon.wagon-http-shared_tests'

--- a/tests/src/org.apache.maven.wagon/wagon-http-shared/1.0-beta-2/src/test/java/org_apache_maven_wagon/wagon_http_shared/Wagon_http_sharedTest.java
+++ b/tests/src/org.apache.maven.wagon/wagon-http-shared/1.0-beta-2/src/test/java/org_apache_maven_wagon/wagon_http_shared/Wagon_http_sharedTest.java
@@ -6,11 +6,115 @@
  */
 package org_apache_maven_wagon.wagon_http_shared;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.apache.maven.wagon.shared.http.HtmlFileListParser;
+import org.apache.maven.wagon.shared.http.NullOutputStream;
 import org.junit.jupiter.api.Test;
 
-class Wagon_http_sharedTest {
+public class Wagon_http_sharedTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void parsesSimpleFileAndDirectoryLinksFromHtmlListing() throws Exception {
+        String html = """
+                <html>
+                  <body>
+                    <h1>Index of /repository/releases/</h1>
+                    <a href="library-1.0.jar">library-1.0.jar</a>
+                    <div><a href=" library-1.0.pom ">library-1.0.pom</a></div>
+                    <span><a href="checksums/">checksums/</a></span>
+                  </body>
+                </html>
+                """;
+
+        List<String> links = parseFileList("http://repo.example.test/repository/releases/", html);
+
+        assertThat(links).containsExactly("library-1.0.jar", "library-1.0.pom", "checksums/");
+    }
+
+    @Test
+    void acceptsSameBaseUrlAndHostRelativeLinks() throws Exception {
+        String html = """
+                <html>
+                  <body>
+                    <a href="http://repo.example.test:8080/repository/releases/app-1.0.jar">jar</a>
+                    <a href="/repository/releases/app-1.0.pom">pom</a>
+                    <a href="http://repo.example.test:8080/repository/releases/snapshots/">snapshots</a>
+                    <a href="/repository/releases/metadata/">metadata</a>
+                  </body>
+                </html>
+                """;
+
+        List<String> links = parseFileList("http://repo.example.test:8080/repository/releases/", html);
+
+        assertThat(links).containsExactly("app-1.0.jar", "app-1.0.pom", "snapshots/", "metadata/");
+    }
+
+    @Test
+    void filtersNavigationAndNonListingLinks() throws Exception {
+        String html = """
+                <html>
+                  <body>
+                    <a href="valid-file.txt">valid-file.txt</a>
+                    <a href="valid-directory/">valid-directory/</a>
+                    <a href="https://other.example.test/file.txt">foreign absolute URL</a>
+                    <a href="file.txt?download=true">query string</a>
+                    <a href="mailto:users@example.test">mail</a>
+                    <a href="deep/path/file.txt">nested file</a>
+                    <a href="one-level/file.txt">path to file</a>
+                    <a href="/repository/other/file.txt">wrong host-relative path</a>
+                    <a href="">empty</a>
+                  </body>
+                </html>
+                """;
+
+        List<String> links = parseFileList("http://repo.example.test/repository/releases/", html);
+
+        assertThat(links).containsExactly("valid-file.txt", "valid-directory/");
+    }
+
+    @Test
+    void recoversAnchorLinksFromMalformedHtml() throws Exception {
+        String html = """
+                <HTML><BODY>
+                  <A HREF="first.txt">first
+                  <table><tr><td><a href="nested/">nested
+                  <a href="bad:name.txt">bad</a>
+                  <a href="second.txt">second</a>
+                """;
+
+        List<String> links = parseFileList("http://repo.example.test/repository/releases/", html);
+
+        assertThat(links).containsExactly("first.txt", "nested/", "second.txt");
+    }
+
+    @Test
+    void nullOutputStreamIgnoresAllWritesAndRemainsUsableAfterClose() {
+        NullOutputStream outputStream = new NullOutputStream();
+        byte[] bytes = "discarded data".getBytes(StandardCharsets.UTF_8);
+
+        assertThatCode(() -> {
+            outputStream.write('x');
+            outputStream.write(bytes);
+            outputStream.write(bytes, 2, 5);
+            outputStream.flush();
+            outputStream.close();
+            outputStream.write('y');
+            outputStream.write(bytes, 0, bytes.length);
+            outputStream.flush();
+        }).doesNotThrowAnyException();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> parseFileList(String baseUrl, String html) throws Exception {
+        return HtmlFileListParser.parseFileList(baseUrl, input(html));
+    }
+
+    private static ByteArrayInputStream input(String html) {
+        return new ByteArrayInputStream(html.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/tests/src/org.apache.maven.wagon/wagon-http-shared/1.0-beta-2/src/test/java/org_apache_maven_wagon/wagon_http_shared/Wagon_http_sharedTest.java
+++ b/tests/src/org.apache.maven.wagon/wagon-http-shared/1.0-beta-2/src/test/java/org_apache_maven_wagon/wagon_http_shared/Wagon_http_sharedTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_wagon.wagon_http_shared;
+
+import org.junit.jupiter.api.Test;
+
+class Wagon_http_sharedTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.apache.maven.wagon/wagon-http-shared/1.0-beta-2/src/test/java/org_apache_maven_wagon/wagon_http_shared/Wagon_http_sharedTest.java
+++ b/tests/src/org.apache.maven.wagon/wagon-http-shared/1.0-beta-2/src/test/java/org_apache_maven_wagon/wagon_http_shared/Wagon_http_sharedTest.java
@@ -55,6 +55,23 @@ public class Wagon_http_sharedTest {
     }
 
     @Test
+    void acceptsHostRelativeLinksWhenListingIsAtServerRoot() throws Exception {
+        String html = """
+                <html>
+                  <body>
+                    <a href="/maven-metadata.xml">metadata</a>
+                    <a href="/releases/">releases</a>
+                    <a href="/nested/artifact.jar">nested file</a>
+                  </body>
+                </html>
+                """;
+
+        List<String> links = parseFileList("http://repo.example.test/", html);
+
+        assertThat(links).containsExactly("maven-metadata.xml", "releases/");
+    }
+
+    @Test
     void filtersNavigationAndNonListingLinks() throws Exception {
         String html = """
                 <html>

--- a/tests/src/org.apache.maven.wagon/wagon-http-shared/1.0-beta-2/src/test/java/org_apache_maven_wagon/wagon_http_shared/Wagon_http_sharedTest.java
+++ b/tests/src/org.apache.maven.wagon/wagon-http-shared/1.0-beta-2/src/test/java/org_apache_maven_wagon/wagon_http_shared/Wagon_http_sharedTest.java
@@ -110,6 +110,23 @@ public class Wagon_http_sharedTest {
     }
 
     @Test
+    void treatsBackslashPathSeparatorsLikeSlashWhenValidatingLinks() throws Exception {
+        String html = """
+                <html>
+                  <body>
+                    <a href="windows-directory\\">windows directory</a>
+                    <a href="nested\\artifact.jar">nested file</a>
+                    <a href="deep\\nested\\">deep directory</a>
+                  </body>
+                </html>
+                """;
+
+        List<String> links = parseFileList("http://repo.example.test/repository/releases/", html);
+
+        assertThat(links).containsExactly("windows-directory\\");
+    }
+
+    @Test
     void nullOutputStreamIgnoresAllWritesAndRemainsUsableAfterClose() {
         NullOutputStream outputStream = new NullOutputStream();
         byte[] bytes = "discarded data".getBytes(StandardCharsets.UTF_8);

--- a/tests/src/org.apache.maven.wagon/wagon-http-shared/1.0-beta-2/user-code-filter.json
+++ b/tests/src/org.apache.maven.wagon/wagon-http-shared/1.0-beta-2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.apache.maven.wagon.shared.http.**"
+    }
+  ]
+}

--- a/tests/src/org.apache.maven.wagon/wagon-http-shared/1.0-beta-2/user-code-filter.json
+++ b/tests/src/org.apache.maven.wagon/wagon-http-shared/1.0-beta-2/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.apache.maven.wagon.shared.http.**"
+      "includeClasses" : "org.apache.maven.wagon.shared.http.**"
+    },
+    {
+      "includeClasses" : "org_apache_maven_wagon.wagon_http_shared.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #2317

This PR introduces tests and metadata for org.apache.maven.wagon:wagon-http-shared:1.0-beta-2, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 110511
- Cached input tokens: 622592
- Output tokens: 12950
- Metadata entries: 1
- Iterations: 4
- Library coverage percentage: 96.49
- Generated lines of code: 129
- Tested library lines of code: 55

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `907319e0f677986d3093c79e99b4badbfd2f50bf`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 203/208 (97.60%)
- Line: 55/57 (96.49%)
- Method: 9/10 (90.00%)

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
