### PR TITLE
[GenAI] Test fix for org.scalatest:scalatest-diagrams_3:3.3.0-SNAP4 using gpt-5.5

### DIFF
--- a/metadata/org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/reachability-metadata.json
+++ b/metadata/org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/reachability-metadata.json
@@ -1,0 +1,78 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Assertions"
+      },
+      "type": "org.scalatest.Assertions$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.diagrams.Diagrams"
+      },
+      "type": "org.scalatest.diagrams.Diagrams$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.source.Position"
+      },
+      "type": "org.scalactic.source.Position$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.diagrams.DiagrammedByNameExpr"
+      },
+      "type": "org.scalatest.diagrams.DiagrammedByNameExpr",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Resources$"
+      },
+      "type": "org.scalatest.Resources$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.exceptions.StackDepthException"
+      },
+      "type": "org.scalatest.exceptions.StackDepthException",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Resources$"
+      },
+      "bundle": "org.scalatest.ScalaTestBundle"
+    }
+  ]
+}

--- a/metadata/org.scalatest/scalatest-diagrams_3/index.json
+++ b/metadata/org.scalatest/scalatest-diagrams_3/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "3.3.0-SNAP4",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-diagrams_3/$version$/scalatest-diagrams_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/scalatest/scalatest",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-diagrams_3/$version$/scalatest-diagrams_3-$version$-javadoc.jar",
+    "description" : "ScalaTest Diagrams adds diagrammed assertion support to ScalaTest, showing evaluated subexpressions when an assertion fails. The Scala 3 artifact provides the org.scalatest.diagrams APIs and macros for writing ScalaTest assertions whose failure messages include expression diagrams.",
     "language" : {
       "name" : "scala",
       "version" : "3"

--- a/metadata/org.scalatest/scalatest-diagrams_3/index.json
+++ b/metadata/org.scalatest/scalatest-diagrams_3/index.json
@@ -1,6 +1,22 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.3.0-SNAP4",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "3.3.0-SNAP4"
+    ],
+    "allowed-packages" : [
+      "org.scalatest.diagrams",
+      "org.scalactic.source",
+      "org.scalatest",
+      "org.scalatest.exceptions"
+    ]
+  },
+  {
     "metadata-version" : "3.2.19",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-diagrams_3/$version$/scalatest-diagrams_3-$version$-sources.jar",
     "repository-url" : "https://github.com/scalatest/scalatest",

--- a/stats/org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/execution-metrics.json
+++ b/stats/org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_java_run_fail:2026-05-18": {
+    "timestamp": "2026-05-18T20:04:55.895554Z",
+    "library": "org.scalatest:scalatest-diagrams_3:3.3.0-SNAP4",
+    "starting_commit": "8e004f42b2aae8ec07ce1ddb671dc3aac08792de",
+    "ending_commit": "5a5112c81eff273f897eb453bd422ef2477ab4cb",
+    "previous_library": "org.scalatest:scalatest-diagrams_3:3.2.19",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.3.0-SNAP4",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 623,
+          "missed": 3019,
+          "ratio": 0.17106,
+          "total": 3642
+        },
+        "line": {
+          "covered": 63,
+          "missed": 128,
+          "ratio": 0.329843,
+          "total": 191
+        },
+        "method": {
+          "covered": 47,
+          "missed": 82,
+          "ratio": 0.364341,
+          "total": 129
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.2.19",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 698,
+          "missed": 3185,
+          "ratio": 0.179758,
+          "total": 3883
+        },
+        "line": {
+          "covered": 67,
+          "missed": 130,
+          "ratio": 0.340102,
+          "total": 197
+        },
+        "method": {
+          "covered": 53,
+          "missed": 89,
+          "ratio": 0.373239,
+          "total": 142
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 28097,
+      "cached_input_tokens_used": 231424,
+      "output_tokens_used": 2373,
+      "iterations": 1,
+      "cost_usd": 0.1869,
+      "tested_library_loc": 63,
+      "metadata_entries": 13,
+      "previous_library_metadata_entries": 13,
+      "code_coverage_percent": 32.98,
+      "previous_library_coverage_percent": 34.01
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/src/test/scala/org_scalatest/scalatest_diagrams_3/Scalatest_diagrams_3Test.scala",
+      "metadata_file": "metadata/org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/stats.json
+++ b/stats/org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.3.0-SNAP4",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 623,
+        "missed" : 3019,
+        "ratio" : 0.17106,
+        "total" : 3642
+      },
+      "line" : {
+        "covered" : 63,
+        "missed" : 128,
+        "ratio" : 0.329843,
+        "total" : 191
+      },
+      "method" : {
+        "covered" : 47,
+        "missed" : 82,
+        "ratio" : 0.364341,
+        "total" : 129
+      }
+    }
+  } ]
+}

--- a/tests/src/org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/.gitignore
+++ b/tests/src/org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/build.gradle
+++ b/tests/src/org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.scalatest:scalatest-diagrams_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/gradle.properties
+++ b/tests/src/org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.scalatest:scalatest-diagrams_3:3.3.0-SNAP4
+library.version = 3.3.0-SNAP4
+metadata.dir = org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/

--- a/tests/src/org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/settings.gradle
+++ b/tests/src/org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.scalatest.scalatest-diagrams_3_tests'

--- a/tests/src/org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/src/test/scala/org_scalatest/scalatest_diagrams_3/Scalatest_diagrams_3Test.scala
+++ b/tests/src/org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/src/test/scala/org_scalatest/scalatest_diagrams_3/Scalatest_diagrams_3Test.scala
@@ -1,0 +1,190 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_scalatest.scalatest_diagrams_3
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertThrows as junitAssertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.function.Executable
+import org.scalatest.diagrams.DiagrammedExpr
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.exceptions.TestCanceledException
+import org.scalatest.exceptions.TestFailedException
+
+class Scalatest_diagrams_3Test extends Diagrams:
+  @Test
+  def passingDiagramAssertionsEvaluateOrdinaryBooleanExpressions(): Unit =
+    val numbers: Vector[Int] = Vector(2, 3, 5, 7)
+    val label: String = "reachability-metadata"
+    val calculator: Calculator = Calculator(40)
+
+    assert(numbers.sum == 17)
+    assert(numbers.filter(_ > 3).contains(7))
+    assert(label.startsWith("reachability") && label.endsWith("metadata"))
+    assert(calculator.incrementedBy(2) == 42, "calculator should add the requested delta")
+
+  @Test
+  def failingDiagramAssertionIncludesExpressionSourceAndCapturedValues(): Unit =
+    val numbers: Vector[Int] = Vector(1, 2, 3)
+    val requested: Int = 4
+
+    val failure: TestFailedException = expectTestFailure {
+      assert(numbers.contains(requested))
+    }
+
+    val message: String = failure.getMessage
+    assertTrue(message.contains("numbers.contains(requested)"), message)
+    assertTrue(message.contains("Vector(1, 2, 3)"), message)
+    assertTrue(message.contains("4"), message)
+    assertTrue(message.contains("false"), message)
+    assertTrue(message.contains("|"), message)
+
+  @Test
+  def failingDiagramAssertionWithCluePreservesTheClueAndDiagramDetails(): Unit =
+    val availableItems: Int = 2
+    val requestedItems: Int = 5
+    val clue: String = "inventory request should fit the available stock"
+
+    val failure: TestFailedException = expectTestFailure {
+      assert(requestedItems <= availableItems, clue)
+    }
+
+    val message: String = failure.getMessage
+    assertTrue(message.contains(clue), message)
+    assertTrue(message.contains("requestedItems <= availableItems"), message)
+    assertTrue(message.contains("5"), message)
+    assertTrue(message.contains("2"), message)
+    assertTrue(message.contains("false"), message)
+    assertTrue(message.contains("|"), message)
+
+  @Test
+  def failingDiagramAssertionRendersNestedSelectionsAndMethodApplications(): Unit =
+    val calculator: Calculator = Calculator(6)
+    val delta: Int = 5
+    val expected: Int = 99
+
+    val failure: TestFailedException = expectTestFailure {
+      assert(calculator.incrementedBy(delta) == expected)
+    }
+
+    val message: String = failure.getMessage
+    assertTrue(message.contains("calculator.incrementedBy(delta) == expected"), message)
+    assertTrue(message.contains("Calculator(6)"), message)
+    assertTrue(message.contains("11"), message)
+    assertTrue(message.contains("5"), message)
+    assertTrue(message.contains("99"), message)
+    assertTrue(message.contains("false"), message)
+
+  @Test
+  def failingTripleEqualsDiagramAssertionRendersComparedValues(): Unit =
+    val actual: Int = 3
+    val expected: Int = 5
+
+    assert(actual === 3)
+
+    val failure: TestFailedException = expectTestFailure {
+      assert(actual === expected)
+    }
+
+    val message: String = failure.getMessage
+    assertTrue(message.contains("actual === expected"), message)
+    assertTrue(message.contains("3"), message)
+    assertTrue(message.contains("5"), message)
+    assertTrue(message.contains("false"), message)
+    assertTrue(message.contains("|"), message)
+
+  @Test
+  def failingDiagramAssumeThrowsCanceledExceptionWithDiagramDetails(): Unit =
+    val serviceName: String = "metadata-service"
+    val requestedPrefix: String = "native-image"
+
+    val cancellation: TestCanceledException = expectTestCancellation {
+      assume(serviceName.startsWith(requestedPrefix))
+    }
+
+    val message: String = cancellation.getMessage
+    assertTrue(message.contains("serviceName.startsWith(requestedPrefix)"), message)
+    assertTrue(message.contains("metadata-service"), message)
+    assertTrue(message.contains("native-image"), message)
+    assertTrue(message.contains("false"), message)
+
+  @Test
+  def diagrammedSimpleAndSelectExpressionsExposeAnchorValues(): Unit =
+    val base: DiagrammedExpr[String] = DiagrammedExpr.simpleExpr("metadata", 2)
+    val selected: DiagrammedExpr[Int] = DiagrammedExpr.selectExpr(base, 8, 12)
+
+    assertEquals("metadata", base.value)
+    assertEquals(2, base.anchor)
+    assertEquals(List("AnchorValue(2,metadata)"), base.anchorValues.map(_.toString))
+
+    assertEquals(8, selected.value)
+    assertEquals(12, selected.anchor)
+    assertEquals(
+      List("AnchorValue(2,metadata)", "AnchorValue(12,8)"),
+      selected.anchorValues.map(_.toString)
+    )
+
+  @Test
+  def diagrammedApplyExpressionCombinesQualifierResultAndArguments(): Unit =
+    val qualifier: DiagrammedExpr[String] = DiagrammedExpr.simpleExpr("scala", 1)
+    val firstArgument: DiagrammedExpr[Int] = DiagrammedExpr.simpleExpr(3, 9)
+    val secondArgument: DiagrammedExpr[Int] = DiagrammedExpr.simpleExpr(4, 14)
+    val syntheticArgument: DiagrammedExpr[String] = DiagrammedExpr.simpleExpr("ignored", -1)
+    val arguments: List[DiagrammedExpr[?]] = List(firstArgument, secondArgument, syntheticArgument)
+
+    val applied: DiagrammedExpr[String] = DiagrammedExpr.applyExpr(qualifier, arguments, "scala-7", 20)
+    val anchors: List[String] = applied.anchorValues.map(_.toString)
+
+    assertEquals("scala-7", applied.value)
+    assertEquals(20, applied.anchor)
+    assertEquals("AnchorValue(1,scala)", anchors.head)
+    assertTrue(anchors.contains("AnchorValue(20,scala-7)"), anchors.toString)
+    assertTrue(anchors.contains("AnchorValue(9,3)"), anchors.toString)
+    assertTrue(anchors.contains("AnchorValue(14,4)"), anchors.toString)
+    assertFalse(anchors.exists(_.contains("ignored")), anchors.toString)
+
+  @Test
+  def byNameDiagrammedExpressionEvaluatesValueLazilyAndOnlyOnce(): Unit =
+    var evaluations: Int = 0
+    val expression: DiagrammedExpr[String] = DiagrammedExpr.byNameExpr(
+      {
+        evaluations += 1
+        "computed-value"
+      },
+      31
+    )
+
+    assertEquals(31, expression.anchor)
+    assertTrue(expression.anchorValues.isEmpty)
+    assertEquals(0, evaluations)
+    assertEquals("computed-value", expression.value)
+    assertEquals("computed-value", expression.value)
+    assertEquals(1, evaluations)
+
+  @Test
+  def useDiagramMarkerCanBeObtainedFromTrait(): Unit =
+    assertNotNull(UseDiagram)
+
+  private def expectTestFailure(block: => Unit): TestFailedException =
+    junitAssertThrows(
+      classOf[TestFailedException],
+      new Executable:
+        override def execute(): Unit = block
+    )
+
+  private def expectTestCancellation(block: => Unit): TestCanceledException =
+    junitAssertThrows(
+      classOf[TestCanceledException],
+      new Executable:
+        override def execute(): Unit = block
+    )
+
+  private final case class Calculator(base: Int):
+    def incrementedBy(delta: Int): Int = base + delta

--- a/tests/src/org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/src/test/scala/org_scalatest/scalatest_diagrams_3/Scalatest_diagrams_3Test.scala
+++ b/tests/src/org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/src/test/scala/org_scalatest/scalatest_diagrams_3/Scalatest_diagrams_3Test.scala
@@ -151,21 +151,16 @@ class Scalatest_diagrams_3Test extends Diagrams:
     assertFalse(anchors.exists(_.contains("ignored")), anchors.toString)
 
   @Test
-  def byNameDiagrammedExpressionEvaluatesValueLazilyAndOnlyOnce(): Unit =
+  def diagrammedAssertionPassesByNameArgumentsWithoutEagerDiagramCapture(): Unit =
     var evaluations: Int = 0
-    val expression: DiagrammedExpr[String] = DiagrammedExpr.byNameExpr(
-      {
-        evaluations += 1
-        "computed-value"
-      },
-      31
-    )
 
-    assertEquals(31, expression.anchor)
-    assertTrue(expression.anchorValues.isEmpty)
-    assertEquals(0, evaluations)
-    assertEquals("computed-value", expression.value)
-    assertEquals("computed-value", expression.value)
+    def acceptsByName(value: => String): Boolean =
+      value == "computed-value"
+
+    assert(acceptsByName {
+      evaluations += 1
+      "computed-value"
+    })
     assertEquals(1, evaluations)
 
   @Test

--- a/tests/src/org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/user-code-filter.json
+++ b/tests/src/org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.scalatest.diagrams.**"
+    },
+    {
+      "includeClasses" : "org_scalatest.scalatest_diagrams_3.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7039

This PR provides test fixes and new metadata for org.scalatest:scalatest-diagrams_3:3.3.0-SNAP4, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 28097
- Cached input tokens: 231424
- Output tokens: 2373
- Metadata entries: 13
- Iterations: 1
- Library coverage percentage: 32.98
- Previous library version metadata entries: 13
- Previous library version coverage percentage: 34.01

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3f69aa1510d519e1825b9bfd59a81bb41ea7ef04`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.scalatest:scalatest-diagrams_3:3.2.19: 0/0 covered calls (100.00%)
- org.scalatest:scalatest-diagrams_3:3.3.0-SNAP4: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.scalatest:scalatest-diagrams_3:3.2.19: 698/3883 (17.98%)
- org.scalatest:scalatest-diagrams_3:3.3.0-SNAP4: 623/3642 (17.11%)

**Line:**
- org.scalatest:scalatest-diagrams_3:3.2.19: 67/197 (34.01%)
- org.scalatest:scalatest-diagrams_3:3.3.0-SNAP4: 63/191 (32.98%)

**Method:**
- org.scalatest:scalatest-diagrams_3:3.2.19: 53/142 (37.32%)
- org.scalatest:scalatest-diagrams_3:3.3.0-SNAP4: 47/129 (36.43%)

**Comparison between existing test version and AI-Generated update**

```diff

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
