### PR TITLE
[GenAI] Test fix for org.springframework:spring-aop:6.0.20 using gpt-5.5

### DIFF
--- a/metadata/org.springframework/spring-aop/6.0.20/reachability-metadata.json
+++ b/metadata/org.springframework/spring-aop/6.0.20/reachability-metadata.json
@@ -1,0 +1,353 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.AbstractAspectJAdvisorFactory"
+      },
+      "type" : "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.AbstractAspectJAdvisorFactory"
+      },
+      "type" : "org.slf4j.Logger"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.ReflectiveAspectJAdvisorFactory"
+      },
+      "type" : "org.springframework.aop.aspectj.annotation.InstantiationModelAwarePointcutAdvisorImpl",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.LazySingletonAspectInstanceFactoryDecorator"
+      },
+      "type" : "org.springframework.aop.aspectj.annotation.LazySingletonAspectInstanceFactoryDecorator",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.SingletonMetadataAwareAspectInstanceFactory"
+      },
+      "type" : "org.springframework.aop.aspectj.annotation.SingletonMetadataAwareAspectInstanceFactory",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.SingletonAspectInstanceFactory"
+      },
+      "type" : "org.springframework.aop.aspectj.SingletonAspectInstanceFactory",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.AspectMetadata"
+      },
+      "type" : "org.springframework.aop.aspectj.annotation.AspectMetadata",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.AspectMetadata"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.AspectMetadata"
+      },
+      "type" : {
+        "proxy" : [
+          "org.aspectj.lang.annotation.Aspect"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.AspectMetadata"
+      },
+      "type" : {
+        "proxy" : [
+          "org.aspectj.lang.annotation.Before"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.ReflectiveAspectJAdvisorFactory"
+      },
+      "type" : "org.springframework.aop.aspectj.annotation.ReflectiveAspectJAdvisorFactory",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.AbstractAspectJAdvisorFactory"
+      },
+      "type" : "org.aspectj.lang.annotation.Before"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.AbstractAspectJAdvisorFactory"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.Deprecated"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.AbstractAspectJAdvisorFactory"
+      },
+      "type" : {
+        "proxy" : [
+          "jdk.internal.vm.annotation.IntrinsicCandidate"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.AbstractAspectJAdvisorFactory"
+      },
+      "type" : "java.lang.annotation.ElementType[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.AbstractAspectJAdvisorFactory"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.AbstractAspectJAdvisorFactory"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Target"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.AbstractAspectJAdvisorFactory"
+      },
+      "type" : {
+        "proxy" : [
+          "org.aspectj.lang.annotation.Aspect"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.ReflectiveAspectJAdvisorFactory"
+      },
+      "type" : "org.springframework.aop.aspectj.AbstractAspectJAdvice",
+      "serializable" : true,
+      "methods" : [
+        {
+          "name" : "readObject",
+          "parameterTypes" : [
+            "java.io.ObjectInputStream"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.ReflectiveAspectJAdvisorFactory"
+      },
+      "type" : "org.springframework.aop.aspectj.AbstractAspectJAdvice"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.ReflectiveAspectJAdvisorFactory"
+      },
+      "type" : "org.springframework.aop.aspectj.AspectJMethodBeforeAdvice"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.ReflectiveAspectJAdvisorFactory"
+      },
+      "type" : "org.springframework.aop.TruePointcut",
+      "methods" : [
+        {
+          "name" : "readResolve",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.ReflectiveAspectJAdvisorFactory"
+      },
+      "type" : "java.lang.Object",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.AspectJExpressionPointcut"
+      },
+      "type" : "java.lang.Object",
+      "allPublicConstructors" : true,
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.AspectJExpressionPointcut"
+      },
+      "type" : "org.springframework.aop.support.AbstractExpressionPointcut",
+      "serializable" : true,
+      "fields" : [
+        {
+          "name" : "expression"
+        },
+        {
+          "name" : "location"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.AspectJExpressionPointcut"
+      },
+      "type" : "org.springframework.aop.aspectj.AspectJExpressionPointcut",
+      "fields" : [
+        {
+          "name" : "beanFactory"
+        },
+        {
+          "name" : "pointcutDeclarationScope"
+        },
+        {
+          "name" : "pointcutParameterNames"
+        },
+        {
+          "name" : "pointcutParameterTypes"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.AspectJExpressionPointcut"
+      },
+      "type" : "org.springframework.util.ConcurrentReferenceHashMap$Segment[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.framework.JdkDynamicAopProxy"
+      },
+      "type" : {
+        "proxy" : [
+          "org.springframework.aop.SpringProxy",
+          "org.springframework.aop.framework.Advised",
+          "org.springframework.core.DecoratingProxy"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.ReflectiveAspectJAdvisorFactory"
+      },
+      "type" : "java.io.Serializable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.framework.ObjenesisCglibAopProxy"
+      },
+      "type" : "org.springframework.aop.framework.ObjenesisCglibAopProxy",
+      "methods" : [
+        {
+          "name" : "setConstructorArguments",
+          "parameterTypes" : [
+            "java.lang.Object[]",
+            "java.lang.Class[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.framework.CglibAopProxy"
+      },
+      "type" : "org.springframework.aop.framework.CglibAopProxy",
+      "methods" : [
+        {
+          "name" : "setConstructorArguments",
+          "parameterTypes" : [
+            "java.lang.Object[]",
+            "java.lang.Class[]"
+          ]
+        }
+      ]
+    }
+  ],
+  "serialization" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.ReflectiveAspectJAdvisorFactory"
+      },
+      "type" : "org.springframework.aop.aspectj.AspectJMethodBeforeAdvice"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.ReflectiveAspectJAdvisorFactory"
+      },
+      "type" : "org.springframework.aop.TruePointcut"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.ReflectiveAspectJAdvisorFactory"
+      },
+      "type" : "org.springframework.aop.aspectj.annotation.InstantiationModelAwarePointcutAdvisorImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.AspectJExpressionPointcut"
+      },
+      "type" : "org.springframework.aop.support.AbstractExpressionPointcut"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.AspectJExpressionPointcut"
+      },
+      "type" : "org.springframework.aop.aspectj.AspectJExpressionPointcut"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.aspectj.annotation.LazySingletonAspectInstanceFactoryDecorator"
+      },
+      "type" : "org.springframework.aop.aspectj.annotation.LazySingletonAspectInstanceFactoryDecorator"
+    }
+  ]
+}

--- a/metadata/org.springframework/spring-aop/index.json
+++ b/metadata/org.springframework/spring-aop/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "6.0.20",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/spring-aop/$version$/spring-aop-$version$-sources.jar",
+    "repository-url" : "https://github.com/spring-projects/spring-framework",
+    "test-code-url" : "https://github.com/spring-projects/spring-framework/tree/v$version$/spring-aop/src/test",
+    "documentation-url" : "https://docs.spring.io/spring-framework/docs/$version$/reference/html/core.html#aop",
+    "description" : "Spring AOP provides Spring Framework's proxy-based aspect-oriented programming support for applying advice to Spring bean method executions. It integrates AOP with the Spring IoC container and supports @AspectJ-style or schema-based configuration for cross-cutting concerns such as transactions, logging, caching, and security.",
     "tested-versions" : [
       "6.0.20"
     ],

--- a/metadata/org.springframework/spring-aop/index.json
+++ b/metadata/org.springframework/spring-aop/index.json
@@ -1,6 +1,16 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "6.0.20",
+    "tested-versions" : [
+      "6.0.20"
+    ],
+    "allowed-packages" : [
+      "org.aopalliance",
+      "org.springframework.aop"
+    ]
+  },
+  {
     "metadata-version" : "6.0.0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/spring-aop/$version$/spring-aop-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-framework",

--- a/stats/org.springframework/spring-aop/6.0.20/execution-metrics.json
+++ b/stats/org.springframework/spring-aop/6.0.20/execution-metrics.json
@@ -1,0 +1,101 @@
+{
+  "fix_java_run_fail:2026-05-19": {
+    "timestamp": "2026-05-19T05:48:04.462574Z",
+    "library": "org.springframework:spring-aop:6.0.20",
+    "starting_commit": "e794a42182888602ee612156152ef6c1c8714067",
+    "ending_commit": "86b011bc114aa6636472e7f5fca30c5d0b27a89d",
+    "previous_library": "org.springframework:spring-aop:6.0.0",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "6.0.20",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 22,
+            "totalCalls": 22
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 22,
+        "totalCalls": 22
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4284,
+          "missed": 18090,
+          "ratio": 0.191472,
+          "total": 22374
+        },
+        "line": {
+          "covered": 1064,
+          "missed": 4279,
+          "ratio": 0.199139,
+          "total": 5343
+        },
+        "method": {
+          "covered": 299,
+          "missed": 1112,
+          "ratio": 0.211906,
+          "total": 1411
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "6.0.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 23,
+            "totalCalls": 23
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 23,
+        "totalCalls": 23
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4310,
+          "missed": 17890,
+          "ratio": 0.194144,
+          "total": 22200
+        },
+        "line": {
+          "covered": 1073,
+          "missed": 4322,
+          "ratio": 0.198888,
+          "total": 5395
+        },
+        "method": {
+          "covered": 288,
+          "missed": 1107,
+          "ratio": 0.206452,
+          "total": 1395
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 34723,
+      "cached_input_tokens_used": 138752,
+      "output_tokens_used": 1599,
+      "iterations": 1,
+      "cost_usd": 0.1174,
+      "tested_library_loc": 1064,
+      "metadata_entries": 54,
+      "test_only_metadata_entries": 24,
+      "previous_library_metadata_entries": 54,
+      "previous_library_test_only_metadata_entries": 24,
+      "code_coverage_percent": 19.91,
+      "previous_library_coverage_percent": 19.89
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/JdkDynamicAopProxyTest.java",
+      "metadata_file": "metadata/org.springframework/spring-aop/6.0.20/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.springframework/spring-aop/6.0.20/stats.json
+++ b/stats/org.springframework/spring-aop/6.0.20/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "6.0.20",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 22,
+          "totalCalls" : 22
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 22,
+      "totalCalls" : 22
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 4284,
+        "missed" : 18090,
+        "ratio" : 0.191472,
+        "total" : 22374
+      },
+      "line" : {
+        "covered" : 1064,
+        "missed" : 4279,
+        "ratio" : 0.199139,
+        "total" : 5343
+      },
+      "method" : {
+        "covered" : 299,
+        "missed" : 1112,
+        "ratio" : 0.211906,
+        "total" : 1411
+      }
+    }
+  } ]
+}

--- a/tests/src/org.springframework/spring-aop/6.0.20/.gitignore
+++ b/tests/src/org.springframework/spring-aop/6.0.20/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.springframework/spring-aop/6.0.20/build.gradle
+++ b/tests/src/org.springframework/spring-aop/6.0.20/build.gradle
@@ -1,0 +1,71 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+File compiledTestClassesDir = layout.buildDirectory.dir("classes/java/test").get().asFile
+File processedTestResourcesDir = layout.buildDirectory.dir("resources/test").get().asFile
+File generatedCglibProxyMarkerFile = layout.buildDirectory.dir("generated/cglib-proxy-test-classes").get().file("done.marker").asFile
+String javaHome = System.getenv("JAVA_HOME")
+
+dependencies {
+    testImplementation "org.springframework:spring-aop:$libraryVersion"
+    testImplementation 'org.aspectj:aspectjrt:1.9.6'
+    testImplementation 'org.aspectj:aspectjweaver:1.9.6'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+tasks.withType(Test).configureEach {
+    systemProperty "spring.objenesis.ignore", "true"
+}
+
+tasks.named("nativeTest") {
+    runtimeArgs.add("-Dspring.objenesis.ignore=true")
+}
+
+tasks.register("generatePredefinedCglibProxyClasses", JavaExec) { JavaExec task ->
+    task.dependsOn(tasks.named("testClasses"))
+    task.inputs.files(compiledTestClassesDir, processedTestResourcesDir, configurations.testRuntimeClasspath)
+    task.outputs.file(generatedCglibProxyMarkerFile)
+    task.classpath = files(compiledTestClassesDir, processedTestResourcesDir, configurations.testRuntimeClasspath)
+    task.mainClass = "org_springframework.spring_aop.PredefinedCglibProxyClassesGenerator"
+    task.args(compiledTestClassesDir.absolutePath)
+    task.executable = new File(javaHome, "bin/java").absolutePath
+    task.environment("JAVA_HOME", javaHome)
+    task.environment("GRAALVM_HOME", System.getenv("GRAALVM_HOME"))
+    task.doLast {
+        generatedCglibProxyMarkerFile.parentFile.mkdirs()
+        generatedCglibProxyMarkerFile.text = "generated"
+    }
+}
+
+tasks.named("nativeTestCompile") {
+    dependsOn("generatePredefinedCglibProxyClasses")
+}
+
+tasks.named("nativeTraceImage") {
+    dependsOn("generatePredefinedCglibProxyClasses")
+}
+
+graalvmNative {
+    binaries {
+        test {
+            buildArgs.add("-Dspring.objenesis.ignore=true")
+        }
+    }
+
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-aop/6.0.20/gradle.properties
+++ b/tests/src/org.springframework/spring-aop/6.0.20/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.springframework:spring-aop:6.0.20
+library.version = 6.0.20
+metadata.dir = org.springframework/spring-aop/6.0.20/

--- a/tests/src/org.springframework/spring-aop/6.0.20/settings.gradle
+++ b/tests/src/org.springframework/spring-aop/6.0.20/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.springframework.spring-aop_tests'

--- a/tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/AbstractAspectJAdviceTest.java
+++ b/tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/AbstractAspectJAdviceTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aop.Advisor;
+import org.springframework.aop.aspectj.annotation.ReflectiveAspectJAdvisorFactory;
+import org.springframework.aop.aspectj.annotation.SingletonMetadataAwareAspectInstanceFactory;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.aop.interceptor.ExposeInvocationInterceptor;
+
+public class AbstractAspectJAdviceTest {
+
+    @Test
+    void invokesAspectJAdviceMethodThroughSpringProxy() {
+        CountingAspect aspect = new CountingAspect();
+        GreetingService proxy = createProxy(new DefaultGreetingService(), aspect);
+
+        String greeting = proxy.greet("GraalVM");
+
+        assertThat(greeting).isEqualTo("Hello GraalVM");
+        assertThat(aspect.invocations()).isEqualTo(1);
+    }
+
+    private static GreetingService createProxy(GreetingService target, CountingAspect aspect) {
+        ReflectiveAspectJAdvisorFactory advisorFactory = new ReflectiveAspectJAdvisorFactory();
+        SingletonMetadataAwareAspectInstanceFactory aspectInstanceFactory =
+                new SingletonMetadataAwareAspectInstanceFactory(aspect, "countingAspect");
+        List<Advisor> advisors = advisorFactory.getAdvisors(aspectInstanceFactory);
+        assertThat(advisors).hasSize(1);
+
+        ProxyFactory proxyFactory = new ProxyFactory(target);
+        proxyFactory.addAdvisor(ExposeInvocationInterceptor.ADVISOR);
+        advisors.forEach(proxyFactory::addAdvisor);
+        return (GreetingService) proxyFactory.getProxy();
+    }
+
+    public interface GreetingService {
+        String greet(String name);
+    }
+
+    public static class DefaultGreetingService implements GreetingService {
+        @Override
+        public String greet(String name) {
+            return "Hello " + name;
+        }
+    }
+
+    @Aspect
+    public static class CountingAspect {
+        private final AtomicInteger invocations = new AtomicInteger();
+
+        @Before("execution(* greet(..))")
+        public void beforeInvocation() {
+            this.invocations.incrementAndGet();
+        }
+
+        int invocations() {
+            return this.invocations.get();
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/AbstractAspectJAdvisorFactoryTest.java
+++ b/tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/AbstractAspectJAdvisorFactoryTest.java
@@ -16,12 +16,12 @@ import org.springframework.aop.aspectj.annotation.ReflectiveAspectJAdvisorFactor
 public class AbstractAspectJAdvisorFactoryTest {
 
     @Test
-    void rejectsAspectWithAjcCompiledMarkerField() {
+    void acceptsAnnotationStyleAspectWithAjcCompiledMarkerField() {
         ReflectiveAspectJAdvisorFactory factory = new ReflectiveAspectJAdvisorFactory();
 
         boolean aspect = factory.isAspect(AjcCompiledMarkerAspect.class);
 
-        assertThat(aspect).isFalse();
+        assertThat(aspect).isTrue();
     }
 
     @Test

--- a/tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/AbstractAspectJAdvisorFactoryTest.java
+++ b/tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/AbstractAspectJAdvisorFactoryTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.aspectj.lang.annotation.Aspect;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aop.aspectj.annotation.ReflectiveAspectJAdvisorFactory;
+
+public class AbstractAspectJAdvisorFactoryTest {
+
+    @Test
+    void rejectsAspectWithAjcCompiledMarkerField() {
+        ReflectiveAspectJAdvisorFactory factory = new ReflectiveAspectJAdvisorFactory();
+
+        boolean aspect = factory.isAspect(AjcCompiledMarkerAspect.class);
+
+        assertThat(aspect).isFalse();
+    }
+
+    @Test
+    void rejectsClassWithoutAspectAnnotation() {
+        ReflectiveAspectJAdvisorFactory factory = new ReflectiveAspectJAdvisorFactory();
+
+        boolean aspect = factory.isAspect(NonAspect.class);
+
+        assertThat(aspect).isFalse();
+    }
+
+    @Test
+    void acceptsAnnotationStyleAspectWithoutAjcCompiledMarkerField() {
+        ReflectiveAspectJAdvisorFactory factory = new ReflectiveAspectJAdvisorFactory();
+
+        boolean aspect = factory.isAspect(AnnotationStyleAspect.class);
+
+        assertThat(aspect).isTrue();
+    }
+
+    @Aspect
+    public static class AjcCompiledMarkerAspect {
+        private Object ajc$perSingletonInstance;
+    }
+
+    @Aspect
+    public static class AnnotationStyleAspect {
+    }
+
+    public static class NonAspect {
+    }
+}

--- a/tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/AopProxyUtilsTest.java
+++ b/tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/AopProxyUtilsTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aop.framework.ProxyFactory;
+
+public class AopProxyUtilsTest {
+    @Test
+    void jdkProxyAdaptsObjectArrayVarargsToDeclaredArrayType() throws Throwable {
+        RecordingVarargsService target = new RecordingVarargsService();
+        VarargsService proxy = createJdkProxy(target);
+        Method method = VarargsService.class.getMethod("join", String.class, String[].class);
+        InvocationHandler invocationHandler = Proxy.getInvocationHandler(proxy);
+
+        Object result = invocationHandler.invoke(proxy, method, new Object[] {", ", new Object[] {"spring", "aop"}});
+
+        assertThat(result).isEqualTo("spring, aop");
+        assertThat(target.lastValuesType).isEqualTo(String[].class);
+    }
+
+    private static VarargsService createJdkProxy(VarargsService target) {
+        ProxyFactory proxyFactory = new ProxyFactory(target);
+        proxyFactory.setInterfaces(VarargsService.class);
+        return (VarargsService) proxyFactory.getProxy();
+    }
+
+    public interface VarargsService {
+        String join(String delimiter, String... values);
+    }
+
+    public static class RecordingVarargsService implements VarargsService {
+        private Class<?> lastValuesType;
+
+        @Override
+        public String join(String delimiter, String... values) {
+            this.lastValuesType = values.getClass();
+            return String.join(delimiter, values);
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/CglibAopProxyTest.java
+++ b/tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/CglibAopProxyTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aop.framework.ProxyFactory;
+
+public class CglibAopProxyTest {
+    @Test
+    void frozenStaticCglibProxyUsesFixedCallbackChain() {
+        AtomicInteger invocationCount = new AtomicInteger();
+        ProxyFactory proxyFactory = new ProxyFactory(new GreetingTarget());
+        proxyFactory.setProxyTargetClass(true);
+        proxyFactory.addAdvice(countingInterceptor(invocationCount));
+        proxyFactory.setFrozen(true);
+
+        GreetingService proxy = (GreetingService) proxyFactory.getProxy();
+
+        assertThat(proxy.greet("Spring")).isEqualTo("Hello Spring");
+        assertThat(invocationCount).hasValue(1);
+    }
+
+    private static MethodInterceptor countingInterceptor(AtomicInteger invocationCount) {
+        return invocation -> {
+            invocationCount.incrementAndGet();
+            return invocation.proceed();
+        };
+    }
+
+    public interface GreetingService {
+        String greet(String name);
+    }
+
+    public static class GreetingTarget implements GreetingService {
+        @Override
+        public String greet(String name) {
+            return "Hello " + name;
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/DelegatePerTargetObjectIntroductionInterceptorTest.java
+++ b/tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/DelegatePerTargetObjectIntroductionInterceptorTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.aop.support.DefaultIntroductionAdvisor;
+import org.springframework.aop.support.DelegatePerTargetObjectIntroductionInterceptor;
+
+public class DelegatePerTargetObjectIntroductionInterceptorTest {
+    @Test
+    void createsSeparateDelegateForEachTargetObject() {
+        DelegatePerTargetObjectIntroductionInterceptor interceptor =
+                new DelegatePerTargetObjectIntroductionInterceptor(CountingMixin.class, CountingOperations.class);
+        DefaultIntroductionAdvisor advisor = new DefaultIntroductionAdvisor(interceptor, CountingOperations.class);
+
+        CountingOperations firstProxy = createProxy(new NamedServiceImpl("first"), advisor);
+        CountingOperations secondProxy = createProxy(new NamedServiceImpl("second"), advisor);
+
+        assertThat(firstProxy.incrementAndGet()).isEqualTo(1);
+        assertThat(firstProxy.incrementAndGet()).isEqualTo(2);
+        assertThat(secondProxy.incrementAndGet()).isEqualTo(1);
+        assertThat(firstProxy.currentValue()).isEqualTo(2);
+        assertThat(secondProxy.currentValue()).isEqualTo(1);
+    }
+
+    @Test
+    void returnsProxyWhenIntroducedMethodReturnsDelegateItself() {
+        DelegatePerTargetObjectIntroductionInterceptor interceptor =
+                new DelegatePerTargetObjectIntroductionInterceptor(CountingMixin.class, CountingOperations.class);
+        DefaultIntroductionAdvisor advisor = new DefaultIntroductionAdvisor(interceptor, CountingOperations.class);
+
+        CountingOperations proxy = createProxy(new NamedServiceImpl("self"), advisor);
+
+        assertThat(proxy.self()).isSameAs(proxy);
+    }
+
+    private static CountingOperations createProxy(NamedService target, DefaultIntroductionAdvisor advisor) {
+        ProxyFactory proxyFactory = new ProxyFactory(target);
+        proxyFactory.addAdvisor(advisor);
+        Object proxy = proxyFactory.getProxy();
+        assertThat(proxy).isInstanceOf(NamedService.class);
+        assertThat(((NamedService) proxy).name()).isEqualTo(target.name());
+        return (CountingOperations) proxy;
+    }
+
+    public interface NamedService {
+        String name();
+    }
+
+    public interface CountingOperations {
+        int incrementAndGet();
+
+        int currentValue();
+
+        CountingOperations self();
+    }
+
+    public static class NamedServiceImpl implements NamedService {
+        private final String name;
+
+        NamedServiceImpl(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String name() {
+            return this.name;
+        }
+    }
+
+    public static class CountingMixin implements CountingOperations {
+        private int value;
+
+        @Override
+        public int incrementAndGet() {
+            this.value++;
+            return this.value;
+        }
+
+        @Override
+        public int currentValue() {
+            return this.value;
+        }
+
+        @Override
+        public CountingOperations self() {
+            return this;
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/InstantiationModelAwarePointcutAdvisorImplTest.java
+++ b/tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/InstantiationModelAwarePointcutAdvisorImplTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.List;
+
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aop.Advisor;
+import org.springframework.aop.aspectj.annotation.ReflectiveAspectJAdvisorFactory;
+import org.springframework.aop.aspectj.annotation.SingletonMetadataAwareAspectInstanceFactory;
+
+public class InstantiationModelAwarePointcutAdvisorImplTest {
+
+    @Test
+    void deserializesAdvisorAndRestoresAdviceMethod() throws Exception {
+        Advisor advisor = createAdvisor(new SerializableAspect());
+
+        Advisor deserializedAdvisor = serializeAndDeserialize(advisor);
+
+        assertThat(deserializedAdvisor).isNotSameAs(advisor);
+        assertThat(deserializedAdvisor.getAdvice()).isNotNull();
+        assertThat(deserializedAdvisor.toString()).contains("beforeInvocation");
+    }
+
+    private static Advisor createAdvisor(SerializableAspect aspect) {
+        ReflectiveAspectJAdvisorFactory advisorFactory = new ReflectiveAspectJAdvisorFactory();
+        SingletonMetadataAwareAspectInstanceFactory aspectInstanceFactory =
+                new SingletonMetadataAwareAspectInstanceFactory(aspect, "serializableAspect");
+        List<Advisor> advisors = advisorFactory.getAdvisors(aspectInstanceFactory);
+
+        assertThat(advisors).hasSize(1);
+        return advisors.get(0);
+    }
+
+    private static Advisor serializeAndDeserialize(Advisor advisor) throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (ObjectOutputStream objectOutput = new ObjectOutputStream(output)) {
+            objectOutput.writeObject(advisor);
+        }
+
+        ByteArrayInputStream input = new ByteArrayInputStream(output.toByteArray());
+        try (ObjectInputStream objectInput = new ObjectInputStream(input)) {
+            return (Advisor) objectInput.readObject();
+        }
+    }
+
+    @Aspect
+    public static class SerializableAspect implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        @Before("execution(* *(..))")
+        public void beforeInvocation() {
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/JdkDynamicAopProxyTest.java
+++ b/tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/JdkDynamicAopProxyTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Proxy;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aop.framework.Advised;
+import org.springframework.aop.framework.ProxyFactory;
+
+public class JdkDynamicAopProxyTest {
+    @Test
+    void getProxyClassCreatesJdkProxyClassForConfiguredInterfaces() {
+        ProxyFactory proxyFactory = new ProxyFactory();
+        proxyFactory.setInterfaces(AopProxyUtilsTest.VarargsService.class);
+
+        Class<?> proxyClass = proxyFactory.getProxyClass(AopProxyUtilsTest.VarargsService.class.getClassLoader());
+
+        assertThat(Proxy.isProxyClass(proxyClass)).isTrue();
+        assertThat(AopProxyUtilsTest.VarargsService.class).isAssignableFrom(proxyClass);
+        assertThat(Advised.class).isAssignableFrom(proxyClass);
+    }
+}

--- a/tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/ObjenesisCglibAopProxyTest.java
+++ b/tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/ObjenesisCglibAopProxyTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aop.framework.AdvisedSupport;
+import org.springframework.aop.framework.AopProxy;
+import org.springframework.aop.framework.DefaultAopProxyFactory;
+import org.springframework.objenesis.SpringObjenesis;
+
+public class ObjenesisCglibAopProxyTest {
+    @BeforeAll
+    static void prepareProxyCreationModes() {
+        System.setProperty(SpringObjenesis.IGNORE_OBJENESIS_PROPERTY_NAME, "true");
+        recordJdkProxyMetadataForNativeImageFallback();
+    }
+
+    @Test
+    void cglibProxyFallsBackToDefaultConstructorWhenObjenesisIsIgnored() {
+        DefaultGreetingService target = new DefaultGreetingService();
+        DefaultGreetingService.constructorInvocations.set(0);
+
+        AopProxy aopProxy = createAopProxy(DefaultGreetingService.class, target);
+        GreetingService proxy = (GreetingService) aopProxy.getProxy();
+
+        assertThat(proxy.greet("Spring")).isEqualTo("Hello Spring");
+        assertThat(DefaultGreetingService.constructorInvocations)
+                .hasValue(isObjenesisCglibProxy(aopProxy) ? 1 : 0);
+    }
+
+    @Test
+    void cglibProxyFallsBackToMatchingConstructorWhenConstructorArgumentsAreConfigured() {
+        ConstructorGreetingService target = new ConstructorGreetingService("Hello");
+        ConstructorGreetingService.lastConstructedGreeting = null;
+        AopProxy aopProxy = createAopProxy(ConstructorGreetingService.class, target);
+        configureConstructorArgumentsIfCglibProxy(aopProxy, new Object[] {"Proxy"}, new Class<?>[] {String.class});
+
+        GreetingService proxy = (GreetingService) aopProxy.getProxy();
+
+        assertThat(proxy.greet("Spring")).isEqualTo("Hello Spring");
+        assertThat(ConstructorGreetingService.lastConstructedGreeting)
+                .isEqualTo(isObjenesisCglibProxy(aopProxy) ? "Proxy" : null);
+    }
+
+    private static GreetingService createProxy(Class<? extends GreetingService> targetClass, GreetingService target) {
+        return (GreetingService) createAopProxy(targetClass, target).getProxy();
+    }
+
+    private static AopProxy createAopProxy(Class<? extends GreetingService> targetClass, GreetingService target) {
+        AdvisedSupport config = new AdvisedSupport(GreetingService.class);
+        config.setTargetClass(targetClass);
+        config.setTarget(target);
+        config.setProxyTargetClass(true);
+        return new DefaultAopProxyFactory().createAopProxy(config);
+    }
+
+    private static void recordJdkProxyMetadataForNativeImageFallback() {
+        AdvisedSupport config = new AdvisedSupport(GreetingService.class);
+        config.setTarget(new DefaultGreetingService());
+        GreetingService proxy = (GreetingService) new DefaultAopProxyFactory().createAopProxy(config).getProxy();
+
+        assertThat(proxy.greet("Spring")).isEqualTo("Hello Spring");
+    }
+
+    private static void configureConstructorArgumentsIfCglibProxy(
+            AopProxy aopProxy, Object[] constructorArgs, Class<?>[] constructorArgTypes) {
+        Class<?> proxyClass = aopProxy.getClass();
+        if (!isObjenesisCglibProxy(aopProxy)) {
+            return;
+        }
+        try {
+            Method method = findSetConstructorArgumentsMethod(proxyClass);
+            method.setAccessible(true);
+            method.invoke(aopProxy, constructorArgs, constructorArgTypes);
+        } catch (ReflectiveOperationException ex) {
+            throw new IllegalStateException("Failed to configure CGLIB proxy constructor arguments", ex);
+        }
+    }
+
+    private static Method findSetConstructorArgumentsMethod(Class<?> proxyClass) throws NoSuchMethodException {
+        Class<?> currentClass = proxyClass;
+        while (currentClass != null) {
+            try {
+                return currentClass.getDeclaredMethod("setConstructorArguments", Object[].class, Class[].class);
+            } catch (NoSuchMethodException ex) {
+                currentClass = currentClass.getSuperclass();
+            }
+        }
+        throw new NoSuchMethodException("setConstructorArguments");
+    }
+
+    private static boolean isObjenesisCglibProxy(AopProxy aopProxy) {
+        return aopProxy.getClass().getName().endsWith("ObjenesisCglibAopProxy");
+    }
+
+    public interface GreetingService {
+        String greet(String name);
+    }
+
+    public static class DefaultGreetingService implements GreetingService {
+        private static final AtomicInteger constructorInvocations = new AtomicInteger();
+
+        public DefaultGreetingService() {
+            constructorInvocations.incrementAndGet();
+        }
+
+        @Override
+        public String greet(String name) {
+            return "Hello " + name;
+        }
+    }
+
+    public static class ConstructorGreetingService implements GreetingService {
+        private static String lastConstructedGreeting;
+
+        private final String greeting;
+
+        public ConstructorGreetingService(String greeting) {
+            lastConstructedGreeting = greeting;
+            this.greeting = greeting;
+        }
+
+        @Override
+        public String greet(String name) {
+            return this.greeting + " " + name;
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/PredefinedCglibProxyClassesGenerator.java
+++ b/tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/PredefinedCglibProxyClassesGenerator.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_aop;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.aopalliance.intercept.MethodInterceptor;
+
+import org.springframework.aop.framework.AdvisedSupport;
+import org.springframework.aop.framework.AopProxy;
+import org.springframework.aop.framework.DefaultAopProxyFactory;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.objenesis.SpringObjenesis;
+
+public final class PredefinedCglibProxyClassesGenerator {
+    private static final String DEBUG_LOCATION_PROPERTY =
+            "cglib.debugLocation";
+    private static final List<String> EXPECTED_CLASS_FILES = List.of(
+            "org_springframework/spring_aop/CglibAopProxyTest$GreetingTarget$$SpringCGLIB$$0.class",
+            "org_springframework/spring_aop/ObjenesisCglibAopProxyTest$ConstructorGreetingService$$SpringCGLIB$$0.class",
+            "org_springframework/spring_aop/ObjenesisCglibAopProxyTest$DefaultGreetingService$$SpringCGLIB$$0.class"
+    );
+
+    private PredefinedCglibProxyClassesGenerator() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length != 1) {
+            throw new IllegalArgumentException("Expected a single output directory argument");
+        }
+        Path outputDirectory = Path.of(args[0]).toAbsolutePath().normalize();
+        Files.createDirectories(outputDirectory);
+
+        String previousDebugLocation = System.getProperty(DEBUG_LOCATION_PROPERTY);
+        String previousObjenesisMode = System.getProperty(SpringObjenesis.IGNORE_OBJENESIS_PROPERTY_NAME);
+        try {
+            System.setProperty(DEBUG_LOCATION_PROPERTY, outputDirectory.toString());
+            System.setProperty(SpringObjenesis.IGNORE_OBJENESIS_PROPERTY_NAME, "true");
+            generateProxyClasses();
+            verifyExpectedClassFiles(outputDirectory);
+        } finally {
+            restoreSystemProperty(DEBUG_LOCATION_PROPERTY, previousDebugLocation);
+            restoreSystemProperty(SpringObjenesis.IGNORE_OBJENESIS_PROPERTY_NAME, previousObjenesisMode);
+        }
+    }
+
+    private static void generateProxyClasses() throws Exception {
+        generateGreetingTargetProxyClass();
+        generateObjenesisProxyClass(
+                ObjenesisCglibAopProxyTest.DefaultGreetingService.class,
+                new ObjenesisCglibAopProxyTest.DefaultGreetingService()
+        );
+        generateObjenesisProxyClass(
+                ObjenesisCglibAopProxyTest.ConstructorGreetingService.class,
+                new ObjenesisCglibAopProxyTest.ConstructorGreetingService("Hello")
+        );
+    }
+
+    private static void generateGreetingTargetProxyClass() {
+        ProxyFactory proxyFactory = new ProxyFactory(new CglibAopProxyTest.GreetingTarget());
+        proxyFactory.setProxyTargetClass(true);
+        proxyFactory.addAdvice((MethodInterceptor) invocation -> invocation.proceed());
+        proxyFactory.setFrozen(true);
+        proxyFactory.getProxyClass(CglibAopProxyTest.GreetingTarget.class.getClassLoader());
+    }
+
+    private static void generateObjenesisProxyClass(
+            Class<? extends ObjenesisCglibAopProxyTest.GreetingService> targetClass,
+            ObjenesisCglibAopProxyTest.GreetingService target
+    ) throws Exception {
+        AdvisedSupport config = new AdvisedSupport(ObjenesisCglibAopProxyTest.GreetingService.class);
+        config.setTargetClass(targetClass);
+        config.setTarget(target);
+        config.setProxyTargetClass(true);
+        AopProxy aopProxy = new DefaultAopProxyFactory().createAopProxy(config);
+
+        Method getProxyClassMethod = aopProxy.getClass().getMethod("getProxyClass", ClassLoader.class);
+        getProxyClassMethod.setAccessible(true);
+        getProxyClassMethod.invoke(aopProxy, targetClass.getClassLoader());
+    }
+
+    private static void verifyExpectedClassFiles(Path outputDirectory) throws IOException {
+        List<String> missingClassFiles = EXPECTED_CLASS_FILES.stream()
+                .filter(relativePath -> !Files.isRegularFile(outputDirectory.resolve(relativePath)))
+                .toList();
+        if (missingClassFiles.isEmpty()) {
+            return;
+        }
+
+        List<String> availableClassFiles;
+        try (Stream<Path> stream = Files.walk(outputDirectory)) {
+            availableClassFiles = stream
+                    .filter(Files::isRegularFile)
+                    .map(outputDirectory::relativize)
+                    .map(Path::toString)
+                    .sorted()
+                    .collect(Collectors.toList());
+        }
+        throw new IOException("Missing generated CGLIB proxy classes: " + missingClassFiles + "; available=" + availableClassFiles);
+    }
+
+    private static void restoreSystemProperty(String key, String value) {
+        if (value == null) {
+            System.clearProperty(key);
+            return;
+        }
+        System.setProperty(key, value);
+    }
+}

--- a/tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/ProxyProcessorSupportTest.java
+++ b/tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/ProxyProcessorSupportTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.aop.framework.ProxyProcessorSupport;
+
+public class ProxyProcessorSupportTest {
+    @Test
+    void evaluateProxyInterfacesAddsReasonableInterfaceWithMethods() {
+        TestProxyProcessorSupport support = new TestProxyProcessorSupport();
+        ProxyFactory proxyFactory = new ProxyFactory();
+
+        support.evaluate(ServiceBean.class, proxyFactory);
+
+        assertThat(proxyFactory.isProxyTargetClass()).isFalse();
+        assertThat(proxyFactory.getProxiedInterfaces()).contains(ServiceContract.class);
+    }
+
+    private static final class TestProxyProcessorSupport extends ProxyProcessorSupport {
+        void evaluate(Class<?> beanClass, ProxyFactory proxyFactory) {
+            evaluateProxyInterfaces(beanClass, proxyFactory);
+        }
+    }
+
+    public interface ServiceContract {
+        String message();
+    }
+
+    public static final class ServiceBean implements ServiceContract {
+        @Override
+        public String message() {
+            return "spring-aop";
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/RuntimeTestWalkerInnerInstanceOfResidueTestVisitorTest.java
+++ b/tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/RuntimeTestWalkerInnerInstanceOfResidueTestVisitorTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aop.aspectj.AspectJExpressionPointcut;
+
+public class RuntimeTestWalkerInnerInstanceOfResidueTestVisitorTest {
+
+    @Test
+    void targetResidueComparesAspectJReferenceTypeWithConcreteTargetClass() throws Exception {
+        AspectJExpressionPointcut pointcut = new AspectJExpressionPointcut();
+        pointcut.setExpression("execution(* *(..)) && target(" + RuntimeWalkerMarker.class.getName() + ")");
+        Method method = RuntimeWalkerService.class.getMethod("process");
+
+        boolean matches = pointcut.matches(method, RuntimeWalkerService.class, false);
+
+        assertThat(matches).isFalse();
+    }
+}
+
+interface RuntimeWalkerMarker {
+}
+
+class RuntimeWalkerService {
+
+    public void process() {
+    }
+}

--- a/tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/RuntimeTestWalkerTest.java
+++ b/tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/RuntimeTestWalkerTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aop.aspectj.AspectJExpressionPointcut;
+
+public class RuntimeTestWalkerTest {
+
+    @Test
+    void staticPointcutMatchInspectsRuntimeResidueForArgumentTypeTest() throws Exception {
+        AspectJExpressionPointcut pointcut = new AspectJExpressionPointcut();
+        pointcut.setExpression("execution(* *(..)) && args(java.lang.String)");
+        Method method = RuntimeArgumentService.class.getMethod("process", Object.class);
+
+        boolean matches = pointcut.matches(method, RuntimeArgumentService.class, false);
+
+        assertThat(matches).isTrue();
+        assertThat(pointcut.isRuntime()).isTrue();
+    }
+
+    public static class RuntimeArgumentService {
+
+        public void process(Object value) {
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/SimpleAspectInstanceFactoryTest.java
+++ b/tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/SimpleAspectInstanceFactoryTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aop.aspectj.SimpleAspectInstanceFactory;
+import org.springframework.core.Ordered;
+
+public class SimpleAspectInstanceFactoryTest {
+
+    @Test
+    void createsNewAspectInstanceUsingDefaultConstructor() {
+        SimpleAspectInstanceFactory factory = new SimpleAspectInstanceFactory(CountingAspect.class);
+
+        Object firstAspect = factory.getAspectInstance();
+        Object secondAspect = factory.getAspectInstance();
+
+        assertThat(firstAspect).isInstanceOf(CountingAspect.class);
+        assertThat(secondAspect).isInstanceOf(CountingAspect.class);
+        assertThat(secondAspect).isNotSameAs(firstAspect);
+        assertThat(((CountingAspect) firstAspect).instanceNumber()).isEqualTo(1);
+        assertThat(((CountingAspect) secondAspect).instanceNumber()).isEqualTo(2);
+    }
+
+    @Test
+    void exposesConfiguredAspectClassMetadata() {
+        SimpleAspectInstanceFactory factory = new SimpleAspectInstanceFactory(CountingAspect.class);
+
+        assertThat(factory.getAspectClass()).isSameAs(CountingAspect.class);
+        assertThat(factory.getAspectClassLoader()).isSameAs(CountingAspect.class.getClassLoader());
+        assertThat(factory.getOrder()).isEqualTo(Ordered.LOWEST_PRECEDENCE);
+    }
+
+    public static class CountingAspect {
+        private static int instanceCount;
+
+        private final int instanceNumber;
+
+        public CountingAspect() {
+            instanceCount++;
+            this.instanceNumber = instanceCount;
+        }
+
+        int instanceNumber() {
+            return this.instanceNumber;
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/ThrowsAdviceInterceptorTest.java
+++ b/tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/ThrowsAdviceInterceptorTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Method;
+
+import org.aopalliance.intercept.MethodInvocation;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aop.ThrowsAdvice;
+import org.springframework.aop.framework.adapter.ThrowsAdviceInterceptor;
+
+public class ThrowsAdviceInterceptorTest {
+
+    @Test
+    void invokesMatchingThrowsAdviceHandlerWhenInvocationThrows() throws Throwable {
+        IllegalStateException failure = new IllegalStateException("expected failure");
+        RecordingThrowsAdvice advice = new RecordingThrowsAdvice();
+        ThrowsAdviceInterceptor interceptor = new ThrowsAdviceInterceptor(advice);
+
+        Throwable thrown = catchThrowable(() -> interceptor.invoke(new FailingMethodInvocation(failure)));
+
+        assertThat(thrown).isSameAs(failure);
+        assertThat(interceptor.getHandlerMethodCount()).isEqualTo(1);
+        assertThat(advice.handledException()).isSameAs(failure);
+    }
+
+    public static class RecordingThrowsAdvice implements ThrowsAdvice {
+        private IllegalStateException handledException;
+
+        public void afterThrowing(IllegalStateException ex) {
+            this.handledException = ex;
+        }
+
+        IllegalStateException handledException() {
+            return this.handledException;
+        }
+    }
+
+    private static class FailingMethodInvocation implements MethodInvocation {
+        private final Throwable failure;
+
+        FailingMethodInvocation(Throwable failure) {
+            this.failure = failure;
+        }
+
+        @Override
+        public Method getMethod() {
+            throw new UnsupportedOperationException("Single-argument throws advice does not need the invoked method");
+        }
+
+        @Override
+        public Object[] getArguments() {
+            throw new UnsupportedOperationException("Single-argument throws advice does not need invocation arguments");
+        }
+
+        @Override
+        public Object proceed() throws Throwable {
+            throw this.failure;
+        }
+
+        @Override
+        public Object getThis() {
+            throw new UnsupportedOperationException("Single-argument throws advice does not need the invocation target");
+        }
+
+        @Override
+        public AccessibleObject getStaticPart() {
+            throw new UnsupportedOperationException("Single-argument throws advice does not need the static part");
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-aop/6.0.20/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.springframework/spring-aop/6.0.20/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,160 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org_springframework.spring_aop.InstantiationModelAwarePointcutAdvisorImplTest$SerializableAspect"
+      },
+      "type" : "org_springframework.spring_aop.InstantiationModelAwarePointcutAdvisorImplTest$SerializableAspect",
+      "serializable" : true,
+      "fields" : [
+        {
+          "name" : "serialVersionUID"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework.spring_aop.InstantiationModelAwarePointcutAdvisorImplTest$SerializableAspect"
+      },
+      "type" : "java.lang.String",
+      "serializable" : true,
+      "fields" : [
+        {
+          "name" : "serialPersistentFields"
+        },
+        {
+          "name" : "serialVersionUID"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework.spring_aop.ObjenesisCglibAopProxyTest$GreetingService"
+      },
+      "type" : {
+        "proxy" : [
+          "org_springframework.spring_aop.ObjenesisCglibAopProxyTest$GreetingService",
+          "org.springframework.aop.SpringProxy",
+          "org.springframework.aop.framework.Advised",
+          "org.springframework.core.DecoratingProxy"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework.spring_aop.CglibAopProxyTest$GreetingService"
+      },
+      "type" : {
+        "proxy" : [
+          "org_springframework.spring_aop.CglibAopProxyTest$GreetingService",
+          "org.springframework.aop.SpringProxy",
+          "org.springframework.aop.framework.Advised",
+          "org.springframework.core.DecoratingProxy"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.cglib.proxy.Enhancer"
+      },
+      "type" : "org_springframework.spring_aop.CglibAopProxyTest$GreetingTarget$$SpringCGLIB$$0",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.cglib.proxy.Enhancer"
+      },
+      "type" : "org_springframework.spring_aop.ObjenesisCglibAopProxyTest$ConstructorGreetingService$$SpringCGLIB$$0",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.cglib.proxy.Enhancer"
+      },
+      "type" : "org_springframework.spring_aop.ObjenesisCglibAopProxyTest$DefaultGreetingService$$SpringCGLIB$$0",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework.spring_aop.RuntimeTestWalkerInnerInstanceOfResidueTestVisitorTest"
+      },
+      "type" : "org_springframework.spring_aop.RuntimeWalkerMarker"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework.spring_aop.RuntimeTestWalkerInnerInstanceOfResidueTestVisitorTest"
+      },
+      "type" : "org_springframework.spring_aop.RuntimeWalkerService"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.framework.JdkDynamicAopProxy"
+      },
+      "type" : {
+        "proxy" : [
+          "org_springframework.spring_aop.AbstractAspectJAdviceTest$GreetingService",
+          "org.springframework.aop.SpringProxy",
+          "org.springframework.aop.framework.Advised",
+          "org.springframework.core.DecoratingProxy"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.framework.JdkDynamicAopProxy"
+      },
+      "type" : {
+        "proxy" : [
+          "org_springframework.spring_aop.AopProxyUtilsTest$VarargsService",
+          "org.springframework.aop.SpringProxy",
+          "org.springframework.aop.framework.Advised",
+          "org.springframework.core.DecoratingProxy"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.framework.JdkDynamicAopProxy"
+      },
+      "type" : {
+        "proxy" : [
+          "org_springframework.spring_aop.DelegatePerTargetObjectIntroductionInterceptorTest$NamedService",
+          "org_springframework.spring_aop.DelegatePerTargetObjectIntroductionInterceptorTest$CountingOperations",
+          "org.springframework.aop.SpringProxy",
+          "org.springframework.aop.framework.Advised",
+          "org.springframework.core.DecoratingProxy"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.framework.JdkDynamicAopProxy"
+      },
+      "type" : {
+        "proxy" : [
+          "org_springframework.spring_aop.ObjenesisCglibAopProxyTest$GreetingService",
+          "org.springframework.aop.SpringProxy",
+          "org.springframework.aop.framework.Advised",
+          "org.springframework.core.DecoratingProxy"
+        ]
+      }
+    }
+  ],
+  "serialization" : [
+    {
+      "condition" : {
+        "typeReached" : "org_springframework.spring_aop.InstantiationModelAwarePointcutAdvisorImplTest$SerializableAspect"
+      },
+      "type" : "org_springframework.spring_aop.InstantiationModelAwarePointcutAdvisorImplTest$SerializableAspect"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework.spring_aop.InstantiationModelAwarePointcutAdvisorImplTest$SerializableAspect"
+      },
+      "type" : "java.lang.String"
+    }
+  ]
+}

--- a/tests/src/org.springframework/spring-aop/6.0.20/user-code-filter.json
+++ b/tests/src/org.springframework/spring-aop/6.0.20/user-code-filter.json
@@ -1,0 +1,16 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.aopalliance.**"
+    },
+    {
+      "includeClasses" : "org.springframework.aop.**"
+    },
+    {
+      "includeClasses" : "org_springframework.spring_aop.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6923

This PR provides test fixes and new metadata for org.springframework:spring-aop:6.0.20, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 34723
- Cached input tokens: 138752
- Output tokens: 1599
- Metadata entries: 54
- Test-only metadata entries: 24
- Iterations: 1
- Library coverage percentage: 19.91
- Previous library version metadata entries: 54
- Previous library version test-only metadata entries: 24
- Previous library version coverage percentage: 19.89

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3439613b2158e936a5da35780ad8150376b3c9e0`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.springframework:spring-aop:6.0.0: 23/23 covered calls (100.00%)
- org.springframework:spring-aop:6.0.20: 22/22 covered calls (100.00%)

**Reflection:**
- org.springframework:spring-aop:6.0.0: 23/23 covered calls (100.00%)
- org.springframework:spring-aop:6.0.20: 22/22 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.springframework:spring-aop:6.0.0: 4310/22200 (19.41%)
- org.springframework:spring-aop:6.0.20: 4284/22374 (19.15%)

**Line:**
- org.springframework:spring-aop:6.0.0: 1073/5395 (19.89%)
- org.springframework:spring-aop:6.0.20: 1064/5343 (19.91%)

**Method:**
- org.springframework:spring-aop:6.0.0: 288/1395 (20.65%)
- org.springframework:spring-aop:6.0.20: 299/1411 (21.19%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.springframework/spring-aop/6.0.0/src/test/java/org_springframework/spring_aop/AbstractAspectJAdvisorFactoryTest.java 2/tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/AbstractAspectJAdvisorFactoryTest.java
index 33ce10826f..e486d864d3 100644
--- 1/tests/src/org.springframework/spring-aop/6.0.0/src/test/java/org_springframework/spring_aop/AbstractAspectJAdvisorFactoryTest.java
+++ 2/tests/src/org.springframework/spring-aop/6.0.20/src/test/java/org_springframework/spring_aop/AbstractAspectJAdvisorFactoryTest.java
@@ -16,12 +16,12 @@ import org.springframework.aop.aspectj.annotation.ReflectiveAspectJAdvisorFactor
 public class AbstractAspectJAdvisorFactoryTest {
 
     @Test
-    void rejectsAspectWithAjcCompiledMarkerField() {
+    void acceptsAnnotationStyleAspectWithAjcCompiledMarkerField() {
         ReflectiveAspectJAdvisorFactory factory = new ReflectiveAspectJAdvisorFactory();
 
         boolean aspect = factory.isAspect(AjcCompiledMarkerAspect.class);
 
-        assertThat(aspect).isFalse();
+        assertThat(aspect).isTrue();
     }
 
     @Test

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
