### PR TITLE
CI workflow hardening

### DIFF
--- a/.github/workflows/create-scheduled-release.yml
+++ b/.github/workflows/create-scheduled-release.yml
@@ -83,7 +83,7 @@ jobs:
         id: set-matrix
         run: |
           LATEST_TAG=$(git tag --list | sort -V | tail -1)
-          ./gradlew generateChangedCoordinatesMatrix -PbaseCommit=$(git show-ref -s $LATEST_TAG) -PnewCommit=$(git rev-parse HEAD)
+          ./gradlew generateChangedCoordinatesMatrix -PbaseCommit="$(git show-ref -s "$LATEST_TAG")" -PnewCommit="$(git rev-parse HEAD)"
 
   release:
     needs: get-changed-metadata
@@ -107,10 +107,16 @@ jobs:
       - name: "Get tags"
         run: |
           PREVIOUS_RELEASE_TAG=$(git tag --list | sort -V | tail -1)
-          echo "PREVIOUS_RELEASE_TAG=$PREVIOUS_RELEASE_TAG" >> ${GITHUB_ENV}
+          if [[ ! "$PREVIOUS_RELEASE_TAG" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+            echo "Unexpected release tag format: $PREVIOUS_RELEASE_TAG" >&2
+            exit 1
+          fi
 
-          CURRENT_RELEASE_TAG=$(sed -E 's/^([0-9]+\.)([0-9]+\.)([0-9]+)/echo \1\2$((\3+1))/e' <<< $PREVIOUS_RELEASE_TAG)
-          echo "CURRENT_RELEASE_TAG=$CURRENT_RELEASE_TAG" >> ${GITHUB_ENV}
+          IFS=. read -r MAJOR MINOR PATCH <<< "$PREVIOUS_RELEASE_TAG"
+          CURRENT_RELEASE_TAG="${MAJOR}.${MINOR}.$((PATCH + 1))"
+
+          printf 'PREVIOUS_RELEASE_TAG=%s\n' "$PREVIOUS_RELEASE_TAG" >> "$GITHUB_ENV"
+          printf 'CURRENT_RELEASE_TAG=%s\n' "$CURRENT_RELEASE_TAG" >> "$GITHUB_ENV"
 
       - name: "⬆️ Update version"
         run: |
@@ -130,9 +136,9 @@ jobs:
           git config --local user.name "Github Actions"
           git add .
           git commit -m "Release version ${{ env.CURRENT_RELEASE_TAG }}"
-          git tag ${{ env.CURRENT_RELEASE_TAG }}
-          git push origin ${{ env.CURRENT_RELEASE_TAG }}
+          git tag "${{ env.CURRENT_RELEASE_TAG }}"
+          git push origin "${{ env.CURRENT_RELEASE_TAG }}"
 
       - name: "📝 Publish a release"
         run: |
-          gh release create ${{ env.CURRENT_RELEASE_TAG }} build/graalvm-reachability-metadata-*.zip --generate-notes --notes-start-tag ${{ env.PREVIOUS_RELEASE_TAG }}
+          gh release create "${{ env.CURRENT_RELEASE_TAG }}" build/graalvm-reachability-metadata-*.zip --generate-notes --notes-start-tag "${{ env.PREVIOUS_RELEASE_TAG }}"

--- a/.github/workflows/publish-scheduled-coverage.yml
+++ b/.github/workflows/publish-scheduled-coverage.yml
@@ -45,7 +45,8 @@ jobs:
           git init
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-          git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git config credential.helper '!f() { echo "username=x-access-token"; echo "password=${GH_TOKEN}"; }; f'
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
 
           if git fetch --depth 1 origin "${COVERAGE_BRANCH}"; then
             git checkout -B "${COVERAGE_BRANCH}" FETCH_HEAD

--- a/.github/workflows/scripts/disable-docker.sh
+++ b/.github/workflows/scripts/disable-docker.sh
@@ -23,10 +23,10 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 sudo apt-get install openbsd-inetd
-sudo bash -c "cat \"${SCRIPT_DIR}/discard-port.conf\" >> /etc/inetd.conf"
+sudo tee -a /etc/inetd.conf < "${SCRIPT_DIR}/discard-port.conf" > /dev/null
 sudo systemctl start inetd
-sudo mkdir /etc/systemd/system/docker.service.d
-sudo bash -c "cat \"${SCRIPT_DIR}/dockerd.service\" > /etc/systemd/system/docker.service.d/http-proxy.conf"
+sudo mkdir -p /etc/systemd/system/docker.service.d
+sudo install -D -m 0644 "${SCRIPT_DIR}/dockerd.service" /etc/systemd/system/docker.service.d/http-proxy.conf
 sudo systemctl daemon-reload
 sudo systemctl restart docker
 echo "Docker outbound network effectively disabled via proxy=http(s)://localhost:9 backed by inetd discard service."

--- a/.github/workflows/scripts/disable-docker.sh
+++ b/.github/workflows/scripts/disable-docker.sh
@@ -18,13 +18,15 @@
 #   - This script is designed for GitHub Actions Ubuntu runners with sudo.
 #   - It is idempotent: re-running it won't duplicate config lines or unnecessarily restart Docker.
 
+set -euo pipefail
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 sudo apt-get install openbsd-inetd
-sudo bash -c "cat ${SCRIPT_DIR}/discard-port.conf >> /etc/inetd.conf"
+sudo bash -c "cat \"${SCRIPT_DIR}/discard-port.conf\" >> /etc/inetd.conf"
 sudo systemctl start inetd
 sudo mkdir /etc/systemd/system/docker.service.d
-sudo bash -c "cat ${SCRIPT_DIR}/dockerd.service > /etc/systemd/system/docker.service.d/http-proxy.conf"
+sudo bash -c "cat \"${SCRIPT_DIR}/dockerd.service\" > /etc/systemd/system/docker.service.d/http-proxy.conf"
 sudo systemctl daemon-reload
 sudo systemctl restart docker
 echo "Docker outbound network effectively disabled via proxy=http(s)://localhost:9 backed by inetd discard service."

--- a/.github/workflows/scripts/run-consecutive-tests.sh
+++ b/.github/workflows/scripts/run-consecutive-tests.sh
@@ -54,11 +54,14 @@ run_multiple_attempts() {
   local result=0
 
   while [ $attempt -lt "$max_attempts" ]; do
-    local native_image_mode_prefix=""
+    local -a environment=("GVM_TCK_LV=$VERSION")
     if [ -n "${GVM_TCK_NATIVE_IMAGE_MODE:-}" ]; then
-      native_image_mode_prefix="GVM_TCK_NATIVE_IMAGE_MODE=\"$GVM_TCK_NATIVE_IMAGE_MODE\" "
+      environment+=("GVM_TCK_NATIVE_IMAGE_MODE=$GVM_TCK_NATIVE_IMAGE_MODE")
     fi
-    local cmd_str="${native_image_mode_prefix}GVM_TCK_LV=\"$VERSION\" ./gradlew clean $gradle_command -Pcoordinates=\"$TEST_COORDINATES\""
+    local -a command=("./gradlew" "clean" "$gradle_command" "-Pcoordinates=$TEST_COORDINATES")
+    local cmd_str
+    printf -v cmd_str '%q ' "env" "${environment[@]}" "${command[@]}"
+    cmd_str="${cmd_str% }"
     if [ $attempt -gt 0 ]; then
       echo "Re-running stage '$stage' (attempt $((attempt + 1))/$max_attempts)"
     fi
@@ -69,7 +72,7 @@ run_multiple_attempts() {
     echo "Starting stage '$stage' for $VERSION at $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
     echo "Command: $cmd_str"
 
-    timeout --signal=QUIT --kill-after=20s "$TIMEOUT" bash -c "$cmd_str"
+    timeout --signal=QUIT --kill-after=20s "$TIMEOUT" env "${environment[@]}" "${command[@]}"
     result=$?
 
     finished_at=$(date +%s)

--- a/.github/workflows/sync-docker-images.yml
+++ b/.github/workflows/sync-docker-images.yml
@@ -30,11 +30,19 @@ jobs:
           # get new FROM lines from PR branch
           NEW_LINES=$(git grep '^FROM ' HEAD -- tests/tck-build-logic/src/main/resources/allowed-docker-images | sed 's/.*:FROM //')
 
+          escape_sed_pattern() {
+            printf '%s' "$1" | sed 's/[][\\.^$*|]/\\&/g'
+          }
+
+          escape_sed_replacement() {
+            printf '%s' "$1" | sed 's/[|&\\/]/\\&/g'
+          }
+
           # replace all occurrences across repo
-          paste <(echo "$OLD_LINES") <(echo "$NEW_LINES") | while read OLD NEW; do
+          paste <(echo "$OLD_LINES") <(echo "$NEW_LINES") | while IFS=$'\t' read -r OLD NEW; do
             if [[ -n "$OLD" && -n "$NEW" && "$OLD" != "$NEW" ]]; then
               echo "Replacing $OLD → $NEW"
-              grep -rl "$OLD" . | xargs sed -i "s|$OLD|$NEW|g" || true
+              grep -rlZF -- "$OLD" . | xargs -0r sed -i "s|$(escape_sed_pattern "$OLD")|$(escape_sed_replacement "$NEW")|g" || true
             fi
           done
 


### PR DESCRIPTION
## Summary

This branch hardens CI workflow shell handling by tightening quoting, removing avoidable shell evaluation, and preventing token exposure in Git remotes.

## Changes

  - Quote workflow script paths in Docker-disabling setup and enable strict shell mode.
  - Escape sed search/replacement values in the Docker image sync workflow.
  - Use null-delimited grep/xargs handling for safer replacement across files.
  - Replace bash -c execution in the consecutive test runner with env/command arrays.
  - Validate scheduled release tags before computing the next release version.
  - Replace executable sed release tag arithmetic with explicit shell parsing.
  - Quote release tag usage in git tag, git push, and gh release create.
  - Avoid embedding GH_TOKEN in the coverage publish Git remote URL.

