### PR TITLE
[GenAI] Test fix for org.json4s:json4s-core_2.13:3.7.0-M13 using gpt-5.5

### DIFF
--- a/metadata/org.json4s/json4s-core_2.13/3.7.0-M13/reachability-metadata.json
+++ b/metadata/org.json4s/json4s-core_2.13/3.7.0-M13/reachability-metadata.json
@@ -1,167 +1,125 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org.json4s.Extraction$CollectionBuilder"
+      "condition" : {
+        "typeReached" : "org.json4s.Extraction$CollectionBuilder"
       },
-      "type": "int[]"
+      "type" : "int[]"
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.reflect.ParanamerReader$"
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
       },
-      "type": "java.lang.String[]"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
       },
-      "type": "java.lang.String[]"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.reflect.ScalaType"
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ScalaType"
       },
-      "type": "java.lang.String[]"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
       },
-      "type": "java.lang.reflect.Constructor[]"
+      "type" : "java.lang.reflect.Constructor[]"
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
       },
-      "type": "java.lang.reflect.Field[]"
+      "type" : "java.lang.reflect.Field[]"
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.Compat$"
+      "condition" : {
+        "typeReached" : "org.json4s.Compat$"
       },
-      "type": "java.lang.reflect.Method[]"
+      "type" : "java.lang.reflect.Method[]"
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
       },
-      "type": "org.json4s.reflect.Executable[]"
+      "type" : "org.json4s.reflect.Executable[]"
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.Extraction$"
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ScalaType"
       },
-      "type": "org_json4s.json4s_core_2_13.ExtractionLazyValFixture"
+      "type" : "scala.Tuple2[]"
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.reflect.Reflector$"
+      "condition" : {
+        "typeReached" : "org.json4s.Compat$"
       },
-      "type": "org_json4s.json4s_core_2_13.ExtractionRecord$"
-    },
-    {
-      "condition": {
-        "typeReached": "org.json4s.reflect.ScalaSigReader$"
-      },
-      "type": "org_json4s.json4s_core_2_13.ExtractionRecord$"
-    },
-    {
-      "condition": {
-        "typeReached": "org.json4s.reflect.Reflector$"
-      },
-      "type": "org_json4s.json4s_core_2_13.ReflectorDefaultValueFixture$"
-    },
-    {
-      "condition": {
-        "typeReached": "org.json4s.reflect.ScalaSigReader$"
-      },
-      "type": "org_json4s.json4s_core_2_13.ReflectorDefaultValueFixture$"
-    },
-    {
-      "condition": {
-        "typeReached": "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
-      },
-      "type": "org_json4s.json4s_core_2_13.ReflectorInnerClassDescriptorBuilderFixtures"
-    },
-    {
-      "condition": {
-        "typeReached": "org.json4s.reflect.Reflector$"
-      },
-      "type": "org_json4s.json4s_core_2_13.ReflectorInnerClassDescriptorBuilderFixtures$NestedRecord$"
-    },
-    {
-      "condition": {
-        "typeReached": "org.json4s.reflect.ScalaType"
-      },
-      "type": "scala.Tuple2[]"
-    },
-    {
-      "condition": {
-        "typeReached": "org.json4s.Compat$"
-      },
-      "type": "scala.collection.immutable.Vector$",
-      "methods": [
+      "type" : "scala.collection.immutable.Vector$",
+      "methods" : [
         {
-          "name": "newBuilder",
-          "parameterTypes": []
+          "name" : "newBuilder",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.reflect.ScalaSigReader$"
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ScalaSigReader$"
       },
-      "type": "scala.collection.immutable.Vector$",
-      "fields": [
+      "type" : "scala.collection.immutable.Vector$",
+      "fields" : [
         {
-          "name": "MODULE$"
+          "name" : "MODULE$"
         }
       ]
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "org.json4s.reflect.ParanamerReader$"
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
       },
-      "glob": "org_json4s/json4s_core_2_13/ExtractionLazyValFixture.class"
+      "glob" : "org_json4s/json4s_core_2_13/ExtractionLazyValFixture.class"
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.reflect.ParanamerReader$"
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
       },
-      "glob": "org_json4s/json4s_core_2_13/ExtractionRecord$.class"
+      "glob" : "org_json4s/json4s_core_2_13/ExtractionRecord$.class"
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.reflect.ParanamerReader$"
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
       },
-      "glob": "org_json4s/json4s_core_2_13/ExtractionRecord.class"
+      "glob" : "org_json4s/json4s_core_2_13/ExtractionRecord.class"
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.reflect.ParanamerReader$"
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
       },
-      "glob": "org_json4s/json4s_core_2_13/ReflectorDefaultValueFixture$.class"
+      "glob" : "org_json4s/json4s_core_2_13/ReflectorDefaultValueFixture$.class"
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.reflect.ParanamerReader$"
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
       },
-      "glob": "org_json4s/json4s_core_2_13/ReflectorDefaultValueFixture.class"
+      "glob" : "org_json4s/json4s_core_2_13/ReflectorDefaultValueFixture.class"
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.reflect.ParanamerReader$"
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
       },
-      "glob": "org_json4s/json4s_core_2_13/ReflectorInnerClassDescriptorBuilderFixtures$NestedRecord$.class"
+      "glob" : "org_json4s/json4s_core_2_13/ReflectorInnerClassDescriptorBuilderFixtures$NestedRecord$.class"
     },
     {
-      "condition": {
-        "typeReached": "org.json4s.reflect.ParanamerReader$"
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
       },
-      "glob": "org_json4s/json4s_core_2_13/ReflectorInnerClassDescriptorBuilderFixtures$NestedRecord.class"
+      "glob" : "org_json4s/json4s_core_2_13/ReflectorInnerClassDescriptorBuilderFixtures$NestedRecord.class"
     }
   ]
 }

--- a/metadata/org.json4s/json4s-core_2.13/3.7.0-M13/reachability-metadata.json
+++ b/metadata/org.json4s/json4s-core_2.13/3.7.0-M13/reachability-metadata.json
@@ -1,0 +1,167 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.json4s.Extraction$CollectionBuilder"
+      },
+      "type": "int[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.ParanamerReader$"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.ScalaType"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
+      },
+      "type": "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
+      },
+      "type": "java.lang.reflect.Field[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.Compat$"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
+      },
+      "type": "org.json4s.reflect.Executable[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.Extraction$"
+      },
+      "type": "org_json4s.json4s_core_2_13.ExtractionLazyValFixture"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.Reflector$"
+      },
+      "type": "org_json4s.json4s_core_2_13.ExtractionRecord$"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.ScalaSigReader$"
+      },
+      "type": "org_json4s.json4s_core_2_13.ExtractionRecord$"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.Reflector$"
+      },
+      "type": "org_json4s.json4s_core_2_13.ReflectorDefaultValueFixture$"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.ScalaSigReader$"
+      },
+      "type": "org_json4s.json4s_core_2_13.ReflectorDefaultValueFixture$"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
+      },
+      "type": "org_json4s.json4s_core_2_13.ReflectorInnerClassDescriptorBuilderFixtures"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.Reflector$"
+      },
+      "type": "org_json4s.json4s_core_2_13.ReflectorInnerClassDescriptorBuilderFixtures$NestedRecord$"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.ScalaType"
+      },
+      "type": "scala.Tuple2[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.Compat$"
+      },
+      "type": "scala.collection.immutable.Vector$",
+      "methods": [
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.ScalaSigReader$"
+      },
+      "type": "scala.collection.immutable.Vector$",
+      "fields": [
+        {
+          "name": "MODULE$"
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob": "org_json4s/json4s_core_2_13/ExtractionLazyValFixture.class"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob": "org_json4s/json4s_core_2_13/ExtractionRecord$.class"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob": "org_json4s/json4s_core_2_13/ExtractionRecord.class"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob": "org_json4s/json4s_core_2_13/ReflectorDefaultValueFixture$.class"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob": "org_json4s/json4s_core_2_13/ReflectorDefaultValueFixture.class"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob": "org_json4s/json4s_core_2_13/ReflectorInnerClassDescriptorBuilderFixtures$NestedRecord$.class"
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob": "org_json4s/json4s_core_2_13/ReflectorInnerClassDescriptorBuilderFixtures$NestedRecord.class"
+    }
+  ]
+}

--- a/metadata/org.json4s/json4s-core_2.13/index.json
+++ b/metadata/org.json4s/json4s-core_2.13/index.json
@@ -1,6 +1,19 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.7.0-M13",
+    "language" : {
+      "name" : "scala",
+      "version" : "2"
+    },
+    "tested-versions" : [
+      "3.7.0-M13"
+    ],
+    "allowed-packages" : [
+      "org.json4s"
+    ]
+  },
+  {
     "metadata-version" : "3.7.0-M11",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/json4s/json4s-core_2.13/$version$/json4s-core_2.13-$version$-sources.jar",
     "repository-url" : "https://github.com/json4s/json4s",

--- a/metadata/org.json4s/json4s-core_2.13/index.json
+++ b/metadata/org.json4s/json4s-core_2.13/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "3.7.0-M13",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/json4s/json4s-core_2.13/$version$/json4s-core_2.13-$version$-sources.jar",
+    "repository-url" : "https://github.com/json4s/json4s",
+    "test-code-url" : "https://github.com/json4s/json4s/tree/v$version$/core/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/json4s/json4s-core_2.13/$version$/json4s-core_2.13-$version$-javadoc.jar",
+    "description" : "json4s-core provides the core Scala JSON AST and transformation/extraction APIs used by the json4s JSON library family. It lets Scala applications model JSON as JValue trees and map between those trees and domain objects while parser implementations are supplied by companion modules such as json4s-native and json4s-jackson.",
     "language" : {
       "name" : "scala",
       "version" : "2"

--- a/stats/org.json4s/json4s-core_2.13/3.7.0-M13/execution-metrics.json
+++ b/stats/org.json4s/json4s-core_2.13/3.7.0-M13/execution-metrics.json
@@ -1,0 +1,101 @@
+{
+  "fix_java_run_fail:2026-05-19": {
+    "timestamp": "2026-05-19T03:33:57.174657Z",
+    "library": "org.json4s:json4s-core_2.13:3.7.0-M13",
+    "starting_commit": "3cb4c75d7b5e1825be5d504c66d903ec93ef8623",
+    "ending_commit": "5dcdf6a74552ac9c2396f241596b8bec1ee28dac",
+    "previous_library": "org.json4s:json4s-core_2.13:3.7.0-M11",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.7.0-M13",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 22,
+            "totalCalls": 22
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 22,
+        "totalCalls": 22
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5389,
+          "missed": 18258,
+          "ratio": 0.227894,
+          "total": 23647
+        },
+        "line": {
+          "covered": 712,
+          "missed": 766,
+          "ratio": 0.481732,
+          "total": 1478
+        },
+        "method": {
+          "covered": 380,
+          "missed": 1313,
+          "ratio": 0.224454,
+          "total": 1693
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.7.0-M11",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 22,
+            "totalCalls": 22
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 22,
+        "totalCalls": 22
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5717,
+          "missed": 28840,
+          "ratio": 0.165437,
+          "total": 34557
+        },
+        "line": {
+          "covered": 759,
+          "missed": 1492,
+          "ratio": 0.337183,
+          "total": 2251
+        },
+        "method": {
+          "covered": 413,
+          "missed": 2270,
+          "ratio": 0.153932,
+          "total": 2683
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 149569,
+      "cached_input_tokens_used": 2243584,
+      "output_tokens_used": 15920,
+      "iterations": 4,
+      "cost_usd": 1.5994,
+      "tested_library_loc": 712,
+      "metadata_entries": 20,
+      "test_only_metadata_entries": 37,
+      "previous_library_metadata_entries": 19,
+      "previous_library_test_only_metadata_entries": 32,
+      "code_coverage_percent": 48.17,
+      "previous_library_coverage_percent": 33.72
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/src/test/scala/org_json4s/json4s_core_2_13/ReflectorInnerClassDescriptorBuilderTest.scala",
+      "metadata_file": "metadata/org.json4s/json4s-core_2.13/3.7.0-M13/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.json4s/json4s-core_2.13/3.7.0-M13/stats.json
+++ b/stats/org.json4s/json4s-core_2.13/3.7.0-M13/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "3.7.0-M13",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 22,
+          "totalCalls" : 22
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 22,
+      "totalCalls" : 22
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 5389,
+        "missed" : 18258,
+        "ratio" : 0.227894,
+        "total" : 23647
+      },
+      "line" : {
+        "covered" : 712,
+        "missed" : 766,
+        "ratio" : 0.481732,
+        "total" : 1478
+      },
+      "method" : {
+        "covered" : 380,
+        "missed" : 1313,
+        "ratio" : 0.224454,
+        "total" : 1693
+      }
+    }
+  } ]
+}

--- a/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/.gitignore
+++ b/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/build.gradle
+++ b/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.json4s:json4s-core_2.13:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala-library:2.13.16'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/build.gradle
+++ b/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/build.gradle
@@ -11,6 +11,10 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 
+configurations.configureEach {
+    exclude group: 'org.scala-native'
+}
+
 dependencies {
     testImplementation "org.json4s:json4s-core_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'

--- a/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/gradle.properties
+++ b/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.json4s:json4s-core_2.13:3.7.0-M13
+library.version = 3.7.0-M13
+metadata.dir = org.json4s/json4s-core_2.13/3.7.0-M13/

--- a/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/settings.gradle
+++ b/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.json4s.json4s-core_2.13_tests'

--- a/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,181 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.Extraction$"
+      },
+      "type" : "org_json4s.json4s_core_2_13.ExtractionLazyValFixture",
+      "methods" : [
+        {
+          "name" : "computed$lzycompute",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.PropertyDescriptor"
+      },
+      "type" : "org_json4s.json4s_core_2_13.ExtractionLazyValFixture",
+      "fields" : [
+        {
+          "name" : "computed"
+        },
+        {
+          "name" : "name"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
+      },
+      "type" : "org_json4s.json4s_core_2_13.ExtractionLazyValFixture"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ScalaSigReader$"
+      },
+      "type" : "org_json4s.json4s_core_2_13.ExtractionLazyValFixture$"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.PropertyDescriptor"
+      },
+      "type" : "org_json4s.json4s_core_2_13.ExtractionRecord",
+      "fields" : [
+        {
+          "name" : "id"
+        },
+        {
+          "name" : "name"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
+      },
+      "type" : "org_json4s.json4s_core_2_13.ExtractionRecord"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$"
+      },
+      "type" : "org_json4s.json4s_core_2_13.ExtractionRecord$"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ScalaSigReader$"
+      },
+      "type" : "org_json4s.json4s_core_2_13.ExtractionRecord$",
+      "fields" : [
+        {
+          "name" : "MODULE$"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Executable"
+      },
+      "type" : "org_json4s.json4s_core_2_13.PropertyDescriptorMutableSubject",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.PropertyDescriptor"
+      },
+      "type" : "org_json4s.json4s_core_2_13.PropertyDescriptorMutableSubject",
+      "fields" : [
+        {
+          "name" : "count"
+        },
+        {
+          "name" : "name"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
+      },
+      "type" : "org_json4s.json4s_core_2_13.PropertyDescriptorMutableSubject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ScalaSigReader$"
+      },
+      "type" : "org_json4s.json4s_core_2_13.PropertyDescriptorMutableSubject$"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
+      },
+      "type" : "org_json4s.json4s_core_2_13.ReflectorDefaultValueFixture"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$"
+      },
+      "type" : "org_json4s.json4s_core_2_13.ReflectorDefaultValueFixture$",
+      "methods" : [
+        {
+          "name" : "$lessinit$greater$default$1",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ScalaSigReader$"
+      },
+      "type" : "org_json4s.json4s_core_2_13.ReflectorDefaultValueFixture$",
+      "fields" : [
+        {
+          "name" : "MODULE$"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
+      },
+      "type" : "org_json4s.json4s_core_2_13.ReflectorInnerClassDescriptorBuilderFixtures",
+      "methods" : [
+        {
+          "name" : "NestedRecord",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
+      },
+      "type" : "org_json4s.json4s_core_2_13.ReflectorInnerClassDescriptorBuilderFixtures$NestedRecord"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$"
+      },
+      "type" : "org_json4s.json4s_core_2_13.ReflectorInnerClassDescriptorBuilderFixtures$NestedRecord$"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ScalaType"
+      },
+      "type" : "org_json4s.json4s_core_2_13.ScalaTypeSingletonFixture$",
+      "fields" : [
+        {
+          "name" : "MODULE$"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -176,6 +176,36 @@
           "name" : "MODULE$"
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.Extraction$"
+      },
+      "type" : "org_json4s.json4s_core_2_13.ExtractionLazyValFixture"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ScalaSigReader$"
+      },
+      "type" : "org_json4s.json4s_core_2_13.ExtractionRecord$"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$"
+      },
+      "type" : "org_json4s.json4s_core_2_13.ReflectorDefaultValueFixture$"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ScalaSigReader$"
+      },
+      "type" : "org_json4s.json4s_core_2_13.ReflectorDefaultValueFixture$"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
+      },
+      "type" : "org_json4s.json4s_core_2_13.ReflectorInnerClassDescriptorBuilderFixtures"
     }
   ]
 }

--- a/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/src/test/scala/org_json4s/json4s_core_2_13/CompatTest.scala
+++ b/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/src/test/scala/org_json4s/json4s_core_2_13/CompatTest.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_json4s.json4s_core_2_13
+
+import org.assertj.core.api.Assertions.assertThat
+import org.json4s.DefaultFormats
+import org.json4s.Extraction
+import org.json4s.Formats
+import org.json4s.JArray
+import org.json4s.JString
+import org.junit.jupiter.api.Test
+
+class CompatTest {
+  @Test
+  def extractsVectorUsingCompanionBuilder(): Unit = {
+    implicit val formats: Formats = DefaultFormats
+    val json: JArray = JArray(List(JString("alpha"), JString("beta"), JString("gamma")))
+
+    val extracted: Vector[String] = Extraction.extract[Vector[String]](json)
+
+    assertThat(extracted).isEqualTo(Vector("alpha", "beta", "gamma"))
+  }
+}

--- a/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/src/test/scala/org_json4s/json4s_core_2_13/ExecutableTest.scala
+++ b/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/src/test/scala/org_json4s/json4s_core_2_13/ExecutableTest.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_json4s.json4s_core_2_13
+
+import org.assertj.core.api.Assertions.assertThat
+import org.json4s.reflect.Executable
+import org.json4s.reflect.ScalaType
+import org.json4s.reflect.SingletonDescriptor
+import org.junit.jupiter.api.Test
+
+class ExecutableTest {
+  @Test
+  def invokesWrappedMethodOnDescriptorInstance(): Unit = {
+    val fixture: ExecutableInvocationFixture = new ExecutableInvocationFixture
+    val method: java.lang.reflect.Method = classOf[ExecutableInvocationFixture]
+      .getMethod("decorate", classOf[String], classOf[java.lang.Integer])
+    val descriptor: SingletonDescriptor = SingletonDescriptor(
+      simpleName = "ExecutableInvocationFixture",
+      fullName = classOf[ExecutableInvocationFixture].getName,
+      erasure = ScalaType(classOf[ExecutableInvocationFixture]),
+      instance = fixture,
+      properties = Seq.empty
+    )
+
+    val result: Any = new Executable(method).invoke(Some(descriptor), Seq("item", Integer.valueOf(12)))
+
+    assertThat(result).isEqualTo("item-12")
+  }
+
+  @Test
+  def invokesWrappedConstructorWithArguments(): Unit = {
+    val constructor: java.lang.reflect.Constructor[ExecutableConstructedFixture] = classOf[ExecutableConstructedFixture]
+      .getConstructor(classOf[String], classOf[java.lang.Integer])
+
+    val result: ExecutableConstructedFixture = new Executable(constructor, isPrimaryCtor = true)
+      .invoke(None, Seq("created", Integer.valueOf(5)))
+      .asInstanceOf[ExecutableConstructedFixture]
+
+    assertThat(result.description).isEqualTo("created:5")
+  }
+}
+
+class ExecutableInvocationFixture {
+  def decorate(prefix: String, count: java.lang.Integer): String = s"$prefix-$count"
+}
+
+class ExecutableConstructedFixture(val name: String, val count: java.lang.Integer) {
+  def description: String = s"$name:$count"
+}

--- a/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/src/test/scala/org_json4s/json4s_core_2_13/ExtractionInnerCollectionBuilderTest.scala
+++ b/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/src/test/scala/org_json4s/json4s_core_2_13/ExtractionInnerCollectionBuilderTest.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_json4s.json4s_core_2_13
+
+import org.assertj.core.api.Assertions.assertThat
+import org.json4s.DefaultFormats
+import org.json4s.Extraction
+import org.json4s.Formats
+import org.json4s.JArray
+import org.json4s.JInt
+import org.junit.jupiter.api.Test
+
+class ExtractionInnerCollectionBuilderTest {
+  @Test
+  def extractsJsonArrayIntoTypedScalaArray(): Unit = {
+    implicit val formats: Formats = DefaultFormats
+    val json: JArray = JArray(List(JInt(2), JInt(3), JInt(5)))
+
+    val values: Array[Int] = Extraction.extract[Array[Int]](json)
+
+    assertThat(values.toList).isEqualTo(List(2, 3, 5))
+  }
+}

--- a/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/src/test/scala/org_json4s/json4s_core_2_13/ExtractionTest.scala
+++ b/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/src/test/scala/org_json4s/json4s_core_2_13/ExtractionTest.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_json4s.json4s_core_2_13
+
+import org.assertj.core.api.Assertions.assertThat
+import org.json4s.DefaultFormats
+import org.json4s.Extraction
+import org.json4s.FieldSerializer
+import org.json4s.Formats
+import org.json4s.JValue
+import org.junit.jupiter.api.Test
+
+class ExtractionTest {
+  @Test
+  def decomposesCaseClassUsingPublicAccessors(): Unit = {
+    implicit val formats: Formats = DefaultFormats
+    val json: JValue = Extraction.decompose(ExtractionRecord(7, "seven"))
+
+    assertThat((json \ "id").values).isEqualTo(7)
+    assertThat((json \ "name").values).isEqualTo("seven")
+  }
+
+  @Test
+  def decomposesLazyValWhenFieldSerializerIncludesLazyValues(): Unit = {
+    implicit val formats: Formats = DefaultFormats + FieldSerializer[ExtractionLazyValFixture](includeLazyVal = true)
+    val fixture: ExtractionLazyValFixture = new ExtractionLazyValFixture("alpha")
+
+    val json: JValue = Extraction.decompose(fixture)
+
+    assertThat((json \ "name").values).isEqualTo("alpha")
+    assertThat((json \ "computed").values).isEqualTo("computed-alpha")
+  }
+}
+
+case class ExtractionRecord(id: Int, name: String)
+
+class ExtractionLazyValFixture(val name: String) {
+  lazy val computed: String = s"computed-$name"
+}

--- a/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/src/test/scala/org_json4s/json4s_core_2_13/PropertyDescriptorTest.scala
+++ b/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/src/test/scala/org_json4s/json4s_core_2_13/PropertyDescriptorTest.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_json4s.json4s_core_2_13
+
+import org.assertj.core.api.Assertions.assertThat
+import org.json4s.DefaultFormats
+import org.json4s.Extraction
+import org.json4s.FieldSerializer
+import org.json4s.Formats
+import org.json4s.JField
+import org.json4s.JInt
+import org.json4s.JObject
+import org.json4s.JString
+import org.junit.jupiter.api.Test
+
+class PropertyDescriptorMutableSubject {
+  var name: String = "initial"
+  var count: Int = -1
+}
+
+class PropertyDescriptorTest {
+  @Test
+  def extractsJsonIntoMutableFieldsUsingFieldSerializer(): Unit = {
+    implicit val formats: Formats = DefaultFormats + FieldSerializer[PropertyDescriptorMutableSubject]()
+    val json: JObject = JObject(
+      List(
+        JField("name", JString("configured")),
+        JField("count", JInt(11))
+      )
+    )
+
+    val extracted: PropertyDescriptorMutableSubject = Extraction.extract[PropertyDescriptorMutableSubject](json)
+
+    assertThat(extracted.name).isEqualTo("configured")
+    assertThat(extracted.count).isEqualTo(11)
+  }
+}

--- a/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/src/test/scala/org_json4s/json4s_core_2_13/ReflectorInnerClassDescriptorBuilderTest.scala
+++ b/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/src/test/scala/org_json4s/json4s_core_2_13/ReflectorInnerClassDescriptorBuilderTest.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_json4s.json4s_core_2_13
+
+import org.assertj.core.api.Assertions.assertThat
+import org.json4s.DefaultFormats
+import org.json4s.Formats
+import org.json4s.reflect.ClassDescriptor
+import org.json4s.reflect.Reflector
+import org.junit.jupiter.api.Test
+
+import scala.jdk.CollectionConverters._
+
+class ReflectorInnerClassDescriptorBuilderTest {
+  @Test
+  def describesInnerCaseClassUsingMappedCompanion(): Unit = {
+    Reflector.clearCaches()
+
+    val owner: ReflectorInnerClassDescriptorBuilderFixtures = new ReflectorInnerClassDescriptorBuilderFixtures
+    val sample: owner.NestedRecord = owner.NestedRecord("alpha")
+    val nestedClass: Class[_] = sample.getClass
+    implicit val formats: Formats = DefaultFormats
+
+    val descriptor: ClassDescriptor = Reflector
+      .createDescriptorWithFormats(
+        Reflector.scalaTypeOf(nestedClass),
+        companionMappings = List(nestedClass -> owner.asInstanceOf[AnyRef])
+      )
+      .asInstanceOf[ClassDescriptor]
+
+    assertThat(descriptor.simpleName).isEqualTo("NestedRecord")
+    assertThat(descriptor.companion.isDefined).isTrue()
+    assertThat(descriptor.properties.map(_.name).asJava).contains("name", "amount")
+    assertThat(descriptor.constructors.size).isGreaterThan(1)
+    assertThat(descriptor.constructors.exists(_.params.forall(_.name != "$outer"))).isTrue()
+    assertThat(descriptor.constructors.flatMap(_.params.map(_.name)).asJava).contains("name", "amount")
+  }
+}
+
+class ReflectorInnerClassDescriptorBuilderFixtures {
+  case class NestedRecord(name: String, amount: Int = 9)
+}

--- a/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/src/test/scala/org_json4s/json4s_core_2_13/ReflectorTest.scala
+++ b/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/src/test/scala/org_json4s/json4s_core_2_13/ReflectorTest.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_json4s.json4s_core_2_13
+
+import org.assertj.core.api.Assertions.assertThat
+import org.json4s.reflect.ClassDescriptor
+import org.json4s.reflect.ConstructorParamDescriptor
+import org.json4s.reflect.Reflector
+import org.junit.jupiter.api.Test
+
+class ReflectorTest {
+  @Test
+  def invokesDefaultValueAccessorFromDescribedConstructor(): Unit = {
+    Reflector.clearCaches()
+
+    val descriptor: ClassDescriptor = Reflector.describe[ReflectorDefaultValueFixture].asInstanceOf[ClassDescriptor]
+    val defaultedParam: ConstructorParamDescriptor = descriptor.mostComprehensive.find(_.name == "label").get
+
+    assertThat(defaultedParam.hasDefault).isTrue()
+    assertThat(defaultedParam.defaultValue.isDefined).isTrue()
+    assertThat(defaultedParam.defaultValue.get.apply()).isEqualTo("from-default")
+  }
+}
+
+case class ReflectorDefaultValueFixture(label: String = "from-default", count: Int = 7)

--- a/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/src/test/scala/org_json4s/json4s_core_2_13/ScalaTypeTest.scala
+++ b/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/src/test/scala/org_json4s/json4s_core_2_13/ScalaTypeTest.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_json4s.json4s_core_2_13
+
+import org.assertj.core.api.Assertions.assertThat
+import org.json4s.reflect.ScalaType
+import org.junit.jupiter.api.Test
+
+class ScalaTypeTest {
+  @Test
+  def resolvesSingletonInstanceForScalaObject(): Unit = {
+    val scalaType: ScalaType = ScalaType(ScalaTypeSingletonFixture.getClass)
+    val singletonInstance: Option[AnyRef] = scalaType.singletonInstance
+
+    assertThat(scalaType.isSingleton).isTrue()
+    assertThat(singletonInstance.isDefined).isTrue()
+    assertThat(singletonInstance.get).isSameAs(ScalaTypeSingletonFixture)
+  }
+}
+
+object ScalaTypeSingletonFixture {
+  val name: String = "json4s-singleton"
+}

--- a/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/user-code-filter.json
+++ b/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.json4s.**"
+    },
+    {
+      "includeClasses" : "org_json4s.json4s_core_2_13.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6944

This PR provides test fixes and new metadata for org.json4s:json4s-core_2.13:3.7.0-M13, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 149569
- Cached input tokens: 2243584
- Output tokens: 15920
- Metadata entries: 20
- Test-only metadata entries: 37
- Iterations: 4
- Library coverage percentage: 48.17
- Previous library version metadata entries: 19
- Previous library version test-only metadata entries: 32
- Previous library version coverage percentage: 33.72

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3f69aa1510d519e1825b9bfd59a81bb41ea7ef04`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.json4s:json4s-core_2.13:3.7.0-M11: 22/22 covered calls (100.00%)
- org.json4s:json4s-core_2.13:3.7.0-M13: 22/22 covered calls (100.00%)

**Reflection:**
- org.json4s:json4s-core_2.13:3.7.0-M11: 22/22 covered calls (100.00%)
- org.json4s:json4s-core_2.13:3.7.0-M13: 22/22 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.json4s:json4s-core_2.13:3.7.0-M11: 5717/34557 (16.54%)
- org.json4s:json4s-core_2.13:3.7.0-M13: 5389/23647 (22.79%)

**Line:**
- org.json4s:json4s-core_2.13:3.7.0-M11: 759/2251 (33.72%)
- org.json4s:json4s-core_2.13:3.7.0-M13: 712/1478 (48.17%)

**Method:**
- org.json4s:json4s-core_2.13:3.7.0-M11: 413/2683 (15.39%)
- org.json4s:json4s-core_2.13:3.7.0-M13: 380/1693 (22.45%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.json4s/json4s-core_2.13/3.7.0-M11/build.gradle 2/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/build.gradle
index b116724dba..b37e988b80 100644
--- 1/tests/src/org.json4s/json4s-core_2.13/3.7.0-M11/build.gradle
+++ 2/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/build.gradle
@@ -11,6 +11,10 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 
+configurations.configureEach {
+    exclude group: 'org.scala-native'
+}
+
 dependencies {
     testImplementation "org.json4s:json4s-core_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
