### PR TITLE
[GenAI] Add support for com.rabbitmq.client:amqp-client:0.8.0 using gpt-5.5

### DIFF
--- a/metadata/com.rabbitmq.client/amqp-client/0.8.0/reachability-metadata.json
+++ b/metadata/com.rabbitmq.client/amqp-client/0.8.0/reachability-metadata.json
@@ -1,0 +1,229 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.AmqpConnection"
+      },
+      "type": "com.rabbitmq.qpid.protonj2.client.impl.ClientConnection"
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.AmqpConnection"
+      },
+      "type": "com.rabbitmq.qpid.protonj2.types.Symbol[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.AmqpConnection"
+      },
+      "type": "io.netty.channel.unix.FileDescriptor"
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.AmqpConnection"
+      },
+      "type": "io.netty.util.AbstractReferenceCounted"
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.AmqpConnection"
+      },
+      "type": "io.netty.util.concurrent.DefaultPromise"
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.AmqpConnection"
+      },
+      "type": "io.netty.util.concurrent.SingleThreadEventExecutor"
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.AmqpConnection"
+      },
+      "type": "io.netty.util.internal.CleanerJava25$CleanableDirectBufferImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.AmqpConnection"
+      },
+      "type": "io.netty.util.internal.NativeLibraryUtil"
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.AmqpConnection"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.atomic.BaseMpscLinkedAtomicArrayQueueColdProducerFields"
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.AmqpConnection"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.atomic.BaseMpscLinkedAtomicArrayQueueConsumerFields"
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.AmqpConnection"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.atomic.BaseMpscLinkedAtomicArrayQueueProducerFields"
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.AmqpConnection"
+      },
+      "type": "java.lang.Class"
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.AmqpConnection"
+      },
+      "type": "java.lang.Class[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.AmqpConnection"
+      },
+      "type": "java.lang.Module"
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.AmqpConnection"
+      },
+      "type": "java.lang.foreign.Arena"
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.AmqpConnection"
+      },
+      "type": "java.lang.foreign.MemorySegment"
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.AmqpConnection"
+      },
+      "type": "java.lang.foreign.SegmentAllocator"
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.AmqpConnection"
+      },
+      "type": "java.lang.invoke.LambdaForm$Name[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.AmqpConnection"
+      },
+      "type": "java.lang.management.RuntimeMXBean"
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.AmqpConnection"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.AmqpConnection"
+      },
+      "type": "java.net.InetAddress[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.AmqpConnection"
+      },
+      "type": "java.net.InterfaceAddress[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.AmqpConnection"
+      },
+      "type": "java.net.NetworkInterface[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.AmqpConnection"
+      },
+      "type": "java.util.Map$Entry[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.AmqpConnection"
+      },
+      "type": "sun.invoke.util.ValueConversions"
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.AmqpConnection"
+      },
+      "type": "sun.security.provider.NativePRNG"
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.AmqpEnvironment"
+      },
+      "type": "com.rabbitmq.qpid.protonj2.client.futures.ClientFuture"
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.AmqpEnvironment"
+      },
+      "type": "com.rabbitmq.qpid.protonj2.client.impl.ClientInstance"
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.AmqpEnvironment"
+      },
+      "type": "sun.security.provider.NativePRNG"
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.AmqpEnvironment"
+      },
+      "type": "sun.security.provider.SHA"
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.DefaultConnectionSettings"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.Utils"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.client.amqp.impl.Utils"
+      },
+      "type": "java.lang.Thread$Builder",
+      "methods": [
+        {
+          "name": "factory",
+          "parameterTypes": []
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String",
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.qpid.protonj2.client.transport.netty4.TcpTransport"
+      },
+      "type": "com.rabbitmq.qpid.protonj2.client.transport.netty4.TcpTransport$1",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.qpid.protonj2.client.transport.netty4.TcpTransport"
+      },
+      "type": "com.rabbitmq.qpid.protonj2.client.transport.netty4.TcpTransport$NettyTcpTransportHandler",
+      "allPublicMethods": true
+    }
+  ]
+}

--- a/metadata/com.rabbitmq.client/amqp-client/0.8.0/reachability-metadata.json
+++ b/metadata/com.rabbitmq.client/amqp-client/0.8.0/reachability-metadata.json
@@ -225,5 +225,13 @@
       "type": "com.rabbitmq.qpid.protonj2.client.transport.netty4.TcpTransport$NettyTcpTransportHandler",
       "allPublicMethods": true
     }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "com.rabbitmq.qpid.protonj2.client.transport.netty4.SslSupport"
+      },
+      "glob": "ssl-support-test-truststore.p12"
+    }
   ]
 }

--- a/metadata/com.rabbitmq.client/amqp-client/index.json
+++ b/metadata/com.rabbitmq.client/amqp-client/index.json
@@ -1,0 +1,18 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "0.8.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/rabbitmq/client/amqp-client/$version$/amqp-client-$version$-sources.jar",
+    "repository-url" : "https://github.com/rabbitmq/rabbitmq-amqp-java-client",
+    "test-code-url" : "https://github.com/rabbitmq/rabbitmq-amqp-java-client/tree/v$version$/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/rabbitmq/client/amqp-client/$version$/amqp-client-$version$-javadoc.jar",
+    "description" : "The RabbitMQ AMQP 1.0 Java client library lets JVM applications connect to RabbitMQ brokers and communicate using AMQP 1.0. It provides APIs for connections, publishers, consumers, management operations, metrics, and related client-side messaging workflows.",
+    "tested-versions" : [
+      "0.8.0"
+    ],
+    "allowed-packages" : [
+      "com.rabbitmq.client.amqp",
+      "com.rabbitmq.qpid.protonj2"
+    ]
+  }
+]

--- a/stats/com.rabbitmq.client/amqp-client/0.8.0/execution-metrics.json
+++ b/stats/com.rabbitmq.client/amqp-client/0.8.0/execution-metrics.json
@@ -1,0 +1,67 @@
+{
+  "add_new_library_support:2026-05-19": {
+    "timestamp": "2026-05-19T01:20:15.429408Z",
+    "library": "com.rabbitmq.client:amqp-client:0.8.0",
+    "starting_commit": "54c5ad373f0860a3b638e031932e1c2e3f436839",
+    "ending_commit": "852c86f8f1646456855f9a029aa164dd2e77b976",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "0.8.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 19,
+            "totalCalls": 19
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 21,
+        "totalCalls": 21
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 11600,
+          "missed": 108730,
+          "ratio": 0.096402,
+          "total": 120330
+        },
+        "line": {
+          "covered": 2927,
+          "missed": 25445,
+          "ratio": 0.103165,
+          "total": 28372
+        },
+        "method": {
+          "covered": 985,
+          "missed": 7246,
+          "ratio": 0.11967,
+          "total": 8231
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 286065,
+      "cached_input_tokens_used": 3195904,
+      "output_tokens_used": 29350,
+      "iterations": 7,
+      "cost_usd": 2.4785,
+      "generated_loc": 308,
+      "tested_library_loc": 2927,
+      "metadata_entries": 40,
+      "code_coverage_percent": 10.32
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.rabbitmq.client/amqp-client/0.8.0/src/test/java/com_rabbitmq_client/amqp_client/UtilsTest.java",
+      "metadata_file": "metadata/com.rabbitmq.client/amqp-client/0.8.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.rabbitmq.client/amqp-client/0.8.0/stats.json
+++ b/stats/com.rabbitmq.client/amqp-client/0.8.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "0.8.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 19,
+          "totalCalls" : 19
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 21,
+      "totalCalls" : 21
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 11600,
+        "missed" : 108730,
+        "ratio" : 0.096402,
+        "total" : 120330
+      },
+      "line" : {
+        "covered" : 2927,
+        "missed" : 25445,
+        "ratio" : 0.103165,
+        "total" : 28372
+      },
+      "method" : {
+        "covered" : 985,
+        "missed" : 7246,
+        "ratio" : 0.11967,
+        "total" : 8231
+      }
+    }
+  } ]
+}

--- a/tests/src/com.rabbitmq.client/amqp-client/0.8.0/.gitignore
+++ b/tests/src/com.rabbitmq.client/amqp-client/0.8.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.rabbitmq.client/amqp-client/0.8.0/build.gradle
+++ b/tests/src/com.rabbitmq.client/amqp-client/0.8.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.rabbitmq.client:amqp-client:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.rabbitmq.client/amqp-client/0.8.0/gradle.properties
+++ b/tests/src/com.rabbitmq.client/amqp-client/0.8.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.rabbitmq.client:amqp-client:0.8.0
+library.version = 0.8.0
+metadata.dir = com.rabbitmq.client/amqp-client/0.8.0/

--- a/tests/src/com.rabbitmq.client/amqp-client/0.8.0/settings.gradle
+++ b/tests/src/com.rabbitmq.client/amqp-client/0.8.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.rabbitmq.client.amqp-client_tests'

--- a/tests/src/com.rabbitmq.client/amqp-client/0.8.0/src/test/java/com_rabbitmq_client/amqp_client/AbstractPrimitiveTypeDecoderTest.java
+++ b/tests/src/com.rabbitmq.client/amqp-client/0.8.0/src/test/java/com_rabbitmq_client/amqp_client/AbstractPrimitiveTypeDecoderTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_rabbitmq_client.amqp_client;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
+import com.rabbitmq.qpid.protonj2.buffer.ProtonBuffer;
+import com.rabbitmq.qpid.protonj2.buffer.ProtonBufferAllocator;
+import com.rabbitmq.qpid.protonj2.codec.decoders.ProtonDecoder;
+import com.rabbitmq.qpid.protonj2.codec.decoders.ProtonStreamDecoder;
+import com.rabbitmq.qpid.protonj2.codec.decoders.primitives.Integer32TypeDecoder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AbstractPrimitiveTypeDecoderTest {
+    @Test
+    void readArrayElementsFromBufferCreatesTypedObjectArray() {
+        Integer32TypeDecoder elementDecoder = new Integer32TypeDecoder();
+        ProtonDecoder protonDecoder = new ProtonDecoder();
+
+        try (ProtonBuffer buffer = ProtonBufferAllocator.defaultAllocator().allocate(8)) {
+            buffer.writeInt(41);
+            buffer.writeInt(42);
+
+            Integer[] values = elementDecoder.readArrayElements(
+                    buffer,
+                    protonDecoder.getCachedDecoderState(),
+                    2);
+
+            assertThat(values).containsExactly(41, 42);
+        }
+    }
+
+    @Test
+    void readArrayElementsFromStreamCreatesTypedObjectArray() {
+        Integer32TypeDecoder elementDecoder = new Integer32TypeDecoder();
+        ProtonStreamDecoder protonDecoder = new ProtonStreamDecoder();
+        InputStream stream = integerStream(43, 44);
+
+        Integer[] values = elementDecoder.readArrayElements(
+                stream,
+                protonDecoder.getCachedDecoderState(),
+                2);
+
+        assertThat(values).containsExactly(43, 44);
+    }
+
+    private static InputStream integerStream(int first, int second) {
+        byte[] bytes = ByteBuffer.allocate(8).putInt(first).putInt(second).array();
+        return new ByteArrayInputStream(bytes);
+    }
+}

--- a/tests/src/com.rabbitmq.client/amqp-client/0.8.0/src/test/java/com_rabbitmq_client/amqp_client/Amqp_clientTest.java
+++ b/tests/src/com.rabbitmq.client/amqp-client/0.8.0/src/test/java/com_rabbitmq_client/amqp_client/Amqp_clientTest.java
@@ -8,9 +8,9 @@ package com_rabbitmq_client.amqp_client;
 
 import org.junit.jupiter.api.Test;
 
-class Amqp_clientTest {
+public class Amqp_clientTest {
     @Test
-    void test() throws Exception {
+    void test() {
         System.out.println("This is just a placeholder, implement your test");
     }
 }

--- a/tests/src/com.rabbitmq.client/amqp-client/0.8.0/src/test/java/com_rabbitmq_client/amqp_client/Amqp_clientTest.java
+++ b/tests/src/com.rabbitmq.client/amqp-client/0.8.0/src/test/java/com_rabbitmq_client/amqp_client/Amqp_clientTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_rabbitmq_client.amqp_client;
+
+import org.junit.jupiter.api.Test;
+
+class Amqp_clientTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/com.rabbitmq.client/amqp-client/0.8.0/src/test/java/com_rabbitmq_client/amqp_client/ClientPropertiesTest.java
+++ b/tests/src/com.rabbitmq.client/amqp-client/0.8.0/src/test/java/com_rabbitmq_client/amqp_client/ClientPropertiesTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_rabbitmq_client.amqp_client;
+
+import com.rabbitmq.client.amqp.AmqpException;
+import com.rabbitmq.client.amqp.Environment;
+import com.rabbitmq.client.amqp.impl.AmqpEnvironmentBuilder;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ClientPropertiesTest {
+
+    @Test
+    void connectionAttemptInitializesDefaultClientProperties() throws IOException {
+        int unavailablePort = unavailableLocalPort();
+
+        try (Environment environment = new AmqpEnvironmentBuilder().build()) {
+            assertThatThrownBy(() -> environment.connectionBuilder()
+                    .host(InetAddress.getLoopbackAddress().getHostAddress())
+                    .port(unavailablePort)
+                    .recovery().activated(false)
+                    .connectionBuilder()
+                    .build())
+                    .isInstanceOf(AmqpException.class);
+        }
+    }
+
+    private static int unavailableLocalPort() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0, 1, InetAddress.getLoopbackAddress())) {
+            return socket.getLocalPort();
+        }
+    }
+}

--- a/tests/src/com.rabbitmq.client/amqp-client/0.8.0/src/test/java/com_rabbitmq_client/amqp_client/IOUringSupportTest.java
+++ b/tests/src/com.rabbitmq.client/amqp-client/0.8.0/src/test/java/com_rabbitmq_client/amqp_client/IOUringSupportTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_rabbitmq_client.amqp_client;
+
+import com.rabbitmq.qpid.protonj2.client.transport.netty4.IOUringSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class IOUringSupportTest {
+    @Test
+    void availabilityCheckInitializesNettyIoUringSupport() {
+        boolean available = IOUringSupport.isAvailable();
+
+        if (available) {
+            assertThat(IOUringSupport.getChannelClass()).isNotNull();
+        } else {
+            assertThatThrownBy(IOUringSupport::ensureAvailability)
+                    .isInstanceOf(UnsupportedOperationException.class)
+                    .hasMessageContaining("io_ring support is not enabled");
+        }
+    }
+}

--- a/tests/src/com.rabbitmq.client/amqp-client/0.8.0/src/test/java/com_rabbitmq_client/amqp_client/ProtonDecoderTest.java
+++ b/tests/src/com.rabbitmq.client/amqp-client/0.8.0/src/test/java/com_rabbitmq_client/amqp_client/ProtonDecoderTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_rabbitmq_client.amqp_client;
+
+import com.rabbitmq.qpid.protonj2.buffer.ProtonBuffer;
+import com.rabbitmq.qpid.protonj2.buffer.ProtonBufferAllocator;
+import com.rabbitmq.qpid.protonj2.codec.decoders.ProtonDecoder;
+import com.rabbitmq.qpid.protonj2.codec.encoders.ProtonEncoder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ProtonDecoderTest {
+    @Test
+    void readMultipleWrapsAssignableScalarInTypedArray() {
+        ProtonDecoder decoder = new ProtonDecoder();
+        ProtonEncoder encoder = new ProtonEncoder();
+
+        try (ProtonBuffer buffer = ProtonBufferAllocator.defaultAllocator().allocate(64)) {
+            encoder.writeString(buffer, encoder.getCachedEncoderState(), "value");
+
+            String[] values = decoder.readMultiple(buffer, decoder.getCachedDecoderState(), String.class);
+
+            assertThat(values).containsExactly("value");
+        }
+    }
+
+    @Test
+    void readMultipleRejectsArrayWithUnexpectedComponentType() {
+        ProtonDecoder decoder = new ProtonDecoder();
+        ProtonEncoder encoder = new ProtonEncoder();
+
+        try (ProtonBuffer buffer = ProtonBufferAllocator.defaultAllocator().allocate(64)) {
+            encoder.writeArray(buffer, encoder.getCachedEncoderState(), new int[] {1, 2});
+
+            assertThatThrownBy(() -> decoder.readMultiple(buffer, decoder.getCachedDecoderState(), String.class))
+                    .isInstanceOf(ClassCastException.class);
+        }
+    }
+
+    @Test
+    void readMultipleRejectsScalarWithUnexpectedType() {
+        ProtonDecoder decoder = new ProtonDecoder();
+        ProtonEncoder encoder = new ProtonEncoder();
+
+        try (ProtonBuffer buffer = ProtonBufferAllocator.defaultAllocator().allocate(64)) {
+            encoder.writeString(buffer, encoder.getCachedEncoderState(), "not an integer");
+
+            assertThatThrownBy(() -> decoder.readMultiple(buffer, decoder.getCachedDecoderState(), Integer.class))
+                    .isInstanceOf(ClassCastException.class);
+        }
+    }
+}

--- a/tests/src/com.rabbitmq.client/amqp-client/0.8.0/src/test/java/com_rabbitmq_client/amqp_client/ProtonStreamDecoderTest.java
+++ b/tests/src/com.rabbitmq.client/amqp-client/0.8.0/src/test/java/com_rabbitmq_client/amqp_client/ProtonStreamDecoderTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_rabbitmq_client.amqp_client;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import com.rabbitmq.qpid.protonj2.buffer.ProtonBuffer;
+import com.rabbitmq.qpid.protonj2.buffer.ProtonBufferAllocator;
+import com.rabbitmq.qpid.protonj2.codec.decoders.ProtonStreamDecoder;
+import com.rabbitmq.qpid.protonj2.codec.encoders.ProtonEncoder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ProtonStreamDecoderTest {
+    @Test
+    void readMultipleWrapsAssignableScalarInTypedArray() {
+        ProtonStreamDecoder decoder = new ProtonStreamDecoder();
+        InputStream stream = streamFromString("value");
+
+        String[] values = decoder.readMultiple(stream, decoder.getCachedDecoderState(), String.class);
+
+        assertThat(values).containsExactly("value");
+    }
+
+    @Test
+    void readMultipleRejectsArrayWithUnexpectedComponentType() {
+        ProtonStreamDecoder decoder = new ProtonStreamDecoder();
+        InputStream stream = streamFromIntegerArray(new int[] {1, 2});
+
+        assertThatThrownBy(() -> decoder.readMultiple(stream, decoder.getCachedDecoderState(), String.class))
+                .isInstanceOf(ClassCastException.class);
+    }
+
+    @Test
+    void readMultipleRejectsScalarWithUnexpectedType() {
+        ProtonStreamDecoder decoder = new ProtonStreamDecoder();
+        InputStream stream = streamFromString("not an integer");
+
+        assertThatThrownBy(() -> decoder.readMultiple(stream, decoder.getCachedDecoderState(), Integer.class))
+                .isInstanceOf(ClassCastException.class);
+    }
+
+    private static InputStream streamFromString(String value) {
+        ProtonEncoder encoder = new ProtonEncoder();
+
+        try (ProtonBuffer buffer = ProtonBufferAllocator.defaultAllocator().allocate(64)) {
+            encoder.writeString(buffer, encoder.getCachedEncoderState(), value);
+            return toInputStream(buffer);
+        }
+    }
+
+    private static InputStream streamFromIntegerArray(int[] values) {
+        ProtonEncoder encoder = new ProtonEncoder();
+
+        try (ProtonBuffer buffer = ProtonBufferAllocator.defaultAllocator().allocate(64)) {
+            encoder.writeArray(buffer, encoder.getCachedEncoderState(), values);
+            return toInputStream(buffer);
+        }
+    }
+
+    private static InputStream toInputStream(ProtonBuffer buffer) {
+        byte[] bytes = new byte[buffer.getReadableBytes()];
+        buffer.copyInto(buffer.getReadOffset(), bytes, 0, bytes.length);
+        return new ByteArrayInputStream(bytes);
+    }
+}

--- a/tests/src/com.rabbitmq.client/amqp-client/0.8.0/src/test/java/com_rabbitmq_client/amqp_client/SslSupportTest.java
+++ b/tests/src/com.rabbitmq.client/amqp-client/0.8.0/src/test/java/com_rabbitmq_client/amqp_client/SslSupportTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_rabbitmq_client.amqp_client;
+
+import com.rabbitmq.qpid.protonj2.client.SslOptions;
+import com.rabbitmq.qpid.protonj2.client.transport.netty4.SslSupport;
+import java.io.ByteArrayOutputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import javax.net.ssl.SSLContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SslSupportTest {
+
+    private static final String TRUST_STORE_RESOURCE = "ssl-support-test-truststore.p12";
+    private static final String TRUST_STORE_PASSWORD = "changeit";
+
+    @Test
+    void jdkSslContextLoadsTrustStoreFromClasspathLocation(@TempDir Path directory) throws Exception {
+        ClassLoader originalContextClassLoader = Thread.currentThread().getContextClassLoader();
+        Path trustStore = directory.resolve(TRUST_STORE_RESOURCE);
+        Files.write(trustStore, createEmptyPkcs12Store());
+        Thread.currentThread().setContextClassLoader(
+                new TrustStoreResourceClassLoader(originalContextClassLoader, trustStore.toUri().toURL()));
+        try {
+            SslOptions options = new SslOptions()
+                    .keyStoreLocation(null)
+                    .trustStoreLocation("classpath:" + TRUST_STORE_RESOURCE)
+                    .trustStorePassword(TRUST_STORE_PASSWORD)
+                    .trustStoreType("PKCS12")
+                    .allowNativeSSL(false);
+
+            SSLContext context = SslSupport.createJdkSslContext(options);
+
+            assertThat(context).isNotNull();
+            assertThat(context.getProtocol()).isEqualTo(options.contextProtocol());
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalContextClassLoader);
+        }
+    }
+
+    private static byte[] createEmptyPkcs12Store() throws Exception {
+        KeyStore keyStore = KeyStore.getInstance("PKCS12");
+        keyStore.load(null, TRUST_STORE_PASSWORD.toCharArray());
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        keyStore.store(output, TRUST_STORE_PASSWORD.toCharArray());
+        return output.toByteArray();
+    }
+
+    private static final class TrustStoreResourceClassLoader extends ClassLoader {
+
+        private final URL trustStore;
+
+        private TrustStoreResourceClassLoader(ClassLoader parent, URL trustStore) {
+            super(parent);
+            this.trustStore = trustStore;
+        }
+
+        @Override
+        protected URL findResource(String name) {
+            if (TRUST_STORE_RESOURCE.equals(name)) {
+                return trustStore;
+            }
+            return null;
+        }
+    }
+}

--- a/tests/src/com.rabbitmq.client/amqp-client/0.8.0/src/test/java/com_rabbitmq_client/amqp_client/UtilsTest.java
+++ b/tests/src/com.rabbitmq.client/amqp-client/0.8.0/src/test/java/com_rabbitmq_client/amqp_client/UtilsTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_rabbitmq_client.amqp_client;
+
+import com.rabbitmq.client.amqp.Environment;
+import com.rabbitmq.client.amqp.impl.AmqpEnvironmentBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UtilsTest {
+    @Test
+    void defaultEnvironmentCreatesAndClosesInternalExecutors() {
+        try (Environment environment = new AmqpEnvironmentBuilder().build()) {
+            assertThat(environment.connectionBuilder()).isNotNull();
+        }
+    }
+}

--- a/tests/src/com.rabbitmq.client/amqp-client/0.8.0/user-code-filter.json
+++ b/tests/src/com.rabbitmq.client/amqp-client/0.8.0/user-code-filter.json
@@ -1,13 +1,16 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.rabbitmq.client.amqp.**"
+      "includeClasses" : "com.rabbitmq.client.amqp.**"
     },
     {
-      "includeClasses": "com.rabbitmq.qpid.protonj2.**"
+      "includeClasses" : "com.rabbitmq.qpid.protonj2.**"
+    },
+    {
+      "includeClasses" : "com_rabbitmq_client.amqp_client.**"
     }
   ]
 }

--- a/tests/src/com.rabbitmq.client/amqp-client/0.8.0/user-code-filter.json
+++ b/tests/src/com.rabbitmq.client/amqp-client/0.8.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.rabbitmq.client.amqp.**"
+    },
+    {
+      "includeClasses": "com.rabbitmq.qpid.protonj2.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #7103

This PR introduces tests and metadata for com.rabbitmq.client:amqp-client:0.8.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 286065
- Cached input tokens: 3195904
- Output tokens: 29350
- Metadata entries: 40
- Iterations: 7
- Library coverage percentage: 10.32
- Generated lines of code: 308
- Tested library lines of code: 2927

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3f69aa1510d519e1825b9bfd59a81bb41ea7ef04`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 21/21 covered calls (100.00%)
- Reflection: 19/19 covered calls (100.00%)
- Resources: 2/2 covered calls (100.00%)

Library coverage:
- Instruction: 11600/120330 (9.64%)
- Line: 2927/28372 (10.32%)
- Method: 985/8231 (11.97%)

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
