### PR TITLE
[GenAI] Mark org.springframework.boot:spring-boot-starter-json as not for Native Image

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-starter-json/index.json
+++ b/metadata/org.springframework.boot/spring-boot-starter-json/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published JAR for org.springframework.boot:spring-boot-starter-json:2.7.18 contains only META-INF files and no JVM class files; it is a dependency starter whose runtime classes are supplied by its dependencies.",
+    "replacement": "Use class-bearing dependencies such as org.springframework:spring-web:5.3.31, com.fasterxml.jackson.core:jackson-databind:2.13.5, com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.5, com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.5, and com.fasterxml.jackson.module:jackson-module-parameter-names:2.13.5."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #2281

This PR records `org.springframework.boot:spring-boot-starter-json` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published JAR for org.springframework.boot:spring-boot-starter-json:2.7.18 contains only META-INF files and no JVM class files; it is a dependency starter whose runtime classes are supplied by its dependencies.

Replacement guidance:
- Use class-bearing dependencies such as org.springframework:spring-web:5.3.31, com.fasterxml.jackson.core:jackson-databind:2.13.5, com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.5, com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.5, and com.fasterxml.jackson.module:jackson-module-parameter-names:2.13.5.

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `a8db50c33012e91c16f4cf2a1d0da2b4341fd586`

### Local CI Verification

- Status: `success`
- Commands run: 6
- Fixup attempts: 0
