### PR TITLE
[GenAI] Add support for org.springframework.boot:spring-boot-netty:4.0.2 using gpt-5.5

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-netty/4.0.2/reachability-metadata.json
+++ b/metadata/org.springframework.boot/spring-boot-netty/4.0.2/reachability-metadata.json
@@ -1,0 +1,131 @@
+{
+  "reflection": [
+    {
+      "type": "org.springframework.boot.netty.autoconfigure.NettyAutoConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.springframework.boot.netty.autoconfigure.NettyProperties"
+          ]
+        },
+        {
+          "name": "nettyAutoConfigurationLazyInitializationExcludeFilter",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.netty.autoconfigure.NettyProperties",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "getLeakDetection",
+          "parameterTypes": []
+        },
+        {
+          "name": "setLeakDetection",
+          "parameterTypes": [
+            "org.springframework.boot.netty.autoconfigure.NettyProperties$LeakDetection"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.netty.autoconfigure.NettyProperties$LeakDetection"
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.OnClassCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.properties.EnableConfigurationPropertiesRegistrar",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.properties.ConfigurationPropertiesBindingPostProcessor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.properties.ConfigurationPropertiesBinder$ConfigurationPropertiesBinderFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.properties.BoundConfigurationProperties",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.validation.beanvalidation.MethodValidationExcludeFilter",
+      "methods": [
+        {
+          "name": "byAnnotation",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "io.netty.util.NettyRuntime"
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.springframework.context.ConfigurableApplicationContext",
+          "org.springframework.boot.test.context.assertj.AssertableApplicationContext"
+        ]
+      }
+    }
+  ],
+  "resources": [
+    {
+      "glob": "org/springframework/boot/netty/autoconfigure/*.class"
+    },
+    {
+      "glob": "META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports"
+    },
+    {
+      "glob": "META-INF/spring-autoconfigure-metadata.properties"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/AutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/condition/ConditionalOnClass.class"
+    },
+    {
+      "glob": "org/springframework/boot/context/properties/EnableConfigurationProperties.class"
+    },
+    {
+      "glob": "org/springframework/boot/context/properties/EnableConfigurationPropertiesRegistrar.class"
+    }
+  ]
+}

--- a/metadata/org.springframework.boot/spring-boot-netty/index.json
+++ b/metadata/org.springframework.boot/spring-boot-netty/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.0.2",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-netty/$version$/spring-boot-netty-$version$-sources.jar",
+    "repository-url" : "https://github.com/spring-projects/spring-boot",
+    "test-code-url" : "https://github.com/spring-projects/spring-boot/tree/v$version$/module/spring-boot-netty/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-netty/$version$/spring-boot-netty-$version$-javadoc.jar",
+    "description" : "Spring Boot Netty provides auto-configuration support for using Netty within Spring Boot applications. It contributes configuration properties and auto-configuration classes that integrate Netty runtime settings, such as leak detection, with Boot's application context.",
+    "tested-versions" : [
+      "4.0.2"
+    ],
+    "allowed-packages" : [
+      "org.springframework.boot.netty.autoconfigure"
+    ]
+  }
+]

--- a/stats/org.springframework.boot/spring-boot-netty/4.0.2/execution-metrics.json
+++ b/stats/org.springframework.boot/spring-boot-netty/4.0.2/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-19": {
+    "timestamp": "2026-05-19T03:03:13.431882Z",
+    "library": "org.springframework.boot:spring-boot-netty:4.0.2",
+    "starting_commit": "4cbfd7a1a02a3b3b61ca75637de90d69cd0abab0",
+    "ending_commit": "e66265c8dc3c2e99770360f2a1ce867dc757bf37",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success_with_intervention",
+    "stats": {
+      "version": "4.0.2",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 58,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 58
+        },
+        "line": {
+          "covered": 15,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 15
+        },
+        "method": {
+          "covered": 6,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 6
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 109227,
+      "cached_input_tokens_used": 1624576,
+      "output_tokens_used": 17131,
+      "iterations": 3,
+      "cost_usd": 1.3262,
+      "generated_loc": 93,
+      "tested_library_loc": 15,
+      "metadata_entries": 29,
+      "code_coverage_percent": 100.0
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.springframework.boot/spring-boot-netty/4.0.2/src/test/java/org_springframework_boot/spring_boot_netty/Spring_boot_nettyTest.java",
+      "metadata_file": "metadata/org.springframework.boot/spring-boot-netty/4.0.2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.springframework.boot/spring-boot-netty/4.0.2/stats.json
+++ b/stats/org.springframework.boot/spring-boot-netty/4.0.2/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.0.2",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 58,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 58
+      },
+      "line" : {
+        "covered" : 15,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 15
+      },
+      "method" : {
+        "covered" : 6,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 6
+      }
+    }
+  } ]
+}

--- a/tests/src/org.springframework.boot/spring-boot-netty/4.0.2/.gitignore
+++ b/tests/src/org.springframework.boot/spring-boot-netty/4.0.2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.springframework.boot/spring-boot-netty/4.0.2/build.gradle
+++ b/tests/src/org.springframework.boot/spring-boot-netty/4.0.2/build.gradle
@@ -11,7 +11,11 @@ plugins {
 String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
+    testImplementation platform("org.springframework.boot:spring-boot-dependencies:$libraryVersion")
     testImplementation "org.springframework.boot:spring-boot-netty:$libraryVersion"
+    testImplementation "org.springframework.boot:spring-boot-autoconfigure:$libraryVersion"
+    testImplementation "org.springframework.boot:spring-boot-test:$libraryVersion"
+    testImplementation "io.netty:netty-common"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.springframework.boot/spring-boot-netty/4.0.2/build.gradle
+++ b/tests/src/org.springframework.boot/spring-boot-netty/4.0.2/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.springframework.boot:spring-boot-netty:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.springframework.boot/spring-boot-netty/4.0.2/gradle.properties
+++ b/tests/src/org.springframework.boot/spring-boot-netty/4.0.2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.springframework.boot:spring-boot-netty:4.0.2
+library.version = 4.0.2
+metadata.dir = org.springframework.boot/spring-boot-netty/4.0.2/

--- a/tests/src/org.springframework.boot/spring-boot-netty/4.0.2/settings.gradle
+++ b/tests/src/org.springframework.boot/spring-boot-netty/4.0.2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.springframework.boot.spring-boot-netty_tests'

--- a/tests/src/org.springframework.boot/spring-boot-netty/4.0.2/src/test/java/org_springframework_boot/spring_boot_netty/Spring_boot_nettyTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-netty/4.0.2/src/test/java/org_springframework_boot/spring_boot_netty/Spring_boot_nettyTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework_boot.spring_boot_netty;
+
+import org.junit.jupiter.api.Test;
+
+class Spring_boot_nettyTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.springframework.boot/spring-boot-netty/4.0.2/src/test/java/org_springframework_boot/spring_boot_netty/Spring_boot_nettyTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-netty/4.0.2/src/test/java/org_springframework_boot/spring_boot_netty/Spring_boot_nettyTest.java
@@ -6,6 +6,7 @@
  */
 package org_springframework_boot.spring_boot_netty;
 
+import io.netty.util.NettyRuntime;
 import io.netty.util.ResourceLeakDetector;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.LazyInitializationExcludeFilter;
@@ -15,6 +16,7 @@ import org.springframework.boot.context.annotation.ImportCandidates;
 import org.springframework.boot.netty.autoconfigure.NettyAutoConfiguration;
 import org.springframework.boot.netty.autoconfigure.NettyProperties;
 import org.springframework.boot.netty.autoconfigure.NettyProperties.LeakDetection;
+import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -45,6 +47,17 @@ public class Spring_boot_nettyTest {
         ImportCandidates candidates = ImportCandidates.load(AutoConfiguration.class, getClass().getClassLoader());
 
         assertThat(candidates.getCandidates()).contains(NettyAutoConfiguration.class.getName());
+    }
+
+    @Test
+    void autoConfigurationBacksOffWhenNettyRuntimeIsUnavailable() {
+        new ApplicationContextRunner().withClassLoader(new FilteredClassLoader(NettyRuntime.class))
+            .withConfiguration(AutoConfigurations.of(NettyAutoConfiguration.class))
+            .run((context) -> {
+                assertThat(context.getBeanNamesForType(NettyAutoConfiguration.class)).isEmpty();
+                assertThat(context.getBeanNamesForType(NettyProperties.class)).isEmpty();
+                assertThat(context.getBeanNamesForType(LazyInitializationExcludeFilter.class)).isEmpty();
+            });
     }
 
     @Test

--- a/tests/src/org.springframework.boot/spring-boot-netty/4.0.2/src/test/java/org_springframework_boot/spring_boot_netty/Spring_boot_nettyTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-netty/4.0.2/src/test/java/org_springframework_boot/spring_boot_netty/Spring_boot_nettyTest.java
@@ -6,7 +6,6 @@
  */
 package org_springframework_boot.spring_boot_netty;
 
-import io.netty.util.NettyRuntime;
 import io.netty.util.ResourceLeakDetector;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.LazyInitializationBeanFactoryPostProcessor;
@@ -17,7 +16,6 @@ import org.springframework.boot.context.annotation.ImportCandidates;
 import org.springframework.boot.netty.autoconfigure.NettyAutoConfiguration;
 import org.springframework.boot.netty.autoconfigure.NettyProperties;
 import org.springframework.boot.netty.autoconfigure.NettyProperties.LeakDetection;
-import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -48,17 +46,6 @@ public class Spring_boot_nettyTest {
         ImportCandidates candidates = ImportCandidates.load(AutoConfiguration.class, getClass().getClassLoader());
 
         assertThat(candidates.getCandidates()).contains(NettyAutoConfiguration.class.getName());
-    }
-
-    @Test
-    void autoConfigurationBacksOffWhenNettyRuntimeIsUnavailable() {
-        new ApplicationContextRunner().withClassLoader(new FilteredClassLoader(NettyRuntime.class))
-            .withConfiguration(AutoConfigurations.of(NettyAutoConfiguration.class))
-            .run((context) -> {
-                assertThat(context.getBeanNamesForType(NettyAutoConfiguration.class)).isEmpty();
-                assertThat(context.getBeanNamesForType(NettyProperties.class)).isEmpty();
-                assertThat(context.getBeanNamesForType(LazyInitializationExcludeFilter.class)).isEmpty();
-            });
     }
 
     @Test
@@ -113,8 +100,7 @@ public class Spring_boot_nettyTest {
         ResourceLeakDetector.Level originalLevel = ResourceLeakDetector.getLevel();
         try {
             runnable.run();
-        }
-        finally {
+        } finally {
             ResourceLeakDetector.setLevel(originalLevel);
         }
     }

--- a/tests/src/org.springframework.boot/spring-boot-netty/4.0.2/src/test/java/org_springframework_boot/spring_boot_netty/Spring_boot_nettyTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-netty/4.0.2/src/test/java/org_springframework_boot/spring_boot_netty/Spring_boot_nettyTest.java
@@ -9,6 +9,7 @@ package org_springframework_boot.spring_boot_netty;
 import io.netty.util.NettyRuntime;
 import io.netty.util.ResourceLeakDetector;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.LazyInitializationBeanFactoryPostProcessor;
 import org.springframework.boot.LazyInitializationExcludeFilter;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -84,6 +85,16 @@ public class Spring_boot_nettyTest {
             assertThat(filter.isExcluded("nettyAutoConfiguration", null, NettyAutoConfiguration.class)).isTrue();
             assertThat(filter.isExcluded("nettyProperties", null, NettyProperties.class)).isFalse();
         });
+    }
+
+    @Test
+    void leakDetectionIsAppliedWhenSpringLazyInitializationIsEnabled() throws Throwable {
+        runWithRestoredLeakDetectionLevel(() -> this.contextRunner
+                .withInitializer((context) -> context
+                    .addBeanFactoryPostProcessor(new LazyInitializationBeanFactoryPostProcessor()))
+                .withPropertyValues("spring.netty.leak-detection=advanced")
+                .run((context) -> assertThat(ResourceLeakDetector.getLevel())
+                    .isEqualTo(ResourceLeakDetector.Level.ADVANCED)));
     }
 
     @Test

--- a/tests/src/org.springframework.boot/spring-boot-netty/4.0.2/src/test/java/org_springframework_boot/spring_boot_netty/Spring_boot_nettyTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-netty/4.0.2/src/test/java/org_springframework_boot/spring_boot_netty/Spring_boot_nettyTest.java
@@ -6,11 +6,100 @@
  */
 package org_springframework_boot.spring_boot_netty;
 
+import io.netty.util.ResourceLeakDetector;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.LazyInitializationExcludeFilter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.context.annotation.ImportCandidates;
+import org.springframework.boot.netty.autoconfigure.NettyAutoConfiguration;
+import org.springframework.boot.netty.autoconfigure.NettyProperties;
+import org.springframework.boot.netty.autoconfigure.NettyProperties.LeakDetection;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
-class Spring_boot_nettyTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Spring_boot_nettyTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(NettyAutoConfiguration.class));
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void nettyPropertiesExposeAllLeakDetectionLevels() {
+        NettyProperties properties = new NettyProperties();
+
+        assertThat(properties.getLeakDetection()).isNull();
+        for (LeakDetection leakDetection : LeakDetection.values()) {
+            properties.setLeakDetection(leakDetection);
+
+            assertThat(properties.getLeakDetection()).isSameAs(leakDetection);
+            assertThat(ResourceLeakDetector.Level.valueOf(leakDetection.name()).name()).isEqualTo(leakDetection.name());
+        }
+
+        properties.setLeakDetection(null);
+        assertThat(properties.getLeakDetection()).isNull();
     }
+
+    @Test
+    void autoConfigurationIsAdvertisedForSpringBootDiscovery() {
+        ImportCandidates candidates = ImportCandidates.load(AutoConfiguration.class, getClass().getClassLoader());
+
+        assertThat(candidates.getCandidates()).contains(NettyAutoConfiguration.class.getName());
+    }
+
+    @Test
+    void autoConfigurationBindsLeakDetectionAndUpdatesNettyGlobalLevel() throws Throwable {
+        runWithRestoredLeakDetectionLevel(() -> this.contextRunner
+                .withPropertyValues("spring.netty.leak-detection=paranoid")
+                .run((context) -> {
+                    assertThat(context.getBeanNamesForType(NettyAutoConfiguration.class)).hasSize(1);
+                    assertThat(context.getBeanNamesForType(NettyProperties.class)).hasSize(1);
+                    NettyProperties properties = context.getBean(NettyProperties.class);
+
+                    assertThat(properties.getLeakDetection()).isSameAs(LeakDetection.PARANOID);
+                    assertThat(ResourceLeakDetector.getLevel()).isEqualTo(ResourceLeakDetector.Level.PARANOID);
+                }));
+    }
+
+    @Test
+    void autoConfigurationContributesLazyInitializationExcludeFilter() {
+        this.contextRunner.run((context) -> {
+            assertThat(context.getBeanNamesForType(NettyAutoConfiguration.class)).hasSize(1);
+            assertThat(context.getBeanNamesForType(LazyInitializationExcludeFilter.class)).hasSize(1);
+            LazyInitializationExcludeFilter filter = context.getBean(LazyInitializationExcludeFilter.class);
+
+            assertThat(filter.isExcluded("nettyAutoConfiguration", null, NettyAutoConfiguration.class)).isTrue();
+            assertThat(filter.isExcluded("nettyProperties", null, NettyProperties.class)).isFalse();
+        });
+    }
+
+    @Test
+    void autoConfigurationLeavesExistingNettyGlobalLevelWhenPropertyIsNotSet() throws Throwable {
+        runWithRestoredLeakDetectionLevel(() -> {
+            ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.ADVANCED);
+
+            this.contextRunner.run((context) -> {
+                assertThat(context.getBean(NettyProperties.class).getLeakDetection()).isNull();
+                assertThat(ResourceLeakDetector.getLevel()).isEqualTo(ResourceLeakDetector.Level.ADVANCED);
+            });
+        });
+    }
+
+    private void runWithRestoredLeakDetectionLevel(ThrowingRunnable runnable) throws Throwable {
+        ResourceLeakDetector.Level originalLevel = ResourceLeakDetector.getLevel();
+        try {
+            runnable.run();
+        }
+        finally {
+            ResourceLeakDetector.setLevel(originalLevel);
+        }
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable {
+
+        void run() throws Throwable;
+
+    }
+
 }

--- a/tests/src/org.springframework.boot/spring-boot-netty/4.0.2/user-code-filter.json
+++ b/tests/src/org.springframework.boot/spring-boot-netty/4.0.2/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.springframework.boot.netty.autoconfigure.**"
+      "includeClasses" : "org.springframework.boot.netty.autoconfigure.**"
+    },
+    {
+      "includeClasses" : "org_springframework_boot.spring_boot_netty.**"
     }
   ]
 }

--- a/tests/src/org.springframework.boot/spring-boot-netty/4.0.2/user-code-filter.json
+++ b/tests/src/org.springframework.boot/spring-boot-netty/4.0.2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.springframework.boot.netty.autoconfigure.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #7101

This PR introduces tests and metadata for org.springframework.boot:spring-boot-netty:4.0.2, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 109227
- Cached input tokens: 1624576
- Output tokens: 17131
- Metadata entries: 29
- Iterations: 3
- Library coverage percentage: 100.0
- Generated lines of code: 93
- Tested library lines of code: 15

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3f69aa1510d519e1825b9bfd59a81bb41ea7ef04`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 58/58 (100.00%)
- Line: 15/15 (100.00%)
- Method: 6/6 (100.00%)

### Post-Generation Intervention

- Stage: `metadata_fix_failed`

- Intervention file: `post-gen-interventions/org.springframework.boot_spring-boot-netty_4.0.2.md`

# Post-generation intervention report

Library: org.springframework.boot:spring-boot-netty:4.0.2
Stage: metadata_fix_failed

## Summary

The metadata-fix run successfully added Spring Boot/Netty support metadata, but one generated native test remained incompatible with the required metadata. The failing test was `autoConfigurationBacksOffWhenNettyRuntimeIsUnavailable()` in `Spring_boot_nettyTest.java`.

Codex found that the metadata must make `io.netty.util.NettyRuntime` visible so Spring Boot's positive `@ConditionalOnClass` path can work in native image. With that registration present, `FilteredClassLoader(NettyRuntime.class)` cannot hide the class from Spring Boot's condition check in the native executable, so the backoff assertion fails with:

```text
Expecting empty but was: ["org.springframework.boot.netty.autoconfigure.NettyAutoConfiguration"]
```

The Gradle excerpt also showed a `nativeTestCompile` failure in JUnit discovery/class-initialization code (`MethodOrderingVisitor` / `DescriptorWrapperOrderer`). After removing the loader-sensitive generated test, the targeted run completed successfully, so the actionable remaining library-test failure was the generated filtered-classloader scenario rather than missing library metadata.

## Root cause and intervention

This was not a metadata-related failure. It was a generated test/native-image limitation around using Spring Boot's test-only `FilteredClassLoader` to simulate absence of a class that must be present through native-image reachability metadata.

Removed generated test:

- `autoConfigurationBacksOffWhenNettyRuntimeIsUnavailable()`

Removed test-only imports that were only needed by that test:

- `io.netty.util.NettyRuntime`
- `org.springframework.boot.test.context.FilteredClassLoader`

No metadata files were modified during this intervention.

## Preserved support

The remaining generated support should be preserved because it exercises real `spring-boot-netty` behavior that is valid in native image:

- `NettyProperties` leak-detection binding and enum mapping.
- Discovery of `NettyAutoConfiguration` through Spring Boot import metadata.
- Creation of the auto-configuration and lazy-initialization exclude filter.
- Applying configured leak-detection levels to Netty's global `ResourceLeakDetector` state.
- Preserving an existing Netty global leak-detection level when no property is configured.

After removing only the unsupported filtered-classloader test, `./gradlew test -Pcoordinates=org.springframework.boot:spring-boot-netty:4.0.2 --stacktrace` passed with 6 native tests successful.

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
