### PR TITLE
[GenAI] Mark org.springframework.boot:spring-boot-starter-tomcat as not for Native Image

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-starter-tomcat/index.json
+++ b/metadata/org.springframework.boot/spring-boot-starter-tomcat/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published JAR for org.springframework.boot:spring-boot-starter-tomcat:2.7.18 contains only META-INF files and no JVM class files; it is a dependency starter whose runtime classes are supplied by its dependencies.",
+    "replacement": "Use class-bearing dependencies such as org.apache.tomcat.embed:tomcat-embed-core:9.0.83, org.apache.tomcat.embed:tomcat-embed-el:9.0.83, and org.apache.tomcat.embed:tomcat-embed-websocket:9.0.83."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #2269

This PR records `org.springframework.boot:spring-boot-starter-tomcat` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published JAR for org.springframework.boot:spring-boot-starter-tomcat:2.7.18 contains only META-INF files and no JVM class files; it is a dependency starter whose runtime classes are supplied by its dependencies.

Replacement guidance:
- Use class-bearing dependencies such as org.apache.tomcat.embed:tomcat-embed-core:9.0.83, org.apache.tomcat.embed:tomcat-embed-el:9.0.83, and org.apache.tomcat.embed:tomcat-embed-websocket:9.0.83.

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `907319e0f677986d3093c79e99b4badbfd2f50bf`

### Local CI Verification

- Status: `success`
- Commands run: 6
- Fixup attempts: 0
