### PR TITLE
[GenAI] Add support for org.scalatest:scalatest-diagrams_3:3.2.19 using gpt-5.5

### DIFF
--- a/metadata/org.scalatest/scalatest-diagrams_3/3.2.19/reachability-metadata.json
+++ b/metadata/org.scalatest/scalatest-diagrams_3/3.2.19/reachability-metadata.json
@@ -1,0 +1,78 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Assertions"
+      },
+      "type": "org.scalatest.Assertions$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.diagrams.Diagrams"
+      },
+      "type": "org.scalatest.diagrams.Diagrams$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.source.Position"
+      },
+      "type": "org.scalactic.source.Position$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.diagrams.DiagrammedByNameExpr"
+      },
+      "type": "org.scalatest.diagrams.DiagrammedByNameExpr",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Resources$"
+      },
+      "type": "org.scalatest.Resources$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.exceptions.StackDepthException"
+      },
+      "type": "org.scalatest.exceptions.StackDepthException",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Resources$"
+      },
+      "bundle": "org.scalatest.ScalaTestBundle"
+    }
+  ]
+}

--- a/metadata/org.scalatest/scalatest-diagrams_3/index.json
+++ b/metadata/org.scalatest/scalatest-diagrams_3/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.2.19",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-diagrams_3/$version$/scalatest-diagrams_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/scalatest/scalatest",
+    "test-code-url" : "https://github.com/scalatest/scalatest/tree/release-$version$/jvm/diagrams-test/src/test/scala/org/scalatest/diagrams",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-diagrams_3/$version$/scalatest-diagrams_3-$version$-javadoc.jar",
+    "description" : "ScalaTest Diagrams adds diagrammed assertion support to ScalaTest, showing evaluated subexpressions when an assertion fails. The Scala 3 artifact provides the org.scalatest.diagrams APIs and macros for writing ScalaTest assertions whose failure messages include expression diagrams.",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "3.2.19"
+    ],
+    "allowed-packages" : [
+      "org.scalatest.diagrams"
+    ]
+  }
+]

--- a/metadata/org.scalatest/scalatest-diagrams_3/index.json
+++ b/metadata/org.scalatest/scalatest-diagrams_3/index.json
@@ -1,21 +1,24 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "3.2.19",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-diagrams_3/$version$/scalatest-diagrams_3-$version$-sources.jar",
-    "repository-url" : "https://github.com/scalatest/scalatest",
-    "test-code-url" : "https://github.com/scalatest/scalatest/tree/release-$version$/jvm/diagrams-test/src/test/scala/org/scalatest/diagrams",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-diagrams_3/$version$/scalatest-diagrams_3-$version$-javadoc.jar",
-    "description" : "ScalaTest Diagrams adds diagrammed assertion support to ScalaTest, showing evaluated subexpressions when an assertion fails. The Scala 3 artifact provides the org.scalatest.diagrams APIs and macros for writing ScalaTest assertions whose failure messages include expression diagrams.",
-    "language" : {
-      "name" : "scala",
-      "version" : "3"
+    "latest": true,
+    "metadata-version": "3.2.19",
+    "source-code-url": "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-diagrams_3/$version$/scalatest-diagrams_3-$version$-sources.jar",
+    "repository-url": "https://github.com/scalatest/scalatest",
+    "test-code-url": "https://github.com/scalatest/scalatest/tree/release-$version$/jvm/diagrams-test/src/test/scala/org/scalatest/diagrams",
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-diagrams_3/$version$/scalatest-diagrams_3-$version$-javadoc.jar",
+    "description": "ScalaTest Diagrams adds diagrammed assertion support to ScalaTest, showing evaluated subexpressions when an assertion fails. The Scala 3 artifact provides the org.scalatest.diagrams APIs and macros for writing ScalaTest assertions whose failure messages include expression diagrams.",
+    "language": {
+      "name": "scala",
+      "version": "3"
     },
-    "tested-versions" : [
+    "tested-versions": [
       "3.2.19"
     ],
-    "allowed-packages" : [
-      "org.scalatest.diagrams"
+    "allowed-packages": [
+      "org.scalatest.diagrams",
+      "org.scalactic.source",
+      "org.scalatest",
+      "org.scalatest.exceptions"
     ]
   }
 ]

--- a/stats/org.scalatest/scalatest-diagrams_3/3.2.19/execution-metrics.json
+++ b/stats/org.scalatest/scalatest-diagrams_3/3.2.19/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-13": {
+    "timestamp": "2026-05-13T18:40:29.782261Z",
+    "library": "org.scalatest:scalatest-diagrams_3:3.2.19",
+    "starting_commit": "84dce20610e34a8f1fac3cfd2520a9f7b1c2f818",
+    "ending_commit": "20fb1ae124600d8cb22a5e35e39887593db1522a",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.2.19",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 698,
+          "missed": 3185,
+          "ratio": 0.179758,
+          "total": 3883
+        },
+        "line": {
+          "covered": 67,
+          "missed": 130,
+          "ratio": 0.340102,
+          "total": 197
+        },
+        "method": {
+          "covered": 53,
+          "missed": 89,
+          "ratio": 0.373239,
+          "total": 142
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 184434,
+      "cached_input_tokens_used": 1131008,
+      "output_tokens_used": 15846,
+      "iterations": 4,
+      "cost_usd": 1.0409,
+      "generated_loc": 159,
+      "tested_library_loc": 67,
+      "metadata_entries": 13,
+      "code_coverage_percent": 34.01
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.scalatest/scalatest-diagrams_3/3.2.19/src/test/scala/org_scalatest/scalatest_diagrams_3/Scalatest_diagrams_3Test.scala",
+      "metadata_file": "metadata/org.scalatest/scalatest-diagrams_3/3.2.19/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.scalatest/scalatest-diagrams_3/3.2.19/stats.json
+++ b/stats/org.scalatest/scalatest-diagrams_3/3.2.19/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.2.19",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 698,
+        "missed" : 3185,
+        "ratio" : 0.179758,
+        "total" : 3883
+      },
+      "line" : {
+        "covered" : 67,
+        "missed" : 130,
+        "ratio" : 0.340102,
+        "total" : 197
+      },
+      "method" : {
+        "covered" : 53,
+        "missed" : 89,
+        "ratio" : 0.373239,
+        "total" : 142
+      }
+    }
+  } ]
+}

--- a/tests/src/org.scalatest/scalatest-diagrams_3/3.2.19/.gitignore
+++ b/tests/src/org.scalatest/scalatest-diagrams_3/3.2.19/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.scalatest/scalatest-diagrams_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-diagrams_3/3.2.19/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.scalatest:scalatest-diagrams_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.scalatest/scalatest-diagrams_3/3.2.19/gradle.properties
+++ b/tests/src/org.scalatest/scalatest-diagrams_3/3.2.19/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.scalatest:scalatest-diagrams_3:3.2.19
+library.version = 3.2.19
+metadata.dir = org.scalatest/scalatest-diagrams_3/3.2.19/

--- a/tests/src/org.scalatest/scalatest-diagrams_3/3.2.19/settings.gradle
+++ b/tests/src/org.scalatest/scalatest-diagrams_3/3.2.19/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.scalatest.scalatest-diagrams_3_tests'

--- a/tests/src/org.scalatest/scalatest-diagrams_3/3.2.19/src/test/scala/org_scalatest/scalatest_diagrams_3/Scalatest_diagrams_3Test.scala
+++ b/tests/src/org.scalatest/scalatest-diagrams_3/3.2.19/src/test/scala/org_scalatest/scalatest_diagrams_3/Scalatest_diagrams_3Test.scala
@@ -65,6 +65,24 @@ class Scalatest_diagrams_3Test extends Diagrams:
     assertTrue(message.contains("false"), message)
 
   @Test
+  def failingTripleEqualsDiagramAssertionRendersComparedValues(): Unit =
+    val actual: Int = 3
+    val expected: Int = 5
+
+    assert(actual === 3)
+
+    val failure: TestFailedException = expectTestFailure {
+      assert(actual === expected)
+    }
+
+    val message: String = failure.getMessage
+    assertTrue(message.contains("actual === expected"), message)
+    assertTrue(message.contains("3"), message)
+    assertTrue(message.contains("5"), message)
+    assertTrue(message.contains("false"), message)
+    assertTrue(message.contains("|"), message)
+
+  @Test
   def failingDiagramAssumeThrowsCanceledExceptionWithDiagramDetails(): Unit =
     val serviceName: String = "metadata-service"
     val requestedPrefix: String = "native-image"

--- a/tests/src/org.scalatest/scalatest-diagrams_3/3.2.19/src/test/scala/org_scalatest/scalatest_diagrams_3/Scalatest_diagrams_3Test.scala
+++ b/tests/src/org.scalatest/scalatest-diagrams_3/3.2.19/src/test/scala/org_scalatest/scalatest_diagrams_3/Scalatest_diagrams_3Test.scala
@@ -6,11 +6,149 @@
  */
 package org_scalatest.scalatest_diagrams_3
 
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertThrows as junitAssertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.function.Executable
+import org.scalatest.diagrams.DiagrammedExpr
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.exceptions.TestCanceledException
+import org.scalatest.exceptions.TestFailedException
 
-class Scalatest_diagrams_3Test {
+class Scalatest_diagrams_3Test extends Diagrams:
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
-  }
-}
+  def passingDiagramAssertionsEvaluateOrdinaryBooleanExpressions(): Unit =
+    val numbers: Vector[Int] = Vector(2, 3, 5, 7)
+    val label: String = "reachability-metadata"
+    val calculator: Calculator = Calculator(40)
+
+    assert(numbers.sum == 17)
+    assert(numbers.filter(_ > 3).contains(7))
+    assert(label.startsWith("reachability") && label.endsWith("metadata"))
+    assert(calculator.incrementedBy(2) == 42, "calculator should add the requested delta")
+
+  @Test
+  def failingDiagramAssertionIncludesExpressionSourceAndCapturedValues(): Unit =
+    val numbers: Vector[Int] = Vector(1, 2, 3)
+    val requested: Int = 4
+
+    val failure: TestFailedException = expectTestFailure {
+      assert(numbers.contains(requested))
+    }
+
+    val message: String = failure.getMessage
+    assertTrue(message.contains("numbers.contains(requested)"), message)
+    assertTrue(message.contains("Vector(1, 2, 3)"), message)
+    assertTrue(message.contains("4"), message)
+    assertTrue(message.contains("false"), message)
+    assertTrue(message.contains("|"), message)
+
+  @Test
+  def failingDiagramAssertionRendersNestedSelectionsAndMethodApplications(): Unit =
+    val calculator: Calculator = Calculator(6)
+    val delta: Int = 5
+    val expected: Int = 99
+
+    val failure: TestFailedException = expectTestFailure {
+      assert(calculator.incrementedBy(delta) == expected)
+    }
+
+    val message: String = failure.getMessage
+    assertTrue(message.contains("calculator.incrementedBy(delta) == expected"), message)
+    assertTrue(message.contains("Calculator(6)"), message)
+    assertTrue(message.contains("11"), message)
+    assertTrue(message.contains("5"), message)
+    assertTrue(message.contains("99"), message)
+    assertTrue(message.contains("false"), message)
+
+  @Test
+  def failingDiagramAssumeThrowsCanceledExceptionWithDiagramDetails(): Unit =
+    val serviceName: String = "metadata-service"
+    val requestedPrefix: String = "native-image"
+
+    val cancellation: TestCanceledException = expectTestCancellation {
+      assume(serviceName.startsWith(requestedPrefix))
+    }
+
+    val message: String = cancellation.getMessage
+    assertTrue(message.contains("serviceName.startsWith(requestedPrefix)"), message)
+    assertTrue(message.contains("metadata-service"), message)
+    assertTrue(message.contains("native-image"), message)
+    assertTrue(message.contains("false"), message)
+
+  @Test
+  def diagrammedSimpleAndSelectExpressionsExposeAnchorValues(): Unit =
+    val base: DiagrammedExpr[String] = DiagrammedExpr.simpleExpr("metadata", 2)
+    val selected: DiagrammedExpr[Int] = DiagrammedExpr.selectExpr(base, 8, 12)
+
+    assertEquals("metadata", base.value)
+    assertEquals(2, base.anchor)
+    assertEquals(List("AnchorValue(2,metadata)"), base.anchorValues.map(_.toString))
+
+    assertEquals(8, selected.value)
+    assertEquals(12, selected.anchor)
+    assertEquals(
+      List("AnchorValue(2,metadata)", "AnchorValue(12,8)"),
+      selected.anchorValues.map(_.toString)
+    )
+
+  @Test
+  def diagrammedApplyExpressionCombinesQualifierResultAndArguments(): Unit =
+    val qualifier: DiagrammedExpr[String] = DiagrammedExpr.simpleExpr("scala", 1)
+    val firstArgument: DiagrammedExpr[Int] = DiagrammedExpr.simpleExpr(3, 9)
+    val secondArgument: DiagrammedExpr[Int] = DiagrammedExpr.simpleExpr(4, 14)
+    val syntheticArgument: DiagrammedExpr[String] = DiagrammedExpr.simpleExpr("ignored", -1)
+    val arguments: List[DiagrammedExpr[?]] = List(firstArgument, secondArgument, syntheticArgument)
+
+    val applied: DiagrammedExpr[String] = DiagrammedExpr.applyExpr(qualifier, arguments, "scala-7", 20)
+    val anchors: List[String] = applied.anchorValues.map(_.toString)
+
+    assertEquals("scala-7", applied.value)
+    assertEquals(20, applied.anchor)
+    assertEquals("AnchorValue(1,scala)", anchors.head)
+    assertTrue(anchors.contains("AnchorValue(20,scala-7)"), anchors.toString)
+    assertTrue(anchors.contains("AnchorValue(9,3)"), anchors.toString)
+    assertTrue(anchors.contains("AnchorValue(14,4)"), anchors.toString)
+    assertFalse(anchors.exists(_.contains("ignored")), anchors.toString)
+
+  @Test
+  def byNameDiagrammedExpressionEvaluatesValueLazilyAndOnlyOnce(): Unit =
+    var evaluations: Int = 0
+    val expression: DiagrammedExpr[String] = DiagrammedExpr.byNameExpr(
+      {
+        evaluations += 1
+        "computed-value"
+      },
+      31
+    )
+
+    assertEquals(31, expression.anchor)
+    assertTrue(expression.anchorValues.isEmpty)
+    assertEquals(0, evaluations)
+    assertEquals("computed-value", expression.value)
+    assertEquals("computed-value", expression.value)
+    assertEquals(1, evaluations)
+
+  @Test
+  def useDiagramMarkerCanBeObtainedFromTrait(): Unit =
+    assertNotNull(UseDiagram)
+
+  private def expectTestFailure(block: => Unit): TestFailedException =
+    junitAssertThrows(
+      classOf[TestFailedException],
+      new Executable:
+        override def execute(): Unit = block
+    )
+
+  private def expectTestCancellation(block: => Unit): TestCanceledException =
+    junitAssertThrows(
+      classOf[TestCanceledException],
+      new Executable:
+        override def execute(): Unit = block
+    )
+
+  private final case class Calculator(base: Int):
+    def incrementedBy(delta: Int): Int = base + delta

--- a/tests/src/org.scalatest/scalatest-diagrams_3/3.2.19/src/test/scala/org_scalatest/scalatest_diagrams_3/Scalatest_diagrams_3Test.scala
+++ b/tests/src/org.scalatest/scalatest-diagrams_3/3.2.19/src/test/scala/org_scalatest/scalatest_diagrams_3/Scalatest_diagrams_3Test.scala
@@ -47,6 +47,24 @@ class Scalatest_diagrams_3Test extends Diagrams:
     assertTrue(message.contains("|"), message)
 
   @Test
+  def failingDiagramAssertionWithCluePreservesTheClueAndDiagramDetails(): Unit =
+    val availableItems: Int = 2
+    val requestedItems: Int = 5
+    val clue: String = "inventory request should fit the available stock"
+
+    val failure: TestFailedException = expectTestFailure {
+      assert(requestedItems <= availableItems, clue)
+    }
+
+    val message: String = failure.getMessage
+    assertTrue(message.contains(clue), message)
+    assertTrue(message.contains("requestedItems <= availableItems"), message)
+    assertTrue(message.contains("5"), message)
+    assertTrue(message.contains("2"), message)
+    assertTrue(message.contains("false"), message)
+    assertTrue(message.contains("|"), message)
+
+  @Test
   def failingDiagramAssertionRendersNestedSelectionsAndMethodApplications(): Unit =
     val calculator: Calculator = Calculator(6)
     val delta: Int = 5

--- a/tests/src/org.scalatest/scalatest-diagrams_3/3.2.19/src/test/scala/org_scalatest/scalatest_diagrams_3/Scalatest_diagrams_3Test.scala
+++ b/tests/src/org.scalatest/scalatest-diagrams_3/3.2.19/src/test/scala/org_scalatest/scalatest_diagrams_3/Scalatest_diagrams_3Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_scalatest.scalatest_diagrams_3
+
+import org.junit.jupiter.api.Test
+
+class Scalatest_diagrams_3Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/org.scalatest/scalatest-diagrams_3/3.2.19/user-code-filter.json
+++ b/tests/src/org.scalatest/scalatest-diagrams_3/3.2.19/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.scalatest.diagrams.**"
+    }
+  ]
+}

--- a/tests/src/org.scalatest/scalatest-diagrams_3/3.2.19/user-code-filter.json
+++ b/tests/src/org.scalatest/scalatest-diagrams_3/3.2.19/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.scalatest.diagrams.**"
+      "includeClasses" : "org.scalatest.diagrams.**"
+    },
+    {
+      "includeClasses" : "org_scalatest.scalatest_diagrams_3.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #2252

This PR introduces tests and metadata for org.scalatest:scalatest-diagrams_3:3.2.19, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 184434
- Cached input tokens: 1131008
- Output tokens: 15846
- Metadata entries: 13
- Iterations: 4
- Library coverage percentage: 34.01
- Generated lines of code: 159
- Tested library lines of code: 67

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `64d8b4f2f9029a39a16be5f267a0520237778c67`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 698/3883 (17.98%)
- Line: 67/197 (34.01%)
- Method: 53/142 (37.32%)

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
