### PR TITLE
[GenAI] Add support for org.scalatest:scalatest-featurespec_3:3.2.19 using gpt-5.5

### DIFF
--- a/metadata/org.scalatest/scalatest-featurespec_3/3.2.19/reachability-metadata.json
+++ b/metadata/org.scalatest/scalatest-featurespec_3/3.2.19/reachability-metadata.json
@@ -1,0 +1,243 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Assertions"
+      },
+      "type": "org.scalatest.Assertions$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.SuperEngine"
+      },
+      "type": "org.scalatest.SuperEngine",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.AsyncSuperEngine"
+      },
+      "type": "org.scalatest.AsyncSuperEngine",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.source.Position"
+      },
+      "type": "org.scalactic.source.Position$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.Resources$"
+      },
+      "type": "org.scalactic.Resources$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.SimpleBool"
+      },
+      "type": "org.scalactic.SimpleBool",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.Bool$"
+      },
+      "type": "org.scalactic.BinaryMacroBool",
+      "fields": [
+        {
+          "name": "0bitmap$6"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.Bool$"
+      },
+      "type": "org.scalactic.LengthSizeMacroBool",
+      "fields": [
+        {
+          "name": "0bitmap$9"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.Bool$"
+      },
+      "type": "org.scalactic.NotBool",
+      "fields": [
+        {
+          "name": "0bitmap$4"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.Bool$"
+      },
+      "type": "org.scalactic.SimpleMacroBool",
+      "fields": [
+        {
+          "name": "0bitmap$5"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Resources$"
+      },
+      "type": "org.scalatest.Resources$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.source.ObjectMeta$$anon$1"
+      },
+      "type": "org.scalactic.source.ObjectMeta$$anon$1",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.NonImplicitAssertions$"
+      },
+      "type": "org.scalatest.NonImplicitAssertions$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.events.Event"
+      },
+      "type": "org.scalatest.events.Event",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.exceptions.StackDepthException"
+      },
+      "type": "org.scalatest.exceptions.StackDepthException",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.package$"
+      },
+      "type": "org.scalatest.package$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.time.Span"
+      },
+      "type": "org.scalatest.time.Span",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.featurespec.AnyFeatureSpec"
+      },
+      "type": "org.scalatest.featurespec.AnyFeatureSpec",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.featurespec.AsyncFeatureSpec"
+      },
+      "type": "org.scalatest.featurespec.AsyncFeatureSpec",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.featurespec.FixtureAnyFeatureSpec"
+      },
+      "type": "org.scalatest.featurespec.FixtureAnyFeatureSpec",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.featurespec.FixtureAsyncFeatureSpec"
+      },
+      "type": "org.scalatest.featurespec.FixtureAsyncFeatureSpec",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Resources$"
+      },
+      "bundle": "org.scalatest.ScalaTestBundle"
+    }
+  ]
+}

--- a/metadata/org.scalatest/scalatest-featurespec_3/index.json
+++ b/metadata/org.scalatest/scalatest-featurespec_3/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.2.19",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-featurespec_3/$version$/scalatest-featurespec_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/scalatest/scalatest",
+    "test-code-url" : "https://github.com/scalatest/scalatest/tree/release-$version$/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-featurespec_3/$version$/scalatest-featurespec_3-$version$-javadoc.jar",
+    "description" : "ScalaTest FeatureSpec is the ScalaTest module that provides the feature-specification style for organizing tests around features and scenarios. It lets Scala 3 projects write behavior-driven, readable test suites that integrate with ScalaTest's assertions, fixtures, and runner ecosystem.",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "3.2.19"
+    ],
+    "allowed-packages" : [
+      "org.scalatest.featurespec"
+    ]
+  }
+]

--- a/metadata/org.scalatest/scalatest-featurespec_3/index.json
+++ b/metadata/org.scalatest/scalatest-featurespec_3/index.json
@@ -1,21 +1,27 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "3.2.19",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-featurespec_3/$version$/scalatest-featurespec_3-$version$-sources.jar",
-    "repository-url" : "https://github.com/scalatest/scalatest",
-    "test-code-url" : "https://github.com/scalatest/scalatest/tree/release-$version$/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-featurespec_3/$version$/scalatest-featurespec_3-$version$-javadoc.jar",
-    "description" : "ScalaTest FeatureSpec is the ScalaTest module that provides the feature-specification style for organizing tests around features and scenarios. It lets Scala 3 projects write behavior-driven, readable test suites that integrate with ScalaTest's assertions, fixtures, and runner ecosystem.",
-    "language" : {
-      "name" : "scala",
-      "version" : "3"
+    "latest": true,
+    "metadata-version": "3.2.19",
+    "source-code-url": "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-featurespec_3/$version$/scalatest-featurespec_3-$version$-sources.jar",
+    "repository-url": "https://github.com/scalatest/scalatest",
+    "test-code-url": "https://github.com/scalatest/scalatest/tree/release-$version$/jvm/featurespec-test/src/test/scala/org/scalatest/featurespec",
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-featurespec_3/$version$/scalatest-featurespec_3-$version$-javadoc.jar",
+    "description": "ScalaTest FeatureSpec is the ScalaTest module that provides the feature-specification style for organizing tests around features and scenarios. It lets Scala 3 projects write behavior-driven, readable test suites that integrate with ScalaTest's assertions, fixtures, and runner ecosystem.",
+    "language": {
+      "name": "scala",
+      "version": "3"
     },
-    "tested-versions" : [
+    "tested-versions": [
       "3.2.19"
     ],
-    "allowed-packages" : [
-      "org.scalatest.featurespec"
+    "allowed-packages": [
+      "org.scalatest.featurespec",
+      "org.scalactic",
+      "org.scalactic.source",
+      "org.scalatest",
+      "org.scalatest.events",
+      "org.scalatest.exceptions",
+      "org.scalatest.time"
     ]
   }
 ]

--- a/stats/org.scalatest/scalatest-featurespec_3/3.2.19/execution-metrics.json
+++ b/stats/org.scalatest/scalatest-featurespec_3/3.2.19/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-13": {
+    "timestamp": "2026-05-13T19:07:59.983274Z",
+    "library": "org.scalatest:scalatest-featurespec_3:3.2.19",
+    "starting_commit": "95cb3f6fb1b5abd1ab6ce74acd2449c1bfe1d52a",
+    "ending_commit": "09e1a726f69b61f151056441c641029387df7398",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.2.19",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1268,
+          "missed": 2144,
+          "ratio": 0.37163,
+          "total": 3412
+        },
+        "line": {
+          "covered": 148,
+          "missed": 119,
+          "ratio": 0.554307,
+          "total": 267
+        },
+        "method": {
+          "covered": 153,
+          "missed": 186,
+          "ratio": 0.451327,
+          "total": 339
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 131618,
+      "cached_input_tokens_used": 1186304,
+      "output_tokens_used": 16129,
+      "iterations": 4,
+      "cost_usd": 1.0771,
+      "generated_loc": 336,
+      "tested_library_loc": 148,
+      "metadata_entries": 43,
+      "code_coverage_percent": 55.43
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.scalatest/scalatest-featurespec_3/3.2.19/src/test/scala/org_scalatest/scalatest_featurespec_3/Scalatest_featurespec_3Test.scala",
+      "metadata_file": "metadata/org.scalatest/scalatest-featurespec_3/3.2.19/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.scalatest/scalatest-featurespec_3/3.2.19/stats.json
+++ b/stats/org.scalatest/scalatest-featurespec_3/3.2.19/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.2.19",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1268,
+        "missed" : 2144,
+        "ratio" : 0.37163,
+        "total" : 3412
+      },
+      "line" : {
+        "covered" : 148,
+        "missed" : 119,
+        "ratio" : 0.554307,
+        "total" : 267
+      },
+      "method" : {
+        "covered" : 153,
+        "missed" : 186,
+        "ratio" : 0.451327,
+        "total" : 339
+      }
+    }
+  } ]
+}

--- a/tests/src/org.scalatest/scalatest-featurespec_3/3.2.19/.gitignore
+++ b/tests/src/org.scalatest/scalatest-featurespec_3/3.2.19/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.scalatest/scalatest-featurespec_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-featurespec_3/3.2.19/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.scalatest:scalatest-featurespec_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.scalatest/scalatest-featurespec_3/3.2.19/gradle.properties
+++ b/tests/src/org.scalatest/scalatest-featurespec_3/3.2.19/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.scalatest:scalatest-featurespec_3:3.2.19
+library.version = 3.2.19
+metadata.dir = org.scalatest/scalatest-featurespec_3/3.2.19/

--- a/tests/src/org.scalatest/scalatest-featurespec_3/3.2.19/settings.gradle
+++ b/tests/src/org.scalatest/scalatest-featurespec_3/3.2.19/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.scalatest.scalatest-featurespec_3_tests'

--- a/tests/src/org.scalatest/scalatest-featurespec_3/3.2.19/src/test/scala/org_scalatest/scalatest_featurespec_3/Scalatest_featurespec_3Test.scala
+++ b/tests/src/org.scalatest/scalatest-featurespec_3/3.2.19/src/test/scala/org_scalatest/scalatest_featurespec_3/Scalatest_featurespec_3Test.scala
@@ -87,6 +87,19 @@ class Scalatest_featurespec_3Test:
     assert(ignoredEvents(result.events).isEmpty)
 
   @Test
+  def registersSharedScenariosWithScenariosFor(): Unit =
+    val suite: SharedCheckoutFeatureSpec = new SharedCheckoutFeatureSpec
+    val sharedTestName: String = findTestName(suite, "validates a reusable checkout total")
+    val specificTestName: String = findTestName(suite, "adds a feature-specific checkout summary")
+
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(suite.executed == Vector("shared-total", "specific-summary"))
+    assert(succeededEvents(result.events).map(_.testName) == Vector(sharedTestName, specificTestName))
+    assert(ignoredEvents(result.events).isEmpty)
+
+  @Test
   def reportsPendingCanceledAndFailedScenarioLifecycleEvents(): Unit =
     val lifecycleSuite: LifecycleFeatureSpec = new LifecycleFeatureSpec
     val lifecycleResult: RunResult = runSuite(lifecycleSuite)
@@ -200,6 +213,24 @@ class Scalatest_featurespec_3Test:
   private object ShoppingCartFeatureSpec:
     val Fast: Tag = Tag("org.scalatest.featurespec.generated.Fast")
     val Slow: Tag = Tag("org.scalatest.featurespec.generated.Slow")
+
+  private final class SharedCheckoutFeatureSpec extends AnyFeatureSpec:
+    var executed: Vector[String] = Vector.empty
+
+    Feature("Reusable checkout behavior") {
+      scenariosFor(sharedCheckoutScenarios(expectedTotal = 12))
+
+      Scenario("adds a feature-specific checkout summary") {
+        executed = executed :+ "specific-summary"
+        assert(s"total=${6 + 6}" == "total=12")
+      }
+    }
+
+    private def sharedCheckoutScenarios(expectedTotal: Int): Unit =
+      Scenario("validates a reusable checkout total") {
+        executed = executed :+ "shared-total"
+        assert(Vector(5, 7).sum == expectedTotal)
+      }
 
   private final class LifecycleFeatureSpec extends AnyFeatureSpec:
     var executed: Vector[String] = Vector.empty

--- a/tests/src/org.scalatest/scalatest-featurespec_3/3.2.19/src/test/scala/org_scalatest/scalatest_featurespec_3/Scalatest_featurespec_3Test.scala
+++ b/tests/src/org.scalatest/scalatest-featurespec_3/3.2.19/src/test/scala/org_scalatest/scalatest_featurespec_3/Scalatest_featurespec_3Test.scala
@@ -24,8 +24,11 @@ import org.scalatest.Outcome
 import org.scalatest.Reporter
 import org.scalatest.Suite
 import org.scalatest.Tag
+import org.scalatest.events.AlertProvided
 import org.scalatest.events.Event
 import org.scalatest.events.InfoProvided
+import org.scalatest.events.MarkupProvided
+import org.scalatest.events.NoteProvided
 import org.scalatest.events.TestCanceled
 import org.scalatest.events.TestFailed
 import org.scalatest.events.TestIgnored
@@ -119,6 +122,20 @@ class Scalatest_featurespec_3Test:
       "Then the order summary contains the guide",
       "checkout summary verified"
     ))
+
+  @Test
+  def publishesNoteAlertAndMarkupEventsFromSucceededScenario(): Unit =
+    val suite: NotificationFeatureSpec = new NotificationFeatureSpec
+    val scenarioTestName: String = findTestName(suite, "publishes notifications and markup")
+
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(suite.executed == Vector("notifications"))
+    assert(succeededEvents(result.events).map(_.testName) == Vector(scenarioTestName))
+    assert(noteMessages(result.events) == Vector("checkout note published"))
+    assert(alertMessages(result.events) == Vector("checkout alert published"))
+    assert(recordedMarkupText(result.events) == Vector("<p>checkout documentation published</p>"))
 
   @Test
   def fixtureAnyFeatureSpecProvidesFreshFixturesAndReportsIgnoredScenarios(): Unit =
@@ -222,6 +239,19 @@ class Scalatest_featurespec_3Test:
         info("checkout summary verified")
         executed = executed :+ "narrative"
         assert(Vector("guide").mkString(",") == "guide")
+      }
+    }
+
+  private final class NotificationFeatureSpec extends AnyFeatureSpec:
+    var executed: Vector[String] = Vector.empty
+
+    Feature("Scenario notifications and documentation") {
+      Scenario("publishes notifications and markup") {
+        note("checkout note published")
+        alert("checkout alert published")
+        markup("<p>checkout documentation published</p>")
+        executed = executed :+ "notifications"
+        assert("cart".reverse.reverse == "cart")
       }
     }
 
@@ -332,6 +362,17 @@ class Scalatest_featurespec_3Test:
   private def recordedInfoMessages(events: Vector[Event]): Vector[String] =
     succeededEvents(events).flatMap { (event: TestSucceeded) =>
       event.recordedEvents.collect { case info: InfoProvided => info.message }.toVector
+    }
+
+  private def noteMessages(events: Vector[Event]): Vector[String] =
+    events.collect { case event: NoteProvided => event.message }
+
+  private def alertMessages(events: Vector[Event]): Vector[String] =
+    events.collect { case event: AlertProvided => event.message }
+
+  private def recordedMarkupText(events: Vector[Event]): Vector[String] =
+    succeededEvents(events).flatMap { (event: TestSucceeded) =>
+      event.recordedEvents.collect { case markup: MarkupProvided => markup.text }.toVector
     }
 
   private final class RecordingReporter extends Reporter:

--- a/tests/src/org.scalatest/scalatest-featurespec_3/3.2.19/src/test/scala/org_scalatest/scalatest_featurespec_3/Scalatest_featurespec_3Test.scala
+++ b/tests/src/org.scalatest/scalatest-featurespec_3/3.2.19/src/test/scala/org_scalatest/scalatest_featurespec_3/Scalatest_featurespec_3Test.scala
@@ -6,11 +6,341 @@
  */
 package org_scalatest.scalatest_featurespec_3
 
-import org.junit.jupiter.api.Test
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 
-class Scalatest_featurespec_3Test {
+import scala.concurrent.Future
+import scala.jdk.CollectionConverters.*
+import scala.util.Try
+
+import org.junit.jupiter.api.Test
+import org.scalatest.Args
+import org.scalatest.Filter
+import org.scalatest.FutureOutcome
+import org.scalatest.GivenWhenThen
+import org.scalatest.Outcome
+import org.scalatest.Reporter
+import org.scalatest.Suite
+import org.scalatest.Tag
+import org.scalatest.events.Event
+import org.scalatest.events.InfoProvided
+import org.scalatest.events.TestCanceled
+import org.scalatest.events.TestFailed
+import org.scalatest.events.TestIgnored
+import org.scalatest.events.TestPending
+import org.scalatest.events.TestSucceeded
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.featurespec.AsyncFeatureSpec
+import org.scalatest.featurespec.FixtureAnyFeatureSpec
+import org.scalatest.featurespec.FixtureAsyncFeatureSpec
+
+class Scalatest_featurespec_3Test:
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
-  }
-}
+  def registersFeatureScenariosTagsAndIgnoredScenarios(): Unit =
+    val suite: ShoppingCartFeatureSpec = new ShoppingCartFeatureSpec
+    val addItemTestName: String = findTestName(suite, "adds an item")
+    val removeItemTestName: String = findTestName(suite, "removes an item")
+    val ignoredTestName: String = findTestName(suite, "checks out without inventory")
+
+    assert(suite.testNames.size == 3)
+    assert(suite.tags(addItemTestName).contains(ShoppingCartFeatureSpec.Fast.name))
+    assert(suite.tags(ignoredTestName).contains(ShoppingCartFeatureSpec.Slow.name))
+    assert(suite.tags(ignoredTestName).contains("org.scalatest.Ignore"))
+
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(suite.executed.toSet == Set("add", "remove"))
+    assert(succeededEvents(result.events).map(_.testName).toSet == Set(addItemTestName, removeItemTestName))
+    assert(ignoredEvents(result.events).map(_.testName) == Vector(ignoredTestName))
+
+  @Test
+  def honorsSelectedScenarioNameWhenRunningFeatureSpec(): Unit =
+    val suite: ShoppingCartFeatureSpec = new ShoppingCartFeatureSpec
+    val selectedName: String = findTestName(suite, "removes an item")
+
+    val result: RunResult = runSuite(suite, testName = Some(selectedName))
+
+    assert(result.succeeded)
+    assert(suite.executed == Vector("remove"))
+    assert(succeededEvents(result.events).map(_.testName) == Vector(selectedName))
+    assert(ignoredEvents(result.events).isEmpty)
+
+  @Test
+  def honorsTagFiltersForFeatureSpecScenarios(): Unit =
+    val suite: ShoppingCartFeatureSpec = new ShoppingCartFeatureSpec
+    val addItemTestName: String = findTestName(suite, "adds an item")
+
+    val result: RunResult = runSuite(
+      suite,
+      filter = Filter(tagsToInclude = Some(Set(ShoppingCartFeatureSpec.Fast.name)), tagsToExclude = Set.empty)
+    )
+
+    assert(result.succeeded)
+    assert(suite.executed == Vector("add"))
+    assert(succeededEvents(result.events).map(_.testName) == Vector(addItemTestName))
+    assert(ignoredEvents(result.events).isEmpty)
+
+  @Test
+  def reportsPendingCanceledAndFailedScenarioLifecycleEvents(): Unit =
+    val lifecycleSuite: LifecycleFeatureSpec = new LifecycleFeatureSpec
+    val lifecycleResult: RunResult = runSuite(lifecycleSuite)
+
+    assert(lifecycleResult.succeeded)
+    assert(lifecycleSuite.executed == Vector("success", "pending", "canceled"))
+    assert(succeededEvents(lifecycleResult.events).exists(_.testName.contains("records ordinary success")))
+    assert(pendingEvents(lifecycleResult.events).exists(_.testName.contains("documents unfinished behavior")))
+    assert(canceledEvents(lifecycleResult.events).exists(_.testName.contains("cancels unavailable behavior")))
+
+    val failingSuite: FailingFeatureSpec = new FailingFeatureSpec
+    val failingResult: RunResult = runSuite(failingSuite)
+    val failures: Vector[TestFailed] = failedEvents(failingResult.events)
+
+    assert(!failingResult.succeeded)
+    assert(failures.size == 1)
+    assert(failures.head.testName.contains("publishes assertion failures"))
+    assert(failures.head.message.contains("inventory count did not match"))
+
+  @Test
+  def publishesGivenWhenThenAndInfoMessagesWithSucceededScenario(): Unit =
+    val suite: CheckoutNarrativeFeatureSpec = new CheckoutNarrativeFeatureSpec
+    val scenarioTestName: String = findTestName(suite, "describes checkout steps")
+
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(suite.executed == Vector("narrative"))
+    assert(succeededEvents(result.events).map(_.testName) == Vector(scenarioTestName))
+    assert(recordedInfoMessages(result.events) == Vector(
+      "Given a cart containing a guide",
+      "When the customer checks out",
+      "Then the order summary contains the guide",
+      "checkout summary verified"
+    ))
+
+  @Test
+  def fixtureAnyFeatureSpecProvidesFreshFixturesAndReportsIgnoredScenarios(): Unit =
+    val suite: TextFixtureFeatureSpec = new TextFixtureFeatureSpec
+    val upperCaseTestName: String = findTestName(suite, "upper-cases fixture text")
+    val suffixTestName: String = findTestName(suite, "appends to a fresh fixture")
+    val ignoredTestName: String = findTestName(suite, "keeps ignored fixture scenarios registered")
+
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(suite.fixtureNames.asScala.toVector == Vector(upperCaseTestName, suffixTestName))
+    assert(suite.finishedFixtures.asScala.toVector == Vector("feature-spec-upper", "feature-spec-suffix"))
+    assert(succeededEvents(result.events).map(_.testName) == Vector(upperCaseTestName, suffixTestName))
+    assert(ignoredEvents(result.events).map(_.testName) == Vector(ignoredTestName))
+
+  @Test
+  def asyncFeatureSpecCompletesFutureScenariosAndExpectedRecoveries(): Unit =
+    val suite: AsyncCalculationFeatureSpec = new AsyncCalculationFeatureSpec
+    val additionTestName: String = findTestName(suite, "adds numbers asynchronously")
+    val recoveryTestName: String = findTestName(suite, "recovers expected failed futures")
+
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(suite.executed == Vector("addition", "recovery"))
+    assert(succeededEvents(result.events).map(_.testName) == Vector(additionTestName, recoveryTestName))
+    assert(ignoredEvents(result.events).isEmpty)
+
+  @Test
+  def fixtureAsyncFeatureSpecProvidesFixturesToFutureScenarios(): Unit =
+    val suite: AsyncTextFixtureFeatureSpec = new AsyncTextFixtureFeatureSpec
+    val scenarioTestName: String = findTestName(suite, "decorates fixture text asynchronously")
+
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(suite.fixtureNames.asScala.toVector == Vector(scenarioTestName))
+    assert(suite.observedFixtures.asScala.toVector == Vector("async-feature-spec"))
+    assert(succeededEvents(result.events).map(_.testName) == Vector(scenarioTestName))
+
+  private final class ShoppingCartFeatureSpec extends AnyFeatureSpec:
+    var executed: Vector[String] = Vector.empty
+
+    Feature("Shopping cart") {
+      Scenario("adds an item", ShoppingCartFeatureSpec.Fast) {
+        executed = executed :+ "add"
+        assert(Vector("book", "pen").contains("book"))
+      }
+
+      Scenario("removes an item", ShoppingCartFeatureSpec.Slow) {
+        executed = executed :+ "remove"
+        assert(Vector("book", "pen").filterNot(_ == "pen") == Vector("book"))
+      }
+
+      ignore("checks out without inventory", ShoppingCartFeatureSpec.Slow) {
+        executed = executed :+ "ignored"
+        fail("ignored AnyFeatureSpec scenario was executed")
+      }
+    }
+
+  private object ShoppingCartFeatureSpec:
+    val Fast: Tag = Tag("org.scalatest.featurespec.generated.Fast")
+    val Slow: Tag = Tag("org.scalatest.featurespec.generated.Slow")
+
+  private final class LifecycleFeatureSpec extends AnyFeatureSpec:
+    var executed: Vector[String] = Vector.empty
+
+    Feature("Scenario lifecycle") {
+      Scenario("records ordinary success") {
+        executed = executed :+ "success"
+        assert(List(1, 2, 3).sum == 6)
+      }
+
+      Scenario("documents unfinished behavior") {
+        executed = executed :+ "pending"
+        pending
+      }
+
+      Scenario("cancels unavailable behavior") {
+        executed = executed :+ "canceled"
+        cancel("external dependency intentionally unavailable")
+      }
+    }
+
+  private final class FailingFeatureSpec extends AnyFeatureSpec:
+    Feature("Failing scenario reporting") {
+      Scenario("publishes assertion failures") {
+        assert(1 == 2, "inventory count did not match")
+      }
+    }
+
+  private final class CheckoutNarrativeFeatureSpec extends AnyFeatureSpec with GivenWhenThen:
+    var executed: Vector[String] = Vector.empty
+
+    Feature("Checkout narrative") {
+      Scenario("describes checkout steps") {
+        Given("a cart containing a guide")
+        When("the customer checks out")
+        Then("the order summary contains the guide")
+        info("checkout summary verified")
+        executed = executed :+ "narrative"
+        assert(Vector("guide").mkString(",") == "guide")
+      }
+    }
+
+  private final class TextFixtureFeatureSpec extends FixtureAnyFeatureSpec:
+    type FixtureParam = StringBuilder
+
+    val fixtureNames: CopyOnWriteArrayList[String] = new CopyOnWriteArrayList[String]()
+    val finishedFixtures: CopyOnWriteArrayList[String] = new CopyOnWriteArrayList[String]()
+
+    override protected def withFixture(test: OneArgTest): Outcome =
+      val fixture: StringBuilder = new StringBuilder("feature-spec")
+      fixtureNames.add(test.name)
+      try withFixture(test.toNoArgTest(fixture))
+      finally finishedFixtures.add(fixture.toString())
+
+    Feature("Synchronous fixture scenarios") {
+      Scenario("upper-cases fixture text") { (builder: StringBuilder) =>
+        builder.append("-upper")
+        assert(builder.toString().toUpperCase == "FEATURE-SPEC-UPPER")
+      }
+
+      Scenario("appends to a fresh fixture") { (builder: StringBuilder) =>
+        builder.append("-suffix")
+        assert(builder.toString() == "feature-spec-suffix")
+      }
+
+      ignore("keeps ignored fixture scenarios registered") { (builder: StringBuilder) =>
+        builder.append("-ignored")
+        fail("ignored FixtureAnyFeatureSpec scenario was executed")
+      }
+    }
+
+  private final class AsyncCalculationFeatureSpec extends AsyncFeatureSpec:
+    var executed: Vector[String] = Vector.empty
+
+    Feature("Asynchronous calculations") {
+      Scenario("adds numbers asynchronously") {
+        Future.successful {
+          executed = executed :+ "addition"
+          assert(2 + 3 == 5)
+        }
+      }
+
+      Scenario("recovers expected failed futures") {
+        executed = executed :+ "recovery"
+        recoverToSucceededIf[IllegalArgumentException] {
+          Future.failed(new IllegalArgumentException("invalid async input"))
+        }
+      }
+    }
+
+  private final class AsyncTextFixtureFeatureSpec extends FixtureAsyncFeatureSpec:
+    type FixtureParam = StringBuilder
+
+    val fixtureNames: CopyOnWriteArrayList[String] = new CopyOnWriteArrayList[String]()
+    val observedFixtures: CopyOnWriteArrayList[String] = new CopyOnWriteArrayList[String]()
+
+    override def withFixture(test: OneArgAsyncTest): FutureOutcome =
+      fixtureNames.add(test.name)
+      withFixture(test.toNoArgAsyncTest(new StringBuilder("async-feature-spec")))
+
+    Feature("Asynchronous fixture scenarios") {
+      Scenario("decorates fixture text asynchronously") { (builder: StringBuilder) =>
+        Future.successful {
+          observedFixtures.add(builder.toString())
+          builder.append("-decorated")
+          assert(builder.toString() == "async-feature-spec-decorated")
+        }
+      }
+    }
+
+  private def findTestName(suite: Suite, fragment: String): String =
+    suite.testNames.find(_.contains(fragment)).getOrElse {
+      throw new AssertionError(s"Could not find test name containing '$fragment'")
+    }
+
+  private def runSuite(
+      suite: Suite,
+      filter: Filter = Filter.default,
+      testName: Option[String] = None): RunResult =
+    val reporter: RecordingReporter = new RecordingReporter
+    val completion: AtomicReference[Try[Boolean]] = new AtomicReference[Try[Boolean]]()
+    val completed: CountDownLatch = new CountDownLatch(1)
+    val status = suite.run(testName, Args(reporter = reporter, filter = filter))
+    status.whenCompleted { (result: Try[Boolean]) =>
+      completion.set(result)
+      completed.countDown()
+    }
+
+    assert(completed.await(30, TimeUnit.SECONDS), s"ScalaTest suite ${suite.suiteName} did not complete")
+    RunResult(completion.get().get, reporter.events)
+
+  private def succeededEvents(events: Vector[Event]): Vector[TestSucceeded] =
+    events.collect { case event: TestSucceeded => event }
+
+  private def ignoredEvents(events: Vector[Event]): Vector[TestIgnored] =
+    events.collect { case event: TestIgnored => event }
+
+  private def pendingEvents(events: Vector[Event]): Vector[TestPending] =
+    events.collect { case event: TestPending => event }
+
+  private def canceledEvents(events: Vector[Event]): Vector[TestCanceled] =
+    events.collect { case event: TestCanceled => event }
+
+  private def failedEvents(events: Vector[Event]): Vector[TestFailed] =
+    events.collect { case event: TestFailed => event }
+
+  private def recordedInfoMessages(events: Vector[Event]): Vector[String] =
+    succeededEvents(events).flatMap { (event: TestSucceeded) =>
+      event.recordedEvents.collect { case info: InfoProvided => info.message }.toVector
+    }
+
+  private final class RecordingReporter extends Reporter:
+    private val recordedEvents: CopyOnWriteArrayList[Event] = new CopyOnWriteArrayList[Event]()
+
+    override def apply(event: Event): Unit =
+      recordedEvents.add(event)
+      ()
+
+    def events: Vector[Event] = recordedEvents.asScala.toVector
+
+  private final case class RunResult(succeeded: Boolean, events: Vector[Event])

--- a/tests/src/org.scalatest/scalatest-featurespec_3/3.2.19/src/test/scala/org_scalatest/scalatest_featurespec_3/Scalatest_featurespec_3Test.scala
+++ b/tests/src/org.scalatest/scalatest-featurespec_3/3.2.19/src/test/scala/org_scalatest/scalatest_featurespec_3/Scalatest_featurespec_3Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_scalatest.scalatest_featurespec_3
+
+import org.junit.jupiter.api.Test
+
+class Scalatest_featurespec_3Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/org.scalatest/scalatest-featurespec_3/3.2.19/user-code-filter.json
+++ b/tests/src/org.scalatest/scalatest-featurespec_3/3.2.19/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.scalatest.featurespec.**"
+    }
+  ]
+}

--- a/tests/src/org.scalatest/scalatest-featurespec_3/3.2.19/user-code-filter.json
+++ b/tests/src/org.scalatest/scalatest-featurespec_3/3.2.19/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.scalatest.featurespec.**"
+      "includeClasses" : "org.scalatest.featurespec.**"
+    },
+    {
+      "includeClasses" : "org_scalatest.scalatest_featurespec_3.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #2254

This PR introduces tests and metadata for org.scalatest:scalatest-featurespec_3:3.2.19, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 131618
- Cached input tokens: 1186304
- Output tokens: 16129
- Metadata entries: 43
- Iterations: 4
- Library coverage percentage: 55.43
- Generated lines of code: 336
- Tested library lines of code: 148

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `64d8b4f2f9029a39a16be5f267a0520237778c67`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1268/3412 (37.16%)
- Line: 148/267 (55.43%)
- Method: 153/339 (45.13%)

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
