### PR TITLE
[GenAI] Test fix for org.codehaus.plexus:plexus-classworlds:1.5.0 using gpt-5.5

### DIFF
--- a/metadata/org.codehaus.plexus/plexus-classworlds/1.5.0/reachability-metadata.json
+++ b/metadata/org.codehaus.plexus/plexus-classworlds/1.5.0/reachability-metadata.json
@@ -1,0 +1,46 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.plexus.classworlds.realm.ClassRealm"
+      },
+      "type": "org.codehaus.plexus.classworlds.ClassWorld"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.plexus.classworlds.strategy.DefaultStrategy"
+      },
+      "type": "org.codehaus.plexus.classworlds.ClassWorld"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type": "org_codehaus_plexus.plexus_classworlds.LauncherTest$EnhancedMain"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type": "org_codehaus_plexus.plexus_classworlds.LauncherTest$EnhancedResourceMain"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type": "org_codehaus_plexus.plexus_classworlds.LauncherTest$StandardMain"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type": "org_codehaus_plexus.plexus_classworlds.LauncherTest$StandardResourceMain"
+    }
+  ]
+}

--- a/metadata/org.codehaus.plexus/plexus-classworlds/1.5.0/reachability-metadata.json
+++ b/metadata/org.codehaus.plexus/plexus-classworlds/1.5.0/reachability-metadata.json
@@ -1,46 +1,22 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org.codehaus.plexus.classworlds.launcher.Launcher"
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.launcher.Launcher"
       },
-      "type": "java.lang.reflect.Method[]"
+      "type" : "java.lang.reflect.Method[]"
     },
     {
-      "condition": {
-        "typeReached": "org.codehaus.plexus.classworlds.realm.ClassRealm"
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.realm.ClassRealm"
       },
-      "type": "org.codehaus.plexus.classworlds.ClassWorld"
+      "type" : "org.codehaus.plexus.classworlds.ClassWorld"
     },
     {
-      "condition": {
-        "typeReached": "org.codehaus.plexus.classworlds.strategy.DefaultStrategy"
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.strategy.DefaultStrategy"
       },
-      "type": "org.codehaus.plexus.classworlds.ClassWorld"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.plexus.classworlds.launcher.Launcher"
-      },
-      "type": "org_codehaus_plexus.plexus_classworlds.LauncherTest$EnhancedMain"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.plexus.classworlds.launcher.Launcher"
-      },
-      "type": "org_codehaus_plexus.plexus_classworlds.LauncherTest$EnhancedResourceMain"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.plexus.classworlds.launcher.Launcher"
-      },
-      "type": "org_codehaus_plexus.plexus_classworlds.LauncherTest$StandardMain"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.plexus.classworlds.launcher.Launcher"
-      },
-      "type": "org_codehaus_plexus.plexus_classworlds.LauncherTest$StandardResourceMain"
+      "type" : "org.codehaus.plexus.classworlds.ClassWorld"
     }
   ]
 }

--- a/metadata/org.codehaus.plexus/plexus-classworlds/index.json
+++ b/metadata/org.codehaus.plexus/plexus-classworlds/index.json
@@ -1,6 +1,16 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.5.0",
+    "tested-versions" : [
+      "1.5.0"
+    ],
+    "allowed-packages" : [
+      "org.codehaus.classworlds",
+      "org.codehaus.plexus.classworlds"
+    ]
+  },
+  {
     "metadata-version" : "1.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/$version$/plexus-classworlds-$version$-sources.jar",
     "repository-url" : "https://github.com/codehaus-plexus/plexus-classworlds",

--- a/metadata/org.codehaus.plexus/plexus-classworlds/index.json
+++ b/metadata/org.codehaus.plexus/plexus-classworlds/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.5.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/$version$/plexus-classworlds-$version$-sources.jar",
+    "repository-url" : "https://github.com/codehaus-plexus/plexus-classworlds",
+    "test-code-url" : "https://github.com/codehaus-plexus/plexus-classworlds/tree/plexus-classworlds-$version$/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/$version$/plexus-classworlds-$version$-javadoc.jar",
+    "description" : "Plexus Classworlds is a framework for creating and managing isolated Java class loader realms. It lets container-style applications and build tools load components with controlled classpath separation and package imports between realms.",
     "tested-versions" : [
       "1.5.0"
     ],

--- a/stats/org.codehaus.plexus/plexus-classworlds/1.5.0/execution-metrics.json
+++ b/stats/org.codehaus.plexus/plexus-classworlds/1.5.0/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_java_run_fail:2026-05-19": {
+    "timestamp": "2026-05-19T06:04:09.849212Z",
+    "library": "org.codehaus.plexus:plexus-classworlds:1.5.0",
+    "starting_commit": "80f1c7465af032765ad9129371939ccb308cddf1",
+    "ending_commit": "e6d7e305f8b263101ac91cbed8d7f41f98632ab8",
+    "previous_library": "org.codehaus.plexus:plexus-classworlds:1.2",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.5.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 9,
+            "totalCalls": 9
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 7,
+            "totalCalls": 7
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 16,
+        "totalCalls": 16
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 857,
+          "missed": 2700,
+          "ratio": 0.240933,
+          "total": 3557
+        },
+        "line": {
+          "covered": 235,
+          "missed": 685,
+          "ratio": 0.255435,
+          "total": 920
+        },
+        "method": {
+          "covered": 64,
+          "missed": 185,
+          "ratio": 0.257028,
+          "total": 249
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.2",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 8,
+            "totalCalls": 8
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 5,
+            "totalCalls": 5
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 13,
+        "totalCalls": 13
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 694,
+          "missed": 2274,
+          "ratio": 0.233827,
+          "total": 2968
+        },
+        "line": {
+          "covered": 188,
+          "missed": 574,
+          "ratio": 0.246719,
+          "total": 762
+        },
+        "method": {
+          "covered": 50,
+          "missed": 161,
+          "ratio": 0.236967,
+          "total": 211
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 79220,
+      "cached_input_tokens_used": 505856,
+      "output_tokens_used": 8275,
+      "iterations": 3,
+      "cost_usd": 0.5011,
+      "tested_library_loc": 235,
+      "metadata_entries": 3,
+      "test_only_metadata_entries": 6,
+      "previous_library_metadata_entries": 3,
+      "previous_library_test_only_metadata_entries": 6,
+      "code_coverage_percent": 25.54,
+      "previous_library_coverage_percent": 24.67
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/src/test/java/org_codehaus_plexus/plexus_classworlds/DefaultStrategyTest.java",
+      "metadata_file": "metadata/org.codehaus.plexus/plexus-classworlds/1.5.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.codehaus.plexus/plexus-classworlds/1.5.0/stats.json
+++ b/stats/org.codehaus.plexus/plexus-classworlds/1.5.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "1.5.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 9,
+          "totalCalls" : 9
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 7,
+          "totalCalls" : 7
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 16,
+      "totalCalls" : 16
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 857,
+        "missed" : 2700,
+        "ratio" : 0.240933,
+        "total" : 3557
+      },
+      "line" : {
+        "covered" : 235,
+        "missed" : 685,
+        "ratio" : 0.255435,
+        "total" : 920
+      },
+      "method" : {
+        "covered" : 64,
+        "missed" : 185,
+        "ratio" : 0.257028,
+        "total" : 249
+      }
+    }
+  } ]
+}

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/.gitignore
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/build.gradle
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.codehaus.plexus:plexus-classworlds:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/gradle.properties
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.codehaus.plexus:plexus-classworlds:1.5.0
+library.version = 1.5.0
+metadata.dir = org.codehaus.plexus/plexus-classworlds/1.5.0/

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/settings.gradle
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.codehaus.plexus.plexus-classworlds_tests'

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java
@@ -9,6 +9,7 @@ package org_codehaus_plexus.plexus_classworlds;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URL;
+import java.util.Enumeration;
 
 import org.codehaus.plexus.classworlds.ClassWorld;
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
@@ -33,6 +34,25 @@ public class ClassRealmTest {
         URL resource = realm.getRealmResource("classworlds.conf");
 
         assertThat(resource).isNotNull();
+    }
+
+    @Test
+    void loadResourceFromParentUsesForeignClassLoader() throws Exception {
+        ClassRealm realm = newRealm();
+
+        URL resource = realm.loadResourceFromParent("classworlds.conf");
+
+        assertThat(resource).isNotNull();
+    }
+
+    @Test
+    void loadResourcesFromParentUsesForeignClassLoader() throws Exception {
+        ClassRealm realm = newRealm();
+
+        Enumeration<?> resources = realm.loadResourcesFromParent("classworlds.conf");
+
+        assertThat(resources).isNotNull();
+        assertThat(resources.hasMoreElements()).isTrue();
     }
 
     private static ClassRealm newRealm() throws Exception {

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_classworlds;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URL;
+
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.junit.jupiter.api.Test;
+
+public class ClassRealmTest {
+    private static final String REALM_ID = "direct-realm";
+
+    @Test
+    void loadRealmClassLoadsClassThroughRealmClassLoader() throws Exception {
+        ClassRealm realm = newRealm();
+
+        Class<?> loadedClass = realm.loadRealmClass(ClassRealmTest.class.getName());
+
+        assertThat(loadedClass).isSameAs(ClassRealmTest.class);
+    }
+
+    @Test
+    void getRealmResourceLoadsResourceThroughRealmClassLoader() throws Exception {
+        ClassRealm realm = newRealm();
+
+        URL resource = realm.getRealmResource("classworlds.conf");
+
+        assertThat(resource).isNotNull();
+    }
+
+    private static ClassRealm newRealm() throws Exception {
+        ClassWorld world = new ClassWorld();
+        return world.newRealm(REALM_ID, ClassRealmTest.class.getClassLoader());
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/src/test/java/org_codehaus_plexus/plexus_classworlds/DefaultStrategyTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/src/test/java/org_codehaus_plexus/plexus_classworlds/DefaultStrategyTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_classworlds;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.classworlds.strategy.DefaultStrategy;
+import org.junit.jupiter.api.Test;
+
+public class DefaultStrategyTest {
+    private static final String REALM_ID = "default-realm";
+
+    @Test
+    void loadClassDelegatesClassworldsClassesToClassworldsClassLoader() throws Exception {
+        ClassRealm realm = new ClassWorld().newRealm(REALM_ID);
+
+        Class<?> loadedClass = realm.loadClass(ClassWorld.class.getName());
+
+        assertThat(realm.getStrategy()).isInstanceOf(DefaultStrategy.class);
+        assertThat(loadedClass).isSameAs(ClassWorld.class);
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ForeignStrategyTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ForeignStrategyTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_classworlds;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.classworlds.strategy.ForeignStrategy;
+import org.junit.jupiter.api.Test;
+
+public class ForeignStrategyTest {
+    private static final String REALM_ID = "foreign-realm";
+    private static final String RESOURCE_NAME = "foreign/resource.txt";
+
+    @Test
+    void getResourceConsultsForeignClassLoaderFirst() throws Exception {
+        RecordingClassLoader foreignClassLoader = new RecordingClassLoader();
+        ClassRealm realm = newRealm(foreignClassLoader);
+
+        URL resource = realm.getResource("/" + RESOURCE_NAME);
+
+        assertThat(realm.getStrategy()).isInstanceOf(ForeignStrategy.class);
+        assertThat(resource).isEqualTo(foreignClassLoader.resource);
+        assertThat(foreignClassLoader.resourceLookups).containsExactly(RESOURCE_NAME);
+    }
+
+    @Test
+    void findResourcesIncludesResourcesFromForeignClassLoader() throws Exception {
+        RecordingClassLoader foreignClassLoader = new RecordingClassLoader();
+        ClassRealm realm = newRealm(foreignClassLoader);
+
+        List<URL> resources = resources(realm.findResources("/" + RESOURCE_NAME));
+
+        assertThat(resources).containsExactly(foreignClassLoader.enumeratedResource);
+        assertThat(foreignClassLoader.resourcesLookups).containsExactly(RESOURCE_NAME);
+    }
+
+    private static ClassRealm newRealm(ClassLoader foreignClassLoader) throws Exception {
+        ClassWorld world = new ClassWorld();
+        return world.newRealm(REALM_ID, foreignClassLoader);
+    }
+
+    private static List<URL> resources(Enumeration enumeration) {
+        List<URL> resources = new ArrayList<>();
+        while (enumeration.hasMoreElements()) {
+            resources.add((URL) enumeration.nextElement());
+        }
+        return resources;
+    }
+
+    private static URL fileUrl(String path) {
+        try {
+            return new URL("file", "", path);
+        } catch (MalformedURLException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static final class RecordingClassLoader extends ClassLoader {
+        private final URL resource = fileUrl("/foreign-resource.txt");
+        private final URL enumeratedResource = fileUrl("/foreign-enumerated-resource.txt");
+        private final List<String> resourceLookups = new ArrayList<>();
+        private final List<String> resourcesLookups = new ArrayList<>();
+
+        private RecordingClassLoader() {
+            super(null);
+        }
+
+        @Override
+        public URL getResource(String name) {
+            resourceLookups.add(name);
+            if (RESOURCE_NAME.equals(name)) {
+                return resource;
+            }
+            return null;
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            resourcesLookups.add(name);
+            if (RESOURCE_NAME.equals(name)) {
+                return Collections.enumeration(Collections.singletonList(enumeratedResource));
+            }
+            return Collections.emptyEnumeration();
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ForeignStrategyTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ForeignStrategyTest.java
@@ -28,11 +28,10 @@ public class ForeignStrategyTest {
     @Test
     void getResourceConsultsForeignClassLoaderFirst() throws Exception {
         RecordingClassLoader foreignClassLoader = new RecordingClassLoader();
-        ClassRealm realm = newRealm(foreignClassLoader);
+        ForeignStrategy strategy = newForeignStrategy(foreignClassLoader);
 
-        URL resource = realm.getResource("/" + RESOURCE_NAME);
+        URL resource = strategy.getResource("/" + RESOURCE_NAME);
 
-        assertThat(realm.getStrategy()).isInstanceOf(ForeignStrategy.class);
         assertThat(resource).isEqualTo(foreignClassLoader.resource);
         assertThat(foreignClassLoader.resourceLookups).containsExactly(RESOURCE_NAME);
     }
@@ -40,20 +39,21 @@ public class ForeignStrategyTest {
     @Test
     void findResourcesIncludesResourcesFromForeignClassLoader() throws Exception {
         RecordingClassLoader foreignClassLoader = new RecordingClassLoader();
-        ClassRealm realm = newRealm(foreignClassLoader);
+        ForeignStrategy strategy = newForeignStrategy(foreignClassLoader);
 
-        List<URL> resources = resources(realm.findResources("/" + RESOURCE_NAME));
+        List<URL> resources = resources(strategy.findResources("/" + RESOURCE_NAME));
 
         assertThat(resources).containsExactly(foreignClassLoader.enumeratedResource);
         assertThat(foreignClassLoader.resourcesLookups).containsExactly(RESOURCE_NAME);
     }
 
-    private static ClassRealm newRealm(ClassLoader foreignClassLoader) throws Exception {
+    private static ForeignStrategy newForeignStrategy(ClassLoader foreignClassLoader) throws Exception {
         ClassWorld world = new ClassWorld();
-        return world.newRealm(REALM_ID, foreignClassLoader);
+        ClassRealm realm = world.newRealm(REALM_ID);
+        return new ForeignStrategy(realm, foreignClassLoader);
     }
 
-    private static List<URL> resources(Enumeration enumeration) {
+    private static List<URL> resources(Enumeration<?> enumeration) {
         List<URL> resources = new ArrayList<>();
         while (enumeration.hasMoreElements()) {
             resources.add((URL) enumeration.nextElement());

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ForeignStrategyTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ForeignStrategyTest.java
@@ -22,8 +22,20 @@ import org.codehaus.plexus.classworlds.strategy.ForeignStrategy;
 import org.junit.jupiter.api.Test;
 
 public class ForeignStrategyTest {
+    private static final String CLASS_NAME = ForeignLoadTarget.class.getName();
     private static final String REALM_ID = "foreign-realm";
     private static final String RESOURCE_NAME = "foreign/resource.txt";
+
+    @Test
+    void loadClassConsultsForeignClassLoaderFirst() throws Exception {
+        ClassLoader foreignClassLoader = new ClassLoader(ForeignStrategyTest.class.getClassLoader()) {
+        };
+        ForeignStrategy strategy = newForeignStrategy(foreignClassLoader);
+
+        Class<?> loadedClass = strategy.loadClass(CLASS_NAME);
+
+        assertThat(loadedClass).isEqualTo(ForeignLoadTarget.class);
+    }
 
     @Test
     void getResourceConsultsForeignClassLoaderFirst() throws Exception {
@@ -67,6 +79,9 @@ public class ForeignStrategyTest {
         } catch (MalformedURLException e) {
             throw new IllegalStateException(e);
         }
+    }
+
+    public static final class ForeignLoadTarget {
     }
 
     private static final class RecordingClassLoader extends ClassLoader {

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/src/test/java/org_codehaus_plexus/plexus_classworlds/LauncherTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/src/test/java/org_codehaus_plexus/plexus_classworlds/LauncherTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_classworlds;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.launcher.Launcher;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.junit.jupiter.api.Test;
+
+public class LauncherTest {
+    private static final String REALM_ID = "test";
+    private static final String CLASSWORLDS_CONF_PROPERTY = "classworlds.conf";
+    private static final String BOOTSTRAPPED_PROPERTY = "classworlds.bootstrapped";
+
+    @Test
+    void launchInvokesEnhancedMainMethodFromConfiguredRealm() throws Exception {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        EnhancedMain.reset();
+        Launcher launcher = configuredLauncher(EnhancedMain.class);
+        try {
+            launcher.launch(new String[] {"alpha", "beta"});
+
+            assertThat(EnhancedMain.args).containsExactly("alpha", "beta");
+            assertThat(EnhancedMain.world).isSameAs(launcher.getWorld());
+            assertThat(Thread.currentThread().getContextClassLoader()).isSameAs(launcher.getMainRealm());
+            assertThat(launcher.getExitCode()).isEqualTo(21);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    @Test
+    void launchFallsBackToStandardMainMethodFromConfiguredRealm() throws Exception {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        StandardMain.reset();
+        Launcher launcher = configuredLauncher(StandardMain.class);
+        try {
+            launcher.launch(new String[] {"gamma"});
+
+            assertThat(StandardMain.args).containsExactly("gamma");
+            assertThat(Thread.currentThread().getContextClassLoader()).isSameAs(launcher.getMainRealm());
+            assertThat(launcher.getExitCode()).isEqualTo(34);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    @Test
+    void mainWithExitCodeLoadsClasspathConfigurationResource() throws Exception {
+        StandardResourceMain.reset();
+        withLauncherResourceLookup(false, () -> {
+            int exitCode = Launcher.mainWithExitCode(new String[] {"from-classpath"});
+
+            assertThat(exitCode).isEqualTo(55);
+            assertThat(StandardResourceMain.args).containsExactly("from-classpath");
+        });
+    }
+
+    @Test
+    void mainWithExitCodeLoadsBootstrappedUberjarConfigurationResource() throws Exception {
+        EnhancedResourceMain.reset();
+        withLauncherResourceLookup(true, () -> {
+            int exitCode = Launcher.mainWithExitCode(new String[] {"from-uberjar"});
+
+            assertThat(exitCode).isEqualTo(89);
+            assertThat(EnhancedResourceMain.args).containsExactly("from-uberjar");
+            assertThat(EnhancedResourceMain.world).isNotNull();
+        });
+    }
+
+    private static Launcher configuredLauncher(Class<?> mainClass) throws Exception {
+        ClassLoader classLoader = LauncherTest.class.getClassLoader();
+        ClassWorld world = new ClassWorld();
+        ClassRealm realm = world.newRealm(REALM_ID, classLoader);
+        Launcher launcher = new Launcher();
+        launcher.setSystemClassLoader(classLoader);
+        launcher.setWorld(world);
+        launcher.setAppMain(mainClass.getName(), realm.getId());
+        return launcher;
+    }
+
+    private static void withLauncherResourceLookup(boolean bootstrapped, ThrowingRunnable runnable) throws Exception {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        String originalConf = System.getProperty(CLASSWORLDS_CONF_PROPERTY);
+        String originalBootstrapped = System.getProperty(BOOTSTRAPPED_PROPERTY);
+        try {
+            Thread.currentThread().setContextClassLoader(LauncherTest.class.getClassLoader());
+            System.clearProperty(CLASSWORLDS_CONF_PROPERTY);
+            if (bootstrapped) {
+                System.setProperty(BOOTSTRAPPED_PROPERTY, "true");
+            } else {
+                System.clearProperty(BOOTSTRAPPED_PROPERTY);
+            }
+            runnable.run();
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+            restoreProperty(CLASSWORLDS_CONF_PROPERTY, originalConf);
+            restoreProperty(BOOTSTRAPPED_PROPERTY, originalBootstrapped);
+        }
+    }
+
+    private static void restoreProperty(String property, String value) {
+        if (value == null) {
+            System.clearProperty(property);
+        } else {
+            System.setProperty(property, value);
+        }
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+
+    public static class EnhancedMain {
+        private static String[] args;
+        private static ClassWorld world;
+
+        public static int main(String[] arguments, ClassWorld classWorld) {
+            args = arguments.clone();
+            world = classWorld;
+            return 21;
+        }
+
+        private static void reset() {
+            args = null;
+            world = null;
+        }
+    }
+
+    public static class StandardMain {
+        private static String[] args;
+
+        public static int main(String[] arguments) {
+            args = arguments.clone();
+            return 34;
+        }
+
+        private static void reset() {
+            args = null;
+        }
+    }
+
+    public static class StandardResourceMain {
+        private static String[] args;
+
+        public static int main(String[] arguments) {
+            args = arguments.clone();
+            return 55;
+        }
+
+        private static void reset() {
+            args = null;
+        }
+    }
+
+    public static class EnhancedResourceMain {
+        private static String[] args;
+        private static ClassWorld world;
+
+        public static int main(String[] arguments, ClassWorld classWorld) {
+            args = arguments.clone();
+            world = classWorld;
+            return 89;
+        }
+
+        private static void reset() {
+            args = null;
+            world = null;
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,42 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type" : "org_codehaus_plexus.plexus_classworlds.LauncherTest$EnhancedMain"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type" : "org_codehaus_plexus.plexus_classworlds.LauncherTest$EnhancedResourceMain"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type" : "org_codehaus_plexus.plexus_classworlds.LauncherTest$StandardMain"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type" : "org_codehaus_plexus.plexus_classworlds.LauncherTest$StandardResourceMain"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "glob" : "WORLDS-INF/conf/classworlds.conf"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.realm.ClassRealm"
+      },
+      "glob" : "classworlds.conf"
+    }
+  ]
+}

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/src/test/resources/WORLDS-INF/conf/classworlds.conf
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/src/test/resources/WORLDS-INF/conf/classworlds.conf
@@ -1,0 +1,3 @@
+main is org_codehaus_plexus.plexus_classworlds.LauncherTest$EnhancedResourceMain from test
+
+[test]

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/src/test/resources/classworlds.conf
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/src/test/resources/classworlds.conf
@@ -1,0 +1,3 @@
+main is org_codehaus_plexus.plexus_classworlds.LauncherTest$StandardResourceMain from test
+
+[test]

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/user-code-filter.json
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/user-code-filter.json
@@ -1,0 +1,16 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.codehaus.classworlds.**"
+    },
+    {
+      "includeClasses" : "org.codehaus.plexus.classworlds.**"
+    },
+    {
+      "includeClasses" : "org_codehaus_plexus.plexus_classworlds.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6916

This PR provides test fixes and new metadata for org.codehaus.plexus:plexus-classworlds:1.5.0, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 79220
- Cached input tokens: 505856
- Output tokens: 8275
- Metadata entries: 3
- Test-only metadata entries: 6
- Iterations: 3
- Library coverage percentage: 25.54
- Previous library version metadata entries: 3
- Previous library version test-only metadata entries: 6
- Previous library version coverage percentage: 24.67

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3439613b2158e936a5da35780ad8150376b3c9e0`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.codehaus.plexus:plexus-classworlds:1.2: 13/13 covered calls (100.00%)
- org.codehaus.plexus:plexus-classworlds:1.5.0: 16/16 covered calls (100.00%)

**Reflection:**
- org.codehaus.plexus:plexus-classworlds:1.2: 8/8 covered calls (100.00%)
- org.codehaus.plexus:plexus-classworlds:1.5.0: 9/9 covered calls (100.00%)

**Resources:**
- org.codehaus.plexus:plexus-classworlds:1.2: 5/5 covered calls (100.00%)
- org.codehaus.plexus:plexus-classworlds:1.5.0: 7/7 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.codehaus.plexus:plexus-classworlds:1.2: 694/2968 (23.38%)
- org.codehaus.plexus:plexus-classworlds:1.5.0: 857/3557 (24.09%)

**Line:**
- org.codehaus.plexus:plexus-classworlds:1.2: 188/762 (24.67%)
- org.codehaus.plexus:plexus-classworlds:1.5.0: 235/920 (25.54%)

**Method:**
- org.codehaus.plexus:plexus-classworlds:1.2: 50/211 (23.70%)
- org.codehaus.plexus:plexus-classworlds:1.5.0: 64/249 (25.70%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.codehaus.plexus/plexus-classworlds/1.2/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java 2/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java
index 6dbbe718a9..3e5cbca78d 100644
--- 1/tests/src/org.codehaus.plexus/plexus-classworlds/1.2/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java
+++ 2/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java
@@ -9,6 +9,7 @@ package org_codehaus_plexus.plexus_classworlds;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URL;
+import java.util.Enumeration;
 
 import org.codehaus.plexus.classworlds.ClassWorld;
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
@@ -35,6 +36,25 @@ public class ClassRealmTest {
         assertThat(resource).isNotNull();
     }
 
+    @Test
+    void loadResourceFromParentUsesForeignClassLoader() throws Exception {
+        ClassRealm realm = newRealm();
+
+        URL resource = realm.loadResourceFromParent("classworlds.conf");
+
+        assertThat(resource).isNotNull();
+    }
+
+    @Test
+    void loadResourcesFromParentUsesForeignClassLoader() throws Exception {
+        ClassRealm realm = newRealm();
+
+        Enumeration<?> resources = realm.loadResourcesFromParent("classworlds.conf");
+
+        assertThat(resources).isNotNull();
+        assertThat(resources.hasMoreElements()).isTrue();
+    }
+
     private static ClassRealm newRealm() throws Exception {
         ClassWorld world = new ClassWorld();
         return world.newRealm(REALM_ID, ClassRealmTest.class.getClassLoader());
diff --git 1/tests/src/org.codehaus.plexus/plexus-classworlds/1.2/src/test/java/org_codehaus_plexus/plexus_classworlds/ForeignStrategyTest.java 2/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ForeignStrategyTest.java
index d461d27c45..ebf1e9e6d9 100644
--- 1/tests/src/org.codehaus.plexus/plexus-classworlds/1.2/src/test/java/org_codehaus_plexus/plexus_classworlds/ForeignStrategyTest.java
+++ 2/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ForeignStrategyTest.java
@@ -22,17 +22,28 @@ import org.codehaus.plexus.classworlds.strategy.ForeignStrategy;
 import org.junit.jupiter.api.Test;
 
 public class ForeignStrategyTest {
+    private static final String CLASS_NAME = ForeignLoadTarget.class.getName();
     private static final String REALM_ID = "foreign-realm";
     private static final String RESOURCE_NAME = "foreign/resource.txt";
 
+    @Test
+    void loadClassConsultsForeignClassLoaderFirst() throws Exception {
+        ClassLoader foreignClassLoader = new ClassLoader(ForeignStrategyTest.class.getClassLoader()) {
+        };
+        ForeignStrategy strategy = newForeignStrategy(foreignClassLoader);
+
+        Class<?> loadedClass = strategy.loadClass(CLASS_NAME);
+
+        assertThat(loadedClass).isEqualTo(ForeignLoadTarget.class);
+    }
+
     @Test
     void getResourceConsultsForeignClassLoaderFirst() throws Exception {
         RecordingClassLoader foreignClassLoader = new RecordingClassLoader();
-        ClassRealm realm = newRealm(foreignClassLoader);
+        ForeignStrategy strategy = newForeignStrategy(foreignClassLoader);
 
-        URL resource = realm.getResource("/" + RESOURCE_NAME);
+        URL resource = strategy.getResource("/" + RESOURCE_NAME);
 
-        assertThat(realm.getStrategy()).isInstanceOf(ForeignStrategy.class);
         assertThat(resource).isEqualTo(foreignClassLoader.resource);
         assertThat(foreignClassLoader.resourceLookups).containsExactly(RESOURCE_NAME);
     }
@@ -40,20 +51,21 @@ public class ForeignStrategyTest {
     @Test
     void findResourcesIncludesResourcesFromForeignClassLoader() throws Exception {
         RecordingClassLoader foreignClassLoader = new RecordingClassLoader();
-        ClassRealm realm = newRealm(foreignClassLoader);
+        ForeignStrategy strategy = newForeignStrategy(foreignClassLoader);
 
-        List<URL> resources = resources(realm.findResources("/" + RESOURCE_NAME));
+        List<URL> resources = resources(strategy.findResources("/" + RESOURCE_NAME));
 
         assertThat(resources).containsExactly(foreignClassLoader.enumeratedResource);
         assertThat(foreignClassLoader.resourcesLookups).containsExactly(RESOURCE_NAME);
     }
 
-    private static ClassRealm newRealm(ClassLoader foreignClassLoader) throws Exception {
+    private static ForeignStrategy newForeignStrategy(ClassLoader foreignClassLoader) throws Exception {
         ClassWorld world = new ClassWorld();
-        return world.newRealm(REALM_ID, foreignClassLoader);
+        ClassRealm realm = world.newRealm(REALM_ID);
+        return new ForeignStrategy(realm, foreignClassLoader);
     }
 
-    private static List<URL> resources(Enumeration enumeration) {
+    private static List<URL> resources(Enumeration<?> enumeration) {
         List<URL> resources = new ArrayList<>();
         while (enumeration.hasMoreElements()) {
             resources.add((URL) enumeration.nextElement());
@@ -69,6 +81,9 @@ public class ForeignStrategyTest {
         }
     }
 
+    public static final class ForeignLoadTarget {
+    }
+
     private static final class RecordingClassLoader extends ClassLoader {
         private final URL resource = fileUrl("/foreign-resource.txt");
         private final URL enumeratedResource = fileUrl("/foreign-enumerated-resource.txt");

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
