### PR TITLE
[GenAI] Test fix for org.web3j:core:4.11.0 using gpt-5.5

### DIFF
--- a/metadata/org.web3j/core/4.11.0/reachability-metadata.json
+++ b/metadata/org.web3j/core/4.11.0/reachability-metadata.json
@@ -1,0 +1,1110 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.asymmetric.COMPOSITE$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.asymmetric.DH$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.asymmetric.DSA$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.asymmetric.DSTU4145$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.asymmetric.EC$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.asymmetric.ECGOST$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.asymmetric.EXTERNAL$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.asymmetric.EdEC$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.asymmetric.ElGamal$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.asymmetric.GM$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.asymmetric.GOST$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.asymmetric.IES$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.asymmetric.LMS$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.asymmetric.RSA$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.asymmetric.SPHINCSPlus$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.asymmetric.X509$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.Blake2b$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.Blake2s$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.Blake3$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.DSTU7564$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.GOST3411$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.Haraka$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.Keccak$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.MD2$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.MD4$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.MD5$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.RIPEMD128$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.RIPEMD160$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.RIPEMD256$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.RIPEMD320$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.SHA1$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.SHA224$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.SHA256$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.SHA3$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.SHA384$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.SHA512$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.SM3$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.Skein$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.Tiger$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.Whirlpool$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.drbg.DRBG$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.keystore.BC$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.keystore.BCFKS$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.keystore.PKCS12$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.AES$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.ARC4$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.ARIA$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.Blowfish$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.CAST5$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.CAST6$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.Camellia$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.ChaCha$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.DES$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.DESede$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.DSTU7624$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.GOST28147$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.GOST3412_2015$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.Grain128$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.Grainv1$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.HC128$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.HC256$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.IDEA$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.Noekeon$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.OpenSSLPBKDF$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.PBEPBKDF1$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.PBEPBKDF2$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.PBEPKCS12$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.Poly1305$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.RC2$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.RC5$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.RC6$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.Rijndael$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.SCRYPT$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.SEED$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.SM4$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.Salsa20$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.Serpent$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.Shacal2$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.SipHash$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.SipHash128$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.Skipjack$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.TEA$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.TLSKDF$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.Threefish$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.Twofish$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.VMPC$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.VMPCKSA3$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.XSalsa20$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.XTEA$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.crypto.Keys"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.Zuc$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.web3j.tx.Contract"
+      },
+      "type": "org.web3j.ens.contracts.generated.ENS",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String",
+            "org.web3j.protocol.Web3j",
+            "org.web3j.crypto.Credentials",
+            "org.web3j.tx.gas.ContractGasProvider"
+          ]
+        },
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String",
+            "org.web3j.protocol.Web3j",
+            "org.web3j.tx.TransactionManager",
+            "org.web3j.tx.gas.ContractGasProvider"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.web3j/core/index.json
+++ b/metadata/org.web3j/core/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "4.11.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/web3j/core/$version$/core-$version$-sources.jar",
+    "repository-url" : "https://github.com/LFDT-web3j/web3j",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/web3j/core/$version$/core-$version$-tests.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/web3j/core/$version$/core-$version$-javadoc.jar",
+    "description" : "web3j core is the central Java API for integrating JVM applications with Ethereum-compatible clients. It provides JSON-RPC communication, transaction and smart-contract support, reactive subscriptions, and supporting utilities for blockchain applications.",
     "tested-versions" : [
       "4.11.0"
     ],

--- a/metadata/org.web3j/core/index.json
+++ b/metadata/org.web3j/core/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "4.11.0",
+    "tested-versions" : [
+      "4.11.0"
+    ],
+    "allowed-packages" : [
+      "org.web3j"
+    ]
+  },
+  {
     "metadata-version" : "4.10.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/web3j/core/$version$/core-$version$-sources.jar",
     "repository-url" : "https://github.com/LFDT-web3j/web3j",

--- a/stats/org.web3j/core/4.11.0/execution-metrics.json
+++ b/stats/org.web3j/core/4.11.0/execution-metrics.json
@@ -1,0 +1,99 @@
+{
+  "fix_java_run_fail:2026-05-18": {
+    "timestamp": "2026-05-18T19:40:09.321015Z",
+    "library": "org.web3j:core:4.11.0",
+    "starting_commit": "d18c2f157c1cb55c89961b62cc5971d9ab75a008",
+    "ending_commit": "681e448b5e4b50f1d48b816736d25562a38147f4",
+    "previous_library": "org.web3j:core:4.10.0",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.11.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 4,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1102,
+          "missed": 23195,
+          "ratio": 0.045355,
+          "total": 24297
+        },
+        "line": {
+          "covered": 246,
+          "missed": 4893,
+          "ratio": 0.047869,
+          "total": 5139
+        },
+        "method": {
+          "covered": 104,
+          "missed": 1743,
+          "ratio": 0.056308,
+          "total": 1847
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "4.10.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 4,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1102,
+          "missed": 22468,
+          "ratio": 0.046754,
+          "total": 23570
+        },
+        "line": {
+          "covered": 246,
+          "missed": 4716,
+          "ratio": 0.049577,
+          "total": 4962
+        },
+        "method": {
+          "covered": 104,
+          "missed": 1687,
+          "ratio": 0.058068,
+          "total": 1791
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 32618,
+      "cached_input_tokens_used": 166400,
+      "output_tokens_used": 2328,
+      "iterations": 1,
+      "cost_usd": 0.153,
+      "tested_library_loc": 246,
+      "metadata_entries": 183,
+      "previous_library_metadata_entries": 183,
+      "code_coverage_percent": 4.79,
+      "previous_library_coverage_percent": 4.96
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.web3j/core/4.11.0/src/test/java/org_web3j/core/ContractTest.java",
+      "metadata_file": "metadata/org.web3j/core/4.11.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.web3j/core/4.11.0/stats.json
+++ b/stats/org.web3j/core/4.11.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "4.11.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 4,
+          "totalCalls" : 4
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 4,
+      "totalCalls" : 4
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1102,
+        "missed" : 23195,
+        "ratio" : 0.045355,
+        "total" : 24297
+      },
+      "line" : {
+        "covered" : 246,
+        "missed" : 4893,
+        "ratio" : 0.047869,
+        "total" : 5139
+      },
+      "method" : {
+        "covered" : 104,
+        "missed" : 1743,
+        "ratio" : 0.056308,
+        "total" : 1847
+      }
+    }
+  } ]
+}

--- a/tests/src/org.web3j/core/4.11.0/.gitignore
+++ b/tests/src/org.web3j/core/4.11.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.web3j/core/4.11.0/build.gradle
+++ b/tests/src/org.web3j/core/4.11.0/build.gradle
@@ -10,6 +10,15 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 
+repositories {
+    maven {
+        url = uri("https://artifacts.consensys.net/public/maven/maven/")
+        content {
+            includeGroup "tech.pegasys"
+        }
+    }
+}
+
 dependencies {
     testImplementation "org.web3j:core:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'

--- a/tests/src/org.web3j/core/4.11.0/build.gradle
+++ b/tests/src/org.web3j/core/4.11.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.web3j:core:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.web3j/core/4.11.0/gradle.properties
+++ b/tests/src/org.web3j/core/4.11.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.web3j:core:4.11.0
+library.version = 4.11.0
+metadata.dir = org.web3j/core/4.11.0/

--- a/tests/src/org.web3j/core/4.11.0/settings.gradle
+++ b/tests/src/org.web3j/core/4.11.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.web3j.core_tests'

--- a/tests/src/org.web3j/core/4.11.0/src/test/java/org_web3j/core/ContractTest.java
+++ b/tests/src/org.web3j/core/4.11.0/src/test/java/org_web3j/core/ContractTest.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_web3j.core;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.concurrent.CompletableFuture;
+
+import io.reactivex.Flowable;
+import org.junit.jupiter.api.Test;
+
+import org.web3j.crypto.Credentials;
+import org.web3j.crypto.Hash;
+import org.web3j.ens.contracts.generated.ENS;
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.Web3jService;
+import org.web3j.protocol.core.BatchRequest;
+import org.web3j.protocol.core.BatchResponse;
+import org.web3j.protocol.core.DefaultBlockParameter;
+import org.web3j.protocol.core.Request;
+import org.web3j.protocol.core.Response;
+import org.web3j.protocol.core.methods.response.EthGetCode;
+import org.web3j.protocol.core.methods.response.EthGetTransactionCount;
+import org.web3j.protocol.core.methods.response.EthGetTransactionReceipt;
+import org.web3j.protocol.core.methods.response.EthSendTransaction;
+import org.web3j.protocol.core.methods.response.TransactionReceipt;
+import org.web3j.protocol.exceptions.TransactionException;
+import org.web3j.protocol.websocket.events.Notification;
+import org.web3j.tx.Contract;
+import org.web3j.tx.TransactionManager;
+import org.web3j.tx.gas.ContractGasProvider;
+import org.web3j.tx.gas.StaticGasProvider;
+import org.web3j.tx.response.TransactionReceiptProcessor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ContractTest {
+    static final String BINARY = "0x60006000";
+    private static final String ENCODED_CONSTRUCTOR = "00";
+    static final String DEPLOYED_ADDRESS = "0x000000000000000000000000000000000000dEaD";
+    static final String TRANSACTION_HASH = "0x1";
+    private static final String PRIVATE_KEY =
+            "0000000000000000000000000000000000000000000000000000000000000001";
+
+    @Test
+    void deployRemoteCallWithCredentialsCreatesContractWrapper() throws Exception {
+        StubWeb3jService service = new StubWeb3jService();
+        Web3j web3j = Web3j.build(service);
+        try {
+            Credentials credentials = Credentials.create(PRIVATE_KEY);
+            ContractGasProvider gasProvider =
+                    new StaticGasProvider(BigInteger.TEN, BigInteger.valueOf(21_000));
+
+            ENS contract =
+                    Contract.deployRemoteCall(
+                                    ENS.class,
+                                    web3j,
+                                    credentials,
+                                    gasProvider,
+                                    BINARY,
+                                    ENCODED_CONSTRUCTOR,
+                                    BigInteger.valueOf(7))
+                            .send();
+
+            assertThat(contract.getContractAddress()).isEqualTo(DEPLOYED_ADDRESS);
+            assertThat(contract.getTransactionReceipt()).isPresent();
+            assertThat(service.sentRawTransactions).isEqualTo(1);
+            assertThat(service.lastRawTransaction).isNotBlank();
+        } finally {
+            web3j.shutdown();
+        }
+        assertThat(service.closed).isTrue();
+    }
+
+    @Test
+    void deployRemoteCallWithTransactionManagerCreatesContractWrapper() throws Exception {
+        RecordingTransactionManager transactionManager = new RecordingTransactionManager();
+        ContractGasProvider gasProvider =
+                new StaticGasProvider(BigInteger.ONE, BigInteger.valueOf(30_000));
+
+        ENS contract =
+                Contract.deployRemoteCall(
+                                ENS.class,
+                                null,
+                                transactionManager,
+                                gasProvider,
+                                BINARY,
+                                ENCODED_CONSTRUCTOR,
+                                BigInteger.valueOf(11))
+                        .send();
+
+        assertThat(contract.getContractAddress()).isEqualTo(DEPLOYED_ADDRESS);
+        assertThat(contract.getTransactionReceipt()).isPresent();
+        assertThat(transactionManager.constructorTransaction).isTrue();
+        assertThat(transactionManager.to).isNull();
+        assertThat(transactionManager.data).isEqualTo(BINARY + ENCODED_CONSTRUCTOR);
+        assertThat(transactionManager.value).isEqualTo(BigInteger.valueOf(11));
+    }
+
+    static TransactionReceipt successfulReceipt(String transactionHash) {
+        TransactionReceipt receipt = new TransactionReceipt();
+        receipt.setTransactionHash(transactionHash);
+        receipt.setStatus("0x1");
+        receipt.setContractAddress(DEPLOYED_ADDRESS);
+        return receipt;
+    }
+}
+
+class RecordingTransactionManager extends TransactionManager {
+    String to;
+    String data;
+    BigInteger value;
+    boolean constructorTransaction;
+
+    RecordingTransactionManager() {
+        super(new ImmediateReceiptProcessor(), "0x0000000000000000000000000000000000000001");
+    }
+
+    @Override
+    public EthSendTransaction sendTransaction(
+            BigInteger gasPrice,
+            BigInteger gasLimit,
+            String to,
+            String data,
+            BigInteger value,
+            boolean constructor) {
+        this.to = to;
+        this.data = data;
+        this.value = value;
+        this.constructorTransaction = constructor;
+        EthSendTransaction transaction = new EthSendTransaction();
+        transaction.setResult(ContractTest.TRANSACTION_HASH);
+        return transaction;
+    }
+
+    @Override
+    public EthSendTransaction sendEIP1559Transaction(
+            long chainId,
+            BigInteger maxPriorityFeePerGas,
+            BigInteger maxFeePerGas,
+            BigInteger gasLimit,
+            String to,
+            String data,
+            BigInteger value,
+            boolean constructor) {
+        return sendTransaction(maxPriorityFeePerGas, gasLimit, to, data, value, constructor);
+    }
+
+    @Override
+    public String sendCall(String to, String data, DefaultBlockParameter defaultBlockParameter) {
+        return "0x";
+    }
+
+    @Override
+    public EthGetCode getCode(String contractAddress, DefaultBlockParameter defaultBlockParameter) {
+        EthGetCode code = new EthGetCode();
+        code.setResult(ContractTest.BINARY);
+        return code;
+    }
+}
+
+class ImmediateReceiptProcessor extends TransactionReceiptProcessor {
+    ImmediateReceiptProcessor() {
+        super(null);
+    }
+
+    @Override
+    public TransactionReceipt waitForTransactionReceipt(String transactionHash)
+            throws IOException, TransactionException {
+        return ContractTest.successfulReceipt(transactionHash);
+    }
+}
+
+class StubWeb3jService implements Web3jService {
+    int sentRawTransactions;
+    String lastRawTransaction;
+    boolean closed;
+
+    @Override
+    public <T extends Response> T send(Request request, Class<T> responseType) throws IOException {
+        if (EthGetTransactionCount.class.equals(responseType)) {
+            EthGetTransactionCount count = new EthGetTransactionCount();
+            count.setResult("0x0");
+            return responseType.cast(count);
+        }
+        if (EthSendTransaction.class.equals(responseType)) {
+            lastRawTransaction = (String) request.getParams().get(0);
+            sentRawTransactions++;
+            EthSendTransaction transaction = new EthSendTransaction();
+            transaction.setResult(Hash.sha3(lastRawTransaction));
+            return responseType.cast(transaction);
+        }
+        if (EthGetTransactionReceipt.class.equals(responseType)) {
+            String transactionHash = (String) request.getParams().get(0);
+            EthGetTransactionReceipt response = new EthGetTransactionReceipt();
+            response.setResult(ContractTest.successfulReceipt(transactionHash));
+            return responseType.cast(response);
+        }
+        throw new IOException("Unexpected response type: " + responseType.getName());
+    }
+
+    @Override
+    public <T extends Response> CompletableFuture<T> sendAsync(
+            Request request, Class<T> responseType) {
+        try {
+            return CompletableFuture.completedFuture(send(request, responseType));
+        } catch (IOException e) {
+            CompletableFuture<T> future = new CompletableFuture<>();
+            future.completeExceptionally(e);
+            return future;
+        }
+    }
+
+    @Override
+    public BatchResponse sendBatch(BatchRequest batchRequest) {
+        throw new UnsupportedOperationException("Batch requests are not used by this test");
+    }
+
+    @Override
+    public CompletableFuture<BatchResponse> sendBatchAsync(BatchRequest batchRequest) {
+        CompletableFuture<BatchResponse> future = new CompletableFuture<>();
+        future.completeExceptionally(
+                new UnsupportedOperationException("Batch requests are not used by this test"));
+        return future;
+    }
+
+    @Override
+    public <T extends Notification<?>> Flowable<T> subscribe(
+            Request request, String unsubscribeMethod, Class<T> responseType) {
+        return Flowable.error(
+                new UnsupportedOperationException("Subscriptions are not used by this test"));
+    }
+
+    @Override
+    public void close() {
+        closed = true;
+    }
+}
+

--- a/tests/src/org.web3j/core/4.11.0/user-code-filter.json
+++ b/tests/src/org.web3j/core/4.11.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.web3j.**"
+    },
+    {
+      "includeClasses" : "org_web3j.core.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7046

This PR provides test fixes and new metadata for org.web3j:core:4.11.0, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 32618
- Cached input tokens: 166400
- Output tokens: 2328
- Metadata entries: 183
- Iterations: 1
- Library coverage percentage: 4.79
- Previous library version metadata entries: 183
- Previous library version coverage percentage: 4.96

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `59bd8a0d3a9ea74ba3a0e46b5fd5f2de0b088007`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.web3j:core:4.10.0: 4/4 covered calls (100.00%)
- org.web3j:core:4.11.0: 4/4 covered calls (100.00%)

**Reflection:**
- org.web3j:core:4.10.0: 4/4 covered calls (100.00%)
- org.web3j:core:4.11.0: 4/4 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.web3j:core:4.10.0: 1102/23570 (4.68%)
- org.web3j:core:4.11.0: 1102/24297 (4.54%)

**Line:**
- org.web3j:core:4.10.0: 246/4962 (4.96%)
- org.web3j:core:4.11.0: 246/5139 (4.79%)

**Method:**
- org.web3j:core:4.10.0: 104/1791 (5.81%)
- org.web3j:core:4.11.0: 104/1847 (5.63%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.web3j/core/4.10.0/build.gradle 2/tests/src/org.web3j/core/4.11.0/build.gradle
index e16c65d96f..e8d0723c3b 100644
--- 1/tests/src/org.web3j/core/4.10.0/build.gradle
+++ 2/tests/src/org.web3j/core/4.11.0/build.gradle
@@ -10,6 +10,15 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 
+repositories {
+    maven {
+        url = uri("https://artifacts.consensys.net/public/maven/maven/")
+        content {
+            includeGroup "tech.pegasys"
+        }
+    }
+}
+
 dependencies {
     testImplementation "org.web3j:core:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
