### PR TITLE
[GenAI] Test fix for org.apache.hadoop:hadoop-auth:2.8.2 using gpt-5.5

### DIFF
--- a/metadata/org.apache.hadoop/hadoop-auth/2.8.2/reachability-metadata.json
+++ b/metadata/org.apache.hadoop/hadoop-auth/2.8.2/reachability-metadata.json
@@ -1,0 +1,71 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.security.authentication.client.AuthenticatedURL"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.security.authentication.client.AuthenticatedURL"
+      },
+      "type": "java.lang.Thread",
+      "methods": [
+        {
+          "name": "getContextClassLoader",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.security.authentication.client.AuthenticatedURL"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.security.authentication.client.AuthenticatedURL"
+      },
+      "type": "org.apache.hadoop.security.authentication.client.KerberosAuthenticator",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.security.authentication.util.KerberosUtil"
+      },
+      "type": "sun.security.jgss.GSSUtil",
+      "fields": [
+        {
+          "name": "GSS_KRB5_MECH_OID"
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.security.authentication.client.AuthenticatedURL"
+      },
+      "glob": "META-INF/services/com.sun.net.httpserver.spi.HttpServerProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.security.authentication.client.AuthenticatedURL"
+      },
+      "glob": "log4j.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.hadoop.security.authentication.client.AuthenticatedURL"
+      },
+      "glob": "log4j.xml"
+    }
+  ]
+}

--- a/metadata/org.apache.hadoop/hadoop-auth/index.json
+++ b/metadata/org.apache.hadoop/hadoop-auth/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.8.2",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/hadoop/hadoop-auth/$version$/hadoop-auth-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/hadoop",
+    "test-code-url" : "https://github.com/apache/hadoop/tree/rel/release-$version$/hadoop-common-project/hadoop-auth/src/test",
+    "documentation-url" : "https://hadoop.apache.org/docs/r$version$/hadoop-auth/index.html",
+    "description" : "Apache Hadoop Auth is a Java HTTP authentication library that provides client and server components for Kerberos SPNEGO authentication over HTTP. It also offers pluggable authentication mechanisms, including pseudo/simple authentication, for Hadoop-compatible HTTP services.",
     "tested-versions" : [
       "2.8.2"
     ],

--- a/metadata/org.apache.hadoop/hadoop-auth/index.json
+++ b/metadata/org.apache.hadoop/hadoop-auth/index.json
@@ -1,6 +1,16 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.8.2",
+    "tested-versions" : [
+      "2.8.2"
+    ],
+    "allowed-packages" : [
+      "org.apache.hadoop.security.authentication",
+      "org.apache.hadoop.util"
+    ]
+  },
+  {
     "metadata-version" : "2.2.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/hadoop/hadoop-auth/$version$/hadoop-auth-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/hadoop",

--- a/stats/org.apache.hadoop/hadoop-auth/2.8.2/execution-metrics.json
+++ b/stats/org.apache.hadoop/hadoop-auth/2.8.2/execution-metrics.json
@@ -1,0 +1,99 @@
+{
+  "fix_java_run_fail:2026-05-18": {
+    "timestamp": "2026-05-18T12:48:58.321980Z",
+    "library": "org.apache.hadoop:hadoop-auth:2.8.2",
+    "starting_commit": "5ac1bfb193c9ea9b387e726daf95632ceeb30ae9",
+    "ending_commit": "6b64dc6923e20ffdd710152377d15d5b99c3e94f",
+    "previous_library": "org.apache.hadoop:hadoop-auth:2.2.0",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.8.2",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 8,
+            "totalCalls": 8
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 8,
+        "totalCalls": 8
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 383,
+          "missed": 6317,
+          "ratio": 0.057164,
+          "total": 6700
+        },
+        "line": {
+          "covered": 97,
+          "missed": 1449,
+          "ratio": 0.062743,
+          "total": 1546
+        },
+        "method": {
+          "covered": 27,
+          "missed": 241,
+          "ratio": 0.100746,
+          "total": 268
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.2.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 5,
+            "totalCalls": 5
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 5,
+        "totalCalls": 5
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 204,
+          "missed": 3049,
+          "ratio": 0.062711,
+          "total": 3253
+        },
+        "line": {
+          "covered": 55,
+          "missed": 685,
+          "ratio": 0.074324,
+          "total": 740
+        },
+        "method": {
+          "covered": 18,
+          "missed": 114,
+          "ratio": 0.136364,
+          "total": 132
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 72249,
+      "cached_input_tokens_used": 836096,
+      "output_tokens_used": 10765,
+      "iterations": 2,
+      "cost_usd": 0.741,
+      "tested_library_loc": 97,
+      "metadata_entries": 11,
+      "previous_library_metadata_entries": 10,
+      "code_coverage_percent": 6.27,
+      "previous_library_coverage_percent": 7.43
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.hadoop/hadoop-auth/2.8.2/src/test/java/org_apache_hadoop/hadoop_auth/KerberosUtilTest.java",
+      "metadata_file": "metadata/org.apache.hadoop/hadoop-auth/2.8.2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.hadoop/hadoop-auth/2.8.2/stats.json
+++ b/stats/org.apache.hadoop/hadoop-auth/2.8.2/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "2.8.2",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 8,
+          "totalCalls" : 8
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 8,
+      "totalCalls" : 8
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 383,
+        "missed" : 6317,
+        "ratio" : 0.057164,
+        "total" : 6700
+      },
+      "line" : {
+        "covered" : 97,
+        "missed" : 1449,
+        "ratio" : 0.062743,
+        "total" : 1546
+      },
+      "method" : {
+        "covered" : 27,
+        "missed" : 241,
+        "ratio" : 0.100746,
+        "total" : 268
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.hadoop/hadoop-auth/2.8.2/.gitignore
+++ b/tests/src/org.apache.hadoop/hadoop-auth/2.8.2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.hadoop/hadoop-auth/2.8.2/build.gradle
+++ b/tests/src/org.apache.hadoop/hadoop-auth/2.8.2/build.gradle
@@ -1,0 +1,43 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.hadoop:hadoop-auth:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+tasks.withType(Test).configureEach {
+    jvmArgs += [
+        '--add-opens=java.security.jgss/sun.security.jgss=ALL-UNNAMED',
+        '--add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED'
+    ]
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+    binaries {
+        all {
+            buildArgs.addAll([
+                '--enable-url-protocols=http',
+                '--add-opens=java.security.jgss/sun.security.jgss=ALL-UNNAMED',
+                '--add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED'
+            ])
+        }
+    }
+}

--- a/tests/src/org.apache.hadoop/hadoop-auth/2.8.2/gradle.properties
+++ b/tests/src/org.apache.hadoop/hadoop-auth/2.8.2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.hadoop:hadoop-auth:2.8.2
+library.version = 2.8.2
+metadata.dir = org.apache.hadoop/hadoop-auth/2.8.2/

--- a/tests/src/org.apache.hadoop/hadoop-auth/2.8.2/settings.gradle
+++ b/tests/src/org.apache.hadoop/hadoop-auth/2.8.2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.hadoop.hadoop-auth_tests'

--- a/tests/src/org.apache.hadoop/hadoop-auth/2.8.2/src/test/java/org_apache_hadoop/hadoop_auth/AuthenticatedURLTest.java
+++ b/tests/src/org.apache.hadoop/hadoop-auth/2.8.2/src/test/java/org_apache_hadoop/hadoop_auth/AuthenticatedURLTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_hadoop.hadoop_auth;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.apache.hadoop.security.authentication.client.AuthenticatedURL;
+import org.apache.hadoop.security.authentication.client.Authenticator;
+import org.apache.hadoop.security.authentication.client.KerberosAuthenticator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AuthenticatedURLTest {
+    @Test
+    void opensConnectionWithDefaultAuthenticatorWhenTokenIsAlreadySet() throws Exception {
+        Class<? extends Authenticator> previousAuthenticator = AuthenticatedURL.getDefaultAuthenticator();
+        AuthenticatedURL.setDefaultAuthenticator(KerberosAuthenticator.class);
+        try {
+            AuthenticatedURL.Token token = new AuthenticatedURL.Token("delegation-token");
+            AuthenticatedURL authenticatedURL = new AuthenticatedURL();
+
+            HttpURLConnection connection = authenticatedURL.openConnection(new URL("http://localhost/"), token);
+            try {
+                assertThat(connection.getRequestProperty("Cookie"))
+                    .isEqualTo("hadoop.auth=\"delegation-token\"");
+            } finally {
+                connection.disconnect();
+            }
+        } finally {
+            AuthenticatedURL.setDefaultAuthenticator(previousAuthenticator);
+        }
+    }
+}

--- a/tests/src/org.apache.hadoop/hadoop-auth/2.8.2/src/test/java/org_apache_hadoop/hadoop_auth/AuthenticatedURLTest.java
+++ b/tests/src/org.apache.hadoop/hadoop-auth/2.8.2/src/test/java/org_apache_hadoop/hadoop_auth/AuthenticatedURLTest.java
@@ -6,9 +6,16 @@
  */
 package org_apache_hadoop.hadoop_auth;
 
+import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
 
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
 import org.apache.hadoop.security.authentication.client.AuthenticatedURL;
 import org.apache.hadoop.security.authentication.client.Authenticator;
 import org.apache.hadoop.security.authentication.client.KerberosAuthenticator;
@@ -22,18 +29,63 @@ public class AuthenticatedURLTest {
         Class<? extends Authenticator> previousAuthenticator = AuthenticatedURL.getDefaultAuthenticator();
         AuthenticatedURL.setDefaultAuthenticator(KerberosAuthenticator.class);
         try {
-            AuthenticatedURL.Token token = new AuthenticatedURL.Token("delegation-token");
-            AuthenticatedURL authenticatedURL = new AuthenticatedURL();
+            AtomicReference<String> cookieHeader = new AtomicReference<>();
+            try (TestHttpServer server = TestHttpServer.create(exchange -> {
+                cookieHeader.set(exchange.getRequestHeaders().getFirst("Cookie"));
+                byte[] response = "ok".getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, response.length);
+                exchange.getResponseBody().write(response);
+            })) {
+                AuthenticatedURL.Token token = new AuthenticatedURL.Token("delegation-token");
+                AuthenticatedURL authenticatedURL = new AuthenticatedURL();
 
-            HttpURLConnection connection = authenticatedURL.openConnection(new URL("http://localhost/"), token);
-            try {
-                assertThat(connection.getRequestProperty("Cookie"))
-                    .isEqualTo("hadoop.auth=\"delegation-token\"");
-            } finally {
-                connection.disconnect();
+                HttpURLConnection connection = authenticatedURL.openConnection(server.url(), token);
+                try {
+                    connection.setConnectTimeout(5_000);
+                    connection.setReadTimeout(5_000);
+                    assertThat(connection.getResponseCode()).isEqualTo(HttpURLConnection.HTTP_OK);
+                    assertThat(cookieHeader.get()).isEqualTo("hadoop.auth=\"delegation-token\"");
+                } finally {
+                    connection.disconnect();
+                }
             }
         } finally {
             AuthenticatedURL.setDefaultAuthenticator(previousAuthenticator);
         }
+    }
+
+    private static final class TestHttpServer implements AutoCloseable {
+        private final HttpServer server;
+
+        private TestHttpServer(HttpServer server) {
+            this.server = server;
+        }
+
+        private static TestHttpServer create(ThrowingHttpHandler handler) throws IOException {
+            HttpServer server = HttpServer.create(
+                new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+            server.createContext("/", exchange -> {
+                try (exchange) {
+                    handler.handle(exchange);
+                }
+            });
+            server.start();
+            return new TestHttpServer(server);
+        }
+
+        private URL url() throws IOException {
+            return new URL("http", server.getAddress().getHostString(),
+                server.getAddress().getPort(), "/");
+        }
+
+        @Override
+        public void close() {
+            server.stop(0);
+        }
+    }
+
+    @FunctionalInterface
+    private interface ThrowingHttpHandler {
+        void handle(HttpExchange exchange) throws IOException;
     }
 }

--- a/tests/src/org.apache.hadoop/hadoop-auth/2.8.2/src/test/java/org_apache_hadoop/hadoop_auth/KerberosUtilTest.java
+++ b/tests/src/org.apache.hadoop/hadoop-auth/2.8.2/src/test/java/org_apache_hadoop/hadoop_auth/KerberosUtilTest.java
@@ -6,6 +6,7 @@
  */
 package org_apache_hadoop.hadoop_auth;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -26,27 +27,57 @@ public class KerberosUtilTest {
 
     @Test
     void readsDefaultRealmFromConfiguredKrb5File(@TempDir Path tempDir) throws Exception {
-        Path krb5Conf = tempDir.resolve("krb5.conf");
-        Files.writeString(krb5Conf, """
-                [libdefaults]
-                    default_realm = EXAMPLE.COM
-
-                [realms]
-                    EXAMPLE.COM = {
-                        kdc = localhost
-                    }
-                """);
+        Path krb5Conf = writeKrb5Conf(tempDir);
 
         String previousKrb5Conf = System.getProperty("java.security.krb5.conf");
         System.setProperty("java.security.krb5.conf", krb5Conf.toString());
         try {
-            assertThat(KerberosUtil.getDefaultRealm()).isEqualTo("EXAMPLE.COM");
+            assertThat(KerberosUtil.getDefaultRealm()).isEqualTo("DEFAULT.EXAMPLE.COM");
         } finally {
-            if (previousKrb5Conf == null) {
-                System.clearProperty("java.security.krb5.conf");
-            } else {
-                System.setProperty("java.security.krb5.conf", previousKrb5Conf);
-            }
+            restoreKrb5Conf(previousKrb5Conf);
+        }
+    }
+
+    @Test
+    void mapsServiceHostDomainToConfiguredRealm(@TempDir Path tempDir) throws Exception {
+        Path krb5Conf = writeKrb5Conf(tempDir);
+
+        String previousKrb5Conf = System.getProperty("java.security.krb5.conf");
+        System.setProperty("java.security.krb5.conf", krb5Conf.toString());
+        try {
+            assertThat(KerberosUtil.getDomainRealm("HTTP/service.example.com"))
+                    .isEqualTo("DOMAIN.EXAMPLE.COM");
+        } finally {
+            restoreKrb5Conf(previousKrb5Conf);
+        }
+    }
+
+    private static Path writeKrb5Conf(Path tempDir) throws IOException {
+        Path krb5Conf = tempDir.resolve("krb5.conf");
+        Files.writeString(krb5Conf, """
+                [libdefaults]
+                    default_realm = DEFAULT.EXAMPLE.COM
+
+                [realms]
+                    DEFAULT.EXAMPLE.COM = {
+                        kdc = localhost
+                    }
+                    DOMAIN.EXAMPLE.COM = {
+                        kdc = localhost
+                    }
+
+                [domain_realm]
+                    example.com = DOMAIN.EXAMPLE.COM
+                    .example.com = DOMAIN.EXAMPLE.COM
+                """);
+        return krb5Conf;
+    }
+
+    private static void restoreKrb5Conf(String previousKrb5Conf) {
+        if (previousKrb5Conf == null) {
+            System.clearProperty("java.security.krb5.conf");
+        } else {
+            System.setProperty("java.security.krb5.conf", previousKrb5Conf);
         }
     }
 }

--- a/tests/src/org.apache.hadoop/hadoop-auth/2.8.2/src/test/java/org_apache_hadoop/hadoop_auth/KerberosUtilTest.java
+++ b/tests/src/org.apache.hadoop/hadoop-auth/2.8.2/src/test/java/org_apache_hadoop/hadoop_auth/KerberosUtilTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_hadoop.hadoop_auth;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.hadoop.security.authentication.util.KerberosUtil;
+import org.ietf.jgss.Oid;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class KerberosUtilTest {
+    @Test
+    void getsKerberosMechanismOidByName() throws Exception {
+        Oid oid = KerberosUtil.getOidInstance("GSS_KRB5_MECH_OID");
+
+        assertThat(oid.toString()).isEqualTo("1.2.840.113554.1.2.2");
+    }
+
+    @Test
+    void readsDefaultRealmFromConfiguredKrb5File(@TempDir Path tempDir) throws Exception {
+        Path krb5Conf = tempDir.resolve("krb5.conf");
+        Files.writeString(krb5Conf, """
+                [libdefaults]
+                    default_realm = EXAMPLE.COM
+
+                [realms]
+                    EXAMPLE.COM = {
+                        kdc = localhost
+                    }
+                """);
+
+        String previousKrb5Conf = System.getProperty("java.security.krb5.conf");
+        System.setProperty("java.security.krb5.conf", krb5Conf.toString());
+        try {
+            assertThat(KerberosUtil.getDefaultRealm()).isEqualTo("EXAMPLE.COM");
+        } finally {
+            if (previousKrb5Conf == null) {
+                System.clearProperty("java.security.krb5.conf");
+            } else {
+                System.setProperty("java.security.krb5.conf", previousKrb5Conf);
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.hadoop/hadoop-auth/2.8.2/user-code-filter.json
+++ b/tests/src/org.apache.hadoop/hadoop-auth/2.8.2/user-code-filter.json
@@ -1,0 +1,16 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.hadoop.security.authentication.**"
+    },
+    {
+      "includeClasses" : "org.apache.hadoop.util.**"
+    },
+    {
+      "includeClasses" : "org_apache_hadoop.hadoop_auth.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6959

This PR provides test fixes and new metadata for org.apache.hadoop:hadoop-auth:2.8.2, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 72249
- Cached input tokens: 836096
- Output tokens: 10765
- Metadata entries: 11
- Iterations: 2
- Library coverage percentage: 6.27
- Previous library version metadata entries: 10
- Previous library version coverage percentage: 7.43

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `2aa22d7ffe404a1fea40c02fa486045997315a20`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.hadoop:hadoop-auth:2.2.0: 5/5 covered calls (100.00%)
- org.apache.hadoop:hadoop-auth:2.8.2: 8/8 covered calls (100.00%)

**Reflection:**
- org.apache.hadoop:hadoop-auth:2.2.0: 5/5 covered calls (100.00%)
- org.apache.hadoop:hadoop-auth:2.8.2: 8/8 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.hadoop:hadoop-auth:2.2.0: 204/3253 (6.27%)
- org.apache.hadoop:hadoop-auth:2.8.2: 383/6700 (5.72%)

**Line:**
- org.apache.hadoop:hadoop-auth:2.2.0: 55/740 (7.43%)
- org.apache.hadoop:hadoop-auth:2.8.2: 97/1546 (6.27%)

**Method:**
- org.apache.hadoop:hadoop-auth:2.2.0: 18/132 (13.64%)
- org.apache.hadoop:hadoop-auth:2.8.2: 27/268 (10.07%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.hadoop/hadoop-auth/2.2.0/src/test/java/org_apache_hadoop/hadoop_auth/AuthenticatedURLTest.java 2/tests/src/org.apache.hadoop/hadoop-auth/2.8.2/src/test/java/org_apache_hadoop/hadoop_auth/AuthenticatedURLTest.java
index a6392e532d..ee4d37f8d8 100644
--- 1/tests/src/org.apache.hadoop/hadoop-auth/2.2.0/src/test/java/org_apache_hadoop/hadoop_auth/AuthenticatedURLTest.java
+++ 2/tests/src/org.apache.hadoop/hadoop-auth/2.8.2/src/test/java/org_apache_hadoop/hadoop_auth/AuthenticatedURLTest.java
@@ -6,9 +6,16 @@
  */
 package org_apache_hadoop.hadoop_auth;
 
+import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
 
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
 import org.apache.hadoop.security.authentication.client.AuthenticatedURL;
 import org.apache.hadoop.security.authentication.client.Authenticator;
 import org.apache.hadoop.security.authentication.client.KerberosAuthenticator;
@@ -22,18 +29,63 @@ public class AuthenticatedURLTest {
         Class<? extends Authenticator> previousAuthenticator = AuthenticatedURL.getDefaultAuthenticator();
         AuthenticatedURL.setDefaultAuthenticator(KerberosAuthenticator.class);
         try {
-            AuthenticatedURL.Token token = new AuthenticatedURL.Token("delegation-token");
-            AuthenticatedURL authenticatedURL = new AuthenticatedURL();
-
-            HttpURLConnection connection = authenticatedURL.openConnection(new URL("http://localhost/"), token);
-            try {
-                assertThat(connection.getRequestProperty("Cookie"))
-                    .isEqualTo("hadoop.auth=\"delegation-token\"");
-            } finally {
-                connection.disconnect();
+            AtomicReference<String> cookieHeader = new AtomicReference<>();
+            try (TestHttpServer server = TestHttpServer.create(exchange -> {
+                cookieHeader.set(exchange.getRequestHeaders().getFirst("Cookie"));
+                byte[] response = "ok".getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, response.length);
+                exchange.getResponseBody().write(response);
+            })) {
+                AuthenticatedURL.Token token = new AuthenticatedURL.Token("delegation-token");
+                AuthenticatedURL authenticatedURL = new AuthenticatedURL();
+
+                HttpURLConnection connection = authenticatedURL.openConnection(server.url(), token);
+                try {
+                    connection.setConnectTimeout(5_000);
+                    connection.setReadTimeout(5_000);
+                    assertThat(connection.getResponseCode()).isEqualTo(HttpURLConnection.HTTP_OK);
+                    assertThat(cookieHeader.get()).isEqualTo("hadoop.auth=\"delegation-token\"");
+                } finally {
+                    connection.disconnect();
+                }
             }
         } finally {
             AuthenticatedURL.setDefaultAuthenticator(previousAuthenticator);
         }
     }
+
+    private static final class TestHttpServer implements AutoCloseable {
+        private final HttpServer server;
+
+        private TestHttpServer(HttpServer server) {
+            this.server = server;
+        }
+
+        private static TestHttpServer create(ThrowingHttpHandler handler) throws IOException {
+            HttpServer server = HttpServer.create(
+                new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+            server.createContext("/", exchange -> {
+                try (exchange) {
+                    handler.handle(exchange);
+                }
+            });
+            server.start();
+            return new TestHttpServer(server);
+        }
+
+        private URL url() throws IOException {
+            return new URL("http", server.getAddress().getHostString(),
+                server.getAddress().getPort(), "/");
+        }
+
+        @Override
+        public void close() {
+            server.stop(0);
+        }
+    }
+
+    @FunctionalInterface
+    private interface ThrowingHttpHandler {
+        void handle(HttpExchange exchange) throws IOException;
+    }
 }
diff --git 1/tests/src/org.apache.hadoop/hadoop-auth/2.2.0/src/test/java/org_apache_hadoop/hadoop_auth/KerberosUtilTest.java 2/tests/src/org.apache.hadoop/hadoop-auth/2.8.2/src/test/java/org_apache_hadoop/hadoop_auth/KerberosUtilTest.java
index 194adbe48e..4337387961 100644
--- 1/tests/src/org.apache.hadoop/hadoop-auth/2.2.0/src/test/java/org_apache_hadoop/hadoop_auth/KerberosUtilTest.java
+++ 2/tests/src/org.apache.hadoop/hadoop-auth/2.8.2/src/test/java/org_apache_hadoop/hadoop_auth/KerberosUtilTest.java
@@ -6,6 +6,7 @@
  */
 package org_apache_hadoop.hadoop_auth;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -26,27 +27,57 @@ public class KerberosUtilTest {
 
     @Test
     void readsDefaultRealmFromConfiguredKrb5File(@TempDir Path tempDir) throws Exception {
+        Path krb5Conf = writeKrb5Conf(tempDir);
+
+        String previousKrb5Conf = System.getProperty("java.security.krb5.conf");
+        System.setProperty("java.security.krb5.conf", krb5Conf.toString());
+        try {
+            assertThat(KerberosUtil.getDefaultRealm()).isEqualTo("DEFAULT.EXAMPLE.COM");
+        } finally {
+            restoreKrb5Conf(previousKrb5Conf);
+        }
+    }
+
+    @Test
+    void mapsServiceHostDomainToConfiguredRealm(@TempDir Path tempDir) throws Exception {
+        Path krb5Conf = writeKrb5Conf(tempDir);
+
+        String previousKrb5Conf = System.getProperty("java.security.krb5.conf");
+        System.setProperty("java.security.krb5.conf", krb5Conf.toString());
+        try {
+            assertThat(KerberosUtil.getDomainRealm("HTTP/service.example.com"))
+                    .isEqualTo("DOMAIN.EXAMPLE.COM");
+        } finally {
+            restoreKrb5Conf(previousKrb5Conf);
+        }
+    }
+
+    private static Path writeKrb5Conf(Path tempDir) throws IOException {
         Path krb5Conf = tempDir.resolve("krb5.conf");
         Files.writeString(krb5Conf, """
                 [libdefaults]
-                    default_realm = EXAMPLE.COM
+                    default_realm = DEFAULT.EXAMPLE.COM
 
                 [realms]
-                    EXAMPLE.COM = {
+                    DEFAULT.EXAMPLE.COM = {
+                        kdc = localhost
+                    }
+                    DOMAIN.EXAMPLE.COM = {
                         kdc = localhost
                     }
+
+                [domain_realm]
+                    example.com = DOMAIN.EXAMPLE.COM
+                    .example.com = DOMAIN.EXAMPLE.COM
                 """);
+        return krb5Conf;
+    }
 
-        String previousKrb5Conf = System.getProperty("java.security.krb5.conf");
-        System.setProperty("java.security.krb5.conf", krb5Conf.toString());
-        try {
-            assertThat(KerberosUtil.getDefaultRealm()).isEqualTo("EXAMPLE.COM");
-        } finally {
-            if (previousKrb5Conf == null) {
-                System.clearProperty("java.security.krb5.conf");
-            } else {
-                System.setProperty("java.security.krb5.conf", previousKrb5Conf);
-            }
+    private static void restoreKrb5Conf(String previousKrb5Conf) {
+        if (previousKrb5Conf == null) {
+            System.clearProperty("java.security.krb5.conf");
+        } else {
+            System.setProperty("java.security.krb5.conf", previousKrb5Conf);
         }
     }
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
