### PR TITLE
Limit workflow tokens and remove write-all permissions

### DIFF
--- a/.github/actions/setup-native-build-tools/action.yml
+++ b/.github/actions/setup-native-build-tools/action.yml
@@ -118,6 +118,7 @@ runs:
         path: ${{ inputs.nbt-path }}
         token: ${{ inputs.github-token }}
         fetch-depth: 1
+        persist-credentials: false
 
     - id: read-version
       if: ${{ inputs.enabled-by-default == 'true' || steps.compute-ref.outputs.same-branch == 'true' }}

--- a/.github/workflows/test-all-metadata.yml
+++ b/.github/workflows/test-all-metadata.yml
@@ -6,9 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  actions: read
   contents: read
-  issues: write
 
 concurrency:
   group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, pr = ${{ github.event.pull_request.id }}"
@@ -43,9 +41,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 480
     needs: get-all-metadata
+    permissions:
+      contents: read
     env:
-      CURRENT_JOB_NAME: "🧪 ${{ matrix.coordinates }} [${{ matrix.nativeImageMode }}] (GraalVM for JDK ${{ matrix.version }} @ ${{ matrix.os }})"
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GVM_TCK_NATIVE_IMAGE_MODE: ${{ matrix.nativeImageMode }}
       LOG_LINES: "300"
     strategy:
@@ -117,16 +115,7 @@ jobs:
               }' >> test-all-results/failures.ndjson
           }
 
-          JOB_ID=$(
-            gh run view "${{ github.run_id }}" --repo "${{ github.repository }}" --json jobs \
-              --jq ".jobs[] | select(.name == \"$CURRENT_JOB_NAME\") | .databaseId" \
-              | head -n1
-          )
-          if [[ -z "$JOB_ID" || "$JOB_ID" == "null" ]]; then
-            RUNNER_LOG_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          else
-            RUNNER_LOG_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/$JOB_ID"
-          fi
+          RUNNER_LOG_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
           MATCHING_MATRIX_OUTPUT_FILE="$(mktemp)"
           GITHUB_OUTPUT="$MATCHING_MATRIX_OUTPUT_FILE" ./gradlew generateMatrixMatchingCoordinates -Pcoordinates="${{ matrix.coordinates }}"
@@ -231,10 +220,11 @@ jobs:
   process-results:
     name: "🧪 Process results"
     runs-on: "ubuntu-22.04"
-    permissions: write-all
+    permissions:
+      actions: read
+      contents: read
+      issues: write
     env:
-      GH_TOKEN: ${{ secrets.GRAALBOT_PR_TOKEN }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       ISSUE_TITLE_PREFIX: "[Automation] "
       ISSUE_TITLE_MIDDLE: " fails for "
       ISSUE_BODY_CHAR_LIMIT: "60000"
@@ -302,6 +292,8 @@ jobs:
 
       - name: "❗ Create aggregated issues for failed metadata tests"
         if: steps.aggregate.outputs.has-failures == 'true' && github.repository == 'oracle/graalvm-reachability-metadata'
+        env:
+          GH_TOKEN: ${{ secrets.GRAALBOT_PR_TOKEN }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/test-all-metadata.yml
+++ b/.github/workflows/test-all-metadata.yml
@@ -52,6 +52,8 @@ jobs:
     steps:
       - name: "☁️ Checkout repository"
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: "🛠️ Setup latest native-build-tools snapshot"
         uses: ./.github/actions/setup-native-build-tools

--- a/.github/workflows/verify-new-library-version-compatibility.yml
+++ b/.github/workflows/verify-new-library-version-compatibility.yml
@@ -125,6 +125,8 @@ jobs:
     steps:
       - name: "☁️ Checkout repository"
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: "🛠️ Setup latest native-build-tools snapshot"
         uses: ./.github/actions/setup-native-build-tools

--- a/.github/workflows/verify-new-library-version-compatibility.yml
+++ b/.github/workflows/verify-new-library-version-compatibility.yml
@@ -6,8 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  actions: write
+  contents: read
 
 concurrency:
   group: "workflow=${{ github.workflow }},ref=${{ github.event.ref }},pr=${{ github.event.pull_request.id }}"
@@ -20,9 +19,9 @@ jobs:
     if: github.repository == 'oracle/graalvm-reachability-metadata'
     runs-on: ubuntu-22.04
     timeout-minutes: 20
-    permissions: write-all
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+      issues: read
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       none-found: ${{ steps.set-matrix.outputs.none-found }}
@@ -45,6 +44,8 @@ jobs:
 
       - name: "🕸️ Populate matrix"
         id: set-matrix
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -o pipefail
           MATRIX_OUTPUT_FILE="$(mktemp)"
@@ -113,11 +114,10 @@ jobs:
     if: needs.get-all-libraries.outputs.none-found != 'true'
     runs-on: ${{ matrix.os }}
     needs: get-all-libraries
-    permissions: write-all
+    permissions:
+      contents: read
     env:
-      CURRENT_JOB_NAME: "🧪 ${{ matrix.name }} [${{ matrix.nativeImageMode }}] (GraalVM for JDK ${{ matrix.version }} @ ${{ matrix.os }})"
       GVM_TCK_NATIVE_IMAGE_MODE: ${{ matrix.nativeImageMode }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       LOG_LINES: "300"
     strategy:
       fail-fast: false
@@ -171,16 +171,7 @@ jobs:
             FAILED_COMMAND="$(printf '%s\n' "$FAILED_LINE" | awk -F'[][]' '{print $6}')"
           fi
 
-          JOB_ID=$(
-            gh run view "${{ github.run_id }}" --repo "${{ github.repository }}" --json jobs \
-              --jq ".jobs[] | select(.name == \"$CURRENT_JOB_NAME\") | .databaseId" \
-              | head -n1
-          )
-          if [[ -z "$JOB_ID" || "$JOB_ID" == "null" ]]; then
-            RUNNER_LOG_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          else
-            RUNNER_LOG_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/$JOB_ID"
-          fi
+          RUNNER_LOG_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
           SUCCESSFUL_VERSIONS_JSON="$(jq -R -s 'split("\n") | map(select(length > 0))' successful_versions.txt)"
 
@@ -235,10 +226,12 @@ jobs:
   process-results:
     name: "🧪 Process results"
     runs-on: ubuntu-22.04
-    permissions: write-all
+    permissions:
+      actions: read
+      contents: write
+      issues: write
+      pull-requests: write
     env:
-      GH_TOKEN: ${{ secrets.GRAALBOT_PR_TOKEN }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       ISSUE_TITLE_PREFIX: "[Automation] "
       ISSUE_TITLE_MIDDLE: " fails for "
       ISSUE_BODY_CHAR_LIMIT: "60000"
@@ -435,6 +428,8 @@ jobs:
 
       - name: "❗ Create aggregated issues for unsupported library versions"
         if: steps.aggregate.outputs.has-failures == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GRAALBOT_PR_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -616,6 +611,7 @@ jobs:
       - name: "🧹 Close old pre-release issues for tested versions"
         if: steps.aggregate.outputs.has-successful-updates == 'true' || steps.aggregate.outputs.has-failures == 'true'
         env:
+          GH_TOKEN: ${{ secrets.GRAALBOT_PR_TOKEN }}
           REPO: ${{ github.repository }}
           PRE_RELEASE_SUFFIX: "(alpha[0-9]*|beta[0-9]*|rc[0-9]*|cr[0-9]*|m[0-9]+|ea[0-9]*|b[0-9]+|[0-9]+|preview)"
         run: |
@@ -676,6 +672,8 @@ jobs:
 
       - name: "✏️ PR for supported versions"
         if: steps.aggregate.outputs.has-successful-updates == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GRAALBOT_PR_TOKEN }}
         run: |
           git fetch origin "${{ needs.get-all-libraries.outputs.branch }}"
           git checkout "${{ needs.get-all-libraries.outputs.branch }}"


### PR DESCRIPTION
This PR removes broad write-all permissions from scheduled metadata workflows and narrows each job to the minimum GitHub scopes it needs. It also stops exposing GITHUB_TOKEN to dependency test jobs that execute third-party artifacts by replacing job-specific gh run view lookups  with the workflow run URL.

