### PR TITLE
[GenAI] Test fix for org.apache.maven:maven-plugin-descriptor:2.1.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.maven/maven-plugin-descriptor/2.1.0/reachability-metadata.json
+++ b/metadata/org.apache.maven/maven-plugin-descriptor/2.1.0/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.plugin.descriptor.PluginDescriptor"
+      },
+      "glob": "META-INF/maven/lifecycle.xml"
+    }
+  ]
+}

--- a/metadata/org.apache.maven/maven-plugin-descriptor/index.json
+++ b/metadata/org.apache.maven/maven-plugin-descriptor/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.1.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/$version$/maven-plugin-descriptor-$version$-sources.jar",
+    "repository-url" : "https://svn.apache.org/repos/asf/maven/components",
+    "test-code-url" : "https://svn.apache.org/repos/asf/maven/components/tags/maven-$version$/maven-plugin-descriptor/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/$version$/maven-plugin-descriptor-$version$-javadoc.jar",
+    "description" : "Apache Maven Plugin Descriptor provides the Maven 2 model classes and XML parser support for reading plugin descriptors that describe Mojos, parameters, requirements, dependencies, and plugin identity. It also includes the lifecycle mapping model and XPP3 readers and writers used to parse and serialize custom plugin lifecycle configuration.",
     "tested-versions" : [
       "2.1.0"
     ],

--- a/metadata/org.apache.maven/maven-plugin-descriptor/index.json
+++ b/metadata/org.apache.maven/maven-plugin-descriptor/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.1.0",
+    "tested-versions" : [
+      "2.1.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.maven.plugin"
+    ]
+  },
+  {
     "metadata-version" : "2.0.6",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/$version$/maven-plugin-descriptor-$version$-sources.jar",
     "repository-url" : "https://svn.apache.org/repos/asf/maven/components",

--- a/stats/org.apache.maven/maven-plugin-descriptor/2.1.0/execution-metrics.json
+++ b/stats/org.apache.maven/maven-plugin-descriptor/2.1.0/execution-metrics.json
@@ -1,0 +1,93 @@
+{
+  "fix_java_run_fail:2026-05-18": {
+    "timestamp": "2026-05-18T22:19:55.258455Z",
+    "library": "org.apache.maven:maven-plugin-descriptor:2.1.0",
+    "starting_commit": "58c5c3605f9733d87ffe46be86e8b3ca9fad4d25",
+    "ending_commit": "d5f30159cd1ba11663632e1ff820d345a92b3477",
+    "previous_library": "org.apache.maven:maven-plugin-descriptor:2.0.6",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.1.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 4,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3182,
+          "missed": 696,
+          "ratio": 0.820526,
+          "total": 3878
+        },
+        "line": {
+          "covered": 799,
+          "missed": 134,
+          "ratio": 0.856377,
+          "total": 933
+        },
+        "method": {
+          "covered": 164,
+          "missed": 31,
+          "ratio": 0.841026,
+          "total": 195
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.0.6",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3122,
+          "missed": 534,
+          "ratio": 0.853939,
+          "total": 3656
+        },
+        "line": {
+          "covered": 814,
+          "missed": 112,
+          "ratio": 0.87905,
+          "total": 926
+        },
+        "method": {
+          "covered": 165,
+          "missed": 27,
+          "ratio": 0.859375,
+          "total": 192
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 91068,
+      "cached_input_tokens_used": 381952,
+      "output_tokens_used": 5956,
+      "iterations": 5,
+      "cost_usd": 0.3697,
+      "tested_library_loc": 799,
+      "metadata_entries": 1,
+      "previous_library_metadata_entries": 0,
+      "code_coverage_percent": 85.64,
+      "previous_library_coverage_percent": 87.91
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/src/test/java/org_apache_maven/maven_plugin_descriptor/LifecycleConfigurationTest.java",
+      "metadata_file": "metadata/org.apache.maven/maven-plugin-descriptor/2.1.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.maven/maven-plugin-descriptor/2.1.0/stats.json
+++ b/stats/org.apache.maven/maven-plugin-descriptor/2.1.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "2.1.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 4,
+          "totalCalls" : 4
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 4,
+      "totalCalls" : 4
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3182,
+        "missed" : 696,
+        "ratio" : 0.820526,
+        "total" : 3878
+      },
+      "line" : {
+        "covered" : 799,
+        "missed" : 134,
+        "ratio" : 0.856377,
+        "total" : 933
+      },
+      "method" : {
+        "covered" : 164,
+        "missed" : 31,
+        "ratio" : 0.841026,
+        "total" : 195
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/.gitignore
+++ b/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/build.gradle
+++ b/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.maven:maven-plugin-descriptor:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/gradle.properties
+++ b/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.maven:maven-plugin-descriptor:2.1.0
+library.version = 2.1.0
+metadata.dir = org.apache.maven/maven-plugin-descriptor/2.1.0/

--- a/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/settings.gradle
+++ b/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.maven.maven-plugin-descriptor_tests'

--- a/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/src/test/java/org_apache_maven/maven_plugin_descriptor/ExecutionTest.java
+++ b/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/src/test/java/org_apache_maven/maven_plugin_descriptor/ExecutionTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven.maven_plugin_descriptor;
+
+import org.apache.maven.plugin.lifecycle.Execution;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ExecutionTest {
+    @Test
+    void rejectsNullGoalWhenAddingGoal() {
+        Execution execution = new Execution();
+
+        ClassCastException exception = assertThrows(ClassCastException.class, () -> execution.addGoal(null));
+
+        assertThat(exception).hasMessageContaining("java.lang.String");
+        assertThat(execution.getGoals()).isEmpty();
+    }
+}

--- a/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/src/test/java/org_apache_maven/maven_plugin_descriptor/LifecycleConfigurationTest.java
+++ b/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/src/test/java/org_apache_maven/maven_plugin_descriptor/LifecycleConfigurationTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven.maven_plugin_descriptor;
+
+import org.apache.maven.plugin.lifecycle.Lifecycle;
+import org.apache.maven.plugin.lifecycle.LifecycleConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class LifecycleConfigurationTest {
+    @Test
+    void rejectsNullLifecycleWhenAddingLifecycle() {
+        LifecycleConfiguration configuration = new LifecycleConfiguration();
+
+        ClassCastException exception = assertThrows(ClassCastException.class, () -> configuration.addLifecycle(null));
+
+        assertThat(exception).hasMessageContaining(Lifecycle.class.getName());
+        assertThat(configuration.getLifecycles()).isEmpty();
+    }
+}

--- a/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/src/test/java/org_apache_maven/maven_plugin_descriptor/LifecycleTest.java
+++ b/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/src/test/java/org_apache_maven/maven_plugin_descriptor/LifecycleTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven.maven_plugin_descriptor;
+
+import org.apache.maven.plugin.lifecycle.Lifecycle;
+import org.apache.maven.plugin.lifecycle.Phase;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class LifecycleTest {
+    @Test
+    void rejectsNullPhaseWhenAddingPhase() {
+        Lifecycle lifecycle = new Lifecycle();
+
+        ClassCastException exception = assertThrows(ClassCastException.class, () -> lifecycle.addPhase(null));
+
+        assertThat(exception).hasMessageContaining(Phase.class.getName());
+        assertThat(lifecycle.getPhases()).isEmpty();
+    }
+}

--- a/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/src/test/java/org_apache_maven/maven_plugin_descriptor/Maven_plugin_descriptorTest.java
+++ b/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/src/test/java/org_apache_maven/maven_plugin_descriptor/Maven_plugin_descriptorTest.java
@@ -319,7 +319,7 @@ public class Maven_plugin_descriptorTest {
         new LifecycleMappingsXpp3Writer().write(writer, configuration);
 
         String xml = writer.toString();
-        assertThat(xml).contains("<lifecycles>", "<lifecycle>", "<id>default</id>", "<goal>compile</goal>");
+        assertThat(xml).contains("<lifecycles", "<lifecycle>", "<id>default</id>", "<goal>compile</goal>");
 
         LifecycleConfiguration parsed = new LifecycleMappingsXpp3Reader().read(new StringReader(xml));
         assertThat(parsed.getLifecycles()).hasSize(1);

--- a/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/src/test/java/org_apache_maven/maven_plugin_descriptor/Maven_plugin_descriptorTest.java
+++ b/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/src/test/java/org_apache_maven/maven_plugin_descriptor/Maven_plugin_descriptorTest.java
@@ -1,0 +1,465 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven.maven_plugin_descriptor;
+
+import java.io.FileNotFoundException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.artifact.versioning.VersionRange;
+import org.apache.maven.plugin.descriptor.DuplicateMojoDescriptorException;
+import org.apache.maven.plugin.descriptor.DuplicateParameterException;
+import org.apache.maven.plugin.descriptor.MojoDescriptor;
+import org.apache.maven.plugin.descriptor.Parameter;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
+import org.apache.maven.plugin.descriptor.PluginDescriptorBuilder;
+import org.apache.maven.plugin.lifecycle.Execution;
+import org.apache.maven.plugin.lifecycle.Lifecycle;
+import org.apache.maven.plugin.lifecycle.LifecycleConfiguration;
+import org.apache.maven.plugin.lifecycle.Phase;
+import org.apache.maven.plugin.lifecycle.io.xpp3.LifecycleMappingsXpp3Reader;
+import org.apache.maven.plugin.lifecycle.io.xpp3.LifecycleMappingsXpp3Writer;
+import org.codehaus.classworlds.ClassRealm;
+import org.codehaus.classworlds.ClassWorld;
+import org.codehaus.plexus.component.repository.ComponentDependency;
+import org.codehaus.plexus.component.repository.ComponentRequirement;
+import org.codehaus.plexus.configuration.PlexusConfiguration;
+import org.codehaus.plexus.configuration.PlexusConfigurationException;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class Maven_plugin_descriptorTest {
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void buildsCompletePluginDescriptorFromXml() throws PlexusConfigurationException {
+        PluginDescriptor descriptor = new PluginDescriptorBuilder().build(new StringReader("""
+                <plugin>
+                  <groupId>com.example.build</groupId>
+                  <artifactId>sample-maven-plugin</artifactId>
+                  <version>1.0</version>
+                  <goalPrefix>sample</goalPrefix>
+                  <name>Sample Plugin</name>
+                  <description>Builds a sample project</description>
+                  <isolatedRealm>true</isolatedRealm>
+                  <inheritedByDefault>false</inheritedByDefault>
+                  <mojos>
+                    <mojo>
+                      <goal>compile</goal>
+                      <implementation>com.example.build.CompileMojo</implementation>
+                      <language>java</language>
+                      <configurator>basic</configurator>
+                      <composer>map-oriented</composer>
+                      <since>1.0</since>
+                      <phase>compile</phase>
+                      <executePhase>generate-sources</executePhase>
+                      <executeGoal>generate</executeGoal>
+                      <executeLifecycle>default</executeLifecycle>
+                      <instantiationStrategy>singleton</instantiationStrategy>
+                      <description>Compiles generated sources</description>
+                      <requiresDependencyResolution>test</requiresDependencyResolution>
+                      <requiresDirectInvocation>true</requiresDirectInvocation>
+                      <requiresProject>false</requiresProject>
+                      <requiresReports>true</requiresReports>
+                      <aggregator>true</aggregator>
+                      <requiresOnline>true</requiresOnline>
+                      <inheritedByDefault>false</inheritedByDefault>
+                      <parameters>
+                        <parameter>
+                          <name>sourceDirectory</name>
+                          <alias>sources</alias>
+                          <type>java.io.File</type>
+                          <required>true</required>
+                          <editable>false</editable>
+                          <description>Directory with sources</description>
+                          <deprecated>Use inputDirectory</deprecated>
+                          <implementation>java.io.File</implementation>
+                        </parameter>
+                      </parameters>
+                      <configuration>
+                        <sourceDirectory implementation="java.io.File">${source}</sourceDirectory>
+                      </configuration>
+                      <requirements>
+                        <requirement>
+                          <role>com.example.build.Compiler</role>
+                          <role-hint>javac</role-hint>
+                          <field-name>compiler</field-name>
+                        </requirement>
+                      </requirements>
+                    </mojo>
+                    <mojo>
+                      <goal>clean</goal>
+                      <implementation>com.example.build.CleanMojo</implementation>
+                      <description>Cleans generated output</description>
+                    </mojo>
+                  </mojos>
+                  <dependencies>
+                    <dependency>
+                      <groupId>com.example</groupId>
+                      <artifactId>build-support</artifactId>
+                      <type>jar</type>
+                      <version>2.1</version>
+                    </dependency>
+                  </dependencies>
+                </plugin>
+                """), "memory-plugin.xml");
+
+        assertThat(descriptor.getSource()).isEqualTo("memory-plugin.xml");
+        assertThat(descriptor.getGroupId()).isEqualTo("com.example.build");
+        assertThat(descriptor.getArtifactId()).isEqualTo("sample-maven-plugin");
+        assertThat(descriptor.getVersion()).isEqualTo("1.0");
+        assertThat(descriptor.getGoalPrefix()).isEqualTo("sample");
+        assertThat(descriptor.getName()).isEqualTo("Sample Plugin");
+        assertThat(descriptor.getDescription()).isEqualTo("Builds a sample project");
+        assertThat(descriptor.isIsolatedRealm()).isTrue();
+        assertThat(descriptor.isInheritedByDefault()).isFalse();
+        assertThat(descriptor.getId()).isEqualTo("com.example.build:sample-maven-plugin:1.0");
+        assertThat(descriptor.getPluginLookupKey()).isEqualTo("com.example.build:sample-maven-plugin");
+        assertThat(descriptor.getMojos()).hasSize(2);
+
+        MojoDescriptor mojo = descriptor.getMojo("compile");
+        assertThat(mojo.getPluginDescriptor()).isSameAs(descriptor);
+        assertThat(mojo.getGoal()).isEqualTo("compile");
+        assertThat(mojo.getFullGoalName()).isEqualTo("sample:compile");
+        assertThat(mojo.getImplementation()).isEqualTo("com.example.build.CompileMojo");
+        assertThat(mojo.getLanguage()).isEqualTo("java");
+        assertThat(mojo.getComponentConfigurator()).isEqualTo("basic");
+        assertThat(mojo.getComponentComposer()).isEqualTo("map-oriented");
+        assertThat(mojo.getSince()).isEqualTo("1.0");
+        assertThat(mojo.getPhase()).isEqualTo("compile");
+        assertThat(mojo.getExecutePhase()).isEqualTo("generate-sources");
+        assertThat(mojo.getExecuteGoal()).isEqualTo("generate");
+        assertThat(mojo.getExecuteLifecycle()).isEqualTo("default");
+        assertThat(mojo.getInstantiationStrategy()).isEqualTo("singleton");
+        assertThat(mojo.getDescription()).isEqualTo("Compiles generated sources");
+        assertThat(mojo.isDependencyResolutionRequired()).isEqualTo("test");
+        assertThat(mojo.isDirectInvocationOnly()).isTrue();
+        assertThat(mojo.isProjectRequired()).isFalse();
+        assertThat(mojo.isRequiresReports()).isTrue();
+        assertThat(mojo.isAggregator()).isTrue();
+        assertThat(mojo.requiresOnline()).isTrue();
+        assertThat(mojo.isInheritedByDefault()).isFalse();
+        assertThat(mojo.getParameterMap()).containsKey("sourceDirectory");
+
+        Parameter parameter = (Parameter) mojo.getParameters().get(0);
+        assertThat(parameter.getName()).isEqualTo("sourceDirectory");
+        assertThat(parameter.getAlias()).isEqualTo("sources");
+        assertThat(parameter.getType()).isEqualTo("java.io.File");
+        assertThat(parameter.isRequired()).isTrue();
+        assertThat(parameter.isEditable()).isFalse();
+        assertThat(parameter.getDescription()).isEqualTo("Directory with sources");
+        assertThat(parameter.getDeprecated()).isEqualTo("Use inputDirectory");
+        assertThat(parameter.getImplementation()).isEqualTo("java.io.File");
+        assertThat(parameter.toString()).contains("sourceDirectory", "sources");
+
+        PlexusConfiguration sourceDirectory = mojo.getMojoConfiguration().getChild("sourceDirectory");
+        assertThat(sourceDirectory.getValue()).isEqualTo("${source}");
+        assertThat(sourceDirectory.getAttribute("implementation")).isEqualTo("java.io.File");
+
+        ComponentRequirement requirement = (ComponentRequirement) mojo.getRequirements().get(0);
+        assertThat(requirement.getRole()).isEqualTo("com.example.build.Compiler");
+        assertThat(requirement.getRoleHint()).isEqualTo("javac");
+        assertThat(requirement.getFieldName()).isEqualTo("compiler");
+
+        ComponentDependency dependency = (ComponentDependency) descriptor.getDependencies().get(0);
+        assertThat(dependency.getGroupId()).isEqualTo("com.example");
+        assertThat(dependency.getArtifactId()).isEqualTo("build-support");
+        assertThat(dependency.getType()).isEqualTo("jar");
+        assertThat(dependency.getVersion()).isEqualTo("2.1");
+        assertThat(descriptor.getMojo("clean").getImplementation()).isEqualTo("com.example.build.CleanMojo");
+        assertThat(descriptor.getMojo("missing")).isNull();
+    }
+
+    @Test
+    void descriptorModelsExposeKeysDefaultsAndDuplicateValidation() throws Exception {
+        assertThat(PluginDescriptor.constructPluginKey("group", "artifact", "1"))
+                .isEqualTo("group:artifact:1");
+        assertThat(PluginDescriptor.getDefaultPluginGroupId()).isEqualTo("org.apache.maven.plugins");
+        assertThat(PluginDescriptor.getDefaultPluginArtifactId("help")).isEqualTo("maven-help-plugin");
+        assertThat(PluginDescriptor.getGoalPrefixFromArtifactId("maven-plugin-plugin")).isEqualTo("plugin");
+        assertThat(PluginDescriptor.getGoalPrefixFromArtifactId("maven-compiler-plugin")).isEqualTo("compiler");
+        assertThat(PluginDescriptor.getGoalPrefixFromArtifactId("sample-plugin-extension"))
+                .isEqualTo("sampleextension");
+
+        PluginDescriptor descriptor = new PluginDescriptor();
+        descriptor.setGroupId("com.example");
+        descriptor.setArtifactId("demo-plugin");
+        descriptor.setVersion("1.0");
+        descriptor.setGoalPrefix("demo");
+        descriptor.setSource("manual");
+        descriptor.setInheritedByDefault(true);
+        descriptor.setArtifacts(Collections.emptyList());
+
+        MojoDescriptor mojo = new MojoDescriptor();
+        mojo.setPluginDescriptor(descriptor);
+        mojo.setGoal("run");
+        mojo.setImplementation("com.example.RunMojo");
+        mojo.setDependencyResolutionRequired("runtime");
+        mojo.setExecutionStrategy("always");
+        mojo.setProjectRequired(true);
+        mojo.setOnlineRequired(false);
+        mojo.setAggregator(false);
+        mojo.setDirectInvocationOnly(false);
+        mojo.setRequiresReports(false);
+        descriptor.addMojo(mojo);
+
+        assertThat(mojo.getId()).isEqualTo("com.example:demo-plugin:1.0:run");
+        assertThat(mojo.getRole()).isEqualTo("org.apache.maven.plugin.Mojo");
+        assertThat(mojo.getRoleHint()).isEqualTo(mojo.getId());
+        assertThat(mojo.getComponentType()).isEqualTo("maven-plugin");
+        assertThat(mojo.alwaysExecute()).isTrue();
+        assertThat(mojo.isDependencyResolutionRequired()).isEqualTo("runtime");
+        assertThat(descriptor.getArtifacts()).isEmpty();
+        assertThat(descriptor.getArtifactMap()).isEmpty();
+
+        MojoDescriptor duplicateMojo = new MojoDescriptor();
+        duplicateMojo.setPluginDescriptor(descriptor);
+        duplicateMojo.setGoal("run");
+        duplicateMojo.setImplementation("com.example.OtherRunMojo");
+        assertThrows(DuplicateMojoDescriptorException.class, () -> descriptor.addMojo(duplicateMojo));
+
+        Parameter parameter = new Parameter();
+        parameter.setName("outputDirectory");
+        parameter.setAlias("output");
+        parameter.setType("java.io.File");
+        parameter.setExpression("${project.build.directory}");
+        parameter.setDefaultValue("target");
+        parameter.setSince("1.0");
+        parameter.setRequirement(new org.apache.maven.plugin.descriptor.Requirement("com.example.Output", "default"));
+        mojo.addParameter(parameter);
+
+        assertThat(parameter.getExpression()).isEqualTo("${project.build.directory}");
+        assertThat(parameter.getDefaultValue()).isEqualTo("target");
+        assertThat(parameter.getSince()).isEqualTo("1.0");
+        assertThat(parameter.getRequirement().getRole()).isEqualTo("com.example.Output");
+        assertThat(parameter.getRequirement().getRoleHint()).isEqualTo("default");
+        assertThat(mojo.getParameterMap()).containsEntry("outputDirectory", parameter);
+
+        Parameter duplicateParameter = new Parameter();
+        duplicateParameter.setName("outputDirectory");
+        assertThrows(DuplicateParameterException.class, () -> mojo.addParameter(duplicateParameter));
+    }
+
+    @Test
+    void pluginDescriptorIndexesArtifactsAndTracksIntroducedDependencies() {
+        Artifact alphaArtifact = new DefaultArtifact("com.example", "alpha-plugin", VersionRange.createFromVersion("1"),
+                Artifact.SCOPE_RUNTIME, "jar", null, new DefaultArtifactHandler("jar"));
+        Artifact betaArtifact = new DefaultArtifact("com.example", "beta-plugin", VersionRange.createFromVersion("1"),
+                Artifact.SCOPE_RUNTIME, "jar", null, new DefaultArtifactHandler("jar"));
+
+        PluginDescriptor descriptor = new PluginDescriptor();
+        descriptor.setArtifacts(Collections.singletonList(alphaArtifact));
+
+        Map artifactMap = descriptor.getArtifactMap();
+        assertThat(artifactMap).hasSize(1).containsEntry("com.example:alpha-plugin", alphaArtifact);
+        assertThat(descriptor.getIntroducedDependencyArtifacts()).isEmpty();
+
+        descriptor.setArtifacts(Collections.singletonList(betaArtifact));
+        assertThat(descriptor.getArtifactMap())
+                .hasSize(1)
+                .containsEntry("com.example:beta-plugin", betaArtifact)
+                .doesNotContainKey("com.example:alpha-plugin");
+
+        Set introducedDependencyArtifacts = new LinkedHashSet(Collections.singleton(betaArtifact));
+        descriptor.setIntroducedDependencyArtifacts(introducedDependencyArtifacts);
+        assertThat(descriptor.getIntroducedDependencyArtifacts()).containsExactly(betaArtifact);
+    }
+
+    @Test
+    void lifecycleMappingsCanBeWrittenReadAndMutated() throws Exception {
+        Xpp3Dom executionConfiguration = new Xpp3Dom("configuration");
+        Xpp3Dom skip = new Xpp3Dom("skip");
+        skip.setValue("false");
+        executionConfiguration.addChild(skip);
+
+        Execution execution = new Execution();
+        execution.addGoal("compile");
+        execution.addGoal("testCompile");
+        execution.removeGoal("testCompile");
+        execution.setConfiguration(executionConfiguration);
+
+        Phase phase = new Phase();
+        phase.setId("process-sources");
+        phase.addExecution(execution);
+
+        Lifecycle lifecycle = new Lifecycle();
+        lifecycle.setId("default");
+        lifecycle.addPhase(phase);
+
+        Lifecycle unusedLifecycle = new Lifecycle();
+        unusedLifecycle.setId("site");
+
+        LifecycleConfiguration configuration = new LifecycleConfiguration();
+        configuration.setModelEncoding("UTF-8");
+        configuration.addLifecycle(lifecycle);
+        configuration.addLifecycle(unusedLifecycle);
+        configuration.removeLifecycle(unusedLifecycle);
+
+        StringWriter writer = new StringWriter();
+        new LifecycleMappingsXpp3Writer().write(writer, configuration);
+
+        String xml = writer.toString();
+        assertThat(xml).contains("<lifecycles>", "<lifecycle>", "<id>default</id>", "<goal>compile</goal>");
+
+        LifecycleConfiguration parsed = new LifecycleMappingsXpp3Reader().read(new StringReader(xml));
+        assertThat(parsed.getLifecycles()).hasSize(1);
+
+        Lifecycle parsedLifecycle = (Lifecycle) parsed.getLifecycles().get(0);
+        assertThat(parsedLifecycle.getId()).isEqualTo("default");
+        assertThat(parsedLifecycle.getPhases()).hasSize(1);
+
+        Phase parsedPhase = (Phase) parsedLifecycle.getPhases().get(0);
+        assertThat(parsedPhase.getId()).isEqualTo("process-sources");
+        assertThat(parsedPhase.getExecutions()).hasSize(1);
+
+        Execution parsedExecution = (Execution) parsedPhase.getExecutions().get(0);
+        assertThat(parsedExecution.getGoals()).containsExactly("compile");
+        Xpp3Dom parsedExecutionConfiguration = (Xpp3Dom) parsedExecution.getConfiguration();
+        assertThat(parsedExecutionConfiguration.getChild("skip").getValue()).isEqualTo("false");
+
+        parsedPhase.removeExecution(parsedExecution);
+        assertThat(parsedPhase.getExecutions()).isEmpty();
+        parsedLifecycle.removePhase(parsedPhase);
+        assertThat(parsedLifecycle.getPhases()).isEmpty();
+    }
+
+    @Test
+    void readersAndBuildersRejectInvalidDescriptors() throws Exception {
+        PluginDescriptorBuilder builder = new PluginDescriptorBuilder();
+        assertThrows(PlexusConfigurationException.class,
+                () -> builder.buildConfiguration(new StringReader("<plugin>")));
+
+        String duplicateLifecycleId = """
+                <lifecycles>
+                  <lifecycle>
+                    <id>default</id>
+                    <id>duplicate</id>
+                  </lifecycle>
+                </lifecycles>
+                """;
+        assertThrows(XmlPullParserException.class,
+                () -> new LifecycleMappingsXpp3Reader().read(new StringReader(duplicateLifecycleId)));
+
+        String unknownLifecycleTag = """
+                <lifecycles>
+                  <lifecycle>
+                    <id>default</id>
+                    <unexpected />
+                  </lifecycle>
+                </lifecycles>
+                """;
+        assertThrows(XmlPullParserException.class,
+                () -> new LifecycleMappingsXpp3Reader().read(new StringReader(unknownLifecycleTag)));
+    }
+
+    @Test
+    void pluginDescriptorReportsMissingLifecycleResourceFromClassRealm() throws Exception {
+        PluginDescriptor descriptor = new PluginDescriptor();
+        ClassRealm realm = new ClassWorld().newRealm("empty-plugin-realm");
+        realm.addConstituent(temporaryDirectory.toUri().toURL());
+        descriptor.setClassRealm(realm);
+
+        assertThrows(FileNotFoundException.class, () -> descriptor.getLifecycleMapping("default"));
+    }
+
+    @Test
+    void pluginDescriptorLoadsLifecycleMappingsFromClassRealmResource() throws Exception {
+        Path lifecycleDirectory = Files.createDirectories(temporaryDirectory.resolve("META-INF/maven"));
+        Files.writeString(lifecycleDirectory.resolve("lifecycle.xml"), """
+                <lifecycles>
+                  <lifecycle>
+                    <id>default</id>
+                    <phases>
+                      <phase>
+                        <id>generate-resources</id>
+                        <executions>
+                          <execution>
+                            <goals>
+                              <goal>resources</goal>
+                            </goals>
+                            <configuration>
+                              <encoding>UTF-8</encoding>
+                            </configuration>
+                          </execution>
+                        </executions>
+                      </phase>
+                    </phases>
+                  </lifecycle>
+                  <lifecycle>
+                    <id>site</id>
+                    <phases>
+                      <phase>
+                        <id>site</id>
+                        <executions>
+                          <execution>
+                            <goals>
+                              <goal>site</goal>
+                            </goals>
+                          </execution>
+                        </executions>
+                      </phase>
+                    </phases>
+                  </lifecycle>
+                </lifecycles>
+                """);
+
+        PluginDescriptor descriptor = new PluginDescriptor();
+        ClassRealm realm = new ClassWorld().newRealm("plugin-lifecycle-realm");
+        realm.addConstituent(temporaryDirectory.toUri().toURL());
+        descriptor.setClassRealm(realm);
+
+        Lifecycle defaultLifecycle = descriptor.getLifecycleMapping("default");
+        assertThat(defaultLifecycle.getId()).isEqualTo("default");
+        Phase defaultPhase = (Phase) defaultLifecycle.getPhases().get(0);
+        assertThat(defaultPhase.getId()).isEqualTo("generate-resources");
+        Execution defaultExecution = (Execution) defaultPhase.getExecutions().get(0);
+        assertThat(defaultExecution.getGoals()).containsExactly("resources");
+        Xpp3Dom configuration = (Xpp3Dom) defaultExecution.getConfiguration();
+        assertThat(configuration.getChild("encoding").getValue()).isEqualTo("UTF-8");
+
+        Lifecycle siteLifecycle = descriptor.getLifecycleMapping("site");
+        assertThat(siteLifecycle.getId()).isEqualTo("site");
+        assertThat(descriptor.getLifecycleMapping("missing")).isNull();
+    }
+
+    @Test
+    void collectionSettersReplaceLifecycleModelContents() {
+        Execution execution = new Execution();
+        execution.setGoals(Arrays.asList("compile", "test"));
+        assertThat(execution.getGoals()).containsExactly("compile", "test");
+
+        Phase phase = new Phase();
+        phase.setExecutions(Collections.singletonList(execution));
+        phase.setConfiguration("phase-configuration");
+        assertThat(phase.getExecutions()).containsExactly(execution);
+        assertThat(phase.getConfiguration()).isEqualTo("phase-configuration");
+
+        Lifecycle lifecycle = new Lifecycle();
+        lifecycle.setPhases(Collections.singletonList(phase));
+        assertThat(lifecycle.getPhases()).containsExactly(phase);
+
+        LifecycleConfiguration configuration = new LifecycleConfiguration();
+        configuration.setLifecycles(Collections.singletonList(lifecycle));
+        assertThat(configuration.getLifecycles()).containsExactly(lifecycle);
+    }
+}

--- a/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/src/test/java/org_apache_maven/maven_plugin_descriptor/PhaseTest.java
+++ b/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/src/test/java/org_apache_maven/maven_plugin_descriptor/PhaseTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven.maven_plugin_descriptor;
+
+import org.apache.maven.plugin.lifecycle.Execution;
+import org.apache.maven.plugin.lifecycle.Phase;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class PhaseTest {
+    @Test
+    void rejectsNullExecutionWhenAddingExecution() {
+        Phase phase = new Phase();
+
+        ClassCastException exception = assertThrows(ClassCastException.class, () -> phase.addExecution(null));
+
+        assertThat(exception).hasMessageContaining(Execution.class.getName());
+        assertThat(phase.getExecutions()).isEmpty();
+    }
+}

--- a/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/user-code-filter.json
+++ b/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.maven.plugin.**"
+    },
+    {
+      "includeClasses" : "org_apache_maven.maven_plugin_descriptor.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7034

This PR provides test fixes and new metadata for org.apache.maven:maven-plugin-descriptor:2.1.0, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 91068
- Cached input tokens: 381952
- Output tokens: 5956
- Metadata entries: 1
- Iterations: 5
- Library coverage percentage: 85.64
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 87.91

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3f69aa1510d519e1825b9bfd59a81bb41ea7ef04`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.maven:maven-plugin-descriptor:2.0.6: 0/0 covered calls (100.00%)
- org.apache.maven:maven-plugin-descriptor:2.1.0: 4/4 covered calls (100.00%)

**Reflection:**
- org.apache.maven:maven-plugin-descriptor:2.0.6: N/A
- org.apache.maven:maven-plugin-descriptor:2.1.0: 4/4 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.maven:maven-plugin-descriptor:2.0.6: 3122/3656 (85.39%)
- org.apache.maven:maven-plugin-descriptor:2.1.0: 3182/3878 (82.05%)

**Line:**
- org.apache.maven:maven-plugin-descriptor:2.0.6: 814/926 (87.91%)
- org.apache.maven:maven-plugin-descriptor:2.1.0: 799/933 (85.64%)

**Method:**
- org.apache.maven:maven-plugin-descriptor:2.0.6: 165/192 (85.94%)
- org.apache.maven:maven-plugin-descriptor:2.1.0: 164/195 (84.10%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/src/test/java/org_apache_maven/maven_plugin_descriptor/ExecutionTest.java 2/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/src/test/java/org_apache_maven/maven_plugin_descriptor/ExecutionTest.java
new file mode 100644
index 0000000000..ee6e8e505c
--- /dev/null
+++ 2/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/src/test/java/org_apache_maven/maven_plugin_descriptor/ExecutionTest.java
@@ -0,0 +1,25 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven.maven_plugin_descriptor;
+
+import org.apache.maven.plugin.lifecycle.Execution;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ExecutionTest {
+    @Test
+    void rejectsNullGoalWhenAddingGoal() {
+        Execution execution = new Execution();
+
+        ClassCastException exception = assertThrows(ClassCastException.class, () -> execution.addGoal(null));
+
+        assertThat(exception).hasMessageContaining("java.lang.String");
+        assertThat(execution.getGoals()).isEmpty();
+    }
+}
diff --git 1/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/src/test/java/org_apache_maven/maven_plugin_descriptor/LifecycleConfigurationTest.java 2/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/src/test/java/org_apache_maven/maven_plugin_descriptor/LifecycleConfigurationTest.java
new file mode 100644
index 0000000000..0e9acfe44d
--- /dev/null
+++ 2/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/src/test/java/org_apache_maven/maven_plugin_descriptor/LifecycleConfigurationTest.java
@@ -0,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven.maven_plugin_descriptor;
+
+import org.apache.maven.plugin.lifecycle.Lifecycle;
+import org.apache.maven.plugin.lifecycle.LifecycleConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class LifecycleConfigurationTest {
+    @Test
+    void rejectsNullLifecycleWhenAddingLifecycle() {
+        LifecycleConfiguration configuration = new LifecycleConfiguration();
+
+        ClassCastException exception = assertThrows(ClassCastException.class, () -> configuration.addLifecycle(null));
+
+        assertThat(exception).hasMessageContaining(Lifecycle.class.getName());
+        assertThat(configuration.getLifecycles()).isEmpty();
+    }
+}
diff --git 1/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/src/test/java/org_apache_maven/maven_plugin_descriptor/LifecycleTest.java 2/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/src/test/java/org_apache_maven/maven_plugin_descriptor/LifecycleTest.java
new file mode 100644
index 0000000000..1fc7a55112
--- /dev/null
+++ 2/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/src/test/java/org_apache_maven/maven_plugin_descriptor/LifecycleTest.java
@@ -0,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven.maven_plugin_descriptor;
+
+import org.apache.maven.plugin.lifecycle.Lifecycle;
+import org.apache.maven.plugin.lifecycle.Phase;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class LifecycleTest {
+    @Test
+    void rejectsNullPhaseWhenAddingPhase() {
+        Lifecycle lifecycle = new Lifecycle();
+
+        ClassCastException exception = assertThrows(ClassCastException.class, () -> lifecycle.addPhase(null));
+
+        assertThat(exception).hasMessageContaining(Phase.class.getName());
+        assertThat(lifecycle.getPhases()).isEmpty();
+    }
+}
diff --git 1/tests/src/org.apache.maven/maven-plugin-descriptor/2.0.6/src/test/java/org_apache_maven/maven_plugin_descriptor/Maven_plugin_descriptorTest.java 2/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/src/test/java/org_apache_maven/maven_plugin_descriptor/Maven_plugin_descriptorTest.java
index 8181d118de..4adb26e7a4 100644
--- 1/tests/src/org.apache.maven/maven-plugin-descriptor/2.0.6/src/test/java/org_apache_maven/maven_plugin_descriptor/Maven_plugin_descriptorTest.java
+++ 2/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/src/test/java/org_apache_maven/maven_plugin_descriptor/Maven_plugin_descriptorTest.java
@@ -319,7 +319,7 @@ public class Maven_plugin_descriptorTest {
         new LifecycleMappingsXpp3Writer().write(writer, configuration);
 
         String xml = writer.toString();
-        assertThat(xml).contains("<lifecycles>", "<lifecycle>", "<id>default</id>", "<goal>compile</goal>");
+        assertThat(xml).contains("<lifecycles", "<lifecycle>", "<id>default</id>", "<goal>compile</goal>");
 
         LifecycleConfiguration parsed = new LifecycleMappingsXpp3Reader().read(new StringReader(xml));
         assertThat(parsed.getLifecycles()).hasSize(1);
diff --git 1/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/src/test/java/org_apache_maven/maven_plugin_descriptor/PhaseTest.java 2/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/src/test/java/org_apache_maven/maven_plugin_descriptor/PhaseTest.java
new file mode 100644
index 0000000000..94cb9d4733
--- /dev/null
+++ 2/tests/src/org.apache.maven/maven-plugin-descriptor/2.1.0/src/test/java/org_apache_maven/maven_plugin_descriptor/PhaseTest.java
@@ -0,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven.maven_plugin_descriptor;
+
+import org.apache.maven.plugin.lifecycle.Execution;
+import org.apache.maven.plugin.lifecycle.Phase;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class PhaseTest {
+    @Test
+    void rejectsNullExecutionWhenAddingExecution() {
+        Phase phase = new Phase();
+
+        ClassCastException exception = assertThrows(ClassCastException.class, () -> phase.addExecution(null));
+
+        assertThat(exception).hasMessageContaining(Execution.class.getName());
+        assertThat(phase.getExecutions()).isEmpty();
+    }
+}

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
