### PR TITLE
[GenAI] Mark org.springframework.boot:spring-boot-starter-jackson as not for Native Image

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-starter-jackson/index.json
+++ b/metadata/org.springframework.boot/spring-boot-starter-jackson/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published spring-boot-starter-jackson-4.0.2 JAR contains only META-INF/MANIFEST.MF, LICENSE.txt, and NOTICE.txt and no JVM class files; the implementation classes are supplied by dependencies such as org.springframework.boot:spring-boot-jackson.",
+    "replacement": "Use the class-bearing dependency org.springframework.boot:spring-boot-jackson:4.0.2 for Spring Boot Jackson integration metadata."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #7027

This PR records `org.springframework.boot:spring-boot-starter-jackson` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published spring-boot-starter-jackson-4.0.2 JAR contains only META-INF/MANIFEST.MF, LICENSE.txt, and NOTICE.txt and no JVM class files; the implementation classes are supplied by dependencies such as org.springframework.boot:spring-boot-jackson.

Replacement guidance:
- Use the class-bearing dependency org.springframework.boot:spring-boot-jackson:4.0.2 for Spring Boot Jackson integration metadata.

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `18f786eec508ba572d4cb748347201b29d4f5b5b`

### Local CI Verification

- Status: `success`
- Commands run: 6
- Fixup attempts: 0
