### PR TITLE
[GenAI] Add support for org.scalatest:scalatest-shouldmatchers_3:3.2.19 using gpt-5.5

### DIFF
--- a/metadata/org.scalatest/scalatest-shouldmatchers_3/3.2.19/reachability-metadata.json
+++ b/metadata/org.scalatest/scalatest-shouldmatchers_3/3.2.19/reachability-metadata.json
@@ -1,0 +1,79 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.scalatest.Assertions"
+      },
+      "type" : "org.scalatest.Assertions$",
+      "fields" : [
+        {
+          "name" : "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.scalatest.matchers.should.Matchers"
+      },
+      "type" : "org.scalatest.matchers.should.Matchers$",
+      "fields" : [
+        {
+          "name" : "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.scalactic.source.Position"
+      },
+      "type" : "org.scalactic.source.Position$",
+      "fields" : [
+        {
+          "name" : "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.scalatest.Resources$"
+      },
+      "type" : "org.scalatest.Resources$",
+      "fields" : [
+        {
+          "name" : "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.scalatest.exceptions.StackDepthException"
+      },
+      "type" : "org.scalatest.exceptions.StackDepthException",
+      "fields" : [
+        {
+          "name" : "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.scalatest.enablers.Messaging$$anon$3"
+      },
+      "type" : "java.lang.Throwable",
+      "methods" : [
+        {
+          "name" : "getMessage",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.scalatest.Resources$"
+      },
+      "bundle" : "org.scalatest.ScalaTestBundle"
+    }
+  ]
+}

--- a/metadata/org.scalatest/scalatest-shouldmatchers_3/index.json
+++ b/metadata/org.scalatest/scalatest-shouldmatchers_3/index.json
@@ -1,21 +1,25 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "3.2.19",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-shouldmatchers_3/$version$/scalatest-shouldmatchers_3-$version$-sources.jar",
-    "repository-url" : "https://github.com/scalatest/scalatest",
-    "test-code-url" : "https://github.com/scalatest/scalatest/tree/release-$version$/dotty/scalatest-test/src/test/scala/org/scalatest/matchers/should",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-shouldmatchers_3/$version$/scalatest-shouldmatchers_3-$version$-javadoc.jar",
-    "description" : "ScalaTest ShouldMatchers provides Scala 3 matcher syntax for writing expressive assertions with words such as should, be, and contain. It is an optional ScalaTest module that adds type-safe matchers and compile-time checks used in Scala test suites.",
-    "language" : {
-      "name" : "scala",
-      "version" : "3"
+    "latest": true,
+    "metadata-version": "3.2.19",
+    "source-code-url": "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-shouldmatchers_3/$version$/scalatest-shouldmatchers_3-$version$-sources.jar",
+    "repository-url": "https://github.com/scalatest/scalatest",
+    "test-code-url": "https://github.com/scalatest/scalatest/tree/release-$version$/dotty/scalatest-test/src/test/scala/org/scalatest/matchers/should",
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-shouldmatchers_3/$version$/scalatest-shouldmatchers_3-$version$-javadoc.jar",
+    "description": "ScalaTest ShouldMatchers provides Scala 3 matcher syntax for writing expressive assertions with words such as should, be, and contain. It is an optional ScalaTest module that adds type-safe matchers and compile-time checks used in Scala test suites.",
+    "language": {
+      "name": "scala",
+      "version": "3"
     },
-    "tested-versions" : [
+    "tested-versions": [
       "3.2.19"
     ],
-    "allowed-packages" : [
-      "org.scalatest.matchers.should"
+    "allowed-packages": [
+      "org.scalatest.matchers.should",
+      "org.scalactic.source",
+      "org.scalatest",
+      "org.scalatest.enablers",
+      "org.scalatest.exceptions"
     ]
   }
 ]

--- a/metadata/org.scalatest/scalatest-shouldmatchers_3/index.json
+++ b/metadata/org.scalatest/scalatest-shouldmatchers_3/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.2.19",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-shouldmatchers_3/$version$/scalatest-shouldmatchers_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/scalatest/scalatest",
+    "test-code-url" : "https://github.com/scalatest/scalatest/tree/release-$version$/dotty/scalatest-test/src/test/scala/org/scalatest/matchers/should",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-shouldmatchers_3/$version$/scalatest-shouldmatchers_3-$version$-javadoc.jar",
+    "description" : "ScalaTest ShouldMatchers provides Scala 3 matcher syntax for writing expressive assertions with words such as should, be, and contain. It is an optional ScalaTest module that adds type-safe matchers and compile-time checks used in Scala test suites.",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "3.2.19"
+    ],
+    "allowed-packages" : [
+      "org.scalatest.matchers.should"
+    ]
+  }
+]

--- a/stats/org.scalatest/scalatest-shouldmatchers_3/3.2.19/execution-metrics.json
+++ b/stats/org.scalatest/scalatest-shouldmatchers_3/3.2.19/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-13": {
+    "timestamp": "2026-05-13T13:51:05.285537Z",
+    "library": "org.scalatest:scalatest-shouldmatchers_3:3.2.19",
+    "starting_commit": "0d8203a5abbcbcbc32d0390be1e5e2ef5a87e7ff",
+    "ending_commit": "e3eb2934109dd20fca982a25d25af71cc7384f2a",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.2.19",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1479,
+          "missed": 12226,
+          "ratio": 0.107917,
+          "total": 13705
+        },
+        "line": {
+          "covered": 154,
+          "missed": 1030,
+          "ratio": 0.130068,
+          "total": 1184
+        },
+        "method": {
+          "covered": 123,
+          "missed": 966,
+          "ratio": 0.112948,
+          "total": 1089
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 293684,
+      "cached_input_tokens_used": 2074624,
+      "output_tokens_used": 20946,
+      "iterations": 6,
+      "cost_usd": 1.6657,
+      "generated_loc": 314,
+      "tested_library_loc": 154,
+      "metadata_entries": 13,
+      "code_coverage_percent": 13.01
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.scalatest/scalatest-shouldmatchers_3/3.2.19/src/test/scala/org_scalatest/scalatest_shouldmatchers_3/Scalatest_shouldmatchers_3Test.scala",
+      "metadata_file": "metadata/org.scalatest/scalatest-shouldmatchers_3/3.2.19/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.scalatest/scalatest-shouldmatchers_3/3.2.19/stats.json
+++ b/stats/org.scalatest/scalatest-shouldmatchers_3/3.2.19/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.2.19",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1479,
+        "missed" : 12226,
+        "ratio" : 0.107917,
+        "total" : 13705
+      },
+      "line" : {
+        "covered" : 154,
+        "missed" : 1030,
+        "ratio" : 0.130068,
+        "total" : 1184
+      },
+      "method" : {
+        "covered" : 123,
+        "missed" : 966,
+        "ratio" : 0.112948,
+        "total" : 1089
+      }
+    }
+  } ]
+}

--- a/tests/src/org.scalatest/scalatest-shouldmatchers_3/3.2.19/.gitignore
+++ b/tests/src/org.scalatest/scalatest-shouldmatchers_3/3.2.19/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.scalatest/scalatest-shouldmatchers_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-shouldmatchers_3/3.2.19/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.scalatest:scalatest-shouldmatchers_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.scalatest/scalatest-shouldmatchers_3/3.2.19/gradle.properties
+++ b/tests/src/org.scalatest/scalatest-shouldmatchers_3/3.2.19/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.scalatest:scalatest-shouldmatchers_3:3.2.19
+library.version = 3.2.19
+metadata.dir = org.scalatest/scalatest-shouldmatchers_3/3.2.19/

--- a/tests/src/org.scalatest/scalatest-shouldmatchers_3/3.2.19/settings.gradle
+++ b/tests/src/org.scalatest/scalatest-shouldmatchers_3/3.2.19/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.scalatest.scalatest-shouldmatchers_3_tests'

--- a/tests/src/org.scalatest/scalatest-shouldmatchers_3/3.2.19/src/test/scala/org_scalatest/scalatest_shouldmatchers_3/Scalatest_shouldmatchers_3Test.scala
+++ b/tests/src/org.scalatest/scalatest-shouldmatchers_3/3.2.19/src/test/scala/org_scalatest/scalatest_shouldmatchers_3/Scalatest_shouldmatchers_3Test.scala
@@ -6,6 +6,9 @@
  */
 package org_scalatest.scalatest_shouldmatchers_3
 
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
 import java.util
 
 import scala.util.Success
@@ -225,6 +228,38 @@ class Scalatest_shouldmatchers_3Test extends Matchers {
       "metadata" should palindrome
     }
     failure.getMessage should include("metadata was not a palindrome")
+  }
+
+  @Test
+  def shouldDslSupportsFileExistenceReadabilityAndWritabilityMatchers(): Unit = {
+    val tempDirectory: Path = Files.createTempDirectory("scalatest-shouldmatchers-")
+    val dataFile: Path = tempDirectory.resolve("metadata.txt")
+    val missingFile: Path = tempDirectory.resolve("missing.txt")
+
+    try {
+      Files.writeString(dataFile, "reachable=true")
+
+      val tempDirectoryFile: File = tempDirectory.toFile
+      val dataFileObject: File = dataFile.toFile
+      val missingFileObject: File = missingFile.toFile
+
+      tempDirectoryFile should exist
+      tempDirectoryFile shouldBe readable
+      tempDirectoryFile shouldBe writable
+      dataFileObject should exist
+      dataFileObject shouldBe readable
+      dataFileObject shouldBe writable
+      missingFileObject should not (exist)
+
+      val failure: TestFailedException = expectMatcherFailure {
+        missingFileObject should exist
+      }
+      failure.getMessage should include("missing.txt")
+    } finally {
+      Files.deleteIfExists(dataFile)
+      Files.deleteIfExists(missingFile)
+      Files.deleteIfExists(tempDirectory)
+    }
   }
 
   @Test

--- a/tests/src/org.scalatest/scalatest-shouldmatchers_3/3.2.19/src/test/scala/org_scalatest/scalatest_shouldmatchers_3/Scalatest_shouldmatchers_3Test.scala
+++ b/tests/src/org.scalatest/scalatest-shouldmatchers_3/3.2.19/src/test/scala/org_scalatest/scalatest_shouldmatchers_3/Scalatest_shouldmatchers_3Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_scalatest.scalatest_shouldmatchers_3
+
+import org.junit.jupiter.api.Test
+
+class Scalatest_shouldmatchers_3Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/org.scalatest/scalatest-shouldmatchers_3/3.2.19/src/test/scala/org_scalatest/scalatest_shouldmatchers_3/Scalatest_shouldmatchers_3Test.scala
+++ b/tests/src/org.scalatest/scalatest-shouldmatchers_3/3.2.19/src/test/scala/org_scalatest/scalatest_shouldmatchers_3/Scalatest_shouldmatchers_3Test.scala
@@ -6,11 +6,283 @@
  */
 package org_scalatest.scalatest_shouldmatchers_3
 
-import org.junit.jupiter.api.Test
+import java.util
 
-class Scalatest_shouldmatchers_3Test {
+import scala.util.Success
+import scala.util.Try
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.function.Executable
+import org.scalatest.exceptions.TestFailedException
+import org.scalatest.matchers.BeMatcher
+import org.scalatest.matchers.BePropertyMatchResult
+import org.scalatest.matchers.BePropertyMatcher
+import org.scalatest.matchers.HavePropertyMatchResult
+import org.scalatest.matchers.HavePropertyMatcher
+import org.scalatest.matchers.MatchResult
+import org.scalatest.matchers.Matcher
+import org.scalatest.matchers.should.Matchers
+
+final case class ServiceEndpoint(name: String, active: Boolean, uri: String, replicas: Int)
+
+class Scalatest_shouldmatchers_3Test extends Matchers {
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
+  def shouldDslSupportsEqualityIdentityOrderingAndNumericTolerance(): Unit = {
+    val serviceName: String = "reachability-metadata"
+    val alias: String = serviceName
+    val totalWeight: Int = List(2, 3, 5).sum
+    val observedRatio: Double = 22.0 / 7.0
+    val thrown: Throwable = new IllegalArgumentException("invalid input")
+
+    serviceName shouldBe "reachability-metadata"
+    serviceName should equal("reachability-metadata")
+    alias should be theSameInstanceAs serviceName
+    totalWeight should (be >= 10 and be < 20)
+    totalWeight should not be 11
+    observedRatio shouldBe (3.142 +- 0.001)
+    Vector(1, 2, 3, 4) shouldBe sorted
+    thrown shouldBe a[RuntimeException]
+
+    val failure: TestFailedException = expectMatcherFailure {
+      observedRatio shouldBe (3.0 +- 0.01)
+    }
+    failure.getMessage should include("3.142857")
+    failure.getMessage should include("3.0")
+  }
+
+  @Test
+  def shouldDslSupportsStringSubstringPrefixSuffixAndRegexMatchers(): Unit = {
+    val message: String = "order-123: shipped to Vienna"
+
+    message should startWith("order-")
+    message should include("shipped")
+    message should endWith("Vienna")
+    message should (startWith("order") and include("Vienna"))
+    message should (endWith("Vienna") or endWith("Graz"))
+    message should not include ("cancelled")
+    "order-123" should fullyMatch regex ("order-(\\d+)" withGroup "123")
+    "status=201" should include regex ("\\d{3}")
+    "scala" should not fullyMatch regex("java-[0-9]+")
+
+    val failure: TestFailedException = expectMatcherFailure {
+      message should startWith("invoice-")
+    }
+    failure.getMessage should include("invoice-")
+  }
+
+  @Test
+  def shouldDslSupportsScalaCollectionsAndSequenceConstraints(): Unit = {
+    val colors: List[String] = List("red", "green", "blue", "green")
+    val orderedNumbers: Vector[Int] = Vector(1, 2, 3, 4, 5)
+
+    colors should contain("red")
+    colors should contain allOf ("red", "blue")
+    colors should contain atLeastOneOf ("purple", "green")
+    colors should contain noneOf ("black", "white")
+    colors should contain only ("red", "green", "blue")
+    orderedNumbers should contain inOrder (2, 3, 5)
+    orderedNumbers should contain inOrderOnly (1, 2, 3, 4, 5)
+    orderedNumbers should contain theSameElementsAs Vector(5, 4, 3, 2, 1)
+    orderedNumbers should have length 5
+    colors.toSet should have size 3
+
+    val failure: TestFailedException = expectMatcherFailure {
+      orderedNumbers should contain only (1, 2, 3)
+    }
+    failure.getMessage should include("4")
+    failure.getMessage should include("5")
+  }
+
+  @Test
+  def shouldDslSupportsOptionsArraysMapsAndJavaCollections(): Unit = {
+    val configured: Option[String] = Some("enabled")
+    val absent: Option[String] = None
+    val byteValues: Array[Byte] = Array[Byte](1, 2, 3)
+    val scalaMap: Map[String, Int] = Map("http" -> 80, "https" -> 443)
+    val javaList: util.ArrayList[String] = new util.ArrayList[String]()
+    javaList.add("alpha")
+    javaList.add("beta")
+    val javaMap: util.HashMap[String, Int] = new util.HashMap[String, Int]()
+    javaMap.put("retries", 3)
+    javaMap.put("timeoutSeconds", 5)
+
+    configured shouldBe defined
+    configured should contain("enabled")
+    absent shouldBe empty
+    byteValues should contain theSameElementsInOrderAs Array[Byte](1, 2, 3)
+    scalaMap should contain key ("https")
+    scalaMap should contain value (80)
+    scalaMap should contain("http" -> 80)
+    javaList should contain("beta")
+    javaList should have length 2
+    javaMap should contain key ("retries")
+    javaMap should contain value (5)
+  }
+
+  @Test
+  def shouldDslSupportsCollectionInspectorsAndQuantifiers(): Unit = {
+    val evenNumbers: List[Int] = List(2, 4, 6, 8)
+    val statusLines: List[String] = List("200 OK", "201 CREATED", "500 ERROR")
+
+    all(evenNumbers) should be < 10
+    all(evenNumbers.map(_ % 2)) shouldBe 0
+    atLeast(2, evenNumbers) should be > 4
+    atMost(1, statusLines) should include("ERROR")
+    exactly(2, statusLines) should startWith("20")
+    between(2, 3, evenNumbers) should be >= 4
+    every(List("agent", "builder", "runner")) should fullyMatch regex ("[a-z]+")
+    no(statusLines) should endWith("PENDING")
+
+    val failure: TestFailedException = expectMatcherFailure {
+      all(evenNumbers) should be < 8
+    }
+    failure.getMessage should include("8")
+  }
+
+  @Test
+  def shouldDslSupportsPatternTypeAndPartialFunctionDefinedAtMatchers(): Unit = {
+    val parsedNumber: Try[Int] = Try("42".toInt)
+    val response: Either[String, (String, Int)] = Right(("created", 201))
+    val endpoint: ServiceEndpoint = ServiceEndpoint(
+      name = "metadata",
+      active = true,
+      uri = "https://metadata.example.test",
+      replicas = 3
+    )
+    val routes: PartialFunction[String, ServiceEndpoint] = {
+      case route if route.startsWith("/services/") =>
+        val serviceName: String = route.stripPrefix("/services/")
+        ServiceEndpoint(serviceName, active = true, s"https://$serviceName.example.test", replicas = 2)
+    }
+
+    parsedNumber should matchPattern { case Success(42) => }
+    response should matchPattern { case Right(("created", status: Int)) if status >= 200 && status < 300 => }
+    endpoint shouldBe a[ServiceEndpoint]
+    endpoint.uri shouldBe a[String]
+    endpoint should not be a[String]
+    endpoint should matchPattern {
+      case ServiceEndpoint("metadata", true, uri, replicas)
+        if uri.startsWith("https://") && replicas >= 3 =>
+    }
+    routes should be definedAt ("/services/metadata")
+    routes should not be definedAt ("/health")
+    routes("/services/search").name shouldBe "search"
+  }
+
+  @Test
+  def shouldDslSupportsExceptionMatchersAndMessageAssertions(): Unit = {
+    an[IllegalArgumentException] should be thrownBy {
+      parsePositive("-4")
+    }
+    noException should be thrownBy {
+      parsePositive("12")
+    }
+
+    val failure: IllegalArgumentException = the[IllegalArgumentException] thrownBy {
+      throw new IllegalArgumentException("invalid port", new NumberFormatException("not numeric"))
+    }
+
+    failure should have message "invalid port"
+    failure.getCause shouldBe a[NumberFormatException]
+
+    val matcherFailure: TestFailedException = expectMatcherFailure {
+      noException should be thrownBy {
+        parsePositive("0")
+      }
+    }
+    matcherFailure.getMessage should include("IllegalArgumentException")
+  }
+
+  @Test
+  def customMatchersIntegrateWithShouldSyntaxAndExposeMatchResults(): Unit = {
+    val palindrome: Matcher[String] = Matcher { (left: String) =>
+      val normalized: String = left.filter(_.isLetterOrDigit).toLowerCase
+      MatchResult(
+        normalized == normalized.reverse,
+        s"$left was not a palindrome",
+        s"$left was a palindrome"
+      )
+    }
+    val stableIdentifier: BeMatcher[String] = BeMatcher { (value: String) =>
+      MatchResult(
+        value.matches("[a-z][a-z0-9_]*"),
+        s"$value was not a stable identifier",
+        s"$value was a stable identifier"
+      )
+    }
+
+    "Never odd or even" should palindrome
+    "ScalaTest" should not(palindrome)
+    "worker_17" should be(stableIdentifier)
+    "Worker-17" should not be (stableIdentifier)
+
+    val directResult: MatchResult = palindrome("not one")
+    directResult.matches shouldBe false
+    directResult.rawFailureMessage shouldBe "not one was not a palindrome"
+
+    val failure: TestFailedException = expectMatcherFailure {
+      "metadata" should palindrome
+    }
+    failure.getMessage should include("metadata was not a palindrome")
+  }
+
+  @Test
+  def propertyMatchersIntegrateWithShouldBeAndShouldHaveSyntax(): Unit = {
+    val active: BePropertyMatcher[ServiceEndpoint] = new BePropertyMatcher[ServiceEndpoint] {
+      override def apply(left: ServiceEndpoint): BePropertyMatchResult = {
+        BePropertyMatchResult(left.active, "active")
+      }
+    }
+    val uri: HavePropertyMatcher[ServiceEndpoint, String] = new HavePropertyMatcher[ServiceEndpoint, String] {
+      override def apply(left: ServiceEndpoint): HavePropertyMatchResult[String] = {
+        HavePropertyMatchResult(
+          left.uri == "https://metadata.example.test",
+          "uri",
+          "https://metadata.example.test",
+          left.uri
+        )
+      }
+    }
+    val replicas: HavePropertyMatcher[ServiceEndpoint, Int] = new HavePropertyMatcher[ServiceEndpoint, Int] {
+      override def apply(left: ServiceEndpoint): HavePropertyMatchResult[Int] = {
+        HavePropertyMatchResult(left.replicas == 3, "replicas", 3, left.replicas)
+      }
+    }
+    val healthyService: ServiceEndpoint = ServiceEndpoint(
+      name = "reachability-metadata",
+      active = true,
+      uri = "https://metadata.example.test",
+      replicas = 3
+    )
+
+    healthyService should be(active)
+    healthyService should have(uri)
+    healthyService should have(replicas)
+    healthyService should have(uri, replicas)
+
+    val failure: TestFailedException = expectMatcherFailure {
+      healthyService.copy(replicas = 2) should have(replicas)
+    }
+    failure.getMessage should include("replicas")
+    failure.getMessage should include("3")
+    failure.getMessage should include("2")
+  }
+
+  private def parsePositive(input: String): Int = {
+    val parsed: Int = input.toInt
+    if (parsed <= 0) {
+      throw new IllegalArgumentException(s"value must be positive: $input")
+    }
+    parsed
+  }
+
+  private def expectMatcherFailure(assertion: => Unit): TestFailedException = {
+    Assertions.assertThrows(
+      classOf[TestFailedException],
+      new Executable {
+        override def execute(): Unit = assertion
+      }
+    )
   }
 }

--- a/tests/src/org.scalatest/scalatest-shouldmatchers_3/3.2.19/src/test/scala/org_scalatest/scalatest_shouldmatchers_3/Scalatest_shouldmatchers_3Test.scala
+++ b/tests/src/org.scalatest/scalatest-shouldmatchers_3/3.2.19/src/test/scala/org_scalatest/scalatest_shouldmatchers_3/Scalatest_shouldmatchers_3Test.scala
@@ -17,6 +17,9 @@ import scala.util.Try
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.function.Executable
+import org.scalactic.Equality
+import org.scalactic.StringNormalizations.lowerCased
+import org.scalactic.StringNormalizations.trimmed
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.matchers.BeMatcher
 import org.scalatest.matchers.BePropertyMatchResult
@@ -52,6 +55,35 @@ class Scalatest_shouldmatchers_3Test extends Matchers {
     }
     failure.getMessage should include("3.142857")
     failure.getMessage should include("3.0")
+  }
+
+  @Test
+  def shouldDslSupportsExplicitEqualityNormalizationAndCustomEquality(): Unit = {
+    val caseInsensitiveEquality: Equality[String] = new Equality[String] {
+      override def areEqual(left: String, right: Any): Boolean = {
+        right match {
+          case expected: String => left.equalsIgnoreCase(expected)
+          case _ => false
+        }
+      }
+    }
+
+    locally {
+      ("  Metadata Service  " should equal("metadata service")) (after being trimmed and lowerCased)
+    }
+    locally {
+      ("SCALATEST" should equal("scalatest")) (after being lowerCased)
+    }
+    locally {
+      ("Reachability" should equal("reachability")) (decided by caseInsensitiveEquality)
+    }
+
+    val failure: TestFailedException = expectMatcherFailure {
+      locally {
+        (" metadata " should equal("monitoring")) (after being trimmed and lowerCased)
+      }
+    }
+    failure.getMessage should include("monitoring")
   }
 
   @Test

--- a/tests/src/org.scalatest/scalatest-shouldmatchers_3/3.2.19/user-code-filter.json
+++ b/tests/src/org.scalatest/scalatest-shouldmatchers_3/3.2.19/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.scalatest.matchers.should.**"
+      "includeClasses" : "org.scalatest.matchers.should.**"
+    },
+    {
+      "includeClasses" : "org_scalatest.scalatest_shouldmatchers_3.**"
     }
   ]
 }

--- a/tests/src/org.scalatest/scalatest-shouldmatchers_3/3.2.19/user-code-filter.json
+++ b/tests/src/org.scalatest/scalatest-shouldmatchers_3/3.2.19/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.scalatest.matchers.should.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #2289

This PR introduces tests and metadata for org.scalatest:scalatest-shouldmatchers_3:3.2.19, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 293684
- Cached input tokens: 2074624
- Output tokens: 20946
- Metadata entries: 13
- Iterations: 6
- Library coverage percentage: 13.01
- Generated lines of code: 314
- Tested library lines of code: 154

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `045603cccdb4e2e1a48165bc1c854257395db46d`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1479/13705 (10.79%)
- Line: 154/1184 (13.01%)
- Method: 123/1089 (11.29%)

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
