### PR TITLE
[GenAI] Add support for org.springframework.boot:spring-boot-validation:4.0.6 using gpt-5.5

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-validation/4.0.6/reachability-metadata.json
+++ b/metadata/org.springframework.boot/spring-boot-validation/4.0.6/reachability-metadata.json
@@ -1,0 +1,146 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.ConfigurationClassParser"
+      },
+      "type" : "org.springframework.boot.validation.autoconfigure.ValidationAutoConfiguration",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "defaultValidator",
+          "parameterTypes" : [
+            "org.springframework.context.ApplicationContext",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        },
+        {
+          "name" : "methodValidationPostProcessor",
+          "parameterTypes" : [
+            "org.springframework.core.env.Environment",
+            "org.springframework.beans.factory.ObjectProvider",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.ConfigurationClassParser"
+      },
+      "type" : "org.springframework.boot.validation.autoconfigure.PrimaryDefaultValidatorPostProcessor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.annotation.AnnotationsScanner"
+      },
+      "type" : {
+        "proxy" : [
+          "org.springframework.boot.autoconfigure.AutoConfiguration"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.type.StandardAnnotationMetadata"
+      },
+      "type" : {
+        "proxy" : [
+          "org.springframework.boot.autoconfigure.AutoConfiguration"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.annotation.AnnotationsScanner"
+      },
+      "type" : {
+        "proxy" : [
+          "org.springframework.boot.autoconfigure.condition.ConditionalOnClass"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.type.StandardAnnotationMetadata"
+      },
+      "type" : {
+        "proxy" : [
+          "org.springframework.boot.autoconfigure.condition.ConditionalOnClass"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.annotation.AnnotationsScanner"
+      },
+      "type" : {
+        "proxy" : [
+          "org.springframework.boot.autoconfigure.condition.ConditionalOnResource"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.type.StandardAnnotationMetadata"
+      },
+      "type" : {
+        "proxy" : [
+          "org.springframework.boot.autoconfigure.condition.ConditionalOnResource"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.annotation.AnnotationsScanner"
+      },
+      "type" : {
+        "proxy" : [
+          "org.springframework.context.annotation.Import"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.type.StandardAnnotationMetadata"
+      },
+      "type" : {
+        "proxy" : [
+          "org.springframework.context.annotation.Import"
+        ]
+      }
+    }
+  ],
+  "resources" : [
+    {
+      "glob" : "org/springframework/boot/validation/autoconfigure/*.class"
+    },
+    {
+      "glob" : "META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports"
+    },
+    {
+      "glob" : "META-INF/spring-autoconfigure-metadata.properties"
+    },
+    {
+      "glob" : "org/springframework/boot/autoconfigure/AutoConfiguration.class"
+    },
+    {
+      "glob" : "org/springframework/boot/autoconfigure/condition/ConditionalOnClass.class"
+    },
+    {
+      "glob" : "org/springframework/boot/autoconfigure/condition/ConditionalOnResource.class"
+    },
+    {
+      "glob" : "org/springframework/context/annotation/Import.class"
+    }
+  ]
+}

--- a/metadata/org.springframework.boot/spring-boot-validation/index.json
+++ b/metadata/org.springframework.boot/spring-boot-validation/index.json
@@ -1,17 +1,20 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "4.0.6",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-validation/$version$/spring-boot-validation-$version$-sources.jar",
-    "repository-url" : "https://github.com/spring-projects/spring-boot",
-    "test-code-url" : "https://github.com/spring-projects/spring-boot/tree/v$version$/module/spring-boot-validation/src/test/java",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-validation/$version$/spring-boot-validation-$version$-javadoc.jar",
-    "description" : "Spring Boot Validation provides auto-configuration support for Jakarta Bean Validation in Spring Boot applications. It configures Boot's validation integration around Hibernate Validator and EL support so applications can expose validators consistently from the application context.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "4.0.6",
+    "source-code-url": "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-validation/$version$/spring-boot-validation-$version$-sources.jar",
+    "repository-url": "https://github.com/spring-projects/spring-boot",
+    "test-code-url": "https://github.com/spring-projects/spring-boot/tree/v$version$/module/spring-boot-validation/src/test/java",
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-validation/$version$/spring-boot-validation-$version$-javadoc.jar",
+    "description": "Spring Boot Validation provides auto-configuration support for Jakarta Bean Validation in Spring Boot applications. It configures Boot's validation integration around Hibernate Validator and EL support so applications can expose validators consistently from the application context.",
+    "tested-versions": [
       "4.0.6"
     ],
-    "allowed-packages" : [
-      "org.springframework.boot.validation.autoconfigure"
+    "allowed-packages": [
+      "org.springframework.boot.validation.autoconfigure",
+      "org.springframework.context.annotation",
+      "org.springframework.core.annotation",
+      "org.springframework.core.type"
     ]
   }
 ]

--- a/metadata/org.springframework.boot/spring-boot-validation/index.json
+++ b/metadata/org.springframework.boot/spring-boot-validation/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.0.6",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-validation/$version$/spring-boot-validation-$version$-sources.jar",
+    "repository-url" : "https://github.com/spring-projects/spring-boot",
+    "test-code-url" : "https://github.com/spring-projects/spring-boot/tree/v$version$/module/spring-boot-validation/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-validation/$version$/spring-boot-validation-$version$-javadoc.jar",
+    "description" : "Spring Boot Validation provides auto-configuration support for Jakarta Bean Validation in Spring Boot applications. It configures Boot's validation integration around Hibernate Validator and EL support so applications can expose validators consistently from the application context.",
+    "tested-versions" : [
+      "4.0.6"
+    ],
+    "allowed-packages" : [
+      "org.springframework.boot.validation.autoconfigure"
+    ]
+  }
+]

--- a/stats/org.springframework.boot/spring-boot-validation/4.0.6/execution-metrics.json
+++ b/stats/org.springframework.boot/spring-boot-validation/4.0.6/execution-metrics.json
@@ -1,0 +1,57 @@
+{
+  "add_new_library_support:2026-05-19": {
+    "timestamp": "2026-05-19T08:32:13.462799Z",
+    "library": "org.springframework.boot:spring-boot-validation:4.0.6",
+    "starting_commit": "193e1578b695d99eb0cf2d87ee4c2b56c7d2441b",
+    "ending_commit": "2fed041d2e4b3aab1ab5f7216d43d53b155f8cd8",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.0.6",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 251,
+          "missed": 118,
+          "ratio": 0.680217,
+          "total": 369
+        },
+        "line": {
+          "covered": 59,
+          "missed": 30,
+          "ratio": 0.662921,
+          "total": 89
+        },
+        "method": {
+          "covered": 20,
+          "missed": 7,
+          "ratio": 0.740741,
+          "total": 27
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 119694,
+      "cached_input_tokens_used": 1255936,
+      "output_tokens_used": 19909,
+      "iterations": 3,
+      "cost_usd": 1.2253,
+      "generated_loc": 312,
+      "tested_library_loc": 59,
+      "metadata_entries": 21,
+      "test_only_metadata_entries": 1,
+      "code_coverage_percent": 66.29
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.springframework.boot/spring-boot-validation/4.0.6/src/test/java/org_springframework_boot/spring_boot_validation/Spring_boot_validationTest.java",
+      "metadata_file": "metadata/org.springframework.boot/spring-boot-validation/4.0.6/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.springframework.boot/spring-boot-validation/4.0.6/stats.json
+++ b/stats/org.springframework.boot/spring-boot-validation/4.0.6/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.0.6",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 251,
+        "missed" : 118,
+        "ratio" : 0.680217,
+        "total" : 369
+      },
+      "line" : {
+        "covered" : 59,
+        "missed" : 30,
+        "ratio" : 0.662921,
+        "total" : 89
+      },
+      "method" : {
+        "covered" : 20,
+        "missed" : 7,
+        "ratio" : 0.740741,
+        "total" : 27
+      }
+    }
+  } ]
+}

--- a/tests/src/org.springframework.boot/spring-boot-validation/4.0.6/.gitignore
+++ b/tests/src/org.springframework.boot/spring-boot-validation/4.0.6/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.springframework.boot/spring-boot-validation/4.0.6/build.gradle
+++ b/tests/src/org.springframework.boot/spring-boot-validation/4.0.6/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.springframework.boot:spring-boot-validation:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.springframework.boot/spring-boot-validation/4.0.6/gradle.properties
+++ b/tests/src/org.springframework.boot/spring-boot-validation/4.0.6/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.springframework.boot:spring-boot-validation:4.0.6
+library.version = 4.0.6
+metadata.dir = org.springframework.boot/spring-boot-validation/4.0.6/

--- a/tests/src/org.springframework.boot/spring-boot-validation/4.0.6/settings.gradle
+++ b/tests/src/org.springframework.boot/spring-boot-validation/4.0.6/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.springframework.boot.spring-boot-validation_tests'

--- a/tests/src/org.springframework.boot/spring-boot-validation/4.0.6/src/test/java/org_springframework_boot/spring_boot_validation/Spring_boot_validationTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-validation/4.0.6/src/test/java/org_springframework_boot/spring_boot_validation/Spring_boot_validationTest.java
@@ -38,6 +38,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.StaticMessageSource;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
@@ -173,6 +174,17 @@ public class Spring_boot_validationTest {
         }
     }
 
+    @Test
+    void autoConfiguredValidatorIsPrimaryWhenAdditionalSpringValidatorBeanExists() {
+        try (AnnotationConfigApplicationContext context = contextWith(AdditionalSpringValidatorConfiguration.class)) {
+            Validator validator = context.getBean(Validator.class);
+
+            assertThat(validator).isInstanceOf(LocalValidatorFactoryBean.class);
+            assertThat(context.getBean("additionalSpringValidator", Validator.class))
+                    .isInstanceOf(NoOpSpringValidator.class);
+        }
+    }
+
     private static AnnotationConfigApplicationContext contextWith(Class<?>... configurationClasses) {
         return contextWithProperties(Map.of(), configurationClasses);
     }
@@ -272,6 +284,16 @@ public class Spring_boot_validationTest {
 
     }
 
+    @Configuration(proxyBeanMethods = false)
+    public static class AdditionalSpringValidatorConfiguration {
+
+        @Bean
+        Validator additionalSpringValidator() {
+            return new NoOpSpringValidator();
+        }
+
+    }
+
     public interface GreetingService {
 
         String greet(@NotBlank String name);
@@ -354,6 +376,20 @@ public class Spring_boot_validationTest {
 
         public int getAge() {
             return this.age;
+        }
+
+    }
+
+    public static class NoOpSpringValidator implements Validator {
+
+        @Override
+        public boolean supports(Class<?> clazz) {
+            return true;
+        }
+
+        @Override
+        public void validate(Object target, Errors errors) {
+            // Intentionally does not add errors; selection of the primary Validator bean is the behavior under test.
         }
 
     }

--- a/tests/src/org.springframework.boot/spring-boot-validation/4.0.6/src/test/java/org_springframework_boot/spring_boot_validation/Spring_boot_validationTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-validation/4.0.6/src/test/java/org_springframework_boot/spring_boot_validation/Spring_boot_validationTest.java
@@ -6,6 +6,10 @@
  */
 package org_springframework_boot.spring_boot_validation;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -27,6 +31,7 @@ import org.springframework.aop.support.AopUtils;
 import org.springframework.boot.validation.autoconfigure.ValidationAutoConfiguration;
 import org.springframework.boot.validation.autoconfigure.ValidationConfigurationCustomizer;
 import org.springframework.boot.validation.autoconfigure.ValidatorAdapter;
+import org.springframework.boot.validation.beanvalidation.MethodValidationExcludeFilter;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -112,6 +117,17 @@ public class Spring_boot_validationTest {
                                 .extracting(ParameterValidationResult::getArgument)
                                 .isEqualTo("");
                     });
+        }
+    }
+
+    @Test
+    void methodValidationExcludeFilterPreventsProxyingMatchedBeans() {
+        try (AnnotationConfigApplicationContext context = contextWithProperties(
+                Map.of("spring.aop.proxy-target-class", (Object) "false"), ExcludedMethodValidationConfiguration.class)) {
+            GreetingService service = context.getBean(GreetingService.class);
+
+            assertThat(AopUtils.isAopProxy(service)).isFalse();
+            assertThat(service.greet("")).isEqualTo("Hello ");
         }
     }
 
@@ -227,6 +243,21 @@ public class Spring_boot_validationTest {
     }
 
     @Configuration(proxyBeanMethods = false)
+    public static class ExcludedMethodValidationConfiguration {
+
+        @Bean
+        GreetingService greetingService() {
+            return new ExcludedGreetingService();
+        }
+
+        @Bean
+        MethodValidationExcludeFilter noMethodValidationFilter() {
+            return MethodValidationExcludeFilter.byAnnotation(NoMethodValidation.class);
+        }
+
+    }
+
+    @Configuration(proxyBeanMethods = false)
     public static class ExistingJakartaValidatorConfiguration {
 
         @Bean(destroyMethod = "close")
@@ -254,6 +285,23 @@ public class Spring_boot_validationTest {
         public String greet(String name) {
             return "Hello " + name;
         }
+
+    }
+
+    @Validated
+    @NoMethodValidation
+    public static class ExcludedGreetingService implements GreetingService {
+
+        @Override
+        public String greet(String name) {
+            return "Hello " + name;
+        }
+
+    }
+
+    @Target(ElementType.TYPE)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface NoMethodValidation {
 
     }
 

--- a/tests/src/org.springframework.boot/spring-boot-validation/4.0.6/src/test/java/org_springframework_boot/spring_boot_validation/Spring_boot_validationTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-validation/4.0.6/src/test/java/org_springframework_boot/spring_boot_validation/Spring_boot_validationTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework_boot.spring_boot_validation;
+
+import org.junit.jupiter.api.Test;
+
+class Spring_boot_validationTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.springframework.boot/spring-boot-validation/4.0.6/src/test/java/org_springframework_boot/spring_boot_validation/Spring_boot_validationTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-validation/4.0.6/src/test/java/org_springframework_boot/spring_boot_validation/Spring_boot_validationTest.java
@@ -152,8 +152,7 @@ public class Spring_boot_validationTest {
                         .isEqualTo("must be greater than or equal to 18");
                 assertThat(((ValidatorAdapter) adapter).getTarget()).isSameAs(target);
                 assertThat(((ValidatorAdapter) adapter).unwrap(LocalValidatorFactoryBean.class)).isSameAs(target);
-            }
-            finally {
+            } finally {
                 target.destroy();
             }
         }
@@ -199,8 +198,7 @@ public class Spring_boot_validationTest {
         context.register(configurationClasses);
         try {
             context.refresh();
-        }
-        catch (RuntimeException ex) {
+        } catch (RuntimeException ex) {
             context.close();
             throw ex;
         }

--- a/tests/src/org.springframework.boot/spring-boot-validation/4.0.6/src/test/java/org_springframework_boot/spring_boot_validation/Spring_boot_validationTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-validation/4.0.6/src/test/java/org_springframework_boot/spring_boot_validation/Spring_boot_validationTest.java
@@ -6,11 +6,308 @@
  */
 package org_springframework_boot.spring_boot_validation;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validation;
+import jakarta.validation.ValidatorFactory;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import org.junit.jupiter.api.Test;
 
-class Spring_boot_validationTest {
+import org.springframework.aop.support.AopUtils;
+import org.springframework.boot.validation.autoconfigure.ValidationAutoConfiguration;
+import org.springframework.boot.validation.autoconfigure.ValidationConfigurationCustomizer;
+import org.springframework.boot.validation.autoconfigure.ValidatorAdapter;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.StaticMessageSource;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.Validator;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+import org.springframework.validation.beanvalidation.MethodValidationPostProcessor;
+import org.springframework.validation.method.MethodValidationException;
+import org.springframework.validation.method.ParameterValidationResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class Spring_boot_validationTest {
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void autoConfiguredValidatorUsesApplicationMessageSource() {
+        try (AnnotationConfigApplicationContext context = contextWith(MessageSourceConfiguration.class)) {
+            jakarta.validation.Validator jakartaValidator = context.getBean(jakarta.validation.Validator.class);
+
+            Set<ConstraintViolation<RegistrationForm>> violations = jakartaValidator.validate(new RegistrationForm(""));
+
+            assertThat(jakartaValidator).isInstanceOf(LocalValidatorFactoryBean.class);
+            assertThat(context.getBeanNamesForType(MethodValidationPostProcessor.class)).hasSize(1);
+            assertThat(violations).singleElement()
+                    .satisfies((violation) -> {
+                        assertThat(violation.getPropertyPath().toString()).isEqualTo("name");
+                        assertThat(violation.getMessage()).isEqualTo("A registration name is required");
+                    });
+        }
     }
+
+    @Test
+    void configurationCustomizersAreAppliedToDefaultValidatorFactory() {
+        ClockProviderConfiguration.reset();
+        try (AnnotationConfigApplicationContext context = contextWith(ClockProviderConfiguration.class)) {
+            jakarta.validation.Validator validator = context.getBean(jakarta.validation.Validator.class);
+
+            Set<ConstraintViolation<DeadlineForm>> violations = validator.validate(
+                    new DeadlineForm(Instant.parse("2029-12-31T00:00:00Z")));
+
+            assertThat(ClockProviderConfiguration.getCustomizationCount()).isEqualTo(1);
+            assertThat(violations).singleElement()
+                    .satisfies((violation) -> assertThat(violation.getPropertyPath().toString()).isEqualTo("deadline"));
+        }
+    }
+
+    @Test
+    void methodValidationPostProcessorRejectsInvalidMethodArguments() {
+        try (AnnotationConfigApplicationContext context = contextWithProperties(
+                Map.of("spring.aop.proxy-target-class", (Object) "false"), MethodValidationConfiguration.class)) {
+            GreetingService service = context.getBean(GreetingService.class);
+
+            assertThat(AopUtils.isAopProxy(service)).isTrue();
+            assertThat(service.greet("Spring")).isEqualTo("Hello Spring");
+            assertThatThrownBy(() -> service.greet(""))
+                    .isInstanceOf(ConstraintViolationException.class)
+                    .hasMessageContaining("must not be blank");
+        }
+    }
+
+    @Test
+    void methodValidationPostProcessorCanAdaptConstraintViolations() {
+        try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+            context.getEnvironment()
+                    .getPropertySources()
+                    .addFirst(new MapPropertySource("test", Map.of(
+                            "spring.aop.proxy-target-class", (Object) "false",
+                            "spring.validation.method.adapt-constraint-violations", "true")));
+            context.register(ValidationAutoConfiguration.class, MethodValidationConfiguration.class);
+            context.refresh();
+            GreetingService service = context.getBean(GreetingService.class);
+
+            assertThatThrownBy(() -> service.greet(""))
+                    .isInstanceOf(MethodValidationException.class)
+                    .satisfies((ex) -> {
+                        MethodValidationException validationException = (MethodValidationException) ex;
+                        assertThat(validationException.getParameterValidationResults())
+                                .singleElement()
+                                .extracting(ParameterValidationResult::getArgument)
+                                .isEqualTo("");
+                    });
+        }
+    }
+
+    @Test
+    void validatorAdapterWrapsJakartaValidatorAndDelegatesSpringValidation() {
+        try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+            context.refresh();
+            LocalValidatorFactoryBean target = new LocalValidatorFactoryBean();
+            target.afterPropertiesSet();
+            try {
+                Validator adapter = ValidatorAdapter.get(context, target);
+                BeanPropertyBindingResult errors = new BeanPropertyBindingResult(new PersonForm("", 12), "personForm");
+
+                adapter.validate(new PersonForm("", 12), errors);
+
+                assertThat(adapter).isInstanceOf(ValidatorAdapter.class);
+                assertThat(adapter.supports(PersonForm.class)).isTrue();
+                assertThat(errors.getFieldErrors()).hasSize(2);
+                assertThat(errors.getFieldError("name").getDefaultMessage()).isEqualTo("must not be blank");
+                assertThat(errors.getFieldError("age").getDefaultMessage())
+                        .isEqualTo("must be greater than or equal to 18");
+                assertThat(((ValidatorAdapter) adapter).getTarget()).isSameAs(target);
+                assertThat(((ValidatorAdapter) adapter).unwrap(LocalValidatorFactoryBean.class)).isSameAs(target);
+            }
+            finally {
+                target.destroy();
+            }
+        }
+    }
+
+    @Test
+    void validatorAdapterFindsExistingJakartaValidatorBeanInApplicationContext() {
+        try (AnnotationConfigApplicationContext context = contextWith(ExistingJakartaValidatorConfiguration.class)) {
+            Validator adapter = ValidatorAdapter.get(context, null);
+            BeanPropertyBindingResult errors = new BeanPropertyBindingResult(new PersonForm("", 18), "personForm");
+
+            adapter.validate(new PersonForm("", 18), errors);
+
+            assertThat(adapter).isInstanceOf(ValidatorAdapter.class);
+            assertThat(errors.getFieldError("name").getDefaultMessage()).isEqualTo("must not be blank");
+            assertThat(((ValidatorAdapter) adapter).unwrap(jakarta.validation.Validator.class))
+                    .isSameAs(context.getBean(jakarta.validation.Validator.class));
+        }
+    }
+
+    private static AnnotationConfigApplicationContext contextWith(Class<?>... configurationClasses) {
+        return contextWithProperties(Map.of(), configurationClasses);
+    }
+
+    private static AnnotationConfigApplicationContext contextWithProperties(Map<String, Object> properties,
+            Class<?>... configurationClasses) {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        if (!properties.isEmpty()) {
+            context.getEnvironment().getPropertySources().addFirst(new MapPropertySource("test", properties));
+        }
+        context.register(ValidationAutoConfiguration.class);
+        context.register(configurationClasses);
+        try {
+            context.refresh();
+        }
+        catch (RuntimeException ex) {
+            context.close();
+            throw ex;
+        }
+        return context;
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    public static class MessageSourceConfiguration {
+
+        @Bean
+        StaticMessageSource messageSource() {
+            StaticMessageSource messageSource = new StaticMessageSource();
+            messageSource.addMessage("registration.name.required", Locale.ENGLISH, "A registration name is required");
+            messageSource.addMessage("registration.name.required", Locale.getDefault(),
+                    "A registration name is required");
+            return messageSource;
+        }
+
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    public static class ClockProviderConfiguration {
+
+        private static final AtomicInteger CUSTOMIZATION_COUNT = new AtomicInteger();
+
+        static void reset() {
+            CUSTOMIZATION_COUNT.set(0);
+        }
+
+        static int getCustomizationCount() {
+            return CUSTOMIZATION_COUNT.get();
+        }
+
+        @Bean
+        ValidationConfigurationCustomizer fixedClockCustomizer() {
+            return (configuration) -> {
+                CUSTOMIZATION_COUNT.incrementAndGet();
+                configuration.clockProvider(() -> Clock.fixed(Instant.parse("2030-01-01T00:00:00Z"), ZoneOffset.UTC));
+            };
+        }
+
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    public static class MethodValidationConfiguration {
+
+        @Bean
+        GreetingService greetingService() {
+            return new DefaultGreetingService();
+        }
+
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    public static class ExistingJakartaValidatorConfiguration {
+
+        @Bean(destroyMethod = "close")
+        ValidatorFactory validatorFactory() {
+            return Validation.buildDefaultValidatorFactory();
+        }
+
+        @Bean
+        jakarta.validation.Validator jakartaValidator(ValidatorFactory validatorFactory) {
+            return validatorFactory.getValidator();
+        }
+
+    }
+
+    public interface GreetingService {
+
+        String greet(@NotBlank String name);
+
+    }
+
+    @Validated
+    public static class DefaultGreetingService implements GreetingService {
+
+        @Override
+        public String greet(String name) {
+            return "Hello " + name;
+        }
+
+    }
+
+    public static class RegistrationForm {
+
+        @NotBlank(message = "{registration.name.required}")
+        private final String name;
+
+        RegistrationForm(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return this.name;
+        }
+
+    }
+
+    public static class DeadlineForm {
+
+        @Future
+        private final Instant deadline;
+
+        DeadlineForm(Instant deadline) {
+            this.deadline = deadline;
+        }
+
+        public Instant getDeadline() {
+            return this.deadline;
+        }
+
+    }
+
+    public static class PersonForm {
+
+        @NotBlank
+        private final String name;
+
+        @Min(18)
+        private final int age;
+
+        PersonForm(String name, int age) {
+            this.name = name;
+            this.age = age;
+        }
+
+        public String getName() {
+            return this.name;
+        }
+
+        public int getAge() {
+            return this.age;
+        }
+
+    }
+
 }

--- a/tests/src/org.springframework.boot/spring-boot-validation/4.0.6/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.springframework.boot/spring-boot-validation/4.0.6/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,17 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.aop.framework.JdkDynamicAopProxy"
+      },
+      "type" : {
+        "proxy" : [
+          "org_springframework_boot.spring_boot_validation.Spring_boot_validationTest$GreetingService",
+          "org.springframework.aop.SpringProxy",
+          "org.springframework.aop.framework.Advised",
+          "org.springframework.core.DecoratingProxy"
+        ]
+      }
+    }
+  ]
+}

--- a/tests/src/org.springframework.boot/spring-boot-validation/4.0.6/user-code-filter.json
+++ b/tests/src/org.springframework.boot/spring-boot-validation/4.0.6/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.springframework.boot.validation.autoconfigure.**"
+    }
+  ]
+}

--- a/tests/src/org.springframework.boot/spring-boot-validation/4.0.6/user-code-filter.json
+++ b/tests/src/org.springframework.boot/spring-boot-validation/4.0.6/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.springframework.boot.validation.autoconfigure.**"
+      "includeClasses" : "org.springframework.boot.validation.autoconfigure.**"
+    },
+    {
+      "includeClasses" : "org_springframework_boot.spring_boot_validation.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #7090

This PR introduces tests and metadata for org.springframework.boot:spring-boot-validation:4.0.6, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 119694
- Cached input tokens: 1255936
- Output tokens: 19909
- Metadata entries: 21
- Test-only metadata entries: 1
- Iterations: 3
- Library coverage percentage: 66.29
- Generated lines of code: 312
- Tested library lines of code: 59

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `2b084b1c88185b0b90b0460c43d2a7a812c413f0`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 251/369 (68.02%)
- Line: 59/89 (66.29%)
- Method: 20/27 (74.07%)

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
