### PR TITLE
[GenAI] Add support for org.scalatest:scalatest-wordspec_3:3.2.19 using gpt-5.5

### DIFF
--- a/metadata/org.scalatest/scalatest-wordspec_3/3.2.19/reachability-metadata.json
+++ b/metadata/org.scalatest/scalatest-wordspec_3/3.2.19/reachability-metadata.json
@@ -1,0 +1,199 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Assertions"
+      },
+      "type": "org.scalatest.Assertions$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.SuperEngine"
+      },
+      "type": "org.scalatest.SuperEngine",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.AsyncSuperEngine"
+      },
+      "type": "org.scalatest.AsyncSuperEngine",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.source.Position"
+      },
+      "type": "org.scalactic.source.Position$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.Resources$"
+      },
+      "type": "org.scalactic.Resources$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.SimpleBool"
+      },
+      "type": "org.scalactic.SimpleBool",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.Bool$"
+      },
+      "type": "org.scalactic.BinaryMacroBool",
+      "fields": [
+        {
+          "name": "0bitmap$6"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.Bool$"
+      },
+      "type": "org.scalactic.LengthSizeMacroBool",
+      "fields": [
+        {
+          "name": "0bitmap$9"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.Bool$"
+      },
+      "type": "org.scalactic.NotBool",
+      "fields": [
+        {
+          "name": "0bitmap$4"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.Bool$"
+      },
+      "type": "org.scalactic.SimpleMacroBool",
+      "fields": [
+        {
+          "name": "0bitmap$5"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Resources$"
+      },
+      "type": "org.scalatest.Resources$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.source.ObjectMeta$$anon$1"
+      },
+      "type": "org.scalactic.source.ObjectMeta$$anon$1",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.NonImplicitAssertions$"
+      },
+      "type": "org.scalatest.NonImplicitAssertions$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.events.Event"
+      },
+      "type": "org.scalatest.events.Event",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.exceptions.StackDepthException"
+      },
+      "type": "org.scalatest.exceptions.StackDepthException",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.package$"
+      },
+      "type": "org.scalatest.package$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.time.Span"
+      },
+      "type": "org.scalatest.time.Span",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Resources$"
+      },
+      "bundle": "org.scalatest.ScalaTestBundle"
+    }
+  ]
+}

--- a/metadata/org.scalatest/scalatest-wordspec_3/index.json
+++ b/metadata/org.scalatest/scalatest-wordspec_3/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.2.19",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-wordspec_3/$version$/scalatest-wordspec_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/scalatest/scalatest",
+    "test-code-url" : "https://github.com/scalatest/scalatest/tree/release-$version$/jvm/wordspec-test/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-wordspec_3/$version$/scalatest-wordspec_3-$version$-javadoc.jar",
+    "description" : "ScalaTest WordSpec provides the WordSpec testing style for ScalaTest, letting Scala developers write BDD-style specifications with nested when and should clauses. This artifact is the Scala 3 JVM module for that style and depends on ScalaTest Core and the Scala 3 library.",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "3.2.19"
+    ],
+    "allowed-packages" : [
+      "org.scalatest.wordspec"
+    ]
+  }
+]

--- a/metadata/org.scalatest/scalatest-wordspec_3/index.json
+++ b/metadata/org.scalatest/scalatest-wordspec_3/index.json
@@ -1,21 +1,27 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "3.2.19",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-wordspec_3/$version$/scalatest-wordspec_3-$version$-sources.jar",
-    "repository-url" : "https://github.com/scalatest/scalatest",
-    "test-code-url" : "https://github.com/scalatest/scalatest/tree/release-$version$/jvm/wordspec-test/src/test",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-wordspec_3/$version$/scalatest-wordspec_3-$version$-javadoc.jar",
-    "description" : "ScalaTest WordSpec provides the WordSpec testing style for ScalaTest, letting Scala developers write BDD-style specifications with nested when and should clauses. This artifact is the Scala 3 JVM module for that style and depends on ScalaTest Core and the Scala 3 library.",
-    "language" : {
-      "name" : "scala",
-      "version" : "3"
+    "latest": true,
+    "metadata-version": "3.2.19",
+    "source-code-url": "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-wordspec_3/$version$/scalatest-wordspec_3-$version$-sources.jar",
+    "repository-url": "https://github.com/scalatest/scalatest",
+    "test-code-url": "https://github.com/scalatest/scalatest/tree/release-$version$/jvm/wordspec-test/src/test",
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-wordspec_3/$version$/scalatest-wordspec_3-$version$-javadoc.jar",
+    "description": "ScalaTest WordSpec provides the WordSpec testing style for ScalaTest, letting Scala developers write BDD-style specifications with nested when and should clauses. This artifact is the Scala 3 JVM module for that style and depends on ScalaTest Core and the Scala 3 library.",
+    "language": {
+      "name": "scala",
+      "version": "3"
     },
-    "tested-versions" : [
+    "tested-versions": [
       "3.2.19"
     ],
-    "allowed-packages" : [
-      "org.scalatest.wordspec"
+    "allowed-packages": [
+      "org.scalatest.wordspec",
+      "org.scalactic",
+      "org.scalactic.source",
+      "org.scalatest",
+      "org.scalatest.events",
+      "org.scalatest.exceptions",
+      "org.scalatest.time"
     ]
   }
 ]

--- a/stats/org.scalatest/scalatest-wordspec_3/3.2.19/execution-metrics.json
+++ b/stats/org.scalatest/scalatest-wordspec_3/3.2.19/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-13": {
+    "timestamp": "2026-05-13T15:05:09.140262Z",
+    "library": "org.scalatest:scalatest-wordspec_3:3.2.19",
+    "starting_commit": "c2956e19388d2fe74a84f825f81cb54c44cc827b",
+    "ending_commit": "063d86f5f83368d1b5f057c8fc98fb2d47f8837d",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success_with_intervention",
+    "stats": {
+      "version": "3.2.19",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1813,
+          "missed": 5872,
+          "ratio": 0.235914,
+          "total": 7685
+        },
+        "line": {
+          "covered": 216,
+          "missed": 399,
+          "ratio": 0.35122,
+          "total": 615
+        },
+        "method": {
+          "covered": 216,
+          "missed": 384,
+          "ratio": 0.36,
+          "total": 600
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 222640,
+      "cached_input_tokens_used": 1327104,
+      "output_tokens_used": 23636,
+      "iterations": 5,
+      "cost_usd": 1.3727,
+      "generated_loc": 353,
+      "tested_library_loc": 216,
+      "metadata_entries": 35,
+      "code_coverage_percent": 35.12
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.scalatest/scalatest-wordspec_3/3.2.19/src/test/scala/org_scalatest/scalatest_wordspec_3/Scalatest_wordspec_3Test.scala",
+      "metadata_file": "metadata/org.scalatest/scalatest-wordspec_3/3.2.19/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.scalatest/scalatest-wordspec_3/3.2.19/stats.json
+++ b/stats/org.scalatest/scalatest-wordspec_3/3.2.19/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.2.19",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1813,
+        "missed" : 5872,
+        "ratio" : 0.235914,
+        "total" : 7685
+      },
+      "line" : {
+        "covered" : 216,
+        "missed" : 399,
+        "ratio" : 0.35122,
+        "total" : 615
+      },
+      "method" : {
+        "covered" : 216,
+        "missed" : 384,
+        "ratio" : 0.36,
+        "total" : 600
+      }
+    }
+  } ]
+}

--- a/tests/src/org.scalatest/scalatest-wordspec_3/3.2.19/.gitignore
+++ b/tests/src/org.scalatest/scalatest-wordspec_3/3.2.19/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.scalatest/scalatest-wordspec_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-wordspec_3/3.2.19/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.scalatest:scalatest-wordspec_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.scalatest/scalatest-wordspec_3/3.2.19/gradle.properties
+++ b/tests/src/org.scalatest/scalatest-wordspec_3/3.2.19/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.scalatest:scalatest-wordspec_3:3.2.19
+library.version = 3.2.19
+metadata.dir = org.scalatest/scalatest-wordspec_3/3.2.19/

--- a/tests/src/org.scalatest/scalatest-wordspec_3/3.2.19/settings.gradle
+++ b/tests/src/org.scalatest/scalatest-wordspec_3/3.2.19/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.scalatest.scalatest-wordspec_3_tests'

--- a/tests/src/org.scalatest/scalatest-wordspec_3/3.2.19/src/test/scala/org_scalatest/scalatest_wordspec_3/Scalatest_wordspec_3Test.scala
+++ b/tests/src/org.scalatest/scalatest-wordspec_3/3.2.19/src/test/scala/org_scalatest/scalatest_wordspec_3/Scalatest_wordspec_3Test.scala
@@ -148,6 +148,18 @@ class Scalatest_wordspec_3Test:
     assert(succeededEvents(fixtureResult.events).size == 1)
     assert(fixtureSuite.seenFixtures == Vector("async-fixture-used"))
 
+  @Test
+  def supportsPluralTheyWordSpecSubjects(): Unit =
+    val suite: PluralSubjectWordSpec = new PluralSubjectWordSpec
+    val names: Vector[String] = suite.testNames.toVector
+    val result: RunResult = runSuite(suite)
+
+    assert(names.exists(_.contains("return their head element")))
+    assert(names.exists(_.contains("preserve insertion order")))
+    assert(result.succeeded)
+    assert(succeededEvents(result.events).size == 2)
+    assert(suite.executed == Vector("head", "order"))
+
   private final class CalculatorWordSpec extends AnyWordSpec:
     var executed: Vector[String] = Vector.empty
 
@@ -326,6 +338,23 @@ class Scalatest_wordspec_3Test:
           assert(builder.toString() == "async-fixture-used")
           succeed
         }
+      }
+    }
+
+  private final class PluralSubjectWordSpec extends AnyWordSpec:
+    var executed: Vector[String] = Vector.empty
+
+    "Ordered collections" should {
+      "return their head element" in {
+        executed = executed :+ "head"
+        assert(Vector("alpha", "beta").head == "alpha")
+      }
+    }
+
+    they must {
+      "preserve insertion order" in {
+        executed = executed :+ "order"
+        assert(List(1, 2, 3).mkString(",") == "1,2,3")
       }
     }
 

--- a/tests/src/org.scalatest/scalatest-wordspec_3/3.2.19/src/test/scala/org_scalatest/scalatest_wordspec_3/Scalatest_wordspec_3Test.scala
+++ b/tests/src/org.scalatest/scalatest-wordspec_3/3.2.19/src/test/scala/org_scalatest/scalatest_wordspec_3/Scalatest_wordspec_3Test.scala
@@ -6,11 +6,371 @@
  */
 package org_scalatest.scalatest_wordspec_3
 
-import org.junit.jupiter.api.Test
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 
-class Scalatest_wordspec_3Test {
+import scala.concurrent.Future
+import scala.jdk.CollectionConverters.*
+import scala.util.Try
+
+import org.junit.jupiter.api.Test
+import org.scalatest.Args
+import org.scalatest.Filter
+import org.scalatest.FutureOutcome
+import org.scalatest.Outcome
+import org.scalatest.Reporter
+import org.scalatest.Suite
+import org.scalatest.Tag
+import org.scalatest.events.Event
+import org.scalatest.events.InfoProvided
+import org.scalatest.events.TestCanceled
+import org.scalatest.events.TestFailed
+import org.scalatest.events.TestIgnored
+import org.scalatest.events.TestPending
+import org.scalatest.events.TestSucceeded
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.wordspec.AsyncWordSpec
+import org.scalatest.wordspec.FixtureAnyWordSpec
+import org.scalatest.wordspec.FixtureAsyncWordSpec
+
+class Scalatest_wordspec_3Test:
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
-  }
-}
+  def registersNestedWordSpecClausesAndRunsSelectedTestByName(): Unit =
+    val suite: CalculatorWordSpec = new CalculatorWordSpec
+    val names: Vector[String] = suite.testNames.toVector
+
+    assert(names.exists(_.contains("return the sum")))
+    assert(names.exists(_.contains("formatted total")))
+    assert(names.exists(_.contains("support shorthand subjects")))
+    assert(names.exists(_.contains("report pending work")))
+    assert(names.exists(_.contains("not execute ignored examples")))
+
+    val selectedName: String = names.find(_.contains("return the sum")).get
+    val result: RunResult = runSuite(suite, testName = Some(selectedName))
+
+    assert(result.succeeded)
+    assert(suite.executed == Vector("sum"))
+    assert(succeededEvents(result.events).map(_.testName) == Vector(selectedName))
+
+  @Test
+  def reportsSucceededPendingCanceledAndIgnoredTests(): Unit =
+    val suite: LifecycleWordSpec = new LifecycleWordSpec
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(succeededEvents(result.events).exists(_.testName.contains("ordinary successes")))
+    assert(pendingEvents(result.events).exists(_.testName.contains("document future behaviour")))
+    assert(canceledEvents(result.events).exists(_.testName.contains("cancel unavailable work")))
+    assert(ignoredEvents(result.events).exists(_.testName.contains("remain registered while ignored")))
+    assert(suite.executed == Vector("success", "canceled"))
+
+  @Test
+  def reportsFailedTestsThroughEventsAndStatus(): Unit =
+    val suite: FailingWordSpec = new FailingWordSpec
+    val result: RunResult = runSuite(suite)
+    val failures: Vector[TestFailed] = failedEvents(result.events)
+
+    assert(!result.succeeded)
+    assert(failures.size == 1)
+    assert(failures.head.testName.contains("publish assertion failures"))
+    assert(failures.head.message.contains("numbers did not match"))
+
+  @Test
+  def recordsInformationalMessagesWithSucceededWordSpecTests(): Unit =
+    val suite: InformingWordSpec = new InformingWordSpec
+    val result: RunResult = runSuite(suite)
+    val success: TestSucceeded = succeededEvents(result.events).head
+    val messages: Vector[String] = success.recordedEvents.collect {
+      case event: InfoProvided => event.message
+    }.toVector
+
+    assert(result.succeeded)
+    assert(success.testName.contains("attach progress messages"))
+    assert(messages == Vector("prepared a sample value", "verified transformed value"))
+    assert(suite.observed == Vector("message-start", "message-end"))
+
+  @Test
+  def exposesTagsAndHonorsTagFilters(): Unit =
+    val suite: TaggedWordSpec = new TaggedWordSpec
+    val taggedName: String = suite.testNames.find(_.contains("run selected fast examples")).get
+    val slowName: String = suite.testNames.find(_.contains("run slow examples")).get
+    val ignoredName: String = suite.testNames.find(_.contains("keep ignored tagged examples registered")).get
+
+    assert(suite.tags(taggedName).contains(FastTag.name))
+    assert(suite.tags(slowName).contains(SlowTag.name))
+    assert(suite.tags(ignoredName).contains(SlowTag.name))
+    assert(suite.tags(ignoredName).contains("org.scalatest.Ignore"))
+
+    val result: RunResult = runSuite(
+      suite,
+      filter = Filter(tagsToInclude = Some(Set(FastTag.name)), tagsToExclude = Set.empty)
+    )
+
+    assert(result.succeeded)
+    assert(succeededEvents(result.events).map(_.testName) == Vector(taggedName))
+    assert(suite.executed == Vector("fast"))
+
+  @Test
+  def passesFreshFixturesToFixtureAnyWordSpecTests(): Unit =
+    val suite: MutableBufferFixtureWordSpec = new MutableBufferFixtureWordSpec
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(succeededEvents(result.events).size == 2)
+    assert(suite.finishedFixtures == Vector("seed-alpha", "seed-beta"))
+
+  @Test
+  def registersAndRunsSharedWordSpecBehaviorsInDifferentContexts(): Unit =
+    val suite: SharedBehaviorWordSpec = new SharedBehaviorWordSpec
+    val names: Vector[String] = suite.testNames.toVector
+    val result: RunResult = runSuite(suite)
+
+    assert(names.count(_.contains("keep the first element available")) == 2)
+    assert(names.exists(_.contains("List-based collection")))
+    assert(names.exists(_.contains("Vector-based collection")))
+    assert(result.succeeded)
+    assert(succeededEvents(result.events).size == 4)
+    assert(suite.observed == Vector("list:first", "list:size", "vector:first", "vector:size"))
+
+  @Test
+  def runsAsyncWordSpecAndFixtureAsyncWordSpecTests(): Unit =
+    val asyncSuite: FutureWordSpec = new FutureWordSpec
+    val asyncResult: RunResult = runSuite(asyncSuite)
+    val fixtureSuite: AsyncFixtureWordSpec = new AsyncFixtureWordSpec
+    val fixtureResult: RunResult = runSuite(fixtureSuite)
+
+    assert(asyncResult.succeeded)
+    assert(succeededEvents(asyncResult.events).size == 2)
+    assert(asyncSuite.executed == Vector("future-value", "recovered-failure"))
+    assert(fixtureResult.succeeded)
+    assert(succeededEvents(fixtureResult.events).size == 1)
+    assert(fixtureSuite.seenFixtures == Vector("async-fixture-used"))
+
+  private final class CalculatorWordSpec extends AnyWordSpec:
+    var executed: Vector[String] = Vector.empty
+
+    private val display = afterWord("display output")
+
+    "A calculator" when {
+      "adding numbers" should {
+        "return the sum" in {
+          executed = executed :+ "sum"
+          assert(2 + 3 == 5)
+        }
+
+        "report pending work" is pending
+
+        "not execute ignored examples" ignore {
+          executed = executed :+ "ignored"
+          fail("ignored example was executed")
+        }
+      }
+
+      "the display" should display {
+        "formatted total" in {
+          executed = executed :+ "display"
+          assert(f"${2.5}%.1f" == "2.5")
+        }
+      }
+    }
+
+    it must {
+      "support shorthand subjects" in {
+        executed = executed :+ "shorthand"
+        assert("scala".startsWith("sca"))
+      }
+    }
+
+  private final class LifecycleWordSpec extends AnyWordSpec:
+    var executed: Vector[String] = Vector.empty
+
+    "A lifecycle word spec" should {
+      "record ordinary successes" in {
+        executed = executed :+ "success"
+        assert(List(1, 2, 3).sum == 6)
+      }
+
+      "document future behaviour" is pending
+
+      "cancel unavailable work" in {
+        executed = executed :+ "canceled"
+        cancel("external service is intentionally unavailable")
+      }
+
+      "remain registered while ignored" ignore {
+        executed = executed :+ "ignored"
+        fail("ignored test body ran")
+      }
+    }
+
+  private final class FailingWordSpec extends AnyWordSpec:
+    "A failing word spec" should {
+      "publish assertion failures" in {
+        assert(1 == 2, "numbers did not match")
+      }
+    }
+
+  private final class InformingWordSpec extends AnyWordSpec:
+    var observed: Vector[String] = Vector.empty
+
+    "An informing word spec" should {
+      "attach progress messages to a successful test" in {
+        observed = observed :+ "message-start"
+        info("prepared a sample value")
+        val transformed: String = "scala".reverse.reverse
+        info("verified transformed value")
+        observed = observed :+ "message-end"
+        assert(transformed == "scala")
+      }
+    }
+
+  private final class TaggedWordSpec extends AnyWordSpec:
+    var executed: Vector[String] = Vector.empty
+
+    "A tagged word spec" should {
+      "run selected fast examples" taggedAs FastTag in {
+        executed = executed :+ "fast"
+        assert(true)
+      }
+
+      "run slow examples" taggedAs SlowTag in {
+        executed = executed :+ "slow"
+        assert(true)
+      }
+
+      "keep ignored tagged examples registered" taggedAs SlowTag ignore {
+        executed = executed :+ "ignored"
+        fail("ignored tagged test body ran")
+      }
+    }
+
+  private final class MutableBufferFixtureWordSpec extends FixtureAnyWordSpec:
+    type FixtureParam = StringBuilder
+
+    var finishedFixtures: Vector[String] = Vector.empty
+
+    override protected def withFixture(test: OneArgTest): Outcome =
+      val fixture: StringBuilder = new StringBuilder("seed")
+      try withFixture(test.toNoArgTest(fixture))
+      finally finishedFixtures = finishedFixtures :+ fixture.toString()
+
+    "A fixture word spec" should {
+      "receive a mutable builder" in { (builder: StringBuilder) =>
+        builder.append("-alpha")
+        assert(builder.toString() == "seed-alpha")
+      }
+
+      "receive a fresh builder for each test" in { (builder: StringBuilder) =>
+        builder.append("-beta")
+        assert(builder.toString() == "seed-beta")
+      }
+    }
+
+  private final class SharedBehaviorWordSpec extends AnyWordSpec:
+    var observed: Vector[String] = Vector.empty
+
+    private def behaveLikeNonEmptyCollection(label: String, values: Seq[String]): Unit =
+      "keep the first element available" in {
+        observed = observed :+ s"$label:first"
+        assert(values.headOption.contains("alpha"))
+      }
+
+      "report the collection size" in {
+        observed = observed :+ s"$label:size"
+        assert(values.size == 2)
+      }
+
+    "A List-based collection" should {
+      behave like behaveLikeNonEmptyCollection("list", List("alpha", "beta"))
+    }
+
+    "A Vector-based collection" should {
+      behave like behaveLikeNonEmptyCollection("vector", Vector("alpha", "beta"))
+    }
+
+  private final class FutureWordSpec extends AsyncWordSpec:
+    var executed: Vector[String] = Vector.empty
+
+    "An async word spec" should {
+      "complete successful futures" in {
+        Future.successful {
+          executed = executed :+ "future-value"
+          assert(21 * 2 == 42)
+          succeed
+        }
+      }
+
+      "recover expected failed futures" in {
+        executed = executed :+ "recovered-failure"
+        recoverToSucceededIf[IllegalArgumentException] {
+          Future.failed(new IllegalArgumentException("invalid async input"))
+        }
+      }
+    }
+
+  private final class AsyncFixtureWordSpec extends FixtureAsyncWordSpec:
+    type FixtureParam = StringBuilder
+
+    var seenFixtures: Vector[String] = Vector.empty
+
+    override def withFixture(test: OneArgAsyncTest): FutureOutcome =
+      withFixture(test.toNoArgAsyncTest(new StringBuilder("async-fixture")))
+
+    "An async fixture word spec" should {
+      "receive an asynchronous fixture" in { (builder: StringBuilder) =>
+        Future.successful {
+          builder.append("-used")
+          seenFixtures = seenFixtures :+ builder.toString()
+          assert(builder.toString() == "async-fixture-used")
+          succeed
+        }
+      }
+    }
+
+  private def runSuite(
+      suite: Suite,
+      filter: Filter = Filter.default,
+      testName: Option[String] = None): RunResult =
+    val reporter: RecordingReporter = new RecordingReporter
+    val completion: AtomicReference[Try[Boolean]] = new AtomicReference[Try[Boolean]]()
+    val completed: CountDownLatch = new CountDownLatch(1)
+    val status = suite.run(testName, Args(reporter = reporter, filter = filter))
+    status.whenCompleted { (result: Try[Boolean]) =>
+      completion.set(result)
+      completed.countDown()
+    }
+
+    assert(completed.await(30, TimeUnit.SECONDS), s"ScalaTest suite ${suite.suiteName} did not complete")
+    RunResult(completion.get().get, reporter.events)
+
+  private def succeededEvents(events: Vector[Event]): Vector[TestSucceeded] =
+    events.collect { case event: TestSucceeded => event }
+
+  private def pendingEvents(events: Vector[Event]): Vector[TestPending] =
+    events.collect { case event: TestPending => event }
+
+  private def canceledEvents(events: Vector[Event]): Vector[TestCanceled] =
+    events.collect { case event: TestCanceled => event }
+
+  private def ignoredEvents(events: Vector[Event]): Vector[TestIgnored] =
+    events.collect { case event: TestIgnored => event }
+
+  private def failedEvents(events: Vector[Event]): Vector[TestFailed] =
+    events.collect { case event: TestFailed => event }
+
+  private final class RecordingReporter extends Reporter:
+    private val recordedEvents: CopyOnWriteArrayList[Event] = new CopyOnWriteArrayList[Event]()
+
+    override def apply(event: Event): Unit =
+      recordedEvents.add(event)
+      ()
+
+    def events: Vector[Event] = recordedEvents.asScala.toVector
+
+  private final case class RunResult(succeeded: Boolean, events: Vector[Event])
+
+  private object FastTag extends Tag("org.scalatest.wordspec.generated.Fast")
+
+  private object SlowTag extends Tag("org.scalatest.wordspec.generated.Slow")

--- a/tests/src/org.scalatest/scalatest-wordspec_3/3.2.19/src/test/scala/org_scalatest/scalatest_wordspec_3/Scalatest_wordspec_3Test.scala
+++ b/tests/src/org.scalatest/scalatest-wordspec_3/3.2.19/src/test/scala/org_scalatest/scalatest_wordspec_3/Scalatest_wordspec_3Test.scala
@@ -160,6 +160,19 @@ class Scalatest_wordspec_3Test:
     assert(succeededEvents(result.events).size == 2)
     assert(suite.executed == Vector("head", "order"))
 
+  @Test
+  def supportsCanWordSpecClausesForCapabilityStyleExamples(): Unit =
+    val suite: CapabilityWordSpec = new CapabilityWordSpec
+    val names: Vector[String] = suite.testNames.toVector
+    val result: RunResult = runSuite(suite)
+
+    assert(names.exists(_.contains("return a cached value")))
+    assert(names.exists(_.contains("evict the oldest value")))
+    assert(names.forall(_.contains(" can ")))
+    assert(result.succeeded)
+    assert(succeededEvents(result.events).size == 2)
+    assert(suite.executed == Vector("return", "evict"))
+
   private final class CalculatorWordSpec extends AnyWordSpec:
     var executed: Vector[String] = Vector.empty
 
@@ -355,6 +368,23 @@ class Scalatest_wordspec_3Test:
       "preserve insertion order" in {
         executed = executed :+ "order"
         assert(List(1, 2, 3).mkString(",") == "1,2,3")
+      }
+    }
+
+  private final class CapabilityWordSpec extends AnyWordSpec:
+    var executed: Vector[String] = Vector.empty
+
+    "A small cache" can {
+      "return a cached value" in {
+        executed = executed :+ "return"
+        val cache: Map[String, Int] = Map("answer" -> 42)
+        assert(cache.get("answer").contains(42))
+      }
+
+      "evict the oldest value" in {
+        executed = executed :+ "evict"
+        val cacheAfterEviction: Vector[String] = Vector("second", "third")
+        assert(!cacheAfterEviction.contains("first"))
       }
     }
 

--- a/tests/src/org.scalatest/scalatest-wordspec_3/3.2.19/src/test/scala/org_scalatest/scalatest_wordspec_3/Scalatest_wordspec_3Test.scala
+++ b/tests/src/org.scalatest/scalatest-wordspec_3/3.2.19/src/test/scala/org_scalatest/scalatest_wordspec_3/Scalatest_wordspec_3Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_scalatest.scalatest_wordspec_3
+
+import org.junit.jupiter.api.Test
+
+class Scalatest_wordspec_3Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/org.scalatest/scalatest-wordspec_3/3.2.19/user-code-filter.json
+++ b/tests/src/org.scalatest/scalatest-wordspec_3/3.2.19/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.scalatest.wordspec.**"
+    }
+  ]
+}

--- a/tests/src/org.scalatest/scalatest-wordspec_3/3.2.19/user-code-filter.json
+++ b/tests/src/org.scalatest/scalatest-wordspec_3/3.2.19/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.scalatest.wordspec.**"
+      "includeClasses" : "org.scalatest.wordspec.**"
+    },
+    {
+      "includeClasses" : "org_scalatest.scalatest_wordspec_3.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #2283

This PR introduces tests and metadata for org.scalatest:scalatest-wordspec_3:3.2.19, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 222640
- Cached input tokens: 1327104
- Output tokens: 23636
- Metadata entries: 35
- Iterations: 5
- Library coverage percentage: 35.12
- Generated lines of code: 353
- Tested library lines of code: 216

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `045603cccdb4e2e1a48165bc1c854257395db46d`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1813/7685 (23.59%)
- Line: 216/615 (35.12%)
- Method: 216/600 (36.00%)

### Post-Generation Intervention

- Stage: `metadata_fix_failed`

- Intervention file: `post-gen-interventions/org.scalatest_scalatest-wordspec_3_3.2.19.md`

# Post-generation intervention report

Library: org.scalatest:scalatest-wordspec_3:3.2.19

Stage: `metadata_fix_failed`

## Summary

The native test failures are metadata-related. All ten generated ScalaTest WordSpec tests failed because ScalaTest/Scalactic Scala 3 classes could not initialize inside the native image. The Gradle excerpt shows `NoClassDefFoundError` for `org.scalatest.Assertions` and `org.scalatest.wordspec.AnyWordSpec`; the Codex log shows the underlying causes were missing native-image metadata for Scala 3 lazy-val synthetic bitmap fields and, during later iterations, a missing ScalaTest resource bundle.

## Root cause by failure

Each failing JUnit method exercised the same ScalaTest WordSpec initialization path, so the failures share one metadata root cause rather than indicating bad generated test logic:

- `registersNestedWordSpecClausesAndRunsSelectedTestByName()` failed while initializing `AnyWordSpec` / ScalaTest engine classes.
- `reportsSucceededPendingCanceledAndIgnoredTests()` failed while initializing `AnyWordSpec` / ScalaTest engine classes.
- `reportsFailedTestsThroughEventsAndStatus()` failed while initializing `AnyWordSpec` / ScalaTest engine classes.
- `recordsInformationalMessagesWithSucceededWordSpecTests()` failed while initializing `AnyWordSpec` / ScalaTest engine classes.
- `exposesTagsAndHonorsTagFilters()` failed while initializing `AnyWordSpec` / ScalaTest engine classes.
- `passesFreshFixturesToFixtureAnyWordSpecTests()` failed while initializing fixture WordSpec support.
- `registersAndRunsSharedWordSpecBehaviorsInDifferentContexts()` failed while initializing shared-behavior WordSpec support.
- `runsAsyncWordSpecAndFixtureAsyncWordSpecTests()` failed while initializing async WordSpec support.
- `supportsPluralTheyWordSpecSubjects()` failed while initializing WordSpec support and later exposed resource/lazy-val metadata gaps.
- `supportsCanWordSpecClausesForCapabilityStyleExamples()` failed while exercising Scalactic boolean assertion helpers and exposed additional lazy-val bitmap fields.

The metadata still missing at the failing stages consisted of reflection access to synthetic fields such as `0bitmap$1`, `0bitmap$4`, `0bitmap$5`, `0bitmap$6`, and `0bitmap$9` on ScalaTest/Scalactic classes including `org.scalatest.Assertions$`, `org.scalatest.SuperEngine`, `org.scalatest.AsyncSuperEngine`, `org.scalatest.Resources$`, `org.scalactic.source.Position$`, and the `org.scalactic.*Bool` implementations. Codex also observed a missing `org.scalatest.ScalaTestBundle` resource bundle before adding a resource entry.

Codex could not resolve the failure in one pass because the native runtime did not report a direct `MissingReflectionRegistrationError` for the Gradle excerpt. It surfaced as `NoClassDefFoundError` after `ExceptionInInitializerError`, with the actionable cause (`NoSuchFieldException` for Scala 3 lazy-val bitmap fields) only visible deeper in the Codex reproduction logs. Each metadata addition uncovered the next hidden ScalaTest/Scalactic initializer or resource requirement.

## Action taken

No generated tests were removed, and no metadata files were modified by this intervention. The failures are not caused by an unsupported platform feature or a defective generated test; they are reachability metadata gaps.

## Why the remaining generated support should be preserved

The generated tests cover the core public behavior of `scalatest-wordspec_3`: nested WordSpec clauses, lifecycle events, failures, informational messages, tags, fixtures, shared behaviors, async specs, plural subjects, and capability-style `can` clauses. These tests are valid coverage for the library and are useful because they reveal the native-image metadata required by ScalaTest/Scalactic's Scala 3 lazy-val implementation and resource loading. Removing them would hide genuine metadata requirements rather than addressing a non-metadata limitation.

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
