### PR TITLE
[GenAI] Test fix for velocity:velocity:1.5 using gpt-5.5

### DIFF
--- a/metadata/velocity/velocity/1.5/reachability-metadata.json
+++ b/metadata/velocity/velocity/1.5/reachability-metadata.json
@@ -1,0 +1,185 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "type" : "org.apache.velocity.runtime.ParserPoolImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "type" : "org.apache.velocity.runtime.directive.Foreach",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "type" : "org.apache.velocity.runtime.directive.Include",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "type" : "org.apache.velocity.runtime.directive.Literal",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "type" : "org.apache.velocity.runtime.directive.Macro",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "type" : "org.apache.velocity.runtime.directive.Parse",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "type" : "org.apache.velocity.runtime.log.NullLogChute",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "type" : "org.apache.velocity.runtime.resource.ResourceCacheImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "type" : "org.apache.velocity.runtime.resource.ResourceManagerImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "type" : "org.apache.velocity.runtime.resource.loader.FileResourceLoader",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.test.IntrospectorTestCase2"
+      },
+      "type" : "org.apache.velocity.test.IntrospectorTestCase2",
+      "fields" : [
+        {
+          "name" : "class$org$apache$velocity$test$IntrospectorTestCase2$Tester"
+        },
+        {
+          "name" : "class$org$apache$velocity$test$IntrospectorTestCase2$Tester2"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.test.IntrospectorTestCase2"
+      },
+      "type" : "org.apache.velocity.test.IntrospectorTestCase2$Tester",
+      "methods" : [
+        {
+          "name" : "find",
+          "parameterTypes" : [
+            "org.apache.velocity.test.IntrospectorTestCase2$Bar",
+            "org.apache.velocity.test.IntrospectorTestCase2$Bar"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.test.IntrospectorTestCase2"
+      },
+      "type" : "org.apache.velocity.test.IntrospectorTestCase2$Tester2"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "type" : "org.apache.velocity.util.introspection.UberspectImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "glob" : "org/apache/velocity/runtime/defaults/directive.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.velocity.runtime.RuntimeInstance"
+      },
+      "glob" : "org/apache/velocity/runtime/defaults/velocity.properties"
+    }
+  ]
+}

--- a/metadata/velocity/velocity/index.json
+++ b/metadata/velocity/velocity/index.json
@@ -13,5 +13,14 @@
     "allowed-packages" : [
       "org.apache.velocity"
     ]
+  },
+  {
+    "metadata-version" : "1.5",
+    "tested-versions" : [
+      "1.5"
+    ],
+    "allowed-packages" : [
+      "org.apache.velocity"
+    ]
   }
 ]

--- a/stats/velocity/velocity/1.5/execution-metrics.json
+++ b/stats/velocity/velocity/1.5/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_javac_fail:2026-05-18": {
+    "timestamp": "2026-05-18T09:21:46.198654Z",
+    "library": "velocity:velocity:1.5",
+    "starting_commit": "0064f120b420ffb82152518da342d9f4d6ca0728",
+    "ending_commit": "bbcd506893a920e1c86d7dfbae78c68cadec3eaf",
+    "previous_library": "velocity:velocity:1.4",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.5",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.794118,
+            "coveredCalls": 27,
+            "totalCalls": 34
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 7,
+            "totalCalls": 7
+          }
+        },
+        "coverageRatio": 0.829268,
+        "coveredCalls": 34,
+        "totalCalls": 41
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 12785,
+          "missed": 38302,
+          "ratio": 0.250259,
+          "total": 51087
+        },
+        "line": {
+          "covered": 2632,
+          "missed": 8313,
+          "ratio": 0.240475,
+          "total": 10945
+        },
+        "method": {
+          "covered": 482,
+          "missed": 1307,
+          "ratio": 0.269424,
+          "total": 1789
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.4",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.882353,
+            "coveredCalls": 45,
+            "totalCalls": 51
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 5,
+            "totalCalls": 5
+          }
+        },
+        "coverageRatio": 0.892857,
+        "coveredCalls": 50,
+        "totalCalls": 56
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 10904,
+          "missed": 39681,
+          "ratio": 0.215558,
+          "total": 50585
+        },
+        "line": {
+          "covered": 2243,
+          "missed": 8060,
+          "ratio": 0.217704,
+          "total": 10303
+        },
+        "method": {
+          "covered": 416,
+          "missed": 1271,
+          "ratio": 0.246592,
+          "total": 1687
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 527886,
+      "cached_input_tokens_used": 5379584,
+      "output_tokens_used": 49418,
+      "iterations": 17,
+      "cost_usd": 4.1723,
+      "tested_library_loc": 2632,
+      "metadata_entries": 30,
+      "test_only_metadata_entries": 78,
+      "previous_library_metadata_entries": 26,
+      "previous_library_test_only_metadata_entries": 58,
+      "code_coverage_percent": 24.05,
+      "previous_library_coverage_percent": 21.77
+    },
+    "artifacts": {
+      "test_file": "tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/UberspectImplTest.java",
+      "metadata_file": "metadata/velocity/velocity/1.5/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/velocity/velocity/1.5/stats.json
+++ b/stats/velocity/velocity/1.5/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "1.5",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.794118,
+          "coveredCalls" : 27,
+          "totalCalls" : 34
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 7,
+          "totalCalls" : 7
+        }
+      },
+      "coverageRatio" : 0.829268,
+      "coveredCalls" : 34,
+      "totalCalls" : 41
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 12785,
+        "missed" : 38302,
+        "ratio" : 0.250259,
+        "total" : 51087
+      },
+      "line" : {
+        "covered" : 2632,
+        "missed" : 8313,
+        "ratio" : 0.240475,
+        "total" : 10945
+      },
+      "method" : {
+        "covered" : 482,
+        "missed" : 1307,
+        "ratio" : 0.269424,
+        "total" : 1789
+      }
+    }
+  } ]
+}

--- a/tests/src/velocity/velocity/1.5/.gitignore
+++ b/tests/src/velocity/velocity/1.5/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/velocity/velocity/1.5/build.gradle
+++ b/tests/src/velocity/velocity/1.5/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "velocity:velocity:$libraryVersion"
+    testImplementation 'jdom:jdom:1.0'
     testImplementation 'junit:junit:3.8.2'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }

--- a/tests/src/velocity/velocity/1.5/build.gradle
+++ b/tests/src/velocity/velocity/1.5/build.gradle
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "velocity:velocity:$libraryVersion"
+    testImplementation 'junit:junit:3.8.2'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/velocity/velocity/1.5/gradle.properties
+++ b/tests/src/velocity/velocity/1.5/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = velocity:velocity:1.5
+library.version = 1.5
+metadata.dir = velocity/velocity/1.5/

--- a/tests/src/velocity/velocity/1.5/settings.gradle
+++ b/tests/src/velocity/velocity/1.5/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'velocity.velocity_tests'

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ASTDirectiveTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ASTDirectiveTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.StringWriter;
+import java.util.Arrays;
+
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.app.VelocityEngine;
+import org.apache.velocity.runtime.RuntimeConstants;
+import org.apache.velocity.runtime.log.NullLogSystem;
+import org.junit.jupiter.api.Test;
+
+public class ASTDirectiveTest {
+    @Test
+    public void instantiatesRegisteredDirectiveWhenInitializingParsedTemplate() throws Exception {
+        VelocityEngine velocityEngine = new VelocityEngine();
+        velocityEngine.setProperty(RuntimeConstants.RUNTIME_LOG_LOGSYSTEM, new NullLogSystem());
+        velocityEngine.init();
+
+        VelocityContext context = new VelocityContext();
+        context.put("items", Arrays.asList("alpha", "beta", "gamma"));
+
+        StringWriter writer = new StringWriter();
+        boolean evaluated = velocityEngine.evaluate(
+                context,
+                writer,
+                "ASTDirectiveTest",
+                "#foreach($item in $items)$item;#end");
+
+        assertThat(evaluated).isTrue();
+        assertThat(writer).hasToString("alpha;beta;gamma;");
+    }
+}

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ASTDirectiveTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ASTDirectiveTest.java
@@ -10,19 +10,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.StringWriter;
 import java.util.Arrays;
+import java.util.Properties;
 
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
 import org.apache.velocity.runtime.RuntimeConstants;
-import org.apache.velocity.runtime.log.NullLogSystem;
+import org.apache.velocity.runtime.log.NullLogChute;
 import org.junit.jupiter.api.Test;
 
 public class ASTDirectiveTest {
     @Test
     public void instantiatesRegisteredDirectiveWhenInitializingParsedTemplate() throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty(RuntimeConstants.RUNTIME_LOG_LOGSYSTEM_CLASS, NullLogChute.class.getName());
         VelocityEngine velocityEngine = new VelocityEngine();
-        velocityEngine.setProperty(RuntimeConstants.RUNTIME_LOG_LOGSYSTEM, new NullLogSystem());
-        velocityEngine.init();
+        velocityEngine.init(properties);
 
         VelocityContext context = new VelocityContext();
         context.put("items", Arrays.asList("alpha", "beta", "gamma"));

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ClassMapInnerMethodInfoTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ClassMapInnerMethodInfoTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+
+import org.apache.velocity.util.introspection.ClassMap;
+import org.junit.jupiter.api.Test;
+
+public class ClassMapInnerMethodInfoTest {
+    @Test
+    void upcastsNonPublicImplementationMethodToPublicInterfaceMethod() throws Exception {
+        final ClassMap classMap = new ClassMap(HiddenLabeler.class);
+
+        final Method method = classMap.findMethod("label", new Object[] {Integer.valueOf(7)});
+
+        assertThat(method).isNotNull();
+        assertThat(method.getDeclaringClass()).isEqualTo(Labeler.class);
+        assertThat(method.getName()).isEqualTo("label");
+    }
+
+    public interface Labeler {
+        String label(Integer value);
+    }
+
+    private static final class HiddenLabeler implements Labeler {
+        @Override
+        public String label(final Integer value) {
+            return "value=" + value;
+        }
+    }
+}

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ClassMapInnerMethodInfoTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ClassMapInnerMethodInfoTest.java
@@ -10,13 +10,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.reflect.Method;
 
+import org.apache.velocity.runtime.log.Log;
+import org.apache.velocity.runtime.log.NullLogChute;
 import org.apache.velocity.util.introspection.ClassMap;
 import org.junit.jupiter.api.Test;
 
 public class ClassMapInnerMethodInfoTest {
     @Test
     void upcastsNonPublicImplementationMethodToPublicInterfaceMethod() throws Exception {
-        final ClassMap classMap = new ClassMap(HiddenLabeler.class);
+        final ClassMap classMap = new ClassMap(HiddenLabeler.class, new Log(new NullLogChute()));
 
         final Method method = classMap.findMethod("label", new Object[] {Integer.valueOf(7)});
 

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ClassMapTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ClassMapTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+
+import org.apache.velocity.util.introspection.ClassMap;
+import org.junit.jupiter.api.Test;
+
+public class ClassMapTest {
+    @Test
+    void resolvesPublicInterfaceMethodForNonPublicImplementationMethod() throws Exception {
+        final Method implementationMethod = HiddenGreetingService.class.getMethod("greet", String.class);
+
+        final Method publicMethod = ClassMap.getPublicMethod(implementationMethod);
+
+        assertThat(publicMethod).isNotNull();
+        assertThat(publicMethod.getDeclaringClass()).isEqualTo(GreetingService.class);
+        assertThat(publicMethod.invoke(new HiddenGreetingService(), "Ada")).isEqualTo("Hello Ada");
+    }
+
+    public interface GreetingService {
+        String greet(String name);
+    }
+
+    private static final class HiddenGreetingService implements GreetingService {
+        @Override
+        public String greet(final String name) {
+            return "Hello " + name;
+        }
+    }
+}

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ClassMapTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ClassMapTest.java
@@ -10,15 +10,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.reflect.Method;
 
+import org.apache.velocity.runtime.log.Log;
+import org.apache.velocity.runtime.log.NullLogChute;
 import org.apache.velocity.util.introspection.ClassMap;
 import org.junit.jupiter.api.Test;
 
 public class ClassMapTest {
     @Test
     void resolvesPublicInterfaceMethodForNonPublicImplementationMethod() throws Exception {
-        final Method implementationMethod = HiddenGreetingService.class.getMethod("greet", String.class);
+        final ClassMap classMap = new ClassMap(HiddenGreetingService.class, new Log(new NullLogChute()));
 
-        final Method publicMethod = ClassMap.getPublicMethod(implementationMethod);
+        final Method publicMethod = classMap.findMethod("greet", new Object[] {"Ada"});
 
         assertThat(publicMethod).isNotNull();
         assertThat(publicMethod.getDeclaringClass()).isEqualTo(GreetingService.class);

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ClassUtilsTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ClassUtilsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.velocity.util.ClassUtils;
+import org.junit.jupiter.api.Test;
+
+public class ClassUtilsTest {
+    private static final String RESOURCE_PATH = "velocity/velocity/classutils-resource.txt";
+
+    @Test
+    public void resolvesClassWithSystemLoaderWhenThreadContextClassLoaderIsUnavailable() throws Exception {
+        withContextClassLoader(null, () -> {
+            Class<?> resolvedClass = ClassUtils.getClass(String.class.getName());
+
+            assertThat(resolvedClass).isSameAs(String.class);
+        });
+    }
+
+    @Test
+    public void readsResourceWithClassLoaderWhenThreadContextClassLoaderIsUnavailable() throws Exception {
+        withContextClassLoader(null, () -> {
+            try (InputStream resource = ClassUtils.getResourceAsStream(ClassUtilsTest.class, RESOURCE_PATH)) {
+                assertResourceContent(resource);
+            }
+        });
+    }
+
+    @Test
+    public void fallsBackToClassLoaderWhenThreadContextClassLoaderCannotFindResource() throws Exception {
+        try (URLClassLoader emptyClassLoader = new URLClassLoader(new URL[0], null)) {
+            withContextClassLoader(emptyClassLoader, () -> {
+                try (InputStream resource = ClassUtils.getResourceAsStream(ClassUtilsTest.class, RESOURCE_PATH)) {
+                    assertResourceContent(resource);
+                }
+            });
+        }
+    }
+
+    private static void assertResourceContent(InputStream resource) throws Exception {
+        assertThat(resource).isNotNull();
+        assertThat(new String(resource.readAllBytes(), StandardCharsets.UTF_8)).contains("classutils-resource");
+    }
+
+    private static void withContextClassLoader(ClassLoader classLoader, ThrowingRunnable runnable) throws Exception {
+        Thread currentThread = Thread.currentThread();
+        ClassLoader originalClassLoader = currentThread.getContextClassLoader();
+        currentThread.setContextClassLoader(classLoader);
+        try {
+            runnable.run();
+        } finally {
+            currentThread.setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    private interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+}

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ClassloaderChangeTestTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ClassloaderChangeTestTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+
+import org.apache.velocity.test.ClassloaderChangeTest;
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+
+public class ClassloaderChangeTestTest {
+    private static final byte[] FOO_CLASS_BYTES = Base64.getDecoder().decode("""
+            yv66vgAAADQAEQoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+AQADKClWCAAIAQAOSGVs
+            bG8gRnJvbSBGb28HAAoBAANGb28BAARDb2RlAQAPTGluZU51bWJlclRhYmxlAQAEZG9JdAEAFCgpTGphdmEvbGFu
+            Zy9TdHJpbmc7AQAKU291cmNlRmlsZQEACEZvby5qYXZhACEACQACAAAAAAACAAEABQAGAAEACwAAAB0AAQABAAAA
+            BSq3AAGxAAAAAQAMAAAABgABAAAAAQABAA0ADgABAAsAAAAbAAEAAQAAAAMSB7AAAAABAAwAAAAGAAEAAAADAAEA
+            DwAAAAIAEA==
+            """.replaceAll("\\s", ""));
+
+    @Test
+    public void reloadsFooClassAndFlushesVelocityIntrospectionCache() throws Exception {
+        writeFooClassFileExpectedByUpstreamTest();
+
+        try {
+            ClassloaderChangeTest test = new ClassloaderChangeTest();
+            test.runTest();
+        } catch (Error error) {
+            if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                throw error;
+            }
+        }
+    }
+
+    private static void writeFooClassFileExpectedByUpstreamTest() throws IOException {
+        Path classFile = Path.of("..", "test", "classloader", "Foo.class");
+        Files.createDirectories(classFile.getParent());
+        Files.write(classFile, FOO_CLASS_BYTES);
+    }
+}

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ClassloaderChangeTestTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ClassloaderChangeTestTest.java
@@ -34,8 +34,13 @@ public class ClassloaderChangeTestTest {
             assertThat(invokeDoIt(introspector, loadFooClass())).isEqualTo("Hello From Foo");
             introspector.triggerClear();
             assertThat(invokeDoIt(introspector, loadFooClass())).isEqualTo("Hello From Foo");
+        } catch (ClassNotFoundException exception) {
+            if (!isUnsupportedNativeImageDynamicClassLoading(exception)) {
+                throw exception;
+            }
         } catch (Error error) {
-            if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+            if (!NativeImageSupport.isUnsupportedFeatureError(error)
+                    && !isUnsupportedNativeImageDynamicClassLoading(error)) {
                 throw error;
             }
         }
@@ -49,6 +54,22 @@ public class ClassloaderChangeTestTest {
         final Method method = introspector.getMethod(fooClass, "doIt", new Object[0]);
         final Object instance = fooClass.getDeclaredConstructor().newInstance();
         return method.invoke(instance);
+    }
+
+    private static boolean isUnsupportedNativeImageDynamicClassLoading(final Throwable throwable) {
+        if (!"runtime".equals(System.getProperty("org.graalvm.nativeimage.imagecode"))) {
+            return false;
+        }
+
+        Throwable current = throwable;
+        while (current != null) {
+            if ((current instanceof ClassNotFoundException || current instanceof NoClassDefFoundError)
+                    && "Foo".equals(current.getMessage())) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
     }
 
     private static final class ByteArrayClassLoader extends ClassLoader {

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ClassloaderChangeTestTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ClassloaderChangeTestTest.java
@@ -6,12 +6,14 @@
  */
 package velocity.velocity;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
 import java.util.Base64;
 
-import org.apache.velocity.test.ClassloaderChangeTest;
+import org.apache.velocity.runtime.log.Log;
+import org.apache.velocity.runtime.log.NullLogChute;
+import org.apache.velocity.util.introspection.Introspector;
 import org.graalvm.internal.tck.NativeImageSupport;
 import org.junit.jupiter.api.Test;
 
@@ -25,12 +27,13 @@ public class ClassloaderChangeTestTest {
             """.replaceAll("\\s", ""));
 
     @Test
-    public void reloadsFooClassAndFlushesVelocityIntrospectionCache() throws Exception {
-        writeFooClassFileExpectedByUpstreamTest();
-
+    public void clearsIntrospectionCacheAfterClassLoaderChange() throws Exception {
         try {
-            ClassloaderChangeTest test = new ClassloaderChangeTest();
-            test.runTest();
+            final Introspector introspector = new Introspector(new Log(new NullLogChute()));
+
+            assertThat(invokeDoIt(introspector, loadFooClass())).isEqualTo("Hello From Foo");
+            introspector.triggerClear();
+            assertThat(invokeDoIt(introspector, loadFooClass())).isEqualTo("Hello From Foo");
         } catch (Error error) {
             if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
                 throw error;
@@ -38,9 +41,23 @@ public class ClassloaderChangeTestTest {
         }
     }
 
-    private static void writeFooClassFileExpectedByUpstreamTest() throws IOException {
-        Path classFile = Path.of("..", "test", "classloader", "Foo.class");
-        Files.createDirectories(classFile.getParent());
-        Files.write(classFile, FOO_CLASS_BYTES);
+    private static Class<?> loadFooClass() throws ClassNotFoundException {
+        return new ByteArrayClassLoader().loadClass("Foo");
+    }
+
+    private static Object invokeDoIt(final Introspector introspector, final Class<?> fooClass) throws Exception {
+        final Method method = introspector.getMethod(fooClass, "doIt", new Object[0]);
+        final Object instance = fooClass.getDeclaredConstructor().newInstance();
+        return method.invoke(instance);
+    }
+
+    private static final class ByteArrayClassLoader extends ClassLoader {
+        @Override
+        protected Class<?> findClass(final String name) throws ClassNotFoundException {
+            if ("Foo".equals(name)) {
+                return defineClass(name, FOO_CLASS_BYTES, 0, FOO_CLASS_BYTES.length);
+            }
+            throw new ClassNotFoundException(name);
+        }
     }
 }

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ClasspathResourceLoaderTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ClasspathResourceLoaderTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
+import org.junit.jupiter.api.Test;
+
+public class ClasspathResourceLoaderTest {
+    private static final String TEMPLATE_RESOURCE = "velocity/velocity/classpath-resource-loader-template.vm";
+
+    @Test
+    public void loadsTemplateResourceFromClasspath() throws Exception {
+        ClasspathResourceLoader loader = new ClasspathResourceLoader();
+
+        try (InputStream stream = loader.getResourceStream(TEMPLATE_RESOURCE)) {
+            assertThat(stream).isNotNull();
+            String template = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+            assertThat(template).contains("Loaded through ClasspathResourceLoader");
+        }
+    }
+}

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ExceptionUtilsTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ExceptionUtilsTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+
+import org.apache.velocity.util.ExceptionUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ExceptionUtilsTest {
+    @BeforeEach
+    public void enableCauseSupport() throws Exception {
+        setCausesAllowed(true);
+    }
+
+    @AfterEach
+    public void restoreCauseSupport() throws Exception {
+        setCausesAllowed(true);
+    }
+
+    @Test
+    public void createsThrowablesUsingModernAndLegacyCausePaths() {
+        IllegalArgumentException cause = new IllegalArgumentException("bad input");
+
+        RuntimeException runtimeException = ExceptionUtils.createRuntimeException(
+                "runtime failure", cause);
+        assertThat(runtimeException)
+                .isExactlyInstanceOf(RuntimeException.class)
+                .hasMessage("runtime failure");
+        assertThat(runtimeException.getCause()).isSameAs(cause);
+
+        Exception target = new Exception("target");
+        ExceptionUtils.setCause(target, cause);
+        assertThat(target.getCause()).isSameAs(cause);
+
+        Throwable fallbackException = ExceptionUtils.createWithCause(
+                MessageOnlyException.class, "message-only failure", cause);
+        assertThat(fallbackException)
+                .isInstanceOf(MessageOnlyException.class)
+                .hasMessageContaining("message-only failure")
+                .hasMessageContaining("caused by")
+                .hasMessageContaining(cause.toString());
+        assertThat(fallbackException.getCause()).isNull();
+    }
+
+    private static void setCausesAllowed(boolean causesAllowed) throws Exception {
+        Field field = ExceptionUtils.class.getDeclaredField("causesAllowed");
+        field.setAccessible(true);
+        field.setBoolean(null, causesAllowed);
+    }
+
+    public static final class MessageOnlyException extends Exception {
+        private static final long serialVersionUID = 1L;
+
+        public MessageOnlyException(String message) {
+            super(message);
+        }
+    }
+}

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ExceptionUtilsTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ExceptionUtilsTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 public class ExceptionUtilsTest {
     @BeforeEach
     public void enableCauseSupport() throws Exception {
+        resetGeneratedClassLiteralCaches();
         setCausesAllowed(true);
     }
 
@@ -51,10 +52,23 @@ public class ExceptionUtilsTest {
         assertThat(fallbackException.getCause()).isNull();
     }
 
+    private static void resetGeneratedClassLiteralCaches() throws Exception {
+        setClassLiteralCache("class$java$lang$RuntimeException", null);
+        setClassLiteralCache("class$java$lang$String", null);
+        setClassLiteralCache("class$java$lang$Throwable", null);
+    }
+
     private static void setCausesAllowed(boolean causesAllowed) throws Exception {
         Field field = ExceptionUtils.class.getDeclaredField("causesAllowed");
         field.setAccessible(true);
         field.setBoolean(null, causesAllowed);
+    }
+
+    private static void setClassLiteralCache(
+            String fieldName, Class<?> cachedClass) throws Exception {
+        Field field = ExceptionUtils.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(null, cachedClass);
     }
 
     public static final class MessageOnlyException extends Exception {

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/FieldMethodizerTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/FieldMethodizerTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.velocity.app.FieldMethodizer;
+import org.apache.velocity.runtime.RuntimeConstants;
+import org.junit.jupiter.api.Test;
+
+public class FieldMethodizerTest {
+    @Test
+    void exposesPublicStaticFieldsFromClassName() throws Exception {
+        FieldMethodizer methodizer = new FieldMethodizer();
+
+        methodizer.addObject(RuntimeConstants.class.getName());
+
+        assertThat(methodizer.get("RUNTIME_LOG")).isEqualTo(RuntimeConstants.RUNTIME_LOG);
+        assertThat(methodizer.get("RUNTIME_LOG_LOGSYSTEM_CLASS"))
+                .isEqualTo(RuntimeConstants.RUNTIME_LOG_LOGSYSTEM_CLASS);
+    }
+}

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/GeneratorTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/GeneratorTest.java
@@ -8,6 +8,7 @@ package velocity.velocity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
 import java.io.Writer;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -81,7 +82,7 @@ public class GeneratorTest {
         }
 
         @Override
-        public void merge(Context context, Writer writer) throws Exception {
+        public void merge(Context context, Writer writer) throws IOException {
             writer.write(templateName);
         }
     }

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/GeneratorTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/GeneratorTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.Writer;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import org.apache.velocity.Template;
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.app.VelocityEngine;
+import org.apache.velocity.context.Context;
+import org.apache.velocity.texen.Generator;
+import org.apache.velocity.texen.util.FileUtil;
+import org.apache.velocity.texen.util.PropertiesUtil;
+import org.apache.velocity.util.StringUtils;
+import org.junit.jupiter.api.Test;
+
+public class GeneratorTest {
+    @Test
+    public void parsesControlTemplateWithDefaultTexenContextObjects() throws Exception {
+        TexenGenerator generator = new TexenGenerator("missing-texen-test.properties");
+        generator.setOutputPath("target/texen-output");
+        clearVelocityEngineClassCache();
+        generator.reloadDefaultProperties();
+        assertThat(resolveVelocityEngineThroughGeneratedHelper())
+                .isSameAs(VelocityEngine.class);
+
+        VelocityContext context = new VelocityContext();
+        String rendered = generator.parse("control.vm", context);
+
+        assertThat(rendered).isEqualTo("control.vm");
+        assertThat(context.get("generator")).isSameAs(Generator.getInstance());
+        assertThat(context.get("outputDirectory")).isEqualTo("target/texen-output");
+        assertThat(context.get("strings")).isInstanceOf(StringUtils.class);
+        assertThat(context.get("files")).isInstanceOf(FileUtil.class);
+        assertThat(context.get("properties")).isInstanceOf(PropertiesUtil.class);
+    }
+
+    private static void clearVelocityEngineClassCache() throws Exception {
+        Field classCache = Generator.class.getDeclaredField(
+                "class$org$apache$velocity$app$VelocityEngine");
+        classCache.setAccessible(true);
+        classCache.set(null, null);
+    }
+
+    private static Class<?> resolveVelocityEngineThroughGeneratedHelper() throws Exception {
+        Method generatedClassLiteralHelper = Generator.class.getDeclaredMethod(
+                "class$", String.class);
+        generatedClassLiteralHelper.setAccessible(true);
+        return (Class<?>) generatedClassLiteralHelper.invoke(
+                null, "org.apache.velocity.app.VelocityEngine");
+    }
+
+    private static final class TexenGenerator extends Generator {
+        private TexenGenerator(String propFile) {
+            super(propFile);
+        }
+
+        private void reloadDefaultProperties() {
+            setDefaultProps();
+        }
+
+        @Override
+        public Template getTemplate(String templateName, String encoding) {
+            return new ControlTemplate(templateName);
+        }
+    }
+
+    private static final class ControlTemplate extends Template {
+        private final String templateName;
+
+        private ControlTemplate(String templateName) {
+            this.templateName = templateName;
+        }
+
+        @Override
+        public void merge(Context context, Writer writer) throws Exception {
+            writer.write(templateName);
+        }
+    }
+}

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/GetExecutorTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/GetExecutorTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.apache.velocity.exception.MethodInvocationException;
+import org.apache.velocity.runtime.RuntimeLogger;
+import org.apache.velocity.runtime.parser.node.GetExecutor;
+import org.apache.velocity.util.introspection.Introspector;
+import org.junit.jupiter.api.Test;
+
+public class GetExecutorTest {
+    @Test
+    void executeInvokesResolvedGetMethod() throws Exception {
+        final GetExecutor executor = newExecutor("answer");
+        final KeyValueStore store = new KeyValueStore();
+
+        final Object result = executor.execute(store);
+
+        assertThat(result).isEqualTo("value:answer");
+        assertThat(store.getLastKey()).isEqualTo("answer");
+    }
+
+    @Test
+    void oldExecuteInvokesResolvedGetMethod() throws Exception {
+        final GetExecutor executor = newExecutor("legacy");
+        final KeyValueStore store = new KeyValueStore();
+
+        final Object result = executor.OLDexecute(store, null);
+
+        assertThat(result).isEqualTo("value:legacy");
+        assertThat(store.getLastKey()).isEqualTo("legacy");
+    }
+
+    @Test
+    void oldExecuteWrapsGetMethodExceptions() throws Exception {
+        final NoOpRuntimeLogger logger = new NoOpRuntimeLogger();
+        final GetExecutor executor = new GetExecutor(logger, new Introspector(logger), FailingKeyValueStore.class,
+                "boom");
+
+        assertThatThrownBy(() -> executor.OLDexecute(new FailingKeyValueStore(), null))
+                .isInstanceOf(MethodInvocationException.class)
+                .hasMessageContaining("Invocation of method 'get(\"boom\")'");
+    }
+
+    private static GetExecutor newExecutor(final String key) throws Exception {
+        final NoOpRuntimeLogger logger = new NoOpRuntimeLogger();
+        return new GetExecutor(logger, new Introspector(logger), KeyValueStore.class, key);
+    }
+
+    public static final class KeyValueStore {
+        private String lastKey;
+
+        public String get(final String key) {
+            lastKey = key;
+            return "value:" + key;
+        }
+
+        String getLastKey() {
+            return lastKey;
+        }
+    }
+
+    public static final class FailingKeyValueStore {
+        public String get(final String key) {
+            throw new IllegalStateException("Cannot resolve " + key);
+        }
+    }
+
+    private static final class NoOpRuntimeLogger implements RuntimeLogger {
+        @Override
+        public void warn(final Object message) {
+        }
+
+        @Override
+        public void info(final Object message) {
+        }
+
+        @Override
+        public void error(final Object message) {
+        }
+
+        @Override
+        public void debug(final Object message) {
+        }
+    }
+}

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/GetExecutorTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/GetExecutorTest.java
@@ -9,8 +9,10 @@ package velocity.velocity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.apache.velocity.exception.MethodInvocationException;
-import org.apache.velocity.runtime.RuntimeLogger;
+import java.lang.reflect.InvocationTargetException;
+
+import org.apache.velocity.runtime.log.Log;
+import org.apache.velocity.runtime.log.NullLogChute;
 import org.apache.velocity.runtime.parser.node.GetExecutor;
 import org.apache.velocity.util.introspection.Introspector;
 import org.junit.jupiter.api.Test;
@@ -28,30 +30,19 @@ public class GetExecutorTest {
     }
 
     @Test
-    void oldExecuteInvokesResolvedGetMethod() throws Exception {
-        final GetExecutor executor = newExecutor("legacy");
-        final KeyValueStore store = new KeyValueStore();
-
-        final Object result = executor.OLDexecute(store, null);
-
-        assertThat(result).isEqualTo("value:legacy");
-        assertThat(store.getLastKey()).isEqualTo("legacy");
-    }
-
-    @Test
-    void oldExecuteWrapsGetMethodExceptions() throws Exception {
-        final NoOpRuntimeLogger logger = new NoOpRuntimeLogger();
-        final GetExecutor executor = new GetExecutor(logger, new Introspector(logger), FailingKeyValueStore.class,
+    void executePropagatesGetMethodInvocationExceptions() throws Exception {
+        final Log log = new Log(new NullLogChute());
+        final GetExecutor executor = new GetExecutor(log, new Introspector(log), FailingKeyValueStore.class,
                 "boom");
 
-        assertThatThrownBy(() -> executor.OLDexecute(new FailingKeyValueStore(), null))
-                .isInstanceOf(MethodInvocationException.class)
-                .hasMessageContaining("Invocation of method 'get(\"boom\")'");
+        assertThatThrownBy(() -> executor.execute(new FailingKeyValueStore()))
+                .isInstanceOf(InvocationTargetException.class)
+                .hasCauseInstanceOf(IllegalStateException.class);
     }
 
     private static GetExecutor newExecutor(final String key) throws Exception {
-        final NoOpRuntimeLogger logger = new NoOpRuntimeLogger();
-        return new GetExecutor(logger, new Introspector(logger), KeyValueStore.class, key);
+        final Log log = new Log(new NullLogChute());
+        return new GetExecutor(log, new Introspector(log), KeyValueStore.class, key);
     }
 
     public static final class KeyValueStore {
@@ -70,24 +61,6 @@ public class GetExecutorTest {
     public static final class FailingKeyValueStore {
         public String get(final String key) {
             throw new IllegalStateException("Cannot resolve " + key);
-        }
-    }
-
-    private static final class NoOpRuntimeLogger implements RuntimeLogger {
-        @Override
-        public void warn(final Object message) {
-        }
-
-        @Override
-        public void info(final Object message) {
-        }
-
-        @Override
-        public void error(final Object message) {
-        }
-
-        @Override
-        public void debug(final Object message) {
         }
     }
 }

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/IntrospectorTestCase2Test.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/IntrospectorTestCase2Test.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import org.apache.velocity.runtime.RuntimeConstants;
+import org.apache.velocity.runtime.RuntimeSingleton;
+import org.apache.velocity.runtime.log.NullLogSystem;
+import org.apache.velocity.test.IntrospectorTestCase2;
+import org.junit.jupiter.api.Test;
+
+public class IntrospectorTestCase2Test {
+    @Test
+    void resolvesMostSpecificOverloadAndRejectsAmbiguousMatch() throws Exception {
+        RuntimeSingleton.setProperty(
+                RuntimeConstants.RUNTIME_LOG_LOGSYSTEM,
+                new NullLogSystem());
+        resolveNestedClassThroughCompilerGeneratedHelper();
+        clearClassLiteralCache("class$org$apache$velocity$test$IntrospectorTestCase2$Tester");
+        clearClassLiteralCache("class$org$apache$velocity$test$IntrospectorTestCase2$Tester2");
+
+        IntrospectorTestCase2 testCase = new IntrospectorTestCase2("runTest");
+        testCase.runTest();
+    }
+
+    private static void resolveNestedClassThroughCompilerGeneratedHelper() throws Exception {
+        /*
+         * `IntrospectorTestCase2` was compiled with a package-private synthetic
+         * `class$(String)` helper for nested class literals. Calling the helper
+         * verifies the same class resolution path used by `runTest()`.
+         */
+        Method classResolver = IntrospectorTestCase2.class.getDeclaredMethod("class$", String.class);
+        classResolver.setAccessible(true);
+
+        Object resolvedClass = classResolver.invoke(
+                null,
+                "org.apache.velocity.test.IntrospectorTestCase2$Tester");
+
+        assertSame(IntrospectorTestCase2.Tester.class, resolvedClass);
+    }
+
+    private static void clearClassLiteralCache(String fieldName) throws Exception {
+        /*
+         * The Velocity 1.4 artifact was compiled with synthetic `Class` caches for
+         * the nested overload test classes. Clear them so `runTest()` exercises
+         * the original `Class.forName(String)` resolution path.
+         */
+        Field classCache = IntrospectorTestCase2.class.getDeclaredField(fieldName);
+        classCache.setAccessible(true);
+        classCache.set(null, null);
+    }
+}

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/IntrospectorTestCase2Test.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/IntrospectorTestCase2Test.java
@@ -6,55 +6,94 @@
  */
 package velocity.velocity;
 
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import java.lang.reflect.Field;
+import java.io.IOException;
 import java.lang.reflect.Method;
 
-import org.apache.velocity.runtime.RuntimeConstants;
-import org.apache.velocity.runtime.RuntimeSingleton;
-import org.apache.velocity.runtime.log.NullLogSystem;
-import org.apache.velocity.test.IntrospectorTestCase2;
+import org.apache.velocity.runtime.log.Log;
+import org.apache.velocity.runtime.log.NullLogChute;
+import org.apache.velocity.util.introspection.Introspector;
 import org.junit.jupiter.api.Test;
 
 public class IntrospectorTestCase2Test {
     @Test
     void resolvesMostSpecificOverloadAndRejectsAmbiguousMatch() throws Exception {
-        RuntimeSingleton.setProperty(
-                RuntimeConstants.RUNTIME_LOG_LOGSYSTEM,
-                new NullLogSystem());
-        resolveNestedClassThroughCompilerGeneratedHelper();
-        clearClassLiteralCache("class$org$apache$velocity$test$IntrospectorTestCase2$Tester");
-        clearClassLiteralCache("class$org$apache$velocity$test$IntrospectorTestCase2$Tester2");
+        final Introspector introspector = new Introspector(new Log(new NullLogChute()));
 
-        IntrospectorTestCase2 testCase = new IntrospectorTestCase2("runTest");
-        testCase.runTest();
+        final Method specificMethod = introspector.getMethod(
+                OverloadedTester.class,
+                "find",
+                new Object[] {Integer.valueOf(7)});
+        final Object specificResult = specificMethod.invoke(new OverloadedTester(), Integer.valueOf(7));
+
+        assertThat(specificMethod.getParameterTypes()).containsExactly(Integer.class);
+        assertThat(specificResult).isEqualTo("integer:7");
+        assertThat(introspector.getMethod(
+                AmbiguousTester.class,
+                "match",
+                new Object[] {new AmbiguousValue()})).isNull();
     }
 
-    private static void resolveNestedClassThroughCompilerGeneratedHelper() throws Exception {
-        /*
-         * `IntrospectorTestCase2` was compiled with a package-private synthetic
-         * `class$(String)` helper for nested class literals. Calling the helper
-         * verifies the same class resolution path used by `runTest()`.
-         */
-        Method classResolver = IntrospectorTestCase2.class.getDeclaredMethod("class$", String.class);
-        classResolver.setAccessible(true);
+    public static final class OverloadedTester {
+        public String find(final Number value) {
+            return "number:" + value;
+        }
 
-        Object resolvedClass = classResolver.invoke(
-                null,
-                "org.apache.velocity.test.IntrospectorTestCase2$Tester");
-
-        assertSame(IntrospectorTestCase2.Tester.class, resolvedClass);
+        public String find(final Integer value) {
+            return "integer:" + value;
+        }
     }
 
-    private static void clearClassLiteralCache(String fieldName) throws Exception {
-        /*
-         * The Velocity 1.4 artifact was compiled with synthetic `Class` caches for
-         * the nested overload test classes. Clear them so `runTest()` exercises
-         * the original `Class.forName(String)` resolution path.
-         */
-        Field classCache = IntrospectorTestCase2.class.getDeclaredField(fieldName);
-        classCache.setAccessible(true);
-        classCache.set(null, null);
+    public static final class AmbiguousTester {
+        public String match(final CharSequence value) {
+            return "chars:" + value;
+        }
+
+        public String match(final Appendable value) {
+            return "appendable:" + value;
+        }
+    }
+
+    public static final class AmbiguousValue implements CharSequence, Appendable {
+        private final StringBuilder text = new StringBuilder("ambiguous");
+
+        @Override
+        public int length() {
+            return text.length();
+        }
+
+        @Override
+        public char charAt(final int index) {
+            return text.charAt(index);
+        }
+
+        @Override
+        public CharSequence subSequence(final int start, final int end) {
+            return text.subSequence(start, end);
+        }
+
+        @Override
+        public Appendable append(final CharSequence value) throws IOException {
+            text.append(value);
+            return this;
+        }
+
+        @Override
+        public Appendable append(final CharSequence value, final int start, final int end) throws IOException {
+            text.append(value, start, end);
+            return this;
+        }
+
+        @Override
+        public Appendable append(final char value) throws IOException {
+            text.append(value);
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            return text.toString();
+        }
     }
 }

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/IntrospectorTestCase3Test.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/IntrospectorTestCase3Test.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.apache.velocity.test.IntrospectorTestCase3;
+import org.junit.jupiter.api.Test;
+
+public class IntrospectorTestCase3Test {
+    @Test
+    void runsPrimitiveOverloadIntrospectionTestCase() throws Exception {
+        junit.framework.Test suite = IntrospectorTestCase3.suite();
+        assertNotNull(suite);
+
+        IntrospectorTestCase3 testCase = new IntrospectorTestCase3("testSimple");
+        testCase.testSimple();
+    }
+}

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/IntrospectorTestCase3Test.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/IntrospectorTestCase3Test.java
@@ -6,18 +6,37 @@
  */
 package velocity.velocity;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.apache.velocity.test.IntrospectorTestCase3;
+import java.lang.reflect.Method;
+
+import org.apache.velocity.runtime.log.Log;
+import org.apache.velocity.runtime.log.NullLogChute;
+import org.apache.velocity.util.introspection.Introspector;
 import org.junit.jupiter.api.Test;
 
 public class IntrospectorTestCase3Test {
     @Test
-    void runsPrimitiveOverloadIntrospectionTestCase() throws Exception {
-        junit.framework.Test suite = IntrospectorTestCase3.suite();
-        assertNotNull(suite);
+    void resolvesPrimitiveOverloadForBoxedArgument() throws Exception {
+        final Introspector introspector = new Introspector(new Log(new NullLogChute()));
 
-        IntrospectorTestCase3 testCase = new IntrospectorTestCase3("testSimple");
-        testCase.testSimple();
+        final Method method = introspector.getMethod(
+                PrimitiveOverloads.class,
+                "inspect",
+                new Object[] {Integer.valueOf(3)});
+        final Object result = method.invoke(new PrimitiveOverloads(), Integer.valueOf(3));
+
+        assertThat(method.getParameterTypes()).containsExactly(int.class);
+        assertThat(result).isEqualTo("int:3");
+    }
+
+    public static final class PrimitiveOverloads {
+        public String inspect(final Object value) {
+            return "object:" + value;
+        }
+
+        public String inspect(final int value) {
+            return "int:" + value;
+        }
     }
 }

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/IntrospectorTestCaseTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/IntrospectorTestCaseTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity;
+
+import java.lang.reflect.Field;
+
+import org.apache.velocity.runtime.RuntimeConstants;
+import org.apache.velocity.runtime.RuntimeSingleton;
+import org.apache.velocity.test.IntrospectorTestCase;
+import org.junit.jupiter.api.Test;
+
+public class IntrospectorTestCaseTest {
+    @Test
+    void runsVelocityPrimitiveIntrospectionTestCase() throws Exception {
+        RuntimeSingleton.setProperty(
+                RuntimeConstants.RUNTIME_LOG_LOGSYSTEM_CLASS,
+                "org.apache.velocity.runtime.log.NullLogSystem");
+        RuntimeSingleton.init();
+        clearMethodProviderClassCache();
+
+        IntrospectorTestCase testCase = new IntrospectorTestCase("runTest");
+        testCase.runTest();
+    }
+
+    private static void clearMethodProviderClassCache() throws Exception {
+        /*
+         * The Velocity 1.4 artifact was compiled with a synthetic `Class` cache for
+         * `MethodProvider.class`. Clear it so `runTest()` exercises the original
+         * `Class.forName(String)` resolution path even if test discovery initialized it.
+         */
+        Field classCache = IntrospectorTestCase.class.getDeclaredField(
+                "class$org$apache$velocity$test$IntrospectorTestCase$MethodProvider");
+        classCache.setAccessible(true);
+        classCache.set(null, null);
+    }
+}

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/IntrospectorTestCaseTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/IntrospectorTestCaseTest.java
@@ -6,35 +6,50 @@
  */
 package velocity.velocity;
 
-import java.lang.reflect.Field;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.StringWriter;
+import java.util.Properties;
+
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.app.VelocityEngine;
 import org.apache.velocity.runtime.RuntimeConstants;
-import org.apache.velocity.runtime.RuntimeSingleton;
-import org.apache.velocity.test.IntrospectorTestCase;
+import org.apache.velocity.runtime.log.NullLogChute;
 import org.junit.jupiter.api.Test;
 
 public class IntrospectorTestCaseTest {
     @Test
-    void runsVelocityPrimitiveIntrospectionTestCase() throws Exception {
-        RuntimeSingleton.setProperty(
-                RuntimeConstants.RUNTIME_LOG_LOGSYSTEM_CLASS,
-                "org.apache.velocity.runtime.log.NullLogSystem");
-        RuntimeSingleton.init();
-        clearMethodProviderClassCache();
+    void rendersTemplateUsingPrimitiveMethodIntrospection() throws Exception {
+        final VelocityEngine engine = newVelocityEngine();
+        final VelocityContext context = new VelocityContext();
+        context.put("provider", new MethodProvider());
+        final StringWriter writer = new StringWriter();
 
-        IntrospectorTestCase testCase = new IntrospectorTestCase("runTest");
-        testCase.runTest();
+        final boolean rendered = engine.evaluate(
+                context,
+                writer,
+                "primitive-introspection",
+                "$provider.get(41) $provider.ready");
+
+        assertThat(rendered).isTrue();
+        assertThat(writer).hasToString("value=41 true");
     }
 
-    private static void clearMethodProviderClassCache() throws Exception {
-        /*
-         * The Velocity 1.4 artifact was compiled with a synthetic `Class` cache for
-         * `MethodProvider.class`. Clear it so `runTest()` exercises the original
-         * `Class.forName(String)` resolution path even if test discovery initialized it.
-         */
-        Field classCache = IntrospectorTestCase.class.getDeclaredField(
-                "class$org$apache$velocity$test$IntrospectorTestCase$MethodProvider");
-        classCache.setAccessible(true);
-        classCache.set(null, null);
+    private static VelocityEngine newVelocityEngine() throws Exception {
+        final Properties properties = new Properties();
+        properties.setProperty(RuntimeConstants.RUNTIME_LOG_LOGSYSTEM_CLASS, NullLogChute.class.getName());
+        final VelocityEngine engine = new VelocityEngine();
+        engine.init(properties);
+        return engine;
+    }
+
+    public static final class MethodProvider {
+        public String get(final int value) {
+            return "value=" + value;
+        }
+
+        public boolean isReady() {
+            return true;
+        }
     }
 }

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/LogManagerTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/LogManagerTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.velocity.runtime.RuntimeConstants;
+import org.apache.velocity.runtime.RuntimeInstance;
+import org.apache.velocity.runtime.log.LogManager;
+import org.apache.velocity.runtime.log.LogSystem;
+import org.apache.velocity.runtime.log.NullLogSystem;
+import org.junit.jupiter.api.Test;
+
+public class LogManagerTest {
+    @Test
+    void createsConfiguredLogSystemFromClassName() throws Exception {
+        final RuntimeInstance runtime = new ConfiguredRuntimeInstance(NullLogSystem.class.getName());
+
+        final LogSystem logSystem = LogManager.createLogSystem(runtime);
+
+        assertThat(logSystem).isInstanceOf(NullLogSystem.class);
+    }
+
+    private static final class ConfiguredRuntimeInstance extends RuntimeInstance {
+        private final String logSystemClass;
+
+        private ConfiguredRuntimeInstance(final String logSystemClass) {
+            this.logSystemClass = logSystemClass;
+        }
+
+        @Override
+        public Object getProperty(final String key) {
+            if (RuntimeConstants.RUNTIME_LOG_LOGSYSTEM_CLASS.equals(key)) {
+                return logSystemClass;
+            }
+            return null;
+        }
+
+        @Override
+        public void info(final Object message) {
+        }
+
+        @Override
+        public void error(final Object message) {
+        }
+
+        @Override
+        public void debug(final Object message) {
+        }
+    }
+}

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/LogManagerTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/LogManagerTest.java
@@ -10,46 +10,85 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.velocity.runtime.RuntimeConstants;
 import org.apache.velocity.runtime.RuntimeInstance;
+import org.apache.velocity.runtime.RuntimeServices;
+import org.apache.velocity.runtime.log.Log;
+import org.apache.velocity.runtime.log.LogChute;
 import org.apache.velocity.runtime.log.LogManager;
-import org.apache.velocity.runtime.log.LogSystem;
-import org.apache.velocity.runtime.log.NullLogSystem;
 import org.junit.jupiter.api.Test;
 
 public class LogManagerTest {
     @Test
-    void createsConfiguredLogSystemFromClassName() throws Exception {
-        final RuntimeInstance runtime = new ConfiguredRuntimeInstance(NullLogSystem.class.getName());
+    void installsConfiguredLogChuteFromClassName() throws Exception {
+        RecordingLogChute.reset();
+        final RuntimeInstance runtime = new ConfiguredRuntimeInstance(RecordingLogChute.class.getName());
+        final Log log = runtime.getLog();
 
-        final LogSystem logSystem = LogManager.createLogSystem(runtime);
+        LogManager.updateLog(log, runtime);
+        log.info("configured");
 
-        assertThat(logSystem).isInstanceOf(NullLogSystem.class);
+        assertThat(RecordingLogChute.isInitialized()).isTrue();
+        assertThat(RecordingLogChute.getLastLevel()).isEqualTo(LogChute.INFO_ID);
+        assertThat(RecordingLogChute.getLastMessage()).isEqualTo("configured");
     }
 
     private static final class ConfiguredRuntimeInstance extends RuntimeInstance {
-        private final String logSystemClass;
+        private final String logChuteClass;
 
-        private ConfiguredRuntimeInstance(final String logSystemClass) {
-            this.logSystemClass = logSystemClass;
+        private ConfiguredRuntimeInstance(final String logChuteClass) {
+            this.logChuteClass = logChuteClass;
         }
 
         @Override
         public Object getProperty(final String key) {
             if (RuntimeConstants.RUNTIME_LOG_LOGSYSTEM_CLASS.equals(key)) {
-                return logSystemClass;
+                return logChuteClass;
             }
             return null;
         }
+    }
 
-        @Override
-        public void info(final Object message) {
+    public static final class RecordingLogChute implements LogChute {
+        private static boolean initialized;
+        private static int lastLevel;
+        private static String lastMessage;
+
+        public static void reset() {
+            initialized = false;
+            lastLevel = -1;
+            lastMessage = null;
+        }
+
+        public static boolean isInitialized() {
+            return initialized;
+        }
+
+        public static int getLastLevel() {
+            return lastLevel;
+        }
+
+        public static String getLastMessage() {
+            return lastMessage;
         }
 
         @Override
-        public void error(final Object message) {
+        public void init(final RuntimeServices runtimeServices) {
+            initialized = true;
         }
 
         @Override
-        public void debug(final Object message) {
+        public void log(final int level, final String message) {
+            lastLevel = level;
+            lastMessage = message;
+        }
+
+        @Override
+        public void log(final int level, final String message, final Throwable throwable) {
+            log(level, message);
+        }
+
+        @Override
+        public boolean isLevelEnabled(final int level) {
+            return true;
         }
     }
 }

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/MapGetExecutorTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/MapGetExecutorTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.velocity.runtime.log.Log;
+import org.apache.velocity.runtime.log.NullLogChute;
+import org.apache.velocity.runtime.parser.node.MapGetExecutor;
+import org.junit.jupiter.api.Test;
+
+public class MapGetExecutorTest {
+    @Test
+    void constructorDiscoversMapGetMethodAndExecuteReturnsStoredValue() throws Exception {
+        final Log log = new Log(new NullLogChute());
+        final MapGetExecutor executor = new MapGetExecutor(log, HashMap.class, "answer");
+        final Map<String, String> values = new HashMap<>();
+        values.put("answer", "forty-two");
+
+        final Object result = executor.execute(values);
+
+        assertThat(executor.isAlive()).isTrue();
+        assertThat(result).isEqualTo("forty-two");
+    }
+}

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/MapSetExecutorTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/MapSetExecutorTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.velocity.runtime.log.Log;
+import org.apache.velocity.runtime.log.NullLogChute;
+import org.apache.velocity.runtime.parser.node.MapSetExecutor;
+import org.junit.jupiter.api.Test;
+
+public class MapSetExecutorTest {
+    @Test
+    void constructorDiscoversMapPutMethodAndExecuteStoresValue() throws Exception {
+        final Log log = new Log(new NullLogChute());
+        final MapSetExecutor executor = new MapSetExecutor(log, HashMap.class, "answer");
+        final Map<String, String> values = new HashMap<>();
+
+        final Object previousValue = executor.execute(values, "forty-two");
+
+        assertThat(executor.isAlive()).isTrue();
+        assertThat(previousValue).isNull();
+        assertThat(values).containsEntry("answer", "forty-two");
+    }
+}

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/MathUtilsTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/MathUtilsTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import org.apache.velocity.runtime.parser.node.MathUtils;
+import org.junit.jupiter.api.Test;
+
+public class MathUtilsTest {
+    @Test
+    public void performsArithmeticAcrossPrimitiveAndBigNumberTypes() {
+        final Number byteValue = MathUtils.wrapPrimitive(7L, Byte.class);
+        final Number shortValue = MathUtils.wrapPrimitive(300L, Short.class);
+        final Number integerValue = MathUtils.add(byteValue, shortValue);
+        final Number longValue = MathUtils.multiply(integerValue, Long.valueOf(2L));
+        final Number decimalValue = MathUtils.divide(new BigDecimal("9.0"), Integer.valueOf(2));
+        final Number bigIntegerValue = MathUtils.add(
+                BigInteger.valueOf(Long.MAX_VALUE),
+                BigInteger.ONE);
+
+        assertThat(byteValue).isEqualTo(Byte.valueOf((byte) 7));
+        assertThat(shortValue).isEqualTo(Short.valueOf((short) 300));
+        assertThat(integerValue).isEqualTo(Short.valueOf((short) 307));
+        assertThat(longValue).isEqualTo(Long.valueOf(614L));
+        assertThat((BigDecimal) decimalValue).isEqualByComparingTo(new BigDecimal("4.5"));
+        assertThat(bigIntegerValue).isEqualTo(new BigInteger("9223372036854775808"));
+    }
+
+    @Test
+    public void comparesAndClassifiesNumericValues() {
+        assertThat(MathUtils.isInteger(Integer.valueOf(10))).isTrue();
+        assertThat(MathUtils.isInteger(Double.valueOf(10.0D))).isFalse();
+        assertThat(MathUtils.isZero(BigDecimal.ZERO)).isTrue();
+        assertThat(MathUtils.isZero(Float.valueOf(0.25F))).isFalse();
+        assertThat(MathUtils.compare(BigInteger.TEN, Long.valueOf(9L))).isPositive();
+        assertThat(MathUtils.modulo(Integer.valueOf(17), Byte.valueOf((byte) 5)))
+                .isEqualTo(Integer.valueOf(2));
+    }
+}

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/NodeListTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/NodeListTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.apache.velocity.anakia.NodeList;
+import org.junit.jupiter.api.Test;
+
+public class NodeListTest {
+    @Test
+    void cloneCreatesIndependentBackingList() throws Exception {
+        String originalNode = "original";
+        NodeList original = new NodeList();
+        original.add(originalNode);
+
+        NodeList cloned = (NodeList) original.clone();
+        List clonedBackingList = cloned.getList();
+
+        original.add("added");
+
+        assertThat(clonedBackingList).isNotSameAs(original.getList());
+        assertThat(cloned).containsExactly(originalNode);
+        assertThat(original).hasSize(2);
+    }
+}

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ParserTestCaseTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ParserTestCaseTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+
+import junit.framework.TestSuite;
+
+import org.apache.velocity.test.ParserTestCase;
+import org.junit.jupiter.api.Test;
+
+public class ParserTestCaseTest {
+    @Test
+    public void createsJUnitThreeSuiteForParserRegressionTests() throws Exception {
+        clearParserTestCaseClassCache();
+
+        TestSuite suite = (TestSuite) ParserTestCase.suite();
+
+        assertThat(suite).isNotNull();
+        assertThat(suite.getName()).isEqualTo(ParserTestCase.class.getName());
+    }
+
+    private static void clearParserTestCaseClassCache() throws Exception {
+        /*
+         * The Velocity 1.4 artifact was compiled with a synthetic `Class` cache for
+         * `ParserTestCase.class`. Clear it so `suite()` exercises the original
+         * `Class.forName(String)` resolution path even if discovery initialized it.
+         */
+        Field classCache = ParserTestCase.class.getDeclaredField(
+                "class$org$apache$velocity$test$ParserTestCase");
+        classCache.setAccessible(true);
+        classCache.set(null, null);
+    }
+}

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ParserTestCaseTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ParserTestCaseTest.java
@@ -8,33 +8,39 @@ package velocity.velocity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.lang.reflect.Field;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.Properties;
 
-import junit.framework.TestSuite;
-
-import org.apache.velocity.test.ParserTestCase;
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.app.VelocityEngine;
+import org.apache.velocity.runtime.RuntimeConstants;
+import org.apache.velocity.runtime.log.NullLogChute;
 import org.junit.jupiter.api.Test;
 
 public class ParserTestCaseTest {
     @Test
-    public void createsJUnitThreeSuiteForParserRegressionTests() throws Exception {
-        clearParserTestCaseClassCache();
+    public void parsesForeachAndSetDirectives() throws Exception {
+        final VelocityEngine engine = newVelocityEngine();
+        final VelocityContext context = new VelocityContext();
+        context.put("items", Arrays.asList("alpha", "beta", "gamma"));
+        final StringWriter writer = new StringWriter();
 
-        TestSuite suite = (TestSuite) ParserTestCase.suite();
+        final boolean rendered = engine.evaluate(
+                context,
+                writer,
+                "parser-regression",
+                "#foreach($item in $items)$velocityCount:$item;#end#set($status = 'done')$status");
 
-        assertThat(suite).isNotNull();
-        assertThat(suite.getName()).isEqualTo(ParserTestCase.class.getName());
+        assertThat(rendered).isTrue();
+        assertThat(writer).hasToString("1:alpha;2:beta;3:gamma;done");
     }
 
-    private static void clearParserTestCaseClassCache() throws Exception {
-        /*
-         * The Velocity 1.4 artifact was compiled with a synthetic `Class` cache for
-         * `ParserTestCase.class`. Clear it so `suite()` exercises the original
-         * `Class.forName(String)` resolution path even if discovery initialized it.
-         */
-        Field classCache = ParserTestCase.class.getDeclaredField(
-                "class$org$apache$velocity$test$ParserTestCase");
-        classCache.setAccessible(true);
-        classCache.set(null, null);
+    private static VelocityEngine newVelocityEngine() throws Exception {
+        final Properties properties = new Properties();
+        properties.setProperty(RuntimeConstants.RUNTIME_LOG_LOGSYSTEM_CLASS, NullLogChute.class.getName());
+        final VelocityEngine engine = new VelocityEngine();
+        engine.init(properties);
+        return engine;
     }
 }

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/PropertiesUtilTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/PropertiesUtilTest.java
@@ -17,7 +17,7 @@ public class PropertiesUtilTest {
     private static final String PROPERTIES_RESOURCE = "velocity/velocity/texen-test.properties";
 
     @Test
-    public void loadsPropertiesResourceFromClasspath() {
+    public void loadsPropertiesResourceFromClasspath() throws Exception {
         ClasspathPropertiesUtil propertiesUtil = new ClasspathPropertiesUtil();
 
         Properties properties = propertiesUtil.loadClasspathResource(PROPERTIES_RESOURCE);
@@ -28,7 +28,7 @@ public class PropertiesUtilTest {
     }
 
     private static final class ClasspathPropertiesUtil extends PropertiesUtil {
-        private Properties loadClasspathResource(String propertiesFile) {
+        private Properties loadClasspathResource(String propertiesFile) throws Exception {
             return loadFromClassPath(propertiesFile);
         }
     }

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/PropertiesUtilTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/PropertiesUtilTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+
+import org.apache.velocity.texen.util.PropertiesUtil;
+import org.junit.jupiter.api.Test;
+
+public class PropertiesUtilTest {
+    private static final String PROPERTIES_RESOURCE = "velocity/velocity/texen-test.properties";
+
+    @Test
+    public void loadsPropertiesResourceFromClasspath() {
+        ClasspathPropertiesUtil propertiesUtil = new ClasspathPropertiesUtil();
+
+        Properties properties = propertiesUtil.loadClasspathResource(PROPERTIES_RESOURCE);
+
+        assertThat(properties)
+                .containsEntry("texen.resource.loaded", "true")
+                .containsEntry("texen.resource.name", "PropertiesUtil");
+    }
+
+    private static final class ClasspathPropertiesUtil extends PropertiesUtil {
+        private Properties loadClasspathResource(String propertiesFile) {
+            return loadFromClassPath(propertiesFile);
+        }
+    }
+}

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/PropertyExecutorTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/PropertyExecutorTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.velocity.runtime.RuntimeLogger;
+import org.apache.velocity.runtime.parser.node.PropertyExecutor;
+import org.apache.velocity.util.introspection.Introspector;
+import org.junit.jupiter.api.Test;
+
+public class PropertyExecutorTest {
+    @Test
+    void executeInvokesResolvedPropertyGetter() throws Exception {
+        final NoOpRuntimeLogger logger = new NoOpRuntimeLogger();
+        final PropertyExecutor executor = new PropertyExecutor(logger, new Introspector(logger), Person.class,
+                "name");
+
+        final Object result = executor.execute(new Person("Ada"));
+
+        assertThat(executor.isAlive()).isTrue();
+        assertThat(result).isEqualTo("Ada");
+    }
+
+    public static final class Person {
+        private final String name;
+
+        Person(final String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+    private static final class NoOpRuntimeLogger implements RuntimeLogger {
+        @Override
+        public void warn(final Object message) {
+        }
+
+        @Override
+        public void info(final Object message) {
+        }
+
+        @Override
+        public void error(final Object message) {
+        }
+
+        @Override
+        public void debug(final Object message) {
+        }
+    }
+}

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/PropertyExecutorTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/PropertyExecutorTest.java
@@ -8,7 +8,8 @@ package velocity.velocity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.apache.velocity.runtime.RuntimeLogger;
+import org.apache.velocity.runtime.log.Log;
+import org.apache.velocity.runtime.log.NullLogChute;
 import org.apache.velocity.runtime.parser.node.PropertyExecutor;
 import org.apache.velocity.util.introspection.Introspector;
 import org.junit.jupiter.api.Test;
@@ -16,9 +17,8 @@ import org.junit.jupiter.api.Test;
 public class PropertyExecutorTest {
     @Test
     void executeInvokesResolvedPropertyGetter() throws Exception {
-        final NoOpRuntimeLogger logger = new NoOpRuntimeLogger();
-        final PropertyExecutor executor = new PropertyExecutor(logger, new Introspector(logger), Person.class,
-                "name");
+        final Log log = new Log(new NullLogChute());
+        final PropertyExecutor executor = new PropertyExecutor(log, new Introspector(log), Person.class, "name");
 
         final Object result = executor.execute(new Person("Ada"));
 
@@ -35,24 +35,6 @@ public class PropertyExecutorTest {
 
         public String getName() {
             return name;
-        }
-    }
-
-    private static final class NoOpRuntimeLogger implements RuntimeLogger {
-        @Override
-        public void warn(final Object message) {
-        }
-
-        @Override
-        public void info(final Object message) {
-        }
-
-        @Override
-        public void error(final Object message) {
-        }
-
-        @Override
-        public void debug(final Object message) {
         }
     }
 }

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/RuntimeInstanceTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/RuntimeInstanceTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.velocity.runtime.RuntimeConstants;
+import org.apache.velocity.runtime.RuntimeInstance;
+import org.apache.velocity.runtime.RuntimeServices;
+import org.apache.velocity.runtime.log.LogChute;
+import org.apache.velocity.runtime.resource.ResourceManager;
+import org.junit.jupiter.api.Test;
+
+public class RuntimeInstanceTest {
+    @Test
+    void reportsConfiguredResourceManagerClassThatDoesNotImplementResourceManager() throws Exception {
+        RuntimeInstance runtime = runtimeWithInitializedConfiguration(
+            RuntimeConstants.RESOURCE_MANAGER_CLASS + " = " + String.class.getName() + "\n");
+
+        assertThatThrownBy(runtime::init)
+            .isInstanceOf(Exception.class)
+            .hasMessageContaining(String.class.getName())
+            .hasMessageContaining(ResourceManager.class.getName());
+    }
+
+    private static RuntimeInstance runtimeWithInitializedConfiguration(String properties) throws Exception {
+        RuntimeInstance runtime = new RuntimeInstance();
+        byte[] bytes = properties.getBytes(StandardCharsets.ISO_8859_1);
+        runtime.getConfiguration().load(new ByteArrayInputStream(bytes));
+        runtime.setProperty(RuntimeConstants.RUNTIME_LOG_LOGSYSTEM, new SilentLogChute());
+        return runtime;
+    }
+
+    private static final class SilentLogChute implements LogChute {
+        @Override
+        public void init(RuntimeServices runtimeServices) {
+        }
+
+        @Override
+        public void log(int level, String message) {
+        }
+
+        @Override
+        public void log(int level, String message, Throwable throwable) {
+        }
+
+        @Override
+        public boolean isLevelEnabled(int level) {
+            return false;
+        }
+    }
+}

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/UberspectImplTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/UberspectImplTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+
+import org.apache.velocity.runtime.RuntimeLogger;
+import org.apache.velocity.util.introspection.Info;
+import org.apache.velocity.util.introspection.UberspectImpl;
+import org.apache.velocity.util.introspection.VelPropertySet;
+import org.junit.jupiter.api.Test;
+
+public class UberspectImplTest {
+    @Test
+    void resolvesVelocityClassThroughCompilerGeneratedClassLiteralHelper() throws Exception {
+        final Method classResolver = UberspectImpl.class.getDeclaredMethod("class$", String.class);
+        classResolver.setAccessible(true);
+
+        final Object resolvedClass = classResolver.invoke(null, "org.apache.velocity.util.introspection.Info");
+
+        assertThat(resolvedClass).isSameAs(Info.class);
+    }
+
+    @Test
+    void resolvesMapClassLiteralWhenCreatingMapBackedPropertySetter() throws Exception {
+        final UberspectImpl uberspect = new UberspectImpl();
+        uberspect.setRuntimeLogger(new NoOpRuntimeLogger());
+        final RecordingMap values = new RecordingMap();
+        final Info info = new Info("map-put.vm", 1, 1);
+
+        final VelPropertySet setter = uberspect.getPropertySet(values, "answer", "forty-two", info);
+
+        assertThat(setter).isNotNull();
+        assertThat(setter.getMethodName()).isEqualTo("put");
+        assertThat(setter.invoke(values, "forty-two")).isNull();
+        assertThat(values).containsEntry("answer", "forty-two");
+    }
+
+    public static final class RecordingMap extends HashMap<Object, Object> {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public Object put(final Object key, final Object value) {
+            return super.put(key, value);
+        }
+    }
+
+    private static final class NoOpRuntimeLogger implements RuntimeLogger {
+        @Override
+        public void warn(final Object message) {
+        }
+
+        @Override
+        public void info(final Object message) {
+        }
+
+        @Override
+        public void error(final Object message) {
+        }
+
+        @Override
+        public void debug(final Object message) {
+        }
+    }
+}

--- a/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/UberspectImplTest.java
+++ b/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/UberspectImplTest.java
@@ -8,30 +8,32 @@ package velocity.velocity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.lang.reflect.Method;
 import java.util.HashMap;
 
-import org.apache.velocity.runtime.RuntimeLogger;
+import org.apache.velocity.runtime.log.Log;
+import org.apache.velocity.runtime.log.NullLogChute;
 import org.apache.velocity.util.introspection.Info;
 import org.apache.velocity.util.introspection.UberspectImpl;
+import org.apache.velocity.util.introspection.VelMethod;
 import org.apache.velocity.util.introspection.VelPropertySet;
 import org.junit.jupiter.api.Test;
 
 public class UberspectImplTest {
     @Test
-    void resolvesVelocityClassThroughCompilerGeneratedClassLiteralHelper() throws Exception {
-        final Method classResolver = UberspectImpl.class.getDeclaredMethod("class$", String.class);
-        classResolver.setAccessible(true);
+    void resolvesMethodUsingConfiguredIntrospector() throws Exception {
+        final UberspectImpl uberspect = newUberspect();
+        final Info info = new Info("method.vm", 1, 1);
 
-        final Object resolvedClass = classResolver.invoke(null, "org.apache.velocity.util.introspection.Info");
+        final VelMethod method = uberspect.getMethod(new Greeter(), "greet", new Object[] {"Ada"}, info);
 
-        assertThat(resolvedClass).isSameAs(Info.class);
+        assertThat(method).isNotNull();
+        assertThat(method.getMethodName()).isEqualTo("greet");
+        assertThat(method.invoke(new Greeter(), new Object[] {"Ada"})).isEqualTo("Hello Ada");
     }
 
     @Test
     void resolvesMapClassLiteralWhenCreatingMapBackedPropertySetter() throws Exception {
-        final UberspectImpl uberspect = new UberspectImpl();
-        uberspect.setRuntimeLogger(new NoOpRuntimeLogger());
+        final UberspectImpl uberspect = newUberspect();
         final RecordingMap values = new RecordingMap();
         final Info info = new Info("map-put.vm", 1, 1);
 
@@ -43,30 +45,25 @@ public class UberspectImplTest {
         assertThat(values).containsEntry("answer", "forty-two");
     }
 
+    private static UberspectImpl newUberspect() {
+        final UberspectImpl uberspect = new UberspectImpl();
+        uberspect.setLog(new Log(new NullLogChute()));
+        uberspect.init();
+        return uberspect;
+    }
+
+    public static final class Greeter {
+        public String greet(final String name) {
+            return "Hello " + name;
+        }
+    }
+
     public static final class RecordingMap extends HashMap<Object, Object> {
         private static final long serialVersionUID = 1L;
 
         @Override
         public Object put(final Object key, final Object value) {
             return super.put(key, value);
-        }
-    }
-
-    private static final class NoOpRuntimeLogger implements RuntimeLogger {
-        @Override
-        public void warn(final Object message) {
-        }
-
-        @Override
-        public void info(final Object message) {
-        }
-
-        @Override
-        public void error(final Object message) {
-        }
-
-        @Override
-        public void debug(final Object message) {
         }
     }
 }

--- a/tests/src/velocity/velocity/1.5/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/velocity/velocity/1.5/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,373 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.ClassMapInnerMethodInfoTest"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.ClassMapTest"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.ClassloaderChangeTestTest"
+      },
+      "type" : "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.IntrospectorTestCase3Test"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.FieldMethodizerTest"
+      },
+      "type" : "java.lang.reflect.Field[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.IntrospectorTestCase3Test"
+      },
+      "type" : "java.lang.reflect.Method[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.IntrospectorTestCase3Test"
+      },
+      "type" : "junit.framework.TestCase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.GeneratorTest"
+      },
+      "type" : "org.apache.velocity.app.VelocityEngine"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.FieldMethodizerTest"
+      },
+      "type" : "org.apache.velocity.runtime.RuntimeConstants",
+      "fields" : [
+        {
+          "name" : "RUNTIME_LOG"
+        },
+        {
+          "name" : "RUNTIME_LOG_LOGSYSTEM_CLASS"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.ASTDirectiveTest"
+      },
+      "type" : "org.apache.velocity.runtime.directive.Foreach"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.ASTDirectiveTest"
+      },
+      "type" : "org.apache.velocity.runtime.directive.Include"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.ASTDirectiveTest"
+      },
+      "type" : "org.apache.velocity.runtime.directive.Literal"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.ASTDirectiveTest"
+      },
+      "type" : "org.apache.velocity.runtime.directive.Macro"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.ASTDirectiveTest"
+      },
+      "type" : "org.apache.velocity.runtime.directive.Parse"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.IntrospectorTestCaseTest"
+      },
+      "type" : "org.apache.velocity.runtime.log.NullLogSystem",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.LogManagerTest"
+      },
+      "type" : "org.apache.velocity.runtime.log.NullLogSystem"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.ASTDirectiveTest"
+      },
+      "type" : "org.apache.velocity.runtime.resource.ResourceCacheImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.ASTDirectiveTest"
+      },
+      "type" : "org.apache.velocity.runtime.resource.ResourceManagerImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.ASTDirectiveTest"
+      },
+      "type" : "org.apache.velocity.runtime.resource.loader.FileResourceLoader"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.IntrospectorTestCase3Test"
+      },
+      "type" : "org.apache.velocity.test.BaseTestCase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.IntrospectorTestCaseTest"
+      },
+      "type" : "org.apache.velocity.test.IntrospectorTestCase$MethodProvider",
+      "methods" : [
+        {
+          "name" : "booleanMethod",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        },
+        {
+          "name" : "byteMethod",
+          "parameterTypes" : [
+            "byte"
+          ]
+        },
+        {
+          "name" : "characterMethod",
+          "parameterTypes" : [
+            "char"
+          ]
+        },
+        {
+          "name" : "doubleMethod",
+          "parameterTypes" : [
+            "double"
+          ]
+        },
+        {
+          "name" : "floatMethod",
+          "parameterTypes" : [
+            "float"
+          ]
+        },
+        {
+          "name" : "integerMethod",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "longMethod",
+          "parameterTypes" : [
+            "long"
+          ]
+        },
+        {
+          "name" : "shortMethod",
+          "parameterTypes" : [
+            "short"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.IntrospectorTestCase2Test"
+      },
+      "type" : "org.apache.velocity.test.IntrospectorTestCase2"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.IntrospectorTestCase3Test"
+      },
+      "type" : "org.apache.velocity.test.IntrospectorTestCase3",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.IntrospectorTestCase3Test"
+      },
+      "type" : "org.apache.velocity.test.IntrospectorTestCase3$MethodProvider",
+      "methods" : [
+        {
+          "name" : "ii",
+          "parameterTypes" : [
+            "int",
+            "int"
+          ]
+        },
+        {
+          "name" : "lii",
+          "parameterTypes" : [
+            "java.util.List",
+            "int",
+            "int"
+          ]
+        },
+        {
+          "name" : "ll",
+          "parameterTypes" : [
+            "long",
+            "long"
+          ]
+        },
+        {
+          "name" : "lll",
+          "parameterTypes" : [
+            "java.util.List",
+            "long"
+          ]
+        },
+        {
+          "name" : "lll",
+          "parameterTypes" : [
+            "java.util.List",
+            "long",
+            "java.util.List"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.ParserTestCaseTest"
+      },
+      "type" : "org.apache.velocity.test.ParserTestCase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.GeneratorTest"
+      },
+      "type" : "org.apache.velocity.texen.util.FileUtil",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.GeneratorTest"
+      },
+      "type" : "org.apache.velocity.texen.util.PropertiesUtil",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.GeneratorTest"
+      },
+      "type" : "org.apache.velocity.util.StringUtils",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.UberspectImplTest"
+      },
+      "type" : "org.apache.velocity.util.introspection.Info"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.ASTDirectiveTest"
+      },
+      "type" : "org.apache.velocity.util.introspection.UberspectImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.ClassMapInnerMethodInfoTest"
+      },
+      "type" : "velocity.velocity.ClassMapInnerMethodInfoTest$Labeler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.ClassMapTest"
+      },
+      "type" : "velocity.velocity.ClassMapTest$GreetingService"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.IntrospectorTestCase3Test"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.Deprecated"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.IntrospectorTestCase3Test"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.GeneratorTest"
+      },
+      "glob" : "org/apache/velocity/texen/defaults/texen.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.ClasspathResourceLoaderTest"
+      },
+      "glob" : "velocity/velocity/classpath-resource-loader-template.vm"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.PropertiesUtilTest$ClasspathPropertiesUtil"
+      },
+      "glob" : "velocity/velocity/texen-test.properties"
+    }
+  ]
+}

--- a/tests/src/velocity/velocity/1.5/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/velocity/velocity/1.5/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -20,6 +20,51 @@
     },
     {
       "condition" : {
+        "typeReached" : "velocity.velocity.UberspectImplTest"
+      },
+      "type" : "java.io.Serializable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.UberspectImplTest"
+      },
+      "type" : "java.lang.Cloneable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.ExceptionUtilsTest"
+      },
+      "type" : "java.lang.Exception"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.ExceptionUtilsTest"
+      },
+      "type" : "java.lang.RuntimeException",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "java.lang.Throwable"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.RuntimeInstanceTest"
+      },
+      "type" : "java.lang.String",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
         "typeReached" : "velocity.velocity.IntrospectorTestCase3Test"
       },
       "type" : "java.lang.String[]"
@@ -35,6 +80,56 @@
         "typeReached" : "velocity.velocity.IntrospectorTestCase3Test"
       },
       "type" : "java.lang.reflect.Method[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.ExceptionUtilsTest"
+      },
+      "type" : "java.lang.Throwable",
+      "methods" : [
+        {
+          "name" : "initCause",
+          "parameterTypes" : [
+            "java.lang.Throwable"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.UberspectImplTest"
+      },
+      "type" : "java.util.AbstractMap"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.NodeListTest"
+      },
+      "type" : "java.util.ArrayList",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.UberspectImplTest"
+      },
+      "type" : "java.util.HashMap"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.MapGetExecutorTest"
+      },
+      "type" : "java.util.Map"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.MapSetExecutorTest"
+      },
+      "type" : "java.util.Map"
     },
     {
       "condition" : {
@@ -307,6 +402,23 @@
     },
     {
       "condition" : {
+        "typeReached" : "velocity.velocity.ExceptionUtilsTest"
+      },
+      "type" : "org.apache.velocity.util.ExceptionUtils",
+      "fields" : [
+        {
+          "name" : "class$java$lang$RuntimeException"
+        },
+        {
+          "name" : "class$java$lang$String"
+        },
+        {
+          "name" : "class$java$lang$Throwable"
+        }
+      ]
+    },
+    {
+      "condition" : {
         "typeReached" : "velocity.velocity.UberspectImplTest"
       },
       "type" : "org.apache.velocity.util.introspection.Info"
@@ -356,6 +468,12 @@
         "typeReached" : "velocity.velocity.GeneratorTest"
       },
       "glob" : "org/apache/velocity/texen/defaults/texen.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "velocity.velocity.ClassUtilsTest"
+      },
+      "glob" : "velocity/velocity/classutils-resource.txt"
     },
     {
       "condition" : {

--- a/tests/src/velocity/velocity/1.5/src/test/resources/velocity/velocity/classpath-resource-loader-template.vm
+++ b/tests/src/velocity/velocity/1.5/src/test/resources/velocity/velocity/classpath-resource-loader-template.vm
@@ -1,0 +1,1 @@
+Loaded through ClasspathResourceLoader

--- a/tests/src/velocity/velocity/1.5/src/test/resources/velocity/velocity/classutils-resource.txt
+++ b/tests/src/velocity/velocity/1.5/src/test/resources/velocity/velocity/classutils-resource.txt
@@ -1,0 +1,1 @@
+classutils-resource

--- a/tests/src/velocity/velocity/1.5/src/test/resources/velocity/velocity/texen-test.properties
+++ b/tests/src/velocity/velocity/1.5/src/test/resources/velocity/velocity/texen-test.properties
@@ -1,0 +1,2 @@
+texen.resource.loaded=true
+texen.resource.name=PropertiesUtil

--- a/tests/src/velocity/velocity/1.5/user-code-filter.json
+++ b/tests/src/velocity/velocity/1.5/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.velocity.**"
+    },
+    {
+      "includeClasses" : "velocity.velocity.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6977

This PR provides test fixes and new metadata for velocity:velocity:1.5, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 527886
- Cached input tokens: 5379584
- Output tokens: 49418
- Metadata entries: 30
- Test-only metadata entries: 78
- Iterations: 17
- Library coverage percentage: 24.05
- Previous library version metadata entries: 26
- Previous library version test-only metadata entries: 58
- Previous library version coverage percentage: 21.77

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `32f80823be833d851d1451bee542d4d1f4a0cdb1`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- velocity:velocity:1.4: 50/56 covered calls (89.29%)
- velocity:velocity:1.5: 34/41 covered calls (82.93%)

**Reflection:**
- velocity:velocity:1.4: 45/51 covered calls (88.24%)
- velocity:velocity:1.5: 27/34 covered calls (79.41%)

**Resources:**
- velocity:velocity:1.4: 5/5 covered calls (100.00%)
- velocity:velocity:1.5: 7/7 covered calls (100.00%)

#### Library coverage

**Instruction:**
- velocity:velocity:1.4: 10904/50585 (21.56%)
- velocity:velocity:1.5: 12785/51087 (25.03%)

**Line:**
- velocity:velocity:1.4: 2243/10303 (21.77%)
- velocity:velocity:1.5: 2632/10945 (24.05%)

**Method:**
- velocity:velocity:1.4: 416/1687 (24.66%)
- velocity:velocity:1.5: 482/1789 (26.94%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/velocity/velocity/1.4/build.gradle 2/tests/src/velocity/velocity/1.5/build.gradle
index cb04777bd0..d650a3823a 100644
--- 1/tests/src/velocity/velocity/1.4/build.gradle
+++ 2/tests/src/velocity/velocity/1.5/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "velocity:velocity:$libraryVersion"
+    testImplementation 'jdom:jdom:1.0'
     testImplementation 'junit:junit:3.8.2'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
diff --git 1/tests/src/velocity/velocity/1.4/src/test/java/velocity/velocity/ASTDirectiveTest.java 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ASTDirectiveTest.java
index 2cd1fbadb2..fa0c2a13fa 100644
--- 1/tests/src/velocity/velocity/1.4/src/test/java/velocity/velocity/ASTDirectiveTest.java
+++ 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ASTDirectiveTest.java
@@ -10,19 +10,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.StringWriter;
 import java.util.Arrays;
+import java.util.Properties;
 
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
 import org.apache.velocity.runtime.RuntimeConstants;
-import org.apache.velocity.runtime.log.NullLogSystem;
+import org.apache.velocity.runtime.log.NullLogChute;
 import org.junit.jupiter.api.Test;
 
 public class ASTDirectiveTest {
     @Test
     public void instantiatesRegisteredDirectiveWhenInitializingParsedTemplate() throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty(RuntimeConstants.RUNTIME_LOG_LOGSYSTEM_CLASS, NullLogChute.class.getName());
         VelocityEngine velocityEngine = new VelocityEngine();
-        velocityEngine.setProperty(RuntimeConstants.RUNTIME_LOG_LOGSYSTEM, new NullLogSystem());
-        velocityEngine.init();
+        velocityEngine.init(properties);
 
         VelocityContext context = new VelocityContext();
         context.put("items", Arrays.asList("alpha", "beta", "gamma"));
diff --git 1/tests/src/velocity/velocity/1.4/src/test/java/velocity/velocity/ClassMapInnerMethodInfoTest.java 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ClassMapInnerMethodInfoTest.java
index 50945baacf..51180e7dfc 100644
--- 1/tests/src/velocity/velocity/1.4/src/test/java/velocity/velocity/ClassMapInnerMethodInfoTest.java
+++ 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ClassMapInnerMethodInfoTest.java
@@ -10,13 +10,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.reflect.Method;
 
+import org.apache.velocity.runtime.log.Log;
+import org.apache.velocity.runtime.log.NullLogChute;
 import org.apache.velocity.util.introspection.ClassMap;
 import org.junit.jupiter.api.Test;
 
 public class ClassMapInnerMethodInfoTest {
     @Test
     void upcastsNonPublicImplementationMethodToPublicInterfaceMethod() throws Exception {
-        final ClassMap classMap = new ClassMap(HiddenLabeler.class);
+        final ClassMap classMap = new ClassMap(HiddenLabeler.class, new Log(new NullLogChute()));
 
         final Method method = classMap.findMethod("label", new Object[] {Integer.valueOf(7)});
 
diff --git 1/tests/src/velocity/velocity/1.4/src/test/java/velocity/velocity/ClassMapTest.java 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ClassMapTest.java
index cbb434ef34..1f8ae2b506 100644
--- 1/tests/src/velocity/velocity/1.4/src/test/java/velocity/velocity/ClassMapTest.java
+++ 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ClassMapTest.java
@@ -10,15 +10,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.reflect.Method;
 
+import org.apache.velocity.runtime.log.Log;
+import org.apache.velocity.runtime.log.NullLogChute;
 import org.apache.velocity.util.introspection.ClassMap;
 import org.junit.jupiter.api.Test;
 
 public class ClassMapTest {
     @Test
     void resolvesPublicInterfaceMethodForNonPublicImplementationMethod() throws Exception {
-        final Method implementationMethod = HiddenGreetingService.class.getMethod("greet", String.class);
+        final ClassMap classMap = new ClassMap(HiddenGreetingService.class, new Log(new NullLogChute()));
 
-        final Method publicMethod = ClassMap.getPublicMethod(implementationMethod);
+        final Method publicMethod = classMap.findMethod("greet", new Object[] {"Ada"});
 
         assertThat(publicMethod).isNotNull();
         assertThat(publicMethod.getDeclaringClass()).isEqualTo(GreetingService.class);
diff --git 1/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ClassUtilsTest.java 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ClassUtilsTest.java
new file mode 100644
index 0000000000..223c844fe4
--- /dev/null
+++ 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ClassUtilsTest.java
@@ -0,0 +1,70 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.velocity.util.ClassUtils;
+import org.junit.jupiter.api.Test;
+
+public class ClassUtilsTest {
+    private static final String RESOURCE_PATH = "velocity/velocity/classutils-resource.txt";
+
+    @Test
+    public void resolvesClassWithSystemLoaderWhenThreadContextClassLoaderIsUnavailable() throws Exception {
+        withContextClassLoader(null, () -> {
+            Class<?> resolvedClass = ClassUtils.getClass(String.class.getName());
+
+            assertThat(resolvedClass).isSameAs(String.class);
+        });
+    }
+
+    @Test
+    public void readsResourceWithClassLoaderWhenThreadContextClassLoaderIsUnavailable() throws Exception {
+        withContextClassLoader(null, () -> {
+            try (InputStream resource = ClassUtils.getResourceAsStream(ClassUtilsTest.class, RESOURCE_PATH)) {
+                assertResourceContent(resource);
+            }
+        });
+    }
+
+    @Test
+    public void fallsBackToClassLoaderWhenThreadContextClassLoaderCannotFindResource() throws Exception {
+        try (URLClassLoader emptyClassLoader = new URLClassLoader(new URL[0], null)) {
+            withContextClassLoader(emptyClassLoader, () -> {
+                try (InputStream resource = ClassUtils.getResourceAsStream(ClassUtilsTest.class, RESOURCE_PATH)) {
+                    assertResourceContent(resource);
+                }
+            });
+        }
+    }
+
+    private static void assertResourceContent(InputStream resource) throws Exception {
+        assertThat(resource).isNotNull();
+        assertThat(new String(resource.readAllBytes(), StandardCharsets.UTF_8)).contains("classutils-resource");
+    }
+
+    private static void withContextClassLoader(ClassLoader classLoader, ThrowingRunnable runnable) throws Exception {
+        Thread currentThread = Thread.currentThread();
+        ClassLoader originalClassLoader = currentThread.getContextClassLoader();
+        currentThread.setContextClassLoader(classLoader);
+        try {
+            runnable.run();
+        } finally {
+            currentThread.setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    private interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+}
diff --git 1/tests/src/velocity/velocity/1.4/src/test/java/velocity/velocity/ClassloaderChangeTestTest.java 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ClassloaderChangeTestTest.java
index 24bf077236..452b648511 100644
--- 1/tests/src/velocity/velocity/1.4/src/test/java/velocity/velocity/ClassloaderChangeTestTest.java
+++ 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ClassloaderChangeTestTest.java
@@ -6,12 +6,14 @@
  */
 package velocity.velocity;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
 import java.util.Base64;
 
-import org.apache.velocity.test.ClassloaderChangeTest;
+import org.apache.velocity.runtime.log.Log;
+import org.apache.velocity.runtime.log.NullLogChute;
+import org.apache.velocity.util.introspection.Introspector;
 import org.graalvm.internal.tck.NativeImageSupport;
 import org.junit.jupiter.api.Test;
 
@@ -25,22 +27,58 @@ public class ClassloaderChangeTestTest {
             """.replaceAll("\\s", ""));
 
     @Test
-    public void reloadsFooClassAndFlushesVelocityIntrospectionCache() throws Exception {
-        writeFooClassFileExpectedByUpstreamTest();
-
+    public void clearsIntrospectionCacheAfterClassLoaderChange() throws Exception {
         try {
-            ClassloaderChangeTest test = new ClassloaderChangeTest();
-            test.runTest();
+            final Introspector introspector = new Introspector(new Log(new NullLogChute()));
+
+            assertThat(invokeDoIt(introspector, loadFooClass())).isEqualTo("Hello From Foo");
+            introspector.triggerClear();
+            assertThat(invokeDoIt(introspector, loadFooClass())).isEqualTo("Hello From Foo");
+        } catch (ClassNotFoundException exception) {
+            if (!isUnsupportedNativeImageDynamicClassLoading(exception)) {
+                throw exception;
+            }
         } catch (Error error) {
-            if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+            if (!NativeImageSupport.isUnsupportedFeatureError(error)
+                    && !isUnsupportedNativeImageDynamicClassLoading(error)) {
                 throw error;
             }
         }
     }
 
-    private static void writeFooClassFileExpectedByUpstreamTest() throws IOException {
-        Path classFile = Path.of("..", "test", "classloader", "Foo.class");
-        Files.createDirectories(classFile.getParent());
-        Files.write(classFile, FOO_CLASS_BYTES);
+    private static Class<?> loadFooClass() throws ClassNotFoundException {
+        return new ByteArrayClassLoader().loadClass("Foo");
+    }
+
+    private static Object invokeDoIt(final Introspector introspector, final Class<?> fooClass) throws Exception {
+        final Method method = introspector.getMethod(fooClass, "doIt", new Object[0]);
+        final Object instance = fooClass.getDeclaredConstructor().newInstance();
+        return method.invoke(instance);
+    }
+
+    private static boolean isUnsupportedNativeImageDynamicClassLoading(final Throwable throwable) {
+        if (!"runtime".equals(System.getProperty("org.graalvm.nativeimage.imagecode"))) {
+            return false;
+        }
+
+        Throwable current = throwable;
+        while (current != null) {
+            if ((current instanceof ClassNotFoundException || current instanceof NoClassDefFoundError)
+                    && "Foo".equals(current.getMessage())) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private static final class ByteArrayClassLoader extends ClassLoader {
+        @Override
+        protected Class<?> findClass(final String name) throws ClassNotFoundException {
+            if ("Foo".equals(name)) {
+                return defineClass(name, FOO_CLASS_BYTES, 0, FOO_CLASS_BYTES.length);
+            }
+            throw new ClassNotFoundException(name);
+        }
     }
 }
diff --git 1/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ExceptionUtilsTest.java 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ExceptionUtilsTest.java
new file mode 100644
index 0000000000..f39f6508bd
--- /dev/null
+++ 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ExceptionUtilsTest.java
@@ -0,0 +1,81 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+
+import org.apache.velocity.util.ExceptionUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ExceptionUtilsTest {
+    @BeforeEach
+    public void enableCauseSupport() throws Exception {
+        resetGeneratedClassLiteralCaches();
+        setCausesAllowed(true);
+    }
+
+    @AfterEach
+    public void restoreCauseSupport() throws Exception {
+        setCausesAllowed(true);
+    }
+
+    @Test
+    public void createsThrowablesUsingModernAndLegacyCausePaths() {
+        IllegalArgumentException cause = new IllegalArgumentException("bad input");
+
+        RuntimeException runtimeException = ExceptionUtils.createRuntimeException(
+                "runtime failure", cause);
+        assertThat(runtimeException)
+                .isExactlyInstanceOf(RuntimeException.class)
+                .hasMessage("runtime failure");
+        assertThat(runtimeException.getCause()).isSameAs(cause);
+
+        Exception target = new Exception("target");
+        ExceptionUtils.setCause(target, cause);
+        assertThat(target.getCause()).isSameAs(cause);
+
+        Throwable fallbackException = ExceptionUtils.createWithCause(
+                MessageOnlyException.class, "message-only failure", cause);
+        assertThat(fallbackException)
+                .isInstanceOf(MessageOnlyException.class)
+                .hasMessageContaining("message-only failure")
+                .hasMessageContaining("caused by")
+                .hasMessageContaining(cause.toString());
+        assertThat(fallbackException.getCause()).isNull();
+    }
+
+    private static void resetGeneratedClassLiteralCaches() throws Exception {
+        setClassLiteralCache("class$java$lang$RuntimeException", null);
+        setClassLiteralCache("class$java$lang$String", null);
+        setClassLiteralCache("class$java$lang$Throwable", null);
+    }
+
+    private static void setCausesAllowed(boolean causesAllowed) throws Exception {
+        Field field = ExceptionUtils.class.getDeclaredField("causesAllowed");
+        field.setAccessible(true);
+        field.setBoolean(null, causesAllowed);
+    }
+
+    private static void setClassLiteralCache(
+            String fieldName, Class<?> cachedClass) throws Exception {
+        Field field = ExceptionUtils.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(null, cachedClass);
+    }
+
+    public static final class MessageOnlyException extends Exception {
+        private static final long serialVersionUID = 1L;
+
+        public MessageOnlyException(String message) {
+            super(message);
+        }
+    }
+}
diff --git 1/tests/src/velocity/velocity/1.4/src/test/java/velocity/velocity/GeneratorTest.java 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/GeneratorTest.java
index 7ed5d82953..6f5a4ca8f1 100644
--- 1/tests/src/velocity/velocity/1.4/src/test/java/velocity/velocity/GeneratorTest.java
+++ 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/GeneratorTest.java
@@ -8,6 +8,7 @@ package velocity.velocity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
 import java.io.Writer;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -81,7 +82,7 @@ public class GeneratorTest {
         }
 
         @Override
-        public void merge(Context context, Writer writer) throws Exception {
+        public void merge(Context context, Writer writer) throws IOException {
             writer.write(templateName);
         }
     }
diff --git 1/tests/src/velocity/velocity/1.4/src/test/java/velocity/velocity/GetExecutorTest.java 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/GetExecutorTest.java
index cd795c57d2..eb446ada80 100644
--- 1/tests/src/velocity/velocity/1.4/src/test/java/velocity/velocity/GetExecutorTest.java
+++ 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/GetExecutorTest.java
@@ -9,8 +9,10 @@ package velocity.velocity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.apache.velocity.exception.MethodInvocationException;
-import org.apache.velocity.runtime.RuntimeLogger;
+import java.lang.reflect.InvocationTargetException;
+
+import org.apache.velocity.runtime.log.Log;
+import org.apache.velocity.runtime.log.NullLogChute;
 import org.apache.velocity.runtime.parser.node.GetExecutor;
 import org.apache.velocity.util.introspection.Introspector;
 import org.junit.jupiter.api.Test;
@@ -28,30 +30,19 @@ public class GetExecutorTest {
     }
 
     @Test
-    void oldExecuteInvokesResolvedGetMethod() throws Exception {
-        final GetExecutor executor = newExecutor("legacy");
-        final KeyValueStore store = new KeyValueStore();
-
-        final Object result = executor.OLDexecute(store, null);
-
-        assertThat(result).isEqualTo("value:legacy");
-        assertThat(store.getLastKey()).isEqualTo("legacy");
-    }
-
-    @Test
-    void oldExecuteWrapsGetMethodExceptions() throws Exception {
-        final NoOpRuntimeLogger logger = new NoOpRuntimeLogger();
-        final GetExecutor executor = new GetExecutor(logger, new Introspector(logger), FailingKeyValueStore.class,
+    void executePropagatesGetMethodInvocationExceptions() throws Exception {
+        final Log log = new Log(new NullLogChute());
+        final GetExecutor executor = new GetExecutor(log, new Introspector(log), FailingKeyValueStore.class,
                 "boom");
 
-        assertThatThrownBy(() -> executor.OLDexecute(new FailingKeyValueStore(), null))
-                .isInstanceOf(MethodInvocationException.class)
-                .hasMessageContaining("Invocation of method 'get(\"boom\")'");
+        assertThatThrownBy(() -> executor.execute(new FailingKeyValueStore()))
+                .isInstanceOf(InvocationTargetException.class)
+                .hasCauseInstanceOf(IllegalStateException.class);
     }
 
     private static GetExecutor newExecutor(final String key) throws Exception {
-        final NoOpRuntimeLogger logger = new NoOpRuntimeLogger();
-        return new GetExecutor(logger, new Introspector(logger), KeyValueStore.class, key);
+        final Log log = new Log(new NullLogChute());
+        return new GetExecutor(log, new Introspector(log), KeyValueStore.class, key);
     }
 
     public static final class KeyValueStore {
@@ -72,22 +63,4 @@ public class GetExecutorTest {
             throw new IllegalStateException("Cannot resolve " + key);
         }
     }
-
-    private static final class NoOpRuntimeLogger implements RuntimeLogger {
-        @Override
-        public void warn(final Object message) {
-        }
-
-        @Override
-        public void info(final Object message) {
-        }
-
-        @Override
-        public void error(final Object message) {
-        }
-
-        @Override
-        public void debug(final Object message) {
-        }
-    }
 }
diff --git 1/tests/src/velocity/velocity/1.4/src/test/java/velocity/velocity/IntrospectorTestCase2Test.java 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/IntrospectorTestCase2Test.java
index 68ffb1563d..793b8a4667 100644
--- 1/tests/src/velocity/velocity/1.4/src/test/java/velocity/velocity/IntrospectorTestCase2Test.java
+++ 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/IntrospectorTestCase2Test.java
@@ -6,55 +6,94 @@
  */
 package velocity.velocity;
 
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import java.lang.reflect.Field;
+import java.io.IOException;
 import java.lang.reflect.Method;
 
-import org.apache.velocity.runtime.RuntimeConstants;
-import org.apache.velocity.runtime.RuntimeSingleton;
-import org.apache.velocity.runtime.log.NullLogSystem;
-import org.apache.velocity.test.IntrospectorTestCase2;
+import org.apache.velocity.runtime.log.Log;
+import org.apache.velocity.runtime.log.NullLogChute;
+import org.apache.velocity.util.introspection.Introspector;
 import org.junit.jupiter.api.Test;
 
 public class IntrospectorTestCase2Test {
     @Test
     void resolvesMostSpecificOverloadAndRejectsAmbiguousMatch() throws Exception {
-        RuntimeSingleton.setProperty(
-                RuntimeConstants.RUNTIME_LOG_LOGSYSTEM,
-                new NullLogSystem());
-        resolveNestedClassThroughCompilerGeneratedHelper();
-        clearClassLiteralCache("class$org$apache$velocity$test$IntrospectorTestCase2$Tester");
-        clearClassLiteralCache("class$org$apache$velocity$test$IntrospectorTestCase2$Tester2");
-
-        IntrospectorTestCase2 testCase = new IntrospectorTestCase2("runTest");
-        testCase.runTest();
+        final Introspector introspector = new Introspector(new Log(new NullLogChute()));
+
+        final Method specificMethod = introspector.getMethod(
+                OverloadedTester.class,
+                "find",
+                new Object[] {Integer.valueOf(7)});
+        final Object specificResult = specificMethod.invoke(new OverloadedTester(), Integer.valueOf(7));
+
+        assertThat(specificMethod.getParameterTypes()).containsExactly(Integer.class);
+        assertThat(specificResult).isEqualTo("integer:7");
+        assertThat(introspector.getMethod(
+                AmbiguousTester.class,
+                "match",
+                new Object[] {new AmbiguousValue()})).isNull();
     }
 
-    private static void resolveNestedClassThroughCompilerGeneratedHelper() throws Exception {
-        /*
-         * `IntrospectorTestCase2` was compiled with a package-private synthetic
-         * `class$(String)` helper for nested class literals. Calling the helper
-         * verifies the same class resolution path used by `runTest()`.
-         */
-        Method classResolver = IntrospectorTestCase2.class.getDeclaredMethod("class$", String.class);
-        classResolver.setAccessible(true);
+    public static final class OverloadedTester {
+        public String find(final Number value) {
+            return "number:" + value;
+        }
+
+        public String find(final Integer value) {
+            return "integer:" + value;
+        }
+    }
 
-        Object resolvedClass = classResolver.invoke(
-                null,
-                "org.apache.velocity.test.IntrospectorTestCase2$Tester");
+    public static final class AmbiguousTester {
+        public String match(final CharSequence value) {
+            return "chars:" + value;
+        }
 
-        assertSame(IntrospectorTestCase2.Tester.class, resolvedClass);
+        public String match(final Appendable value) {
+            return "appendable:" + value;
+        }
     }
 
-    private static void clearClassLiteralCache(String fieldName) throws Exception {
-        /*
-         * The Velocity 1.4 artifact was compiled with synthetic `Class` caches for
-         * the nested overload test classes. Clear them so `runTest()` exercises
-         * the original `Class.forName(String)` resolution path.
-         */
-        Field classCache = IntrospectorTestCase2.class.getDeclaredField(fieldName);
-        classCache.setAccessible(true);
-        classCache.set(null, null);
+    public static final class AmbiguousValue implements CharSequence, Appendable {
+        private final StringBuilder text = new StringBuilder("ambiguous");
+
+        @Override
+        public int length() {
+            return text.length();
+        }
+
+        @Override
+        public char charAt(final int index) {
+            return text.charAt(index);
+        }
+
+        @Override
+        public CharSequence subSequence(final int start, final int end) {
+            return text.subSequence(start, end);
+        }
+
+        @Override
+        public Appendable append(final CharSequence value) throws IOException {
+            text.append(value);
+            return this;
+        }
+
+        @Override
+        public Appendable append(final CharSequence value, final int start, final int end) throws IOException {
+            text.append(value, start, end);
+            return this;
+        }
+
+        @Override
+        public Appendable append(final char value) throws IOException {
+            text.append(value);
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            return text.toString();
+        }
     }
 }
diff --git 1/tests/src/velocity/velocity/1.4/src/test/java/velocity/velocity/IntrospectorTestCase3Test.java 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/IntrospectorTestCase3Test.java
index 2416b18e26..8cd3b83a9e 100644
--- 1/tests/src/velocity/velocity/1.4/src/test/java/velocity/velocity/IntrospectorTestCase3Test.java
+++ 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/IntrospectorTestCase3Test.java
@@ -6,18 +6,37 @@
  */
 package velocity.velocity;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.apache.velocity.test.IntrospectorTestCase3;
+import java.lang.reflect.Method;
+
+import org.apache.velocity.runtime.log.Log;
+import org.apache.velocity.runtime.log.NullLogChute;
+import org.apache.velocity.util.introspection.Introspector;
 import org.junit.jupiter.api.Test;
 
 public class IntrospectorTestCase3Test {
     @Test
-    void runsPrimitiveOverloadIntrospectionTestCase() throws Exception {
-        junit.framework.Test suite = IntrospectorTestCase3.suite();
-        assertNotNull(suite);
+    void resolvesPrimitiveOverloadForBoxedArgument() throws Exception {
+        final Introspector introspector = new Introspector(new Log(new NullLogChute()));
+
+        final Method method = introspector.getMethod(
+                PrimitiveOverloads.class,
+                "inspect",
+                new Object[] {Integer.valueOf(3)});
+        final Object result = method.invoke(new PrimitiveOverloads(), Integer.valueOf(3));
+
+        assertThat(method.getParameterTypes()).containsExactly(int.class);
+        assertThat(result).isEqualTo("int:3");
+    }
+
+    public static final class PrimitiveOverloads {
+        public String inspect(final Object value) {
+            return "object:" + value;
+        }
 
-        IntrospectorTestCase3 testCase = new IntrospectorTestCase3("testSimple");
-        testCase.testSimple();
+        public String inspect(final int value) {
+            return "int:" + value;
+        }
     }
 }
diff --git 1/tests/src/velocity/velocity/1.4/src/test/java/velocity/velocity/IntrospectorTestCaseTest.java 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/IntrospectorTestCaseTest.java
index def394ae08..6b434edb2d 100644
--- 1/tests/src/velocity/velocity/1.4/src/test/java/velocity/velocity/IntrospectorTestCaseTest.java
+++ 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/IntrospectorTestCaseTest.java
@@ -6,35 +6,50 @@
  */
 package velocity.velocity;
 
-import java.lang.reflect.Field;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.StringWriter;
+import java.util.Properties;
+
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.app.VelocityEngine;
 import org.apache.velocity.runtime.RuntimeConstants;
-import org.apache.velocity.runtime.RuntimeSingleton;
-import org.apache.velocity.test.IntrospectorTestCase;
+import org.apache.velocity.runtime.log.NullLogChute;
 import org.junit.jupiter.api.Test;
 
 public class IntrospectorTestCaseTest {
     @Test
-    void runsVelocityPrimitiveIntrospectionTestCase() throws Exception {
-        RuntimeSingleton.setProperty(
-                RuntimeConstants.RUNTIME_LOG_LOGSYSTEM_CLASS,
-                "org.apache.velocity.runtime.log.NullLogSystem");
-        RuntimeSingleton.init();
-        clearMethodProviderClassCache();
-
-        IntrospectorTestCase testCase = new IntrospectorTestCase("runTest");
-        testCase.runTest();
+    void rendersTemplateUsingPrimitiveMethodIntrospection() throws Exception {
+        final VelocityEngine engine = newVelocityEngine();
+        final VelocityContext context = new VelocityContext();
+        context.put("provider", new MethodProvider());
+        final StringWriter writer = new StringWriter();
+
+        final boolean rendered = engine.evaluate(
+                context,
+                writer,
+                "primitive-introspection",
+                "$provider.get(41) $provider.ready");
+
+        assertThat(rendered).isTrue();
+        assertThat(writer).hasToString("value=41 true");
     }
 
-    private static void clearMethodProviderClassCache() throws Exception {
-        /*
-         * The Velocity 1.4 artifact was compiled with a synthetic `Class` cache for
-         * `MethodProvider.class`. Clear it so `runTest()` exercises the original
-         * `Class.forName(String)` resolution path even if test discovery initialized it.
-         */
-        Field classCache = IntrospectorTestCase.class.getDeclaredField(
-                "class$org$apache$velocity$test$IntrospectorTestCase$MethodProvider");
-        classCache.setAccessible(true);
-        classCache.set(null, null);
+    private static VelocityEngine newVelocityEngine() throws Exception {
+        final Properties properties = new Properties();
+        properties.setProperty(RuntimeConstants.RUNTIME_LOG_LOGSYSTEM_CLASS, NullLogChute.class.getName());
+        final VelocityEngine engine = new VelocityEngine();
+        engine.init(properties);
+        return engine;
+    }
+
+    public static final class MethodProvider {
+        public String get(final int value) {
+            return "value=" + value;
+        }
+
+        public boolean isReady() {
+            return true;
+        }
     }
 }
diff --git 1/tests/src/velocity/velocity/1.4/src/test/java/velocity/velocity/LogManagerTest.java 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/LogManagerTest.java
index 409407f7a0..b488bad14d 100644
--- 1/tests/src/velocity/velocity/1.4/src/test/java/velocity/velocity/LogManagerTest.java
+++ 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/LogManagerTest.java
@@ -10,46 +10,85 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.velocity.runtime.RuntimeConstants;
 import org.apache.velocity.runtime.RuntimeInstance;
+import org.apache.velocity.runtime.RuntimeServices;
+import org.apache.velocity.runtime.log.Log;
+import org.apache.velocity.runtime.log.LogChute;
 import org.apache.velocity.runtime.log.LogManager;
-import org.apache.velocity.runtime.log.LogSystem;
-import org.apache.velocity.runtime.log.NullLogSystem;
 import org.junit.jupiter.api.Test;
 
 public class LogManagerTest {
     @Test
-    void createsConfiguredLogSystemFromClassName() throws Exception {
-        final RuntimeInstance runtime = new ConfiguredRuntimeInstance(NullLogSystem.class.getName());
+    void installsConfiguredLogChuteFromClassName() throws Exception {
+        RecordingLogChute.reset();
+        final RuntimeInstance runtime = new ConfiguredRuntimeInstance(RecordingLogChute.class.getName());
+        final Log log = runtime.getLog();
 
-        final LogSystem logSystem = LogManager.createLogSystem(runtime);
+        LogManager.updateLog(log, runtime);
+        log.info("configured");
 
-        assertThat(logSystem).isInstanceOf(NullLogSystem.class);
+        assertThat(RecordingLogChute.isInitialized()).isTrue();
+        assertThat(RecordingLogChute.getLastLevel()).isEqualTo(LogChute.INFO_ID);
+        assertThat(RecordingLogChute.getLastMessage()).isEqualTo("configured");
     }
 
     private static final class ConfiguredRuntimeInstance extends RuntimeInstance {
-        private final String logSystemClass;
+        private final String logChuteClass;
 
-        private ConfiguredRuntimeInstance(final String logSystemClass) {
-            this.logSystemClass = logSystemClass;
+        private ConfiguredRuntimeInstance(final String logChuteClass) {
+            this.logChuteClass = logChuteClass;
         }
 
         @Override
         public Object getProperty(final String key) {
             if (RuntimeConstants.RUNTIME_LOG_LOGSYSTEM_CLASS.equals(key)) {
-                return logSystemClass;
+                return logChuteClass;
             }
             return null;
         }
+    }
+
+    public static final class RecordingLogChute implements LogChute {
+        private static boolean initialized;
+        private static int lastLevel;
+        private static String lastMessage;
+
+        public static void reset() {
+            initialized = false;
+            lastLevel = -1;
+            lastMessage = null;
+        }
+
+        public static boolean isInitialized() {
+            return initialized;
+        }
+
+        public static int getLastLevel() {
+            return lastLevel;
+        }
+
+        public static String getLastMessage() {
+            return lastMessage;
+        }
+
+        @Override
+        public void init(final RuntimeServices runtimeServices) {
+            initialized = true;
+        }
 
         @Override
-        public void info(final Object message) {
+        public void log(final int level, final String message) {
+            lastLevel = level;
+            lastMessage = message;
         }
 
         @Override
-        public void error(final Object message) {
+        public void log(final int level, final String message, final Throwable throwable) {
+            log(level, message);
         }
 
         @Override
-        public void debug(final Object message) {
+        public boolean isLevelEnabled(final int level) {
+            return true;
         }
     }
 }
diff --git 1/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/MapGetExecutorTest.java 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/MapGetExecutorTest.java
new file mode 100644
index 0000000000..3f73c729c6
--- /dev/null
+++ 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/MapGetExecutorTest.java
@@ -0,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.velocity.runtime.log.Log;
+import org.apache.velocity.runtime.log.NullLogChute;
+import org.apache.velocity.runtime.parser.node.MapGetExecutor;
+import org.junit.jupiter.api.Test;
+
+public class MapGetExecutorTest {
+    @Test
+    void constructorDiscoversMapGetMethodAndExecuteReturnsStoredValue() throws Exception {
+        final Log log = new Log(new NullLogChute());
+        final MapGetExecutor executor = new MapGetExecutor(log, HashMap.class, "answer");
+        final Map<String, String> values = new HashMap<>();
+        values.put("answer", "forty-two");
+
+        final Object result = executor.execute(values);
+
+        assertThat(executor.isAlive()).isTrue();
+        assertThat(result).isEqualTo("forty-two");
+    }
+}
diff --git 1/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/MapSetExecutorTest.java 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/MapSetExecutorTest.java
new file mode 100644
index 0000000000..1ac0015399
--- /dev/null
+++ 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/MapSetExecutorTest.java
@@ -0,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.velocity.runtime.log.Log;
+import org.apache.velocity.runtime.log.NullLogChute;
+import org.apache.velocity.runtime.parser.node.MapSetExecutor;
+import org.junit.jupiter.api.Test;
+
+public class MapSetExecutorTest {
+    @Test
+    void constructorDiscoversMapPutMethodAndExecuteStoresValue() throws Exception {
+        final Log log = new Log(new NullLogChute());
+        final MapSetExecutor executor = new MapSetExecutor(log, HashMap.class, "answer");
+        final Map<String, String> values = new HashMap<>();
+
+        final Object previousValue = executor.execute(values, "forty-two");
+
+        assertThat(executor.isAlive()).isTrue();
+        assertThat(previousValue).isNull();
+        assertThat(values).containsEntry("answer", "forty-two");
+    }
+}
diff --git 1/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/MathUtilsTest.java 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/MathUtilsTest.java
new file mode 100644
index 0000000000..377b1fae97
--- /dev/null
+++ 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/MathUtilsTest.java
@@ -0,0 +1,47 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import org.apache.velocity.runtime.parser.node.MathUtils;
+import org.junit.jupiter.api.Test;
+
+public class MathUtilsTest {
+    @Test
+    public void performsArithmeticAcrossPrimitiveAndBigNumberTypes() {
+        final Number byteValue = MathUtils.wrapPrimitive(7L, Byte.class);
+        final Number shortValue = MathUtils.wrapPrimitive(300L, Short.class);
+        final Number integerValue = MathUtils.add(byteValue, shortValue);
+        final Number longValue = MathUtils.multiply(integerValue, Long.valueOf(2L));
+        final Number decimalValue = MathUtils.divide(new BigDecimal("9.0"), Integer.valueOf(2));
+        final Number bigIntegerValue = MathUtils.add(
+                BigInteger.valueOf(Long.MAX_VALUE),
+                BigInteger.ONE);
+
+        assertThat(byteValue).isEqualTo(Byte.valueOf((byte) 7));
+        assertThat(shortValue).isEqualTo(Short.valueOf((short) 300));
+        assertThat(integerValue).isEqualTo(Short.valueOf((short) 307));
+        assertThat(longValue).isEqualTo(Long.valueOf(614L));
+        assertThat((BigDecimal) decimalValue).isEqualByComparingTo(new BigDecimal("4.5"));
+        assertThat(bigIntegerValue).isEqualTo(new BigInteger("9223372036854775808"));
+    }
+
+    @Test
+    public void comparesAndClassifiesNumericValues() {
+        assertThat(MathUtils.isInteger(Integer.valueOf(10))).isTrue();
+        assertThat(MathUtils.isInteger(Double.valueOf(10.0D))).isFalse();
+        assertThat(MathUtils.isZero(BigDecimal.ZERO)).isTrue();
+        assertThat(MathUtils.isZero(Float.valueOf(0.25F))).isFalse();
+        assertThat(MathUtils.compare(BigInteger.TEN, Long.valueOf(9L))).isPositive();
+        assertThat(MathUtils.modulo(Integer.valueOf(17), Byte.valueOf((byte) 5)))
+                .isEqualTo(Integer.valueOf(2));
+    }
+}
diff --git 1/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/NodeListTest.java 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/NodeListTest.java
new file mode 100644
index 0000000000..8d013f82e7
--- /dev/null
+++ 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/NodeListTest.java
@@ -0,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.apache.velocity.anakia.NodeList;
+import org.junit.jupiter.api.Test;
+
+public class NodeListTest {
+    @Test
+    void cloneCreatesIndependentBackingList() throws Exception {
+        String originalNode = "original";
+        NodeList original = new NodeList();
+        original.add(originalNode);
+
+        NodeList cloned = (NodeList) original.clone();
+        List clonedBackingList = cloned.getList();
+
+        original.add("added");
+
+        assertThat(clonedBackingList).isNotSameAs(original.getList());
+        assertThat(cloned).containsExactly(originalNode);
+        assertThat(original).hasSize(2);
+    }
+}
diff --git 1/tests/src/velocity/velocity/1.4/src/test/java/velocity/velocity/ParserTestCaseTest.java 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ParserTestCaseTest.java
index 3122a31462..e71c3f8af0 100644
--- 1/tests/src/velocity/velocity/1.4/src/test/java/velocity/velocity/ParserTestCaseTest.java
+++ 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/ParserTestCaseTest.java
@@ -8,33 +8,39 @@ package velocity.velocity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.lang.reflect.Field;
-
-import junit.framework.TestSuite;
-
-import org.apache.velocity.test.ParserTestCase;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.Properties;
+
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.app.VelocityEngine;
+import org.apache.velocity.runtime.RuntimeConstants;
+import org.apache.velocity.runtime.log.NullLogChute;
 import org.junit.jupiter.api.Test;
 
 public class ParserTestCaseTest {
     @Test
-    public void createsJUnitThreeSuiteForParserRegressionTests() throws Exception {
-        clearParserTestCaseClassCache();
-
-        TestSuite suite = (TestSuite) ParserTestCase.suite();
-
-        assertThat(suite).isNotNull();
-        assertThat(suite.getName()).isEqualTo(ParserTestCase.class.getName());
+    public void parsesForeachAndSetDirectives() throws Exception {
+        final VelocityEngine engine = newVelocityEngine();
+        final VelocityContext context = new VelocityContext();
+        context.put("items", Arrays.asList("alpha", "beta", "gamma"));
+        final StringWriter writer = new StringWriter();
+
+        final boolean rendered = engine.evaluate(
+                context,
+                writer,
+                "parser-regression",
+                "#foreach($item in $items)$velocityCount:$item;#end#set($status = 'done')$status");
+
+        assertThat(rendered).isTrue();
+        assertThat(writer).hasToString("1:alpha;2:beta;3:gamma;done");
     }
 
-    private static void clearParserTestCaseClassCache() throws Exception {
-        /*
-         * The Velocity 1.4 artifact was compiled with a synthetic `Class` cache for
-         * `ParserTestCase.class`. Clear it so `suite()` exercises the original
-         * `Class.forName(String)` resolution path even if discovery initialized it.
-         */
-        Field classCache = ParserTestCase.class.getDeclaredField(
-                "class$org$apache$velocity$test$ParserTestCase");
-        classCache.setAccessible(true);
-        classCache.set(null, null);
+    private static VelocityEngine newVelocityEngine() throws Exception {
+        final Properties properties = new Properties();
+        properties.setProperty(RuntimeConstants.RUNTIME_LOG_LOGSYSTEM_CLASS, NullLogChute.class.getName());
+        final VelocityEngine engine = new VelocityEngine();
+        engine.init(properties);
+        return engine;
     }
 }
diff --git 1/tests/src/velocity/velocity/1.4/src/test/java/velocity/velocity/PropertiesUtilTest.java 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/PropertiesUtilTest.java
index e3f3deef7b..d839a440f1 100644
--- 1/tests/src/velocity/velocity/1.4/src/test/java/velocity/velocity/PropertiesUtilTest.java
+++ 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/PropertiesUtilTest.java
@@ -17,7 +17,7 @@ public class PropertiesUtilTest {
     private static final String PROPERTIES_RESOURCE = "velocity/velocity/texen-test.properties";
 
     @Test
-    public void loadsPropertiesResourceFromClasspath() {
+    public void loadsPropertiesResourceFromClasspath() throws Exception {
         ClasspathPropertiesUtil propertiesUtil = new ClasspathPropertiesUtil();
 
         Properties properties = propertiesUtil.loadClasspathResource(PROPERTIES_RESOURCE);
@@ -28,7 +28,7 @@ public class PropertiesUtilTest {
     }
 
     private static final class ClasspathPropertiesUtil extends PropertiesUtil {
-        private Properties loadClasspathResource(String propertiesFile) {
+        private Properties loadClasspathResource(String propertiesFile) throws Exception {
             return loadFromClassPath(propertiesFile);
         }
     }
diff --git 1/tests/src/velocity/velocity/1.4/src/test/java/velocity/velocity/PropertyExecutorTest.java 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/PropertyExecutorTest.java
index e84fc32a41..e59e94f016 100644
--- 1/tests/src/velocity/velocity/1.4/src/test/java/velocity/velocity/PropertyExecutorTest.java
+++ 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/PropertyExecutorTest.java
@@ -8,7 +8,8 @@ package velocity.velocity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.apache.velocity.runtime.RuntimeLogger;
+import org.apache.velocity.runtime.log.Log;
+import org.apache.velocity.runtime.log.NullLogChute;
 import org.apache.velocity.runtime.parser.node.PropertyExecutor;
 import org.apache.velocity.util.introspection.Introspector;
 import org.junit.jupiter.api.Test;
@@ -16,9 +17,8 @@ import org.junit.jupiter.api.Test;
 public class PropertyExecutorTest {
     @Test
     void executeInvokesResolvedPropertyGetter() throws Exception {
-        final NoOpRuntimeLogger logger = new NoOpRuntimeLogger();
-        final PropertyExecutor executor = new PropertyExecutor(logger, new Introspector(logger), Person.class,
-                "name");
+        final Log log = new Log(new NullLogChute());
+        final PropertyExecutor executor = new PropertyExecutor(log, new Introspector(log), Person.class, "name");
 
         final Object result = executor.execute(new Person("Ada"));
 
@@ -37,22 +37,4 @@ public class PropertyExecutorTest {
             return name;
         }
     }
-
-    private static final class NoOpRuntimeLogger implements RuntimeLogger {
-        @Override
-        public void warn(final Object message) {
-        }
-
-        @Override
-        public void info(final Object message) {
-        }
-
-        @Override
-        public void error(final Object message) {
-        }
-
-        @Override
-        public void debug(final Object message) {
-        }
-    }
 }
diff --git 1/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/RuntimeInstanceTest.java 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/RuntimeInstanceTest.java
new file mode 100644
index 0000000000..5f6236fa7f
--- /dev/null
+++ 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/RuntimeInstanceTest.java
@@ -0,0 +1,59 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package velocity.velocity;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.velocity.runtime.RuntimeConstants;
+import org.apache.velocity.runtime.RuntimeInstance;
+import org.apache.velocity.runtime.RuntimeServices;
+import org.apache.velocity.runtime.log.LogChute;
+import org.apache.velocity.runtime.resource.ResourceManager;
+import org.junit.jupiter.api.Test;
+
+public class RuntimeInstanceTest {
+    @Test
+    void reportsConfiguredResourceManagerClassThatDoesNotImplementResourceManager() throws Exception {
+        RuntimeInstance runtime = runtimeWithInitializedConfiguration(
+            RuntimeConstants.RESOURCE_MANAGER_CLASS + " = " + String.class.getName() + "\n");
+
+        assertThatThrownBy(runtime::init)
+            .isInstanceOf(Exception.class)
+            .hasMessageContaining(String.class.getName())
+            .hasMessageContaining(ResourceManager.class.getName());
+    }
+
+    private static RuntimeInstance runtimeWithInitializedConfiguration(String properties) throws Exception {
+        RuntimeInstance runtime = new RuntimeInstance();
+        byte[] bytes = properties.getBytes(StandardCharsets.ISO_8859_1);
+        runtime.getConfiguration().load(new ByteArrayInputStream(bytes));
+        runtime.setProperty(RuntimeConstants.RUNTIME_LOG_LOGSYSTEM, new SilentLogChute());
+        return runtime;
+    }
+
+    private static final class SilentLogChute implements LogChute {
+        @Override
+        public void init(RuntimeServices runtimeServices) {
+        }
+
+        @Override
+        public void log(int level, String message) {
+        }
+
+        @Override
+        public void log(int level, String message, Throwable throwable) {
+        }
+
+        @Override
+        public boolean isLevelEnabled(int level) {
+            return false;
+        }
+    }
+}
diff --git 1/tests/src/velocity/velocity/1.4/src/test/java/velocity/velocity/UberspectImplTest.java 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/UberspectImplTest.java
index c62964f5ff..7144dd7ad3 100644
--- 1/tests/src/velocity/velocity/1.4/src/test/java/velocity/velocity/UberspectImplTest.java
+++ 2/tests/src/velocity/velocity/1.5/src/test/java/velocity/velocity/UberspectImplTest.java
@@ -8,30 +8,32 @@ package velocity.velocity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.lang.reflect.Method;
 import java.util.HashMap;
 
-import org.apache.velocity.runtime.RuntimeLogger;
+import org.apache.velocity.runtime.log.Log;
+import org.apache.velocity.runtime.log.NullLogChute;
 import org.apache.velocity.util.introspection.Info;
 import org.apache.velocity.util.introspection.UberspectImpl;
+import org.apache.velocity.util.introspection.VelMethod;
 import org.apache.velocity.util.introspection.VelPropertySet;
 import org.junit.jupiter.api.Test;
 
 public class UberspectImplTest {
     @Test
-    void resolvesVelocityClassThroughCompilerGeneratedClassLiteralHelper() throws Exception {
-        final Method classResolver = UberspectImpl.class.getDeclaredMethod("class$", String.class);
-        classResolver.setAccessible(true);
+    void resolvesMethodUsingConfiguredIntrospector() throws Exception {
+        final UberspectImpl uberspect = newUberspect();
+        final Info info = new Info("method.vm", 1, 1);
 
-        final Object resolvedClass = classResolver.invoke(null, "org.apache.velocity.util.introspection.Info");
+        final VelMethod method = uberspect.getMethod(new Greeter(), "greet", new Object[] {"Ada"}, info);
 
-        assertThat(resolvedClass).isSameAs(Info.class);
+        assertThat(method).isNotNull();
+        assertThat(method.getMethodName()).isEqualTo("greet");
+        assertThat(method.invoke(new Greeter(), new Object[] {"Ada"})).isEqualTo("Hello Ada");
     }
 
     @Test
     void resolvesMapClassLiteralWhenCreatingMapBackedPropertySetter() throws Exception {
-        final UberspectImpl uberspect = new UberspectImpl();
-        uberspect.setRuntimeLogger(new NoOpRuntimeLogger());
+        final UberspectImpl uberspect = newUberspect();
         final RecordingMap values = new RecordingMap();
         final Info info = new Info("map-put.vm", 1, 1);
 
@@ -43,30 +45,25 @@ public class UberspectImplTest {
         assertThat(values).containsEntry("answer", "forty-two");
     }
 
-    public static final class RecordingMap extends HashMap<Object, Object> {
-        private static final long serialVersionUID = 1L;
-
-        @Override
-        public Object put(final Object key, final Object value) {
-            return super.put(key, value);
-        }
+    private static UberspectImpl newUberspect() {
+        final UberspectImpl uberspect = new UberspectImpl();
+        uberspect.setLog(new Log(new NullLogChute()));
+        uberspect.init();
+        return uberspect;
     }
 
-    private static final class NoOpRuntimeLogger implements RuntimeLogger {
-        @Override
-        public void warn(final Object message) {
-        }
-
-        @Override
-        public void info(final Object message) {
+    public static final class Greeter {
+        public String greet(final String name) {
+            return "Hello " + name;
         }
+    }
 
-        @Override
-        public void error(final Object message) {
-        }
+    public static final class RecordingMap extends HashMap<Object, Object> {
+        private static final long serialVersionUID = 1L;
 
         @Override
-        public void debug(final Object message) {
+        public Object put(final Object key, final Object value) {
+            return super.put(key, value);
         }
     }
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
