### PR TITLE
[GenAI] Add support for org.springframework.boot:spring-boot-reactor:4.0.2 using gpt-5.5

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-reactor/4.0.2/reachability-metadata.json
+++ b/metadata/org.springframework.boot/spring-boot-reactor/4.0.2/reachability-metadata.json
@@ -1,0 +1,283 @@
+{
+  "reflection": [
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.OnClassCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.boot.autoconfigure.condition.OnClassCondition"
+      },
+      "type": "reactor.core.publisher.Hooks"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.boot.context.properties.bind.JavaBeanBinder"
+      },
+      "type": "org.springframework.boot.reactor.autoconfigure.ReactorProperties",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.boot.thread.Threading"
+      },
+      "type": "java.io.Console",
+      "methods": [
+        {
+          "name": "charset",
+          "parameterTypes": []
+        },
+        {
+          "name": "isTerminal",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.boot.thread.Threading"
+      },
+      "type": "java.io.Reader",
+      "methods": [
+        {
+          "name": "of",
+          "parameterTypes": [
+            "java.lang.CharSequence"
+          ]
+        },
+        {
+          "name": "readAllLines",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.boot.thread.Threading"
+      },
+      "type": "java.lang.Class",
+      "methods": [
+        {
+          "name": "accessFlags",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.boot.thread.Threading"
+      },
+      "type": "java.text.NumberFormat",
+      "methods": [
+        {
+          "name": "isStrict",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.boot.thread.Threading"
+      },
+      "type": "java.time.Duration",
+      "methods": [
+        {
+          "name": "isPositive",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.boot.thread.Threading"
+      },
+      "type": "java.util.SortedSet",
+      "methods": [
+        {
+          "name": "getFirst",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.boot.thread.Threading"
+      },
+      "type": "java.util.concurrent.Future",
+      "methods": [
+        {
+          "name": "state",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.annotation.AnnotationsScanner"
+      },
+      "type": {
+        "proxy": [
+          "org.springframework.boot.autoconfigure.AutoConfiguration"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.type.StandardAnnotationMetadata"
+      },
+      "type": {
+        "proxy": [
+          "org.springframework.boot.autoconfigure.AutoConfiguration"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.annotation.AnnotationsScanner"
+      },
+      "type": {
+        "proxy": [
+          "org.springframework.boot.autoconfigure.condition.ConditionalOnClass"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.type.StandardAnnotationMetadata"
+      },
+      "type": {
+        "proxy": [
+          "org.springframework.boot.autoconfigure.condition.ConditionalOnClass"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.annotation.AnnotationsScanner"
+      },
+      "type": {
+        "proxy": [
+          "org.springframework.boot.context.properties.EnableConfigurationProperties"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.type.StandardAnnotationMetadata"
+      },
+      "type": {
+        "proxy": [
+          "org.springframework.boot.context.properties.EnableConfigurationProperties"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.context.annotation.ConfigurationClassParser"
+      },
+      "type": "org.springframework.boot.context.properties.EnableConfigurationPropertiesRegistrar",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.boot.context.properties.EnableConfigurationPropertiesRegistrar"
+      },
+      "type": "org.springframework.boot.context.properties.ConfigurationPropertiesBindingPostProcessor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.boot.context.properties.ConfigurationPropertiesBindingPostProcessor"
+      },
+      "type": "org.springframework.boot.context.properties.ConfigurationPropertiesBinder$ConfigurationPropertiesBinderFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.boot.reactor.autoconfigure.ReactorProperties"
+      },
+      "type": "org.springframework.boot.reactor.autoconfigure.ReactorAutoConfiguration",
+      "allDeclaredConstructors": true,
+      "methods": [
+        {
+          "name": "reactorAutoConfigurationLazyInitializationExcludeFilter",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.boot.context.properties.EnableConfigurationPropertiesRegistrar"
+      },
+      "type": "org.springframework.boot.context.properties.BoundConfigurationProperties",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.boot.context.properties.EnableConfigurationPropertiesRegistrar"
+      },
+      "type": "org.springframework.boot.validation.beanvalidation.MethodValidationExcludeFilter",
+      "methods": [
+        {
+          "name": "byAnnotation",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.springframework.boot.reactor.ReactorEnvironmentPostProcessor"
+      },
+      "glob": "META-INF/spring.factories"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.boot.context.annotation.ImportCandidates"
+      },
+      "glob": "META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.boot.autoconfigure.AutoConfigurationMetadataLoader"
+      },
+      "glob": "META-INF/spring-autoconfigure-metadata.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.context.annotation.ConfigurationClassParser"
+      },
+      "glob": "org/springframework/boot/context/properties/EnableConfigurationPropertiesRegistrar.class"
+    }
+  ]
+}

--- a/metadata/org.springframework.boot/spring-boot-reactor/index.json
+++ b/metadata/org.springframework.boot/spring-boot-reactor/index.json
@@ -1,17 +1,26 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "4.0.2",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-reactor/$version$/spring-boot-reactor-$version$-sources.jar",
-    "repository-url" : "https://github.com/spring-projects/spring-boot",
-    "test-code-url" : "https://github.com/spring-projects/spring-boot/tree/v$version$/module/spring-boot-reactor/src/test/java",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-reactor/$version$/spring-boot-reactor-$version$-javadoc.jar",
-    "description" : "Spring Boot Reactor provides auto-configuration and startup integration for Project Reactor in Spring Boot applications. It configures Reactor context propagation, optional debug-agent initialization, and virtual-thread scheduler behavior based on Spring Boot environment properties.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "4.0.2",
+    "source-code-url": "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-reactor/$version$/spring-boot-reactor-$version$-sources.jar",
+    "repository-url": "https://github.com/spring-projects/spring-boot",
+    "test-code-url": "https://github.com/spring-projects/spring-boot/tree/v$version$/module/spring-boot-reactor/src/test/java",
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-reactor/$version$/spring-boot-reactor-$version$-javadoc.jar",
+    "description": "Spring Boot Reactor provides auto-configuration and startup integration for Project Reactor in Spring Boot applications. It configures Reactor context propagation, optional debug-agent initialization, and virtual-thread scheduler behavior based on Spring Boot environment properties.",
+    "tested-versions": [
       "4.0.2"
     ],
-    "allowed-packages" : [
-      "org.springframework.boot.reactor"
+    "allowed-packages": [
+      "org.springframework.boot.reactor",
+      "org.springframework.boot.autoconfigure",
+      "org.springframework.boot.autoconfigure.condition",
+      "org.springframework.boot.context.annotation",
+      "org.springframework.boot.context.properties",
+      "org.springframework.boot.context.properties.bind",
+      "org.springframework.boot.thread",
+      "org.springframework.context.annotation",
+      "org.springframework.core.annotation",
+      "org.springframework.core.type"
     ]
   }
 ]

--- a/metadata/org.springframework.boot/spring-boot-reactor/index.json
+++ b/metadata/org.springframework.boot/spring-boot-reactor/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.0.2",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-reactor/$version$/spring-boot-reactor-$version$-sources.jar",
+    "repository-url" : "https://github.com/spring-projects/spring-boot",
+    "test-code-url" : "https://github.com/spring-projects/spring-boot/tree/v$version$/module/spring-boot-reactor/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-reactor/$version$/spring-boot-reactor-$version$-javadoc.jar",
+    "description" : "Spring Boot Reactor provides auto-configuration and startup integration for Project Reactor in Spring Boot applications. It configures Reactor context propagation, optional debug-agent initialization, and virtual-thread scheduler behavior based on Spring Boot environment properties.",
+    "tested-versions" : [
+      "4.0.2"
+    ],
+    "allowed-packages" : [
+      "org.springframework.boot.reactor"
+    ]
+  }
+]

--- a/stats/org.springframework.boot/spring-boot-reactor/4.0.2/execution-metrics.json
+++ b/stats/org.springframework.boot/spring-boot-reactor/4.0.2/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-19": {
+    "timestamp": "2026-05-19T04:11:56.295867Z",
+    "library": "org.springframework.boot:spring-boot-reactor:4.0.2",
+    "starting_commit": "4fc6c0142b0ec9eeabf8d9dab7a8cbe1ea741667",
+    "ending_commit": "ae5736695fa22d0e000dce983305a2b99097e754",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.0.2",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 62,
+          "missed": 30,
+          "ratio": 0.673913,
+          "total": 92
+        },
+        "line": {
+          "covered": 19,
+          "missed": 7,
+          "ratio": 0.730769,
+          "total": 26
+        },
+        "method": {
+          "covered": 9,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 9
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 166389,
+      "cached_input_tokens_used": 1815040,
+      "output_tokens_used": 26953,
+      "iterations": 5,
+      "cost_usd": 1.7161,
+      "generated_loc": 198,
+      "tested_library_loc": 19,
+      "metadata_entries": 46,
+      "code_coverage_percent": 73.08
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.springframework.boot/spring-boot-reactor/4.0.2/src/test/java/org_springframework_boot/spring_boot_reactor/Spring_boot_reactorTest.java",
+      "metadata_file": "metadata/org.springframework.boot/spring-boot-reactor/4.0.2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.springframework.boot/spring-boot-reactor/4.0.2/stats.json
+++ b/stats/org.springframework.boot/spring-boot-reactor/4.0.2/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.0.2",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 62,
+        "missed" : 30,
+        "ratio" : 0.673913,
+        "total" : 92
+      },
+      "line" : {
+        "covered" : 19,
+        "missed" : 7,
+        "ratio" : 0.730769,
+        "total" : 26
+      },
+      "method" : {
+        "covered" : 9,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 9
+      }
+    }
+  } ]
+}

--- a/tests/src/org.springframework.boot/spring-boot-reactor/4.0.2/.gitignore
+++ b/tests/src/org.springframework.boot/spring-boot-reactor/4.0.2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.springframework.boot/spring-boot-reactor/4.0.2/build.gradle
+++ b/tests/src/org.springframework.boot/spring-boot-reactor/4.0.2/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.springframework.boot:spring-boot-reactor:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.springframework.boot/spring-boot-reactor/4.0.2/build.gradle
+++ b/tests/src/org.springframework.boot/spring-boot-reactor/4.0.2/build.gradle
@@ -11,7 +11,10 @@ plugins {
 String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
+    testImplementation platform("org.springframework.boot:spring-boot-dependencies:$libraryVersion")
     testImplementation "org.springframework.boot:spring-boot-reactor:$libraryVersion"
+    testImplementation "org.springframework.boot:spring-boot-autoconfigure:$libraryVersion"
+    testImplementation "io.micrometer:context-propagation"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.springframework.boot/spring-boot-reactor/4.0.2/gradle.properties
+++ b/tests/src/org.springframework.boot/spring-boot-reactor/4.0.2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.springframework.boot:spring-boot-reactor:4.0.2
+library.version = 4.0.2
+metadata.dir = org.springframework.boot/spring-boot-reactor/4.0.2/

--- a/tests/src/org.springframework.boot/spring-boot-reactor/4.0.2/settings.gradle
+++ b/tests/src/org.springframework.boot/spring-boot-reactor/4.0.2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.springframework.boot.spring-boot-reactor_tests'

--- a/tests/src/org.springframework.boot/spring-boot-reactor/4.0.2/src/test/java/org_springframework_boot/spring_boot_reactor/Spring_boot_reactorTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-reactor/4.0.2/src/test/java/org_springframework_boot/spring_boot_reactor/Spring_boot_reactorTest.java
@@ -168,8 +168,7 @@ public class Spring_boot_reactorTest {
 
             assertThat(context.getBean(ReactorAutoConfiguration.class)).isNotNull();
             assertThat(observedThreadLocalValue.get()).isEqualTo("updated");
-        }
-        finally {
+        } finally {
             registry.removeThreadLocalAccessor(THREAD_LOCAL_ACCESSOR_KEY);
             threadLocal.remove();
         }
@@ -230,12 +229,10 @@ public class Spring_boot_reactorTest {
         try {
             System.clearProperty(name);
             action.run();
-        }
-        finally {
+        } finally {
             if (previousValue != null) {
                 System.setProperty(name, previousValue);
-            }
-            else {
+            } else {
                 System.clearProperty(name);
             }
         }

--- a/tests/src/org.springframework.boot/spring-boot-reactor/4.0.2/src/test/java/org_springframework_boot/spring_boot_reactor/Spring_boot_reactorTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-reactor/4.0.2/src/test/java/org_springframework_boot/spring_boot_reactor/Spring_boot_reactorTest.java
@@ -12,10 +12,14 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
 
+import io.micrometer.context.ContextRegistry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Hooks;
+import reactor.core.publisher.Mono;
+import reactor.util.context.Context;
 
 import org.springframework.boot.EnvironmentPostProcessor;
 import org.springframework.boot.LazyInitializationBeanFactoryPostProcessor;
@@ -46,6 +50,8 @@ public class Spring_boot_reactorTest {
 
     private static final String BOUNDED_ELASTIC_ON_VIRTUAL_THREADS =
             "reactor.schedulers.defaultBoundedElasticOnVirtualThreads";
+
+    private static final String THREAD_LOCAL_ACCESSOR_KEY = Spring_boot_reactorTest.class.getName() + ".threadLocal";
 
     @AfterEach
     void resetReactorHooks() {
@@ -141,6 +147,31 @@ public class Spring_boot_reactorTest {
                     .isEqualTo(ContextPropagationMode.AUTO);
             assertThat(context.getBeansOfType(LazyInitializationExcludeFilter.class)).hasSize(1);
             assertThat(Hooks.isAutomaticContextPropagationEnabled()).isTrue();
+        }
+    }
+
+    @Test
+    void autoConfigurationPropagatesRegisteredThreadLocalAccessorInAutoMode() {
+        Hooks.disableAutomaticContextPropagation();
+        ThreadLocal<String> threadLocal = ThreadLocal.withInitial(() -> "initial");
+        ContextRegistry registry = ContextRegistry.getInstance();
+        registry.registerThreadLocalAccessor(THREAD_LOCAL_ACCESSOR_KEY, threadLocal);
+
+        try (AnnotationConfigApplicationContext context = autoConfigurationContext(
+                Map.of(REACTOR_CONTEXT_PROPAGATION, "auto"))) {
+            AtomicReference<String> observedThreadLocalValue = new AtomicReference<>();
+
+            Mono.just("test")
+                    .doOnNext((element) -> observedThreadLocalValue.set(threadLocal.get()))
+                    .contextWrite(Context.of(THREAD_LOCAL_ACCESSOR_KEY, "updated"))
+                    .block();
+
+            assertThat(context.getBean(ReactorAutoConfiguration.class)).isNotNull();
+            assertThat(observedThreadLocalValue.get()).isEqualTo("updated");
+        }
+        finally {
+            registry.removeThreadLocalAccessor(THREAD_LOCAL_ACCESSOR_KEY);
+            threadLocal.remove();
         }
     }
 

--- a/tests/src/org.springframework.boot/spring-boot-reactor/4.0.2/src/test/java/org_springframework_boot/spring_boot_reactor/Spring_boot_reactorTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-reactor/4.0.2/src/test/java/org_springframework_boot/spring_boot_reactor/Spring_boot_reactorTest.java
@@ -6,11 +6,185 @@
  */
 package org_springframework_boot.spring_boot_reactor;
 
-import org.junit.jupiter.api.Test;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
-class Spring_boot_reactorTest {
-    @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Hooks;
+
+import org.springframework.boot.EnvironmentPostProcessor;
+import org.springframework.boot.LazyInitializationExcludeFilter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.context.annotation.ImportCandidates;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.reactor.ReactorEnvironmentPostProcessor;
+import org.springframework.boot.reactor.autoconfigure.ReactorAutoConfiguration;
+import org.springframework.boot.reactor.autoconfigure.ReactorProperties;
+import org.springframework.boot.reactor.autoconfigure.ReactorProperties.ContextPropagationMode;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.io.UrlResource;
+import org.springframework.core.io.support.PropertiesLoaderUtils;
+import org.springframework.core.io.support.SpringFactoriesLoader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Spring_boot_reactorTest {
+
+    private static final String REACTOR_CONTEXT_PROPAGATION = "spring.reactor.context-propagation";
+
+    private static final String VIRTUAL_THREADS_ENABLED = "spring.threads.virtual.enabled";
+
+    private static final String BOUNDED_ELASTIC_ON_VIRTUAL_THREADS =
+            "reactor.schedulers.defaultBoundedElasticOnVirtualThreads";
+
+    @AfterEach
+    void resetReactorHooks() {
+        Hooks.disableAutomaticContextPropagation();
     }
+
+    @Test
+    void propertiesExposeLimitedContextPropagationByDefault() {
+        ReactorProperties properties = new ReactorProperties();
+
+        assertThat(properties.getContextPropagation()).isEqualTo(ContextPropagationMode.LIMITED);
+        assertThat(ContextPropagationMode.values())
+                .containsExactly(ContextPropagationMode.AUTO, ContextPropagationMode.LIMITED);
+    }
+
+    @Test
+    void propertiesCanBeBoundFromSpringEnvironment() {
+        StandardEnvironment environment = environmentWith(Map.of(REACTOR_CONTEXT_PROPAGATION, "auto"));
+
+        ReactorProperties properties = Binder.get(environment)
+                .bind("spring.reactor", Bindable.of(ReactorProperties.class))
+                .get();
+
+        assertThat(properties.getContextPropagation()).isEqualTo(ContextPropagationMode.AUTO);
+    }
+
+    @Test
+    void springFactoriesDiscoversReactorEnvironmentPostProcessor() throws Exception {
+        ClassLoader classLoader = ReactorEnvironmentPostProcessor.class.getClassLoader();
+
+        assertThat(springFactoryResourceValues(classLoader, EnvironmentPostProcessor.class.getName()))
+                .anySatisfy((factoryNames) -> assertThat(factoryNames)
+                        .contains(ReactorEnvironmentPostProcessor.class.getName()));
+    }
+
+    @Test
+    void autoConfigurationIsPublishedAsImportCandidate() {
+        ClassLoader classLoader = ReactorAutoConfiguration.class.getClassLoader();
+
+        assertThat(ImportCandidates.load(AutoConfiguration.class, classLoader).getCandidates())
+                .contains(ReactorAutoConfiguration.class.getName());
+    }
+
+    @Test
+    void environmentPostProcessorUsesLowestPrecedenceOrder() {
+        ReactorEnvironmentPostProcessor postProcessor = new ReactorEnvironmentPostProcessor();
+
+        assertThat(postProcessor.getOrder()).isEqualTo(Ordered.LOWEST_PRECEDENCE);
+    }
+
+    @Test
+    void environmentPostProcessorLeavesBoundedElasticSchedulerUnchangedWhenVirtualThreadsAreDisabled() {
+        withSystemPropertyCleared(BOUNDED_ELASTIC_ON_VIRTUAL_THREADS, () -> {
+            StandardEnvironment environment = environmentWith(Map.of(VIRTUAL_THREADS_ENABLED, "false"));
+
+            new ReactorEnvironmentPostProcessor().postProcessEnvironment(environment, null);
+
+            assertThat(System.getProperty(BOUNDED_ELASTIC_ON_VIRTUAL_THREADS)).isNull();
+        });
+    }
+
+    @Test
+    void environmentPostProcessorEnablesBoundedElasticSchedulerVirtualThreadsWhenVirtualThreadsAreActive() {
+        withSystemPropertyCleared(BOUNDED_ELASTIC_ON_VIRTUAL_THREADS, () -> {
+            StandardEnvironment environment = environmentWith(Map.of(VIRTUAL_THREADS_ENABLED, "true"));
+
+            new ReactorEnvironmentPostProcessor().postProcessEnvironment(environment, null);
+
+            assertThat(System.getProperty(BOUNDED_ELASTIC_ON_VIRTUAL_THREADS)).isEqualTo("true");
+        });
+    }
+
+    @Test
+    void autoConfigurationLeavesAutomaticContextPropagationDisabledInLimitedMode() {
+        Hooks.disableAutomaticContextPropagation();
+
+        try (AnnotationConfigApplicationContext context = autoConfigurationContext(Map.of())) {
+            assertThat(context.getBean(ReactorAutoConfiguration.class)).isNotNull();
+            assertThat(context.getBean(ReactorProperties.class).getContextPropagation())
+                    .isEqualTo(ContextPropagationMode.LIMITED);
+            assertThat(Hooks.isAutomaticContextPropagationEnabled()).isFalse();
+        }
+    }
+
+    @Test
+    void autoConfigurationEnablesAutomaticContextPropagationInAutoMode() {
+        Hooks.disableAutomaticContextPropagation();
+
+        try (AnnotationConfigApplicationContext context = autoConfigurationContext(
+                Map.of(REACTOR_CONTEXT_PROPAGATION, "auto"))) {
+            assertThat(context.getBean(ReactorAutoConfiguration.class)).isNotNull();
+            assertThat(context.getBean(ReactorProperties.class).getContextPropagation())
+                    .isEqualTo(ContextPropagationMode.AUTO);
+            assertThat(context.getBeansOfType(LazyInitializationExcludeFilter.class)).hasSize(1);
+            assertThat(Hooks.isAutomaticContextPropagationEnabled()).isTrue();
+        }
+    }
+
+    private static AnnotationConfigApplicationContext autoConfigurationContext(Map<String, Object> properties) {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        context.getEnvironment().getPropertySources().addFirst(new MapPropertySource("test", properties));
+        context.register(ReactorAutoConfiguration.class);
+        context.refresh();
+        return context;
+    }
+
+    private static List<String> springFactoryResourceValues(ClassLoader classLoader, String factoryTypeName)
+            throws Exception {
+        List<String> values = new ArrayList<>();
+        Enumeration<URL> resources = classLoader.getResources(SpringFactoriesLoader.FACTORIES_RESOURCE_LOCATION);
+        while (resources.hasMoreElements()) {
+            Properties properties = PropertiesLoaderUtils.loadProperties(new UrlResource(resources.nextElement()));
+            String value = properties.getProperty(factoryTypeName);
+            if (value != null) {
+                values.add(value);
+            }
+        }
+        return values;
+    }
+
+    private static StandardEnvironment environmentWith(Map<String, Object> properties) {
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources().addFirst(new MapPropertySource("test", properties));
+        return environment;
+    }
+
+    private static void withSystemPropertyCleared(String name, Runnable action) {
+        String previousValue = System.getProperty(name);
+        try {
+            System.clearProperty(name);
+            action.run();
+        }
+        finally {
+            if (previousValue != null) {
+                System.setProperty(name, previousValue);
+            }
+            else {
+                System.clearProperty(name);
+            }
+        }
+    }
+
 }

--- a/tests/src/org.springframework.boot/spring-boot-reactor/4.0.2/src/test/java/org_springframework_boot/spring_boot_reactor/Spring_boot_reactorTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-reactor/4.0.2/src/test/java/org_springframework_boot/spring_boot_reactor/Spring_boot_reactorTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Hooks;
 
 import org.springframework.boot.EnvironmentPostProcessor;
+import org.springframework.boot.LazyInitializationBeanFactoryPostProcessor;
 import org.springframework.boot.LazyInitializationExcludeFilter;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.context.annotation.ImportCandidates;
@@ -143,9 +144,31 @@ public class Spring_boot_reactorTest {
         }
     }
 
+    @Test
+    void autoConfigurationEnablesAutomaticContextPropagationWhenLazyInitializationIsEnabled() {
+        Hooks.disableAutomaticContextPropagation();
+
+        try (AnnotationConfigApplicationContext context = lazyAutoConfigurationContext(
+                Map.of(REACTOR_CONTEXT_PROPAGATION, "auto"))) {
+            assertThat(context.getBeanFactory().getBeanDefinition("lazyTestBean").isLazyInit()).isTrue();
+            assertThat(context.getBeanFactory().containsSingleton("lazyTestBean")).isFalse();
+            assertThat(Hooks.isAutomaticContextPropagationEnabled()).isTrue();
+        }
+    }
+
     private static AnnotationConfigApplicationContext autoConfigurationContext(Map<String, Object> properties) {
         AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
         context.getEnvironment().getPropertySources().addFirst(new MapPropertySource("test", properties));
+        context.register(ReactorAutoConfiguration.class);
+        context.refresh();
+        return context;
+    }
+
+    private static AnnotationConfigApplicationContext lazyAutoConfigurationContext(Map<String, Object> properties) {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        context.getEnvironment().getPropertySources().addFirst(new MapPropertySource("test", properties));
+        context.addBeanFactoryPostProcessor(new LazyInitializationBeanFactoryPostProcessor());
+        context.registerBean("lazyTestBean", Object.class, Object::new);
         context.register(ReactorAutoConfiguration.class);
         context.refresh();
         return context;

--- a/tests/src/org.springframework.boot/spring-boot-reactor/4.0.2/src/test/java/org_springframework_boot/spring_boot_reactor/Spring_boot_reactorTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-reactor/4.0.2/src/test/java/org_springframework_boot/spring_boot_reactor/Spring_boot_reactorTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework_boot.spring_boot_reactor;
+
+import org.junit.jupiter.api.Test;
+
+class Spring_boot_reactorTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.springframework.boot/spring-boot-reactor/4.0.2/user-code-filter.json
+++ b/tests/src/org.springframework.boot/spring-boot-reactor/4.0.2/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.springframework.boot.reactor.**"
+      "includeClasses" : "org.springframework.boot.reactor.**"
+    },
+    {
+      "includeClasses" : "org_springframework_boot.spring_boot_reactor.**"
     }
   ]
 }

--- a/tests/src/org.springframework.boot/spring-boot-reactor/4.0.2/user-code-filter.json
+++ b/tests/src/org.springframework.boot/spring-boot-reactor/4.0.2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.springframework.boot.reactor.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #7100

This PR introduces tests and metadata for org.springframework.boot:spring-boot-reactor:4.0.2, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 166389
- Cached input tokens: 1815040
- Output tokens: 26953
- Metadata entries: 46
- Iterations: 5
- Library coverage percentage: 73.08
- Generated lines of code: 198
- Tested library lines of code: 19

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3f69aa1510d519e1825b9bfd59a81bb41ea7ef04`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 62/92 (67.39%)
- Line: 19/26 (73.08%)
- Method: 9/9 (100.00%)

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
