### PR TITLE
[GenAI] Add support for org.springframework.boot:spring-boot-webflux:4.0.2 using gpt-5.5

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-webflux/4.0.2/reachability-metadata.json
+++ b/metadata/org.springframework.boot/spring-boot-webflux/4.0.2/reachability-metadata.json
@@ -1,0 +1,148 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.io.support.SpringFactoriesLoader"
+      },
+      "type" : "org.springframework.boot.ClearCachesApplicationListener",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.io.support.SpringFactoriesLoader"
+      },
+      "type" : "org.springframework.boot.builder.ParentContextCloserApplicationListener",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.io.support.SpringFactoriesLoader"
+      },
+      "type" : "org.springframework.boot.context.ConfigurationWarningsApplicationContextInitializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.io.support.SpringFactoriesLoader"
+      },
+      "type" : "org.springframework.boot.context.ContextIdApplicationContextInitializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.io.support.SpringFactoriesLoader"
+      },
+      "type" : "org.springframework.boot.context.FileEncodingApplicationListener",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.io.support.SpringFactoriesLoader"
+      },
+      "type" : "org.springframework.boot.context.logging.LoggingApplicationListener",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.io.support.SpringFactoriesLoader"
+      },
+      "type" : "org.springframework.boot.io.ProtocolResolverApplicationContextInitializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.io.support.SpringFactoriesLoader"
+      },
+      "type" : "org.springframework.boot.support.AnsiOutputApplicationListener",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.io.support.SpringFactoriesLoader"
+      },
+      "type" : "org.springframework.boot.support.EnvironmentPostProcessorApplicationListener",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.io.support.SpringFactoriesLoader"
+      },
+      "type" : "org.springframework.boot.web.server.context.ServerPortInfoApplicationContextInitializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.io.support.SpringFactoriesLoader"
+      },
+      "type" : "org.springframework.boot.webflux.WebFluxWebApplicationTypeDeducer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.webflux.WebFluxWebApplicationTypeDeducer"
+      },
+      "type" : "org.springframework.web.reactive.DispatcherHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.webflux.WebFluxWebApplicationTypeDeducer"
+      },
+      "type" : "reactor.core.publisher.Mono"
+    }
+  ]
+}

--- a/metadata/org.springframework.boot/spring-boot-webflux/index.json
+++ b/metadata/org.springframework.boot/spring-boot-webflux/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.0.2",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-webflux/$version$/spring-boot-webflux-$version$-sources.jar",
+    "repository-url" : "https://github.com/spring-projects/spring-boot",
+    "test-code-url" : "https://github.com/spring-projects/spring-boot/tree/v$version$/module/spring-boot-webflux/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-webflux/$version$/spring-boot-webflux-$version$-javadoc.jar",
+    "description" : "Spring Boot WebFlux provides auto-configuration and supporting infrastructure for reactive Spring WebFlux applications. It configures WebFlux handlers, HTTP handling, multipart support, sessions, observability, actuator endpoint mappings, and related runtime hints for Spring Boot applications.",
+    "tested-versions" : [
+      "4.0.2"
+    ],
+    "allowed-packages" : [
+      "org.springframework.boot.webflux"
+    ]
+  }
+]

--- a/metadata/org.springframework.boot/spring-boot-webflux/index.json
+++ b/metadata/org.springframework.boot/spring-boot-webflux/index.json
@@ -1,17 +1,18 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "4.0.2",
-    "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-webflux/$version$/spring-boot-webflux-$version$-sources.jar",
-    "repository-url" : "https://github.com/spring-projects/spring-boot",
-    "test-code-url" : "https://github.com/spring-projects/spring-boot/tree/v$version$/module/spring-boot-webflux/src/test",
-    "documentation-url" : "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-webflux/$version$/spring-boot-webflux-$version$-javadoc.jar",
-    "description" : "Spring Boot WebFlux provides auto-configuration and supporting infrastructure for reactive Spring WebFlux applications. It configures WebFlux handlers, HTTP handling, multipart support, sessions, observability, actuator endpoint mappings, and related runtime hints for Spring Boot applications.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "4.0.2",
+    "source-code-url": "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-webflux/$version$/spring-boot-webflux-$version$-sources.jar",
+    "repository-url": "https://github.com/spring-projects/spring-boot",
+    "test-code-url": "https://github.com/spring-projects/spring-boot/tree/v$version$/module/spring-boot-webflux/src/test",
+    "documentation-url": "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-webflux/$version$/spring-boot-webflux-$version$-javadoc.jar",
+    "description": "Spring Boot WebFlux provides auto-configuration and supporting infrastructure for reactive Spring WebFlux applications. It configures WebFlux handlers, HTTP handling, multipart support, sessions, observability, actuator endpoint mappings, and related runtime hints for Spring Boot applications.",
+    "tested-versions": [
       "4.0.2"
     ],
-    "allowed-packages" : [
-      "org.springframework.boot.webflux"
+    "allowed-packages": [
+      "org.springframework.boot.webflux",
+      "org.springframework.core.io.support"
     ]
   }
 ]

--- a/stats/org.springframework.boot/spring-boot-webflux/4.0.2/execution-metrics.json
+++ b/stats/org.springframework.boot/spring-boot-webflux/4.0.2/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-19": {
+    "timestamp": "2026-05-19T02:01:51.977222Z",
+    "library": "org.springframework.boot:spring-boot-webflux:4.0.2",
+    "starting_commit": "e35e6350d68e0be7eed305ca88a3b61356190e64",
+    "ending_commit": "e419ef3c58a4f0fafa08a9d2c6f5f37de518e872",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.0.2",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 525,
+          "missed": 4533,
+          "ratio": 0.103796,
+          "total": 5058
+        },
+        "line": {
+          "covered": 154,
+          "missed": 995,
+          "ratio": 0.13403,
+          "total": 1149
+        },
+        "method": {
+          "covered": 68,
+          "missed": 324,
+          "ratio": 0.173469,
+          "total": 392
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 178488,
+      "cached_input_tokens_used": 2492928,
+      "output_tokens_used": 27974,
+      "iterations": 4,
+      "cost_usd": 2.0857,
+      "generated_loc": 292,
+      "tested_library_loc": 154,
+      "metadata_entries": 24,
+      "code_coverage_percent": 13.4
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.springframework.boot/spring-boot-webflux/4.0.2/src/test/java/org_springframework_boot/spring_boot_webflux/Spring_boot_webfluxTest.java",
+      "metadata_file": "metadata/org.springframework.boot/spring-boot-webflux/4.0.2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.springframework.boot/spring-boot-webflux/4.0.2/stats.json
+++ b/stats/org.springframework.boot/spring-boot-webflux/4.0.2/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.0.2",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 525,
+        "missed" : 4533,
+        "ratio" : 0.103796,
+        "total" : 5058
+      },
+      "line" : {
+        "covered" : 154,
+        "missed" : 995,
+        "ratio" : 0.13403,
+        "total" : 1149
+      },
+      "method" : {
+        "covered" : 68,
+        "missed" : 324,
+        "ratio" : 0.173469,
+        "total" : 392
+      }
+    }
+  } ]
+}

--- a/tests/src/org.springframework.boot/spring-boot-webflux/4.0.2/.gitignore
+++ b/tests/src/org.springframework.boot/spring-boot-webflux/4.0.2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.springframework.boot/spring-boot-webflux/4.0.2/build.gradle
+++ b/tests/src/org.springframework.boot/spring-boot-webflux/4.0.2/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.springframework.boot:spring-boot-webflux:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.springframework.boot/spring-boot-webflux/4.0.2/gradle.properties
+++ b/tests/src/org.springframework.boot/spring-boot-webflux/4.0.2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.springframework.boot:spring-boot-webflux:4.0.2
+library.version = 4.0.2
+metadata.dir = org.springframework.boot/spring-boot-webflux/4.0.2/

--- a/tests/src/org.springframework.boot/spring-boot-webflux/4.0.2/settings.gradle
+++ b/tests/src/org.springframework.boot/spring-boot-webflux/4.0.2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.springframework.boot.spring-boot-webflux_tests'

--- a/tests/src/org.springframework.boot/spring-boot-webflux/4.0.2/src/test/java/org_springframework_boot/spring_boot_webflux/Spring_boot_webfluxTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-webflux/4.0.2/src/test/java/org_springframework_boot/spring_boot_webflux/Spring_boot_webfluxTest.java
@@ -25,6 +25,7 @@ import org.springframework.boot.webflux.autoconfigure.ReactiveMultipartPropertie
 import org.springframework.boot.webflux.autoconfigure.WebFluxProperties;
 import org.springframework.boot.webflux.error.DefaultErrorAttributes;
 import org.springframework.boot.webflux.filter.OrderedHiddenHttpMethodFilter;
+import org.springframework.context.MessageSourceResolvable;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DefaultDataBufferFactory;
@@ -40,6 +41,7 @@ import org.springframework.http.server.reactive.SslInfo;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.unit.DataSize;
+import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.server.ResponseStatusException;
@@ -177,6 +179,30 @@ public class Spring_boot_webfluxTest {
         assertThat(result).doesNotContainKey("trace");
     }
 
+    @Test
+    void defaultErrorAttributesIncludeBindingErrorsWhenRequested() {
+        DefaultErrorAttributes attributes = new DefaultErrorAttributes();
+        ServerWebExchange exchange = createExchange(HttpMethod.POST, "/registrations", "");
+        BindException failure = new BindException(new RegistrationForm(), "registrationForm");
+        failure.reject("registration.invalid", "Registration is invalid");
+        attributes.storeErrorInformation(failure, exchange);
+        ServerRequest request = createServerRequest(exchange);
+
+        Map<String, Object> result = attributes.getErrorAttributes(request,
+                ErrorAttributeOptions.of(Include.STATUS, Include.ERROR, Include.PATH, Include.MESSAGE,
+                        Include.EXCEPTION, Include.BINDING_ERRORS));
+
+        assertThat(result).containsEntry("status", 500)
+                .containsEntry("error", "Internal Server Error")
+                .containsEntry("path", "/registrations")
+                .containsEntry("message", failure.getMessage())
+                .containsEntry("exception", BindException.class.getName());
+        assertThat(result.get("errors")).asList()
+                .singleElement()
+                .satisfies((error) -> assertThat(((MessageSourceResolvable) error).getDefaultMessage())
+                        .isEqualTo("Registration is invalid"));
+    }
+
     private static ServerRequest createServerRequest(ServerWebExchange exchange) {
         return ServerRequest.create(exchange, ServerCodecConfigurer.create().getReaders());
     }
@@ -201,6 +227,10 @@ public class Spring_boot_webfluxTest {
 
     @ResponseStatus(code = HttpStatus.BAD_REQUEST, reason = "invalid annotated request")
     static final class AnnotatedBadRequestException extends RuntimeException {
+
+    }
+
+    static final class RegistrationForm {
 
     }
 

--- a/tests/src/org.springframework.boot/spring-boot-webflux/4.0.2/src/test/java/org_springframework_boot/spring_boot_webflux/Spring_boot_webfluxTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-webflux/4.0.2/src/test/java/org_springframework_boot/spring_boot_webflux/Spring_boot_webfluxTest.java
@@ -23,6 +23,7 @@ import org.springframework.boot.web.error.ErrorAttributeOptions;
 import org.springframework.boot.web.error.ErrorAttributeOptions.Include;
 import org.springframework.boot.webflux.autoconfigure.ReactiveMultipartProperties;
 import org.springframework.boot.webflux.autoconfigure.WebFluxProperties;
+import org.springframework.boot.webflux.autoconfigure.WebHttpHandlerBuilderCustomizer;
 import org.springframework.boot.webflux.error.DefaultErrorAttributes;
 import org.springframework.boot.webflux.filter.OrderedHiddenHttpMethodFilter;
 import org.springframework.context.MessageSourceResolvable;
@@ -37,6 +38,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.codec.ServerCodecConfigurer;
 import org.springframework.http.server.reactive.AbstractServerHttpRequest;
 import org.springframework.http.server.reactive.AbstractServerHttpResponse;
+import org.springframework.http.server.reactive.HttpHandler;
 import org.springframework.http.server.reactive.SslInfo;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -48,6 +50,7 @@ import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilterChain;
 import org.springframework.web.server.adapter.DefaultServerWebExchange;
+import org.springframework.web.server.adapter.WebHttpHandlerBuilder;
 import org.springframework.web.server.i18n.AcceptHeaderLocaleContextResolver;
 import org.springframework.web.server.session.DefaultWebSessionManager;
 
@@ -120,6 +123,28 @@ public class Spring_boot_webfluxTest {
         assertThat(properties.getMaxParts()).isEqualTo(12);
         assertThat(properties.getFileStorageDirectory()).isEqualTo("/tmp/uploads");
         assertThat(properties.getHeadersCharset()).isEqualTo(StandardCharsets.ISO_8859_1);
+    }
+
+    @Test
+    void webHttpHandlerBuilderCustomizerCanAddWebFilter() {
+        WebHttpHandlerBuilderCustomizer customizer = (builder) -> builder.filters((filters) ->
+                filters.add((exchange, chain) -> {
+                    exchange.getResponse().getHeaders().add("X-Customized", "true");
+                    return chain.filter(exchange);
+                }));
+        WebHttpHandlerBuilder builder = WebHttpHandlerBuilder.webHandler((exchange) -> {
+            exchange.getResponse().setStatusCode(HttpStatus.ACCEPTED);
+            return Mono.empty();
+        });
+        customizer.customize(builder);
+        HttpHandler handler = builder.build();
+        TestServerHttpResponse response = new TestServerHttpResponse();
+
+        handler.handle(new TestServerHttpRequest(HttpMethod.GET, URI.create("https://example.test/customizer"),
+                new HttpHeaders(), ""), response).block(TIMEOUT);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.ACCEPTED);
+        assertThat(response.getHeaders().getFirst("X-Customized")).isEqualTo("true");
     }
 
     @Test

--- a/tests/src/org.springframework.boot/spring-boot-webflux/4.0.2/src/test/java/org_springframework_boot/spring_boot_webflux/Spring_boot_webfluxTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-webflux/4.0.2/src/test/java/org_springframework_boot/spring_boot_webflux/Spring_boot_webfluxTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework_boot.spring_boot_webflux;
+
+import org.junit.jupiter.api.Test;
+
+class Spring_boot_webfluxTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.springframework.boot/spring-boot-webflux/4.0.2/src/test/java/org_springframework_boot/spring_boot_webflux/Spring_boot_webfluxTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-webflux/4.0.2/src/test/java/org_springframework_boot/spring_boot_webflux/Spring_boot_webfluxTest.java
@@ -6,11 +6,292 @@
  */
 package org_springframework_boot.spring_boot_webflux;
 
-import org.junit.jupiter.api.Test;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
 
-class Spring_boot_webfluxTest {
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.web.error.ErrorAttributeOptions;
+import org.springframework.boot.web.error.ErrorAttributeOptions.Include;
+import org.springframework.boot.webflux.autoconfigure.ReactiveMultipartProperties;
+import org.springframework.boot.webflux.autoconfigure.WebFluxProperties;
+import org.springframework.boot.webflux.error.DefaultErrorAttributes;
+import org.springframework.boot.webflux.filter.OrderedHiddenHttpMethodFilter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.HttpCookie;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerCodecConfigurer;
+import org.springframework.http.server.reactive.AbstractServerHttpRequest;
+import org.springframework.http.server.reactive.AbstractServerHttpResponse;
+import org.springframework.http.server.reactive.SslInfo;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.unit.DataSize;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilterChain;
+import org.springframework.web.server.adapter.DefaultServerWebExchange;
+import org.springframework.web.server.i18n.AcceptHeaderLocaleContextResolver;
+import org.springframework.web.server.session.DefaultWebSessionManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Spring_boot_webfluxTest {
+
+    private static final Duration TIMEOUT = Duration.ofSeconds(5);
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void springApplicationDeducesReactiveWebApplicationType() {
+        SpringApplication application = new SpringApplication(BasicConfiguration.class);
+
+        assertThat(application.getWebApplicationType()).isEqualTo(WebApplicationType.REACTIVE);
     }
+
+    @Test
+    void webFluxPropertiesExposeNestedConfiguration() {
+        WebFluxProperties properties = new WebFluxProperties();
+
+        properties.setBasePath("/api");
+        properties.setStaticPathPattern("/assets/**");
+        properties.setWebjarsPathPattern("/vendor/**");
+        properties.getFormat().setDate("yyyy-MM-dd");
+        properties.getFormat().setTime("HH:mm:ss");
+        properties.getFormat().setDateTime("yyyy-MM-dd'T'HH:mm:ss");
+        properties.getProblemdetails().setEnabled(true);
+        properties.getApiversion().setRequired(true);
+        properties.getApiversion().setDefaultVersion("2026-05-19");
+        properties.getApiversion().setSupported(List.of("2026-05-19", "2026-06-01"));
+        properties.getApiversion().setDetectSupported(false);
+        properties.getApiversion().getUse().setHeader("X-API-Version");
+        properties.getApiversion().getUse().setQueryParameter("api-version");
+        properties.getApiversion().getUse().setPathSegment(1);
+        properties.getApiversion().getUse()
+                .setMediaTypeParameter(Map.of(MediaType.APPLICATION_JSON, "version"));
+
+        assertThat(properties.getBasePath()).isEqualTo("/api");
+        assertThat(properties.getStaticPathPattern()).isEqualTo("/assets/**");
+        assertThat(properties.getWebjarsPathPattern()).isEqualTo("/vendor/**");
+        assertThat(properties.getFormat().getDate()).isEqualTo("yyyy-MM-dd");
+        assertThat(properties.getFormat().getTime()).isEqualTo("HH:mm:ss");
+        assertThat(properties.getFormat().getDateTime()).isEqualTo("yyyy-MM-dd'T'HH:mm:ss");
+        assertThat(properties.getProblemdetails().isEnabled()).isTrue();
+        assertThat(properties.getApiversion().getRequired()).isTrue();
+        assertThat(properties.getApiversion().getDefaultVersion()).isEqualTo("2026-05-19");
+        assertThat(properties.getApiversion().getSupported()).containsExactly("2026-05-19", "2026-06-01");
+        assertThat(properties.getApiversion().getDetectSupported()).isFalse();
+        assertThat(properties.getApiversion().getUse().getHeader()).isEqualTo("X-API-Version");
+        assertThat(properties.getApiversion().getUse().getQueryParameter()).isEqualTo("api-version");
+        assertThat(properties.getApiversion().getUse().getPathSegment()).isEqualTo(1);
+        assertThat(properties.getApiversion().getUse().getMediaTypeParameter())
+                .containsEntry(MediaType.APPLICATION_JSON, "version");
+    }
+
+    @Test
+    void reactiveMultipartPropertiesExposeLimitsAndStorageOptions() {
+        ReactiveMultipartProperties properties = new ReactiveMultipartProperties();
+
+        properties.setMaxInMemorySize(DataSize.ofKilobytes(64));
+        properties.setMaxHeadersSize(DataSize.ofKilobytes(16));
+        properties.setMaxDiskUsagePerPart(DataSize.ofMegabytes(8));
+        properties.setMaxParts(12);
+        properties.setFileStorageDirectory("/tmp/uploads");
+        properties.setHeadersCharset(StandardCharsets.ISO_8859_1);
+
+        assertThat(properties.getMaxInMemorySize()).isEqualTo(DataSize.ofKilobytes(64));
+        assertThat(properties.getMaxHeadersSize()).isEqualTo(DataSize.ofKilobytes(16));
+        assertThat(properties.getMaxDiskUsagePerPart()).isEqualTo(DataSize.ofMegabytes(8));
+        assertThat(properties.getMaxParts()).isEqualTo(12);
+        assertThat(properties.getFileStorageDirectory()).isEqualTo("/tmp/uploads");
+        assertThat(properties.getHeadersCharset()).isEqualTo(StandardCharsets.ISO_8859_1);
+    }
+
+    @Test
+    void orderedHiddenHttpMethodFilterOverridesFormPostMethod() {
+        OrderedHiddenHttpMethodFilter filter = new OrderedHiddenHttpMethodFilter();
+        filter.setOrder(123);
+        ServerWebExchange exchange = createExchange(HttpMethod.POST, "/items/42", "_method=PATCH&name=alpha");
+        CapturingWebFilterChain chain = new CapturingWebFilterChain();
+
+        filter.filter(exchange, chain).block(TIMEOUT);
+
+        assertThat(filter.getOrder()).isEqualTo(123);
+        assertThat(chain.getFilteredMethod()).isEqualTo(HttpMethod.PATCH);
+    }
+
+    @Test
+    void defaultErrorAttributesReturnIncludedDetailsForResponseStatusException() {
+        DefaultErrorAttributes attributes = new DefaultErrorAttributes();
+        ServerWebExchange exchange = createExchange(HttpMethod.GET, "/catalog/99", "");
+        ResponseStatusException failure = new ResponseStatusException(HttpStatus.NOT_FOUND, "missing item");
+        attributes.storeErrorInformation(failure, exchange);
+        ServerRequest request = createServerRequest(exchange);
+
+        Map<String, Object> result = attributes.getErrorAttributes(request,
+                ErrorAttributeOptions.of(Include.STATUS, Include.ERROR, Include.PATH, Include.MESSAGE,
+                        Include.EXCEPTION, Include.STACK_TRACE));
+
+        assertThat(attributes.getError(request)).isSameAs(failure);
+        assertThat(result).containsEntry("status", 404)
+                .containsEntry("error", "Not Found")
+                .containsEntry("path", "/catalog/99")
+                .containsEntry("message", "missing item")
+                .containsEntry("exception", ResponseStatusException.class.getName());
+        assertThat(result.get("trace")).asString().contains(ResponseStatusException.class.getName());
+        assertThat(result.get("requestId")).isInstanceOf(String.class);
+    }
+
+    @Test
+    void defaultErrorAttributesUseResponseStatusAnnotationAndKeepFirstStoredError() {
+        DefaultErrorAttributes attributes = new DefaultErrorAttributes();
+        ServerWebExchange exchange = createExchange(HttpMethod.GET, "/annotated", "");
+        AnnotatedBadRequestException failure = new AnnotatedBadRequestException();
+        attributes.storeErrorInformation(failure, exchange);
+        attributes.storeErrorInformation(new IllegalStateException("second error"), exchange);
+        ServerRequest request = createServerRequest(exchange);
+
+        Map<String, Object> result = attributes.getErrorAttributes(request,
+                ErrorAttributeOptions.of(Include.STATUS, Include.ERROR, Include.PATH, Include.MESSAGE,
+                        Include.EXCEPTION));
+
+        assertThat(attributes.getError(request)).isSameAs(failure);
+        assertThat(result).containsEntry("status", 400)
+                .containsEntry("error", "Bad Request")
+                .containsEntry("path", "/annotated")
+                .containsEntry("message", "invalid annotated request")
+                .containsEntry("exception", AnnotatedBadRequestException.class.getName());
+        assertThat(result).doesNotContainKey("trace");
+    }
+
+    private static ServerRequest createServerRequest(ServerWebExchange exchange) {
+        return ServerRequest.create(exchange, ServerCodecConfigurer.create().getReaders());
+    }
+
+    private static ServerWebExchange createExchange(HttpMethod method, String path, String body) {
+        HttpHeaders headers = new HttpHeaders();
+        if (!body.isEmpty()) {
+            headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+            headers.setContentLength(body.getBytes(StandardCharsets.UTF_8).length);
+        }
+        TestServerHttpRequest request = new TestServerHttpRequest(method, URI.create("https://example.test" + path),
+                headers, body);
+        TestServerHttpResponse response = new TestServerHttpResponse();
+        return new DefaultServerWebExchange(request, response, new DefaultWebSessionManager(),
+                ServerCodecConfigurer.create(), new AcceptHeaderLocaleContextResolver());
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class BasicConfiguration {
+
+    }
+
+    @ResponseStatus(code = HttpStatus.BAD_REQUEST, reason = "invalid annotated request")
+    static final class AnnotatedBadRequestException extends RuntimeException {
+
+    }
+
+    private static final class CapturingWebFilterChain implements WebFilterChain {
+
+        private HttpMethod filteredMethod;
+
+        @Override
+        public Mono<Void> filter(ServerWebExchange exchange) {
+            this.filteredMethod = exchange.getRequest().getMethod();
+            return Mono.empty();
+        }
+
+        HttpMethod getFilteredMethod() {
+            return this.filteredMethod;
+        }
+
+    }
+
+    private static final class TestServerHttpRequest extends AbstractServerHttpRequest {
+
+        private final byte[] body;
+
+        TestServerHttpRequest(HttpMethod method, URI uri, HttpHeaders headers, String body) {
+            super(method, uri, "", headers);
+            this.body = body.getBytes(StandardCharsets.UTF_8);
+        }
+
+        @Override
+        protected MultiValueMap<String, HttpCookie> initCookies() {
+            return new LinkedMultiValueMap<>();
+        }
+
+        @Override
+        protected SslInfo initSslInfo() {
+            return null;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getNativeRequest() {
+            return (T) this;
+        }
+
+        @Override
+        public Flux<DataBuffer> getBody() {
+            if (this.body.length == 0) {
+                return Flux.empty();
+            }
+            return Flux.just(DefaultDataBufferFactory.sharedInstance.wrap(this.body));
+        }
+
+    }
+
+    private static final class TestServerHttpResponse extends AbstractServerHttpResponse {
+
+        TestServerHttpResponse() {
+            super(DefaultDataBufferFactory.sharedInstance);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getNativeResponse() {
+            return (T) this;
+        }
+
+        @Override
+        protected Mono<Void> writeWithInternal(Publisher<? extends DataBuffer> body) {
+            return Mono.empty();
+        }
+
+        @Override
+        protected Mono<Void> writeAndFlushWithInternal(Publisher<? extends Publisher<? extends DataBuffer>> body) {
+            return Mono.empty();
+        }
+
+        @Override
+        protected void applyStatusCode() {
+            // No underlying response state is needed for these exchange-level tests.
+        }
+
+        @Override
+        protected void applyHeaders() {
+            // No underlying response state is needed for these exchange-level tests.
+        }
+
+        @Override
+        protected void applyCookies() {
+            // No underlying response state is needed for these exchange-level tests.
+        }
+
+    }
+
 }

--- a/tests/src/org.springframework.boot/spring-boot-webflux/4.0.2/user-code-filter.json
+++ b/tests/src/org.springframework.boot/spring-boot-webflux/4.0.2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.springframework.boot.webflux.**"
+    }
+  ]
+}

--- a/tests/src/org.springframework.boot/spring-boot-webflux/4.0.2/user-code-filter.json
+++ b/tests/src/org.springframework.boot/spring-boot-webflux/4.0.2/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.springframework.boot.webflux.**"
+      "includeClasses" : "org.springframework.boot.webflux.**"
+    },
+    {
+      "includeClasses" : "org_springframework_boot.spring_boot_webflux.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #7102

This PR introduces tests and metadata for org.springframework.boot:spring-boot-webflux:4.0.2, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 178488
- Cached input tokens: 2492928
- Output tokens: 27974
- Metadata entries: 24
- Iterations: 4
- Library coverage percentage: 13.4
- Generated lines of code: 292
- Tested library lines of code: 154

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3f69aa1510d519e1825b9bfd59a81bb41ea7ef04`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 525/5058 (10.38%)
- Line: 154/1149 (13.40%)
- Method: 68/392 (17.35%)

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
