### PR TITLE
[GenAI] Test fix for io.circe:circe-core_3:0.15.0-M1 using gpt-5.5

### DIFF
--- a/metadata/io.circe/circe-core_3/0.15.0-M1/reachability-metadata.json
+++ b/metadata/io.circe/circe-core_3/0.15.0-M1/reachability-metadata.json
@@ -1,0 +1,49 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.circe.Decoder"
+      },
+      "type": "io.circe.Decoder$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.circe.DecodingFailure$$anon$2"
+      },
+      "type": "io.circe.DecodingFailure$$anon$2",
+      "fields": [
+        {
+          "name": "0bitmap$2"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.circe.Encoder"
+      },
+      "type": "io.circe.Encoder$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.circe.Decoder"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "io.circe.Decoder$$anon$55"
+      },
+      "type": "java.time.format.DateTimeFormatterBuilder$DateTimePrinterParser[]"
+    }
+  ]
+}

--- a/metadata/io.circe/circe-core_3/index.json
+++ b/metadata/io.circe/circe-core_3/index.json
@@ -1,6 +1,19 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "0.15.0-M1",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "0.15.0-M1"
+    ],
+    "allowed-packages" : [
+      "io.circe"
+    ]
+  },
+  {
     "metadata-version" : "0.14.11",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/circe/circe-core_3/$version$/circe-core_3-$version$-sources.jar",
     "repository-url" : "https://github.com/circe/circe",

--- a/metadata/io.circe/circe-core_3/index.json
+++ b/metadata/io.circe/circe-core_3/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "0.15.0-M1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/circe/circe-core_3/$version$/circe-core_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/circe/circe",
+    "test-code-url" : "https://github.com/circe/circe/tree/v$version$/modules/tests/shared/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/circe/circe-core_3/$version$/circe-core_3-$version$-javadoc.jar",
+    "description" : "Circe Core provides the core JSON data model and type classes for encoding and decoding JSON in Scala. It includes the JSON AST, cursor APIs, codec abstractions, printers, parser interfaces, and standard instances used by other Circe modules.",
     "language" : {
       "name" : "scala",
       "version" : "3"

--- a/stats/io.circe/circe-core_3/0.15.0-M1/execution-metrics.json
+++ b/stats/io.circe/circe-core_3/0.15.0-M1/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_java_run_fail:2026-05-18": {
+    "timestamp": "2026-05-18T14:45:23.290293Z",
+    "library": "io.circe:circe-core_3:0.15.0-M1",
+    "starting_commit": "a346779eeaadbeeeb0a3fed03c3fa84d41c2e522",
+    "ending_commit": "40361f097ec0d12b87c264694a1173f22e4c2442",
+    "previous_library": "io.circe:circe-core_3:0.14.11",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "0.15.0-M1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5450,
+          "missed": 51846,
+          "ratio": 0.09512,
+          "total": 57296
+        },
+        "line": {
+          "covered": 859,
+          "missed": 1919,
+          "ratio": 0.309215,
+          "total": 2778
+        },
+        "method": {
+          "covered": 535,
+          "missed": 2318,
+          "ratio": 0.187522,
+          "total": 2853
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "0.14.11",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5854,
+          "missed": 173258,
+          "ratio": 0.032683,
+          "total": 179112
+        },
+        "line": {
+          "covered": 856,
+          "missed": 3629,
+          "ratio": 0.190858,
+          "total": 4485
+        },
+        "method": {
+          "covered": 554,
+          "missed": 5485,
+          "ratio": 0.091737,
+          "total": 6039
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 63536,
+      "cached_input_tokens_used": 462848,
+      "output_tokens_used": 3742,
+      "iterations": 2,
+      "cost_usd": 0.3437,
+      "tested_library_loc": 859,
+      "metadata_entries": 8,
+      "previous_library_metadata_entries": 2,
+      "code_coverage_percent": 30.92,
+      "previous_library_coverage_percent": 19.09
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.circe/circe-core_3/0.15.0-M1/src/test/scala/io_circe/circe_core_3/Circe_core_3Test.scala",
+      "metadata_file": "metadata/io.circe/circe-core_3/0.15.0-M1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.circe/circe-core_3/0.15.0-M1/stats.json
+++ b/stats/io.circe/circe-core_3/0.15.0-M1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "0.15.0-M1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 5450,
+        "missed" : 51846,
+        "ratio" : 0.09512,
+        "total" : 57296
+      },
+      "line" : {
+        "covered" : 859,
+        "missed" : 1919,
+        "ratio" : 0.309215,
+        "total" : 2778
+      },
+      "method" : {
+        "covered" : 535,
+        "missed" : 2318,
+        "ratio" : 0.187522,
+        "total" : 2853
+      }
+    }
+  } ]
+}

--- a/tests/src/io.circe/circe-core_3/0.15.0-M1/.gitignore
+++ b/tests/src/io.circe/circe-core_3/0.15.0-M1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.circe/circe-core_3/0.15.0-M1/build.gradle
+++ b/tests/src/io.circe/circe-core_3/0.15.0-M1/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.circe:circe-core_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.circe/circe-core_3/0.15.0-M1/gradle.properties
+++ b/tests/src/io.circe/circe-core_3/0.15.0-M1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.circe:circe-core_3:0.15.0-M1
+library.version = 0.15.0-M1
+metadata.dir = io.circe/circe-core_3/0.15.0-M1/

--- a/tests/src/io.circe/circe-core_3/0.15.0-M1/settings.gradle
+++ b/tests/src/io.circe/circe-core_3/0.15.0-M1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.circe.circe-core_3_tests'

--- a/tests/src/io.circe/circe-core_3/0.15.0-M1/src/test/scala/io_circe/circe_core_3/Circe_core_3Test.scala
+++ b/tests/src/io.circe/circe-core_3/0.15.0-M1/src/test/scala/io_circe/circe_core_3/Circe_core_3Test.scala
@@ -1,0 +1,327 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_circe.circe_core_3
+
+import io.circe.Decoder
+import io.circe.DecodingFailure
+import io.circe.Encoder
+import io.circe.HCursor
+import io.circe.Json
+import io.circe.JsonNumber
+import io.circe.JsonObject
+import io.circe.KeyDecoder
+import io.circe.KeyEncoder
+import io.circe.Printer
+import io.circe.syntax._
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
+
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import java.time.Instant
+import java.util.UUID
+import scala.jdk.CollectionConverters._
+import scala.util.Try
+
+final case class Profile(
+    name: String,
+    age: Int,
+    created: Instant,
+    aliases: List[String],
+    metadata: Map[UUID, BigDecimal]
+)
+
+object Profile {
+  given Encoder[Profile] = Encoder.forProduct5("name", "age", "created", "aliases", "metadata") { profile =>
+    (profile.name, profile.age, profile.created, profile.aliases, profile.metadata)
+  }
+
+  given Decoder[Profile] = Decoder.forProduct5("name", "age", "created", "aliases", "metadata")(Profile.apply)
+}
+
+final case class AccountId(value: UUID)
+
+object AccountId {
+  given KeyEncoder[AccountId] = KeyEncoder.instance(_.value.toString)
+
+  given KeyDecoder[AccountId] = KeyDecoder.instance { key =>
+    Try(UUID.fromString(key)).toOption.map(AccountId.apply)
+  }
+}
+
+final case class Command(action: String, target: Option[String])
+
+final case class DerivedJob(jobId: String, ownerName: String, maxRetries: Int = 3)
+
+object DerivedJob {
+  private val jsonFields: Set[String] = Set("job_id", "owner_name", "max_retries")
+
+  given Encoder.AsObject[DerivedJob] = Encoder.AsObject.instance { job =>
+    JsonObject(
+      "job_id" -> Json.fromString(job.jobId),
+      "owner_name" -> Json.fromString(job.ownerName),
+      "max_retries" -> Json.fromInt(job.maxRetries)
+    )
+  }
+
+  given Decoder[DerivedJob] = Decoder.instance { cursor =>
+    cursor.keys match {
+      case Some(keys) =>
+        val unexpectedFields: List[String] = keys.filterNot(field => jsonFields.contains(field)).toList
+        if unexpectedFields.nonEmpty then
+          Left(DecodingFailure(s"Unexpected fields: ${unexpectedFields.mkString(", ")}", cursor.history))
+        else
+          for {
+            jobId <- cursor.get[String]("job_id")
+            ownerName <- cursor.get[String]("owner_name")
+            maxRetries <- cursor.get[Option[Int]]("max_retries").map(_.getOrElse(3))
+          } yield DerivedJob(jobId, ownerName, maxRetries)
+      case None => Left(DecodingFailure("Expected JSON object", cursor.history))
+    }
+  }
+}
+
+enum TicketState {
+  case Open, InProgress, Closed
+}
+
+object TicketState {
+  given Encoder[TicketState] = Encoder.instance(state => Json.fromString(state.toString))
+
+  given Decoder[TicketState] = Decoder.decodeString.emap {
+    case "Open" => Right(TicketState.Open)
+    case "InProgress" => Right(TicketState.InProgress)
+    case "Closed" => Right(TicketState.Closed)
+    case other => Left(s"enum TicketState does not contain case: $other")
+  }
+}
+
+object Command {
+  given Decoder[Command] = Decoder.instance { (cursor: HCursor) =>
+    val actionCursor = cursor.downField("action")
+    cursor.get[String]("action").flatMap {
+      case "start" => cursor.get[String]("target").map(target => Command("start", Some(target)))
+      case "stop" => Right(Command("stop", None))
+      case other => Left(DecodingFailure(s"Unsupported action: $other", actionCursor.history))
+    }
+  }
+}
+
+class Circe_core_3Test {
+  @Test
+  def buildsTransformsAndPrintsJsonDocuments(): Unit = {
+    val document: Json = Json.obj(
+      "b" -> Json.Null,
+      "a" -> Json.arr(Json.fromInt(2), Json.fromString("text")),
+      "nested" -> Json.obj("keep" -> Json.True, "drop" -> Json.Null)
+    )
+
+    assertThat(document.isObject).isTrue
+    assertThat(document.hcursor.downField("nested").downField("keep").as[Boolean]).isEqualTo(Right(true))
+    assertThat(Json.fromDouble(Double.NaN).isEmpty).isTrue
+    assertThat(Json.fromDoubleOrString(Double.NaN).asString).isEqualTo(Some("NaN"))
+
+    val transformed: Json = document.deepDropNullValues.mapObject(_.add("z", Json.fromLong(3L)))
+    assertThat(transformed.noSpacesSortKeys).isEqualTo("""{"a":[2,"text"],"nested":{"keep":true},"z":3}""")
+
+    val pretty: String = Printer.spaces2SortKeys.print(transformed)
+    assertThat(pretty).contains("\n  \"a\" : [")
+    assertThat(pretty).contains("\n  \"nested\" : {")
+
+    val compactBuffer: ByteBuffer = Printer.noSpaces.printToByteBuffer(transformed, StandardCharsets.UTF_8)
+    val compactBytes: Array[Byte] = new Array[Byte](compactBuffer.remaining)
+    compactBuffer.get(compactBytes)
+    assertThat(new String(compactBytes, StandardCharsets.UTF_8)).isEqualTo(transformed.noSpaces)
+  }
+
+  @Test
+  def manipulatesJsonObjectsWithoutLosingInsertionOrder(): Unit = {
+    val base: JsonObject = JsonObject(
+      "name" -> Json.fromString("Ada"),
+      "nullable" -> Json.Null
+    )
+    val updated: JsonObject = base
+      .add("enabled", Json.fromBoolean(true))
+      .remove("nullable")
+      .mapValues(_.withString(value => Json.fromString(value.toUpperCase)))
+
+    assertThat(updated.keys.toSeq.asJava).containsExactly("name", "enabled")
+    assertThat(updated("name")).isEqualTo(Some(Json.fromString("ADA")))
+    assertThat(updated.contains("nullable")).isFalse
+    assertThat(updated.size).isEqualTo(2)
+
+    val left: JsonObject = JsonObject(
+      "config" -> Json.obj("threads" -> Json.fromInt(2), "debug" -> Json.False),
+      "owner" -> Json.fromString("test")
+    )
+    val right: JsonObject = JsonObject(
+      "config" -> Json.obj("debug" -> Json.True, "region" -> Json.fromString("eu"))
+    )
+
+    assertThat(left.deepMerge(right).toJson.noSpacesSortKeys)
+      .isEqualTo("""{"config":{"debug":true,"region":"eu","threads":2},"owner":"test"}""")
+  }
+
+  @Test
+  def navigatesEditsAndDeletesWithCursors(): Unit = {
+    val document: Json = Json.obj(
+      "users" -> Json.arr(
+        Json.obj("name" -> Json.fromString("Ada"), "scores" -> Json.arr(Json.fromInt(1), Json.fromInt(2))),
+        Json.obj("name" -> Json.fromString("Linus"), "scores" -> Json.arr(Json.fromInt(3), Json.fromInt(5)))
+      )
+    )
+
+    val secondName = document.hcursor.downField("users").downN(1).downField("name")
+    assertThat(secondName.succeeded).isTrue
+    assertThat(secondName.key).isEqualTo(Some("name"))
+    assertThat(secondName.as[String]).isEqualTo(Right("Linus"))
+    assertThat(secondName.pathString).isEqualTo(".users[1].name")
+
+    val incremented: Json = decodeOptionOrFail(
+      document.hcursor
+        .downField("users")
+        .downArray
+        .downField("scores")
+        .downN(1)
+        .withFocus(incrementJsonIntegerBy(10))
+        .top
+    )
+    assertThat(incremented.hcursor.downField("users").downArray.downField("scores").downN(1).as[Int])
+      .isEqualTo(Right(12))
+
+    val withoutFirstUserScores: Json = decodeOptionOrFail(
+      incremented.hcursor.downField("users").downArray.downField("scores").delete.top
+    )
+    assertThat(withoutFirstUserScores.hcursor.downField("users").downArray.downField("scores").succeeded).isFalse
+    assertThat(withoutFirstUserScores.hcursor.downField("users").downN(1).downField("scores").as[List[Int]])
+      .isEqualTo(Right(List(3, 5)))
+  }
+
+  @Test
+  def encodesAndDecodesProductsCollectionsAndJavaTimeValues(): Unit = {
+    val firstMetadataKey: UUID = UUID.fromString("00000000-0000-0000-0000-000000000001")
+    val secondMetadataKey: UUID = UUID.fromString("00000000-0000-0000-0000-000000000002")
+    val profile: Profile = Profile(
+      name = "Ada Lovelace",
+      age = 36,
+      created = Instant.parse("2024-01-02T03:04:05Z"),
+      aliases = List("analyst", "programmer"),
+      metadata = Map(firstMetadataKey -> BigDecimal("12.5"), secondMetadataKey -> BigDecimal("7"))
+    )
+
+    val json: Json = profile.asJson
+    assertThat(json.hcursor.get[String]("name")).isEqualTo(Right("Ada Lovelace"))
+    assertThat(json.hcursor.get[Instant]("created")).isEqualTo(Right(profile.created))
+    assertThat(decodeOrFail(json.hcursor.get[List[String]]("aliases")).asJava).containsExactly("analyst", "programmer")
+    assertThat(decodeOrFail(json.hcursor.get[Map[UUID, BigDecimal]]("metadata"))).isEqualTo(profile.metadata)
+    assertThat(json.as[Profile]).isEqualTo(Right(profile))
+  }
+
+  @Test
+  def accumulatesFieldDecodingFailuresForProductDecoders(): Unit = {
+    val invalidProfile: Json = Json.obj(
+      "name" -> Json.fromInt(42),
+      "age" -> Json.fromString("old"),
+      "created" -> Json.fromString("not-an-instant"),
+      "aliases" -> Json.fromString("not-a-list"),
+      "metadata" -> Json.obj("not-a-uuid" -> Json.fromString("not-a-number"))
+    )
+
+    val failures: List[DecodingFailure] = invalidProfile.asAccumulating[Profile].fold(
+      _.toList,
+      value => fail(s"Expected decoding to fail, but decoded: $value")
+    )
+
+    assertThat(failures.size).isGreaterThanOrEqualTo(4)
+    assertThat(failures.map(_.history.nonEmpty).asJava).contains(true)
+  }
+
+  @Test
+  def encodesAndDecodesMapsWithCustomKeyCodecs(): Unit = {
+    val first: AccountId = AccountId(UUID.fromString("11111111-1111-1111-1111-111111111111"))
+    val second: AccountId = AccountId(UUID.fromString("22222222-2222-2222-2222-222222222222"))
+
+    val json: Json = Map(first -> 10, second -> 20).asJson
+
+    assertThat(json.noSpacesSortKeys)
+      .isEqualTo("""{"11111111-1111-1111-1111-111111111111":10,"22222222-2222-2222-2222-222222222222":20}""")
+    assertThat(json.as[Map[AccountId, Int]]).isEqualTo(Right(Map(first -> 10, second -> 20)))
+
+    val invalid: Either[DecodingFailure, Map[AccountId, Int]] = Json.obj("not-a-uuid" -> Json.fromInt(1)).as[Map[AccountId, Int]]
+    assertThat(invalid.isLeft).isTrue
+  }
+
+  @Test
+  def usesCustomDecoderInstancesForDomainValidation(): Unit = {
+    val start: Json = Json.obj("action" -> Json.fromString("start"), "target" -> Json.fromString("service-a"))
+    val stop: Json = Json.obj("action" -> Json.fromString("stop"))
+    val unsupported: Json = Json.obj("action" -> Json.fromString("restart"), "target" -> Json.fromString("service-a"))
+
+    assertThat(start.as[Command]).isEqualTo(Right(Command("start", Some("service-a"))))
+    assertThat(stop.as[Command]).isEqualTo(Right(Command("stop", None)))
+
+    val error: DecodingFailure = unsupported.as[Command] match {
+      case Left(error) => error
+      case Right(value) => fail(s"Expected unsupported action to fail, but decoded: $value")
+    }
+    assertThat(error.message).isEqualTo("Unsupported action: restart")
+    assertThat(error.history.asJava).isNotEmpty
+  }
+
+  @Test
+  def encodesAndDecodesProductsWithDefaultsAndStrictDecoding(): Unit = {
+    val encoded: Json = DerivedJob("job-1", "Ada", 5).asJson
+    assertThat(encoded.noSpacesSortKeys).isEqualTo("""{"job_id":"job-1","max_retries":5,"owner_name":"Ada"}""")
+
+    val decodedWithDefault: Either[DecodingFailure, DerivedJob] = Json.obj(
+      "job_id" -> Json.fromString("job-2"),
+      "owner_name" -> Json.fromString("Linus")
+    ).as[DerivedJob]
+    assertThat(decodedWithDefault).isEqualTo(Right(DerivedJob("job-2", "Linus")))
+
+    val decodedWithUnknownField: Either[DecodingFailure, DerivedJob] = Json.obj(
+      "job_id" -> Json.fromString("job-3"),
+      "owner_name" -> Json.fromString("Grace"),
+      "unexpected" -> Json.True
+    ).as[DerivedJob]
+    assertThat(decodedWithUnknownField.isLeft).isTrue
+  }
+
+  @Test
+  def encodesAndDecodesSingletonEnums(): Unit = {
+    assertThat(TicketState.Open.asJson).isEqualTo(Json.fromString("Open"))
+    assertThat(TicketState.InProgress.asJson).isEqualTo(Json.fromString("InProgress"))
+    assertThat(Json.fromString("Closed").as[TicketState]).isEqualTo(Right(TicketState.Closed))
+
+    val invalid: Either[DecodingFailure, TicketState] = Json.fromString("Blocked").as[TicketState]
+    assertThat(invalid.isLeft).isTrue
+  }
+
+  @Test
+  def preservesJsonNumberPrecisionAndRejectsInvalidNumericInput(): Unit = {
+    val number: JsonNumber = decodeOptionOrFail(JsonNumber.fromString("12345678901234567890.125"))
+    val json: Json = Json.fromJsonNumber(number)
+
+    assertThat(json.asNumber.flatMap(_.toBigDecimal)).isEqualTo(Some(BigDecimal("12345678901234567890.125")))
+    assertThat(json.as[BigDecimal]).isEqualTo(Right(BigDecimal("12345678901234567890.125")))
+    assertThat(JsonNumber.fromString("1.2.3").isEmpty).isTrue
+    assertThat(JsonNumber.fromString("not-a-number").isEmpty).isTrue
+  }
+
+  private def incrementJsonIntegerBy(amount: Int)(json: Json): Json = {
+    json.asNumber.flatMap(_.toInt).map(value => Json.fromInt(value + amount)).getOrElse(json)
+  }
+
+  private def decodeOrFail[A](result: Either[DecodingFailure, A]): A = {
+    result.fold(error => fail(s"Expected decoding success but got: $error"), identity)
+  }
+
+  private def decodeOptionOrFail[A](option: Option[A]): A = {
+    option.getOrElse(fail("Expected value to be present"))
+  }
+}

--- a/tests/src/io.circe/circe-core_3/0.15.0-M1/src/test/scala/io_circe/circe_core_3/Circe_core_3Test.scala
+++ b/tests/src/io.circe/circe-core_3/0.15.0-M1/src/test/scala/io_circe/circe_core_3/Circe_core_3Test.scala
@@ -6,6 +6,7 @@
  */
 package io_circe.circe_core_3
 
+import io.circe.CursorOp
 import io.circe.Decoder
 import io.circe.DecodingFailure
 import io.circe.Encoder
@@ -163,7 +164,7 @@ class Circe_core_3Test {
       "config" -> Json.obj("debug" -> Json.True, "region" -> Json.fromString("eu"))
     )
 
-    assertThat(left.deepMerge(right).toJson.noSpacesSortKeys)
+    assertThat(Json.fromJsonObject(left.deepMerge(right)).noSpacesSortKeys)
       .isEqualTo("""{"config":{"debug":true,"region":"eu","threads":2},"owner":"test"}""")
   }
 
@@ -180,7 +181,7 @@ class Circe_core_3Test {
     assertThat(secondName.succeeded).isTrue
     assertThat(secondName.key).isEqualTo(Some("name"))
     assertThat(secondName.as[String]).isEqualTo(Right("Linus"))
-    assertThat(secondName.pathString).isEqualTo(".users[1].name")
+    assertThat(CursorOp.opsToPath(secondName.history)).isEqualTo(".users{=\\(1)}.name")
 
     val incremented: Json = decodeOptionOrFail(
       document.hcursor
@@ -232,7 +233,7 @@ class Circe_core_3Test {
       "metadata" -> Json.obj("not-a-uuid" -> Json.fromString("not-a-number"))
     )
 
-    val failures: List[DecodingFailure] = invalidProfile.asAccumulating[Profile].fold(
+    val failures: List[DecodingFailure] = Decoder[Profile].decodeAccumulating(invalidProfile.hcursor).fold(
       _.toList,
       value => fail(s"Expected decoding to fail, but decoded: $value")
     )

--- a/tests/src/io.circe/circe-core_3/0.15.0-M1/user-code-filter.json
+++ b/tests/src/io.circe/circe-core_3/0.15.0-M1/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "io.circe.**"
+    },
+    {
+      "includeClasses" : "io_circe.circe_core_3.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6953

This PR provides test fixes and new metadata for io.circe:circe-core_3:0.15.0-M1, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 63536
- Cached input tokens: 462848
- Output tokens: 3742
- Metadata entries: 8
- Iterations: 2
- Library coverage percentage: 30.92
- Previous library version metadata entries: 2
- Previous library version coverage percentage: 19.09

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `59bd8a0d3a9ea74ba3a0e46b5fd5f2de0b088007`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.circe:circe-core_3:0.14.11: 0/0 covered calls (100.00%)
- io.circe:circe-core_3:0.15.0-M1: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.circe:circe-core_3:0.14.11: 5854/179112 (3.27%)
- io.circe:circe-core_3:0.15.0-M1: 5450/57296 (9.51%)

**Line:**
- io.circe:circe-core_3:0.14.11: 856/4485 (19.09%)
- io.circe:circe-core_3:0.15.0-M1: 859/2778 (30.92%)

**Method:**
- io.circe:circe-core_3:0.14.11: 554/6039 (9.17%)
- io.circe:circe-core_3:0.15.0-M1: 535/2853 (18.75%)

**Comparison between existing test version and AI-Generated update**

```diff

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
