### PR TITLE
[GenAI] Test fix for org.scalactic:scalactic_3:3.3.0-alpha.1 using gpt-5.5

### DIFF
--- a/metadata/org.scalactic/scalactic_3/3.3.0-alpha.1/reachability-metadata.json
+++ b/metadata/org.scalactic/scalactic_3/3.3.0-alpha.1/reachability-metadata.json
@@ -1,66 +1,42 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org.scalactic.Resources$"
+      "condition" : {
+        "typeReached" : "org.scalactic.Resources$"
       },
-      "type": "java.lang.StackTraceElement[]"
+      "type" : "java.lang.StackTraceElement[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalactic.source.ObjectMeta$$anon$1"
+      "condition" : {
+        "typeReached" : "org.scalactic.source.ObjectMeta$$anon$1"
       },
-      "type": "java.lang.String[]"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalactic.source.ObjectMeta$$anon$1"
+      "condition" : {
+        "typeReached" : "org.scalactic.source.ObjectMeta$$anon$1"
       },
-      "type": "java.lang.reflect.Constructor[]"
+      "type" : "java.lang.reflect.Constructor[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalactic.source.ObjectMeta$$anon$1"
+      "condition" : {
+        "typeReached" : "org.scalactic.source.ObjectMeta$$anon$1"
       },
-      "type": "java.lang.reflect.Field[]"
+      "type" : "java.lang.reflect.Field[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalactic.source.ObjectMeta$$anon$1"
+      "condition" : {
+        "typeReached" : "org.scalactic.source.ObjectMeta$$anon$1"
       },
-      "type": "java.lang.reflect.Method[]"
-    },
-    {
-      "condition": {
-        "typeReached": "org.scalactic.source.ObjectMeta$$anon$1"
-      },
-      "type": "org_scalactic.scalactic_3.ObjectMetaPrivateFixture"
-    },
-    {
-      "condition": {
-        "typeReached": "org.scalactic.source.ObjectMeta$$anon$1"
-      },
-      "type": "org_scalactic.scalactic_3.ObjectMetaSpecializedAccessorFixture"
-    },
-    {
-      "condition": {
-        "typeReached": "org.scalactic.source.ObjectMeta$$anon$1$$anon$2"
-      },
-      "type": "org_scalactic.scalactic_3.ObjectMetaSpecializedAccessorFixture"
-    },
-    {
-      "condition": {
-        "typeReached": "org.scalactic.source.ObjectMeta$$anon$1"
-      },
-      "type": "org_scalactic.scalactic_3.ObjectMetaVisibleFixture"
+      "type" : "java.lang.reflect.Method[]"
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "org.scalactic.Resources$"
+      "condition" : {
+        "typeReached" : "org.scalactic.Resources$"
       },
-      "bundle": "org.scalactic.ScalacticBundle"
+      "bundle" : "org.scalactic.ScalacticBundle"
     }
   ]
 }

--- a/metadata/org.scalactic/scalactic_3/3.3.0-alpha.1/reachability-metadata.json
+++ b/metadata/org.scalactic/scalactic_3/3.3.0-alpha.1/reachability-metadata.json
@@ -1,0 +1,66 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.scalactic.Resources$"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.source.ObjectMeta$$anon$1"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.source.ObjectMeta$$anon$1"
+      },
+      "type": "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.source.ObjectMeta$$anon$1"
+      },
+      "type": "java.lang.reflect.Field[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.source.ObjectMeta$$anon$1"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.source.ObjectMeta$$anon$1"
+      },
+      "type": "org_scalactic.scalactic_3.ObjectMetaPrivateFixture"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.source.ObjectMeta$$anon$1"
+      },
+      "type": "org_scalactic.scalactic_3.ObjectMetaSpecializedAccessorFixture"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.source.ObjectMeta$$anon$1$$anon$2"
+      },
+      "type": "org_scalactic.scalactic_3.ObjectMetaSpecializedAccessorFixture"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.source.ObjectMeta$$anon$1"
+      },
+      "type": "org_scalactic.scalactic_3.ObjectMetaVisibleFixture"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.scalactic.Resources$"
+      },
+      "bundle": "org.scalactic.ScalacticBundle"
+    }
+  ]
+}

--- a/metadata/org.scalactic/scalactic_3/index.json
+++ b/metadata/org.scalactic/scalactic_3/index.json
@@ -1,6 +1,19 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.3.0-alpha.1",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "3.3.0-alpha.1"
+    ],
+    "allowed-packages" : [
+      "org.scalactic"
+    ]
+  },
+  {
     "metadata-version" : "3.2.19",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/scalactic/scalactic_3/$version$/scalactic_3-$version$-sources.jar",
     "repository-url" : "https://github.com/scalatest/scalatest",

--- a/metadata/org.scalactic/scalactic_3/index.json
+++ b/metadata/org.scalactic/scalactic_3/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "3.3.0-alpha.1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/scalactic/scalactic_3/$version$/scalactic_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/scalatest/scalatest",
+    "test-code-url" : "https://github.com/scalatest/scalatest/tree/feature-$version$/jvm/scalactic-test/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/scalactic/scalactic_3/$version$/scalactic_3-$version$-javadoc.jar",
+    "description" : "Scalactic provides core constructs used by ScalaTest for expressive assertions and validation, including equality, normalization, value constraints, and Or/Every data types. The scalactic_3 artifact is the Scala 3 JVM build and can be used independently by Scala applications that want those testing and validation utilities without depending on the full ScalaTest suite.",
     "language" : {
       "name" : "scala",
       "version" : "3"

--- a/stats/org.scalactic/scalactic_3/3.3.0-alpha.1/execution-metrics.json
+++ b/stats/org.scalactic/scalactic_3/3.3.0-alpha.1/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_java_run_fail:2026-05-18": {
+    "timestamp": "2026-05-18T20:40:25.359582Z",
+    "library": "org.scalactic:scalactic_3:3.3.0-alpha.1",
+    "starting_commit": "d32e7da88422484c88610468f5e66862bf162eb3",
+    "ending_commit": "462c1628ab46fc391bef7e241b8472c940dbdffc",
+    "previous_library": "org.scalactic:scalactic_3:3.2.19",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.3.0-alpha.1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 7,
+            "totalCalls": 7
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 8,
+        "totalCalls": 8
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 543,
+          "missed": 114602,
+          "ratio": 0.004716,
+          "total": 115145
+        },
+        "line": {
+          "covered": 59,
+          "missed": 7653,
+          "ratio": 0.00765,
+          "total": 7712
+        },
+        "method": {
+          "covered": 44,
+          "missed": 16233,
+          "ratio": 0.002703,
+          "total": 16277
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.2.19",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 6,
+            "totalCalls": 6
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 7,
+        "totalCalls": 7
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 481,
+          "missed": 115667,
+          "ratio": 0.004141,
+          "total": 116148
+        },
+        "line": {
+          "covered": 61,
+          "missed": 7658,
+          "ratio": 0.007903,
+          "total": 7719
+        },
+        "method": {
+          "covered": 39,
+          "missed": 16228,
+          "ratio": 0.002397,
+          "total": 16267
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 20761,
+      "cached_input_tokens_used": 173568,
+      "output_tokens_used": 2538,
+      "iterations": 1,
+      "cost_usd": 0.1629,
+      "tested_library_loc": 59,
+      "metadata_entries": 6,
+      "test_only_metadata_entries": 11,
+      "previous_library_metadata_entries": 11,
+      "previous_library_test_only_metadata_entries": 8,
+      "code_coverage_percent": 0.77,
+      "previous_library_coverage_percent": 0.79
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/src/test/scala/org_scalactic/scalactic_3/ObjectMetaAnonymous1Anonymous2Test.scala",
+      "metadata_file": "metadata/org.scalactic/scalactic_3/3.3.0-alpha.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.scalactic/scalactic_3/3.3.0-alpha.1/stats.json
+++ b/stats/org.scalactic/scalactic_3/3.3.0-alpha.1/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "3.3.0-alpha.1",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 7,
+          "totalCalls" : 7
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 8,
+      "totalCalls" : 8
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 543,
+        "missed" : 114602,
+        "ratio" : 0.004716,
+        "total" : 115145
+      },
+      "line" : {
+        "covered" : 59,
+        "missed" : 7653,
+        "ratio" : 0.00765,
+        "total" : 7712
+      },
+      "method" : {
+        "covered" : 44,
+        "missed" : 16233,
+        "ratio" : 0.002703,
+        "total" : 16277
+      }
+    }
+  } ]
+}

--- a/tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/.gitignore
+++ b/tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/build.gradle
+++ b/tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.scalactic:scalactic_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/gradle.properties
+++ b/tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.scalactic:scalactic_3:3.3.0-alpha.1
+library.version = 3.3.0-alpha.1
+metadata.dir = org.scalactic/scalactic_3/3.3.0-alpha.1/

--- a/tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/settings.gradle
+++ b/tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.scalactic.scalactic_3_tests'

--- a/tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,50 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.scalactic.source.ObjectMeta$$anon$1"
+      },
+      "type" : "org_scalactic.scalactic_3.ObjectMetaPrivateFixture",
+      "methods" : [
+        {
+          "name" : "secret",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.scalactic.source.ObjectMeta$$anon$1"
+      },
+      "type" : "org_scalactic.scalactic_3.ObjectMetaSpecializedAccessorFixture",
+      "methods" : [
+        {
+          "name" : "score$mcI$sp",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.scalactic.source.ObjectMeta$$anon$1$$anon$2"
+      },
+      "type" : "org_scalactic.scalactic_3.ObjectMetaSpecializedAccessorFixture"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.scalactic.source.ObjectMeta$$anon$1"
+      },
+      "type" : "org_scalactic.scalactic_3.ObjectMetaVisibleFixture",
+      "methods" : [
+        {
+          "name" : "count",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "name",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -45,6 +45,24 @@
           "parameterTypes" : [ ]
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.scalactic.source.ObjectMeta$$anon$1"
+      },
+      "type" : "org_scalactic.scalactic_3.ObjectMetaPrivateFixture"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.scalactic.source.ObjectMeta$$anon$1"
+      },
+      "type" : "org_scalactic.scalactic_3.ObjectMetaSpecializedAccessorFixture"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.scalactic.source.ObjectMeta$$anon$1"
+      },
+      "type" : "org_scalactic.scalactic_3.ObjectMetaVisibleFixture"
     }
   ]
 }

--- a/tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/src/test/scala/org_scalactic/scalactic_3/ObjectMetaAnonymous1Anonymous2Test.scala
+++ b/tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/src/test/scala/org_scalactic/scalactic_3/ObjectMetaAnonymous1Anonymous2Test.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_scalactic.scalactic_3
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.scalactic.source.ObjectMeta
+
+import scala.annotation.targetName
+
+class ObjectMetaAnonymous1Anonymous2Test {
+  @Test
+  def valueFallsBackToSpecializedAccessorName(): Unit = {
+    val fixture: ObjectMetaSpecializedAccessorFixture = new ObjectMetaSpecializedAccessorFixture(42)
+    val meta: ObjectMeta = ObjectMeta(fixture)
+
+    assertThat(meta.value("score")).isEqualTo(42)
+  }
+}
+
+final class ObjectMetaSpecializedAccessorFixture(scoreInput: Int) {
+  private[this] val storedScore: Int = scoreInput
+
+  @targetName("score$mcI$sp")
+  private def specializedScore: Int = storedScore
+}

--- a/tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/src/test/scala/org_scalactic/scalactic_3/ObjectMetaAnonymous1Test.scala
+++ b/tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/src/test/scala/org_scalactic/scalactic_3/ObjectMetaAnonymous1Test.scala
@@ -10,8 +10,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.scalactic.source.ObjectMeta
 
-import scala.annotation.targetName
-
 class ObjectMetaAnonymous1Test {
   @Test
   def fieldNamesAndPublicValuesUseJavaReflection(): Unit = {
@@ -39,9 +37,4 @@ class ObjectMetaAnonymous1Test {
 
 final case class ObjectMetaVisibleFixture(name: String, count: Int)
 
-final class ObjectMetaPrivateFixture(secretInput: String) {
-  private[this] val secret: String = secretInput
-
-  @targetName("secret")
-  private def hiddenSecret: String = secret
-}
+final class ObjectMetaPrivateFixture(private val secret: String)

--- a/tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/src/test/scala/org_scalactic/scalactic_3/ObjectMetaAnonymous1Test.scala
+++ b/tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/src/test/scala/org_scalactic/scalactic_3/ObjectMetaAnonymous1Test.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_scalactic.scalactic_3
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.scalactic.source.ObjectMeta
+
+import scala.annotation.targetName
+
+class ObjectMetaAnonymous1Test {
+  @Test
+  def fieldNamesAndPublicValuesUseJavaReflection(): Unit = {
+    val fixture: ObjectMetaVisibleFixture = ObjectMetaVisibleFixture("Ada", 37)
+    val meta: ObjectMeta = ObjectMeta(fixture)
+
+    assertThat(meta.fieldNames.contains("name")).isTrue()
+    assertThat(meta.fieldNames.contains("count")).isTrue()
+    assertThat(meta.hasField("name")).isTrue()
+    assertThat(meta.value("name")).isEqualTo("Ada")
+    assertThat(meta.value("count")).isEqualTo(37)
+    assertThat(meta.typeName("name")).isEqualTo(classOf[String].getName)
+    assertThat(meta.shortTypeName("count")).isEqualTo("Integer")
+  }
+
+  @Test
+  def privateValueFallsBackToAccessibleInvocation(): Unit = {
+    val fixture: ObjectMetaPrivateFixture = new ObjectMetaPrivateFixture("classified")
+    val meta: ObjectMeta = ObjectMeta(fixture)
+
+    assertThat(meta.fieldNames.contains("secret")).isTrue()
+    assertThat(meta.value("secret")).isEqualTo("classified")
+  }
+}
+
+final case class ObjectMetaVisibleFixture(name: String, count: Int)
+
+final class ObjectMetaPrivateFixture(secretInput: String) {
+  private[this] val secret: String = secretInput
+
+  @targetName("secret")
+  private def hiddenSecret: String = secret
+}

--- a/tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/src/test/scala/org_scalactic/scalactic_3/ResourcesTest.scala
+++ b/tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/src/test/scala/org_scalactic/scalactic_3/ResourcesTest.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_scalactic.scalactic_3
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.scalactic.Requirements
+
+class ResourcesTest {
+  @Test
+  def failedRequirementLoadsLocalizedFailureMessage(): Unit = {
+    val thrown: IllegalArgumentException = assertThrows(
+      classOf[IllegalArgumentException],
+      () => Requirements.require(false)
+    )
+
+    assertThat(thrown.getMessage).isNotBlank()
+    assertThat(thrown.getMessage).contains("false")
+  }
+}

--- a/tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/user-code-filter.json
+++ b/tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.scalactic.**"
+    },
+    {
+      "includeClasses" : "org_scalactic.scalactic_3.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7126

This PR provides test fixes and new metadata for org.scalactic:scalactic_3:3.3.0-alpha.1, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 20761
- Cached input tokens: 173568
- Output tokens: 2538
- Metadata entries: 6
- Test-only metadata entries: 11
- Iterations: 1
- Library coverage percentage: 0.77
- Previous library version metadata entries: 11
- Previous library version test-only metadata entries: 8
- Previous library version coverage percentage: 0.79

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3f69aa1510d519e1825b9bfd59a81bb41ea7ef04`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.scalactic:scalactic_3:3.2.19: 7/7 covered calls (100.00%)
- org.scalactic:scalactic_3:3.3.0-alpha.1: 8/8 covered calls (100.00%)

**Reflection:**
- org.scalactic:scalactic_3:3.2.19: 6/6 covered calls (100.00%)
- org.scalactic:scalactic_3:3.3.0-alpha.1: 7/7 covered calls (100.00%)

**Resources:**
- org.scalactic:scalactic_3:3.2.19: 1/1 covered calls (100.00%)
- org.scalactic:scalactic_3:3.3.0-alpha.1: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.scalactic:scalactic_3:3.2.19: 481/116148 (0.41%)
- org.scalactic:scalactic_3:3.3.0-alpha.1: 543/115145 (0.47%)

**Line:**
- org.scalactic:scalactic_3:3.2.19: 61/7719 (0.79%)
- org.scalactic:scalactic_3:3.3.0-alpha.1: 59/7712 (0.77%)

**Method:**
- org.scalactic:scalactic_3:3.2.19: 39/16267 (0.24%)
- org.scalactic:scalactic_3:3.3.0-alpha.1: 44/16277 (0.27%)

**Comparison between existing test version and AI-Generated update**

```diff

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
