### PR TITLE
[GenAI] Test fix for org.glassfish.hk2:hk2-api:2.5.0 using gpt-5.5

### DIFF
--- a/metadata/org.glassfish.hk2/hk2-api/2.5.0/reachability-metadata.json
+++ b/metadata/org.glassfish.hk2/hk2-api/2.5.0/reachability-metadata.json
@@ -1,0 +1,136 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.hk2.utilities.AliasDescriptor"
+      },
+      "type" : "java.lang.Runnable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.hk2.api.AnnotationLiteral$1"
+      },
+      "type" : "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.hk2.utilities.reflection.ReflectionHelper"
+      },
+      "type" : "java.lang.annotation.Annotation[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.hk2.utilities.reflection.ReflectionHelper"
+      },
+      "type" : "java.lang.annotation.ElementType[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.hk2.api.AnnotationLiteral$1"
+      },
+      "type" : "java.lang.reflect.Method[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.hk2.utilities.BuilderHelper"
+      },
+      "type" : "java.util.HashMap",
+      "methods" : [
+        {
+          "name" : "clone",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.hk2.api.AnnotationLiteral"
+      },
+      "type" : "javax.inject.Named",
+      "methods" : [
+        {
+          "name" : "value",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.hk2.api.AnnotationLiteral$1"
+      },
+      "type" : "javax.inject.Named"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.hk2.utilities.binding.AbstractBinder$2"
+      },
+      "type" : "org.glassfish.hk2.utilities.DescriptorImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.hk2.utilities.HK2LoaderImpl"
+      },
+      "type" : "org.glassfish.hk2.utilities.HK2LoaderImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.hk2.utilities.reflection.ReflectionHelper"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.FunctionalInterface"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.hk2.utilities.reflection.ReflectionHelper"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Documented"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.hk2.utilities.BuilderHelper"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.hk2.utilities.reflection.ReflectionHelper"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.hk2.utilities.reflection.ReflectionHelper"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Target"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.hk2.utilities.BuilderHelper"
+      },
+      "type" : {
+        "proxy" : [
+          "org.glassfish.hk2.api.Metadata"
+        ]
+      }
+    }
+  ]
+}

--- a/metadata/org.glassfish.hk2/hk2-api/index.json
+++ b/metadata/org.glassfish.hk2/hk2-api/index.json
@@ -17,6 +17,11 @@
   },
   {
     "metadata-version" : "2.5.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/glassfish/hk2/hk2-api/$version$/hk2-api-$version$-sources.jar",
+    "repository-url" : "https://github.com/eclipse-ee4j/glassfish-hk2",
+    "test-code-url" : "https://github.com/eclipse-ee4j/glassfish-hk2/tree/$version$-RELEASE/hk2-api/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/glassfish/hk2/hk2-api/$version$/hk2-api-$version$-javadoc.jar",
+    "description" : "HK2 API provides the core contracts, annotations, descriptors, and service locator interfaces for the HK2 dependency injection framework. It lets applications and HK2 extensions describe services, manage dynamic configurations, resolve injections, define scopes, and observe service lifecycle events.",
     "tested-versions" : [
       "2.5.0"
     ],

--- a/metadata/org.glassfish.hk2/hk2-api/index.json
+++ b/metadata/org.glassfish.hk2/hk2-api/index.json
@@ -14,5 +14,15 @@
       "org.glassfish.hk2",
       "org.jvnet.hk2.annotations"
     ]
+  },
+  {
+    "metadata-version" : "2.5.0",
+    "tested-versions" : [
+      "2.5.0"
+    ],
+    "allowed-packages" : [
+      "org.glassfish.hk2",
+      "org.jvnet.hk2.annotations"
+    ]
   }
 ]

--- a/stats/org.glassfish.hk2/hk2-api/2.5.0/execution-metrics.json
+++ b/stats/org.glassfish.hk2/hk2-api/2.5.0/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_javac_fail:2026-05-18": {
+    "timestamp": "2026-05-18T22:56:00.527453Z",
+    "library": "org.glassfish.hk2:hk2-api:2.5.0",
+    "starting_commit": "5322465a91cc0903e1fc687f1e883a4d1010e83b",
+    "ending_commit": "8806d12c4ac171ee3b74be937267a9634ee51ffb",
+    "previous_library": "org.glassfish.hk2:hk2-api:2.5.0-b05",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.5.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 6,
+            "totalCalls": 6
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 7,
+        "totalCalls": 7
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1309,
+          "missed": 9828,
+          "ratio": 0.117536,
+          "total": 11137
+        },
+        "line": {
+          "covered": 356,
+          "missed": 2154,
+          "ratio": 0.141833,
+          "total": 2510
+        },
+        "method": {
+          "covered": 85,
+          "missed": 499,
+          "ratio": 0.145548,
+          "total": 584
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.5.0-b05",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 6,
+            "totalCalls": 6
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 7,
+        "totalCalls": 7
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1309,
+          "missed": 9368,
+          "ratio": 0.1226,
+          "total": 10677
+        },
+        "line": {
+          "covered": 345,
+          "missed": 2020,
+          "ratio": 0.145877,
+          "total": 2365
+        },
+        "method": {
+          "covered": 85,
+          "missed": 469,
+          "ratio": 0.15343,
+          "total": 554
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 12509,
+      "cached_input_tokens_used": 54272,
+      "output_tokens_used": 961,
+      "iterations": 1,
+      "cost_usd": 0.0559,
+      "tested_library_loc": 356,
+      "metadata_entries": 18,
+      "test_only_metadata_entries": 1,
+      "previous_library_metadata_entries": 18,
+      "previous_library_test_only_metadata_entries": 1,
+      "code_coverage_percent": 14.18,
+      "previous_library_coverage_percent": 14.59
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.glassfish.hk2/hk2-api/2.5.0/src/test/java/org_glassfish_hk2/hk2_api/ClasspathDescriptorFileFinderTest.java",
+      "metadata_file": "metadata/org.glassfish.hk2/hk2-api/2.5.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.glassfish.hk2/hk2-api/2.5.0/stats.json
+++ b/stats/org.glassfish.hk2/hk2-api/2.5.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "2.5.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 6,
+          "totalCalls" : 6
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 7,
+      "totalCalls" : 7
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1309,
+        "missed" : 9828,
+        "ratio" : 0.117536,
+        "total" : 11137
+      },
+      "line" : {
+        "covered" : 356,
+        "missed" : 2154,
+        "ratio" : 0.141833,
+        "total" : 2510
+      },
+      "method" : {
+        "covered" : 85,
+        "missed" : 499,
+        "ratio" : 0.145548,
+        "total" : 584
+      }
+    }
+  } ]
+}

--- a/tests/src/org.glassfish.hk2/hk2-api/2.5.0/.gitignore
+++ b/tests/src/org.glassfish.hk2/hk2-api/2.5.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.glassfish.hk2/hk2-api/2.5.0/build.gradle
+++ b/tests/src/org.glassfish.hk2/hk2-api/2.5.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.glassfish.hk2:hk2-api:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.glassfish.hk2/hk2-api/2.5.0/gradle.properties
+++ b/tests/src/org.glassfish.hk2/hk2-api/2.5.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.glassfish.hk2:hk2-api:2.5.0
+library.version = 2.5.0
+metadata.dir = org.glassfish.hk2/hk2-api/2.5.0/

--- a/tests/src/org.glassfish.hk2/hk2-api/2.5.0/settings.gradle
+++ b/tests/src/org.glassfish.hk2/hk2-api/2.5.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.glassfish.hk2.hk2-api_tests'

--- a/tests/src/org.glassfish.hk2/hk2-api/2.5.0/src/test/java/org_glassfish_hk2/hk2_api/AbstractBinderAnonymous2Test.java
+++ b/tests/src/org.glassfish.hk2/hk2-api/2.5.0/src/test/java/org_glassfish_hk2/hk2_api/AbstractBinderAnonymous2Test.java
@@ -15,6 +15,7 @@ import org.glassfish.hk2.api.Factory;
 import org.glassfish.hk2.api.FactoryDescriptors;
 import org.glassfish.hk2.api.Filter;
 import org.glassfish.hk2.api.MultiException;
+import org.glassfish.hk2.api.TwoPhaseResource;
 import org.glassfish.hk2.utilities.DescriptorImpl;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.junit.jupiter.api.Test;
@@ -98,6 +99,11 @@ public class AbstractBinderAnonymous2Test {
         @Override
         public void addIdempotentFilter(Filter... unbindFilter) throws IllegalArgumentException {
             throw new UnsupportedOperationException("Idempotent filters are not used by this test");
+        }
+
+        @Override
+        public void registerTwoPhaseResources(TwoPhaseResource... resources) {
+            throw new UnsupportedOperationException("Two-phase resources are not used by this test");
         }
 
         @Override

--- a/tests/src/org.glassfish.hk2/hk2-api/2.5.0/src/test/java/org_glassfish_hk2/hk2_api/AbstractBinderAnonymous2Test.java
+++ b/tests/src/org.glassfish.hk2/hk2-api/2.5.0/src/test/java/org_glassfish_hk2/hk2_api/AbstractBinderAnonymous2Test.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_hk2.hk2_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.glassfish.hk2.api.ActiveDescriptor;
+import org.glassfish.hk2.api.Descriptor;
+import org.glassfish.hk2.api.DynamicConfiguration;
+import org.glassfish.hk2.api.Factory;
+import org.glassfish.hk2.api.FactoryDescriptors;
+import org.glassfish.hk2.api.Filter;
+import org.glassfish.hk2.api.MultiException;
+import org.glassfish.hk2.utilities.DescriptorImpl;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.junit.jupiter.api.Test;
+
+public class AbstractBinderAnonymous2Test {
+    @Test
+    void defaultBinderLoaderCanLoadClassForBoundDescriptor() {
+        final DescriptorImpl descriptor = new DescriptorImpl();
+        descriptor.setImplementation(DescriptorImpl.class.getName());
+        descriptor.addAdvertisedContract(DescriptorImpl.class.getName());
+        final RecordingDynamicConfiguration configuration = new RecordingDynamicConfiguration();
+        final AbstractBinder binder = new AbstractBinder() {
+            @Override
+            protected void configure() {
+                bind(descriptor);
+            }
+        };
+
+        binder.bind(configuration);
+
+        assertThat(configuration.boundDescriptor).isSameAs(descriptor);
+        assertThat(configuration.boundDescriptor.getLoader()).isNotNull();
+        final Class<?> loadedClass = configuration.boundDescriptor.getLoader()
+                .loadClass(DescriptorImpl.class.getName());
+        assertThat(loadedClass).isSameAs(DescriptorImpl.class);
+    }
+
+    private static final class RecordingDynamicConfiguration implements DynamicConfiguration {
+        private Descriptor boundDescriptor;
+
+        @Override
+        public <T> ActiveDescriptor<T> bind(Descriptor key) {
+            return bind(key, true);
+        }
+
+        @Override
+        public <T> ActiveDescriptor<T> bind(Descriptor key, boolean requiresDeepCopy) {
+            boundDescriptor = key;
+            return null;
+        }
+
+        @Override
+        public FactoryDescriptors bind(FactoryDescriptors factoryDescriptors) {
+            return bind(factoryDescriptors, true);
+        }
+
+        @Override
+        public FactoryDescriptors bind(FactoryDescriptors factoryDescriptors, boolean requiresDeepCopy) {
+            throw new UnsupportedOperationException("Factory descriptor binding is not used by this test");
+        }
+
+        @Override
+        public <T> ActiveDescriptor<T> addActiveDescriptor(ActiveDescriptor<T> activeDescriptor)
+                throws IllegalArgumentException {
+            throw new UnsupportedOperationException("Active descriptor binding is not used by this test");
+        }
+
+        @Override
+        public <T> ActiveDescriptor<T> addActiveDescriptor(ActiveDescriptor<T> activeDescriptor,
+                boolean requiresDeepCopy) throws IllegalArgumentException {
+            throw new UnsupportedOperationException("Active descriptor binding is not used by this test");
+        }
+
+        @Override
+        public <T> ActiveDescriptor<T> addActiveDescriptor(Class<T> rawClass)
+                throws MultiException, IllegalArgumentException {
+            throw new UnsupportedOperationException("Class-based active descriptor binding is not used by this test");
+        }
+
+        @Override
+        public <T> FactoryDescriptors addActiveFactoryDescriptor(Class<? extends Factory<T>> rawFactoryClass)
+                throws MultiException, IllegalArgumentException {
+            throw new UnsupportedOperationException("Active factory descriptor binding is not used by this test");
+        }
+
+        @Override
+        public void addUnbindFilter(Filter unbindFilter) throws IllegalArgumentException {
+            throw new UnsupportedOperationException("Unbind filters are not used by this test");
+        }
+
+        @Override
+        public void addIdempotentFilter(Filter... unbindFilter) throws IllegalArgumentException {
+            throw new UnsupportedOperationException("Idempotent filters are not used by this test");
+        }
+
+        @Override
+        public void commit() throws MultiException {
+            throw new UnsupportedOperationException("Commit is not used by this test");
+        }
+    }
+}

--- a/tests/src/org.glassfish.hk2/hk2-api/2.5.0/src/test/java/org_glassfish_hk2/hk2_api/AliasDescriptorTest.java
+++ b/tests/src/org.glassfish.hk2/hk2-api/2.5.0/src/test/java/org_glassfish_hk2/hk2_api/AliasDescriptorTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_hk2.hk2_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Type;
+import java.util.Set;
+
+import org.glassfish.hk2.api.ActiveDescriptor;
+import org.glassfish.hk2.utilities.AliasDescriptor;
+import org.glassfish.hk2.utilities.BuilderHelper;
+import org.junit.jupiter.api.Test;
+
+public class AliasDescriptorTest {
+    @Test
+    void contractTypesResolveAliasContractWithImplementationClassLoader() {
+        final ActiveDescriptor<AliasedRunnableService> descriptor = BuilderHelper.createConstantDescriptor(
+                new AliasedRunnableService(), "primary", Runnable.class);
+        final AliasDescriptor<AliasedRunnableService> alias = new AliasDescriptor<>(
+                null, descriptor, Runnable.class.getName(), "alias");
+
+        final Set<Type> contractTypes = alias.getContractTypes();
+
+        assertThat(contractTypes).contains(Runnable.class);
+        assertThat(alias.getImplementationClass()).isEqualTo(AliasedRunnableService.class);
+    }
+
+    private static final class AliasedRunnableService implements Runnable {
+        @Override
+        public void run() {
+            throw new UnsupportedOperationException("The descriptor test does not execute the service");
+        }
+    }
+}

--- a/tests/src/org.glassfish.hk2/hk2-api/2.5.0/src/test/java/org_glassfish_hk2/hk2_api/AnnotationLiteralTest.java
+++ b/tests/src/org.glassfish.hk2/hk2-api/2.5.0/src/test/java/org_glassfish_hk2/hk2_api/AnnotationLiteralTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_hk2.hk2_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.glassfish.hk2.api.AnnotationLiteral;
+import org.glassfish.hk2.api.Rank;
+import org.junit.jupiter.api.Test;
+
+public class AnnotationLiteralTest {
+    @Test
+    void equalsComparesAnnotationMembers() {
+        RankLiteral rank = new RankLiteral(37);
+        RankLiteral sameRank = new RankLiteral(37);
+        RankLiteral differentRank = new RankLiteral(38);
+
+        assertThat(rank).isEqualTo(sameRank);
+        assertThat(rank).isNotEqualTo(differentRank);
+    }
+
+    @Test
+    void hashCodeUsesAnnotationMemberValues() {
+        RankLiteral rank = new RankLiteral(12);
+
+        int expectedHashCode = (127 * "value".hashCode()) ^ Integer.valueOf(12).hashCode();
+        assertThat(rank.annotationType()).isEqualTo(Rank.class);
+        assertThat(rank.hashCode()).isEqualTo(expectedHashCode);
+    }
+
+    private static final class RankLiteral extends AnnotationLiteral<Rank> implements Rank {
+        private static final long serialVersionUID = 1L;
+
+        private final int value;
+
+        private RankLiteral(int value) {
+            this.value = value;
+        }
+
+        @Override
+        public int value() {
+            return value;
+        }
+    }
+}

--- a/tests/src/org.glassfish.hk2/hk2-api/2.5.0/src/test/java/org_glassfish_hk2/hk2_api/BuilderHelperAnonymous3Test.java
+++ b/tests/src/org.glassfish.hk2/hk2-api/2.5.0/src/test/java/org_glassfish_hk2/hk2_api/BuilderHelperAnonymous3Test.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_hk2.hk2_api;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.glassfish.hk2.api.Metadata;
+import org.glassfish.hk2.utilities.BuilderHelper;
+import org.junit.jupiter.api.Test;
+
+public class BuilderHelperAnonymous3Test {
+    @Test
+    void getMetadataValuesReadsMetadataAnnotatedAnnotationMethods() {
+        final Class<AnnotatedService> annotatedServiceAnnotationAccess = AnnotatedService.class;
+        final ServiceMetadata annotation = annotatedServiceAnnotationAccess.getAnnotation(ServiceMetadata.class);
+        final Map<String, List<String>> metadata = new HashMap<>();
+
+        BuilderHelper.getMetadataValues(annotation, metadata);
+
+        assertThat(metadata).containsOnlyKeys("name", "contract", "tags");
+        assertThat(metadata.get("name")).containsExactly("configured-service");
+        assertThat(metadata.get("contract")).containsExactly(Runnable.class.getName());
+        assertThat(metadata.get("tags")).containsExactly("fast", "native-image");
+    }
+
+    @ServiceMetadata(
+            name = "configured-service",
+            contract = Runnable.class,
+            tags = {"fast", "native-image"},
+            ignored = "not metadata")
+    private static final class AnnotatedService {
+    }
+
+    @Retention(RUNTIME)
+    @Target(TYPE)
+    private @interface ServiceMetadata {
+        @Metadata("name")
+        String name();
+
+        @Metadata("contract")
+        Class<?> contract();
+
+        @Metadata("tags")
+        String[] tags();
+
+        String ignored();
+    }
+}

--- a/tests/src/org.glassfish.hk2/hk2-api/2.5.0/src/test/java/org_glassfish_hk2/hk2_api/ClasspathDescriptorFileFinderTest.java
+++ b/tests/src/org.glassfish.hk2/hk2-api/2.5.0/src/test/java/org_glassfish_hk2/hk2_api/ClasspathDescriptorFileFinderTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_hk2.hk2_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.glassfish.hk2.utilities.ClasspathDescriptorFileFinder;
+import org.junit.jupiter.api.Test;
+
+public class ClasspathDescriptorFileFinderTest {
+    private static final String DESCRIPTOR_NAME = "coverage-test-descriptor";
+    private static final String DESCRIPTOR_RESOURCE = "META-INF/hk2-locator/" + DESCRIPTOR_NAME;
+
+    @Test
+    void findDescriptorFilesLoadsNamedDescriptorsFromClasspath() throws IOException {
+        final ClassLoader classLoader = ClasspathDescriptorFileFinderTest.class.getClassLoader();
+        final ClasspathDescriptorFileFinder finder = new ClasspathDescriptorFileFinder(classLoader, DESCRIPTOR_NAME);
+
+        final List<InputStream> descriptorFiles = finder.findDescriptorFiles();
+
+        try {
+            assertThat(descriptorFiles).hasSize(1);
+            final InputStream descriptorFile = descriptorFiles.get(0);
+            final String descriptorText = new String(descriptorFile.readAllBytes(), StandardCharsets.UTF_8);
+            assertThat(descriptorText).contains("org.example.CoverageDescriptor");
+            assertThat(finder.getDescriptorFileInformation())
+                    .hasSize(1)
+                    .allSatisfy(identifier -> assertThat(identifier).contains(DESCRIPTOR_RESOURCE));
+        } finally {
+            for (InputStream descriptorFile : descriptorFiles) {
+                descriptorFile.close();
+            }
+        }
+    }
+}

--- a/tests/src/org.glassfish.hk2/hk2-api/2.5.0/src/test/java/org_glassfish_hk2/hk2_api/HK2LoaderImplTest.java
+++ b/tests/src/org.glassfish.hk2/hk2-api/2.5.0/src/test/java/org_glassfish_hk2/hk2_api/HK2LoaderImplTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_hk2.hk2_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.glassfish.hk2.utilities.HK2LoaderImpl;
+import org.junit.jupiter.api.Test;
+
+public class HK2LoaderImplTest {
+    @Test
+    void loadClassUsesConfiguredClassLoader() {
+        final ClassLoader classLoader = HK2LoaderImplTest.class.getClassLoader();
+        final HK2LoaderImpl loader = new HK2LoaderImpl(classLoader);
+
+        final Class<?> loadedClass = loader.loadClass(HK2LoaderImpl.class.getName());
+
+        assertThat(loadedClass).isSameAs(HK2LoaderImpl.class);
+    }
+}

--- a/tests/src/org.glassfish.hk2/hk2-api/2.5.0/src/test/resources/META-INF/hk2-locator/coverage-test-descriptor
+++ b/tests/src/org.glassfish.hk2/hk2-api/2.5.0/src/test/resources/META-INF/hk2-locator/coverage-test-descriptor
@@ -1,0 +1,2 @@
+# Test descriptor opened by ClasspathDescriptorFileFinderTest
+[org.example.CoverageDescriptor]

--- a/tests/src/org.glassfish.hk2/hk2-api/2.5.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.glassfish.hk2/hk2-api/2.5.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.hk2.utilities.ClasspathDescriptorFileFinder"
+      },
+      "glob" : "META-INF/hk2-locator/coverage-test-descriptor"
+    }
+  ]
+}

--- a/tests/src/org.glassfish.hk2/hk2-api/2.5.0/user-code-filter.json
+++ b/tests/src/org.glassfish.hk2/hk2-api/2.5.0/user-code-filter.json
@@ -1,0 +1,16 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.glassfish.hk2.**"
+    },
+    {
+      "includeClasses" : "org.jvnet.hk2.annotations.**"
+    },
+    {
+      "includeClasses" : "org_glassfish_hk2.hk2_api.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6968

This PR provides test fixes and new metadata for org.glassfish.hk2:hk2-api:2.5.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 12509
- Cached input tokens: 54272
- Output tokens: 961
- Metadata entries: 18
- Test-only metadata entries: 1
- Iterations: 1
- Library coverage percentage: 14.18
- Previous library version metadata entries: 18
- Previous library version test-only metadata entries: 1
- Previous library version coverage percentage: 14.59

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3f69aa1510d519e1825b9bfd59a81bb41ea7ef04`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.glassfish.hk2:hk2-api:2.5.0-b05: 7/7 covered calls (100.00%)
- org.glassfish.hk2:hk2-api:2.5.0: 7/7 covered calls (100.00%)

**Reflection:**
- org.glassfish.hk2:hk2-api:2.5.0-b05: 6/6 covered calls (100.00%)
- org.glassfish.hk2:hk2-api:2.5.0: 6/6 covered calls (100.00%)

**Resources:**
- org.glassfish.hk2:hk2-api:2.5.0-b05: 1/1 covered calls (100.00%)
- org.glassfish.hk2:hk2-api:2.5.0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.glassfish.hk2:hk2-api:2.5.0-b05: 1309/10677 (12.26%)
- org.glassfish.hk2:hk2-api:2.5.0: 1309/11137 (11.75%)

**Line:**
- org.glassfish.hk2:hk2-api:2.5.0-b05: 345/2365 (14.59%)
- org.glassfish.hk2:hk2-api:2.5.0: 356/2510 (14.18%)

**Method:**
- org.glassfish.hk2:hk2-api:2.5.0-b05: 85/554 (15.34%)
- org.glassfish.hk2:hk2-api:2.5.0: 85/584 (14.55%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.glassfish.hk2/hk2-api/2.5.0-b05/src/test/java/org_glassfish_hk2/hk2_api/AbstractBinderAnonymous2Test.java 2/tests/src/org.glassfish.hk2/hk2-api/2.5.0/src/test/java/org_glassfish_hk2/hk2_api/AbstractBinderAnonymous2Test.java
index 2aabe17a41..f81bba388d 100644
--- 1/tests/src/org.glassfish.hk2/hk2-api/2.5.0-b05/src/test/java/org_glassfish_hk2/hk2_api/AbstractBinderAnonymous2Test.java
+++ 2/tests/src/org.glassfish.hk2/hk2-api/2.5.0/src/test/java/org_glassfish_hk2/hk2_api/AbstractBinderAnonymous2Test.java
@@ -15,6 +15,7 @@ import org.glassfish.hk2.api.Factory;
 import org.glassfish.hk2.api.FactoryDescriptors;
 import org.glassfish.hk2.api.Filter;
 import org.glassfish.hk2.api.MultiException;
+import org.glassfish.hk2.api.TwoPhaseResource;
 import org.glassfish.hk2.utilities.DescriptorImpl;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.junit.jupiter.api.Test;
@@ -100,6 +101,11 @@ public class AbstractBinderAnonymous2Test {
             throw new UnsupportedOperationException("Idempotent filters are not used by this test");
         }
 
+        @Override
+        public void registerTwoPhaseResources(TwoPhaseResource... resources) {
+            throw new UnsupportedOperationException("Two-phase resources are not used by this test");
+        }
+
         @Override
         public void commit() throws MultiException {
             throw new UnsupportedOperationException("Commit is not used by this test");

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
