### PR TITLE
[GenAI] Test fix for org.json4s:json4s-jackson_2.13:3.7.0-M13 using gpt-5.5

### DIFF
--- a/metadata/org.json4s/json4s-jackson_2.13/3.7.0-M13/reachability-metadata.json
+++ b/metadata/org.json4s/json4s-jackson_2.13/3.7.0-M13/reachability-metadata.json
@@ -1,191 +1,113 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org.json4s.jackson.JValueDeserializer"
+      "condition" : {
+        "typeReached" : "org.json4s.jackson.JValueDeserializer"
       },
-      "type": "com.fasterxml.jackson.core.sym.CharsToNameCanonicalizer$Bucket[]"
+      "type" : "com.fasterxml.jackson.core.sym.CharsToNameCanonicalizer$Bucket[]"
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.jackson.Json4sScalaModule"
+      "condition" : {
+        "typeReached" : "org.json4s.jackson.Json4sScalaModule"
       },
-      "type": "com.fasterxml.jackson.databind.deser.Deserializers[]"
+      "type" : "com.fasterxml.jackson.databind.deser.Deserializers[]"
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.jackson.JsonMethods"
+      "condition" : {
+        "typeReached" : "org.json4s.jackson.JsonMethods"
       },
-      "type": "com.fasterxml.jackson.databind.ext.Java7SupportImpl"
+      "type" : "com.fasterxml.jackson.databind.ext.Java7SupportImpl"
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.jackson.Json4sScalaModule"
+      "condition" : {
+        "typeReached" : "org.json4s.jackson.Json4sScalaModule"
       },
-      "type": "com.fasterxml.jackson.databind.ser.Serializers[]"
+      "type" : "com.fasterxml.jackson.databind.ser.Serializers[]"
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.scalap.StateRules"
+      "condition" : {
+        "typeReached" : "org.json4s.scalap.StateRules"
       },
-      "type": "java.lang.Object[][]"
+      "type" : "java.lang.Object[][]"
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.scalap.scalasig.ScalaSigParsers$"
+      "condition" : {
+        "typeReached" : "org.json4s.scalap.scalasig.ScalaSigParsers$"
       },
-      "type": "java.lang.Object[][]"
+      "type" : "java.lang.Object[][]"
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.jackson.JacksonSerialization"
+      "condition" : {
+        "typeReached" : "org.json4s.jackson.JacksonSerialization"
       },
-      "type": "java.lang.annotation.Annotation[]"
+      "type" : "java.lang.annotation.Annotation[]"
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.jackson.JsonMethods"
+      "condition" : {
+        "typeReached" : "org.json4s.jackson.JsonMethods"
       },
-      "type": "java.lang.annotation.Annotation[]"
+      "type" : "java.lang.annotation.Annotation[]"
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
       },
-      "type": "java.lang.reflect.Type[]"
+      "type" : "java.lang.reflect.Type[]"
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.reflect.Reflector$"
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Executable"
       },
-      "type": "org_json4s.json4s_jackson_2_13.JacksonEmailNotification$"
+      "type" : "scala.Option"
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.reflect.ScalaSigReader$"
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
       },
-      "type": "org_json4s.json4s_jackson_2_13.JacksonEmailNotification$"
+      "type" : "scala.Option"
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.reflect.Reflector$"
+      "condition" : {
+        "typeReached" : "org.json4s.scalap.scalasig.ConstantPool"
       },
-      "type": "org_json4s.json4s_jackson_2_13.JacksonFieldMappedAccount$"
+      "type" : "scala.Option[]"
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.reflect.ScalaSigReader$"
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Executable"
       },
-      "type": "org_json4s.json4s_jackson_2_13.JacksonFieldMappedAccount$"
+      "type" : "scala.collection.immutable.List"
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.reflect.Executable"
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
       },
-      "type": "org_json4s.json4s_jackson_2_13.JacksonNotification"
+      "type" : "scala.collection.immutable.List"
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
+      "condition" : {
+        "typeReached" : "org.json4s.scalap.DefaultMemoisable"
       },
-      "type": "org_json4s.json4s_jackson_2_13.JacksonNotification"
+      "type" : "scala.collection.mutable.HashMap$Node[]"
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.reflect.ScalaSigReader$"
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ManifestFactory$"
       },
-      "type": "org_json4s.json4s_jackson_2_13.JacksonNotification$"
+      "type" : "scala.reflect.Manifest[]"
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.reflect.Reflector$"
+      "condition" : {
+        "typeReached" : "org.json4s.jackson.JsonMethods"
       },
-      "type": "org_json4s.json4s_jackson_2_13.JacksonNotificationBatch$"
+      "type" : "sun.util.resources.cldr.CalendarData"
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.reflect.ScalaSigReader$"
+      "condition" : {
+        "typeReached" : "org.json4s.jackson.JacksonSerialization"
       },
-      "type": "org_json4s.json4s_jackson_2_13.JacksonNotificationBatch$"
-    },
-    {
-      "condition": {
-        "typeReached": "org.json4s.reflect.Reflector$"
-      },
-      "type": "org_json4s.json4s_jackson_2_13.JacksonOptionalProfile$"
-    },
-    {
-      "condition": {
-        "typeReached": "org.json4s.reflect.ScalaSigReader$"
-      },
-      "type": "org_json4s.json4s_jackson_2_13.JacksonOptionalProfile$"
-    },
-    {
-      "condition": {
-        "typeReached": "org.json4s.reflect.Reflector$"
-      },
-      "type": "org_json4s.json4s_jackson_2_13.JacksonSmsNotification$"
-    },
-    {
-      "condition": {
-        "typeReached": "org.json4s.reflect.ScalaSigReader$"
-      },
-      "type": "org_json4s.json4s_jackson_2_13.JacksonSmsNotification$"
-    },
-    {
-      "condition": {
-        "typeReached": "org.json4s.reflect.Executable"
-      },
-      "type": "scala.Option"
-    },
-    {
-      "condition": {
-        "typeReached": "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
-      },
-      "type": "scala.Option"
-    },
-    {
-      "condition": {
-        "typeReached": "org.json4s.scalap.scalasig.ConstantPool"
-      },
-      "type": "scala.Option[]"
-    },
-    {
-      "condition": {
-        "typeReached": "org.json4s.reflect.Executable"
-      },
-      "type": "scala.collection.immutable.List"
-    },
-    {
-      "condition": {
-        "typeReached": "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
-      },
-      "type": "scala.collection.immutable.List"
-    },
-    {
-      "condition": {
-        "typeReached": "org.json4s.scalap.DefaultMemoisable"
-      },
-      "type": "scala.collection.mutable.HashMap$Node[]"
-    },
-    {
-      "condition": {
-        "typeReached": "org.json4s.reflect.ManifestFactory$"
-      },
-      "type": "scala.reflect.Manifest[]"
-    },
-    {
-      "condition": {
-        "typeReached": "org.json4s.jackson.JsonMethods"
-      },
-      "type": "sun.util.resources.cldr.CalendarData"
-    },
-    {
-      "condition": {
-        "typeReached": "org.json4s.jackson.JacksonSerialization"
-      },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "scala.reflect.ScalaSignature"
         ]
       }

--- a/metadata/org.json4s/json4s-jackson_2.13/3.7.0-M13/reachability-metadata.json
+++ b/metadata/org.json4s/json4s-jackson_2.13/3.7.0-M13/reachability-metadata.json
@@ -1,0 +1,194 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.json4s.jackson.JValueDeserializer"
+      },
+      "type": "com.fasterxml.jackson.core.sym.CharsToNameCanonicalizer$Bucket[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.jackson.Json4sScalaModule"
+      },
+      "type": "com.fasterxml.jackson.databind.deser.Deserializers[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.jackson.JsonMethods"
+      },
+      "type": "com.fasterxml.jackson.databind.ext.Java7SupportImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.jackson.Json4sScalaModule"
+      },
+      "type": "com.fasterxml.jackson.databind.ser.Serializers[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.scalap.StateRules"
+      },
+      "type": "java.lang.Object[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.scalap.scalasig.ScalaSigParsers$"
+      },
+      "type": "java.lang.Object[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.jackson.JacksonSerialization"
+      },
+      "type": "java.lang.annotation.Annotation[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.jackson.JsonMethods"
+      },
+      "type": "java.lang.annotation.Annotation[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
+      },
+      "type": "java.lang.reflect.Type[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.Reflector$"
+      },
+      "type": "org_json4s.json4s_jackson_2_13.JacksonEmailNotification$"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.ScalaSigReader$"
+      },
+      "type": "org_json4s.json4s_jackson_2_13.JacksonEmailNotification$"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.Reflector$"
+      },
+      "type": "org_json4s.json4s_jackson_2_13.JacksonFieldMappedAccount$"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.ScalaSigReader$"
+      },
+      "type": "org_json4s.json4s_jackson_2_13.JacksonFieldMappedAccount$"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.Executable"
+      },
+      "type": "org_json4s.json4s_jackson_2_13.JacksonNotification"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
+      },
+      "type": "org_json4s.json4s_jackson_2_13.JacksonNotification"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.ScalaSigReader$"
+      },
+      "type": "org_json4s.json4s_jackson_2_13.JacksonNotification$"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.Reflector$"
+      },
+      "type": "org_json4s.json4s_jackson_2_13.JacksonNotificationBatch$"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.ScalaSigReader$"
+      },
+      "type": "org_json4s.json4s_jackson_2_13.JacksonNotificationBatch$"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.Reflector$"
+      },
+      "type": "org_json4s.json4s_jackson_2_13.JacksonOptionalProfile$"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.ScalaSigReader$"
+      },
+      "type": "org_json4s.json4s_jackson_2_13.JacksonOptionalProfile$"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.Reflector$"
+      },
+      "type": "org_json4s.json4s_jackson_2_13.JacksonSmsNotification$"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.ScalaSigReader$"
+      },
+      "type": "org_json4s.json4s_jackson_2_13.JacksonSmsNotification$"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.Executable"
+      },
+      "type": "scala.Option"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
+      },
+      "type": "scala.Option"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.scalap.scalasig.ConstantPool"
+      },
+      "type": "scala.Option[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.Executable"
+      },
+      "type": "scala.collection.immutable.List"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
+      },
+      "type": "scala.collection.immutable.List"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.scalap.DefaultMemoisable"
+      },
+      "type": "scala.collection.mutable.HashMap$Node[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.ManifestFactory$"
+      },
+      "type": "scala.reflect.Manifest[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.jackson.JsonMethods"
+      },
+      "type": "sun.util.resources.cldr.CalendarData"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.jackson.JacksonSerialization"
+      },
+      "type": {
+        "proxy": [
+          "scala.reflect.ScalaSignature"
+        ]
+      }
+    }
+  ]
+}

--- a/metadata/org.json4s/json4s-jackson_2.13/index.json
+++ b/metadata/org.json4s/json4s-jackson_2.13/index.json
@@ -1,39 +1,42 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "3.7.0-M13",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/org/json4s/json4s-jackson_2.13/$version$/json4s-jackson_2.13-$version$-sources.jar",
-    "repository-url" : "https://github.com/json4s/json4s",
-    "test-code-url" : "https://github.com/json4s/json4s/tree/v$version$/tests/src/test/scala/org/json4s/jackson",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/org/json4s/json4s-jackson_2.13/$version$/json4s-jackson_2.13-$version$-javadoc.jar",
-    "description" : "Json4s is a Scala JSON library that provides a shared JSON AST plus parsing, querying, transformation, extraction, and serialization APIs. The json4s-jackson artifact supplies the Jackson-backed parser and serializer integration for using that AST on Scala 2/JVM projects.",
-    "language" : {
-      "name" : "scala",
-      "version" : "2"
+    "latest": true,
+    "metadata-version": "3.7.0-M13",
+    "source-code-url": "https://repo.maven.apache.org/maven2/org/json4s/json4s-jackson_2.13/$version$/json4s-jackson_2.13-$version$-sources.jar",
+    "repository-url": "https://github.com/json4s/json4s",
+    "test-code-url": "https://github.com/json4s/json4s/tree/v$version$/tests/src/test/scala/org/json4s/jackson",
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/json4s/json4s-jackson_2.13/$version$/json4s-jackson_2.13-$version$-javadoc.jar",
+    "description": "Json4s is a Scala JSON library that provides a shared JSON AST plus parsing, querying, transformation, extraction, and serialization APIs. The json4s-jackson artifact supplies the Jackson-backed parser and serializer integration for using that AST on Scala 2/JVM projects.",
+    "language": {
+      "name": "scala",
+      "version": "2"
     },
-    "tested-versions" : [
+    "tested-versions": [
       "3.7.0-M13"
     ],
-    "allowed-packages" : [
-      "org.json4s.jackson"
+    "allowed-packages": [
+      "org.json4s.jackson",
+      "org.json4s.reflect",
+      "org.json4s.scalap",
+      "org.json4s.scalap.scalasig"
     ]
   },
   {
-    "metadata-version" : "3.7.0-M11",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/org/json4s/json4s-jackson_2.13/$version$/json4s-jackson_2.13-$version$-sources.jar",
-    "repository-url" : "https://github.com/json4s/json4s",
-    "test-code-url" : "https://github.com/json4s/json4s/tree/v$version$/tests/src/test/scala/org/json4s/jackson",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/org/json4s/json4s-jackson_2.13/$version$/json4s-jackson_2.13-$version$-javadoc.jar",
-    "description" : "Json4s is a Scala JSON library that provides a shared JSON AST plus parsing, querying, transformation, extraction, and serialization APIs. The json4s-jackson artifact supplies the Jackson-backed parser and serializer integration for using that AST on Scala 2/JVM projects.",
-    "language" : {
-      "name" : "scala",
-      "version" : "2"
+    "metadata-version": "3.7.0-M11",
+    "source-code-url": "https://repo.maven.apache.org/maven2/org/json4s/json4s-jackson_2.13/$version$/json4s-jackson_2.13-$version$-sources.jar",
+    "repository-url": "https://github.com/json4s/json4s",
+    "test-code-url": "https://github.com/json4s/json4s/tree/v$version$/tests/src/test/scala/org/json4s/jackson",
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/json4s/json4s-jackson_2.13/$version$/json4s-jackson_2.13-$version$-javadoc.jar",
+    "description": "Json4s is a Scala JSON library that provides a shared JSON AST plus parsing, querying, transformation, extraction, and serialization APIs. The json4s-jackson artifact supplies the Jackson-backed parser and serializer integration for using that AST on Scala 2/JVM projects.",
+    "language": {
+      "name": "scala",
+      "version": "2"
     },
-    "tested-versions" : [
+    "tested-versions": [
       "3.7.0-M11",
       "3.7.0-M12"
     ],
-    "allowed-packages" : [
+    "allowed-packages": [
       "org.json4s.jackson"
     ]
   }

--- a/metadata/org.json4s/json4s-jackson_2.13/index.json
+++ b/metadata/org.json4s/json4s-jackson_2.13/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "3.7.0-M13",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/json4s/json4s-jackson_2.13/$version$/json4s-jackson_2.13-$version$-sources.jar",
+    "repository-url" : "https://github.com/json4s/json4s",
+    "test-code-url" : "https://github.com/json4s/json4s/tree/v$version$/tests/src/test/scala/org/json4s/jackson",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/json4s/json4s-jackson_2.13/$version$/json4s-jackson_2.13-$version$-javadoc.jar",
+    "description" : "Json4s is a Scala JSON library that provides a shared JSON AST plus parsing, querying, transformation, extraction, and serialization APIs. The json4s-jackson artifact supplies the Jackson-backed parser and serializer integration for using that AST on Scala 2/JVM projects.",
     "language" : {
       "name" : "scala",
       "version" : "2"

--- a/metadata/org.json4s/json4s-jackson_2.13/index.json
+++ b/metadata/org.json4s/json4s-jackson_2.13/index.json
@@ -1,6 +1,19 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.7.0-M13",
+    "language" : {
+      "name" : "scala",
+      "version" : "2"
+    },
+    "tested-versions" : [
+      "3.7.0-M13"
+    ],
+    "allowed-packages" : [
+      "org.json4s.jackson"
+    ]
+  },
+  {
     "metadata-version" : "3.7.0-M11",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/json4s/json4s-jackson_2.13/$version$/json4s-jackson_2.13-$version$-sources.jar",
     "repository-url" : "https://github.com/json4s/json4s",

--- a/stats/org.json4s/json4s-jackson_2.13/3.7.0-M13/execution-metrics.json
+++ b/stats/org.json4s/json4s-jackson_2.13/3.7.0-M13/execution-metrics.json
@@ -1,0 +1,89 @@
+{
+  "fix_java_run_fail:2026-05-19": {
+    "timestamp": "2026-05-19T02:02:09.229021Z",
+    "library": "org.json4s:json4s-jackson_2.13:3.7.0-M13",
+    "starting_commit": "6dba071bd01f1fc5f37ec49a22197bbf0b061e0a",
+    "ending_commit": "e4a81ef4e7d83390c3d12a5a2e0eea06886296ba",
+    "previous_library": "org.json4s:json4s-jackson_2.13:3.7.0-M11",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.7.0-M13",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 226,
+          "missed": 228,
+          "ratio": 0.497797,
+          "total": 454
+        },
+        "line": {
+          "covered": 29,
+          "missed": 8,
+          "ratio": 0.783784,
+          "total": 37
+        },
+        "method": {
+          "covered": 29,
+          "missed": 43,
+          "ratio": 0.402778,
+          "total": 72
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.7.0-M11",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 981,
+          "missed": 484,
+          "ratio": 0.669625,
+          "total": 1465
+        },
+        "line": {
+          "covered": 136,
+          "missed": 15,
+          "ratio": 0.900662,
+          "total": 151
+        },
+        "method": {
+          "covered": 87,
+          "missed": 67,
+          "ratio": 0.564935,
+          "total": 154
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 71623,
+      "cached_input_tokens_used": 970240,
+      "output_tokens_used": 6825,
+      "iterations": 2,
+      "cost_usd": 0.6899,
+      "tested_library_loc": 29,
+      "metadata_entries": 18,
+      "test_only_metadata_entries": 50,
+      "previous_library_metadata_entries": 0,
+      "previous_library_test_only_metadata_entries": 52,
+      "code_coverage_percent": 78.38,
+      "previous_library_coverage_percent": 90.07
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/src/test/scala/org_json4s/json4s_jackson_2_13/Json4s_jackson_2_13Test.scala",
+      "metadata_file": "metadata/org.json4s/json4s-jackson_2.13/3.7.0-M13/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.json4s/json4s-jackson_2.13/3.7.0-M13/stats.json
+++ b/stats/org.json4s/json4s-jackson_2.13/3.7.0-M13/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.7.0-M13",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 226,
+        "missed" : 228,
+        "ratio" : 0.497797,
+        "total" : 454
+      },
+      "line" : {
+        "covered" : 29,
+        "missed" : 8,
+        "ratio" : 0.783784,
+        "total" : 37
+      },
+      "method" : {
+        "covered" : 29,
+        "missed" : 43,
+        "ratio" : 0.402778,
+        "total" : 72
+      }
+    }
+  } ]
+}

--- a/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/.gitignore
+++ b/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/build.gradle
+++ b/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/build.gradle
@@ -12,7 +12,9 @@ plugins {
 String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
-    testImplementation "org.json4s:json4s-jackson_2.13:$libraryVersion"
+    testImplementation("org.json4s:json4s-jackson_2.13:$libraryVersion") {
+        exclude group: 'org.scala-native'
+    }
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'org.scala-lang:scala-library:2.13.16'
     testImplementation 'org.scala-lang:scala-compiler:2.13.16'

--- a/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/build.gradle
+++ b/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.json4s:json4s-jackson_2.13:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala-library:2.13.16'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/gradle.properties
+++ b/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.json4s:json4s-jackson_2.13:3.7.0-M13
+library.version = 3.7.0-M13
+metadata.dir = org.json4s/json4s-jackson_2.13/3.7.0-M13/

--- a/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/settings.gradle
+++ b/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.json4s.json4s-jackson_2.13_tests'

--- a/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -237,68 +237,54 @@
           "name" : "MODULE$"
         }
       ]
-    }
-  ],
-  "resources" : [
-    {
-      "condition" : {
-        "typeReached" : "org.json4s.reflect.ParanamerReader$"
-      },
-      "glob" : "org_json4s/json4s_jackson_2_13/JacksonEmailNotification$.class"
     },
     {
       "condition" : {
-        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+        "typeReached" : "org.json4s.reflect.ScalaSigReader$"
       },
-      "glob" : "org_json4s/json4s_jackson_2_13/JacksonEmailNotification.class"
+      "type" : "org_json4s.json4s_jackson_2_13.JacksonEmailNotification$"
     },
     {
       "condition" : {
-        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+        "typeReached" : "org.json4s.reflect.ScalaSigReader$"
       },
-      "glob" : "org_json4s/json4s_jackson_2_13/JacksonFieldMappedAccount$.class"
+      "type" : "org_json4s.json4s_jackson_2_13.JacksonFieldMappedAccount$"
     },
     {
       "condition" : {
-        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+        "typeReached" : "org.json4s.reflect.Executable"
       },
-      "glob" : "org_json4s/json4s_jackson_2_13/JacksonFieldMappedAccount.class"
+      "type" : "org_json4s.json4s_jackson_2_13.JacksonNotification"
     },
     {
       "condition" : {
-        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+        "typeReached" : "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
       },
-      "glob" : "org_json4s/json4s_jackson_2_13/JacksonNotificationBatch$.class"
+      "type" : "org_json4s.json4s_jackson_2_13.JacksonNotification"
     },
     {
       "condition" : {
-        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+        "typeReached" : "org.json4s.reflect.ScalaSigReader$"
       },
-      "glob" : "org_json4s/json4s_jackson_2_13/JacksonNotificationBatch.class"
+      "type" : "org_json4s.json4s_jackson_2_13.JacksonNotification$"
     },
     {
       "condition" : {
-        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+        "typeReached" : "org.json4s.reflect.ScalaSigReader$"
       },
-      "glob" : "org_json4s/json4s_jackson_2_13/JacksonOptionalProfile$.class"
+      "type" : "org_json4s.json4s_jackson_2_13.JacksonNotificationBatch$"
     },
     {
       "condition" : {
-        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+        "typeReached" : "org.json4s.reflect.ScalaSigReader$"
       },
-      "glob" : "org_json4s/json4s_jackson_2_13/JacksonOptionalProfile.class"
+      "type" : "org_json4s.json4s_jackson_2_13.JacksonOptionalProfile$"
     },
     {
       "condition" : {
-        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+        "typeReached" : "org.json4s.reflect.ScalaSigReader$"
       },
-      "glob" : "org_json4s/json4s_jackson_2_13/JacksonSmsNotification$.class"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.json4s.reflect.ParanamerReader$"
-      },
-      "glob" : "org_json4s/json4s_jackson_2_13/JacksonSmsNotification.class"
+      "type" : "org_json4s.json4s_jackson_2_13.JacksonSmsNotification$"
     }
   ]
 }

--- a/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,304 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.PropertyDescriptor"
+      },
+      "type" : "org_json4s.json4s_jackson_2_13.JacksonEmailNotification",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "java.lang.String"
+          ]
+        }
+      ],
+      "fields" : [
+        {
+          "name" : "recipient"
+        },
+        {
+          "name" : "subject"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.PropertyDescriptor"
+      },
+      "type" : "org_json4s.json4s_jackson_2_13.JacksonFieldMappedAccount",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "java.lang.String",
+            "int"
+          ]
+        }
+      ],
+      "fields" : [
+        {
+          "name" : "accountStatus"
+        },
+        {
+          "name" : "givenName"
+        },
+        {
+          "name" : "loginCount"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.PropertyDescriptor"
+      },
+      "type" : "org_json4s.json4s_jackson_2_13.JacksonNotificationBatch",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "scala.collection.immutable.List"
+          ]
+        }
+      ],
+      "fields" : [
+        {
+          "name" : "notifications"
+        },
+        {
+          "name" : "owner"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.PropertyDescriptor"
+      },
+      "type" : "org_json4s.json4s_jackson_2_13.JacksonOptionalProfile",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "scala.Option",
+            "scala.Option"
+          ]
+        }
+      ],
+      "fields" : [
+        {
+          "name" : "email"
+        },
+        {
+          "name" : "name"
+        },
+        {
+          "name" : "scores"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.PropertyDescriptor"
+      },
+      "type" : "org_json4s.json4s_jackson_2_13.JacksonSmsNotification",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "boolean"
+          ]
+        }
+      ],
+      "fields" : [
+        {
+          "name" : "number"
+        },
+        {
+          "name" : "urgent"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$"
+      },
+      "type" : "org_json4s.json4s_jackson_2_13.JacksonEmailNotification$"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$"
+      },
+      "type" : "org_json4s.json4s_jackson_2_13.JacksonFieldMappedAccount$"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$"
+      },
+      "type" : "org_json4s.json4s_jackson_2_13.JacksonNotificationBatch$"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$"
+      },
+      "type" : "org_json4s.json4s_jackson_2_13.JacksonOptionalProfile$"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$"
+      },
+      "type" : "org_json4s.json4s_jackson_2_13.JacksonSmsNotification$"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
+      },
+      "type" : "org_json4s.json4s_jackson_2_13.JacksonEmailNotification"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
+      },
+      "type" : "org_json4s.json4s_jackson_2_13.JacksonFieldMappedAccount"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
+      },
+      "type" : "org_json4s.json4s_jackson_2_13.JacksonNotificationBatch"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
+      },
+      "type" : "org_json4s.json4s_jackson_2_13.JacksonOptionalProfile"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
+      },
+      "type" : "org_json4s.json4s_jackson_2_13.JacksonSmsNotification"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ScalaSigReader$"
+      },
+      "type" : "org_json4s.json4s_jackson_2_13.JacksonEmailNotification$",
+      "fields" : [
+        {
+          "name" : "MODULE$"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ScalaSigReader$"
+      },
+      "type" : "org_json4s.json4s_jackson_2_13.JacksonFieldMappedAccount$",
+      "fields" : [
+        {
+          "name" : "MODULE$"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ScalaSigReader$"
+      },
+      "type" : "org_json4s.json4s_jackson_2_13.JacksonNotificationBatch$",
+      "fields" : [
+        {
+          "name" : "MODULE$"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ScalaSigReader$"
+      },
+      "type" : "org_json4s.json4s_jackson_2_13.JacksonOptionalProfile$",
+      "fields" : [
+        {
+          "name" : "MODULE$"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ScalaSigReader$"
+      },
+      "type" : "org_json4s.json4s_jackson_2_13.JacksonSmsNotification$",
+      "fields" : [
+        {
+          "name" : "MODULE$"
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob" : "org_json4s/json4s_jackson_2_13/JacksonEmailNotification$.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob" : "org_json4s/json4s_jackson_2_13/JacksonEmailNotification.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob" : "org_json4s/json4s_jackson_2_13/JacksonFieldMappedAccount$.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob" : "org_json4s/json4s_jackson_2_13/JacksonFieldMappedAccount.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob" : "org_json4s/json4s_jackson_2_13/JacksonNotificationBatch$.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob" : "org_json4s/json4s_jackson_2_13/JacksonNotificationBatch.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob" : "org_json4s/json4s_jackson_2_13/JacksonOptionalProfile$.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob" : "org_json4s/json4s_jackson_2_13/JacksonOptionalProfile.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob" : "org_json4s/json4s_jackson_2_13/JacksonSmsNotification$.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob" : "org_json4s/json4s_jackson_2_13/JacksonSmsNotification.class"
+    }
+  ]
+}

--- a/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -286,5 +286,67 @@
       },
       "type" : "org_json4s.json4s_jackson_2_13.JacksonSmsNotification$"
     }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob" : "org_json4s/json4s_jackson_2_13/JacksonEmailNotification$.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob" : "org_json4s/json4s_jackson_2_13/JacksonEmailNotification.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob" : "org_json4s/json4s_jackson_2_13/JacksonFieldMappedAccount$.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob" : "org_json4s/json4s_jackson_2_13/JacksonFieldMappedAccount.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob" : "org_json4s/json4s_jackson_2_13/JacksonNotificationBatch$.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob" : "org_json4s/json4s_jackson_2_13/JacksonNotificationBatch.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob" : "org_json4s/json4s_jackson_2_13/JacksonOptionalProfile$.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob" : "org_json4s/json4s_jackson_2_13/JacksonOptionalProfile.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob" : "org_json4s/json4s_jackson_2_13/JacksonSmsNotification$.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob" : "org_json4s/json4s_jackson_2_13/JacksonSmsNotification.class"
+    }
   ]
 }

--- a/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/src/test/scala/org_json4s/json4s_jackson_2_13/Json4s_jackson_2_13Test.scala
+++ b/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/src/test/scala/org_json4s/json4s_jackson_2_13/Json4s_jackson_2_13Test.scala
@@ -125,7 +125,11 @@ class Json4s_jackson_2_13Test {
 
     try {
       val preservingFormats: Formats = DefaultFormats.withEscapeUnicode.preservingEmptyValues
-      val renderedWithNulls: JValue = render(value)(preservingFormats)
+      val renderedWithNulls: JValue = render(
+        value,
+        alwaysEscapeUnicode = preservingFormats.alwaysEscapeUnicode,
+        emptyValueStrategy = preservingFormats.emptyValueStrategy
+      )
       assertEquals(
         JObject(
           JField("name", JString("café")),
@@ -146,11 +150,20 @@ class Json4s_jackson_2_13Test {
       assertTrue(prettyText.contains("\"nested\""))
       assertTrue(prettyText.contains("caf\\u00E9"))
 
-      val renderedSkippingEmptyValues: JValue = render(value)(DefaultFormats.skippingEmptyValues)
+      val skippingFormats: Formats = DefaultFormats.skippingEmptyValues
+      val renderedSkippingEmptyValues: JValue = render(
+        value,
+        alwaysEscapeUnicode = skippingFormats.alwaysEscapeUnicode,
+        emptyValueStrategy = skippingFormats.emptyValueStrategy
+      )
       assertEquals(JNothing, renderedSkippingEmptyValues \ "missing")
       assertEquals(JArray(List(JInt(1), JNothing, JNull)), renderedSkippingEmptyValues \ "items")
     } finally {
-      render(JNothing)(DefaultFormats)
+      render(
+        JNothing,
+        alwaysEscapeUnicode = DefaultFormats.alwaysEscapeUnicode,
+        emptyValueStrategy = DefaultFormats.emptyValueStrategy
+      )
     }
   }
 
@@ -197,7 +210,11 @@ class Json4s_jackson_2_13Test {
       assertEquals(Some(parsed), parseJsonOpt("""{"ok":true,"numbers":[1,2,3]}"""))
       assertEquals(None, parseJsonOpt("""{"ok":]}"""))
     } finally {
-      render(JNothing)(DefaultFormats)
+      render(
+        JNothing,
+        alwaysEscapeUnicode = DefaultFormats.alwaysEscapeUnicode,
+        emptyValueStrategy = DefaultFormats.emptyValueStrategy
+      )
     }
   }
 

--- a/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/src/test/scala/org_json4s/json4s_jackson_2_13/Json4s_jackson_2_13Test.scala
+++ b/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/src/test/scala/org_json4s/json4s_jackson_2_13/Json4s_jackson_2_13Test.scala
@@ -1,0 +1,447 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_json4s.json4s_jackson_2_13
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
+import org.json4s._
+import org.json4s.jackson.Json
+import org.json4s.jackson.Json4sScalaModule
+import org.json4s.jackson.JsonMethods._
+import org.json4s.jackson.{Serialization => JacksonSerialization, compactJson, parseJson, parseJsonOpt, prettyJson, renderJValue}
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.StringReader
+import java.io.StringWriter
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import scala.jdk.CollectionConverters._
+
+case class JacksonMoney(amount: BigDecimal, currency: String)
+
+case class JacksonAccount(name: String, score: Int)
+
+case class JacksonFieldMappedAccount(givenName: String, accountStatus: String, loginCount: Int)
+
+case class JacksonOptionalProfile(name: String, email: Option[String], scores: Option[List[Int]])
+
+sealed trait JacksonNotification
+
+case class JacksonEmailNotification(subject: String, recipient: String) extends JacksonNotification
+
+case class JacksonSmsNotification(number: String, urgent: Boolean) extends JacksonNotification
+
+case class JacksonNotificationBatch(owner: String, notifications: List[JacksonNotification])
+
+class JacksonMoneySerializer extends CustomSerializer[JacksonMoney](_ => (
+  {
+    case JObject(fields) =>
+      val amount: BigDecimal = fields.collectFirst { case JField("amount", JDecimal(value)) => value }.get
+      val currency: String = fields.collectFirst { case JField("currency", JString(value)) => value }.get
+      JacksonMoney(amount, currency)
+  },
+  { case money: JacksonMoney =>
+    JObject(
+      JField("amount", JDecimal(money.amount)),
+      JField("currency", JString(money.currency))
+    )
+  }
+))
+
+class Json4s_jackson_2_13Test {
+  @Test
+  def parsesJsonFromSupportedInputsAndHonorsNumberModes(): Unit = {
+    val jsonText: String =
+      """
+        |{
+        |  "message": "hello\nworld",
+        |  "unicode": "café",
+        |  "flags": [true, false, null],
+        |  "price": 12.50,
+        |  "maxLong": 9223372036854775807,
+        |  "largeInteger": 922337203685477580812345
+        |}
+        |""".stripMargin
+
+    val parsedWithBigNumbers: JValue = parse(jsonText, useBigDecimalForDouble = true, useBigIntForLong = true)
+    assertEquals(JString("hello\nworld"), parsedWithBigNumbers \ "message")
+    assertEquals(JString("café"), parsedWithBigNumbers \ "unicode")
+    assertEquals(JArray(List(JBool.True, JBool.False, JNull)), parsedWithBigNumbers \ "flags")
+    assertEquals(JDecimal(BigDecimal("12.50")), parsedWithBigNumbers \ "price")
+    assertEquals(JInt(BigInt("9223372036854775807")), parsedWithBigNumbers \ "maxLong")
+    assertEquals(JInt(BigInt("922337203685477580812345")), parsedWithBigNumbers \ "largeInteger")
+
+    val parsedWithJvmNumbers: JValue = parse(
+      new StringReader("""{"price":12.5,"maxLong":9223372036854775807}"""),
+      useBigDecimalForDouble = false,
+      useBigIntForLong = false
+    )
+    assertEquals(JDouble(12.5d), parsedWithJvmNumbers \ "price")
+    assertEquals(JLong(9223372036854775807L), parsedWithJvmNumbers \ "maxLong")
+
+    val bytes: Array[Byte] = """{"stream":true,"values":[1,2]}""".getBytes(StandardCharsets.UTF_8)
+    val inputStream: ByteArrayInputStream = new ByteArrayInputStream(bytes)
+    try {
+      val parsedFromStream: JValue = parse(inputStream, useBigDecimalForDouble = true)
+      assertEquals(JBool.True, parsedFromStream \ "stream")
+      assertEquals(JArray(List(JInt(1), JInt(2))), parsedFromStream \ "values")
+    } finally {
+      inputStream.close()
+    }
+
+    val tempFile: Path = Files.createTempFile("json4s-jackson", ".json")
+    try {
+      Files.write(tempFile, """{"file":"ok","nested":{"n":3}}""".getBytes(StandardCharsets.UTF_8))
+      val parsedFromFile: JValue = parse(tempFile.toFile)
+      assertEquals(JString("ok"), parsedFromFile \ "file")
+      assertEquals(JInt(3), parsedFromFile \ "nested" \ "n")
+    } finally {
+      Files.deleteIfExists(tempFile)
+    }
+
+    assertEquals(Some(JArray(List(JInt(1), JInt(2), JInt(3)))), parseOpt("[1,2,3]"))
+    assertEquals(None, parseOpt("""{"broken":]}"""))
+  }
+
+  @Test
+  def rendersCompactsAndPrettyPrintsJacksonJsonValues(): Unit = {
+    val value: JObject = JObject(
+      JField("name", JString("café")),
+      JField("line", JString("one\ntwo")),
+      JField("missing", JNothing),
+      JField("items", JArray(List(JInt(1), JNothing, JNull))),
+      JField("nested", JObject(JField("enabled", JBool.True)))
+    )
+
+    try {
+      val preservingFormats: Formats = DefaultFormats.withEscapeUnicode.preservingEmptyValues
+      val renderedWithNulls: JValue = render(value)(preservingFormats)
+      assertEquals(
+        JObject(
+          JField("name", JString("café")),
+          JField("line", JString("one\ntwo")),
+          JField("missing", JNull),
+          JField("items", JArray(List(JInt(1), JNull, JNull))),
+          JField("nested", JObject(JField("enabled", JBool.True)))
+        ),
+        renderedWithNulls
+      )
+      assertEquals(
+        "{\"name\":\"caf\\u00E9\",\"line\":\"one\\ntwo\",\"missing\":null,\"items\":[1,null,null],\"nested\":{\"enabled\":true}}",
+        compact(renderedWithNulls)
+      )
+
+      val prettyText: String = pretty(renderedWithNulls)
+      assertTrue(prettyText.contains("\n"))
+      assertTrue(prettyText.contains("\"nested\""))
+      assertTrue(prettyText.contains("caf\\u00E9"))
+
+      val renderedSkippingEmptyValues: JValue = render(value)(DefaultFormats.skippingEmptyValues)
+      assertEquals(JNothing, renderedSkippingEmptyValues \ "missing")
+      assertEquals(JArray(List(JInt(1), JNothing, JNull)), renderedSkippingEmptyValues \ "items")
+    } finally {
+      render(JNothing)(DefaultFormats)
+    }
+  }
+
+  @Test
+  def convertsBetweenJValuesAndJacksonJsonNodes(): Unit = {
+    val objectNode: ObjectNode = mapper.createObjectNode()
+    objectNode.put("name", "Ada")
+    objectNode.put("active", true)
+    objectNode.putArray("scores").add(10).add(20)
+    objectNode.putObject("address").put("city", "London")
+
+    val value: JValue = fromJsonNode(objectNode)
+    assertEquals(JString("Ada"), value \ "name")
+    assertEquals(JBool.True, value \ "active")
+    assertEquals(JArray(List(JInt(10), JInt(20))), value \ "scores")
+    assertEquals(JString("London"), value \ "address" \ "city")
+
+    val jsonNode: JsonNode = asJsonNode(value)
+    assertTrue(jsonNode.isObject)
+    assertEquals("Ada", jsonNode.get("name").asText())
+    assertEquals(20, jsonNode.get("scores").get(1).asInt())
+    assertEquals(value, fromJsonNode(jsonNode))
+  }
+
+  @Test
+  def exposesPackageLevelJacksonHelpers(): Unit = {
+    val formats: Formats = DefaultFormats.withEscapeUnicode.preservingEmptyValues
+    val value: JObject = JObject(
+      JField("name", JString("café")),
+      JField("missing", JNothing),
+      JField("values", JArray(List(JInt(1), JNothing, JNull)))
+    )
+
+    try {
+      val rendered: JValue = renderJValue(value)(formats)
+      assertEquals(JNull, rendered \ "missing")
+      assertEquals(JArray(List(JInt(1), JNull, JNull)), rendered \ "values")
+      assertEquals("{\"name\":\"caf\\u00E9\",\"missing\":null,\"values\":[1,null,null]}", compactJson(rendered))
+      assertTrue(prettyJson(rendered).contains("\n"))
+
+      val parsed: JValue = parseJson("""{"ok":true,"numbers":[1,2,3]}""")
+      assertEquals(JBool.True, parsed \ "ok")
+      assertEquals(JArray(List(JInt(1), JInt(2), JInt(3))), parsed \ "numbers")
+      assertEquals(Some(parsed), parseJsonOpt("""{"ok":true,"numbers":[1,2,3]}"""))
+      assertEquals(None, parseJsonOpt("""{"ok":]}"""))
+    } finally {
+      render(JNothing)(DefaultFormats)
+    }
+  }
+
+  @Test
+  def serializesAndReadsCollectionsThroughJacksonSerialization(): Unit = {
+    implicit val formats: Formats = JacksonSerialization.formats(NoTypeHints).withBigDecimal
+
+    val source: Map[String, Any] = Map(
+      "title" -> "Quarterly",
+      "active" -> true,
+      "ids" -> List(1, 2, 3),
+      "amounts" -> List(BigDecimal("12.50"), BigDecimal("19.99")),
+      "metadata" -> Map("region" -> "EMEA", "priority" -> 2)
+    )
+
+    val jsonText: String = JacksonSerialization.write(source)
+    val parsed: JValue = parse(jsonText, useBigDecimalForDouble = true)
+    assertEquals(JString("Quarterly"), parsed \ "title")
+    assertEquals(JBool.True, parsed \ "active")
+    assertEquals(JArray(List(JInt(1), JInt(2), JInt(3))), parsed \ "ids")
+    assertEquals(JArray(List(JDecimal(BigDecimal("12.50")), JDecimal(BigDecimal("19.99")))), parsed \ "amounts")
+    assertEquals(JString("EMEA"), parsed \ "metadata" \ "region")
+    assertEquals(JInt(2), parsed \ "metadata" \ "priority")
+
+    val readerValue: Map[String, List[Int]] = JacksonSerialization.read[Map[String, List[Int]]](new StringReader("""{"ids":[1,2,3]}"""))
+    assertEquals(Map("ids" -> List(1, 2, 3)), readerValue)
+
+    val prettyWriter: StringWriter = new StringWriter()
+    assertSame(prettyWriter, JacksonSerialization.writePretty(source, prettyWriter))
+    assertTrue(prettyWriter.toString.contains("\n"))
+    assertEquals(parsed, parse(prettyWriter.toString, useBigDecimalForDouble = true))
+
+    val outputStream: ByteArrayOutputStream = new ByteArrayOutputStream()
+    JacksonSerialization.write(source, outputStream)
+    val streamedJson: String = outputStream.toString(StandardCharsets.UTF_8.name())
+    assertEquals(parsed, parse(streamedJson, useBigDecimalForDouble = true))
+  }
+
+  @Test
+  def appliesFieldSerializersWhenWritingAndReadingCaseClasses(): Unit = {
+    import org.json4s.FieldSerializer._
+
+    implicit val formats: Formats = JacksonSerialization.formats(NoTypeHints) + FieldSerializer[JacksonFieldMappedAccount](
+      renameTo("givenName", "given_name") orElse renameTo("accountStatus", "status"),
+      renameFrom("given_name", "givenName") orElse renameFrom("status", "accountStatus")
+    )
+
+    val account: JacksonFieldMappedAccount = JacksonFieldMappedAccount("Ada", "active", 7)
+    val jsonText: String = JacksonSerialization.write(account)
+    val parsed: JValue = parse(jsonText)
+
+    assertEquals(JString("Ada"), parsed \ "given_name")
+    assertEquals(JString("active"), parsed \ "status")
+    assertEquals(JInt(7), parsed \ "loginCount")
+    assertEquals(JNothing, parsed \ "givenName")
+    assertEquals(JNothing, parsed \ "accountStatus")
+
+    val restored: JacksonFieldMappedAccount = JacksonSerialization.read[JacksonFieldMappedAccount](
+      """{"given_name":"Grace","status":"locked","loginCount":3}"""
+    )
+    assertEquals(JacksonFieldMappedAccount("Grace", "locked", 3), restored)
+  }
+
+  @Test
+  def readsAndWritesOptionalCaseClassMembers(): Unit = {
+    implicit val formats: Formats = JacksonSerialization.formats(NoTypeHints)
+
+    val profile: JacksonOptionalProfile = JacksonOptionalProfile(
+      name = "Ada",
+      email = Some("ada@example.com"),
+      scores = Some(List(10, 20))
+    )
+    val jsonText: String = JacksonSerialization.write(profile)
+    val parsed: JValue = parse(jsonText)
+
+    assertEquals(JString("Ada"), parsed \ "name")
+    assertEquals(JString("ada@example.com"), parsed \ "email")
+    assertEquals(JArray(List(JInt(10), JInt(20))), parsed \ "scores")
+    assertEquals(profile, JacksonSerialization.read[JacksonOptionalProfile](jsonText))
+
+    val missingOptionalMembers: JacksonOptionalProfile = JacksonSerialization.read[JacksonOptionalProfile](
+      """{"name":"Grace"}"""
+    )
+    assertEquals(JacksonOptionalProfile("Grace", None, None), missingOptionalMembers)
+
+    val nullOptionalMembers: JacksonOptionalProfile = JacksonSerialization.read[JacksonOptionalProfile](
+      """{"name":"Linus","email":null,"scores":null}"""
+    )
+    assertEquals(JacksonOptionalProfile("Linus", None, None), nullOptionalMembers)
+  }
+
+  @Test
+  def writesAndReadsPolymorphicValuesWithShortTypeHints(): Unit = {
+    implicit val formats: Formats = JacksonSerialization.formats(
+      ShortTypeHints(
+        List(classOf[JacksonEmailNotification], classOf[JacksonSmsNotification]),
+        "kind"
+      )
+    )
+
+    val batch: JacksonNotificationBatch = JacksonNotificationBatch(
+      owner = "operations",
+      notifications = List(
+        JacksonEmailNotification("deployment", "ops@example.com"),
+        JacksonSmsNotification("+15550101", urgent = true)
+      )
+    )
+
+    val jsonText: String = JacksonSerialization.write(batch)
+    val parsed: JValue = parse(jsonText)
+    assertEquals(JString("operations"), parsed \ "owner")
+    assertEquals(JString("JacksonEmailNotification"), (parsed \ "notifications")(0) \ "kind")
+    assertEquals(JString("deployment"), (parsed \ "notifications")(0) \ "subject")
+    assertEquals(JString("JacksonSmsNotification"), (parsed \ "notifications")(1) \ "kind")
+    assertEquals(JBool.True, (parsed \ "notifications")(1) \ "urgent")
+
+    val restored: JacksonNotificationBatch = JacksonSerialization.read[JacksonNotificationBatch](jsonText)
+    assertEquals(batch, restored)
+  }
+
+  @Test
+  def appliesCustomSerializersToCollections(): Unit = {
+    implicit val formats: Formats = DefaultFormats.withBigDecimal + new JacksonMoneySerializer
+
+    val prices: List[JacksonMoney] = List(
+      JacksonMoney(BigDecimal("19.99"), "EUR"),
+      JacksonMoney(BigDecimal("2.50"), "EUR")
+    )
+    val pricesJson: String = JacksonSerialization.write(prices)
+    val pricesValue: JValue = parse(pricesJson, useBigDecimalForDouble = true)
+
+    assertEquals(JDecimal(BigDecimal("19.99")), pricesValue(0) \ "amount")
+    assertEquals(JString("EUR"), pricesValue(0) \ "currency")
+    assertEquals(JDecimal(BigDecimal("2.50")), pricesValue(1) \ "amount")
+    assertEquals(prices, JacksonSerialization.read[List[JacksonMoney]](pricesJson))
+
+    val mappedJson: String = JacksonSerialization.write(Map("total" -> prices.head))
+    val mappedValue: JValue = parse(mappedJson, useBigDecimalForDouble = true)
+    assertEquals(JDecimal(BigDecimal("19.99")), mappedValue \ "total" \ "amount")
+    assertEquals(Map("total" -> prices.head), JacksonSerialization.read[Map[String, JacksonMoney]](mappedJson))
+  }
+
+  @Test
+  def usesJsonFacadeWithExplicitFormatsAndMapper(): Unit = {
+    val customMapper: ObjectMapper = new ObjectMapper()
+    customMapper.registerModule(new Json4sScalaModule)
+    val json: Json = Json(DefaultFormats.withBigDecimal.withLong, customMapper)
+
+    val parsed: JValue = json.parse("""{"price":12.50,"maxLong":9223372036854775807}""")
+    assertEquals(JDecimal(BigDecimal("12.50")), parsed \ "price")
+    assertEquals(JLong(9223372036854775807L), parsed \ "maxLong")
+    assertEquals(None, json.parseOpt("""{"broken":]}"""))
+
+    val writer: StringWriter = new StringWriter()
+    val returnedWriter: StringWriter = json.write(List(Map("letter" -> "a"), Map("letter" -> "b")), writer)
+    assertSame(writer, returnedWriter)
+    assertEquals(
+      JArray(List(JObject(JField("letter", JString("a"))), JObject(JField("letter", JString("b"))))),
+      json.parse(writer.toString)
+    )
+
+    val prettyText: String = json.writePretty(Map("message" -> "hello", "count" -> 2))
+    val prettyAst: JValue = json.parse(prettyText)
+    assertEquals(JString("hello"), prettyAst \ "message")
+    assertEquals(JLong(2L), prettyAst \ "count")
+    assertTrue(prettyText.contains("\n"))
+  }
+
+  @Test
+  def integratesJson4sAstWithJacksonObjectMapperModule(): Unit = {
+    val jacksonMapper: ObjectMapper = new ObjectMapper()
+    jacksonMapper.registerModule(new Json4sScalaModule)
+    jacksonMapper.configure(DeserializationFeature.USE_BIG_INTEGER_FOR_INTS, true)
+    jacksonMapper.configure(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, true)
+
+    val value: JValue = JObject(
+      JField("title", JString("module")),
+      JField("omitted", JNothing),
+      JField("numbers", JArray(List(JInt(BigInt("1234567890123456789012345")), JDecimal(BigDecimal("10.25"))))),
+      JField("labels", JSet(Set(JString("json4s"), JString("jackson")))),
+      JField("presentNull", JNull)
+    )
+
+    val jsonText: String = jacksonMapper.writeValueAsString(value)
+    val jsonNode: JsonNode = jacksonMapper.readTree(jsonText)
+    assertEquals("module", jsonNode.get("title").asText())
+    assertFalse(jsonNode.has("omitted"))
+    assertTrue(jsonNode.get("labels").isArray)
+    assertEquals(Set("json4s", "jackson"), jsonNode.get("labels").elements().asScala.map(_.asText()).toSet)
+    assertTrue(jsonNode.get("presentNull").isNull)
+
+    val restored: JValue = jacksonMapper.readValue(jsonText, classOf[JValue])
+    assertEquals(JString("module"), restored \ "title")
+    assertEquals(JNothing, restored \ "omitted")
+    assertEquals(JInt(BigInt("1234567890123456789012345")), (restored \ "numbers")(0))
+    assertEquals(JDecimal(BigDecimal("10.25")), (restored \ "numbers")(1))
+    val restoredLabels: Set[String] = (restored \ "labels") match {
+      case JArray(labels) => labels.collect { case JString(label) => label }.toSet
+      case other => fail(s"Expected labels array but got $other")
+    }
+    assertEquals(Set("json4s", "jackson"), restoredLabels)
+    assertEquals(JNull, restored \ "presentNull")
+
+    val objectValue: JObject = jacksonMapper.readValue("""{"active":true,"count":3}""", classOf[JObject])
+    assertEquals(JBool.True, objectValue \ "active")
+    assertEquals(JInt(3), objectValue \ "count")
+  }
+
+  @Test
+  def usesJacksonJsonMethodsWithPublicReadersAndWriters(): Unit = {
+    import org.json4s.DefaultReaders._
+    import org.json4s.DefaultWriters._
+
+    implicit val accountWriter: Writer[JacksonAccount] = new Writer[JacksonAccount] {
+      override def write(account: JacksonAccount): JValue = JObject(
+        JField("name", JString(account.name)),
+        JField("score", JInt(account.score))
+      )
+    }
+    implicit def listWriter[T](implicit valueWriter: Writer[T]): Writer[List[T]] = new Writer[List[T]] {
+      override def write(values: List[T]): JValue = JArray(values.map(valueWriter.write))
+    }
+    implicit val accountReader: Reader[JacksonAccount] = new Reader[JacksonAccount] {
+      override def read(value: JValue): JacksonAccount = {
+        val name: String = (value \ "name") match {
+          case JString(text) => text
+          case other => fail(s"Expected account name string but got $other")
+        }
+        val score: Int = (value \ "score") match {
+          case JInt(number) => number.intValue
+          case JLong(number) => number.toInt
+          case other => fail(s"Expected account score integer but got $other")
+        }
+        JacksonAccount(name, score)
+      }
+    }
+
+    val account: JacksonAccount = JacksonAccount("jackson", 42)
+    val accountJson: JValue = asJValue(account)
+    assertEquals(JObject(JField("name", JString("jackson")), JField("score", JInt(42))), accountJson)
+    assertEquals(account, fromJValue[JacksonAccount](accountJson))
+
+    val collectionJson: JValue = asJValue(Map("ids" -> List(1, 2, 3), "scores" -> List(10, 20)))
+    assertEquals(JArray(List(JInt(1), JInt(2), JInt(3))), collectionJson \ "ids")
+    assertEquals(Map("ids" -> List(1, 2, 3)), fromJValue[Map[String, List[Int]]](JObject(JField("ids", JArray(List(JInt(1), JInt(2), JInt(3)))))))
+  }
+}

--- a/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/user-code-filter.json
+++ b/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.json4s.jackson.**"
+    },
+    {
+      "includeClasses" : "org_json4s.json4s_jackson_2_13.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6945

This PR provides test fixes and new metadata for org.json4s:json4s-jackson_2.13:3.7.0-M13, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 71623
- Cached input tokens: 970240
- Output tokens: 6825
- Metadata entries: 18
- Test-only metadata entries: 50
- Iterations: 2
- Library coverage percentage: 78.38
- Previous library version metadata entries: 0
- Previous library version test-only metadata entries: 52
- Previous library version coverage percentage: 90.07

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3f69aa1510d519e1825b9bfd59a81bb41ea7ef04`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.json4s:json4s-jackson_2.13:3.7.0-M11: 0/0 covered calls (100.00%)
- org.json4s:json4s-jackson_2.13:3.7.0-M13: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.json4s:json4s-jackson_2.13:3.7.0-M11: 981/1465 (66.96%)
- org.json4s:json4s-jackson_2.13:3.7.0-M13: 226/454 (49.78%)

**Line:**
- org.json4s:json4s-jackson_2.13:3.7.0-M11: 136/151 (90.07%)
- org.json4s:json4s-jackson_2.13:3.7.0-M13: 29/37 (78.38%)

**Method:**
- org.json4s:json4s-jackson_2.13:3.7.0-M11: 87/154 (56.49%)
- org.json4s:json4s-jackson_2.13:3.7.0-M13: 29/72 (40.28%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M11/build.gradle 2/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/build.gradle
index 60132d5e2c..89c40433ed 100644
--- 1/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M11/build.gradle
+++ 2/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/build.gradle
@@ -12,7 +12,9 @@ plugins {
 String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
-    testImplementation "org.json4s:json4s-jackson_2.13:$libraryVersion"
+    testImplementation("org.json4s:json4s-jackson_2.13:$libraryVersion") {
+        exclude group: 'org.scala-native'
+    }
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'org.scala-lang:scala-library:2.13.16'
     testImplementation 'org.scala-lang:scala-compiler:2.13.16'

```

### Local CI Verification

- Status: `success`
- Commands run: 23
- Fixup attempts: 1
