### PR TITLE
[GenAI] Test fix for software.amazon.awssdk:sdk-core:2.37.0 using gpt-5.5

### DIFF
--- a/metadata/software.amazon.awssdk/sdk-core/2.37.0/reachability-metadata.json
+++ b/metadata/software.amazon.awssdk/sdk-core/2.37.0/reachability-metadata.json
@@ -1,52 +1,46 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "software.amazon.awssdk.core.internal.util.ClassLoaderHelper"
+      "condition" : {
+        "typeReached" : "software.amazon.awssdk.core.internal.util.ClassLoaderHelper"
       },
-      "type": "example.missing.ClassLoaderHelperTarget"
+      "type" : "example.missing.ClassLoaderHelperTarget"
     },
     {
-      "condition": {
-        "typeReached": "software.amazon.awssdk.core.internal.util.ClassLoaderHelper"
+      "condition" : {
+        "typeReached" : "software.amazon.awssdk.core.internal.util.ClassLoaderHelper"
       },
-      "type": "java.lang.Integer"
+      "type" : "java.lang.Integer"
     },
     {
-      "condition": {
-        "typeReached": "software.amazon.awssdk.core.internal.util.ClassLoaderHelper"
+      "condition" : {
+        "typeReached" : "software.amazon.awssdk.core.internal.util.ClassLoaderHelper"
       },
-      "type": "java.lang.StackTraceElement[]"
+      "type" : "java.lang.StackTraceElement[]"
     },
     {
-      "condition": {
-        "typeReached": "software.amazon.awssdk.checksums.internal.ConstructorCache"
+      "condition" : {
+        "typeReached" : "software.amazon.awssdk.checksums.internal.ConstructorCache"
       },
-      "type": "java.util.zip.CRC32C"
+      "type" : "java.util.zip.CRC32C"
     },
     {
-      "condition": {
-        "typeReached": "software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory"
+      "condition" : {
+        "typeReached" : "software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory"
       },
-      "type": "software.amazon.awssdk.core.internal.interceptor.HttpChecksumValidationInterceptor",
-      "methods": [
+      "type" : "software.amazon.awssdk.core.internal.interceptor.HttpChecksumValidationInterceptor",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "software.amazon.awssdk.core.internal.util.ClassLoaderHelper"
+      "condition" : {
+        "typeReached" : "software.amazon.awssdk.core.internal.util.ClassLoaderHelper"
       },
-      "type": "software.amazon.awssdk.core.internal.interceptor.HttpChecksumValidationInterceptor"
-    },
-    {
-      "condition": {
-        "typeReached": "software.amazon.awssdk.core.internal.http.loader.SystemPropertyHttpServiceProvider"
-      },
-      "type": "software_amazon_awssdk.sdk_core.SystemPropertyHttpServiceProviderTest$TestSdkHttpService"
+      "type" : "software.amazon.awssdk.core.internal.interceptor.HttpChecksumValidationInterceptor"
     }
   ]
 }

--- a/metadata/software.amazon.awssdk/sdk-core/2.37.0/reachability-metadata.json
+++ b/metadata/software.amazon.awssdk/sdk-core/2.37.0/reachability-metadata.json
@@ -1,0 +1,52 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "software.amazon.awssdk.core.internal.util.ClassLoaderHelper"
+      },
+      "type": "example.missing.ClassLoaderHelperTarget"
+    },
+    {
+      "condition": {
+        "typeReached": "software.amazon.awssdk.core.internal.util.ClassLoaderHelper"
+      },
+      "type": "java.lang.Integer"
+    },
+    {
+      "condition": {
+        "typeReached": "software.amazon.awssdk.core.internal.util.ClassLoaderHelper"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "software.amazon.awssdk.checksums.internal.ConstructorCache"
+      },
+      "type": "java.util.zip.CRC32C"
+    },
+    {
+      "condition": {
+        "typeReached": "software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory"
+      },
+      "type": "software.amazon.awssdk.core.internal.interceptor.HttpChecksumValidationInterceptor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "software.amazon.awssdk.core.internal.util.ClassLoaderHelper"
+      },
+      "type": "software.amazon.awssdk.core.internal.interceptor.HttpChecksumValidationInterceptor"
+    },
+    {
+      "condition": {
+        "typeReached": "software.amazon.awssdk.core.internal.http.loader.SystemPropertyHttpServiceProvider"
+      },
+      "type": "software_amazon_awssdk.sdk_core.SystemPropertyHttpServiceProviderTest$TestSdkHttpService"
+    }
+  ]
+}

--- a/metadata/software.amazon.awssdk/sdk-core/index.json
+++ b/metadata/software.amazon.awssdk/sdk-core/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.37.0",
+    "tested-versions" : [
+      "2.37.0"
+    ],
+    "allowed-packages" : [
+      "software.amazon.awssdk.core"
+    ]
+  },
+  {
     "metadata-version" : "2.34.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/software/amazon/awssdk/sdk-core/$version$/sdk-core-$version$-sources.jar",
     "repository-url" : "https://github.com/aws/aws-sdk-java-v2",

--- a/metadata/software.amazon.awssdk/sdk-core/index.json
+++ b/metadata/software.amazon.awssdk/sdk-core/index.json
@@ -1,27 +1,28 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "2.37.0",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/software/amazon/awssdk/sdk-core/$version$/sdk-core-$version$-sources.jar",
-    "repository-url" : "https://github.com/aws/aws-sdk-java-v2",
-    "test-code-url" : "https://github.com/aws/aws-sdk-java-v2/tree/$version$/core/sdk-core/src/test",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/software/amazon/awssdk/sdk-core/$version$/sdk-core-$version$-javadoc.jar",
-    "description" : "AWS SDK for Java v2 SDK Core provides runtime classes and shared infrastructure used by AWS service clients to make requests, configure clients, transform payloads, handle responses, retries, pagination, checksums, and exceptions. It is a foundational JVM module for AWS SDK service artifacts rather than a standalone service client.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "2.37.0",
+    "source-code-url": "https://repo.maven.apache.org/maven2/software/amazon/awssdk/sdk-core/$version$/sdk-core-$version$-sources.jar",
+    "repository-url": "https://github.com/aws/aws-sdk-java-v2",
+    "test-code-url": "https://github.com/aws/aws-sdk-java-v2/tree/$version$/core/sdk-core/src/test",
+    "documentation-url": "https://repo.maven.apache.org/maven2/software/amazon/awssdk/sdk-core/$version$/sdk-core-$version$-javadoc.jar",
+    "description": "AWS SDK for Java v2 SDK Core provides runtime classes and shared infrastructure used by AWS service clients to make requests, configure clients, transform payloads, handle responses, retries, pagination, checksums, and exceptions. It is a foundational JVM module for AWS SDK service artifacts rather than a standalone service client.",
+    "tested-versions": [
       "2.37.0"
     ],
-    "allowed-packages" : [
-      "software.amazon.awssdk.core"
+    "allowed-packages": [
+      "software.amazon.awssdk.core",
+      "software.amazon.awssdk.checksums.internal"
     ]
   },
   {
-    "metadata-version" : "2.34.0",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/software/amazon/awssdk/sdk-core/$version$/sdk-core-$version$-sources.jar",
-    "repository-url" : "https://github.com/aws/aws-sdk-java-v2",
-    "test-code-url" : "https://github.com/aws/aws-sdk-java-v2/tree/$version$/core/sdk-core/src/test",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/software/amazon/awssdk/sdk-core/$version$/sdk-core-$version$-javadoc.jar",
-    "description" : "AWS SDK for Java v2 SDK Core provides runtime classes and shared infrastructure used by AWS service clients to make requests, configure clients, transform payloads, handle responses, retries, pagination, checksums, and exceptions. It is a foundational JVM module for AWS SDK service artifacts rather than a standalone service client.",
-    "tested-versions" : [
+    "metadata-version": "2.34.0",
+    "source-code-url": "https://repo.maven.apache.org/maven2/software/amazon/awssdk/sdk-core/$version$/sdk-core-$version$-sources.jar",
+    "repository-url": "https://github.com/aws/aws-sdk-java-v2",
+    "test-code-url": "https://github.com/aws/aws-sdk-java-v2/tree/$version$/core/sdk-core/src/test",
+    "documentation-url": "https://repo.maven.apache.org/maven2/software/amazon/awssdk/sdk-core/$version$/sdk-core-$version$-javadoc.jar",
+    "description": "AWS SDK for Java v2 SDK Core provides runtime classes and shared infrastructure used by AWS service clients to make requests, configure clients, transform payloads, handle responses, retries, pagination, checksums, and exceptions. It is a foundational JVM module for AWS SDK service artifacts rather than a standalone service client.",
+    "tested-versions": [
       "2.34.0",
       "2.34.1",
       "2.34.2",
@@ -49,7 +50,7 @@
       "2.36.2",
       "2.36.3"
     ],
-    "allowed-packages" : [
+    "allowed-packages": [
       "software.amazon.awssdk.core"
     ]
   }

--- a/metadata/software.amazon.awssdk/sdk-core/index.json
+++ b/metadata/software.amazon.awssdk/sdk-core/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.37.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/software/amazon/awssdk/sdk-core/$version$/sdk-core-$version$-sources.jar",
+    "repository-url" : "https://github.com/aws/aws-sdk-java-v2",
+    "test-code-url" : "https://github.com/aws/aws-sdk-java-v2/tree/$version$/core/sdk-core/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/software/amazon/awssdk/sdk-core/$version$/sdk-core-$version$-javadoc.jar",
+    "description" : "AWS SDK for Java v2 SDK Core provides runtime classes and shared infrastructure used by AWS service clients to make requests, configure clients, transform payloads, handle responses, retries, pagination, checksums, and exceptions. It is a foundational JVM module for AWS SDK service artifacts rather than a standalone service client.",
     "tested-versions" : [
       "2.37.0"
     ],

--- a/stats/software.amazon.awssdk/sdk-core/2.37.0/execution-metrics.json
+++ b/stats/software.amazon.awssdk/sdk-core/2.37.0/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_java_run_fail:2026-05-18": {
+    "timestamp": "2026-05-18T08:48:34.436400Z",
+    "library": "software.amazon.awssdk:sdk-core:2.37.0",
+    "starting_commit": "ecb5b32d29d6b52a715207375f0ef130a3833eb1",
+    "ending_commit": "bad6df1cbb28b5417f974f58772ce79e1d04b6eb",
+    "previous_library": "software.amazon.awssdk:sdk-core:2.34.0",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.37.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 6,
+            "totalCalls": 6
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 8,
+        "totalCalls": 8
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1098,
+          "missed": 43190,
+          "ratio": 0.024792,
+          "total": 44288
+        },
+        "line": {
+          "covered": 208,
+          "missed": 10527,
+          "ratio": 0.019376,
+          "total": 10735
+        },
+        "method": {
+          "covered": 55,
+          "missed": 3602,
+          "ratio": 0.01504,
+          "total": 3657
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.34.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 12,
+            "totalCalls": 12
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 14,
+        "totalCalls": 14
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1377,
+          "missed": 59690,
+          "ratio": 0.022549,
+          "total": 61067
+        },
+        "line": {
+          "covered": 257,
+          "missed": 10560,
+          "ratio": 0.023759,
+          "total": 10817
+        },
+        "method": {
+          "covered": 74,
+          "missed": 3640,
+          "ratio": 0.019925,
+          "total": 3714
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 44017,
+      "cached_input_tokens_used": 304640,
+      "output_tokens_used": 5336,
+      "iterations": 1,
+      "cost_usd": 0.3124,
+      "tested_library_loc": 208,
+      "metadata_entries": 7,
+      "test_only_metadata_entries": 2,
+      "previous_library_metadata_entries": 6,
+      "previous_library_test_only_metadata_entries": 12,
+      "code_coverage_percent": 1.94,
+      "previous_library_coverage_percent": 2.38
+    },
+    "artifacts": {
+      "test_file": "tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/java/software/amazon/awssdk/crt/checksums/CRC32C.java",
+      "metadata_file": "metadata/software.amazon.awssdk/sdk-core/2.37.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/software.amazon.awssdk/sdk-core/2.37.0/stats.json
+++ b/stats/software.amazon.awssdk/sdk-core/2.37.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "2.37.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 6,
+          "totalCalls" : 6
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 8,
+      "totalCalls" : 8
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1098,
+        "missed" : 43190,
+        "ratio" : 0.024792,
+        "total" : 44288
+      },
+      "line" : {
+        "covered" : 208,
+        "missed" : 10527,
+        "ratio" : 0.019376,
+        "total" : 10735
+      },
+      "method" : {
+        "covered" : 55,
+        "missed" : 3602,
+        "ratio" : 0.01504,
+        "total" : 3657
+      }
+    }
+  } ]
+}

--- a/tests/src/software.amazon.awssdk/sdk-core/2.37.0/.gitignore
+++ b/tests/src/software.amazon.awssdk/sdk-core/2.37.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/software.amazon.awssdk/sdk-core/2.37.0/build.gradle
+++ b/tests/src/software.amazon.awssdk/sdk-core/2.37.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "software.amazon.awssdk:sdk-core:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/software.amazon.awssdk/sdk-core/2.37.0/gradle.properties
+++ b/tests/src/software.amazon.awssdk/sdk-core/2.37.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = software.amazon.awssdk:sdk-core:2.37.0
+library.version = 2.37.0
+metadata.dir = software.amazon.awssdk/sdk-core/2.37.0/

--- a/tests/src/software.amazon.awssdk/sdk-core/2.37.0/settings.gradle
+++ b/tests/src/software.amazon.awssdk/sdk-core/2.37.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'software.amazon.awssdk.sdk-core_tests'

--- a/tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/java/software/amazon/awssdk/crt/checksums/CRC32.java
+++ b/tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/java/software/amazon/awssdk/crt/checksums/CRC32.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package software.amazon.awssdk.crt.checksums;
+
+import java.util.zip.Checksum;
+
+public class CRC32 implements Checksum, Cloneable {
+    private long value;
+
+    @Override
+    public void update(int b) {
+        value = (value * 33 + (b & 0xFF)) & 0xFFFFFFFFL;
+    }
+
+    @Override
+    public void update(byte[] b, int off, int len) {
+        for (int index = off; index < off + len; index++) {
+            update(b[index]);
+        }
+    }
+
+    @Override
+    public long getValue() {
+        return value;
+    }
+
+    @Override
+    public void reset() {
+        value = 0;
+    }
+
+    @Override
+    public CRC32 clone() {
+        try {
+            return (CRC32) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/java/software/amazon/awssdk/crt/checksums/CRC32C.java
+++ b/tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/java/software/amazon/awssdk/crt/checksums/CRC32C.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package software.amazon.awssdk.crt.checksums;
+
+import java.util.zip.Checksum;
+
+public class CRC32C implements Checksum, Cloneable {
+    private long value;
+
+    @Override
+    public void update(int b) {
+        value = (value * 31 + (b & 0xFF)) & 0xFFFFFFFFL;
+    }
+
+    @Override
+    public void update(byte[] b, int off, int len) {
+        for (int index = off; index < off + len; index++) {
+            update(b[index]);
+        }
+    }
+
+    @Override
+    public long getValue() {
+        return value;
+    }
+
+    @Override
+    public void reset() {
+        value = 0;
+    }
+
+    @Override
+    public CRC32C clone() {
+        try {
+            return (CRC32C) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/java/software_amazon_awssdk/sdk_core/ClassLoaderHelperTest.java
+++ b/tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/java/software_amazon_awssdk/sdk_core/ClassLoaderHelperTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package software_amazon_awssdk.sdk_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.internal.util.ClassLoaderHelper;
+
+public class ClassLoaderHelperTest {
+    @Test
+    void loadClassUsesProvidedClassLoaderBeforeContextLoader() throws Exception {
+        Class<?> loadedClass = ClassLoaderHelper.loadClass(String.class.getName(), true, ClassLoaderHelperTest.class);
+
+        assertThat(loadedClass).isSameAs(String.class);
+    }
+
+    @Test
+    void loadClassUsesThreadContextClassLoaderBeforeProvidedClassLoaders() throws Exception {
+        ClassLoader originalContextClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(ClassLoaderHelperTest.class.getClassLoader());
+        try {
+            Class<?> loadedClass = ClassLoaderHelper.loadClass(Integer.class.getName(), false, (Class<?>[]) null);
+
+            assertThat(loadedClass).isSameAs(Integer.class);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalContextClassLoader);
+        }
+    }
+
+    @Test
+    void loadClassFallsBackToClassForNameAfterTryingOtherLoaders() {
+        String missingClassName = "example.missing.ClassLoaderHelperTarget";
+
+        assertThatThrownBy(() -> ClassLoaderHelper.loadClass(missingClassName, true, (Class<?>[]) null))
+                .isInstanceOf(ClassNotFoundException.class)
+                .hasMessage(missingClassName);
+    }
+}

--- a/tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/java/software_amazon_awssdk/sdk_core/ClasspathInterceptorChainFactoryTest.java
+++ b/tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/java/software_amazon_awssdk/sdk_core/ClasspathInterceptorChainFactoryTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package software_amazon_awssdk.sdk_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.core.internal.interceptor.HttpChecksumValidationInterceptor;
+
+public class ClasspathInterceptorChainFactoryTest {
+    @Test
+    void getInterceptorsLoadsExecutionInterceptorsDeclaredInClasspathResource() {
+        ClasspathInterceptorChainFactory factory = new ClasspathInterceptorChainFactory();
+
+        List<ExecutionInterceptor> interceptors = factory.getInterceptors("sdk-core-test/execution.interceptors");
+
+        assertThat(interceptors)
+                .hasSize(1)
+                .first()
+                .isInstanceOf(HttpChecksumValidationInterceptor.class);
+    }
+}

--- a/tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/java/software_amazon_awssdk/sdk_core/Crc32CChecksumTest.java
+++ b/tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/java/software_amazon_awssdk/sdk_core/Crc32CChecksumTest.java
@@ -9,9 +9,9 @@ package software_amazon_awssdk.sdk_core;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.charset.StandardCharsets;
+import java.util.zip.CRC32C;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.checksums.Crc32CChecksum;
-import software.amazon.awssdk.crt.checksums.CRC32C;
 
 @SuppressWarnings("deprecation")
 public class Crc32CChecksumTest {
@@ -20,7 +20,7 @@ public class Crc32CChecksumTest {
     private static final byte[] REPLACEMENT_SUFFIX = "cat naps".getBytes(StandardCharsets.UTF_8);
 
     @Test
-    void markAndResetCloneTheCrtChecksumState() {
+    void markAndResetRestoreTheDelegatedChecksumState() {
         Crc32CChecksum checksum = new Crc32CChecksum();
         checksum.update(PREFIX, 0, PREFIX.length);
         long markedValue = checksum.getValue();
@@ -37,7 +37,7 @@ public class Crc32CChecksumTest {
         CRC32C expected = new CRC32C();
         expected.update(PREFIX, 0, PREFIX.length);
         expected.update(REPLACEMENT_SUFFIX, 0, REPLACEMENT_SUFFIX.length);
-        assertThat(checksum.getValue()).isEqualTo(expected.getValue());
+        assertThat(checksum.getValue() & 0xFFFF_FFFFL).isEqualTo(expected.getValue());
         assertThat(checksum.getChecksumBytes()).hasSize(Integer.BYTES);
     }
 }

--- a/tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/java/software_amazon_awssdk/sdk_core/Crc32CChecksumTest.java
+++ b/tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/java/software_amazon_awssdk/sdk_core/Crc32CChecksumTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package software_amazon_awssdk.sdk_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.checksums.Crc32CChecksum;
+import software.amazon.awssdk.crt.checksums.CRC32C;
+
+@SuppressWarnings("deprecation")
+public class Crc32CChecksumTest {
+    private static final byte[] PREFIX = "The quick brown ".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] DISCARDED_SUFFIX = "fox jumps over the lazy dog".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] REPLACEMENT_SUFFIX = "cat naps".getBytes(StandardCharsets.UTF_8);
+
+    @Test
+    void markAndResetCloneTheCrtChecksumState() {
+        Crc32CChecksum checksum = new Crc32CChecksum();
+        checksum.update(PREFIX, 0, PREFIX.length);
+        long markedValue = checksum.getValue();
+
+        checksum.mark(Integer.MAX_VALUE);
+        checksum.update(DISCARDED_SUFFIX, 0, DISCARDED_SUFFIX.length);
+        assertThat(checksum.getValue()).isNotEqualTo(markedValue);
+
+        checksum.reset();
+        assertThat(checksum.getValue()).isEqualTo(markedValue);
+
+        checksum.update(REPLACEMENT_SUFFIX, 0, REPLACEMENT_SUFFIX.length);
+
+        CRC32C expected = new CRC32C();
+        expected.update(PREFIX, 0, PREFIX.length);
+        expected.update(REPLACEMENT_SUFFIX, 0, REPLACEMENT_SUFFIX.length);
+        assertThat(checksum.getValue()).isEqualTo(expected.getValue());
+        assertThat(checksum.getChecksumBytes()).hasSize(Integer.BYTES);
+    }
+}

--- a/tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/java/software_amazon_awssdk/sdk_core/Crc32ChecksumTest.java
+++ b/tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/java/software_amazon_awssdk/sdk_core/Crc32ChecksumTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package software_amazon_awssdk.sdk_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.checksums.Crc32Checksum;
+import software.amazon.awssdk.crt.checksums.CRC32;
+
+@SuppressWarnings("deprecation")
+public class Crc32ChecksumTest {
+    private static final byte[] PREFIX = "The quick brown ".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] DISCARDED_SUFFIX = "fox jumps over the lazy dog".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] REPLACEMENT_SUFFIX = "cat naps".getBytes(StandardCharsets.UTF_8);
+
+    @Test
+    void markAndResetCloneTheCrtChecksumState() {
+        Crc32Checksum checksum = new Crc32Checksum();
+        checksum.update(PREFIX, 0, PREFIX.length);
+        long markedValue = checksum.getValue();
+
+        checksum.mark(Integer.MAX_VALUE);
+        checksum.update(DISCARDED_SUFFIX, 0, DISCARDED_SUFFIX.length);
+        assertThat(checksum.getValue()).isNotEqualTo(markedValue);
+
+        checksum.reset();
+        assertThat(checksum.getValue()).isEqualTo(markedValue);
+
+        checksum.update(REPLACEMENT_SUFFIX, 0, REPLACEMENT_SUFFIX.length);
+
+        CRC32 expected = new CRC32();
+        expected.update(PREFIX, 0, PREFIX.length);
+        expected.update(REPLACEMENT_SUFFIX, 0, REPLACEMENT_SUFFIX.length);
+        assertThat(checksum.getValue()).isEqualTo(expected.getValue());
+        assertThat(checksum.getChecksumBytes()).hasSize(Integer.BYTES);
+    }
+}

--- a/tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/java/software_amazon_awssdk/sdk_core/Crc32ChecksumTest.java
+++ b/tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/java/software_amazon_awssdk/sdk_core/Crc32ChecksumTest.java
@@ -9,9 +9,9 @@ package software_amazon_awssdk.sdk_core;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.charset.StandardCharsets;
+import java.util.zip.CRC32;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.checksums.Crc32Checksum;
-import software.amazon.awssdk.crt.checksums.CRC32;
 
 @SuppressWarnings("deprecation")
 public class Crc32ChecksumTest {
@@ -20,7 +20,7 @@ public class Crc32ChecksumTest {
     private static final byte[] REPLACEMENT_SUFFIX = "cat naps".getBytes(StandardCharsets.UTF_8);
 
     @Test
-    void markAndResetCloneTheCrtChecksumState() {
+    void markAndResetRestoreTheDelegatedChecksumState() {
         Crc32Checksum checksum = new Crc32Checksum();
         checksum.update(PREFIX, 0, PREFIX.length);
         long markedValue = checksum.getValue();

--- a/tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/java/software_amazon_awssdk/sdk_core/MimetypeTest.java
+++ b/tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/java/software_amazon_awssdk/sdk_core/MimetypeTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package software_amazon_awssdk.sdk_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.internal.util.Mimetype;
+
+public class MimetypeTest {
+    @Test
+    void getInstanceInitializesClasspathBackedMimetypeRegistry() {
+        Mimetype mimetype = Mimetype.getInstance();
+
+        assertThat(mimetype).isSameAs(Mimetype.getInstance());
+        assertThat(mimetype.getMimetype(Path.of("payload.unknown-extension")))
+                .isEqualTo(Mimetype.MIMETYPE_OCTET_STREAM);
+    }
+}

--- a/tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/java/software_amazon_awssdk/sdk_core/SystemPropertyHttpServiceProviderTest.java
+++ b/tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/java/software_amazon_awssdk/sdk_core/SystemPropertyHttpServiceProviderTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package software_amazon_awssdk.sdk_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.core.internal.http.loader.DefaultSdkHttpClientBuilder;
+import software.amazon.awssdk.http.ExecutableHttpRequest;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpService;
+import software.amazon.awssdk.utils.AttributeMap;
+
+public class SystemPropertyHttpServiceProviderTest {
+    @Test
+    void defaultSyncClientBuilderInstantiatesClassNamedBySystemProperty() {
+        String property = SdkSystemSetting.SYNC_HTTP_SERVICE_IMPL.property();
+        String previousValue = System.getProperty(property);
+        System.setProperty(property, TestSdkHttpService.class.getName());
+        try (SdkHttpClient client = new DefaultSdkHttpClientBuilder().buildWithDefaults(AttributeMap.empty())) {
+            assertThat(client).isInstanceOf(TestSdkHttpClient.class);
+        } finally {
+            restoreProperty(property, previousValue);
+        }
+    }
+
+    public static final class TestSdkHttpService implements SdkHttpService {
+        @Override
+        public SdkHttpClient.Builder<?> createHttpClientBuilder() {
+            return new TestSdkHttpClientBuilder();
+        }
+    }
+
+    public static final class TestSdkHttpClientBuilder implements SdkHttpClient.Builder<TestSdkHttpClientBuilder> {
+        @Override
+        public SdkHttpClient buildWithDefaults(AttributeMap serviceDefaults) {
+            return new TestSdkHttpClient();
+        }
+    }
+
+    public static final class TestSdkHttpClient implements SdkHttpClient {
+        @Override
+        public ExecutableHttpRequest prepareRequest(HttpExecuteRequest request) {
+            throw new UnsupportedOperationException("Requests are not executed by this test client");
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    private static void restoreProperty(String property, String previousValue) {
+        if (previousValue == null) {
+            System.clearProperty(property);
+        } else {
+            System.setProperty(property, previousValue);
+        }
+    }
+}

--- a/tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,78 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "software.amazon.awssdk.core.checksums.Crc32Checksum"
+      },
+      "type" : "software.amazon.awssdk.crt.checksums.CRC32",
+      "methods" : [
+        {
+          "name" : "clone",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "software.amazon.awssdk.core.internal.checksums.factory.CrtBasedChecksumProvider"
+      },
+      "type" : "software.amazon.awssdk.crt.checksums.CRC32",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "software.amazon.awssdk.core.internal.util.ClassLoaderHelper"
+      },
+      "type" : "software.amazon.awssdk.crt.checksums.CRC32"
+    },
+    {
+      "condition" : {
+        "typeReached" : "software.amazon.awssdk.core.checksums.Crc32CChecksum"
+      },
+      "type" : "software.amazon.awssdk.crt.checksums.CRC32C",
+      "methods" : [
+        {
+          "name" : "clone",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "software.amazon.awssdk.core.internal.checksums.factory.CrtBasedChecksumProvider"
+      },
+      "type" : "software.amazon.awssdk.crt.checksums.CRC32C",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "software.amazon.awssdk.core.internal.util.ClassLoaderHelper"
+      },
+      "type" : "software.amazon.awssdk.crt.checksums.CRC32C"
+    },
+    {
+      "condition" : {
+        "typeReached" : "software.amazon.awssdk.core.internal.http.loader.SystemPropertyHttpServiceProvider"
+      },
+      "type" : "software_amazon_awssdk.sdk_core.SystemPropertyHttpServiceProviderTest$TestSdkHttpService"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory"
+      },
+      "glob" : "sdk-core-test/execution.interceptors"
+    }
+  ]
+}

--- a/tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -2,66 +2,6 @@
   "reflection" : [
     {
       "condition" : {
-        "typeReached" : "software.amazon.awssdk.core.checksums.Crc32Checksum"
-      },
-      "type" : "software.amazon.awssdk.crt.checksums.CRC32",
-      "methods" : [
-        {
-          "name" : "clone",
-          "parameterTypes" : [ ]
-        }
-      ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "software.amazon.awssdk.core.internal.checksums.factory.CrtBasedChecksumProvider"
-      },
-      "type" : "software.amazon.awssdk.crt.checksums.CRC32",
-      "methods" : [
-        {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
-        }
-      ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "software.amazon.awssdk.core.internal.util.ClassLoaderHelper"
-      },
-      "type" : "software.amazon.awssdk.crt.checksums.CRC32"
-    },
-    {
-      "condition" : {
-        "typeReached" : "software.amazon.awssdk.core.checksums.Crc32CChecksum"
-      },
-      "type" : "software.amazon.awssdk.crt.checksums.CRC32C",
-      "methods" : [
-        {
-          "name" : "clone",
-          "parameterTypes" : [ ]
-        }
-      ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "software.amazon.awssdk.core.internal.checksums.factory.CrtBasedChecksumProvider"
-      },
-      "type" : "software.amazon.awssdk.crt.checksums.CRC32C",
-      "methods" : [
-        {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
-        }
-      ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "software.amazon.awssdk.core.internal.util.ClassLoaderHelper"
-      },
-      "type" : "software.amazon.awssdk.crt.checksums.CRC32C"
-    },
-    {
-      "condition" : {
         "typeReached" : "software.amazon.awssdk.core.internal.http.loader.SystemPropertyHttpServiceProvider"
       },
       "type" : "software_amazon_awssdk.sdk_core.SystemPropertyHttpServiceProviderTest$TestSdkHttpService"

--- a/tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/resources/sdk-core-test/execution.interceptors
+++ b/tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/resources/sdk-core-test/execution.interceptors
@@ -1,0 +1,1 @@
+software.amazon.awssdk.core.internal.interceptor.HttpChecksumValidationInterceptor

--- a/tests/src/software.amazon.awssdk/sdk-core/2.37.0/user-code-filter.json
+++ b/tests/src/software.amazon.awssdk/sdk-core/2.37.0/user-code-filter.json
@@ -1,0 +1,16 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "software.amazon.awssdk.core.**"
+    },
+    {
+      "includeClasses" : "software.amazon.awssdk.crt.checksums.**"
+    },
+    {
+      "includeClasses" : "software_amazon_awssdk.sdk_core.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6976

This PR provides test fixes and new metadata for software.amazon.awssdk:sdk-core:2.37.0, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 44017
- Cached input tokens: 304640
- Output tokens: 5336
- Metadata entries: 7
- Test-only metadata entries: 2
- Iterations: 1
- Library coverage percentage: 1.94
- Previous library version metadata entries: 6
- Previous library version test-only metadata entries: 12
- Previous library version coverage percentage: 2.38

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `32f80823be833d851d1451bee542d4d1f4a0cdb1`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- software.amazon.awssdk:sdk-core:2.34.0: 14/14 covered calls (100.00%)
- software.amazon.awssdk:sdk-core:2.37.0: 8/8 covered calls (100.00%)

**Reflection:**
- software.amazon.awssdk:sdk-core:2.34.0: 12/12 covered calls (100.00%)
- software.amazon.awssdk:sdk-core:2.37.0: 6/6 covered calls (100.00%)

**Resources:**
- software.amazon.awssdk:sdk-core:2.34.0: 2/2 covered calls (100.00%)
- software.amazon.awssdk:sdk-core:2.37.0: 2/2 covered calls (100.00%)

#### Library coverage

**Instruction:**
- software.amazon.awssdk:sdk-core:2.34.0: 1377/61067 (2.25%)
- software.amazon.awssdk:sdk-core:2.37.0: 1098/44288 (2.48%)

**Line:**
- software.amazon.awssdk:sdk-core:2.34.0: 257/10817 (2.38%)
- software.amazon.awssdk:sdk-core:2.37.0: 208/10735 (1.94%)

**Method:**
- software.amazon.awssdk:sdk-core:2.34.0: 74/3714 (1.99%)
- software.amazon.awssdk:sdk-core:2.37.0: 55/3657 (1.50%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/software.amazon.awssdk/sdk-core/2.34.0/src/test/java/software_amazon_awssdk/sdk_core/Crc32CChecksumTest.java 2/tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/java/software_amazon_awssdk/sdk_core/Crc32CChecksumTest.java
index 71dcf13378..751a403e9c 100644
--- 1/tests/src/software.amazon.awssdk/sdk-core/2.34.0/src/test/java/software_amazon_awssdk/sdk_core/Crc32CChecksumTest.java
+++ 2/tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/java/software_amazon_awssdk/sdk_core/Crc32CChecksumTest.java
@@ -9,9 +9,9 @@ package software_amazon_awssdk.sdk_core;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.charset.StandardCharsets;
+import java.util.zip.CRC32C;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.checksums.Crc32CChecksum;
-import software.amazon.awssdk.crt.checksums.CRC32C;
 
 @SuppressWarnings("deprecation")
 public class Crc32CChecksumTest {
@@ -20,7 +20,7 @@ public class Crc32CChecksumTest {
     private static final byte[] REPLACEMENT_SUFFIX = "cat naps".getBytes(StandardCharsets.UTF_8);
 
     @Test
-    void markAndResetCloneTheCrtChecksumState() {
+    void markAndResetRestoreTheDelegatedChecksumState() {
         Crc32CChecksum checksum = new Crc32CChecksum();
         checksum.update(PREFIX, 0, PREFIX.length);
         long markedValue = checksum.getValue();
@@ -37,7 +37,7 @@ public class Crc32CChecksumTest {
         CRC32C expected = new CRC32C();
         expected.update(PREFIX, 0, PREFIX.length);
         expected.update(REPLACEMENT_SUFFIX, 0, REPLACEMENT_SUFFIX.length);
-        assertThat(checksum.getValue()).isEqualTo(expected.getValue());
+        assertThat(checksum.getValue() & 0xFFFF_FFFFL).isEqualTo(expected.getValue());
         assertThat(checksum.getChecksumBytes()).hasSize(Integer.BYTES);
     }
 }
diff --git 1/tests/src/software.amazon.awssdk/sdk-core/2.34.0/src/test/java/software_amazon_awssdk/sdk_core/Crc32ChecksumTest.java 2/tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/java/software_amazon_awssdk/sdk_core/Crc32ChecksumTest.java
index fa624a4406..c2af105aa8 100644
--- 1/tests/src/software.amazon.awssdk/sdk-core/2.34.0/src/test/java/software_amazon_awssdk/sdk_core/Crc32ChecksumTest.java
+++ 2/tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/java/software_amazon_awssdk/sdk_core/Crc32ChecksumTest.java
@@ -9,9 +9,9 @@ package software_amazon_awssdk.sdk_core;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.charset.StandardCharsets;
+import java.util.zip.CRC32;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.checksums.Crc32Checksum;
-import software.amazon.awssdk.crt.checksums.CRC32;
 
 @SuppressWarnings("deprecation")
 public class Crc32ChecksumTest {
@@ -20,7 +20,7 @@ public class Crc32ChecksumTest {
     private static final byte[] REPLACEMENT_SUFFIX = "cat naps".getBytes(StandardCharsets.UTF_8);
 
     @Test
-    void markAndResetCloneTheCrtChecksumState() {
+    void markAndResetRestoreTheDelegatedChecksumState() {
         Crc32Checksum checksum = new Crc32Checksum();
         checksum.update(PREFIX, 0, PREFIX.length);
         long markedValue = checksum.getValue();

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
