### PR TITLE
[GenAI] Test fix for org.glassfish.grizzly:grizzly-framework:2.3.6 using gpt-5.5

### DIFF
--- a/metadata/org.glassfish.grizzly/grizzly-framework/2.3.6/reachability-metadata.json
+++ b/metadata/org.glassfish.grizzly/grizzly-framework/2.3.6/reachability-metadata.json
@@ -1,426 +1,452 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.utils.DataStructures"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.utils.DataStructures"
       },
-      "type": "java.lang.StackTraceElement[]"
+      "type" : "java.lang.StackTraceElement[]"
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.utils.ArraySet"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.utils.ArraySet"
       },
-      "type": "java.lang.String[]"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.utils.ArrayUtils"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.utils.ArrayUtils"
       },
-      "type": "java.lang.String[]"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.memory.AbstractBufferArray"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.memory.AbstractBufferArray"
       },
-      "type": "java.nio.ByteBuffer[]"
+      "type" : "java.nio.ByteBuffer[]"
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.utils.DataStructures"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.utils.DataStructures"
       },
-      "type": "java.util.concurrent.LinkedTransferQueue",
-      "methods": [
+      "type" : "java.util.concurrent.LinkedTransferQueue",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.memory.MemoryManagerInitializer"
       },
-      "type": "org.glassfish.grizzly.utils.ConcurrentHashMapV8",
-      "serializable": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
-      },
-      "type": "org.glassfish.grizzly.utils.ConcurrentHashMapV8$Segment",
-      "serializable": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
-      },
-      "type": "org.glassfish.grizzly.utils.ConcurrentHashMapV8$Segment[]"
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
-      },
-      "type": "java.util.concurrent.locks.ReentrantLock",
-      "serializable": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
-      },
-      "type": "java.util.concurrent.locks.ReentrantLock$NonfairSync",
-      "serializable": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
-      },
-      "type": "java.util.concurrent.locks.ReentrantLock$Sync",
-      "serializable": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
-      },
-      "type": "java.util.concurrent.locks.AbstractQueuedSynchronizer",
-      "serializable": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
-      },
-      "type": "java.util.concurrent.locks.AbstractOwnableSynchronizer",
-      "serializable": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
-      },
-      "type": "java.lang.String",
-      "serializable": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
-      },
-      "type": "java.lang.Integer",
-      "serializable": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
-      },
-      "type": "java.lang.Number",
-      "serializable": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
-      },
-      "type": "sun.misc.Unsafe",
-      "fields": [
+      "type" : "org.glassfish.grizzly.memory.ByteBufferManager",
+      "methods" : [
         {
-          "name": "theUnsafe"
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "type": "org.glassfish.grizzly.utils.LinkedTransferQueue",
-      "serializable": true
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
+      },
+      "type" : "org.glassfish.grizzly.utils.ConcurrentHashMapV8",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.utils.LinkedTransferQueue"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
       },
-      "type": "sun.misc.Unsafe",
-      "fields": [
+      "type" : "org.glassfish.grizzly.utils.ConcurrentHashMapV8$Segment",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
+      },
+      "type" : "org.glassfish.grizzly.utils.ConcurrentHashMapV8$Segment[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
+      },
+      "type" : "java.util.concurrent.locks.ReentrantLock",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
+      },
+      "type" : "java.util.concurrent.locks.ReentrantLock$NonfairSync",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
+      },
+      "type" : "java.util.concurrent.locks.ReentrantLock$Sync",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
+      },
+      "type" : "java.util.concurrent.locks.AbstractQueuedSynchronizer",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
+      },
+      "type" : "java.util.concurrent.locks.AbstractOwnableSynchronizer",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
+      },
+      "type" : "java.lang.String",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
+      },
+      "type" : "java.lang.Integer",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
+      },
+      "type" : "java.lang.Number",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
+      },
+      "type" : "sun.misc.Unsafe",
+      "fields" : [
         {
-          "name": "theUnsafe"
+          "name" : "theUnsafe"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
-      },
-      "type": "java.lang.Enum$EnumDesc"
+      "type" : "org.glassfish.grizzly.utils.LinkedTransferQueue",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.utils.LinkedTransferQueue"
       },
-      "type": "java.lang.constant.ClassDesc"
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
-      },
-      "type": "java.lang.constant.ConstantDesc[]"
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
-      },
-      "type": "java.lang.constant.DirectMethodHandleDesc"
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
-      },
-      "type": "java.lang.constant.DirectMethodHandleDesc$Kind"
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
-      },
-      "type": "java.lang.constant.DynamicConstantDesc"
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
-      },
-      "type": "java.lang.constant.MethodHandleDesc"
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
-      },
-      "type": "java.lang.reflect.AccessFlag"
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
-      },
-      "type": "java.net.URL"
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
-      },
-      "type": "java.security.CodeSource"
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
-      },
-      "type": "java.security.ProtectionDomain"
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
-      },
-      "type": "java.util.Locale$Category"
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
-      },
-      "type": "org.glassfish.gmbal.impl.ManagedObjectManagerImpl"
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
-      },
-      "type": {
-        "proxy": [
-          "com.oracle.svm.shared.Uninterruptible"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
-      },
-      "type": {
-        "proxy": [
-          "java.lang.Deprecated"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
-      },
-      "type": {
-        "proxy": [
-          "java.lang.FunctionalInterface"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
-      },
-      "type": {
-        "proxy": [
-          "java.lang.SafeVarargs"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
-      },
-      "type": {
-        "proxy": [
-          "java.lang.annotation.Inherited"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
-      },
-      "type": {
-        "proxy": [
-          "java.lang.annotation.Retention"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
-      },
-      "type": {
-        "proxy": [
-          "jdk.internal.ValueBased"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
-      },
-      "type": {
-        "proxy": [
-          "jdk.internal.reflect.CallerSensitive"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
-      },
-      "type": {
-        "proxy": [
-          "jdk.internal.vm.annotation.ForceInline"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
-      },
-      "type": {
-        "proxy": [
-          "jdk.internal.vm.annotation.IntrinsicCandidate"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
-      },
-      "type": {
-        "proxy": [
-          "org.glassfish.gmbal.AMXMetadata"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.monitoring.MonitoringUtils"
-      },
-      "type": "org.glassfish.grizzly.TransformationException",
-      "methods": [
+      "type" : "sun.misc.Unsafe",
+      "fields" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "theUnsafe"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.jmxbase.GrizzlyJmxManager"
+      },
+      "type" : "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type" : "java.lang.Enum$EnumDesc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type" : "java.lang.constant.ClassDesc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type" : "java.lang.constant.ConstantDesc[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type" : "java.lang.constant.DirectMethodHandleDesc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type" : "java.lang.constant.DirectMethodHandleDesc$Kind"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type" : "java.lang.constant.DynamicConstantDesc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type" : "java.lang.constant.MethodHandleDesc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type" : "java.lang.reflect.AccessFlag"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type" : "java.net.URL"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type" : "java.security.CodeSource"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type" : "java.security.ProtectionDomain"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type" : "java.util.Locale$Category"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type" : "org.glassfish.gmbal.impl.ManagedObjectManagerImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.String"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.nio.transport.UDPNIOConnection"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
       },
-      "type": "java.nio.channels.MembershipKey",
-      "methods": [
+      "type" : {
+        "proxy" : [
+          "com.oracle.svm.shared.Uninterruptible"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.Deprecated"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.FunctionalInterface"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.SafeVarargs"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Inherited"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type" : {
+        "proxy" : [
+          "jdk.internal.ValueBased"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type" : {
+        "proxy" : [
+          "jdk.internal.reflect.CallerSensitive"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type" : {
+        "proxy" : [
+          "jdk.internal.vm.annotation.ForceInline"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type" : {
+        "proxy" : [
+          "jdk.internal.vm.annotation.IntrinsicCandidate"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type" : {
+        "proxy" : [
+          "org.glassfish.gmbal.AMXMetadata"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.monitoring.MonitoringUtils"
+      },
+      "type" : "org.glassfish.grizzly.TransformationException",
+      "methods" : [
         {
-          "name": "networkInterface",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.nio.transport.UDPNIOConnection"
+      },
+      "type" : "java.nio.channels.MembershipKey",
+      "methods" : [
+        {
+          "name" : "networkInterface",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "sourceAddress",
-          "parameterTypes": []
+          "name" : "sourceAddress",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "drop",
-          "parameterTypes": []
+          "name" : "drop",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "block",
-          "parameterTypes": [
+          "name" : "block",
+          "parameterTypes" : [
             "java.net.InetAddress"
           ]
         },
         {
-          "name": "unblock",
-          "parameterTypes": [
+          "name" : "unblock",
+          "parameterTypes" : [
             "java.net.InetAddress"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.nio.DefaultSelectionKeyHandler"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.nio.DefaultSelectionKeyHandler"
       },
-      "type": "org.glassfish.grizzly.IOEvent[]"
+      "type" : "org.glassfish.grizzly.IOEvent[]"
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.ThreadCache$ObjectCache"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.ThreadCache$ObjectCache"
       },
-      "type": "org.glassfish.grizzly.ThreadCache$ObjectCacheElement[]"
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.utils.ServiceFinder$LazyIterator"
-      },
-      "type": "org_glassfish_grizzly.grizzly_framework.ServiceFinderInnerLazyIteratorTest$SampleServiceProvider"
+      "type" : "org.glassfish.grizzly.ThreadCache$ObjectCacheElement[]"
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.utils.ServiceFinder$LazyIterator"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.utils.ServiceFinder$LazyIterator"
       },
-      "glob": "META-INF/services/org_glassfish_grizzly.grizzly_framework.ServiceFinderInnerLazyIteratorTest$MissingService"
+      "glob" : "META-INF/services/org_glassfish_grizzly.grizzly_framework.ServiceFinderInnerLazyIteratorTest$MissingService"
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.utils.ServiceFinder$LazyIterator"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.utils.ServiceFinder$LazyIterator"
       },
-      "glob": "META-INF/services/org_glassfish_grizzly.grizzly_framework.ServiceFinderTest$EmptyService"
+      "glob" : "META-INF/services/org_glassfish_grizzly.grizzly_framework.ServiceFinderTest$EmptyService"
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.localization.Localizer"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.localization.Localizer"
       },
-      "bundle": "LocalizerFallbackMessages"
+      "bundle" : "LocalizerFallbackMessages"
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.localization.Localizer"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.localization.Localizer"
       },
-      "bundle": "org_glassfish_grizzly.grizzly_framework.LocalizerFallbackMessages"
+      "bundle" : "org_glassfish_grizzly.grizzly_framework.LocalizerFallbackMessages"
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.localization.Localizer"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.localization.Localizer"
       },
-      "bundle": "org_glassfish_grizzly.grizzly_framework.LocalizerMessages"
+      "bundle" : "org_glassfish_grizzly.grizzly_framework.LocalizerMessages"
     }
   ]
 }

--- a/metadata/org.glassfish.grizzly/grizzly-framework/2.3.6/reachability-metadata.json
+++ b/metadata/org.glassfish.grizzly/grizzly-framework/2.3.6/reachability-metadata.json
@@ -1,0 +1,238 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.utils.DataStructures"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.utils.ArraySet"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.utils.ArrayUtils"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.memory.AbstractBufferArray"
+      },
+      "type": "java.nio.ByteBuffer[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.utils.DataStructures"
+      },
+      "type": "java.util.concurrent.LinkedTransferQueue",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
+      },
+      "type": "org.glassfish.grizzly.utils.ConcurrentHashMapV8",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
+      },
+      "type": "org.glassfish.grizzly.utils.ConcurrentHashMapV8$Segment",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
+      },
+      "type": "org.glassfish.grizzly.utils.ConcurrentHashMapV8$Segment[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
+      },
+      "type": "java.util.concurrent.locks.ReentrantLock",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
+      },
+      "type": "java.util.concurrent.locks.ReentrantLock$NonfairSync",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
+      },
+      "type": "java.util.concurrent.locks.ReentrantLock$Sync",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
+      },
+      "type": "java.util.concurrent.locks.AbstractQueuedSynchronizer",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
+      },
+      "type": "java.util.concurrent.locks.AbstractOwnableSynchronizer",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
+      },
+      "type": "java.lang.String",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
+      },
+      "type": "java.lang.Integer",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
+      },
+      "type": "java.lang.Number",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.utils.ConcurrentHashMapV8"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ]
+    },
+    {
+      "type": "org.glassfish.grizzly.utils.LinkedTransferQueue",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.utils.LinkedTransferQueue"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.monitoring.MonitoringUtils"
+      },
+      "type": "org.glassfish.grizzly.TransformationException",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.nio.transport.UDPNIOConnection"
+      },
+      "type": "java.nio.channels.MembershipKey",
+      "methods": [
+        {
+          "name": "networkInterface",
+          "parameterTypes": []
+        },
+        {
+          "name": "sourceAddress",
+          "parameterTypes": []
+        },
+        {
+          "name": "drop",
+          "parameterTypes": []
+        },
+        {
+          "name": "block",
+          "parameterTypes": [
+            "java.net.InetAddress"
+          ]
+        },
+        {
+          "name": "unblock",
+          "parameterTypes": [
+            "java.net.InetAddress"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.nio.DefaultSelectionKeyHandler"
+      },
+      "type": "org.glassfish.grizzly.IOEvent[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.ThreadCache$ObjectCache"
+      },
+      "type": "org.glassfish.grizzly.ThreadCache$ObjectCacheElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.utils.ServiceFinder$LazyIterator"
+      },
+      "type": "org_glassfish_grizzly.grizzly_framework.ServiceFinderInnerLazyIteratorTest$SampleServiceProvider"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.utils.ServiceFinder$LazyIterator"
+      },
+      "glob": "META-INF/services/org_glassfish_grizzly.grizzly_framework.ServiceFinderInnerLazyIteratorTest$MissingService"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.utils.ServiceFinder$LazyIterator"
+      },
+      "glob": "META-INF/services/org_glassfish_grizzly.grizzly_framework.ServiceFinderTest$EmptyService"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.localization.Localizer"
+      },
+      "bundle": "LocalizerFallbackMessages"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.localization.Localizer"
+      },
+      "bundle": "org_glassfish_grizzly.grizzly_framework.LocalizerFallbackMessages"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.localization.Localizer"
+      },
+      "bundle": "org_glassfish_grizzly.grizzly_framework.LocalizerMessages"
+    }
+  ]
+}

--- a/metadata/org.glassfish.grizzly/grizzly-framework/2.3.6/reachability-metadata.json
+++ b/metadata/org.glassfish.grizzly/grizzly-framework/2.3.6/reachability-metadata.json
@@ -140,6 +140,194 @@
     },
     {
       "condition": {
+        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type": "java.lang.Enum$EnumDesc"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type": "java.lang.constant.ClassDesc"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type": "java.lang.constant.ConstantDesc[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type": "java.lang.constant.DirectMethodHandleDesc"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type": "java.lang.constant.DirectMethodHandleDesc$Kind"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type": "java.lang.constant.DynamicConstantDesc"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type": "java.lang.constant.MethodHandleDesc"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type": "java.lang.reflect.AccessFlag"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type": "java.net.URL"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type": "java.security.CodeSource"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type": "java.security.ProtectionDomain"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type": "java.util.Locale$Category"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type": "org.glassfish.gmbal.impl.ManagedObjectManagerImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type": {
+        "proxy": [
+          "com.oracle.svm.shared.Uninterruptible"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.Deprecated"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.FunctionalInterface"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.SafeVarargs"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Inherited"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type": {
+        "proxy": [
+          "jdk.internal.ValueBased"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type": {
+        "proxy": [
+          "jdk.internal.reflect.CallerSensitive"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type": {
+        "proxy": [
+          "jdk.internal.vm.annotation.ForceInline"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type": {
+        "proxy": [
+          "jdk.internal.vm.annotation.IntrinsicCandidate"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager"
+      },
+      "type": {
+        "proxy": [
+          "org.glassfish.gmbal.AMXMetadata"
+        ]
+      }
+    },
+    {
+      "condition": {
         "typeReached": "org.glassfish.grizzly.monitoring.MonitoringUtils"
       },
       "type": "org.glassfish.grizzly.TransformationException",

--- a/metadata/org.glassfish.grizzly/grizzly-framework/index.json
+++ b/metadata/org.glassfish.grizzly/grizzly-framework/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.3.6",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/glassfish/grizzly/grizzly-framework/$version$/grizzly-framework-$version$-sources.jar",
+    "repository-url" : "https://github.com/javaee/grizzly",
+    "test-code-url" : "https://github.com/javaee/grizzly/tree/2_3_6/modules/grizzly/src/test?version=$version$",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/glassfish/grizzly/grizzly-framework/$version$/grizzly-framework-$version$-javadoc.jar",
+    "description" : "Grizzly Framework provides the core Java NIO runtime used to build scalable asynchronous network clients and servers. It supplies TCP and UDP transports, filter chains, buffers, memory management, thread pools, SSL support, and monitoring hooks used by higher-level Grizzly modules.",
     "tested-versions" : [
       "2.3.6"
     ],

--- a/metadata/org.glassfish.grizzly/grizzly-framework/index.json
+++ b/metadata/org.glassfish.grizzly/grizzly-framework/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.3.6",
+    "tested-versions" : [
+      "2.3.6"
+    ],
+    "allowed-packages" : [
+      "org.glassfish.grizzly"
+    ]
+  },
+  {
     "metadata-version" : "2.1.2",
     "source-code-url" : "https://repo1.maven.org/maven2/org/glassfish/grizzly/grizzly-framework/$version$/grizzly-framework-$version$-sources.jar",
     "repository-url" : "https://github.com/javaee/grizzly",

--- a/stats/org.glassfish.grizzly/grizzly-framework/2.3.6/execution-metrics.json
+++ b/stats/org.glassfish.grizzly/grizzly-framework/2.3.6/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_java_run_fail:2026-05-18": {
+    "timestamp": "2026-05-18T22:53:31.108222Z",
+    "library": "org.glassfish.grizzly:grizzly-framework:2.3.6",
+    "starting_commit": "a269519f05e148101c9c0ac6942f47ca5fc9ef52",
+    "ending_commit": "39cec5ab54de99fe386005e54dccb702b653d01b",
+    "previous_library": "org.glassfish.grizzly:grizzly-framework:2.1.2",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.3.6",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 47,
+            "totalCalls": 47
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 51,
+        "totalCalls": 51
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5446,
+          "missed": 63533,
+          "ratio": 0.078952,
+          "total": 68979
+        },
+        "line": {
+          "covered": 1356,
+          "missed": 15105,
+          "ratio": 0.082377,
+          "total": 16461
+        },
+        "method": {
+          "covered": 347,
+          "missed": 3531,
+          "ratio": 0.089479,
+          "total": 3878
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.1.2",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 15,
+            "totalCalls": 15
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 19,
+        "totalCalls": 19
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2510,
+          "missed": 53756,
+          "ratio": 0.04461,
+          "total": 56266
+        },
+        "line": {
+          "covered": 630,
+          "missed": 12903,
+          "ratio": 0.046553,
+          "total": 13533
+        },
+        "method": {
+          "covered": 180,
+          "missed": 3059,
+          "ratio": 0.055573,
+          "total": 3239
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 451828,
+      "cached_input_tokens_used": 4693504,
+      "output_tokens_used": 59305,
+      "iterations": 15,
+      "cost_usd": 4.126,
+      "tested_library_loc": 1356,
+      "metadata_entries": 77,
+      "test_only_metadata_entries": 2,
+      "previous_library_metadata_entries": 19,
+      "previous_library_test_only_metadata_entries": 2,
+      "code_coverage_percent": 8.24,
+      "previous_library_coverage_percent": 4.66
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/ServiceFinderInnerLazyIteratorTest.java",
+      "metadata_file": "metadata/org.glassfish.grizzly/grizzly-framework/2.3.6/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.glassfish.grizzly/grizzly-framework/2.3.6/stats.json
+++ b/stats/org.glassfish.grizzly/grizzly-framework/2.3.6/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "2.3.6",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 47,
+          "totalCalls" : 47
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 4,
+          "totalCalls" : 4
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 51,
+      "totalCalls" : 51
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 5446,
+        "missed" : 63533,
+        "ratio" : 0.078952,
+        "total" : 68979
+      },
+      "line" : {
+        "covered" : 1356,
+        "missed" : 15105,
+        "ratio" : 0.082377,
+        "total" : 16461
+      },
+      "method" : {
+        "covered" : 347,
+        "missed" : 3531,
+        "ratio" : 0.089479,
+        "total" : 3878
+      }
+    }
+  } ]
+}

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/.gitignore
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/build.gradle
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/build.gradle
@@ -16,6 +16,15 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
+tasks.withType(Test).configureEach {
+    systemProperty "org.glassfish.grizzly.DEFAULT_MEMORY_MANAGER",
+            "org.glassfish.grizzly.memory.ByteBufferManager"
+}
+
+tasks.named("nativeTest") {
+    runtimeArgs.add("-Dorg.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.ByteBufferManager")
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/build.gradle
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/build.gradle
@@ -9,6 +9,8 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+String configuredSelectionKeyHandlerClass =
+        'org_glassfish_grizzly.grizzly_framework.SelectionKeyHandlerInitializerTest$ConfiguredSelectionKeyHandler'
 
 dependencies {
     testImplementation "org.glassfish.grizzly:grizzly-framework:$libraryVersion"
@@ -19,13 +21,21 @@ dependencies {
 tasks.withType(Test).configureEach {
     systemProperty "org.glassfish.grizzly.DEFAULT_MEMORY_MANAGER",
             "org.glassfish.grizzly.memory.ByteBufferManager"
+    systemProperty "org.glassfish.grizzly.DEFAULT_SELECTION_KEY_HANDLER", configuredSelectionKeyHandlerClass
 }
 
 tasks.named("nativeTest") {
     runtimeArgs.add("-Dorg.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.ByteBufferManager")
+    runtimeArgs.add("-Dorg.glassfish.grizzly.DEFAULT_SELECTION_KEY_HANDLER=${configuredSelectionKeyHandlerClass}")
 }
 
 graalvmNative {
+    binaries {
+        test {
+            buildArgs.add("-Dorg.glassfish.grizzly.DEFAULT_SELECTION_KEY_HANDLER=${configuredSelectionKeyHandlerClass}")
+        }
+    }
+
     agent {
         defaultMode = "conditional"
         modes {

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/build.gradle
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/build.gradle
@@ -12,12 +12,8 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.glassfish.grizzly:grizzly-framework:$libraryVersion"
+    testImplementation "org.glassfish.grizzly:grizzly-framework-monitoring:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-}
-
-test {
-    systemProperty "org.glassfish.grizzly.DEFAULT_ATTRIBUTE_BUILDER",
-            "org_glassfish_grizzly.grizzly_framework.AttributeBuilderInitializerTest\$ConfiguredAttributeBuilder"
 }
 
 graalvmNative {

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/build.gradle
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.glassfish.grizzly:grizzly-framework:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/build.gradle
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/build.gradle
@@ -15,6 +15,11 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
+test {
+    systemProperty "org.glassfish.grizzly.DEFAULT_ATTRIBUTE_BUILDER",
+            "org_glassfish_grizzly.grizzly_framework.AttributeBuilderInitializerTest\$ConfiguredAttributeBuilder"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/gradle.properties
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.glassfish.grizzly:grizzly-framework:2.3.6
+library.version = 2.3.6
+metadata.dir = org.glassfish.grizzly/grizzly-framework/2.3.6/

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/settings.gradle
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.glassfish.grizzly.grizzly-framework_tests'

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org/glassfish/grizzly/attributes/AttributeBuilderTestAccess.java
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org/glassfish/grizzly/attributes/AttributeBuilderTestAccess.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.glassfish.grizzly.attributes;
+
+/**
+ * Package-private bridge for testing builder initialization without relying on
+ * global static initialization timing in the native test image.
+ */
+public final class AttributeBuilderTestAccess {
+    private AttributeBuilderTestAccess() {
+    }
+
+    public static AttributeBuilder initBuilder() {
+        return AttributeBuilderInitializer.initBuilder();
+    }
+}

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/AbstractBufferArrayTest.java
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/AbstractBufferArrayTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_grizzly.grizzly_framework;
+
+import org.glassfish.grizzly.memory.ByteBufferArray;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AbstractBufferArrayTest {
+    @Test
+    void createsTypedArrayAndRestoresBufferState() {
+        ByteBufferArray[] arrays = new ByteBufferArray[5];
+
+        try {
+            for (int i = 0; i < arrays.length; i++) {
+                arrays[i] = ByteBufferArray.create();
+            }
+
+            ByteBufferArray array = arrays[arrays.length - 1];
+            ByteBuffer first = ByteBuffer.allocate(8);
+            first.position(2);
+            first.limit(6);
+            ByteBuffer second = ByteBuffer.allocate(4);
+            second.position(1);
+            second.limit(3);
+
+            array.add(first, 0, 8);
+            array.add(second);
+
+            assertThat(array.size()).isEqualTo(2);
+            assertThat(array.getArray()).isInstanceOf(ByteBuffer[].class);
+            assertThat(array.getInitialPosition(0)).isEqualTo(2);
+            assertThat(array.getInitialLimit(0)).isEqualTo(6);
+            assertThat(array.getInitialBufferSize(0)).isEqualTo(4);
+            assertThat(array.getInitialPosition(1)).isEqualTo(1);
+            assertThat(array.getInitialLimit(1)).isEqualTo(3);
+
+            first.position(4);
+            first.limit(5);
+            second.position(2);
+            second.limit(4);
+
+            array.restore();
+
+            assertThat(first.position()).isZero();
+            assertThat(first.limit()).isEqualTo(8);
+            assertThat(second.position()).isEqualTo(1);
+            assertThat(second.limit()).isEqualTo(3);
+        } finally {
+            for (ByteBufferArray array : arrays) {
+                if (array != null) {
+                    array.recycle();
+                }
+            }
+        }
+    }
+}

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/ArraySetTest.java
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/ArraySetTest.java
@@ -17,6 +17,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ArraySetTest {
     @Test
+    void addInitializesTypedBackingArray() {
+        ArraySet<String> set = new ArraySet<>(String.class);
+
+        boolean changed = set.add("direct");
+
+        assertThat(changed).isTrue();
+        assertThat(set.getArray())
+                .isInstanceOf(String[].class)
+                .containsExactly("direct");
+    }
+
+    @Test
     void createsTypedEmptyArrayForElementClass() {
         ArraySet<String> set = new ArraySet<>(String.class);
 

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/ArraySetTest.java
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/ArraySetTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_grizzly.grizzly_framework;
+
+import org.glassfish.grizzly.utils.ArraySet;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ArraySetTest {
+    @Test
+    void createsTypedEmptyArrayForElementClass() {
+        ArraySet<String> set = new ArraySet<>(String.class);
+
+        String[] values = set.obtainArrayCopy();
+
+        assertThat(values).isInstanceOf(String[].class);
+        assertThat(values).isEmpty();
+    }
+
+    @Test
+    void varargsAddAllInitializesTypedBackingArray() {
+        ArraySet<String> set = new ArraySet<>(String.class);
+
+        boolean changed = set.addAll("alpha", "beta", "alpha");
+
+        assertThat(changed).isTrue();
+        assertThat(set.getArray())
+                .isInstanceOf(String[].class)
+                .containsExactly("alpha", "beta");
+    }
+
+    @Test
+    void collectionAddAllInitializesTypedBackingArray() {
+        ArraySet<String> set = new ArraySet<>(String.class);
+        List<String> values = Arrays.asList("one", "two", "one");
+
+        boolean changed = set.addAll(values);
+
+        assertThat(changed).isTrue();
+        assertThat(set.getArray())
+                .isInstanceOf(String[].class)
+                .contains("one", "two");
+    }
+
+    @Test
+    void retainAllRebuildsTypedBackingArrayWithKeptValues() {
+        ArraySet<String> set = new ArraySet<>(String.class);
+        set.addAll("alpha", "beta", "gamma");
+
+        boolean changed = set.retainAll(Arrays.asList("beta", "gamma", "delta"));
+
+        assertThat(changed).isTrue();
+        assertThat(set.getArray())
+                .isInstanceOf(String[].class)
+                .containsExactly("beta", "gamma");
+    }
+
+    @Test
+    void removeAllCollectionRebuildsTypedBackingArrayWithoutRemovedValues() {
+        ArraySet<String> set = new ArraySet<>(String.class);
+        set.addAll("alpha", "beta", "gamma");
+
+        boolean changed = set.removeAll(Collections.singleton("beta"));
+
+        assertThat(changed).isTrue();
+        assertThat(set.getArray())
+                .isInstanceOf(String[].class)
+                .containsExactly("alpha", "gamma");
+    }
+}

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/ArrayUtilsTest.java
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/ArrayUtilsTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_grizzly.grizzly_framework;
+
+import org.glassfish.grizzly.utils.ArrayUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ArrayUtilsTest {
+    @Test
+    void removeCreatesTypedArrayWithoutRemovedElement() {
+        String[] values = {"alpha", "beta", "gamma"};
+
+        String[] result = ArrayUtils.remove(values, "beta");
+
+        assertThat(result)
+                .isInstanceOf(String[].class)
+                .containsExactly("alpha", "gamma");
+    }
+}

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/AttributeBuilderInitializerTest.java
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/AttributeBuilderInitializerTest.java
@@ -8,6 +8,7 @@ package org_glassfish_grizzly.grizzly_framework;
 
 import org.glassfish.grizzly.attributes.Attribute;
 import org.glassfish.grizzly.attributes.AttributeBuilder;
+import org.glassfish.grizzly.attributes.AttributeBuilderTestAccess;
 import org.glassfish.grizzly.attributes.DefaultAttributeBuilder;
 import org.junit.jupiter.api.Test;
 
@@ -23,7 +24,7 @@ public class AttributeBuilderInitializerTest {
         System.setProperty(DEFAULT_ATTRIBUTE_BUILDER_PROPERTY, ConfiguredAttributeBuilder.class.getName());
 
         try {
-            AttributeBuilder builder = AttributeBuilder.DEFAULT_ATTRIBUTE_BUILDER;
+            AttributeBuilder builder = AttributeBuilderTestAccess.initBuilder();
             Attribute<String> attribute = builder.createAttribute("configured-builder-attribute", "configured-value");
 
             assertThat(builder).isExactlyInstanceOf(ConfiguredAttributeBuilder.class);

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/AttributeBuilderInitializerTest.java
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/AttributeBuilderInitializerTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_grizzly.grizzly_framework;
+
+import org.glassfish.grizzly.attributes.Attribute;
+import org.glassfish.grizzly.attributes.AttributeBuilder;
+import org.glassfish.grizzly.attributes.DefaultAttributeBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AttributeBuilderInitializerTest {
+    private static final String DEFAULT_ATTRIBUTE_BUILDER_PROPERTY =
+            "org.glassfish.grizzly.DEFAULT_ATTRIBUTE_BUILDER";
+
+    @Test
+    void defaultAttributeBuilderUsesConfiguredPublicBuilderClass() {
+        String previousBuilderClass = System.getProperty(DEFAULT_ATTRIBUTE_BUILDER_PROPERTY);
+        System.setProperty(DEFAULT_ATTRIBUTE_BUILDER_PROPERTY, ConfiguredAttributeBuilder.class.getName());
+
+        try {
+            AttributeBuilder builder = AttributeBuilder.DEFAULT_ATTRIBUTE_BUILDER;
+            Attribute<String> attribute = builder.createAttribute("configured-builder-attribute", "configured-value");
+
+            assertThat(builder).isExactlyInstanceOf(ConfiguredAttributeBuilder.class);
+            assertThat(attribute.toString()).contains("configured-builder-attribute");
+        } finally {
+            restoreDefaultAttributeBuilderProperty(previousBuilderClass);
+        }
+    }
+
+    private static void restoreDefaultAttributeBuilderProperty(String previousBuilderClass) {
+        if (previousBuilderClass == null) {
+            System.clearProperty(DEFAULT_ATTRIBUTE_BUILDER_PROPERTY);
+        } else {
+            System.setProperty(DEFAULT_ATTRIBUTE_BUILDER_PROPERTY, previousBuilderClass);
+        }
+    }
+
+    public static class ConfiguredAttributeBuilder extends DefaultAttributeBuilder {
+        public ConfiguredAttributeBuilder() {
+        }
+    }
+}

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/ConcurrentHashMapV8InnerCollectionViewTest.java
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/ConcurrentHashMapV8InnerCollectionViewTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_grizzly.grizzly_framework;
+
+import org.glassfish.grizzly.utils.DataStructures;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConcurrentHashMapV8InnerCollectionViewTest {
+    @Test
+    void createsTypedArrayForMapKeyCollectionView() {
+        ConcurrentMap<String, Integer> map = DataStructures.getConcurrentMap();
+        map.put("alpha", 1);
+        map.put("bravo", 2);
+
+        Set<String> keys = map.keySet();
+        String[] keyArray = keys.toArray(new String[0]);
+
+        assertThat(map.getClass().getName()).isEqualTo("org.glassfish.grizzly.utils.ConcurrentHashMapV8");
+        assertThat(keys.getClass().getName())
+                .isEqualTo("org.glassfish.grizzly.utils.ConcurrentHashMapV8$KeySetView");
+        assertThat(keyArray)
+                .containsExactlyInAnyOrder("alpha", "bravo");
+    }
+}

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/ConcurrentHashMapV8Test.java
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/ConcurrentHashMapV8Test.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_grizzly.grizzly_framework;
+
+import org.glassfish.grizzly.utils.DataStructures;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.concurrent.ConcurrentMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConcurrentHashMapV8Test {
+    @Test
+    void serializesAndDeserializesConcurrentMapEntries() throws Exception {
+        ConcurrentMap<String, Integer> map = DataStructures.getConcurrentMap();
+        map.put("first", 1);
+        map.put("second", 2);
+
+        assertThat(map.getClass().getName()).isEqualTo("org.glassfish.grizzly.utils.ConcurrentHashMapV8");
+
+        byte[] serialized = serialize(map);
+
+        ConcurrentMap<String, Integer> restored = deserialize(serialized);
+        assertThat(restored.getClass().getName()).isEqualTo("org.glassfish.grizzly.utils.ConcurrentHashMapV8");
+        assertThat(restored)
+                .containsEntry("first", 1)
+                .containsEntry("second", 2)
+                .hasSize(2);
+    }
+
+    private static byte[] serialize(ConcurrentMap<String, Integer> map) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+            output.writeObject(map);
+        }
+        return bytes.toByteArray();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ConcurrentMap<String, Integer> deserialize(byte[] serialized) throws Exception {
+        try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            return (ConcurrentMap<String, Integer>) input.readObject();
+        }
+    }
+}

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/DataStructuresTest.java
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/DataStructuresTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_grizzly.grizzly_framework;
+
+import org.glassfish.grizzly.utils.DataStructures;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.BlockingQueue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DataStructuresTest {
+    @Test
+    void createsLinkedTransferQueueInstance() throws Exception {
+        BlockingQueue<String> queue = DataStructures.getLTQInstance();
+
+        queue.put("value");
+
+        assertThat(queue.getClass().getName()).isEqualTo("java.util.concurrent.LinkedTransferQueue");
+        assertThat(queue.take()).isEqualTo("value");
+        assertThat(queue).isEmpty();
+    }
+
+    @Test
+    void createsLinkedTransferQueueInstanceFromTypedFactoryMethod() {
+        BlockingQueue<Integer> queue = DataStructures.getLTQInstance(Integer.class);
+
+        assertThat(queue.offer(42)).isTrue();
+        assertThat(queue.poll()).isEqualTo(42);
+        assertThat(queue).isEmpty();
+    }
+}

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/GrizzlyJmxManagerTest.java
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/GrizzlyJmxManagerTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_grizzly.grizzly_framework;
+
+import org.glassfish.grizzly.jmxbase.GrizzlyJmxManager;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GrizzlyJmxManagerTest {
+    @Test
+    void instanceLoadsDefaultJmxManagerWhenMonitoringImplementationIsAvailable() {
+        GrizzlyJmxManager manager = GrizzlyJmxManager.instance();
+
+        assertThat(manager).isNotNull();
+        assertThat(manager.getClass().getName()).isEqualTo("org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager");
+    }
+}

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/LinkedTransferQueueTest.java
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/LinkedTransferQueueTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_grizzly.grizzly_framework;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.concurrent.BlockingQueue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LinkedTransferQueueTest {
+    private static final String LINKED_TRANSFER_QUEUE_CLASS_NAME =
+            "org.glassfish.grizzly.utils.LinkedTransferQueue";
+
+    @Test
+    void serializesAndDeserializesQueueElements() throws Exception {
+        BlockingQueue<Object> queue = deserialize(serializedQueueWithTwoElements());
+
+        assertThat(queue.getClass().getName()).isEqualTo(LINKED_TRANSFER_QUEUE_CLASS_NAME);
+        assertThat(queue).containsExactly("first", "second");
+
+        byte[] serialized = serialize(queue);
+        BlockingQueue<Object> restored = deserialize(serialized);
+
+        assertThat(restored.getClass().getName()).isEqualTo(LINKED_TRANSFER_QUEUE_CLASS_NAME);
+        assertThat(restored).containsExactly("first", "second");
+    }
+
+    private static byte[] serializedQueueWithTwoElements() {
+        return hexToBytes("""
+                ac ed 00 05 73 72 00 2f 6f 72 67 2e 67 6c 61 73
+                73 66 69 73 68 2e 67 72 69 7a 7a 6c 79 2e 75 74
+                69 6c 73 2e 4c 69 6e 6b 65 64 54 72 61 6e 73 66
+                65 72 51 75 65 75 65 d3 45 33 6e 1f 5c 3e 9a 03
+                00 00 78 70 74 00 05 66 69 72 73 74 74 00 06 73
+                65 63 6f 6e 64 70 78
+                """);
+    }
+
+    private static byte[] serialize(BlockingQueue<?> queue) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+            output.writeObject(queue);
+        }
+        return bytes.toByteArray();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static BlockingQueue<Object> deserialize(byte[] serialized) throws Exception {
+        try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            Object value = input.readObject();
+            assertThat(value).isInstanceOf(BlockingQueue.class);
+            return (BlockingQueue<Object>) value;
+        }
+    }
+
+    private static byte[] hexToBytes(String hex) {
+        String normalized = hex.replaceAll("\\s+", "");
+        assertThat(normalized.length() % 2).isZero();
+
+        byte[] bytes = new byte[normalized.length() / 2];
+        for (int i = 0; i < bytes.length; i++) {
+            int fromIndex = i * 2;
+            bytes[i] = (byte) Integer.parseInt(normalized.substring(fromIndex, fromIndex + 2), 16);
+        }
+        return bytes;
+    }
+}

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/LocalizerTest.java
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/LocalizerTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_grizzly.grizzly_framework;
+
+import org.glassfish.grizzly.localization.Localizable;
+import org.glassfish.grizzly.localization.Localizer;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LocalizerTest {
+    private static final String PACKAGE_BUNDLE =
+            "org_glassfish_grizzly.grizzly_framework.LocalizerMessages";
+    private static final String FALLBACK_BUNDLE =
+            "org_glassfish_grizzly.grizzly_framework.LocalizerFallbackMessages";
+
+    @Test
+    void localizesMessageFromPackageResourceBundle() {
+        Localizer localizer = new Localizer(Locale.US);
+
+        String message = localizer.localize(localizable(PACKAGE_BUNDLE, "greeting", "Grizzly"));
+
+        assertThat(message).isEqualTo("Hello Grizzly");
+    }
+
+    @Test
+    void localizesMessageFromTopLevelFallbackBundle() {
+        Localizer localizer = new Localizer(Locale.US);
+
+        String message = localizer.localize(localizable(FALLBACK_BUNDLE, "fallback", "resource"));
+
+        assertThat(message).isEqualTo("Fallback resource");
+    }
+
+    private static Localizable localizable(String bundleName, String key, Object... arguments) {
+        return new Localizable() {
+            @Override
+            public String getKey() {
+                return key;
+            }
+
+            @Override
+            public Object[] getArguments() {
+                return arguments;
+            }
+
+            @Override
+            public String getResourceBundleName() {
+                return bundleName;
+            }
+        };
+    }
+}

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/MemoryManagerInitializerTest.java
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/MemoryManagerInitializerTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_grizzly.grizzly_framework;
+
+import org.glassfish.grizzly.memory.ByteBufferManager;
+import org.glassfish.grizzly.memory.MemoryManager;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MemoryManagerInitializerTest {
+    private static final String DEFAULT_MEMORY_MANAGER_PROPERTY =
+            "org.glassfish.grizzly.DEFAULT_MEMORY_MANAGER";
+
+    @Test
+    void defaultMemoryManagerUsesConfiguredPublicManagerClass() {
+        String configuredManagerClass = ByteBufferManager.class.getName();
+
+        assertThat(System.getProperty(DEFAULT_MEMORY_MANAGER_PROPERTY)).isEqualTo(configuredManagerClass);
+        assertThat(MemoryManager.DEFAULT_MEMORY_MANAGER).isExactlyInstanceOf(ByteBufferManager.class);
+    }
+}

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/MonitoringUtilsTest.java
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/MonitoringUtilsTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_grizzly.grizzly_framework;
+
+import org.glassfish.grizzly.TransformationException;
+import org.glassfish.grizzly.monitoring.MonitoringUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MonitoringUtilsTest {
+    @Test
+    void loadJmxObjectCreatesObjectWithExplicitConstructorType() {
+        String message = "grizzly-monitoring";
+
+        Object jmxObject = MonitoringUtils.loadJmxObject(TransformationException.class.getName(), message, String.class);
+
+        assertThat(jmxObject).isInstanceOf(TransformationException.class);
+        assertThat(((TransformationException) jmxObject).getMessage()).isEqualTo(message);
+    }
+}

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/NIOTransportBuilderTest.java
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/NIOTransportBuilderTest.java
@@ -24,18 +24,20 @@ public class NIOTransportBuilderTest {
         TCPNIOTransportBuilder builder = TCPNIOTransportBuilder.newInstance();
 
         TCPNIOTransport transport = builder.build();
-        ThreadPoolConfig selectorConfig = builder.getSelectorThreadPoolConfig();
-        int expectedSelectorRunnerCount = Runtime.getRuntime().availableProcessors();
+        ThreadPoolConfig workerConfig = transport.getWorkerThreadPoolConfig();
+        ThreadPoolConfig kernelConfig = transport.getKernelThreadPoolConfig();
+        int availableProcessors = Runtime.getRuntime().availableProcessors();
 
         assertThat(transport).isNotNull();
-        assertThat(builder.getIOStrategy()).isSameAs(WorkerThreadIOStrategy.getInstance());
-        assertThat(builder.getMemoryManager()).isSameAs(MemoryManager.DEFAULT_MEMORY_MANAGER);
-        assertThat(builder.getAttributeBuilder()).isSameAs(AttributeBuilder.DEFAULT_ATTRIBUTE_BUILDER);
-        assertThat(builder.getSelectorHandler()).isSameAs(SelectorHandler.DEFAULT_SELECTOR_HANDLER);
-        assertThat(builder.getSelectionKeyHandler()).isSameAs(SelectionKeyHandler.DEFAULT_SELECTION_KEY_HANDLER);
-        assertThat(builder.getWorkerThreadPoolConfig()).isNotNull();
-        assertThat(selectorConfig.getCorePoolSize()).isEqualTo(expectedSelectorRunnerCount);
-        assertThat(selectorConfig.getMaxPoolSize()).isEqualTo(expectedSelectorRunnerCount);
-        assertThat(transport.getSelectorRunnersCount()).isEqualTo(expectedSelectorRunnerCount);
+        assertThat(transport.getIOStrategy()).isSameAs(WorkerThreadIOStrategy.getInstance());
+        assertThat(transport.getMemoryManager()).isSameAs(MemoryManager.DEFAULT_MEMORY_MANAGER);
+        assertThat(transport.getAttributeBuilder()).isSameAs(AttributeBuilder.DEFAULT_ATTRIBUTE_BUILDER);
+        assertThat(transport.getSelectorHandler()).isSameAs(SelectorHandler.DEFAULT_SELECTOR_HANDLER);
+        assertThat(transport.getSelectionKeyHandler()).isSameAs(SelectionKeyHandler.DEFAULT_SELECTION_KEY_HANDLER);
+        assertThat(workerConfig).isNotNull();
+        assertThat(workerConfig.getCorePoolSize()).isEqualTo(availableProcessors * 2);
+        assertThat(workerConfig.getMaxPoolSize()).isEqualTo(availableProcessors * 2);
+        assertThat(kernelConfig).isNotNull();
+        assertThat(transport.getSelectorRunnersCount()).isEqualTo(availableProcessors + 1);
     }
 }

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/NIOTransportBuilderTest.java
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/NIOTransportBuilderTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_grizzly.grizzly_framework;
+
+import org.glassfish.grizzly.attributes.AttributeBuilder;
+import org.glassfish.grizzly.memory.MemoryManager;
+import org.glassfish.grizzly.nio.SelectionKeyHandler;
+import org.glassfish.grizzly.nio.SelectorHandler;
+import org.glassfish.grizzly.nio.transport.TCPNIOTransport;
+import org.glassfish.grizzly.nio.transport.TCPNIOTransportBuilder;
+import org.glassfish.grizzly.strategies.WorkerThreadIOStrategy;
+import org.glassfish.grizzly.threadpool.ThreadPoolConfig;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NIOTransportBuilderTest {
+    @Test
+    void tcpBuilderCreatesTransportWithDefaultNioConfiguration() {
+        TCPNIOTransportBuilder builder = TCPNIOTransportBuilder.newInstance();
+
+        TCPNIOTransport transport = builder.build();
+        ThreadPoolConfig selectorConfig = builder.getSelectorThreadPoolConfig();
+        int expectedSelectorRunnerCount = Runtime.getRuntime().availableProcessors();
+
+        assertThat(transport).isNotNull();
+        assertThat(builder.getIOStrategy()).isSameAs(WorkerThreadIOStrategy.getInstance());
+        assertThat(builder.getMemoryManager()).isSameAs(MemoryManager.DEFAULT_MEMORY_MANAGER);
+        assertThat(builder.getAttributeBuilder()).isSameAs(AttributeBuilder.DEFAULT_ATTRIBUTE_BUILDER);
+        assertThat(builder.getSelectorHandler()).isSameAs(SelectorHandler.DEFAULT_SELECTOR_HANDLER);
+        assertThat(builder.getSelectionKeyHandler()).isSameAs(SelectionKeyHandler.DEFAULT_SELECTION_KEY_HANDLER);
+        assertThat(builder.getWorkerThreadPoolConfig()).isNotNull();
+        assertThat(selectorConfig.getCorePoolSize()).isEqualTo(expectedSelectorRunnerCount);
+        assertThat(selectorConfig.getMaxPoolSize()).isEqualTo(expectedSelectorRunnerCount);
+        assertThat(transport.getSelectorRunnersCount()).isEqualTo(expectedSelectorRunnerCount);
+    }
+}

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/SelectionKeyHandlerInitializerTest.java
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/SelectionKeyHandlerInitializerTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_grizzly.grizzly_framework;
+
+import org.glassfish.grizzly.IOEvent;
+import org.glassfish.grizzly.nio.DefaultSelectionKeyHandler;
+import org.glassfish.grizzly.nio.NIOConnection;
+import org.glassfish.grizzly.nio.SelectionKeyHandler;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.channels.SelectionKey;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SelectionKeyHandlerInitializerTest {
+    private static final String DEFAULT_SELECTION_KEY_HANDLER_PROPERTY =
+            "org.glassfish.grizzly.DEFAULT_SELECTION_KEY_HANDLER";
+
+    @Test
+    void defaultSelectionKeyHandlerUsesConfiguredPublicHandlerClass() {
+        assertThat(System.getProperty(DEFAULT_SELECTION_KEY_HANDLER_PROPERTY))
+                .isEqualTo(ConfiguredSelectionKeyHandler.class.getName());
+        assertThat(SelectionKeyHandler.DEFAULT_SELECTION_KEY_HANDLER)
+                .isExactlyInstanceOf(ConfiguredSelectionKeyHandler.class);
+    }
+
+    public static class ConfiguredSelectionKeyHandler implements SelectionKeyHandler {
+        private final SelectionKeyHandler delegate = new DefaultSelectionKeyHandler();
+
+        public ConfiguredSelectionKeyHandler() {
+        }
+
+        @Override
+        public void onKeyRegistered(SelectionKey key) {
+            delegate.onKeyRegistered(key);
+        }
+
+        @Override
+        public void onKeyDeregistered(SelectionKey key) {
+            delegate.onKeyDeregistered(key);
+        }
+
+        @Override
+        public boolean onProcessInterest(SelectionKey key, int interest) throws IOException {
+            return delegate.onProcessInterest(key, interest);
+        }
+
+        @Override
+        public void cancel(SelectionKey key) throws IOException {
+            delegate.cancel(key);
+        }
+
+        @Override
+        public NIOConnection getConnectionForKey(SelectionKey selectionKey) {
+            return delegate.getConnectionForKey(selectionKey);
+        }
+
+        @Override
+        public void setConnectionForKey(NIOConnection connection, SelectionKey selectionKey) {
+            delegate.setConnectionForKey(connection, selectionKey);
+        }
+
+        @Override
+        public int ioEvent2SelectionKeyInterest(IOEvent ioEvent) {
+            return delegate.ioEvent2SelectionKeyInterest(ioEvent);
+        }
+
+        @Override
+        public IOEvent selectionKeyInterest2IoEvent(int selectionKeyInterest) {
+            return delegate.selectionKeyInterest2IoEvent(selectionKeyInterest);
+        }
+
+        @Override
+        public IOEvent[] getIOEvents(int interest) {
+            return delegate.getIOEvents(interest);
+        }
+    }
+}

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/ServiceFinderInnerLazyIteratorTest.java
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/ServiceFinderInnerLazyIteratorTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_grizzly.grizzly_framework;
+
+import org.glassfish.grizzly.utils.ServiceFinder;
+import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ServiceFinderInnerLazyIteratorTest {
+    @Test
+    void discoversAndInstantiatesProviderWithExplicitClassLoader() {
+        ClassLoader classLoader = ServiceFinderInnerLazyIteratorTest.class.getClassLoader();
+        Iterator<SampleService> providers = ServiceFinder.find(SampleService.class, classLoader).iterator();
+
+        assertThat(providers.hasNext()).isTrue();
+        SampleService provider = providers.next();
+
+        assertThat(provider.name()).isEqualTo("sample-provider");
+        assertThat(providers.hasNext()).isFalse();
+    }
+
+    @Test
+    void queriesSystemResourcesWhenNoClassLoaderIsProvided() {
+        Iterator<MissingService> providers = ServiceFinder.find(MissingService.class, null).iterator();
+
+        assertThat(providers.hasNext()).isFalse();
+    }
+
+    public interface SampleService {
+        String name();
+    }
+
+    public static class SampleServiceProvider implements SampleService {
+        @Override
+        public String name() {
+            return "sample-provider";
+        }
+    }
+
+    public interface MissingService {
+    }
+}

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/ServiceFinderTest.java
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/ServiceFinderTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_grizzly.grizzly_framework;
+
+import org.glassfish.grizzly.utils.ServiceFinder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ServiceFinderTest {
+    @Test
+    void toArrayReturnsTypedEmptyArrayWhenNoProviderIsConfigured() {
+        EmptyService[] providers = ServiceFinder.find(EmptyService.class, getClass().getClassLoader()).toArray();
+
+        assertThat(providers).isEmpty();
+        assertThat(providers).isInstanceOf(EmptyService[].class);
+    }
+
+    public interface EmptyService {
+    }
+}

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/UDPNIOConnectionTest.java
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/UDPNIOConnectionTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_grizzly.grizzly_framework;
+
+import java.io.IOException;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.net.StandardProtocolFamily;
+import java.nio.channels.DatagramChannel;
+import java.util.Enumeration;
+import org.glassfish.grizzly.nio.transport.UDPNIOConnection;
+import org.glassfish.grizzly.nio.transport.UDPNIOTransport;
+import org.glassfish.grizzly.nio.transport.UDPNIOTransportBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UDPNIOConnectionTest {
+    @Test
+    void multicastLifecycleUsesJdkMembershipMethods() throws Exception {
+        UDPNIOTransport transport = UDPNIOTransportBuilder.newInstance().build();
+        try (DatagramChannel channel = DatagramChannel.open(StandardProtocolFamily.INET)) {
+            channel.bind(new InetSocketAddress(0));
+
+            UDPNIOConnection connection = new UDPNIOConnection(transport, channel);
+            InetAddress group = InetAddress.getByName("230.0.0.1");
+            InetAddress source = InetAddress.getByName("127.0.0.1");
+            NetworkInterface networkInterface = firstIpv4NetworkInterface();
+
+            boolean joined = tryJoin(connection, group, networkInterface);
+            if (joined) {
+                tryBlockAndUnblock(connection, group, networkInterface, source);
+                connection.drop(group, networkInterface);
+            }
+
+            assertThat(connection.isConnected()).isFalse();
+            assertThat(connection.getLocalAddress()).isNotNull();
+            assertThat(connection.toString()).contains("UDPNIOConnection");
+        } finally {
+            transport.shutdownNow();
+        }
+    }
+
+    private static boolean tryJoin(UDPNIOConnection connection, InetAddress group,
+            NetworkInterface networkInterface) throws IOException {
+        try {
+            connection.join(group, networkInterface);
+            return true;
+        } catch (IOException e) {
+            assertThat(e).isNotNull();
+            return false;
+        }
+    }
+
+    private static void tryBlockAndUnblock(UDPNIOConnection connection, InetAddress group,
+            NetworkInterface networkInterface, InetAddress source) throws IOException {
+        try {
+            connection.block(group, networkInterface, source);
+            connection.unblock(group, networkInterface, source);
+        } catch (IOException e) {
+            assertThat(e).isNotNull();
+        } catch (UnsupportedOperationException | IllegalArgumentException e) {
+            assertThat(e).isNotNull();
+        }
+    }
+
+    private static NetworkInterface firstIpv4NetworkInterface() throws SocketException {
+        NetworkInterface fallback = null;
+        Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+        while (interfaces.hasMoreElements()) {
+            NetworkInterface networkInterface = interfaces.nextElement();
+            if (hasIpv4Address(networkInterface)) {
+                if (fallback == null) {
+                    fallback = networkInterface;
+                }
+                if (networkInterface.isUp() && networkInterface.supportsMulticast()) {
+                    return networkInterface;
+                }
+            }
+        }
+
+        assertThat(fallback).as("an IPv4 network interface is required").isNotNull();
+        return fallback;
+    }
+
+    private static boolean hasIpv4Address(NetworkInterface networkInterface) {
+        Enumeration<InetAddress> addresses = networkInterface.getInetAddresses();
+        while (addresses.hasMoreElements()) {
+            if (addresses.nextElement() instanceof Inet4Address) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/resources/LocalizerFallbackMessages.properties
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/resources/LocalizerFallbackMessages.properties
@@ -1,0 +1,2 @@
+fallback=Fallback {0}
+undefined=Fallback undefined {0}

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.utils.ServiceFinder$LazyIterator"
+      },
+      "type" : "org_glassfish_grizzly.grizzly_framework.ServiceFinderInnerLazyIteratorTest$SampleServiceProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.utils.ServiceFinder"
+      },
+      "type" : "org_glassfish_grizzly.grizzly_framework.ServiceFinderTest$EmptyService[]"
+    }
+  ]
+}

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/resources/META-INF/services/org_glassfish_grizzly.grizzly_framework.ServiceFinderInnerLazyIteratorTest$SampleService
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/resources/META-INF/services/org_glassfish_grizzly.grizzly_framework.ServiceFinderInnerLazyIteratorTest$SampleService
@@ -1,0 +1,2 @@
+# Provider used by ServiceFinderInnerLazyIteratorTest
+org_glassfish_grizzly.grizzly_framework.ServiceFinderInnerLazyIteratorTest$SampleServiceProvider

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/resources/org_glassfish_grizzly/grizzly_framework/LocalizerMessages.properties
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/resources/org_glassfish_grizzly/grizzly_framework/LocalizerMessages.properties
@@ -1,0 +1,2 @@
+greeting=Hello {0}
+undefined=Undefined {0}

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/user-code-filter.json
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.glassfish.grizzly.**"
+    },
+    {
+      "includeClasses" : "org_glassfish_grizzly.grizzly_framework.**"
+    }
+  ]
+}

--- a/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/user-code-filter.json
+++ b/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/user-code-filter.json
@@ -8,6 +8,9 @@
     },
     {
       "includeClasses" : "org_glassfish_grizzly.grizzly_framework.**"
+    },
+    {
+      "includeClasses" : "org.glassfish.grizzly.attributes.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #7037

This PR provides test fixes and new metadata for org.glassfish.grizzly:grizzly-framework:2.3.6, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 451828
- Cached input tokens: 4693504
- Output tokens: 59305
- Metadata entries: 77
- Test-only metadata entries: 2
- Iterations: 15
- Library coverage percentage: 8.24
- Previous library version metadata entries: 19
- Previous library version test-only metadata entries: 2
- Previous library version coverage percentage: 4.66

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3f69aa1510d519e1825b9bfd59a81bb41ea7ef04`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.glassfish.grizzly:grizzly-framework:2.1.2: 19/19 covered calls (100.00%)
- org.glassfish.grizzly:grizzly-framework:2.3.6: 51/51 covered calls (100.00%)

**Reflection:**
- org.glassfish.grizzly:grizzly-framework:2.1.2: 15/15 covered calls (100.00%)
- org.glassfish.grizzly:grizzly-framework:2.3.6: 47/47 covered calls (100.00%)

**Resources:**
- org.glassfish.grizzly:grizzly-framework:2.1.2: 4/4 covered calls (100.00%)
- org.glassfish.grizzly:grizzly-framework:2.3.6: 4/4 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.glassfish.grizzly:grizzly-framework:2.1.2: 2510/56266 (4.46%)
- org.glassfish.grizzly:grizzly-framework:2.3.6: 5446/68979 (7.90%)

**Line:**
- org.glassfish.grizzly:grizzly-framework:2.1.2: 630/13533 (4.66%)
- org.glassfish.grizzly:grizzly-framework:2.3.6: 1356/16461 (8.24%)

**Method:**
- org.glassfish.grizzly:grizzly-framework:2.1.2: 180/3239 (5.56%)
- org.glassfish.grizzly:grizzly-framework:2.3.6: 347/3878 (8.95%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.glassfish.grizzly/grizzly-framework/2.1.2/build.gradle 2/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/build.gradle
index 9818de9f00..c1f661fac0 100644
--- 1/tests/src/org.glassfish.grizzly/grizzly-framework/2.1.2/build.gradle
+++ 2/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/build.gradle
@@ -9,13 +9,33 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+String configuredSelectionKeyHandlerClass =
+        'org_glassfish_grizzly.grizzly_framework.SelectionKeyHandlerInitializerTest$ConfiguredSelectionKeyHandler'
 
 dependencies {
     testImplementation "org.glassfish.grizzly:grizzly-framework:$libraryVersion"
+    testImplementation "org.glassfish.grizzly:grizzly-framework-monitoring:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
+tasks.withType(Test).configureEach {
+    systemProperty "org.glassfish.grizzly.DEFAULT_MEMORY_MANAGER",
+            "org.glassfish.grizzly.memory.ByteBufferManager"
+    systemProperty "org.glassfish.grizzly.DEFAULT_SELECTION_KEY_HANDLER", configuredSelectionKeyHandlerClass
+}
+
+tasks.named("nativeTest") {
+    runtimeArgs.add("-Dorg.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.ByteBufferManager")
+    runtimeArgs.add("-Dorg.glassfish.grizzly.DEFAULT_SELECTION_KEY_HANDLER=${configuredSelectionKeyHandlerClass}")
+}
+
 graalvmNative {
+    binaries {
+        test {
+            buildArgs.add("-Dorg.glassfish.grizzly.DEFAULT_SELECTION_KEY_HANDLER=${configuredSelectionKeyHandlerClass}")
+        }
+    }
+
     agent {
         defaultMode = "conditional"
         modes {
diff --git 1/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org/glassfish/grizzly/attributes/AttributeBuilderTestAccess.java 2/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org/glassfish/grizzly/attributes/AttributeBuilderTestAccess.java
new file mode 100644
index 0000000000..4b2a5d36be
--- /dev/null
+++ 2/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org/glassfish/grizzly/attributes/AttributeBuilderTestAccess.java
@@ -0,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.glassfish.grizzly.attributes;
+
+/**
+ * Package-private bridge for testing builder initialization without relying on
+ * global static initialization timing in the native test image.
+ */
+public final class AttributeBuilderTestAccess {
+    private AttributeBuilderTestAccess() {
+    }
+
+    public static AttributeBuilder initBuilder() {
+        return AttributeBuilderInitializer.initBuilder();
+    }
+}
diff --git 1/tests/src/org.glassfish.grizzly/grizzly-framework/2.1.2/src/test/java/org_glassfish_grizzly/grizzly_framework/ArraySetTest.java 2/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/ArraySetTest.java
index feb4dce58d..45917ec8e7 100644
--- 1/tests/src/org.glassfish.grizzly/grizzly-framework/2.1.2/src/test/java/org_glassfish_grizzly/grizzly_framework/ArraySetTest.java
+++ 2/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/ArraySetTest.java
@@ -16,6 +16,18 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ArraySetTest {
+    @Test
+    void addInitializesTypedBackingArray() {
+        ArraySet<String> set = new ArraySet<>(String.class);
+
+        boolean changed = set.add("direct");
+
+        assertThat(changed).isTrue();
+        assertThat(set.getArray())
+                .isInstanceOf(String[].class)
+                .containsExactly("direct");
+    }
+
     @Test
     void createsTypedEmptyArrayForElementClass() {
         ArraySet<String> set = new ArraySet<>(String.class);
diff --git 1/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/AttributeBuilderInitializerTest.java 2/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/AttributeBuilderInitializerTest.java
new file mode 100644
index 0000000000..00374ba3d5
--- /dev/null
+++ 2/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/AttributeBuilderInitializerTest.java
@@ -0,0 +1,49 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_grizzly.grizzly_framework;
+
+import org.glassfish.grizzly.attributes.Attribute;
+import org.glassfish.grizzly.attributes.AttributeBuilder;
+import org.glassfish.grizzly.attributes.AttributeBuilderTestAccess;
+import org.glassfish.grizzly.attributes.DefaultAttributeBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AttributeBuilderInitializerTest {
+    private static final String DEFAULT_ATTRIBUTE_BUILDER_PROPERTY =
+            "org.glassfish.grizzly.DEFAULT_ATTRIBUTE_BUILDER";
+
+    @Test
+    void defaultAttributeBuilderUsesConfiguredPublicBuilderClass() {
+        String previousBuilderClass = System.getProperty(DEFAULT_ATTRIBUTE_BUILDER_PROPERTY);
+        System.setProperty(DEFAULT_ATTRIBUTE_BUILDER_PROPERTY, ConfiguredAttributeBuilder.class.getName());
+
+        try {
+            AttributeBuilder builder = AttributeBuilderTestAccess.initBuilder();
+            Attribute<String> attribute = builder.createAttribute("configured-builder-attribute", "configured-value");
+
+            assertThat(builder).isExactlyInstanceOf(ConfiguredAttributeBuilder.class);
+            assertThat(attribute.toString()).contains("configured-builder-attribute");
+        } finally {
+            restoreDefaultAttributeBuilderProperty(previousBuilderClass);
+        }
+    }
+
+    private static void restoreDefaultAttributeBuilderProperty(String previousBuilderClass) {
+        if (previousBuilderClass == null) {
+            System.clearProperty(DEFAULT_ATTRIBUTE_BUILDER_PROPERTY);
+        } else {
+            System.setProperty(DEFAULT_ATTRIBUTE_BUILDER_PROPERTY, previousBuilderClass);
+        }
+    }
+
+    public static class ConfiguredAttributeBuilder extends DefaultAttributeBuilder {
+        public ConfiguredAttributeBuilder() {
+        }
+    }
+}
diff --git 1/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/ConcurrentHashMapV8InnerCollectionViewTest.java 2/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/ConcurrentHashMapV8InnerCollectionViewTest.java
new file mode 100644
index 0000000000..a03184728b
--- /dev/null
+++ 2/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/ConcurrentHashMapV8InnerCollectionViewTest.java
@@ -0,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_grizzly.grizzly_framework;
+
+import org.glassfish.grizzly.utils.DataStructures;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConcurrentHashMapV8InnerCollectionViewTest {
+    @Test
+    void createsTypedArrayForMapKeyCollectionView() {
+        ConcurrentMap<String, Integer> map = DataStructures.getConcurrentMap();
+        map.put("alpha", 1);
+        map.put("bravo", 2);
+
+        Set<String> keys = map.keySet();
+        String[] keyArray = keys.toArray(new String[0]);
+
+        assertThat(map.getClass().getName()).isEqualTo("org.glassfish.grizzly.utils.ConcurrentHashMapV8");
+        assertThat(keys.getClass().getName())
+                .isEqualTo("org.glassfish.grizzly.utils.ConcurrentHashMapV8$KeySetView");
+        assertThat(keyArray)
+                .containsExactlyInAnyOrder("alpha", "bravo");
+    }
+}
diff --git 1/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/ConcurrentHashMapV8Test.java 2/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/ConcurrentHashMapV8Test.java
new file mode 100644
index 0000000000..20ea3b659e
--- /dev/null
+++ 2/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/ConcurrentHashMapV8Test.java
@@ -0,0 +1,53 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_grizzly.grizzly_framework;
+
+import org.glassfish.grizzly.utils.DataStructures;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.concurrent.ConcurrentMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConcurrentHashMapV8Test {
+    @Test
+    void serializesAndDeserializesConcurrentMapEntries() throws Exception {
+        ConcurrentMap<String, Integer> map = DataStructures.getConcurrentMap();
+        map.put("first", 1);
+        map.put("second", 2);
+
+        assertThat(map.getClass().getName()).isEqualTo("org.glassfish.grizzly.utils.ConcurrentHashMapV8");
+
+        byte[] serialized = serialize(map);
+
+        ConcurrentMap<String, Integer> restored = deserialize(serialized);
+        assertThat(restored.getClass().getName()).isEqualTo("org.glassfish.grizzly.utils.ConcurrentHashMapV8");
+        assertThat(restored)
+                .containsEntry("first", 1)
+                .containsEntry("second", 2)
+                .hasSize(2);
+    }
+
+    private static byte[] serialize(ConcurrentMap<String, Integer> map) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+            output.writeObject(map);
+        }
+        return bytes.toByteArray();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ConcurrentMap<String, Integer> deserialize(byte[] serialized) throws Exception {
+        try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            return (ConcurrentMap<String, Integer>) input.readObject();
+        }
+    }
+}
diff --git 1/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/GrizzlyJmxManagerTest.java 2/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/GrizzlyJmxManagerTest.java
new file mode 100644
index 0000000000..6f14dc280a
--- /dev/null
+++ 2/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/GrizzlyJmxManagerTest.java
@@ -0,0 +1,22 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_grizzly.grizzly_framework;
+
+import org.glassfish.grizzly.jmxbase.GrizzlyJmxManager;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GrizzlyJmxManagerTest {
+    @Test
+    void instanceLoadsDefaultJmxManagerWhenMonitoringImplementationIsAvailable() {
+        GrizzlyJmxManager manager = GrizzlyJmxManager.instance();
+
+        assertThat(manager).isNotNull();
+        assertThat(manager.getClass().getName()).isEqualTo("org.glassfish.grizzly.monitoring.jmx.DefaultJmxManager");
+    }
+}
diff --git 1/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/LinkedTransferQueueTest.java 2/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/LinkedTransferQueueTest.java
new file mode 100644
index 0000000000..0319987311
--- /dev/null
+++ 2/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/LinkedTransferQueueTest.java
@@ -0,0 +1,76 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_grizzly.grizzly_framework;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.concurrent.BlockingQueue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LinkedTransferQueueTest {
+    private static final String LINKED_TRANSFER_QUEUE_CLASS_NAME =
+            "org.glassfish.grizzly.utils.LinkedTransferQueue";
+
+    @Test
+    void serializesAndDeserializesQueueElements() throws Exception {
+        BlockingQueue<Object> queue = deserialize(serializedQueueWithTwoElements());
+
+        assertThat(queue.getClass().getName()).isEqualTo(LINKED_TRANSFER_QUEUE_CLASS_NAME);
+        assertThat(queue).containsExactly("first", "second");
+
+        byte[] serialized = serialize(queue);
+        BlockingQueue<Object> restored = deserialize(serialized);
+
+        assertThat(restored.getClass().getName()).isEqualTo(LINKED_TRANSFER_QUEUE_CLASS_NAME);
+        assertThat(restored).containsExactly("first", "second");
+    }
+
+    private static byte[] serializedQueueWithTwoElements() {
+        return hexToBytes("""
+                ac ed 00 05 73 72 00 2f 6f 72 67 2e 67 6c 61 73
+                73 66 69 73 68 2e 67 72 69 7a 7a 6c 79 2e 75 74
+                69 6c 73 2e 4c 69 6e 6b 65 64 54 72 61 6e 73 66
+                65 72 51 75 65 75 65 d3 45 33 6e 1f 5c 3e 9a 03
+                00 00 78 70 74 00 05 66 69 72 73 74 74 00 06 73
+                65 63 6f 6e 64 70 78
+                """);
+    }
+
+    private static byte[] serialize(BlockingQueue<?> queue) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+            output.writeObject(queue);
+        }
+        return bytes.toByteArray();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static BlockingQueue<Object> deserialize(byte[] serialized) throws Exception {
+        try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            Object value = input.readObject();
+            assertThat(value).isInstanceOf(BlockingQueue.class);
+            return (BlockingQueue<Object>) value;
+        }
+    }
+
+    private static byte[] hexToBytes(String hex) {
+        String normalized = hex.replaceAll("\\s+", "");
+        assertThat(normalized.length() % 2).isZero();
+
+        byte[] bytes = new byte[normalized.length() / 2];
+        for (int i = 0; i < bytes.length; i++) {
+            int fromIndex = i * 2;
+            bytes[i] = (byte) Integer.parseInt(normalized.substring(fromIndex, fromIndex + 2), 16);
+        }
+        return bytes;
+    }
+}
diff --git 1/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/MemoryManagerInitializerTest.java 2/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/MemoryManagerInitializerTest.java
new file mode 100644
index 0000000000..561b244fa0
--- /dev/null
+++ 2/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/MemoryManagerInitializerTest.java
@@ -0,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_grizzly.grizzly_framework;
+
+import org.glassfish.grizzly.memory.ByteBufferManager;
+import org.glassfish.grizzly.memory.MemoryManager;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MemoryManagerInitializerTest {
+    private static final String DEFAULT_MEMORY_MANAGER_PROPERTY =
+            "org.glassfish.grizzly.DEFAULT_MEMORY_MANAGER";
+
+    @Test
+    void defaultMemoryManagerUsesConfiguredPublicManagerClass() {
+        String configuredManagerClass = ByteBufferManager.class.getName();
+
+        assertThat(System.getProperty(DEFAULT_MEMORY_MANAGER_PROPERTY)).isEqualTo(configuredManagerClass);
+        assertThat(MemoryManager.DEFAULT_MEMORY_MANAGER).isExactlyInstanceOf(ByteBufferManager.class);
+    }
+}
diff --git 1/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/MonitoringUtilsTest.java 2/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/MonitoringUtilsTest.java
new file mode 100644
index 0000000000..a4485a068b
--- /dev/null
+++ 2/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/MonitoringUtilsTest.java
@@ -0,0 +1,25 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_grizzly.grizzly_framework;
+
+import org.glassfish.grizzly.TransformationException;
+import org.glassfish.grizzly.monitoring.MonitoringUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MonitoringUtilsTest {
+    @Test
+    void loadJmxObjectCreatesObjectWithExplicitConstructorType() {
+        String message = "grizzly-monitoring";
+
+        Object jmxObject = MonitoringUtils.loadJmxObject(TransformationException.class.getName(), message, String.class);
+
+        assertThat(jmxObject).isInstanceOf(TransformationException.class);
+        assertThat(((TransformationException) jmxObject).getMessage()).isEqualTo(message);
+    }
+}
diff --git 1/tests/src/org.glassfish.grizzly/grizzly-framework/2.1.2/src/test/java/org_glassfish_grizzly/grizzly_framework/NIOTransportBuilderTest.java 2/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/NIOTransportBuilderTest.java
index 92e02c786a..fd9a14462c 100644
--- 1/tests/src/org.glassfish.grizzly/grizzly-framework/2.1.2/src/test/java/org_glassfish_grizzly/grizzly_framework/NIOTransportBuilderTest.java
+++ 2/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/NIOTransportBuilderTest.java
@@ -24,18 +24,20 @@ public class NIOTransportBuilderTest {
         TCPNIOTransportBuilder builder = TCPNIOTransportBuilder.newInstance();
 
         TCPNIOTransport transport = builder.build();
-        ThreadPoolConfig selectorConfig = builder.getSelectorThreadPoolConfig();
-        int expectedSelectorRunnerCount = Runtime.getRuntime().availableProcessors();
+        ThreadPoolConfig workerConfig = transport.getWorkerThreadPoolConfig();
+        ThreadPoolConfig kernelConfig = transport.getKernelThreadPoolConfig();
+        int availableProcessors = Runtime.getRuntime().availableProcessors();
 
         assertThat(transport).isNotNull();
-        assertThat(builder.getIOStrategy()).isSameAs(WorkerThreadIOStrategy.getInstance());
-        assertThat(builder.getMemoryManager()).isSameAs(MemoryManager.DEFAULT_MEMORY_MANAGER);
-        assertThat(builder.getAttributeBuilder()).isSameAs(AttributeBuilder.DEFAULT_ATTRIBUTE_BUILDER);
-        assertThat(builder.getSelectorHandler()).isSameAs(SelectorHandler.DEFAULT_SELECTOR_HANDLER);
-        assertThat(builder.getSelectionKeyHandler()).isSameAs(SelectionKeyHandler.DEFAULT_SELECTION_KEY_HANDLER);
-        assertThat(builder.getWorkerThreadPoolConfig()).isNotNull();
-        assertThat(selectorConfig.getCorePoolSize()).isEqualTo(expectedSelectorRunnerCount);
-        assertThat(selectorConfig.getMaxPoolSize()).isEqualTo(expectedSelectorRunnerCount);
-        assertThat(transport.getSelectorRunnersCount()).isEqualTo(expectedSelectorRunnerCount);
+        assertThat(transport.getIOStrategy()).isSameAs(WorkerThreadIOStrategy.getInstance());
+        assertThat(transport.getMemoryManager()).isSameAs(MemoryManager.DEFAULT_MEMORY_MANAGER);
+        assertThat(transport.getAttributeBuilder()).isSameAs(AttributeBuilder.DEFAULT_ATTRIBUTE_BUILDER);
+        assertThat(transport.getSelectorHandler()).isSameAs(SelectorHandler.DEFAULT_SELECTOR_HANDLER);
+        assertThat(transport.getSelectionKeyHandler()).isSameAs(SelectionKeyHandler.DEFAULT_SELECTION_KEY_HANDLER);
+        assertThat(workerConfig).isNotNull();
+        assertThat(workerConfig.getCorePoolSize()).isEqualTo(availableProcessors * 2);
+        assertThat(workerConfig.getMaxPoolSize()).isEqualTo(availableProcessors * 2);
+        assertThat(kernelConfig).isNotNull();
+        assertThat(transport.getSelectorRunnersCount()).isEqualTo(availableProcessors + 1);
     }
 }
diff --git 1/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/SelectionKeyHandlerInitializerTest.java 2/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/SelectionKeyHandlerInitializerTest.java
new file mode 100644
index 0000000000..2f9e16b9ab
--- /dev/null
+++ 2/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/SelectionKeyHandlerInitializerTest.java
@@ -0,0 +1,83 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_grizzly.grizzly_framework;
+
+import org.glassfish.grizzly.IOEvent;
+import org.glassfish.grizzly.nio.DefaultSelectionKeyHandler;
+import org.glassfish.grizzly.nio.NIOConnection;
+import org.glassfish.grizzly.nio.SelectionKeyHandler;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.channels.SelectionKey;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SelectionKeyHandlerInitializerTest {
+    private static final String DEFAULT_SELECTION_KEY_HANDLER_PROPERTY =
+            "org.glassfish.grizzly.DEFAULT_SELECTION_KEY_HANDLER";
+
+    @Test
+    void defaultSelectionKeyHandlerUsesConfiguredPublicHandlerClass() {
+        assertThat(System.getProperty(DEFAULT_SELECTION_KEY_HANDLER_PROPERTY))
+                .isEqualTo(ConfiguredSelectionKeyHandler.class.getName());
+        assertThat(SelectionKeyHandler.DEFAULT_SELECTION_KEY_HANDLER)
+                .isExactlyInstanceOf(ConfiguredSelectionKeyHandler.class);
+    }
+
+    public static class ConfiguredSelectionKeyHandler implements SelectionKeyHandler {
+        private final SelectionKeyHandler delegate = new DefaultSelectionKeyHandler();
+
+        public ConfiguredSelectionKeyHandler() {
+        }
+
+        @Override
+        public void onKeyRegistered(SelectionKey key) {
+            delegate.onKeyRegistered(key);
+        }
+
+        @Override
+        public void onKeyDeregistered(SelectionKey key) {
+            delegate.onKeyDeregistered(key);
+        }
+
+        @Override
+        public boolean onProcessInterest(SelectionKey key, int interest) throws IOException {
+            return delegate.onProcessInterest(key, interest);
+        }
+
+        @Override
+        public void cancel(SelectionKey key) throws IOException {
+            delegate.cancel(key);
+        }
+
+        @Override
+        public NIOConnection getConnectionForKey(SelectionKey selectionKey) {
+            return delegate.getConnectionForKey(selectionKey);
+        }
+
+        @Override
+        public void setConnectionForKey(NIOConnection connection, SelectionKey selectionKey) {
+            delegate.setConnectionForKey(connection, selectionKey);
+        }
+
+        @Override
+        public int ioEvent2SelectionKeyInterest(IOEvent ioEvent) {
+            return delegate.ioEvent2SelectionKeyInterest(ioEvent);
+        }
+
+        @Override
+        public IOEvent selectionKeyInterest2IoEvent(int selectionKeyInterest) {
+            return delegate.selectionKeyInterest2IoEvent(selectionKeyInterest);
+        }
+
+        @Override
+        public IOEvent[] getIOEvents(int interest) {
+            return delegate.getIOEvents(interest);
+        }
+    }
+}
diff --git 1/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/UDPNIOConnectionTest.java 2/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/UDPNIOConnectionTest.java
new file mode 100644
index 0000000000..75450179d8
--- /dev/null
+++ 2/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/src/test/java/org_glassfish_grizzly/grizzly_framework/UDPNIOConnectionTest.java
@@ -0,0 +1,102 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_grizzly.grizzly_framework;
+
+import java.io.IOException;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.net.StandardProtocolFamily;
+import java.nio.channels.DatagramChannel;
+import java.util.Enumeration;
+import org.glassfish.grizzly.nio.transport.UDPNIOConnection;
+import org.glassfish.grizzly.nio.transport.UDPNIOTransport;
+import org.glassfish.grizzly.nio.transport.UDPNIOTransportBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UDPNIOConnectionTest {
+    @Test
+    void multicastLifecycleUsesJdkMembershipMethods() throws Exception {
+        UDPNIOTransport transport = UDPNIOTransportBuilder.newInstance().build();
+        try (DatagramChannel channel = DatagramChannel.open(StandardProtocolFamily.INET)) {
+            channel.bind(new InetSocketAddress(0));
+
+            UDPNIOConnection connection = new UDPNIOConnection(transport, channel);
+            InetAddress group = InetAddress.getByName("230.0.0.1");
+            InetAddress source = InetAddress.getByName("127.0.0.1");
+            NetworkInterface networkInterface = firstIpv4NetworkInterface();
+
+            boolean joined = tryJoin(connection, group, networkInterface);
+            if (joined) {
+                tryBlockAndUnblock(connection, group, networkInterface, source);
+                connection.drop(group, networkInterface);
+            }
+
+            assertThat(connection.isConnected()).isFalse();
+            assertThat(connection.getLocalAddress()).isNotNull();
+            assertThat(connection.toString()).contains("UDPNIOConnection");
+        } finally {
+            transport.shutdownNow();
+        }
+    }
+
+    private static boolean tryJoin(UDPNIOConnection connection, InetAddress group,
+            NetworkInterface networkInterface) throws IOException {
+        try {
+            connection.join(group, networkInterface);
+            return true;
+        } catch (IOException e) {
+            assertThat(e).isNotNull();
+            return false;
+        }
+    }
+
+    private static void tryBlockAndUnblock(UDPNIOConnection connection, InetAddress group,
+            NetworkInterface networkInterface, InetAddress source) throws IOException {
+        try {
+            connection.block(group, networkInterface, source);
+            connection.unblock(group, networkInterface, source);
+        } catch (IOException e) {
+            assertThat(e).isNotNull();
+        } catch (UnsupportedOperationException | IllegalArgumentException e) {
+            assertThat(e).isNotNull();
+        }
+    }
+
+    private static NetworkInterface firstIpv4NetworkInterface() throws SocketException {
+        NetworkInterface fallback = null;
+        Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+        while (interfaces.hasMoreElements()) {
+            NetworkInterface networkInterface = interfaces.nextElement();
+            if (hasIpv4Address(networkInterface)) {
+                if (fallback == null) {
+                    fallback = networkInterface;
+                }
+                if (networkInterface.isUp() && networkInterface.supportsMulticast()) {
+                    return networkInterface;
+                }
+            }
+        }
+
+        assertThat(fallback).as("an IPv4 network interface is required").isNotNull();
+        return fallback;
+    }
+
+    private static boolean hasIpv4Address(NetworkInterface networkInterface) {
+        Enumeration<InetAddress> addresses = networkInterface.getInetAddresses();
+        while (addresses.hasMoreElements()) {
+            if (addresses.nextElement() instanceof Inet4Address) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
diff --git 1/tests/src/org.glassfish.grizzly/grizzly-framework/2.1.2/user-code-filter.json 2/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/user-code-filter.json
index 0b3f3e8c27..e653f45c88 100644
--- 1/tests/src/org.glassfish.grizzly/grizzly-framework/2.1.2/user-code-filter.json
+++ 2/tests/src/org.glassfish.grizzly/grizzly-framework/2.3.6/user-code-filter.json
@@ -8,6 +8,9 @@
     },
     {
       "includeClasses" : "org_glassfish_grizzly.grizzly_framework.**"
+    },
+    {
+      "includeClasses" : "org.glassfish.grizzly.attributes.**"
     }
   ]
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
