### PR TITLE
[GenAI] Add support for org.scalatest:scalatest-mustmatchers_3:3.2.19 using gpt-5.5

### DIFF
--- a/metadata/org.scalatest/scalatest-mustmatchers_3/3.2.19/reachability-metadata.json
+++ b/metadata/org.scalatest/scalatest-mustmatchers_3/3.2.19/reachability-metadata.json
@@ -1,0 +1,67 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Assertions"
+      },
+      "type": "org.scalatest.Assertions$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.matchers.must.Matchers"
+      },
+      "type": "org.scalatest.matchers.must.Matchers$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.source.Position"
+      },
+      "type": "org.scalactic.source.Position$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.matchers.must.Matchers"
+      },
+      "type": "org.scalatest.Resources$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.matchers.must.Matchers"
+      },
+      "type": "org.scalatest.exceptions.StackDepthException",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.scalatest.matchers.must.Matchers"
+      },
+      "bundle": "org.scalatest.ScalaTestBundle"
+    }
+  ]
+}

--- a/metadata/org.scalatest/scalatest-mustmatchers_3/index.json
+++ b/metadata/org.scalatest/scalatest-mustmatchers_3/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.2.19",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-mustmatchers_3/$version$/scalatest-mustmatchers_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/scalatest/scalatest",
+    "test-code-url" : "https://github.com/scalatest/scalatest/tree/release-$version$/dotty/scalatest-test/src/test/scala/org/scalatest/matchers/must",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-mustmatchers_3/$version$/scalatest-mustmatchers_3-$version$-javadoc.jar",
+    "description" : "ScalaTest Must Matchers provides the must-style matcher syntax for ScalaTest assertions on the JVM. It supplies the org.scalatest.matchers.must.Matchers API, allowing Scala 3 tests to express expectations such as values must equal, include, contain, start with, or satisfy custom matchers.",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "3.2.19"
+    ],
+    "allowed-packages" : [
+      "org.scalatest.matchers.must"
+    ]
+  }
+]

--- a/metadata/org.scalatest/scalatest-mustmatchers_3/index.json
+++ b/metadata/org.scalatest/scalatest-mustmatchers_3/index.json
@@ -1,21 +1,23 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "3.2.19",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-mustmatchers_3/$version$/scalatest-mustmatchers_3-$version$-sources.jar",
-    "repository-url" : "https://github.com/scalatest/scalatest",
-    "test-code-url" : "https://github.com/scalatest/scalatest/tree/release-$version$/dotty/scalatest-test/src/test/scala/org/scalatest/matchers/must",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-mustmatchers_3/$version$/scalatest-mustmatchers_3-$version$-javadoc.jar",
-    "description" : "ScalaTest Must Matchers provides the must-style matcher syntax for ScalaTest assertions on the JVM. It supplies the org.scalatest.matchers.must.Matchers API, allowing Scala 3 tests to express expectations such as values must equal, include, contain, start with, or satisfy custom matchers.",
-    "language" : {
-      "name" : "scala",
-      "version" : "3"
+    "latest": true,
+    "metadata-version": "3.2.19",
+    "source-code-url": "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-mustmatchers_3/$version$/scalatest-mustmatchers_3-$version$-sources.jar",
+    "repository-url": "https://github.com/scalatest/scalatest",
+    "test-code-url": "https://github.com/scalatest/scalatest/tree/release-$version$/dotty/scalatest-test/src/test/scala/org/scalatest/matchers/must",
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-mustmatchers_3/$version$/scalatest-mustmatchers_3-$version$-javadoc.jar",
+    "description": "ScalaTest Must Matchers provides the must-style matcher syntax for ScalaTest assertions on the JVM. It supplies the org.scalatest.matchers.must.Matchers API, allowing Scala 3 tests to express expectations such as values must equal, include, contain, start with, or satisfy custom matchers.",
+    "language": {
+      "name": "scala",
+      "version": "3"
     },
-    "tested-versions" : [
+    "tested-versions": [
       "3.2.19"
     ],
-    "allowed-packages" : [
-      "org.scalatest.matchers.must"
+    "allowed-packages": [
+      "org.scalatest.matchers.must",
+      "org.scalactic.source",
+      "org.scalatest"
     ]
   }
 ]

--- a/stats/org.scalatest/scalatest-mustmatchers_3/3.2.19/execution-metrics.json
+++ b/stats/org.scalatest/scalatest-mustmatchers_3/3.2.19/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-13": {
+    "timestamp": "2026-05-13T15:44:21.277952Z",
+    "library": "org.scalatest:scalatest-mustmatchers_3:3.2.19",
+    "starting_commit": "ef51fa36eed3586b0d744b36fab42e9ff45634ab",
+    "ending_commit": "bd0bea781ab51098abf21b43607bc54d918e9b8b",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.2.19",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1039,
+          "missed": 12656,
+          "ratio": 0.075867,
+          "total": 13695
+        },
+        "line": {
+          "covered": 113,
+          "missed": 1070,
+          "ratio": 0.09552,
+          "total": 1183
+        },
+        "method": {
+          "covered": 86,
+          "missed": 1001,
+          "ratio": 0.079117,
+          "total": 1087
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 126994,
+      "cached_input_tokens_used": 451072,
+      "output_tokens_used": 11795,
+      "iterations": 4,
+      "cost_usd": 0.5793,
+      "generated_loc": 150,
+      "tested_library_loc": 113,
+      "metadata_entries": 11,
+      "code_coverage_percent": 9.55
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.scalatest/scalatest-mustmatchers_3/3.2.19/src/test/scala/org_scalatest/scalatest_mustmatchers_3/Scalatest_mustmatchers_3Test.scala",
+      "metadata_file": "metadata/org.scalatest/scalatest-mustmatchers_3/3.2.19/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.scalatest/scalatest-mustmatchers_3/3.2.19/stats.json
+++ b/stats/org.scalatest/scalatest-mustmatchers_3/3.2.19/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.2.19",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1039,
+        "missed" : 12656,
+        "ratio" : 0.075867,
+        "total" : 13695
+      },
+      "line" : {
+        "covered" : 113,
+        "missed" : 1070,
+        "ratio" : 0.09552,
+        "total" : 1183
+      },
+      "method" : {
+        "covered" : 86,
+        "missed" : 1001,
+        "ratio" : 0.079117,
+        "total" : 1087
+      }
+    }
+  } ]
+}

--- a/tests/src/org.scalatest/scalatest-mustmatchers_3/3.2.19/.gitignore
+++ b/tests/src/org.scalatest/scalatest-mustmatchers_3/3.2.19/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.scalatest/scalatest-mustmatchers_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-mustmatchers_3/3.2.19/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.scalatest:scalatest-mustmatchers_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.scalatest/scalatest-mustmatchers_3/3.2.19/gradle.properties
+++ b/tests/src/org.scalatest/scalatest-mustmatchers_3/3.2.19/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.scalatest:scalatest-mustmatchers_3:3.2.19
+library.version = 3.2.19
+metadata.dir = org.scalatest/scalatest-mustmatchers_3/3.2.19/

--- a/tests/src/org.scalatest/scalatest-mustmatchers_3/3.2.19/settings.gradle
+++ b/tests/src/org.scalatest/scalatest-mustmatchers_3/3.2.19/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.scalatest.scalatest-mustmatchers_3_tests'

--- a/tests/src/org.scalatest/scalatest-mustmatchers_3/3.2.19/src/test/scala/org_scalatest/scalatest_mustmatchers_3/Scalatest_mustmatchers_3Test.scala
+++ b/tests/src/org.scalatest/scalatest-mustmatchers_3/3.2.19/src/test/scala/org_scalatest/scalatest_mustmatchers_3/Scalatest_mustmatchers_3Test.scala
@@ -6,11 +6,143 @@
  */
 package org_scalatest.scalatest_mustmatchers_3
 
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.Test
+import org.scalactic.Equality
+import org.scalatest.exceptions.TestFailedException
+import org.scalatest.matchers.{MatchResult, Matcher}
+import org.scalatest.matchers.must.Matchers
 
-class Scalatest_mustmatchers_3Test {
+import java.util.ArrayList
+
+class Scalatest_mustmatchers_3Test extends Matchers {
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
+  def checksEqualityNumericToleranceAndOrderingMatchers(): Unit = {
+    val exactCount: Int = 12
+    exactCount mustBe 12
+    exactCount mustEqual 12
+    exactCount must be >= 10
+    exactCount must be < 20
+
+    val measuredDistance: Double = 10.004
+    measuredDistance mustBe 10.0 +- 0.01
+    measuredDistance mustEqual 10.0 +- 0.01
+
+    Array(1, 2, 3) must be (Array(1, 2, 3))
   }
+
+  @Test
+  def appliesCustomEqualityToMustEqualAndContain(): Unit = {
+    given caseInsensitiveStringEquality: Equality[String] with
+      override def areEqual(a: String, b: Any): Boolean =
+        b match {
+          case right: String => a.equalsIgnoreCase(right)
+          case _ => false
+        }
+
+    "ScalaTest" mustEqual "scalatest"
+    List("Native", "Image", "Matchers") must contain ("image")
+  }
+
+  @Test
+  def checksCollectionContainmentCardinalityAndOrder(): Unit = {
+    val numbers: Vector[Int] = Vector(1, 2, 3, 2)
+
+    numbers must contain (2)
+    numbers must contain allOf (1, 3)
+    numbers must contain oneOf (0, 3, 5)
+    numbers must contain noneOf (7, 8, 9)
+    numbers must contain only (1, 2, 3)
+    numbers must contain theSameElementsAs List(2, 1, 2, 3)
+    numbers must contain theSameElementsInOrderAs List(1, 2, 3, 2)
+    numbers must not contain (4)
+  }
+
+  @Test
+  def checksMapsOptionsAndJavaCollections(): Unit = {
+    val scores: Map[String, Int] = Map("alpha" -> 1, "beta" -> 2)
+    scores must contain key ("alpha")
+    scores must contain value (2)
+    scores must contain ("beta" -> 2)
+
+    Some("native-image") must contain ("native-image")
+    Option.empty[String] mustBe empty
+
+    val names: ArrayList[String] = new ArrayList[String]()
+    names.add("graal")
+    names.add("scala")
+    names must contain ("scala")
+    names must have size (2)
+  }
+
+  @Test
+  def checksStringAndRegexMatchers(): Unit = {
+    val message: String = "native image exercises scalatest matchers"
+
+    message must startWith ("native")
+    message must include ("scalatest")
+    message must endWith ("matchers")
+    message must fullyMatch regex ("native (\\w+) exercises scalatest (\\w+)" withGroups ("image", "matchers"))
+    message must not include ("reflection-only")
+  }
+
+  @Test
+  def checksInspectorQuantifiers(): Unit = {
+    val readings: Vector[Int] = Vector(1, 2, 2, 3, 4)
+
+    all (readings) must be > 0
+    atLeast (3, readings) must be <= 2
+    atMost (2, readings) must be >= 3
+    exactly (2, readings) mustEqual 2
+    no (readings) must be < 0
+  }
+
+  @Test
+  def checksExceptionMatchers(): Unit = {
+    an[IllegalArgumentException] must be thrownBy {
+      Integer.parseInt("not-a-number")
+    }
+
+    val thrown: ArithmeticException = the[ArithmeticException] thrownBy {
+      1 / 0
+    }
+    thrown.getMessage mustBe "/ by zero"
+  }
+
+  @Test
+  def supportsCustomMatcherImplementations(): Unit = {
+    val bePalindrome: Matcher[String] = Matcher { (value: String) =>
+      MatchResult(
+        value == value.reverse,
+        s"$value was not a palindrome",
+        s"$value was a palindrome"
+      )
+    }
+
+    "radar" must bePalindrome
+
+    val failure: TestFailedException = expectMatcherFailure {
+      "scala" must bePalindrome
+    }
+    assertTrue(failure.getMessage.contains("scala was not a palindrome"))
+  }
+
+  @Test
+  def reportsUsefulFailuresFromBuiltInMatchers(): Unit = {
+    val failure: TestFailedException = expectMatcherFailure {
+      List(1, 2) must contain (3)
+    }
+
+    assertTrue(failure.getMessage.contains("3"))
+    assertTrue(failure.getMessage.contains("did not contain"))
+    assertEquals(classOf[TestFailedException], failure.getClass)
+  }
+
+  private def expectMatcherFailure(assertion: => Unit): TestFailedException =
+    try {
+      assertion
+      throw new AssertionError("Expected TestFailedException")
+    } catch {
+      case failure: TestFailedException => failure
+    }
 }

--- a/tests/src/org.scalatest/scalatest-mustmatchers_3/3.2.19/src/test/scala/org_scalatest/scalatest_mustmatchers_3/Scalatest_mustmatchers_3Test.scala
+++ b/tests/src/org.scalatest/scalatest-mustmatchers_3/3.2.19/src/test/scala/org_scalatest/scalatest_mustmatchers_3/Scalatest_mustmatchers_3Test.scala
@@ -98,6 +98,20 @@ class Scalatest_mustmatchers_3Test extends Matchers {
   }
 
   @Test
+  def combinesMatchersWithLogicalOperators(): Unit = {
+    val sourceFileName: String = "native-image-test.scala"
+
+    sourceFileName must (startWith ("native") and endWith (".scala"))
+    sourceFileName must (include ("image") or include ("metadata"))
+
+    val failure: TestFailedException = expectMatcherFailure {
+      sourceFileName must (startWith ("jvm") or endWith (".java"))
+    }
+    assertTrue(failure.getMessage.contains("jvm"))
+    assertTrue(failure.getMessage.contains(".java"))
+  }
+
+  @Test
   def checksPartialFunctionDefinedAtMatcher(): Unit = {
     val routeStatuses: PartialFunction[String, Int] = {
       case "/health" => 200

--- a/tests/src/org.scalatest/scalatest-mustmatchers_3/3.2.19/src/test/scala/org_scalatest/scalatest_mustmatchers_3/Scalatest_mustmatchers_3Test.scala
+++ b/tests/src/org.scalatest/scalatest-mustmatchers_3/3.2.19/src/test/scala/org_scalatest/scalatest_mustmatchers_3/Scalatest_mustmatchers_3Test.scala
@@ -98,6 +98,24 @@ class Scalatest_mustmatchers_3Test extends Matchers {
   }
 
   @Test
+  def checksPartialFunctionDefinedAtMatcher(): Unit = {
+    val routeStatuses: PartialFunction[String, Int] = {
+      case "/health" => 200
+      case path if path.startsWith("/assets/") => path.length
+    }
+
+    routeStatuses must be definedAt ("/health")
+    routeStatuses must be definedAt ("/assets/app.js")
+    routeStatuses must not be definedAt ("/metrics")
+
+    val failure: TestFailedException = expectMatcherFailure {
+      routeStatuses must be definedAt ("/metrics")
+    }
+    assertTrue(failure.getMessage.contains("was not defined at"))
+    assertTrue(failure.getMessage.contains("/metrics"))
+  }
+
+  @Test
   def checksExceptionMatchers(): Unit = {
     an[IllegalArgumentException] must be thrownBy {
       Integer.parseInt("not-a-number")

--- a/tests/src/org.scalatest/scalatest-mustmatchers_3/3.2.19/src/test/scala/org_scalatest/scalatest_mustmatchers_3/Scalatest_mustmatchers_3Test.scala
+++ b/tests/src/org.scalatest/scalatest-mustmatchers_3/3.2.19/src/test/scala/org_scalatest/scalatest_mustmatchers_3/Scalatest_mustmatchers_3Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_scalatest.scalatest_mustmatchers_3
+
+import org.junit.jupiter.api.Test
+
+class Scalatest_mustmatchers_3Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/org.scalatest/scalatest-mustmatchers_3/3.2.19/user-code-filter.json
+++ b/tests/src/org.scalatest/scalatest-mustmatchers_3/3.2.19/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.scalatest.matchers.must.**"
+    }
+  ]
+}

--- a/tests/src/org.scalatest/scalatest-mustmatchers_3/3.2.19/user-code-filter.json
+++ b/tests/src/org.scalatest/scalatest-mustmatchers_3/3.2.19/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.scalatest.matchers.must.**"
+      "includeClasses" : "org.scalatest.matchers.must.**"
+    },
+    {
+      "includeClasses" : "org_scalatest.scalatest_mustmatchers_3.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #2285

This PR introduces tests and metadata for org.scalatest:scalatest-mustmatchers_3:3.2.19, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 126994
- Cached input tokens: 451072
- Output tokens: 11795
- Metadata entries: 11
- Iterations: 4
- Library coverage percentage: 9.55
- Generated lines of code: 150
- Tested library lines of code: 113

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `045603cccdb4e2e1a48165bc1c854257395db46d`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1039/13695 (7.59%)
- Line: 113/1183 (9.55%)
- Method: 86/1087 (7.91%)

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
