### PR TITLE
Handle Maven Central rate limits in compatibility discovery

### DIFF
--- a/.github/workflows/verify-new-library-version-compatibility.yml
+++ b/.github/workflows/verify-new-library-version-compatibility.yml
@@ -19,7 +19,7 @@ jobs:
     # Opens PRs, with labels and assignees. Works only on the main repo.
     if: github.repository == 'oracle/graalvm-reachability-metadata'
     runs-on: ubuntu-22.04
-    timeout-minutes: 5
+    timeout-minutes: 20
     permissions: write-all
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -46,6 +46,7 @@ jobs:
       - name: "🕸️ Populate matrix"
         id: set-matrix
         run: |
+          set -o pipefail
           MATRIX_OUTPUT_FILE="$(mktemp)"
           RAW_OUTPUT="$(./gradlew fetchExistingLibrariesWithNewerVersions --quiet | sed -n '/\[/,$p')"
           JSON_PAYLOAD="$(printf '%s' "$RAW_OUTPUT" | jq -c '.')"

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/harness/tasks/FetchExistingLibrariesWithNewerVersionsTask.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/harness/tasks/FetchExistingLibrariesWithNewerVersionsTask.java
@@ -21,9 +21,24 @@ import org.gradle.util.internal.VersionNumber;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.net.URI;
+import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -34,6 +49,14 @@ public abstract class FetchExistingLibrariesWithNewerVersionsTask extends Defaul
     public abstract ListProperty<String> getAllLibraryCoordinates();
 
     private static final List<String> INFRASTRUCTURE_TESTS = List.of("samples", "org.example");
+    private static final String MAVEN_CENTRAL_BASE_URL = "https://repo.maven.apache.org/maven2";
+    private static final int MAX_METADATA_READ_ATTEMPTS = 5;
+    private static final Duration MIN_REMOTE_REQUEST_INTERVAL = Duration.ofMillis(250);
+    private static final Duration DEFAULT_RETRY_DELAY = Duration.ofSeconds(2);
+    private static final Duration MAX_RETRY_DELAY = Duration.ofSeconds(30);
+    private static final int CONNECTION_TIMEOUT_MILLIS = (int) Duration.ofSeconds(30).toMillis();
+    private static final String USER_AGENT = "graalvm-reachability-metadata-new-library-version-checker";
+    private static Instant nextRemoteRequest = Instant.EPOCH;
 
     @TaskAction
     public void action() {
@@ -82,11 +105,11 @@ public abstract class FetchExistingLibrariesWithNewerVersionsTask extends Defaul
     }
 
     static List<String> getNewerVersionsFor(String library, String startingVersion) {
-        String baseUrl = "https://repo1.maven.org/maven2";
         String[] libraryParts = library.split(":");
         String group = libraryParts[0].replace(".", "/");
         String artifact = libraryParts[1];
-        Optional<String> metadata = readMavenMetadata(baseUrl + "/" + group + "/" + artifact + "/maven-metadata.xml");
+        Optional<String> metadata = readMavenMetadata(
+                MAVEN_CENTRAL_BASE_URL + "/" + group + "/" + artifact + "/maven-metadata.xml");
         if (metadata.isEmpty()) {
             return Collections.emptyList();
         }
@@ -100,12 +123,138 @@ public abstract class FetchExistingLibrariesWithNewerVersionsTask extends Defaul
     }
 
     static Optional<String> readMavenMetadata(String metadataUrl) {
+        return readMavenMetadata(metadataUrl, millis -> {
+            try {
+                Thread.sleep(millis);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted while waiting to retry Maven metadata request", e);
+            }
+        });
+    }
+
+    static Optional<String> readMavenMetadata(String metadataUrl, MetadataReadSleeper sleeper) {
+        URI metadataUri = URI.create(metadataUrl);
         try {
-            return Optional.of(new String(URI.create(metadataUrl).toURL().openStream().readAllBytes(), StandardCharsets.UTF_8));
+            for (int attempt = 1; attempt <= MAX_METADATA_READ_ATTEMPTS; attempt++) {
+                try {
+                    return readMavenMetadataOnce(metadataUri);
+                } catch (RetryableMetadataReadException e) {
+                    if (attempt == MAX_METADATA_READ_ATTEMPTS) {
+                        throw new IOException("Failed to read Maven metadata after " + MAX_METADATA_READ_ATTEMPTS
+                                + " attempts from " + metadataUrl + ": " + e.getMessage(), e);
+                    }
+                    sleeper.sleep(retryDelay(e, attempt).toMillis());
+                }
+            }
+            throw new IOException("Failed to read Maven metadata from " + metadataUrl);
         } catch (FileNotFoundException e) {
             return Optional.empty();
         } catch (IOException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    private static Optional<String> readMavenMetadataOnce(URI metadataUri) throws IOException {
+        URLConnection connection = metadataUri.toURL().openConnection();
+        connection.setConnectTimeout(CONNECTION_TIMEOUT_MILLIS);
+        connection.setReadTimeout(CONNECTION_TIMEOUT_MILLIS);
+        connection.setRequestProperty("User-Agent", USER_AGENT);
+        HttpURLConnection httpConnection = connection instanceof HttpURLConnection http ? http : null;
+        try {
+            if (httpConnection != null) {
+                throttleRemoteRequest();
+                int responseCode = httpConnection.getResponseCode();
+                if (responseCode == HttpURLConnection.HTTP_NOT_FOUND) {
+                    return Optional.empty();
+                }
+                if (isRetryableResponse(responseCode)) {
+                    throw new RetryableMetadataReadException(
+                            "HTTP " + responseCode + " for URL: " + metadataUri,
+                            retryAfter(httpConnection));
+                }
+                if (responseCode >= HttpURLConnection.HTTP_BAD_REQUEST) {
+                    throw new IOException("Server returned HTTP response code: " + responseCode
+                            + " for URL: " + metadataUri);
+                }
+            }
+            return Optional.of(new String(connection.getInputStream().readAllBytes(), StandardCharsets.UTF_8));
+        } finally {
+            if (httpConnection != null) {
+                httpConnection.disconnect();
+            }
+        }
+    }
+
+    private static synchronized void throttleRemoteRequest() {
+        Instant now = Instant.now();
+        if (now.isBefore(nextRemoteRequest)) {
+            sleepUnchecked(Duration.between(now, nextRemoteRequest));
+        }
+        nextRemoteRequest = Instant.now().plus(MIN_REMOTE_REQUEST_INTERVAL);
+    }
+
+    private static void sleepUnchecked(Duration duration) {
+        try {
+            Thread.sleep(duration.toMillis());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while throttling Maven metadata requests", e);
+        }
+    }
+
+    private static boolean isRetryableResponse(int responseCode) {
+        return responseCode == 429
+                || responseCode == HttpURLConnection.HTTP_INTERNAL_ERROR
+                || responseCode == HttpURLConnection.HTTP_BAD_GATEWAY
+                || responseCode == HttpURLConnection.HTTP_UNAVAILABLE
+                || responseCode == HttpURLConnection.HTTP_GATEWAY_TIMEOUT;
+    }
+
+    private static Optional<Duration> retryAfter(HttpURLConnection connection) {
+        String retryAfterHeader = connection.getHeaderField("Retry-After");
+        if (retryAfterHeader == null || retryAfterHeader.isBlank()) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(Duration.ofSeconds(Long.parseLong(retryAfterHeader)));
+        } catch (NumberFormatException e) {
+            try {
+                Instant retryAt = DateTimeFormatter.RFC_1123_DATE_TIME.parse(retryAfterHeader, Instant::from);
+                return Optional.of(Duration.between(Instant.now(), retryAt));
+            } catch (DateTimeParseException ignored) {
+                return Optional.empty();
+            }
+        }
+    }
+
+    private static Duration retryDelay(RetryableMetadataReadException e, int attempt) {
+        Duration delay = e.retryAfter().orElse(DEFAULT_RETRY_DELAY.multipliedBy(1L << (attempt - 1)));
+        if (delay.isNegative() || delay.isZero()) {
+            return DEFAULT_RETRY_DELAY;
+        }
+        if (delay.compareTo(MAX_RETRY_DELAY) > 0) {
+            return MAX_RETRY_DELAY;
+        }
+        return delay;
+    }
+
+    @FunctionalInterface
+    interface MetadataReadSleeper {
+        void sleep(long millis) throws IOException;
+    }
+
+    private static final class RetryableMetadataReadException extends IOException {
+
+        private final Optional<Duration> retryAfter;
+
+        private RetryableMetadataReadException(String message, Optional<Duration> retryAfter) {
+            super(message);
+            this.retryAfter = retryAfter;
+        }
+
+        private Optional<Duration> retryAfter() {
+            return retryAfter;
         }
     }
 

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/FetchExistingLibrariesWithNewerVersionsTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/FetchExistingLibrariesWithNewerVersionsTaskTests.java
@@ -6,13 +6,18 @@
  */
 package org.graalvm.internal.tck.harness.tasks;
 
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -46,6 +51,45 @@ class FetchExistingLibrariesWithNewerVersionsTaskTests {
     }
 
     @Test
+    void readMavenMetadataRetriesRateLimitedRequests() throws IOException {
+        AtomicInteger requests = new AtomicInteger();
+        HttpServer server = startServer(exchange -> {
+            if (requests.incrementAndGet() == 1) {
+                exchange.getResponseHeaders().add("Retry-After", "1");
+                exchange.sendResponseHeaders(429, -1);
+                exchange.close();
+                return;
+            }
+
+            byte[] response = """
+                    <metadata>
+                      <versioning>
+                        <versions>
+                          <version>1.0.0</version>
+                        </versions>
+                      </versioning>
+                    </metadata>
+                    """.getBytes();
+            exchange.sendResponseHeaders(200, response.length);
+            exchange.getResponseBody().write(response);
+            exchange.close();
+        });
+        List<Long> retryDelays = new ArrayList<>();
+
+        try {
+            assertThat(FetchExistingLibrariesWithNewerVersionsTask.readMavenMetadata(
+                    "http://localhost:" + server.getAddress().getPort() + "/maven-metadata.xml",
+                    retryDelays::add))
+                    .hasValueSatisfying(metadata -> assertThat(metadata).contains("<version>1.0.0</version>"));
+        } finally {
+            server.stop(0);
+        }
+
+        assertThat(requests).hasValue(2);
+        assertThat(retryDelays).containsExactly(1_000L);
+    }
+
+    @Test
     void getNewerVersionsFromLibraryIndexKeepsVersionsAfterStartingVersion() {
         String metadata = """
                 <metadata>
@@ -63,5 +107,24 @@ class FetchExistingLibrariesWithNewerVersionsTaskTests {
                 metadata, "1.0.0", "com.example:demo");
 
         assertThat(newerVersions).containsExactly("1.1.0", "1.2.0");
+    }
+
+    private HttpServer startServer(ThrowingExchangeHandler handler) throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/", exchange -> {
+            try {
+                handler.handle(exchange);
+            } catch (Exception e) {
+                exchange.sendResponseHeaders(500, -1);
+                exchange.close();
+            }
+        });
+        server.start();
+        return server;
+    }
+
+    @FunctionalInterface
+    private interface ThrowingExchangeHandler {
+        void handle(HttpExchange exchange) throws Exception;
     }
 }


### PR DESCRIPTION
## Summary

Fixes the scheduled compatibility workflow failure caused by Maven Central rate limiting during newer-version discovery.

## Changes

- Use the canonical Maven Central host for `maven-metadata.xml` reads.
- Add throttling, retry/backoff, `Retry-After` support, request timeouts, and a user agent for metadata requests.
- Add `set -o pipefail` so the workflow reports the real metadata fetch failure instead of a later empty JSON error.
- Increase the gather-job timeout to account for throttled discovery.
- Add a focused test covering retry behavior for `429` responses.

## Verification

```text
./gradlew :tck-build-logic:test --tests org.graalvm.internal.tck.harness.tasks.FetchExistingLibrariesWithNewerVersionsTaskTests --stacktrace
./gradlew spotlessJavaCheck --stacktrace
./gradlew fetchExistingLibrariesWithNewerVersions --quiet -Pcoordinates=org.apache.maven:maven-model:2.0.11
```

Fixes #6892
