### PR TITLE
[GenAI] Test fix for org.jboss.arquillian.container:arquillian-container-test-impl-base:1.3.0.Final using gpt-5.5

### DIFF
--- a/metadata/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/reachability-metadata.json
+++ b/metadata/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/reachability-metadata.json
@@ -1,0 +1,74 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.arquillian.container.test.impl.SecurityActions"
+      },
+      "type" : "org.jboss.arquillian.container.test.impl.SecurityActions",
+      "methods" : [
+        {
+          "name" : "loadClass",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "newInstance",
+          "parameterTypes" : [
+            "java.lang.String",
+            "java.lang.Class[]",
+            "java.lang.Object[]",
+            "java.lang.Class",
+            "java.lang.ClassLoader"
+          ]
+        },
+        {
+          "name" : "setFieldValue",
+          "parameterTypes" : [
+            "java.lang.Class",
+            "java.lang.Object",
+            "java.lang.String",
+            "java.lang.Object"
+          ]
+        },
+        {
+          "name" : "getFieldsWithAnnotation",
+          "parameterTypes" : [
+            "java.lang.Class",
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name" : "getMethodsWithAnnotation",
+          "parameterTypes" : [
+            "java.lang.Class",
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.arquillian.container.test.impl.SecurityActions"
+      },
+      "type" : "org.jboss.arquillian.container.test.impl.RemoteExtensionLoader",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.arquillian.container.test.impl.client.deployment.tool.ToolingDeploymentFormatter"
+      },
+      "type" : "org.jboss.shrinkwrap.api.asset.FileAsset",
+      "fields" : [
+        {
+          "name" : "file"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.jboss.arquillian.container/arquillian-container-test-impl-base/index.json
+++ b/metadata/org.jboss.arquillian.container/arquillian-container-test-impl-base/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.3.0.Final",
+    "tested-versions" : [
+      "1.3.0.Final"
+    ],
+    "allowed-packages" : [
+      "org.jboss.arquillian.container.test.impl"
+    ]
+  },
+  {
     "metadata-version" : "1.1.10.Final",
     "source-code-url" : "https://repo1.maven.org/maven2/org/jboss/arquillian/container/arquillian-container-test-impl-base/$version$/arquillian-container-test-impl-base-$version$-sources.jar",
     "repository-url" : "https://github.com/arquillian/arquillian-core",

--- a/metadata/org.jboss.arquillian.container/arquillian-container-test-impl-base/index.json
+++ b/metadata/org.jboss.arquillian.container/arquillian-container-test-impl-base/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.3.0.Final",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/jboss/arquillian/container/arquillian-container-test-impl-base/$version$/arquillian-container-test-impl-base-$version$-sources.jar",
+    "repository-url" : "https://github.com/arquillian/arquillian-core",
+    "test-code-url" : "https://repo1.maven.org/maven2/org/jboss/arquillian/container/arquillian-container-test-impl-base/$version$/arquillian-container-test-impl-base-$version$-tests.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/jboss/arquillian/container/arquillian-container-test-impl-base/$version$/arquillian-container-test-impl-base-$version$-javadoc.jar",
+    "description" : "Arquillian Container Test Implementation Base provides the base implementation for Arquillian's container test extension, integrating deployment generation, run-mode selection, protocol execution, and resource enrichment into the Arquillian test lifecycle. It supplies client and container-side components for starting containers, deploying archives, executing tests locally or remotely, and exposing container resources such as URLs, URIs, InitialContext, Deployer, and ContainerController.",
     "tested-versions" : [
       "1.3.0.Final"
     ],

--- a/stats/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/execution-metrics.json
+++ b/stats/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_java_run_fail:2026-05-18": {
+    "timestamp": "2026-05-18T21:09:11.625058Z",
+    "library": "org.jboss.arquillian.container:arquillian-container-test-impl-base:1.3.0.Final",
+    "starting_commit": "6deb5c9c538c74ac6daeb4caee06dd9e5e68db67",
+    "ending_commit": "a4ec6330e77de51eb582eaa799447fc0ac1a180d",
+    "previous_library": "org.jboss.arquillian.container:arquillian-container-test-impl-base:1.1.10.Final",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.3.0.Final",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 19,
+            "totalCalls": 19
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 21,
+        "totalCalls": 21
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1341,
+          "missed": 4967,
+          "ratio": 0.212587,
+          "total": 6308
+        },
+        "line": {
+          "covered": 303,
+          "missed": 1079,
+          "ratio": 0.219247,
+          "total": 1382
+        },
+        "method": {
+          "covered": 64,
+          "missed": 237,
+          "ratio": 0.212625,
+          "total": 301
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.1.10.Final",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 16,
+            "totalCalls": 16
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 17,
+        "totalCalls": 17
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1014,
+          "missed": 4706,
+          "ratio": 0.177273,
+          "total": 5720
+        },
+        "line": {
+          "covered": 221,
+          "missed": 1012,
+          "ratio": 0.179238,
+          "total": 1233
+        },
+        "method": {
+          "covered": 50,
+          "missed": 232,
+          "ratio": 0.177305,
+          "total": 282
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 139613,
+      "cached_input_tokens_used": 1170944,
+      "output_tokens_used": 16422,
+      "iterations": 3,
+      "cost_usd": 1.0782,
+      "tested_library_loc": 303,
+      "metadata_entries": 10,
+      "test_only_metadata_entries": 14,
+      "previous_library_metadata_entries": 10,
+      "previous_library_test_only_metadata_entries": 11,
+      "code_coverage_percent": 21.92,
+      "previous_library_coverage_percent": 17.92
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/SecurityActionsAnonymous3Test.java",
+      "metadata_file": "metadata/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/stats.json
+++ b/stats/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "1.3.0.Final",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 19,
+          "totalCalls" : 19
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 21,
+      "totalCalls" : 21
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1341,
+        "missed" : 4967,
+        "ratio" : 0.212587,
+        "total" : 6308
+      },
+      "line" : {
+        "covered" : 303,
+        "missed" : 1079,
+        "ratio" : 0.219247,
+        "total" : 1382
+      },
+      "method" : {
+        "covered" : 64,
+        "missed" : 237,
+        "ratio" : 0.212625,
+        "total" : 301
+      }
+    }
+  } ]
+}

--- a/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/.gitignore
+++ b/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/build.gradle
+++ b/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.jboss.arquillian.container:arquillian-container-test-impl-base:$libraryVersion"
+    testImplementation 'org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.2'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/build.gradle
+++ b/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.jboss.arquillian.container:arquillian-container-test-impl-base:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/gradle.properties
+++ b/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.jboss.arquillian.container:arquillian-container-test-impl-base:1.3.0.Final
+library.version = 1.3.0.Final
+metadata.dir = org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/

--- a/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/settings.gradle
+++ b/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.jboss.arquillian.container.arquillian-container-test-impl-base_tests'

--- a/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/AnnotationDeploymentScenarioGeneratorTest.java
+++ b/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/AnnotationDeploymentScenarioGeneratorTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_arquillian_container.arquillian_container_test_impl_base;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.jboss.arquillian.container.spi.client.deployment.DeploymentDescription;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.container.test.impl.client.deployment.AnnotationDeploymentScenarioGenerator;
+import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.shrinkwrap.descriptor.api.Descriptor;
+import org.jboss.shrinkwrap.descriptor.api.DescriptorExportException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AnnotationDeploymentScenarioGeneratorTest {
+    @Test
+    void generateInvokesStaticDescriptorDeploymentMethod() {
+        DescriptorDeploymentFixture.invocationCount = 0;
+
+        List<DeploymentDescription> deployments = new AnnotationDeploymentScenarioGenerator()
+                .generate(new TestClass(DescriptorDeploymentFixture.class));
+
+        assertThat(DescriptorDeploymentFixture.invocationCount).isEqualTo(1);
+        assertThat(deployments).hasSize(1);
+        DeploymentDescription deployment = deployments.get(0);
+        assertThat(deployment.getName()).isEqualTo("application-descriptor");
+        assertThat(deployment.getDescriptor()).isSameAs(DescriptorDeploymentFixture.DESCRIPTOR);
+        assertThat(deployment.isDescriptorDeployment()).isTrue();
+        assertThat(deployment.managed()).isFalse();
+        assertThat(deployment.getOrder()).isEqualTo(5);
+        assertThat(deployment.getTarget().getName()).isEqualTo("configured-container");
+        assertThat(deployment.getProtocol().getName()).isEqualTo("Servlet 3.0");
+    }
+
+    public static final class DescriptorDeploymentFixture {
+        private static final Descriptor DESCRIPTOR = new SimpleDescriptor("test-web.xml");
+        private static int invocationCount;
+
+        @Deployment(name = "application-descriptor", managed = false, order = 5)
+        @TargetsContainer("configured-container")
+        @OverProtocol("Servlet 3.0")
+        public static Descriptor descriptorDeployment() {
+            invocationCount++;
+            return DESCRIPTOR;
+        }
+    }
+
+    private static final class SimpleDescriptor implements Descriptor {
+        private final String name;
+
+        private SimpleDescriptor(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String getDescriptorName() {
+            return name;
+        }
+
+        @Override
+        public String exportAsString() {
+            return "<web-app/>";
+        }
+
+        @Override
+        public void exportTo(OutputStream outputStream) {
+            try {
+                outputStream.write(exportAsString().getBytes(StandardCharsets.UTF_8));
+            } catch (IOException e) {
+                throw new DescriptorExportException("Could not write descriptor", e);
+            }
+        }
+    }
+}

--- a/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/AnnotationDeploymentScenarioGeneratorTest.java
+++ b/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/AnnotationDeploymentScenarioGeneratorTest.java
@@ -6,9 +6,6 @@
  */
 package org_jboss_arquillian_container.arquillian_container_test_impl_base;
 
-import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.jboss.arquillian.container.spi.client.deployment.DeploymentDescription;
@@ -17,69 +14,42 @@ import org.jboss.arquillian.container.test.api.OverProtocol;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.container.test.impl.client.deployment.AnnotationDeploymentScenarioGenerator;
 import org.jboss.arquillian.test.spi.TestClass;
-import org.jboss.shrinkwrap.descriptor.api.Descriptor;
-import org.jboss.shrinkwrap.descriptor.api.DescriptorExportException;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AnnotationDeploymentScenarioGeneratorTest {
     @Test
-    void generateInvokesStaticDescriptorDeploymentMethod() {
-        DescriptorDeploymentFixture.invocationCount = 0;
+    void generateInvokesStaticArchiveDeploymentMethod() {
+        ArchiveDeploymentFixture.invocationCount = 0;
 
         List<DeploymentDescription> deployments = new AnnotationDeploymentScenarioGenerator()
-                .generate(new TestClass(DescriptorDeploymentFixture.class));
+                .generate(new TestClass(ArchiveDeploymentFixture.class));
 
-        assertThat(DescriptorDeploymentFixture.invocationCount).isEqualTo(1);
+        assertThat(ArchiveDeploymentFixture.invocationCount).isEqualTo(1);
         assertThat(deployments).hasSize(1);
         DeploymentDescription deployment = deployments.get(0);
-        assertThat(deployment.getName()).isEqualTo("application-descriptor");
-        assertThat(deployment.getDescriptor()).isSameAs(DescriptorDeploymentFixture.DESCRIPTOR);
-        assertThat(deployment.isDescriptorDeployment()).isTrue();
+        assertThat(deployment.getName()).isEqualTo("application-archive");
+        assertThat(deployment.getArchive()).isSameAs(ArchiveDeploymentFixture.ARCHIVE);
+        assertThat(deployment.isArchiveDeployment()).isTrue();
         assertThat(deployment.managed()).isFalse();
         assertThat(deployment.getOrder()).isEqualTo(5);
         assertThat(deployment.getTarget().getName()).isEqualTo("configured-container");
         assertThat(deployment.getProtocol().getName()).isEqualTo("Servlet 3.0");
     }
 
-    public static final class DescriptorDeploymentFixture {
-        private static final Descriptor DESCRIPTOR = new SimpleDescriptor("test-web.xml");
+    public static final class ArchiveDeploymentFixture {
+        private static final JavaArchive ARCHIVE = ShrinkWrap.create(JavaArchive.class, "application-archive.jar");
         private static int invocationCount;
 
-        @Deployment(name = "application-descriptor", managed = false, order = 5)
+        @Deployment(name = "application-archive", managed = false, order = 5)
         @TargetsContainer("configured-container")
         @OverProtocol("Servlet 3.0")
-        public static Descriptor descriptorDeployment() {
+        public static JavaArchive archiveDeployment() {
             invocationCount++;
-            return DESCRIPTOR;
-        }
-    }
-
-    private static final class SimpleDescriptor implements Descriptor {
-        private final String name;
-
-        private SimpleDescriptor(String name) {
-            this.name = name;
-        }
-
-        @Override
-        public String getDescriptorName() {
-            return name;
-        }
-
-        @Override
-        public String exportAsString() {
-            return "<web-app/>";
-        }
-
-        @Override
-        public void exportTo(OutputStream outputStream) {
-            try {
-                outputStream.write(exportAsString().getBytes(StandardCharsets.UTF_8));
-            } catch (IOException e) {
-                throw new DescriptorExportException("Could not write descriptor", e);
-            }
+            return ARCHIVE;
         }
     }
 }

--- a/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/AutomaticDeploymentScenarioGeneratorTest.java
+++ b/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/AutomaticDeploymentScenarioGeneratorTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_arquillian_container.arquillian_container_test_impl_base;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.arquillian.container.spi.client.deployment.DeploymentDescription;
+import org.jboss.arquillian.container.test.api.BeforeDeployment;
+import org.jboss.arquillian.container.test.api.DeploymentConfiguration;
+import org.jboss.arquillian.container.test.impl.client.deployment.AutomaticDeploymentScenarioGenerator;
+import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AutomaticDeploymentScenarioGeneratorTest {
+    private static final String DEPLOYMENT_NAME = "automatic-deployment";
+
+    @Test
+    void generateInvokesMatchingBeforeDeploymentMethod() {
+        BeforeDeploymentFixture.invocationCount = 0;
+        JavaArchive originalArchive = ShrinkWrap.create(JavaArchive.class, "original.jar");
+        JavaArchive preparedArchive = ShrinkWrap.create(JavaArchive.class, "prepared.jar");
+        BeforeDeploymentFixture.preparedArchive = preparedArchive;
+
+        List<DeploymentDescription> deployments = new FixedDeploymentGenerator(originalArchive)
+                .generate(new TestClass(BeforeDeploymentFixture.class));
+
+        assertThat(BeforeDeploymentFixture.invocationCount).isEqualTo(1);
+        assertThat(BeforeDeploymentFixture.receivedArchive).isSameAs(originalArchive);
+        assertThat(deployments).hasSize(1);
+        assertThat(deployments.get(0).getArchive()).isSameAs(preparedArchive);
+    }
+
+    private static final class FixedDeploymentGenerator extends AutomaticDeploymentScenarioGenerator {
+        private final Archive<?> archive;
+
+        private FixedDeploymentGenerator(Archive<?> archive) {
+            this.archive = archive;
+        }
+
+        @Override
+        protected List<DeploymentConfiguration> generateDeploymentContent(TestClass testClass) {
+            DeploymentConfiguration.DeploymentContentBuilder deploymentContentBuilder =
+                    new DeploymentConfiguration.DeploymentContentBuilder(archive)
+                            .withDeployment()
+                            .withName(DEPLOYMENT_NAME)
+                            .build();
+            return Collections.singletonList(deploymentContentBuilder.get());
+        }
+    }
+
+    public static final class BeforeDeploymentFixture {
+        private static Archive<?> preparedArchive;
+        private static Archive<?> receivedArchive;
+        private static int invocationCount;
+
+        @BeforeDeployment(name = DEPLOYMENT_NAME)
+        public static Archive<?> prepareDeployment(Archive<?> archive) {
+            invocationCount++;
+            receivedArchive = archive;
+            return preparedArchive;
+        }
+    }
+}

--- a/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/MapObjectTest.java
+++ b/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/MapObjectTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_arquillian_container.arquillian_container_test_impl_base;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.jboss.arquillian.container.test.impl.MapObject;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MapObjectTest {
+    @Test
+    void populateDiscoversSettersAndInvokesMatchingProperties() throws Exception {
+        ContainerConfiguration configuration = new ContainerConfiguration();
+        Map<String, String> values = new LinkedHashMap<>();
+        values.put("name", "  managed   container\n");
+        values.put("port", "8181");
+        values.put("requestTimeout", "120000");
+        values.put("loadFactor", "0.75");
+        values.put("enabled", "true");
+
+        MapObject.populate(configuration, values);
+
+        assertThat(configuration.getName()).isEqualTo("managed container");
+        assertThat(configuration.getPort()).isEqualTo(8181);
+        assertThat(configuration.getRequestTimeout()).isEqualTo(120000L);
+        assertThat(configuration.getLoadFactor()).isEqualTo(0.75D);
+        assertThat(configuration.isEnabled()).isTrue();
+    }
+
+    public static final class ContainerConfiguration {
+        private String name;
+        private int port;
+        private long requestTimeout;
+        private double loadFactor;
+        private boolean enabled;
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setPort(int port) {
+            this.port = port;
+        }
+
+        public int getPort() {
+            return port;
+        }
+
+        public void setRequestTimeout(long requestTimeout) {
+            this.requestTimeout = requestTimeout;
+        }
+
+        public long getRequestTimeout() {
+            return requestTimeout;
+        }
+
+        public void setLoadFactor(double loadFactor) {
+            this.loadFactor = loadFactor;
+        }
+
+        public double getLoadFactor() {
+            return loadFactor;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+    }
+}

--- a/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/ProtocolDefinitionTest.java
+++ b/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/ProtocolDefinitionTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_arquillian_container.arquillian_container_test_impl_base;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.jboss.arquillian.container.spi.client.protocol.ProtocolDescription;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.ProtocolMetaData;
+import org.jboss.arquillian.container.test.impl.domain.ProtocolDefinition;
+import org.jboss.arquillian.container.test.spi.ContainerMethodExecutor;
+import org.jboss.arquillian.container.test.spi.client.deployment.DeploymentPackager;
+import org.jboss.arquillian.container.test.spi.client.protocol.Protocol;
+import org.jboss.arquillian.container.test.spi.client.protocol.ProtocolConfiguration;
+import org.jboss.arquillian.container.test.spi.command.CommandCallback;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProtocolDefinitionTest {
+    @Test
+    void createProtocolConfigurationInstantiatesConfiguredProtocolConfigurationClass() throws Exception {
+        Map<String, String> values = new LinkedHashMap<>();
+        values.put("host", "127.0.0.1");
+        values.put("port", "8080");
+        ProtocolDefinition definition = new ProtocolDefinition(new ConfigurableProtocol(), values, true);
+
+        ProtocolConfiguration configuration = definition.createProtocolConfiguration();
+
+        assertThat(configuration).isInstanceOf(ConfigurableProtocolConfiguration.class);
+        ConfigurableProtocolConfiguration configurableConfiguration = (ConfigurableProtocolConfiguration) configuration;
+        assertThat(configurableConfiguration.getHost()).isEqualTo("127.0.0.1");
+        assertThat(configurableConfiguration.getPort()).isEqualTo(8080);
+        assertThat(definition.getName()).isEqualTo("configurable");
+        assertThat(definition.isDefaultProtocol()).isTrue();
+    }
+
+    public static final class ConfigurableProtocol implements Protocol<ConfigurableProtocolConfiguration> {
+        @Override
+        public Class<ConfigurableProtocolConfiguration> getProtocolConfigurationClass() {
+            return ConfigurableProtocolConfiguration.class;
+        }
+
+        @Override
+        public ProtocolDescription getDescription() {
+            return new ProtocolDescription("configurable");
+        }
+
+        @Override
+        public DeploymentPackager getPackager() {
+            return null;
+        }
+
+        @Override
+        public ContainerMethodExecutor getExecutor(ConfigurableProtocolConfiguration protocolConfiguration,
+                ProtocolMetaData metaData, CommandCallback callback) {
+            return null;
+        }
+    }
+
+    public static final class ConfigurableProtocolConfiguration implements ProtocolConfiguration {
+        private String host;
+        private int port;
+
+        public void setHost(String host) {
+            this.host = host;
+        }
+
+        public String getHost() {
+            return host;
+        }
+
+        public void setPort(int port) {
+            this.port = port;
+        }
+
+        public int getPort() {
+            return port;
+        }
+    }
+}

--- a/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/RemoteExtensionLoaderTest.java
+++ b/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/RemoteExtensionLoaderTest.java
@@ -13,9 +13,12 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.Map;
+import java.util.Set;
 
 import org.jboss.arquillian.container.test.impl.RemoteExtensionLoader;
 import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
@@ -50,6 +53,31 @@ public class RemoteExtensionLoaderTest {
         }
     }
 
+    @Test
+    void loadVetoedDiscoversExclusionsAndLoadsServiceImplementations() {
+        String firstProviderName = VetoedRemoteExtensionProviderOne.class.getName();
+        String secondProviderName = VetoedRemoteExtensionProviderTwo.class.getName();
+        String missingProviderName = "org.example.DoesNotExist";
+        VetoedResourceClassLoader vetoedClassLoader = new VetoedResourceClassLoader(
+                RemoteExtensionLoaderTest.class.getClassLoader(),
+                VetoedRemoteExtensionService.class.getName() + "="
+                        + firstProviderName + ", " + missingProviderName + ", " + secondProviderName + "\n");
+
+        Map<Class<?>, Set<Class<?>>> vetoed = new RemoteExtensionLoader().loadVetoed(vetoedClassLoader);
+
+        assertThat(vetoed)
+                .containsOnlyKeys(VetoedRemoteExtensionService.class);
+        assertThat(vetoed.get(VetoedRemoteExtensionService.class))
+                .containsExactly(VetoedRemoteExtensionProviderOne.class, VetoedRemoteExtensionProviderTwo.class);
+        assertThat(vetoedClassLoader.requestedResourceName).isEqualTo("META-INF/exclusions");
+        assertThat(vetoedClassLoader.requestedClassNames)
+                .containsExactly(
+                        VetoedRemoteExtensionService.class.getName(),
+                        firstProviderName,
+                        missingProviderName,
+                        secondProviderName);
+    }
+
     private static final class ServiceResourceClassLoader extends ClassLoader {
         private final String providerClassName;
         private String requestedResourceName;
@@ -82,6 +110,39 @@ public class RemoteExtensionLoaderTest {
         }
     }
 
+    private static final class VetoedResourceClassLoader extends ClassLoader {
+        private final String exclusionsContent;
+        private final Collection<String> requestedClassNames = new ArrayList<>();
+        private String requestedResourceName;
+
+        private VetoedResourceClassLoader(ClassLoader parent, String exclusionsContent) {
+            super(parent);
+            this.exclusionsContent = exclusionsContent;
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            requestedResourceName = name;
+            if (!"META-INF/exclusions".equals(name)) {
+                return Collections.emptyEnumeration();
+            }
+            URL serviceDescriptor = new URL(null, "memory:remote-extension-exclusions", new StringUrlStreamHandler(
+                    exclusionsContent));
+            return Collections.enumeration(Collections.singletonList(serviceDescriptor));
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (name.equals(VetoedRemoteExtensionService.class.getName())
+                    || name.equals(VetoedRemoteExtensionProviderOne.class.getName())
+                    || name.equals(VetoedRemoteExtensionProviderTwo.class.getName())
+                    || name.equals("org.example.DoesNotExist")) {
+                requestedClassNames.add(name);
+            }
+            return super.loadClass(name, resolve);
+        }
+    }
+
     private static final class StringUrlStreamHandler extends URLStreamHandler {
         private final String content;
 
@@ -109,4 +170,13 @@ class RemoteExtensionLoaderProvider implements RemoteLoadableExtension {
     @Override
     public void register(LoadableExtension.ExtensionBuilder builder) {
     }
+}
+
+interface VetoedRemoteExtensionService {
+}
+
+class VetoedRemoteExtensionProviderOne implements VetoedRemoteExtensionService {
+}
+
+class VetoedRemoteExtensionProviderTwo implements VetoedRemoteExtensionService {
 }

--- a/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/RemoteExtensionLoaderTest.java
+++ b/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/RemoteExtensionLoaderTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_arquillian_container.arquillian_container_test_impl_base;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+
+import org.jboss.arquillian.container.test.impl.RemoteExtensionLoader;
+import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RemoteExtensionLoaderTest {
+    private static final String REMOTE_EXTENSION_SERVICE_FILE =
+            "META-INF/services/org.jboss.arquillian.container.test.spi.RemoteLoadableExtension";
+
+    @Test
+    void loadDiscoversRemoteExtensionsFromThreadContextClassLoaderServices() {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        ServiceResourceClassLoader serviceClassLoader = new ServiceResourceClassLoader(
+                originalClassLoader,
+                RemoteExtensionLoaderProvider.class.getName());
+        try {
+            Thread.currentThread().setContextClassLoader(serviceClassLoader);
+
+            Collection<LoadableExtension> extensions = new RemoteExtensionLoader().load();
+
+            assertThat(extensions)
+                    .hasSize(1)
+                    .first()
+                    .isInstanceOf(RemoteExtensionLoaderProvider.class);
+            assertThat(serviceClassLoader.requestedResourceName).isEqualTo(REMOTE_EXTENSION_SERVICE_FILE);
+            assertThat(serviceClassLoader.requestedClassName).isEqualTo(RemoteExtensionLoaderProvider.class.getName());
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    private static final class ServiceResourceClassLoader extends ClassLoader {
+        private final String providerClassName;
+        private String requestedResourceName;
+        private String requestedClassName;
+
+        private ServiceResourceClassLoader(ClassLoader parent, String providerClassName) {
+            super(parent);
+            this.providerClassName = providerClassName;
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            requestedResourceName = name;
+            if (!REMOTE_EXTENSION_SERVICE_FILE.equals(name)) {
+                return Collections.emptyEnumeration();
+            }
+            URL serviceDescriptor = new URL(null, "memory:remote-extension-services", new StringUrlStreamHandler(
+                    "# comment lines are ignored\n"
+                            + providerClassName
+                            + " # inline comments are ignored\n"));
+            return Collections.enumeration(Collections.singletonList(serviceDescriptor));
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (providerClassName.equals(name)) {
+                requestedClassName = name;
+            }
+            return super.loadClass(name, resolve);
+        }
+    }
+
+    private static final class StringUrlStreamHandler extends URLStreamHandler {
+        private final String content;
+
+        private StringUrlStreamHandler(String content) {
+            this.content = content;
+        }
+
+        @Override
+        protected URLConnection openConnection(URL url) {
+            return new URLConnection(url) {
+                @Override
+                public void connect() {
+                }
+
+                @Override
+                public InputStream getInputStream() {
+                    return new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+                }
+            };
+        }
+    }
+}
+
+class RemoteExtensionLoaderProvider implements RemoteLoadableExtension {
+    @Override
+    public void register(LoadableExtension.ExtensionBuilder builder) {
+    }
+}

--- a/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/SecurityActionsAnonymous2Test.java
+++ b/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/SecurityActionsAnonymous2Test.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_arquillian_container.arquillian_container_test_impl_base;
+
+import java.lang.reflect.Method;
+
+import org.jboss.arquillian.container.test.impl.RemoteExtensionLoader;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SecurityActionsAnonymous2Test {
+    private static final String SECURITY_ACTIONS_CLASS_NAME =
+            "org.jboss.arquillian.container.test.impl.SecurityActions";
+
+    @Test
+    void setFieldValueUpdatesPrivateFieldOnTargetObject() throws Exception {
+        MutableHolder holder = new MutableHolder("initial");
+
+        invokeSetFieldValue(MutableHolder.class, holder, "value", "updated");
+
+        assertThat(holder.value()).isEqualTo("updated");
+    }
+
+    private static void invokeSetFieldValue(
+            Class<?> source,
+            Object target,
+            String fieldName,
+            Object value) throws Exception {
+        Method setFieldValueMethod = securityActionsClass().getDeclaredMethod(
+                "setFieldValue",
+                Class.class,
+                Object.class,
+                String.class,
+                Object.class);
+        setFieldValueMethod.setAccessible(true);
+        setFieldValueMethod.invoke(null, source, target, fieldName, value);
+    }
+
+    private static Class<?> securityActionsClass() throws ClassNotFoundException {
+        return RemoteExtensionLoader.class.getClassLoader().loadClass(SECURITY_ACTIONS_CLASS_NAME);
+    }
+
+    private static final class MutableHolder {
+        private String value;
+
+        private MutableHolder(String value) {
+            this.value = value;
+        }
+
+        private String value() {
+            return value;
+        }
+    }
+}

--- a/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/SecurityActionsAnonymous3Test.java
+++ b/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/SecurityActionsAnonymous3Test.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_arquillian_container.arquillian_container_test_impl_base;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import org.jboss.arquillian.container.test.impl.RemoteExtensionLoader;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SecurityActionsAnonymous3Test {
+    private static final String SECURITY_ACTIONS_CLASS_NAME =
+            "org.jboss.arquillian.container.test.impl.SecurityActions";
+
+    @Test
+    void getFieldsWithAnnotationFindsAnnotatedFieldsAcrossClassHierarchy() throws Exception {
+        List<Field> fields = invokeGetFieldsWithAnnotation(ChildHolder.class, Marker.class);
+
+        assertThat(fields)
+                .extracting(Field::getName)
+                .containsExactlyInAnyOrder("childValue", "parentValue");
+        assertThat(fields).allMatch(Field::isAccessible);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Field> invokeGetFieldsWithAnnotation(
+            Class<?> source,
+            Class<? extends Annotation> annotationClass) throws Exception {
+        Method getFieldsWithAnnotationMethod = securityActionsClass().getDeclaredMethod(
+                "getFieldsWithAnnotation",
+                Class.class,
+                Class.class);
+        getFieldsWithAnnotationMethod.setAccessible(true);
+        return (List<Field>) getFieldsWithAnnotationMethod.invoke(null, source, annotationClass);
+    }
+
+    private static Class<?> securityActionsClass() throws ClassNotFoundException {
+        return RemoteExtensionLoader.class.getClassLoader().loadClass(SECURITY_ACTIONS_CLASS_NAME);
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    private @interface Marker {
+    }
+
+    private static class ParentHolder {
+        @Marker
+        private String parentValue;
+    }
+
+    private static final class ChildHolder extends ParentHolder {
+        @Marker
+        private String childValue;
+
+        @SuppressWarnings("unused")
+        private String unmarkedValue;
+    }
+}

--- a/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/SecurityActionsAnonymous4Test.java
+++ b/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/SecurityActionsAnonymous4Test.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_arquillian_container.arquillian_container_test_impl_base;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import org.jboss.arquillian.container.test.impl.RemoteExtensionLoader;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SecurityActionsAnonymous4Test {
+    private static final String SECURITY_ACTIONS_CLASS_NAME =
+            "org.jboss.arquillian.container.test.impl.SecurityActions";
+
+    @Test
+    void getMethodsWithAnnotationFindsAnnotatedMethodsAcrossClassHierarchy() throws Exception {
+        List<Method> methods = invokeGetMethodsWithAnnotation(ChildOperations.class, Marker.class);
+
+        assertThat(methods)
+                .extracting(Method::getName)
+                .containsExactlyInAnyOrder("childOperation", "parentOperation");
+        assertThat(methods).allMatch(Method::isAccessible);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Method> invokeGetMethodsWithAnnotation(
+            Class<?> source,
+            Class<? extends Annotation> annotationClass) throws Exception {
+        Method getMethodsWithAnnotationMethod = securityActionsClass().getDeclaredMethod(
+                "getMethodsWithAnnotation",
+                Class.class,
+                Class.class);
+        getMethodsWithAnnotationMethod.setAccessible(true);
+        return (List<Method>) getMethodsWithAnnotationMethod.invoke(null, source, annotationClass);
+    }
+
+    private static Class<?> securityActionsClass() throws ClassNotFoundException {
+        return RemoteExtensionLoader.class.getClassLoader().loadClass(SECURITY_ACTIONS_CLASS_NAME);
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    private @interface Marker {
+    }
+
+    private static class ParentOperations {
+        @Marker
+        private void parentOperation() {
+        }
+    }
+
+    private static final class ChildOperations extends ParentOperations {
+        @Marker
+        private void childOperation() {
+        }
+
+        @SuppressWarnings("unused")
+        private void unmarkedOperation() {
+        }
+    }
+}

--- a/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/SecurityActionsTest.java
+++ b/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/SecurityActionsTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_arquillian_container.arquillian_container_test_impl_base;
+
+import java.lang.reflect.Method;
+
+import org.jboss.arquillian.container.test.impl.RemoteExtensionLoader;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SecurityActionsTest {
+    private static final String SECURITY_ACTIONS_CLASS_NAME =
+            "org.jboss.arquillian.container.test.impl.SecurityActions";
+
+    @Test
+    void loadClassUsesThreadContextClassLoaderWhenClassIsAvailable() throws Exception {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(SecurityActionsTest.class.getClassLoader());
+
+            Class<?> loadedClass = invokeLoadClass(RemoteExtensionLoader.class.getName());
+
+            assertThat(loadedClass).isSameAs(RemoteExtensionLoader.class);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    @Test
+    void loadClassFallsBackToSecurityActionsClassLoaderWhenTcclCannotLoadClass() throws Exception {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(new BlockingClassLoader(RemoteExtensionLoader.class.getName()));
+
+            Class<?> loadedClass = invokeLoadClass(RemoteExtensionLoader.class.getName());
+
+            assertThat(loadedClass).isSameAs(RemoteExtensionLoader.class);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    @Test
+    void newInstanceLoadsClassWithProvidedClassLoaderAndInvokesConstructor() throws Exception {
+        RemoteExtensionLoader instance = invokeNewInstance(
+                RemoteExtensionLoader.class.getName(),
+                new Class<?>[0],
+                new Object[0],
+                RemoteExtensionLoader.class,
+                RemoteExtensionLoader.class.getClassLoader());
+
+        assertThat(instance).isNotNull();
+    }
+
+    private static Class<?> invokeLoadClass(String className) throws Exception {
+        Method loadClassMethod = securityActionsClass().getDeclaredMethod("loadClass", String.class);
+        loadClassMethod.setAccessible(true);
+        return (Class<?>) loadClassMethod.invoke(null, className);
+    }
+
+    private static <T> T invokeNewInstance(
+            String className,
+            Class<?>[] argumentTypes,
+            Object[] arguments,
+            Class<T> expectedType,
+            ClassLoader classLoader) throws Exception {
+        Method newInstanceMethod = securityActionsClass().getDeclaredMethod(
+                "newInstance",
+                String.class,
+                Class[].class,
+                Object[].class,
+                Class.class,
+                ClassLoader.class);
+        newInstanceMethod.setAccessible(true);
+        Object instance = newInstanceMethod.invoke(
+                null,
+                className,
+                argumentTypes,
+                arguments,
+                expectedType,
+                classLoader);
+        return expectedType.cast(instance);
+    }
+
+    private static Class<?> securityActionsClass() throws ClassNotFoundException {
+        return RemoteExtensionLoader.class.getClassLoader().loadClass(SECURITY_ACTIONS_CLASS_NAME);
+    }
+
+    private static final class BlockingClassLoader extends ClassLoader {
+        private final String blockedClassName;
+
+        private BlockingClassLoader(String blockedClassName) {
+            super(null);
+            this.blockedClassName = blockedClassName;
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (blockedClassName.equals(name)) {
+                throw new ClassNotFoundException(name);
+            }
+            return super.loadClass(name, resolve);
+        }
+    }
+}
+

--- a/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/ToolingDeploymentFormatterTest.java
+++ b/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/ToolingDeploymentFormatterTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_arquillian_container.arquillian_container_test_impl_base;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Set;
+
+import org.jboss.arquillian.container.test.impl.client.deployment.tool.ToolingDeploymentFormatter;
+import org.jboss.shrinkwrap.api.ArchivePath;
+import org.jboss.shrinkwrap.api.Node;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.FileAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ToolingDeploymentFormatterTest {
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void formatNodeIncludesFileAssetSourceLocation() throws IOException {
+        Path configurationFile = temporaryDirectory.resolve("arquillian.xml");
+        Files.writeString(configurationFile, "<arquillian/>\n");
+        File sourceFile = configurationFile.toFile();
+        StringBuilder deployment = new StringBuilder();
+        Node fileNode = new SimpleNode(new FileAsset(sourceFile), "/META-INF/arquillian.xml");
+
+        new ToolingDeploymentFormatter(ToolingDeploymentFormatterTest.class).formatNode(fileNode, deployment);
+
+        assertThat(deployment.toString())
+                .contains("type=\"FileAsset\"")
+                .contains("path=\"/META-INF/arquillian.xml\"")
+                .contains("source=\"" + sourceFile.getAbsolutePath() + "\"");
+    }
+
+    private static final class SimpleNode implements Node {
+        private final Asset asset;
+        private final ArchivePath path;
+
+        private SimpleNode(Asset asset, String path) {
+            this.asset = asset;
+            this.path = new SimpleArchivePath(path);
+        }
+
+        @Override
+        public Asset getAsset() {
+            return asset;
+        }
+
+        @Override
+        public Set<Node> getChildren() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public ArchivePath getPath() {
+            return path;
+        }
+    }
+
+    private static final class SimpleArchivePath implements ArchivePath {
+        private final String path;
+
+        private SimpleArchivePath(String path) {
+            this.path = path;
+        }
+
+        @Override
+        public String get() {
+            return path;
+        }
+
+        @Override
+        public ArchivePath getParent() {
+            return null;
+        }
+
+        @Override
+        public int compareTo(ArchivePath other) {
+            return path.compareTo(other.get());
+        }
+    }
+}

--- a/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -84,30 +84,6 @@
         "typeReached" : "org.jboss.arquillian.container.test.impl.RemoteExtensionLoader"
       },
       "type" : "org_jboss_arquillian_container.arquillian_container_test_impl_base.VetoedRemoteExtensionService"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.jboss.arquillian.container.test.impl.RemoteExtensionLoader"
-      },
-      "type" : "java.util.HashMap",
-      "methods" : [
-        {
-          "name" : "clone",
-          "parameterTypes" : [ ]
-        }
-      ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.jboss.arquillian.container.test.impl.RemoteExtensionLoader"
-      },
-      "type" : "java.util.LinkedHashMap",
-      "methods" : [
-        {
-          "name" : "clone",
-          "parameterTypes" : [ ]
-        }
-      ]
     }
   ]
 }

--- a/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -66,6 +66,48 @@
           ]
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.arquillian.container.test.impl.RemoteExtensionLoader"
+      },
+      "type" : "org_jboss_arquillian_container.arquillian_container_test_impl_base.VetoedRemoteExtensionProviderOne"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.arquillian.container.test.impl.RemoteExtensionLoader"
+      },
+      "type" : "org_jboss_arquillian_container.arquillian_container_test_impl_base.VetoedRemoteExtensionProviderTwo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.arquillian.container.test.impl.RemoteExtensionLoader"
+      },
+      "type" : "org_jboss_arquillian_container.arquillian_container_test_impl_base.VetoedRemoteExtensionService"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.arquillian.container.test.impl.RemoteExtensionLoader"
+      },
+      "type" : "java.util.HashMap",
+      "methods" : [
+        {
+          "name" : "clone",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.arquillian.container.test.impl.RemoteExtensionLoader"
+      },
+      "type" : "java.util.LinkedHashMap",
+      "methods" : [
+        {
+          "name" : "clone",
+          "parameterTypes" : [ ]
+        }
+      ]
     }
   ]
 }

--- a/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,71 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.arquillian.container.test.impl.RemoteExtensionLoader"
+      },
+      "type" : "org_jboss_arquillian_container.arquillian_container_test_impl_base.RemoteExtensionLoaderProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.arquillian.container.test.impl.SecurityActions"
+      },
+      "type" : "org_jboss_arquillian_container.arquillian_container_test_impl_base.RemoteExtensionLoaderProvider",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.arquillian.container.test.impl.SecurityActions$2"
+      },
+      "type" : "org_jboss_arquillian_container.arquillian_container_test_impl_base.SecurityActionsAnonymous2Test$MutableHolder",
+      "fields" : [
+        {
+          "name" : "value"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.arquillian.container.test.impl.MapObject"
+      },
+      "type" : "org_jboss_arquillian_container.arquillian_container_test_impl_base.MapObjectTest$ContainerConfiguration",
+      "methods" : [
+        {
+          "name" : "setEnabled",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        },
+        {
+          "name" : "setLoadFactor",
+          "parameterTypes" : [
+            "double"
+          ]
+        },
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setPort",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "setRequestTimeout",
+          "parameterTypes" : [
+            "long"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/user-code-filter.json
+++ b/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.jboss.arquillian.container.test.impl.**"
+    },
+    {
+      "includeClasses" : "org_jboss_arquillian_container.arquillian_container_test_impl_base.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7038

This PR provides test fixes and new metadata for org.jboss.arquillian.container:arquillian-container-test-impl-base:1.3.0.Final, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 139613
- Cached input tokens: 1170944
- Output tokens: 16422
- Metadata entries: 10
- Test-only metadata entries: 14
- Iterations: 3
- Library coverage percentage: 21.92
- Previous library version metadata entries: 10
- Previous library version test-only metadata entries: 11
- Previous library version coverage percentage: 17.92

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3f69aa1510d519e1825b9bfd59a81bb41ea7ef04`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.jboss.arquillian.container:arquillian-container-test-impl-base:1.1.10.Final: 17/17 covered calls (100.00%)
- org.jboss.arquillian.container:arquillian-container-test-impl-base:1.3.0.Final: 21/21 covered calls (100.00%)

**Reflection:**
- org.jboss.arquillian.container:arquillian-container-test-impl-base:1.1.10.Final: 16/16 covered calls (100.00%)
- org.jboss.arquillian.container:arquillian-container-test-impl-base:1.3.0.Final: 19/19 covered calls (100.00%)

**Resources:**
- org.jboss.arquillian.container:arquillian-container-test-impl-base:1.1.10.Final: 1/1 covered calls (100.00%)
- org.jboss.arquillian.container:arquillian-container-test-impl-base:1.3.0.Final: 2/2 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.jboss.arquillian.container:arquillian-container-test-impl-base:1.1.10.Final: 1014/5720 (17.73%)
- org.jboss.arquillian.container:arquillian-container-test-impl-base:1.3.0.Final: 1341/6308 (21.26%)

**Line:**
- org.jboss.arquillian.container:arquillian-container-test-impl-base:1.1.10.Final: 221/1233 (17.92%)
- org.jboss.arquillian.container:arquillian-container-test-impl-base:1.3.0.Final: 303/1382 (21.92%)

**Method:**
- org.jboss.arquillian.container:arquillian-container-test-impl-base:1.1.10.Final: 50/282 (17.73%)
- org.jboss.arquillian.container:arquillian-container-test-impl-base:1.3.0.Final: 64/301 (21.26%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.1.10.Final/build.gradle 2/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/build.gradle
index ca16cd76a3..0ec069ccfe 100644
--- 1/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.1.10.Final/build.gradle
+++ 2/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.jboss.arquillian.container:arquillian-container-test-impl-base:$libraryVersion"
+    testImplementation 'org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.2'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
diff --git 1/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.1.10.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/AnnotationDeploymentScenarioGeneratorTest.java 2/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/AnnotationDeploymentScenarioGeneratorTest.java
index d3f32c5b67..16363485ee 100644
--- 1/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.1.10.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/AnnotationDeploymentScenarioGeneratorTest.java
+++ 2/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/AnnotationDeploymentScenarioGeneratorTest.java
@@ -6,9 +6,6 @@
  */
 package org_jboss_arquillian_container.arquillian_container_test_impl_base;
 
-import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.jboss.arquillian.container.spi.client.deployment.DeploymentDescription;
@@ -17,69 +14,42 @@ import org.jboss.arquillian.container.test.api.OverProtocol;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.container.test.impl.client.deployment.AnnotationDeploymentScenarioGenerator;
 import org.jboss.arquillian.test.spi.TestClass;
-import org.jboss.shrinkwrap.descriptor.api.Descriptor;
-import org.jboss.shrinkwrap.descriptor.api.DescriptorExportException;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AnnotationDeploymentScenarioGeneratorTest {
     @Test
-    void generateInvokesStaticDescriptorDeploymentMethod() {
-        DescriptorDeploymentFixture.invocationCount = 0;
+    void generateInvokesStaticArchiveDeploymentMethod() {
+        ArchiveDeploymentFixture.invocationCount = 0;
 
         List<DeploymentDescription> deployments = new AnnotationDeploymentScenarioGenerator()
-                .generate(new TestClass(DescriptorDeploymentFixture.class));
+                .generate(new TestClass(ArchiveDeploymentFixture.class));
 
-        assertThat(DescriptorDeploymentFixture.invocationCount).isEqualTo(1);
+        assertThat(ArchiveDeploymentFixture.invocationCount).isEqualTo(1);
         assertThat(deployments).hasSize(1);
         DeploymentDescription deployment = deployments.get(0);
-        assertThat(deployment.getName()).isEqualTo("application-descriptor");
-        assertThat(deployment.getDescriptor()).isSameAs(DescriptorDeploymentFixture.DESCRIPTOR);
-        assertThat(deployment.isDescriptorDeployment()).isTrue();
+        assertThat(deployment.getName()).isEqualTo("application-archive");
+        assertThat(deployment.getArchive()).isSameAs(ArchiveDeploymentFixture.ARCHIVE);
+        assertThat(deployment.isArchiveDeployment()).isTrue();
         assertThat(deployment.managed()).isFalse();
         assertThat(deployment.getOrder()).isEqualTo(5);
         assertThat(deployment.getTarget().getName()).isEqualTo("configured-container");
         assertThat(deployment.getProtocol().getName()).isEqualTo("Servlet 3.0");
     }
 
-    public static final class DescriptorDeploymentFixture {
-        private static final Descriptor DESCRIPTOR = new SimpleDescriptor("test-web.xml");
+    public static final class ArchiveDeploymentFixture {
+        private static final JavaArchive ARCHIVE = ShrinkWrap.create(JavaArchive.class, "application-archive.jar");
         private static int invocationCount;
 
-        @Deployment(name = "application-descriptor", managed = false, order = 5)
+        @Deployment(name = "application-archive", managed = false, order = 5)
         @TargetsContainer("configured-container")
         @OverProtocol("Servlet 3.0")
-        public static Descriptor descriptorDeployment() {
+        public static JavaArchive archiveDeployment() {
             invocationCount++;
-            return DESCRIPTOR;
-        }
-    }
-
-    private static final class SimpleDescriptor implements Descriptor {
-        private final String name;
-
-        private SimpleDescriptor(String name) {
-            this.name = name;
-        }
-
-        @Override
-        public String getDescriptorName() {
-            return name;
-        }
-
-        @Override
-        public String exportAsString() {
-            return "<web-app/>";
-        }
-
-        @Override
-        public void exportTo(OutputStream outputStream) {
-            try {
-                outputStream.write(exportAsString().getBytes(StandardCharsets.UTF_8));
-            } catch (IOException e) {
-                throw new DescriptorExportException("Could not write descriptor", e);
-            }
+            return ARCHIVE;
         }
     }
 }
diff --git 1/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/AutomaticDeploymentScenarioGeneratorTest.java 2/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/AutomaticDeploymentScenarioGeneratorTest.java
new file mode 100644
index 0000000000..dc10382922
--- /dev/null
+++ 2/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/AutomaticDeploymentScenarioGeneratorTest.java
@@ -0,0 +1,73 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_arquillian_container.arquillian_container_test_impl_base;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.arquillian.container.spi.client.deployment.DeploymentDescription;
+import org.jboss.arquillian.container.test.api.BeforeDeployment;
+import org.jboss.arquillian.container.test.api.DeploymentConfiguration;
+import org.jboss.arquillian.container.test.impl.client.deployment.AutomaticDeploymentScenarioGenerator;
+import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AutomaticDeploymentScenarioGeneratorTest {
+    private static final String DEPLOYMENT_NAME = "automatic-deployment";
+
+    @Test
+    void generateInvokesMatchingBeforeDeploymentMethod() {
+        BeforeDeploymentFixture.invocationCount = 0;
+        JavaArchive originalArchive = ShrinkWrap.create(JavaArchive.class, "original.jar");
+        JavaArchive preparedArchive = ShrinkWrap.create(JavaArchive.class, "prepared.jar");
+        BeforeDeploymentFixture.preparedArchive = preparedArchive;
+
+        List<DeploymentDescription> deployments = new FixedDeploymentGenerator(originalArchive)
+                .generate(new TestClass(BeforeDeploymentFixture.class));
+
+        assertThat(BeforeDeploymentFixture.invocationCount).isEqualTo(1);
+        assertThat(BeforeDeploymentFixture.receivedArchive).isSameAs(originalArchive);
+        assertThat(deployments).hasSize(1);
+        assertThat(deployments.get(0).getArchive()).isSameAs(preparedArchive);
+    }
+
+    private static final class FixedDeploymentGenerator extends AutomaticDeploymentScenarioGenerator {
+        private final Archive<?> archive;
+
+        private FixedDeploymentGenerator(Archive<?> archive) {
+            this.archive = archive;
+        }
+
+        @Override
+        protected List<DeploymentConfiguration> generateDeploymentContent(TestClass testClass) {
+            DeploymentConfiguration.DeploymentContentBuilder deploymentContentBuilder =
+                    new DeploymentConfiguration.DeploymentContentBuilder(archive)
+                            .withDeployment()
+                            .withName(DEPLOYMENT_NAME)
+                            .build();
+            return Collections.singletonList(deploymentContentBuilder.get());
+        }
+    }
+
+    public static final class BeforeDeploymentFixture {
+        private static Archive<?> preparedArchive;
+        private static Archive<?> receivedArchive;
+        private static int invocationCount;
+
+        @BeforeDeployment(name = DEPLOYMENT_NAME)
+        public static Archive<?> prepareDeployment(Archive<?> archive) {
+            invocationCount++;
+            receivedArchive = archive;
+            return preparedArchive;
+        }
+    }
+}
diff --git 1/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.1.10.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/RemoteExtensionLoaderTest.java 2/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/RemoteExtensionLoaderTest.java
index eb142bb865..ba4ff35579 100644
--- 1/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.1.10.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/RemoteExtensionLoaderTest.java
+++ 2/tests/src/org.jboss.arquillian.container/arquillian-container-test-impl-base/1.3.0.Final/src/test/java/org_jboss_arquillian_container/arquillian_container_test_impl_base/RemoteExtensionLoaderTest.java
@@ -13,9 +13,12 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.Map;
+import java.util.Set;
 
 import org.jboss.arquillian.container.test.impl.RemoteExtensionLoader;
 import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
@@ -50,6 +53,31 @@ public class RemoteExtensionLoaderTest {
         }
     }
 
+    @Test
+    void loadVetoedDiscoversExclusionsAndLoadsServiceImplementations() {
+        String firstProviderName = VetoedRemoteExtensionProviderOne.class.getName();
+        String secondProviderName = VetoedRemoteExtensionProviderTwo.class.getName();
+        String missingProviderName = "org.example.DoesNotExist";
+        VetoedResourceClassLoader vetoedClassLoader = new VetoedResourceClassLoader(
+                RemoteExtensionLoaderTest.class.getClassLoader(),
+                VetoedRemoteExtensionService.class.getName() + "="
+                        + firstProviderName + ", " + missingProviderName + ", " + secondProviderName + "\n");
+
+        Map<Class<?>, Set<Class<?>>> vetoed = new RemoteExtensionLoader().loadVetoed(vetoedClassLoader);
+
+        assertThat(vetoed)
+                .containsOnlyKeys(VetoedRemoteExtensionService.class);
+        assertThat(vetoed.get(VetoedRemoteExtensionService.class))
+                .containsExactly(VetoedRemoteExtensionProviderOne.class, VetoedRemoteExtensionProviderTwo.class);
+        assertThat(vetoedClassLoader.requestedResourceName).isEqualTo("META-INF/exclusions");
+        assertThat(vetoedClassLoader.requestedClassNames)
+                .containsExactly(
+                        VetoedRemoteExtensionService.class.getName(),
+                        firstProviderName,
+                        missingProviderName,
+                        secondProviderName);
+    }
+
     private static final class ServiceResourceClassLoader extends ClassLoader {
         private final String providerClassName;
         private String requestedResourceName;
@@ -82,6 +110,39 @@ public class RemoteExtensionLoaderTest {
         }
     }
 
+    private static final class VetoedResourceClassLoader extends ClassLoader {
+        private final String exclusionsContent;
+        private final Collection<String> requestedClassNames = new ArrayList<>();
+        private String requestedResourceName;
+
+        private VetoedResourceClassLoader(ClassLoader parent, String exclusionsContent) {
+            super(parent);
+            this.exclusionsContent = exclusionsContent;
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            requestedResourceName = name;
+            if (!"META-INF/exclusions".equals(name)) {
+                return Collections.emptyEnumeration();
+            }
+            URL serviceDescriptor = new URL(null, "memory:remote-extension-exclusions", new StringUrlStreamHandler(
+                    exclusionsContent));
+            return Collections.enumeration(Collections.singletonList(serviceDescriptor));
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (name.equals(VetoedRemoteExtensionService.class.getName())
+                    || name.equals(VetoedRemoteExtensionProviderOne.class.getName())
+                    || name.equals(VetoedRemoteExtensionProviderTwo.class.getName())
+                    || name.equals("org.example.DoesNotExist")) {
+                requestedClassNames.add(name);
+            }
+            return super.loadClass(name, resolve);
+        }
+    }
+
     private static final class StringUrlStreamHandler extends URLStreamHandler {
         private final String content;
 
@@ -110,3 +171,12 @@ class RemoteExtensionLoaderProvider implements RemoteLoadableExtension {
     public void register(LoadableExtension.ExtensionBuilder builder) {
     }
 }
+
+interface VetoedRemoteExtensionService {
+}
+
+class VetoedRemoteExtensionProviderOne implements VetoedRemoteExtensionService {
+}
+
+class VetoedRemoteExtensionProviderTwo implements VetoedRemoteExtensionService {
+}

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
