### PR TITLE
[GenAI] Add support for org.scalatest:scalatest-funsuite_3:3.2.19 using gpt-5.5

### DIFF
--- a/metadata/org.scalatest/scalatest-funsuite_3/3.2.19/reachability-metadata.json
+++ b/metadata/org.scalatest/scalatest-funsuite_3/3.2.19/reachability-metadata.json
@@ -1,0 +1,210 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Assertions"
+      },
+      "type": "org.scalatest.Assertions$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.SuperEngine"
+      },
+      "type": "org.scalatest.SuperEngine",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.AsyncSuperEngine"
+      },
+      "type": "org.scalatest.AsyncSuperEngine",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.source.Position"
+      },
+      "type": "org.scalactic.source.Position$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.Resources$"
+      },
+      "type": "org.scalactic.Resources$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.SimpleBool"
+      },
+      "type": "org.scalactic.SimpleBool",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.Bool$"
+      },
+      "type": "org.scalactic.BinaryMacroBool",
+      "fields": [
+        {
+          "name": "0bitmap$6"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.Bool$"
+      },
+      "type": "org.scalactic.LengthSizeMacroBool",
+      "fields": [
+        {
+          "name": "0bitmap$9"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.Bool$"
+      },
+      "type": "org.scalactic.NotBool",
+      "fields": [
+        {
+          "name": "0bitmap$4"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.Bool$"
+      },
+      "type": "org.scalactic.SimpleMacroBool",
+      "fields": [
+        {
+          "name": "0bitmap$5"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.Bool$"
+      },
+      "type": "org.scalactic.UnaryMacroBool",
+      "fields": [
+        {
+          "name": "0bitmap$7"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Resources$"
+      },
+      "type": "org.scalatest.Resources$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.source.ObjectMeta$$anon$1"
+      },
+      "type": "org.scalactic.source.ObjectMeta$$anon$1",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.NonImplicitAssertions$"
+      },
+      "type": "org.scalatest.NonImplicitAssertions$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.events.Event"
+      },
+      "type": "org.scalatest.events.Event",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.exceptions.StackDepthException"
+      },
+      "type": "org.scalatest.exceptions.StackDepthException",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.package$"
+      },
+      "type": "org.scalatest.package$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.time.Span"
+      },
+      "type": "org.scalatest.time.Span",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Resources$"
+      },
+      "bundle": "org.scalatest.ScalaTestBundle"
+    }
+  ]
+}

--- a/metadata/org.scalatest/scalatest-funsuite_3/index.json
+++ b/metadata/org.scalatest/scalatest-funsuite_3/index.json
@@ -1,21 +1,27 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "3.2.19",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-funsuite_3/$version$/scalatest-funsuite_3-$version$-sources.jar",
-    "repository-url" : "https://github.com/scalatest/scalatest",
-    "test-code-url" : "https://github.com/scalatest/scalatest/tree/release-$version$/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-funsuite_3/$version$/scalatest-funsuite_3-$version$-javadoc.jar",
-    "description" : "ScalaTest FunSuite provides the FunSuite testing style for ScalaTest, where each test is registered and executed as a function value. This artifact is the Scala 3 JVM module for that style, including synchronous, asynchronous, and fixture-based FunSuite APIs for Scala test suites.",
-    "language" : {
-      "name" : "scala",
-      "version" : "3"
+    "latest": true,
+    "metadata-version": "3.2.19",
+    "source-code-url": "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-funsuite_3/$version$/scalatest-funsuite_3-$version$-sources.jar",
+    "repository-url": "https://github.com/scalatest/scalatest",
+    "test-code-url": "https://github.com/scalatest/scalatest/tree/release-$version$/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite",
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-funsuite_3/$version$/scalatest-funsuite_3-$version$-javadoc.jar",
+    "description": "ScalaTest FunSuite provides the FunSuite testing style for ScalaTest, where each test is registered and executed as a function value. This artifact is the Scala 3 JVM module for that style, including synchronous, asynchronous, and fixture-based FunSuite APIs for Scala test suites.",
+    "language": {
+      "name": "scala",
+      "version": "3"
     },
-    "tested-versions" : [
+    "tested-versions": [
       "3.2.19"
     ],
-    "allowed-packages" : [
-      "org.scalatest.funsuite"
+    "allowed-packages": [
+      "org.scalatest.funsuite",
+      "org.scalactic",
+      "org.scalactic.source",
+      "org.scalatest",
+      "org.scalatest.events",
+      "org.scalatest.exceptions",
+      "org.scalatest.time"
     ]
   }
 ]

--- a/metadata/org.scalatest/scalatest-funsuite_3/index.json
+++ b/metadata/org.scalatest/scalatest-funsuite_3/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.2.19",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-funsuite_3/$version$/scalatest-funsuite_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/scalatest/scalatest",
+    "test-code-url" : "https://github.com/scalatest/scalatest/tree/release-$version$/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-funsuite_3/$version$/scalatest-funsuite_3-$version$-javadoc.jar",
+    "description" : "ScalaTest FunSuite provides the FunSuite testing style for ScalaTest, where each test is registered and executed as a function value. This artifact is the Scala 3 JVM module for that style, including synchronous, asynchronous, and fixture-based FunSuite APIs for Scala test suites.",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "3.2.19"
+    ],
+    "allowed-packages" : [
+      "org.scalatest.funsuite"
+    ]
+  }
+]

--- a/stats/org.scalatest/scalatest-funsuite_3/3.2.19/execution-metrics.json
+++ b/stats/org.scalatest/scalatest-funsuite_3/3.2.19/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-13": {
+    "timestamp": "2026-05-13T17:21:29.496755Z",
+    "library": "org.scalatest:scalatest-funsuite_3:3.2.19",
+    "starting_commit": "62660025df3527ed7ff748d63f2f9b27ba849f29",
+    "ending_commit": "dd7f1097cfb41a7d90e9270970627a8be8654905",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.2.19",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1085,
+          "missed": 1449,
+          "ratio": 0.428177,
+          "total": 2534
+        },
+        "line": {
+          "covered": 125,
+          "missed": 86,
+          "ratio": 0.592417,
+          "total": 211
+        },
+        "method": {
+          "covered": 131,
+          "missed": 160,
+          "ratio": 0.450172,
+          "total": 291
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 154784,
+      "cached_input_tokens_used": 1526784,
+      "output_tokens_used": 21224,
+      "iterations": 4,
+      "cost_usd": 1.4001,
+      "generated_loc": 365,
+      "tested_library_loc": 125,
+      "metadata_entries": 37,
+      "code_coverage_percent": 59.24
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.scalatest/scalatest-funsuite_3/3.2.19/src/test/scala/org_scalatest/scalatest_funsuite_3/Scalatest_funsuite_3Test.scala",
+      "metadata_file": "metadata/org.scalatest/scalatest-funsuite_3/3.2.19/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.scalatest/scalatest-funsuite_3/3.2.19/stats.json
+++ b/stats/org.scalatest/scalatest-funsuite_3/3.2.19/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.2.19",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1085,
+        "missed" : 1449,
+        "ratio" : 0.428177,
+        "total" : 2534
+      },
+      "line" : {
+        "covered" : 125,
+        "missed" : 86,
+        "ratio" : 0.592417,
+        "total" : 211
+      },
+      "method" : {
+        "covered" : 131,
+        "missed" : 160,
+        "ratio" : 0.450172,
+        "total" : 291
+      }
+    }
+  } ]
+}

--- a/tests/src/org.scalatest/scalatest-funsuite_3/3.2.19/.gitignore
+++ b/tests/src/org.scalatest/scalatest-funsuite_3/3.2.19/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.scalatest/scalatest-funsuite_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-funsuite_3/3.2.19/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.scalatest:scalatest-funsuite_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.scalatest/scalatest-funsuite_3/3.2.19/gradle.properties
+++ b/tests/src/org.scalatest/scalatest-funsuite_3/3.2.19/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.scalatest:scalatest-funsuite_3:3.2.19
+library.version = 3.2.19
+metadata.dir = org.scalatest/scalatest-funsuite_3/3.2.19/

--- a/tests/src/org.scalatest/scalatest-funsuite_3/3.2.19/settings.gradle
+++ b/tests/src/org.scalatest/scalatest-funsuite_3/3.2.19/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.scalatest.scalatest-funsuite_3_tests'

--- a/tests/src/org.scalatest/scalatest-funsuite_3/3.2.19/src/test/scala/org_scalatest/scalatest_funsuite_3/Scalatest_funsuite_3Test.scala
+++ b/tests/src/org.scalatest/scalatest-funsuite_3/3.2.19/src/test/scala/org_scalatest/scalatest_funsuite_3/Scalatest_funsuite_3Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_scalatest.scalatest_funsuite_3
+
+import org.junit.jupiter.api.Test
+
+class Scalatest_funsuite_3Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/org.scalatest/scalatest-funsuite_3/3.2.19/src/test/scala/org_scalatest/scalatest_funsuite_3/Scalatest_funsuite_3Test.scala
+++ b/tests/src/org.scalatest/scalatest-funsuite_3/3.2.19/src/test/scala/org_scalatest/scalatest_funsuite_3/Scalatest_funsuite_3Test.scala
@@ -25,8 +25,11 @@ import org.scalatest.Outcome
 import org.scalatest.Reporter
 import org.scalatest.Suite
 import org.scalatest.Tag
+import org.scalatest.events.AlertProvided
 import org.scalatest.events.Event
 import org.scalatest.events.InfoProvided
+import org.scalatest.events.MarkupProvided
+import org.scalatest.events.NoteProvided
 import org.scalatest.events.TestCanceled
 import org.scalatest.events.TestFailed
 import org.scalatest.events.TestIgnored
@@ -79,6 +82,20 @@ class Scalatest_funsuite_3Test:
       case event: InfoProvided => event.message
     }.toVector
     assert(messages == Vector("diagnostic details"))
+
+  @Test
+  def anyFunSuiteReportsNotificationsAndRecordedMarkup(): Unit =
+    val suite: DocumentationFunSuite = new DocumentationFunSuite
+    val result: RunResult = runSuite(suite)
+    val success: TestSucceeded = succeededEvents(result.events).head
+    val markup: Vector[String] = success.recordedEvents.collect {
+      case event: MarkupProvided => event.text
+    }.toVector
+
+    assert(result.succeeded)
+    assert(noteEvents(result.events).map(_.message) == Vector("note for the operator"))
+    assert(alertEvents(result.events).map(_.message) == Vector("alert for the operator"))
+    assert(markup == Vector("### supporting details"))
 
   @Test
   def anyFunSuiteReportsCanceledTestsAndContinuesTheSuite(): Unit =
@@ -236,6 +253,13 @@ class Scalatest_funsuite_3Test:
     test("failing test") {
       executionLog = executionLog :+ "failed"
       throw new IllegalStateException("intentional failure")
+    }
+
+  private final class DocumentationFunSuite extends AnyFunSuite:
+    test("emits notifications and markup") {
+      note("note for the operator")
+      alert("alert for the operator")
+      markup("### supporting details")
     }
 
   private final class CancelingFunSuite extends AnyFunSuite:
@@ -403,6 +427,12 @@ class Scalatest_funsuite_3Test:
 
   private def canceledEvents(events: Vector[Event]): Vector[TestCanceled] =
     events.collect { case event: TestCanceled => event }
+
+  private def noteEvents(events: Vector[Event]): Vector[NoteProvided] =
+    events.collect { case event: NoteProvided => event }
+
+  private def alertEvents(events: Vector[Event]): Vector[AlertProvided] =
+    events.collect { case event: AlertProvided => event }
 
   private def ignoredEvents(events: Vector[Event]): Vector[TestIgnored] =
     events.collect { case event: TestIgnored => event }

--- a/tests/src/org.scalatest/scalatest-funsuite_3/3.2.19/src/test/scala/org_scalatest/scalatest_funsuite_3/Scalatest_funsuite_3Test.scala
+++ b/tests/src/org.scalatest/scalatest-funsuite_3/3.2.19/src/test/scala/org_scalatest/scalatest_funsuite_3/Scalatest_funsuite_3Test.scala
@@ -6,11 +6,393 @@
  */
 package org_scalatest.scalatest_funsuite_3
 
-import org.junit.jupiter.api.Test
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 
-class Scalatest_funsuite_3Test {
+import scala.concurrent.Future
+import scala.jdk.CollectionConverters.*
+import scala.util.Try
+
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.scalatest.Args
+import org.scalatest.ConfigMap
+import org.scalatest.Filter
+import org.scalatest.FutureOutcome
+import org.scalatest.Outcome
+import org.scalatest.Reporter
+import org.scalatest.Suite
+import org.scalatest.Tag
+import org.scalatest.events.Event
+import org.scalatest.events.InfoProvided
+import org.scalatest.events.TestCanceled
+import org.scalatest.events.TestFailed
+import org.scalatest.events.TestIgnored
+import org.scalatest.events.TestPending
+import org.scalatest.events.TestStarting
+import org.scalatest.events.TestSucceeded
+import org.scalatest.exceptions.DuplicateTestNameException
+import org.scalatest.exceptions.TestRegistrationClosedException
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.funsuite.AsyncFunSuite
+import org.scalatest.funsuite.FixtureAnyFunSuite
+import org.scalatest.funsuite.FixtureAsyncFunSuite
+
+class Scalatest_funsuite_3Test:
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
-  }
-}
+  def anyFunSuiteRegistersAndRunsTestsInDeclarationOrder(): Unit =
+    val suite: OrderedFunSuite = new OrderedFunSuite
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(suite.testNames.toVector == Vector("first test", "second test"))
+    assert(suite.executionLog == Vector("first", "second"))
+    assert(startingEvents(result.events).map(_.testName) == Vector("first test", "second test"))
+    assert(succeededEvents(result.events).map(_.testName) == Vector("first test", "second test"))
+
+  @Test
+  def anyFunSuiteRunsASingleNamedTestWithoutExecutingTheOthers(): Unit =
+    val suite: OrderedFunSuite = new OrderedFunSuite
+    val result: RunResult = runSuite(suite, testName = Some("second test"))
+
+    assert(result.succeeded)
+    assert(suite.executionLog == Vector("second"))
+    assert(startingEvents(result.events).map(_.testName) == Vector("second test"))
+    assert(succeededEvents(result.events).map(_.testName) == Vector("second test"))
+
+  @Test
+  def anyFunSuiteReportsSucceededIgnoredPendingFailedAndInfoEvents(): Unit =
+    val suite: OutcomeFunSuite = new OutcomeFunSuite
+    val result: RunResult = runSuite(suite)
+
+    assert(!result.succeeded)
+    assert(succeededEvents(result.events).map(_.testName) == Vector("succeeds with info"))
+    assert(ignoredEvents(result.events).map(_.testName) == Vector("ignored test"))
+    assert(pendingEvents(result.events).map(_.testName) == Vector("pending test"))
+    assert(failedEvents(result.events).map(_.testName) == Vector("failing test"))
+    assert(suite.executionLog == Vector("succeeded", "pending", "failed"))
+
+    val success: TestSucceeded = succeededEvents(result.events).head
+    val messages: Vector[String] = success.recordedEvents.collect {
+      case event: InfoProvided => event.message
+    }.toVector
+    assert(messages == Vector("diagnostic details"))
+
+  @Test
+  def anyFunSuiteReportsCanceledTestsAndContinuesTheSuite(): Unit =
+    val suite: CancelingFunSuite = new CancelingFunSuite
+    val result: RunResult = runSuite(suite)
+    val canceled: Vector[TestCanceled] = canceledEvents(result.events)
+
+    assert(result.succeeded)
+    assert(suite.executionLog == Vector("before", "cancel", "after"))
+    assert(succeededEvents(result.events).map(_.testName) == Vector("test before cancellation", "test after cancellation"))
+    assert(canceled.map(_.testName) == Vector("canceled test"))
+    assert(canceled.head.message.contains("external service unavailable"))
+    assert(failedEvents(result.events).isEmpty)
+
+  @Test
+  def anyFunSuiteExposesTagsForCountingAndFiltering(): Unit =
+    val suite: TaggedFunSuite = new TaggedFunSuite
+    val includeFastOnly: Filter = Filter(tagsToInclude = Some(Set(FastTag.name)), tagsToExclude = Set.empty)
+    val excludeDatabase: Filter = Filter(tagsToExclude = Set(DatabaseTag.name))
+
+    assert(suite.tags("fast test") == Set(FastTag.name))
+    assert(suite.tags("database test") == Set(DatabaseTag.name))
+    assert(suite.expectedTestCount(includeFastOnly) == 1)
+    assert(suite.expectedTestCount(excludeDatabase) == 1)
+
+    val result: RunResult = runSuite(suite, filter = includeFastOnly)
+
+    assert(result.succeeded)
+    assert(suite.executionLog == Vector("fast"))
+    assert(succeededEvents(result.events).map(_.testName) == Vector("fast test"))
+
+  @Test
+  def anyFunSuiteRegistersSharedBehaviorThroughTestsFor(): Unit =
+    val suite: SharedBehaviorFunSuite = new SharedBehaviorFunSuite
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(suite.testNames.toVector == Vector(
+      "stack created with one element is non-empty",
+      "stack created with one element returns the top element"
+    ))
+    assert(succeededEvents(result.events).map(_.testName) == Vector(
+      "stack created with one element is non-empty",
+      "stack created with one element returns the top element"
+    ))
+
+  @Test
+  def fixtureAnyFunSuiteProvidesFixturesNoArgTestsAndConfigMaps(): Unit =
+    val suite: FixtureBackedFunSuite = new FixtureBackedFunSuite
+    val result: RunResult = runSuite(suite, configMap = ConfigMap("seed" -> "configured value"))
+
+    assert(result.succeeded)
+    assert(suite.events == Vector(
+      "create:uses fixture argument",
+      "test:configured value",
+      "cleanup:configured value",
+      "test:no-arg"
+    ))
+    assert(succeededEvents(result.events).map(_.testName) == Vector(
+      "uses fixture argument",
+      "uses no-arg fixture wrapper"
+    ))
+
+  @Test
+  def anyFunSuiteAppliesNoArgFixturesAroundEachTest(): Unit =
+    val suite: NoArgFixtureFunSuite = new NoArgFixtureFunSuite
+    val result: RunResult = runSuite(suite, configMap = ConfigMap("mode" -> "fixture value"))
+
+    assert(result.succeeded)
+    assert(suite.events == Vector(
+      "before:first wrapped:fixture value",
+      "body:first",
+      "after:first wrapped",
+      "before:second wrapped:fixture value",
+      "body:second",
+      "after:second wrapped"
+    ))
+    assert(succeededEvents(result.events).map(_.testName) == Vector("first wrapped", "second wrapped"))
+
+  @Test
+  def asyncFunSuiteRunsFutureBackedTestsAndReportsOutcomes(): Unit =
+    val suite: FutureFunSuite = new FutureFunSuite
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(suite.executionLog == Vector("future-value", "recovered-failure"))
+    assert(succeededEvents(result.events).map(_.testName) == Vector(
+      "completes a successful future",
+      "recovers an expected failed future"
+    ))
+
+  @Test
+  def fixtureAsyncFunSuiteProvidesAsynchronousFixtures(): Unit =
+    val suite: AsyncFixtureBackedFunSuite = new AsyncFixtureBackedFunSuite
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(suite.seenFixtures == Vector("async-fixture-used"))
+    assert(succeededEvents(result.events).map(_.testName) == Vector("uses an asynchronous fixture"))
+
+  @Test
+  def anyFunSuiteRejectsDuplicateTestNames(): Unit =
+    assertThrows(classOf[DuplicateTestNameException], () => new DuplicateNameFunSuite)
+    ()
+
+  @Test
+  def anyFunSuiteClosesRegistrationAfterRunStarts(): Unit =
+    val suite: LateRegistrationFunSuite = new LateRegistrationFunSuite
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assertThrows(classOf[TestRegistrationClosedException], () => suite.registerAdditionalTest())
+    ()
+
+  private final class OrderedFunSuite extends AnyFunSuite:
+    var executionLog: Vector[String] = Vector.empty
+
+    test("first test") {
+      executionLog = executionLog :+ "first"
+    }
+
+    test("second test") {
+      executionLog = executionLog :+ "second"
+    }
+
+  private final class OutcomeFunSuite extends AnyFunSuite:
+    var executionLog: Vector[String] = Vector.empty
+
+    test("succeeds with info") {
+      executionLog = executionLog :+ "succeeded"
+      info("diagnostic details")
+    }
+
+    ignore("ignored test") {
+      executionLog = executionLog :+ "ignored"
+    }
+
+    test("pending test") {
+      executionLog = executionLog :+ "pending"
+      pending
+    }
+
+    test("failing test") {
+      executionLog = executionLog :+ "failed"
+      throw new IllegalStateException("intentional failure")
+    }
+
+  private final class CancelingFunSuite extends AnyFunSuite:
+    var executionLog: Vector[String] = Vector.empty
+
+    test("test before cancellation") {
+      executionLog = executionLog :+ "before"
+    }
+
+    test("canceled test") {
+      executionLog = executionLog :+ "cancel"
+      cancel("external service unavailable")
+    }
+
+    test("test after cancellation") {
+      executionLog = executionLog :+ "after"
+    }
+
+  private final class TaggedFunSuite extends AnyFunSuite:
+    var executionLog: Vector[String] = Vector.empty
+
+    test("fast test", FastTag) {
+      executionLog = executionLog :+ "fast"
+    }
+
+    test("database test", DatabaseTag) {
+      executionLog = executionLog :+ "database"
+    }
+
+  private final class SharedBehaviorFunSuite extends AnyFunSuite:
+    testsFor(nonEmptyStack("stack created with one element", List(1)))
+
+    private def nonEmptyStack(description: String, stack: List[Int]): Unit =
+      test(s"$description is non-empty") {
+        assert(stack.nonEmpty)
+      }
+
+      test(s"$description returns the top element") {
+        assert(stack.head == 1)
+      }
+
+  private final class FixtureBackedFunSuite extends FixtureAnyFunSuite:
+    type FixtureParam = String
+
+    var events: Vector[String] = Vector.empty
+
+    override protected def withFixture(test: OneArgTest): Outcome =
+      events = events :+ s"create:${test.name}"
+      val fixture: String = test.configMap("seed").asInstanceOf[String]
+      try test(fixture)
+      finally events = events :+ s"cleanup:$fixture"
+
+    test("uses fixture argument") { (fixture: String) =>
+      events = events :+ s"test:$fixture"
+      assert(fixture == "configured value")
+    }
+
+    test("uses no-arg fixture wrapper") { () =>
+      events = events :+ "test:no-arg"
+    }
+
+  private final class NoArgFixtureFunSuite extends AnyFunSuite:
+    var events: Vector[String] = Vector.empty
+
+    override protected def withFixture(test: NoArgTest): Outcome =
+      events = events :+ s"before:${test.name}:${test.configMap("mode")}"
+      try test()
+      finally events = events :+ s"after:${test.name}"
+
+    test("first wrapped") {
+      events = events :+ "body:first"
+    }
+
+    test("second wrapped") {
+      events = events :+ "body:second"
+    }
+
+  private final class FutureFunSuite extends AsyncFunSuite:
+    var executionLog: Vector[String] = Vector.empty
+
+    test("completes a successful future") {
+      Future.successful {
+        executionLog = executionLog :+ "future-value"
+        assert(21 * 2 == 42)
+        succeed
+      }
+    }
+
+    test("recovers an expected failed future") {
+      executionLog = executionLog :+ "recovered-failure"
+      recoverToSucceededIf[IllegalArgumentException] {
+        Future.failed(new IllegalArgumentException("invalid async input"))
+      }
+    }
+
+  private final class AsyncFixtureBackedFunSuite extends FixtureAsyncFunSuite:
+    type FixtureParam = StringBuilder
+
+    var seenFixtures: Vector[String] = Vector.empty
+
+    override def withFixture(test: OneArgAsyncTest): FutureOutcome =
+      withFixture(test.toNoArgAsyncTest(new StringBuilder("async-fixture")))
+
+    test("uses an asynchronous fixture") { (builder: StringBuilder) =>
+      Future.successful {
+        builder.append("-used")
+        seenFixtures = seenFixtures :+ builder.toString()
+        assert(builder.toString() == "async-fixture-used")
+        succeed
+      }
+    }
+
+  private final class DuplicateNameFunSuite extends AnyFunSuite:
+    test("duplicate") {}
+    test("duplicate") {}
+
+  private final class LateRegistrationFunSuite extends AnyFunSuite:
+    test("registered before run") {}
+
+    def registerAdditionalTest(): Unit =
+      test("registered after run") {}
+
+  private def runSuite(
+      suite: Suite,
+      filter: Filter = Filter.default,
+      testName: Option[String] = None,
+      configMap: ConfigMap = ConfigMap()): RunResult =
+    val reporter: RecordingReporter = new RecordingReporter
+    val completion: AtomicReference[Try[Boolean]] = new AtomicReference[Try[Boolean]]()
+    val completed: CountDownLatch = new CountDownLatch(1)
+    val runArgs: Args = Args(reporter = reporter, filter = filter, configMap = configMap)
+    val status = suite.run(testName, runArgs)
+    status.whenCompleted { (result: Try[Boolean]) =>
+      completion.set(result)
+      completed.countDown()
+    }
+
+    assert(completed.await(30, TimeUnit.SECONDS), s"ScalaTest suite ${suite.suiteName} did not complete")
+    RunResult(completion.get().get, reporter.events)
+
+  private def startingEvents(events: Vector[Event]): Vector[TestStarting] =
+    events.collect { case event: TestStarting => event }
+
+  private def succeededEvents(events: Vector[Event]): Vector[TestSucceeded] =
+    events.collect { case event: TestSucceeded => event }
+
+  private def pendingEvents(events: Vector[Event]): Vector[TestPending] =
+    events.collect { case event: TestPending => event }
+
+  private def canceledEvents(events: Vector[Event]): Vector[TestCanceled] =
+    events.collect { case event: TestCanceled => event }
+
+  private def ignoredEvents(events: Vector[Event]): Vector[TestIgnored] =
+    events.collect { case event: TestIgnored => event }
+
+  private def failedEvents(events: Vector[Event]): Vector[TestFailed] =
+    events.collect { case event: TestFailed => event }
+
+  private final class RecordingReporter extends Reporter:
+    private val recordedEvents: CopyOnWriteArrayList[Event] = new CopyOnWriteArrayList[Event]()
+
+    override def apply(event: Event): Unit =
+      recordedEvents.add(event)
+      ()
+
+    def events: Vector[Event] = recordedEvents.asScala.toVector
+
+  private final case class RunResult(succeeded: Boolean, events: Vector[Event])
+
+  private object FastTag extends Tag("org.scalatest.funsuite.generated.Fast")
+
+  private object DatabaseTag extends Tag("org.scalatest.funsuite.generated.Database")

--- a/tests/src/org.scalatest/scalatest-funsuite_3/3.2.19/src/test/scala/org_scalatest/scalatest_funsuite_3/Scalatest_funsuite_3Test.scala
+++ b/tests/src/org.scalatest/scalatest-funsuite_3/3.2.19/src/test/scala/org_scalatest/scalatest_funsuite_3/Scalatest_funsuite_3Test.scala
@@ -180,6 +180,18 @@ class Scalatest_funsuite_3Test:
     assert(succeededEvents(result.events).map(_.testName) == Vector("uses an asynchronous fixture"))
 
   @Test
+  def fixtureAsyncFunSuiteRunsNoArgAsynchronousTestsThroughFixtureLifecycle(): Unit =
+    val suite: AsyncFixtureNoArgFunSuite = new AsyncFixtureNoArgFunSuite
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(suite.events == Vector(
+      "fixture:uses no-arg asynchronous test body",
+      "body:no-arg async"
+    ))
+    assert(succeededEvents(result.events).map(_.testName) == Vector("uses no-arg asynchronous test body"))
+
+  @Test
   def anyFunSuiteRejectsDuplicateTestNames(): Unit =
     assertThrows(classOf[DuplicateTestNameException], () => new DuplicateNameFunSuite)
     ()
@@ -332,6 +344,22 @@ class Scalatest_funsuite_3Test:
         builder.append("-used")
         seenFixtures = seenFixtures :+ builder.toString()
         assert(builder.toString() == "async-fixture-used")
+        succeed
+      }
+    }
+
+  private final class AsyncFixtureNoArgFunSuite extends FixtureAsyncFunSuite:
+    type FixtureParam = StringBuilder
+
+    var events: Vector[String] = Vector.empty
+
+    override def withFixture(test: OneArgAsyncTest): FutureOutcome =
+      events = events :+ s"fixture:${test.name}"
+      withFixture(test.toNoArgAsyncTest(new StringBuilder("unused")))
+
+    test("uses no-arg asynchronous test body") { () =>
+      Future.successful {
+        events = events :+ "body:no-arg async"
         succeed
       }
     }

--- a/tests/src/org.scalatest/scalatest-funsuite_3/3.2.19/user-code-filter.json
+++ b/tests/src/org.scalatest/scalatest-funsuite_3/3.2.19/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.scalatest.funsuite.**"
+    }
+  ]
+}

--- a/tests/src/org.scalatest/scalatest-funsuite_3/3.2.19/user-code-filter.json
+++ b/tests/src/org.scalatest/scalatest-funsuite_3/3.2.19/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.scalatest.funsuite.**"
+      "includeClasses" : "org.scalatest.funsuite.**"
+    },
+    {
+      "includeClasses" : "org_scalatest.scalatest_funsuite_3.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #2268

This PR introduces tests and metadata for org.scalatest:scalatest-funsuite_3:3.2.19, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 154784
- Cached input tokens: 1526784
- Output tokens: 21224
- Metadata entries: 37
- Iterations: 4
- Library coverage percentage: 59.24
- Generated lines of code: 365
- Tested library lines of code: 125

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `a8db50c33012e91c16f4cf2a1d0da2b4341fd586`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1085/2534 (42.82%)
- Line: 125/211 (59.24%)
- Method: 131/291 (45.02%)

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
