### PR TITLE
[GenAI] Add support for org.springframework.boot:spring-boot-kafka:4.0.2 using gpt-5.5

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-kafka/4.0.2/reachability-metadata.json
+++ b/metadata/org.springframework.boot/spring-boot-kafka/4.0.2/reachability-metadata.json
@@ -1,0 +1,394 @@
+{
+  "reflection": [
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaAutoConfiguration",
+      "allDeclaredConstructors": true,
+      "methods": [
+        {
+          "name": "kafkaConnectionDetails",
+          "parameterTypes": [
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        },
+        {
+          "name": "kafkaTemplate",
+          "parameterTypes": [
+            "org.springframework.kafka.core.ProducerFactory",
+            "org.springframework.kafka.support.ProducerListener",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        },
+        {
+          "name": "kafkaProducerListener",
+          "parameterTypes": []
+        },
+        {
+          "name": "kafkaConsumerFactory",
+          "parameterTypes": [
+            "org.springframework.boot.kafka.autoconfigure.KafkaConnectionDetails",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        },
+        {
+          "name": "kafkaProducerFactory",
+          "parameterTypes": [
+            "org.springframework.boot.kafka.autoconfigure.KafkaConnectionDetails",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        },
+        {
+          "name": "kafkaTransactionManager",
+          "parameterTypes": [
+            "org.springframework.kafka.core.ProducerFactory"
+          ]
+        },
+        {
+          "name": "kafkaJaasInitializer",
+          "parameterTypes": []
+        },
+        {
+          "name": "kafkaAdmin",
+          "parameterTypes": [
+            "org.springframework.boot.kafka.autoconfigure.KafkaConnectionDetails"
+          ]
+        },
+        {
+          "name": "kafkaRetryTopicConfiguration",
+          "parameterTypes": [
+            "org.springframework.kafka.core.KafkaTemplate"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties$Admin",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties$Cleanup",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties$Consumer",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties$IsolationLevel",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties$Jaas",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties$Listener",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties$Listener$Type",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties$Producer",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties$Properties",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties$Retry",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties$Retry$Topic",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties$Retry$Topic$Backoff",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties$Security",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties$Ssl",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties$Streams",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties$Template",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.OnClassCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.OnBeanCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.OnPropertyCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.OnThreadingCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.kafka.annotation.KafkaListenerConfigurationSelector",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "selectImports",
+          "parameterTypes": [
+            "org.springframework.core.type.AnnotationMetadata"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.kafka.annotation.KafkaBootstrapConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "registerBeanDefinitions",
+          "parameterTypes": [
+            "org.springframework.core.type.AnnotationMetadata",
+            "org.springframework.beans.factory.support.BeanDefinitionRegistry"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.kafka.annotation.KafkaListenerAnnotationBeanPostProcessor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.kafka.config.KafkaListenerEndpointRegistry",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.apache.kafka.common.serialization.StringDeserializer",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.kafka.common.serialization.StringSerializer",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.springframework.kafka.listener.ContainerProperties$AckMode",
+      "allDeclaredFields": true,
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.springframework.kafka.listener.ContainerProperties",
+      "allPublicMethods": true
+    },
+    {
+      "type": "sun.security.provider.ConfigFile",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.springframework.context.annotation.ConfigurationClassParser$DefaultDeferredImportSelectorGroup",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaAnnotationDrivenConfiguration",
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaAnnotationDrivenConfiguration$EnableKafkaConfiguration",
+      "allDeclaredConstructors": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaStreamsAnnotationDrivenConfiguration",
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.springframework.boot.autoconfigure.AutoConfiguration"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.springframework.boot.autoconfigure.condition.ConditionalOnClass"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.springframework.boot.context.properties.EnableConfigurationProperties"
+        ]
+      }
+    },
+    {
+      "type": "org.springframework.boot.context.properties.EnableConfigurationPropertiesRegistrar",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.properties.ConfigurationPropertiesBindingPostProcessor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.properties.ConfigurationPropertiesBinder$ConfigurationPropertiesBinderFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.properties.BoundConfigurationProperties",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.validation.beanvalidation.MethodValidationExcludeFilter",
+      "methods": [
+        {
+          "name": "byAnnotation",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.springframework.context.ConfigurableApplicationContext",
+          "org.springframework.boot.test.context.assertj.AssertableApplicationContext"
+        ]
+      }
+    }
+  ],
+  "resources": [
+    {
+      "glob": "org/springframework/boot/kafka/autoconfigure/*.class"
+    },
+    {
+      "glob": "org/springframework/kafka/annotation/*.class"
+    },
+    {
+      "glob": "org/springframework/context/annotation/*.class"
+    },
+    {
+      "glob": "META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports"
+    },
+    {
+      "glob": "META-INF/spring-autoconfigure-metadata.properties"
+    },
+    {
+      "glob": "org/springframework/boot/context/properties/EnableConfigurationPropertiesRegistrar.class"
+    }
+  ]
+}

--- a/metadata/org.springframework.boot/spring-boot-kafka/index.json
+++ b/metadata/org.springframework.boot/spring-boot-kafka/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.0.2",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-kafka/$version$/spring-boot-kafka-$version$-sources.jar",
+    "repository-url" : "https://github.com/spring-projects/spring-boot",
+    "test-code-url" : "https://github.com/spring-projects/spring-boot/tree/v$version$/module/spring-boot-kafka/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-kafka/$version$/spring-boot-kafka-$version$-javadoc.jar",
+    "description" : "Spring Boot Kafka provides auto-configuration and support classes for integrating Spring Boot applications with Apache Kafka through Spring for Apache Kafka. It configures Kafka producers, consumers, listener containers, transactions, metrics, Kafka Streams, and Testcontainers connection details based on Spring Boot properties and user-defined beans.",
+    "tested-versions" : [
+      "4.0.2"
+    ],
+    "allowed-packages" : [
+      "org.springframework.boot.kafka"
+    ]
+  }
+]

--- a/stats/org.springframework.boot/spring-boot-kafka/4.0.2/execution-metrics.json
+++ b/stats/org.springframework.boot/spring-boot-kafka/4.0.2/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-19": {
+    "timestamp": "2026-05-19T09:47:52.853467Z",
+    "library": "org.springframework.boot:spring-boot-kafka:4.0.2",
+    "starting_commit": "55a4f24bb1de43562dd78bce10ea25b61b3666e8",
+    "ending_commit": "d451d280146189c02277093c66fc43aaa2503f61",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success_with_intervention",
+    "stats": {
+      "version": "4.0.2",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2488,
+          "missed": 824,
+          "ratio": 0.751208,
+          "total": 3312
+        },
+        "line": {
+          "covered": 580,
+          "missed": 252,
+          "ratio": 0.697115,
+          "total": 832
+        },
+        "method": {
+          "covered": 223,
+          "missed": 133,
+          "ratio": 0.626404,
+          "total": 356
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 268650,
+      "cached_input_tokens_used": 2337280,
+      "output_tokens_used": 20054,
+      "iterations": 5,
+      "cost_usd": 1.7702,
+      "generated_loc": 261,
+      "tested_library_loc": 580,
+      "metadata_entries": 141,
+      "code_coverage_percent": 69.71
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.springframework.boot/spring-boot-kafka/4.0.2/src/test/java/org_springframework_boot/spring_boot_kafka/Spring_boot_kafkaTest.java",
+      "metadata_file": "metadata/org.springframework.boot/spring-boot-kafka/4.0.2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.springframework.boot/spring-boot-kafka/4.0.2/stats.json
+++ b/stats/org.springframework.boot/spring-boot-kafka/4.0.2/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.0.2",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2488,
+        "missed" : 824,
+        "ratio" : 0.751208,
+        "total" : 3312
+      },
+      "line" : {
+        "covered" : 580,
+        "missed" : 252,
+        "ratio" : 0.697115,
+        "total" : 832
+      },
+      "method" : {
+        "covered" : 223,
+        "missed" : 133,
+        "ratio" : 0.626404,
+        "total" : 356
+      }
+    }
+  } ]
+}

--- a/tests/src/org.springframework.boot/spring-boot-kafka/4.0.2/.gitignore
+++ b/tests/src/org.springframework.boot/spring-boot-kafka/4.0.2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.springframework.boot/spring-boot-kafka/4.0.2/build.gradle
+++ b/tests/src/org.springframework.boot/spring-boot-kafka/4.0.2/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.springframework.boot:spring-boot-kafka:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.springframework.boot/spring-boot-kafka/4.0.2/build.gradle
+++ b/tests/src/org.springframework.boot/spring-boot-kafka/4.0.2/build.gradle
@@ -12,6 +12,8 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.springframework.boot:spring-boot-kafka:$libraryVersion"
+    testImplementation "org.springframework.boot:spring-boot-autoconfigure:$libraryVersion"
+    testImplementation "org.springframework.boot:spring-boot-test:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.springframework.boot/spring-boot-kafka/4.0.2/gradle.properties
+++ b/tests/src/org.springframework.boot/spring-boot-kafka/4.0.2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.springframework.boot:spring-boot-kafka:4.0.2
+library.version = 4.0.2
+metadata.dir = org.springframework.boot/spring-boot-kafka/4.0.2/

--- a/tests/src/org.springframework.boot/spring-boot-kafka/4.0.2/settings.gradle
+++ b/tests/src/org.springframework.boot/spring-boot-kafka/4.0.2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.springframework.boot.spring-boot-kafka_tests'

--- a/tests/src/org.springframework.boot/spring-boot-kafka/4.0.2/src/test/java/org_springframework_boot/spring_boot_kafka/Spring_boot_kafkaTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-kafka/4.0.2/src/test/java/org_springframework_boot/spring_boot_kafka/Spring_boot_kafkaTest.java
@@ -6,11 +6,235 @@
  */
 package org_springframework_boot.spring_boot_kafka;
 
-import org.junit.jupiter.api.Test;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
 
-class Spring_boot_kafkaTest {
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.context.annotation.ImportCandidates;
+import org.springframework.boot.kafka.autoconfigure.KafkaAutoConfiguration;
+import org.springframework.boot.kafka.autoconfigure.KafkaConnectionDetails;
+import org.springframework.boot.kafka.autoconfigure.KafkaProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaAdmin;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.retrytopic.RetryTopicConfiguration;
+import org.springframework.kafka.transaction.KafkaTransactionManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Spring_boot_kafkaTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(KafkaAutoConfiguration.class));
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void autoConfigurationIsAdvertisedForSpringBootDiscovery() {
+        ImportCandidates candidates = ImportCandidates.load(AutoConfiguration.class, getClass().getClassLoader());
+
+        assertThat(candidates.getCandidates()).contains(KafkaAutoConfiguration.class.getName());
     }
+
+    @Test
+    void kafkaConnectionDetailsConfigurationExposesSuppliedClientSettings() {
+        List<String> bootstrapServers = List.of("broker-a:9092", "broker-b:9092");
+        KafkaConnectionDetails.Configuration configuration = KafkaConnectionDetails.Configuration
+                .of(bootstrapServers, null, "SASL_SSL");
+
+        assertThat(configuration.getBootstrapServers()).containsExactlyElementsOf(bootstrapServers);
+        assertThat(configuration.getSslBundle()).isNull();
+        assertThat(configuration.getSecurityProtocol()).isEqualTo("SASL_SSL");
+    }
+
+    @Test
+    void kafkaPropertiesBuildSeparateClientConfigurationMaps() {
+        KafkaProperties properties = new KafkaProperties();
+        properties.setBootstrapServers(List.of("common:9092"));
+        properties.setClientId("common-client");
+        properties.getConsumer().setGroupId("orders");
+        properties.getConsumer().setEnableAutoCommit(false);
+        properties.getConsumer().setKeyDeserializer(StringDeserializer.class);
+        properties.getConsumer().getProperties().put("max.partition.fetch.bytes", "4096");
+        properties.getProducer().setAcks("all");
+        properties.getProducer().setRetries(2);
+        properties.getProducer().setKeySerializer(StringSerializer.class);
+        properties.getProducer().getProperties().put("linger.ms", "5");
+        properties.getAdmin().setClientId("admin-client");
+        properties.getAdmin().getProperties().put("request.timeout.ms", "2000");
+        properties.getStreams().setApplicationId("stream-app");
+        properties.getStreams().getProperties().put("num.stream.threads", "2");
+
+        Map<String, Object> consumerProperties = properties.buildConsumerProperties();
+        Map<String, Object> producerProperties = properties.buildProducerProperties();
+        Map<String, Object> adminProperties = properties.buildAdminProperties();
+        Map<String, Object> streamsProperties = properties.buildStreamsProperties();
+
+        assertThat(consumerProperties).containsEntry(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, List.of("common:9092"))
+                .containsEntry(ConsumerConfig.CLIENT_ID_CONFIG, "common-client")
+                .containsEntry(ConsumerConfig.GROUP_ID_CONFIG, "orders")
+                .containsEntry(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false)
+                .containsEntry(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class)
+                .containsEntry("max.partition.fetch.bytes", "4096");
+        assertThat(producerProperties).containsEntry(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, List.of("common:9092"))
+                .containsEntry(ProducerConfig.CLIENT_ID_CONFIG, "common-client")
+                .containsEntry(ProducerConfig.ACKS_CONFIG, "all")
+                .containsEntry(ProducerConfig.RETRIES_CONFIG, 2)
+                .containsEntry(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class)
+                .containsEntry("linger.ms", "5");
+        assertThat(adminProperties).containsEntry(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, List.of("common:9092"))
+                .containsEntry(AdminClientConfig.CLIENT_ID_CONFIG, "admin-client")
+                .containsEntry("request.timeout.ms", "2000");
+        assertThat(streamsProperties).containsEntry("bootstrap.servers", List.of("common:9092"))
+                .containsEntry("client.id", "common-client")
+                .containsEntry("application.id", "stream-app")
+                .containsEntry("num.stream.threads", "2");
+    }
+
+    @Test
+    void autoConfigurationBindsPropertiesAndCreatesKafkaInfrastructureBeans() {
+        this.contextRunner
+                .withPropertyValues("spring.kafka.bootstrap-servers=localhost:9092",
+                        "spring.kafka.consumer.group-id=orders",
+                        "spring.kafka.consumer.auto-offset-reset=earliest",
+                        "spring.kafka.consumer.key-deserializer="
+                                + "org.apache.kafka.common.serialization.StringDeserializer",
+                        "spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer",
+                        "spring.kafka.producer.transaction-id-prefix=tx-",
+                        "spring.kafka.template.default-topic=orders",
+                        "spring.kafka.template.transaction-id-prefix=template-tx-",
+                        "spring.kafka.admin.auto-create=false",
+                        "spring.kafka.admin.fail-fast=true",
+                        "spring.kafka.listener.ack-mode=manual",
+                        "spring.kafka.listener.concurrency=3",
+                        "spring.kafka.listener.poll-timeout=125ms",
+                        "spring.kafka.listener.missing-topics-fatal=false",
+                        "spring.kafka.listener.auto-startup=false",
+                        "spring.kafka.retry.topic.enabled=true",
+                        "spring.kafka.retry.topic.attempts=4")
+                .run((context) -> {
+                    assertThat(context).hasSingleBean(KafkaProperties.class);
+                    assertThat(context).hasSingleBean(KafkaConnectionDetails.class);
+                    assertThat(context).hasSingleBean(DefaultKafkaConsumerFactory.class);
+                    assertThat(context).hasSingleBean(DefaultKafkaProducerFactory.class);
+                    assertThat(context).hasSingleBean(KafkaTemplate.class);
+                    assertThat(context).hasSingleBean(KafkaAdmin.class);
+                    assertThat(context).hasSingleBean(KafkaTransactionManager.class);
+                    assertThat(context).hasSingleBean(ConcurrentKafkaListenerContainerFactory.class);
+                    assertThat(context).hasSingleBean(RetryTopicConfiguration.class);
+
+                    KafkaProperties properties = context.getBean(KafkaProperties.class);
+                    assertThat(properties.getConsumer().getGroupId()).isEqualTo("orders");
+                    assertThat(properties.getListener().getPollTimeout()).isEqualTo(Duration.ofMillis(125));
+                    assertThat(properties.getRetry().getTopic().getAttempts()).isEqualTo(4);
+
+                    DefaultKafkaConsumerFactory<?, ?> consumerFactory = context
+                            .getBean(DefaultKafkaConsumerFactory.class);
+                    DefaultKafkaProducerFactory<?, ?> producerFactory = context
+                            .getBean(DefaultKafkaProducerFactory.class);
+                    KafkaTemplate<?, ?> kafkaTemplate = context.getBean(KafkaTemplate.class);
+                    KafkaAdmin kafkaAdmin = context.getBean(KafkaAdmin.class);
+
+                    assertThat(consumerFactory.getConfigurationProperties())
+                            .containsEntry(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, List.of("localhost:9092"))
+                            .containsEntry(ConsumerConfig.GROUP_ID_CONFIG, "orders")
+                            .containsEntry(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+                            .containsEntry(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+                    assertThat(producerFactory.getConfigurationProperties())
+                            .containsEntry(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, List.of("localhost:9092"))
+                            .containsEntry(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+                    assertThat(producerFactory.getTransactionIdPrefix()).isEqualTo("tx-");
+                    assertThat(kafkaTemplate.getDefaultTopic()).isEqualTo("orders");
+                    assertThat(kafkaTemplate.getTransactionIdPrefix()).isEqualTo("template-tx-");
+                    assertThat(kafkaAdmin.getConfigurationProperties())
+                            .containsEntry(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, List.of("localhost:9092"));
+
+                    assertListenerContainerProperties(context.getBean(ConcurrentKafkaListenerContainerFactory.class));
+                });
+    }
+
+    @Test
+    void customConnectionDetailsOverridePropertyBasedBootstrapServersForClientFactories() {
+        this.contextRunner
+                .withBean(KafkaConnectionDetails.class, TestKafkaConnectionDetails::new)
+                .withPropertyValues("spring.kafka.bootstrap-servers=ignored:9092",
+                        "spring.kafka.admin.auto-create=false")
+                .run((context) -> {
+                    DefaultKafkaConsumerFactory<?, ?> consumerFactory = context
+                            .getBean(DefaultKafkaConsumerFactory.class);
+                    DefaultKafkaProducerFactory<?, ?> producerFactory = context
+                            .getBean(DefaultKafkaProducerFactory.class);
+                    KafkaAdmin kafkaAdmin = context.getBean(KafkaAdmin.class);
+
+                    assertThat(consumerFactory.getConfigurationProperties())
+                            .containsEntry(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, List.of("consumer:9092"))
+                            .containsEntry(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_PLAINTEXT");
+                    assertThat(producerFactory.getConfigurationProperties())
+                            .containsEntry(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, List.of("producer:9092"))
+                            .containsEntry(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL");
+                    assertThat(kafkaAdmin.getConfigurationProperties())
+                            .containsEntry(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, List.of("admin:9092"))
+                            .containsEntry(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "PLAINTEXT");
+                });
+    }
+
+    @SuppressWarnings("unchecked")
+    private void assertListenerContainerProperties(ConcurrentKafkaListenerContainerFactory<?, ?> rawFactory) {
+        ConcurrentKafkaListenerContainerFactory<Object, Object> factory =
+                (ConcurrentKafkaListenerContainerFactory<Object, Object>) rawFactory;
+        ConcurrentMessageListenerContainer<Object, Object> container = factory.createContainer("orders");
+        try {
+            ContainerProperties containerProperties = container.getContainerProperties();
+
+            assertThat(container.getConcurrency()).isEqualTo(3);
+            assertThat(containerProperties.getAckMode()).isSameAs(ContainerProperties.AckMode.MANUAL);
+            assertThat(containerProperties.getPollTimeout()).isEqualTo(125L);
+            assertThat(containerProperties.isMissingTopicsFatal()).isFalse();
+            assertThat(container.isAutoStartup()).isFalse();
+        } finally {
+            container.stop();
+        }
+    }
+
+    private static final class TestKafkaConnectionDetails implements KafkaConnectionDetails {
+
+        @Override
+        public List<String> getBootstrapServers() {
+            return List.of("default:9092");
+        }
+
+        @Override
+        public String getSecurityProtocol() {
+            return "SASL_PLAINTEXT";
+        }
+
+        @Override
+        public KafkaConnectionDetails.Configuration getConsumer() {
+            return KafkaConnectionDetails.Configuration.of(List.of("consumer:9092"), null, "SASL_PLAINTEXT");
+        }
+
+        @Override
+        public KafkaConnectionDetails.Configuration getProducer() {
+            return KafkaConnectionDetails.Configuration.of(List.of("producer:9092"), null, "SSL");
+        }
+
+        @Override
+        public KafkaConnectionDetails.Configuration getAdmin() {
+            return KafkaConnectionDetails.Configuration.of(List.of("admin:9092"), null, "PLAINTEXT");
+        }
+
+    }
+
 }

--- a/tests/src/org.springframework.boot/spring-boot-kafka/4.0.2/src/test/java/org_springframework_boot/spring_boot_kafka/Spring_boot_kafkaTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-kafka/4.0.2/src/test/java/org_springframework_boot/spring_boot_kafka/Spring_boot_kafkaTest.java
@@ -20,6 +20,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.context.annotation.ImportCandidates;
+import org.springframework.boot.kafka.autoconfigure.DefaultKafkaConsumerFactoryCustomizer;
+import org.springframework.boot.kafka.autoconfigure.DefaultKafkaProducerFactoryCustomizer;
 import org.springframework.boot.kafka.autoconfigure.KafkaAutoConfiguration;
 import org.springframework.boot.kafka.autoconfigure.KafkaConnectionDetails;
 import org.springframework.boot.kafka.autoconfigure.KafkaProperties;
@@ -162,6 +164,29 @@ public class Spring_boot_kafkaTest {
                             .containsEntry(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, List.of("localhost:9092"));
 
                     assertListenerContainerProperties(context.getBean(ConcurrentKafkaListenerContainerFactory.class));
+                });
+    }
+
+    @Test
+    void factoryCustomizersContributeAdditionalClientConfiguration() {
+        this.contextRunner
+                .withBean(DefaultKafkaConsumerFactoryCustomizer.class,
+                        () -> (factory) -> factory
+                                .updateConfigs(Map.of(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "25")))
+                .withBean(DefaultKafkaProducerFactoryCustomizer.class,
+                        () -> (factory) -> factory.updateConfigs(Map.of(ProducerConfig.LINGER_MS_CONFIG, "7")))
+                .withPropertyValues("spring.kafka.bootstrap-servers=localhost:9092",
+                        "spring.kafka.admin.auto-create=false")
+                .run((context) -> {
+                    DefaultKafkaConsumerFactory<?, ?> consumerFactory = context
+                            .getBean(DefaultKafkaConsumerFactory.class);
+                    DefaultKafkaProducerFactory<?, ?> producerFactory = context
+                            .getBean(DefaultKafkaProducerFactory.class);
+
+                    assertThat(consumerFactory.getConfigurationProperties())
+                            .containsEntry(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "25");
+                    assertThat(producerFactory.getConfigurationProperties())
+                            .containsEntry(ProducerConfig.LINGER_MS_CONFIG, "7");
                 });
     }
 

--- a/tests/src/org.springframework.boot/spring-boot-kafka/4.0.2/src/test/java/org_springframework_boot/spring_boot_kafka/Spring_boot_kafkaTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-kafka/4.0.2/src/test/java/org_springframework_boot/spring_boot_kafka/Spring_boot_kafkaTest.java
@@ -10,10 +10,14 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.Configuration;
+
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.security.plain.PlainLoginModule;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.Test;
@@ -34,6 +38,7 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
 import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.retrytopic.RetryTopicConfiguration;
+import org.springframework.kafka.security.jaas.KafkaJaasLoginModuleInitializer;
 import org.springframework.kafka.transaction.KafkaTransactionManager;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -164,6 +169,31 @@ public class Spring_boot_kafkaTest {
                             .containsEntry(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, List.of("localhost:9092"));
 
                     assertListenerContainerProperties(context.getBean(ConcurrentKafkaListenerContainerFactory.class));
+                });
+    }
+
+    @Test
+    void autoConfigurationCreatesJaasInitializerFromConfiguredLoginModule() {
+        this.contextRunner
+                .withPropertyValues("spring.kafka.bootstrap-servers=localhost:9092",
+                        "spring.kafka.admin.auto-create=false",
+                        "spring.kafka.jaas.enabled=true",
+                        "spring.kafka.jaas.login-module=" + PlainLoginModule.class.getName(),
+                        "spring.kafka.jaas.control-flag=required",
+                        "spring.kafka.jaas.options.username=alice",
+                        "spring.kafka.jaas.options.password=secret")
+                .run((context) -> {
+                    assertThat(context).hasSingleBean(KafkaJaasLoginModuleInitializer.class);
+
+                    AppConfigurationEntry[] entries = Configuration.getConfiguration().getAppConfigurationEntry(
+                            KafkaJaasLoginModuleInitializer.KAFKA_CLIENT_CONTEXT_NAME);
+                    assertThat(entries).hasSize(1);
+                    AppConfigurationEntry entry = entries[0];
+                    assertThat(entry.getLoginModuleName()).isEqualTo(PlainLoginModule.class.getName());
+                    assertThat(entry.getControlFlag()).isSameAs(
+                            AppConfigurationEntry.LoginModuleControlFlag.REQUIRED);
+                    assertThat(entry.getOptions().get("username")).isEqualTo("alice");
+                    assertThat(entry.getOptions().get("password")).isEqualTo("secret");
                 });
     }
 

--- a/tests/src/org.springframework.boot/spring-boot-kafka/4.0.2/src/test/java/org_springframework_boot/spring_boot_kafka/Spring_boot_kafkaTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-kafka/4.0.2/src/test/java/org_springframework_boot/spring_boot_kafka/Spring_boot_kafkaTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework_boot.spring_boot_kafka;
+
+import org.junit.jupiter.api.Test;
+
+class Spring_boot_kafkaTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.springframework.boot/spring-boot-kafka/4.0.2/user-code-filter.json
+++ b/tests/src/org.springframework.boot/spring-boot-kafka/4.0.2/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.springframework.boot.kafka.**"
+      "includeClasses" : "org.springframework.boot.kafka.**"
+    },
+    {
+      "includeClasses" : "org_springframework_boot.spring_boot_kafka.**"
     }
   ]
 }

--- a/tests/src/org.springframework.boot/spring-boot-kafka/4.0.2/user-code-filter.json
+++ b/tests/src/org.springframework.boot/spring-boot-kafka/4.0.2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.springframework.boot.kafka.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #7091

This PR introduces tests and metadata for org.springframework.boot:spring-boot-kafka:4.0.2, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 268650
- Cached input tokens: 2337280
- Output tokens: 20054
- Metadata entries: 141
- Iterations: 5
- Library coverage percentage: 69.71
- Generated lines of code: 261
- Tested library lines of code: 580

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `616ec1c4599bbf490061d254abcd0acd076f78af`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 2488/3312 (75.12%)
- Line: 580/832 (69.71%)
- Method: 223/356 (62.64%)

### Post-Generation Intervention

- Stage: `metadata_fix_failed`

- Intervention file: `post-gen-interventions/org.springframework.boot_spring-boot-kafka_4.0.2.md`

# Post-generation intervention report

Library: org.springframework.boot:spring-boot-kafka:4.0.2
Stage: metadata_fix_failed

## Summary

The reported native test failures are metadata-related. All seven generated JUnit tests failed in `:nativeTest` with the same startup-time Spring Boot auto-configuration error:

`java.lang.IllegalStateException: Unable to read meta-data for class org.springframework.boot.kafka.autoconfigure.KafkaAutoConfiguration`

The direct cause in the Gradle excerpt is:

`java.io.FileNotFoundException: class path resource [org/springframework/boot/kafka/autoconfigure/KafkaAutoConfiguration.class] cannot be opened because it does not exist`

Spring Boot's `AutoConfigurationSorter` reads auto-configuration class files as classpath resources through `SimpleMetadataReader`. In the native image, the `KafkaAutoConfiguration.class` resource was not available, so every test method that instantiated the generated test class or started the `ApplicationContextRunner` failed before the Kafka assertions could run.

## Root cause classification

This is not a generated-test bug, unsupported platform feature, or native-image limitation. The failing tests exercise valid Spring Boot Kafka behavior, and the failure is caused by missing native-image metadata for Spring Boot/Spring Kafka auto-configuration class resources and related reflective/class-loading paths.

At the failing checkpoint, the missing support included at least the class-file resource for:

- `org/springframework/boot/kafka/autoconfigure/KafkaAutoConfiguration.class`

The Codex metadata-fix log shows that fixing this first gap exposed further metadata gaps in the same startup path, including Spring Boot condition processing, Spring Kafka import selector resources, deferred import selector reflection, Kafka configuration/property binding reflection, Kafka serializer/deserializer class loading, JAAS login-module loading, and listener container configuration access. Those are all metadata requirements for the same generated Spring Boot Kafka support surface.

## Intervention decision

No generated test was removed.

The failures are metadata-related, so removing the tests would hide real reachability requirements for `org.springframework.boot:spring-boot-kafka:4.0.2`. The remaining generated support should be preserved because it covers meaningful library behavior:

- Spring Boot auto-configuration discovery for `KafkaAutoConfiguration`.
- Kafka property binding into consumer, producer, admin, streams, listener, retry, and JAAS settings.
- Creation of Kafka infrastructure beans such as consumer/producer factories, `KafkaTemplate`, `KafkaAdmin`, transaction manager, listener container factory, and retry topic configuration.
- Customizer and `KafkaConnectionDetails` override paths that are part of the public Spring Boot Kafka integration contract.

Keeping these tests preserves coverage for the metadata that native-image needs to run Spring Boot Kafka auto-configuration correctly.

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
