### PR TITLE
Fix shaded Netty native-image initialization in gRPC tests

### DIFF
--- a/metadata/io.grpc/grpc-netty-shaded/1.68.0/reachability-metadata.json
+++ b/metadata/io.grpc/grpc-netty-shaded/1.68.0/reachability-metadata.json
@@ -266,6 +266,39 @@
           ]
         }
       ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent"
+      },
+      "type": "io.grpc.netty.shaded.io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueColdProducerFields",
+      "fields": [
+        {
+          "name": "producerLimit"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent"
+      },
+      "type": "io.grpc.netty.shaded.io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueConsumerFields",
+      "fields": [
+        {
+          "name": "consumerIndex"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent"
+      },
+      "type": "io.grpc.netty.shaded.io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueProducerFields",
+      "fields": [
+        {
+          "name": "producerIndex"
+        }
+      ]
     }
   ],
   "resources": [

--- a/metadata/io.grpc/grpc-xds/1.68.0/reachability-metadata.json
+++ b/metadata/io.grpc/grpc-xds/1.68.0/reachability-metadata.json
@@ -153,6 +153,102 @@
       },
       "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.TlsKeyLog$Builder",
       "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.com.github.xds.data.orca.v3.OrcaLoadReport"
+      },
+      "type": "com.google.protobuf.ExtensionRegistry",
+      "methods": [
+        {
+          "name": "getEmptyRegistry",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.com.github.xds.service.orca.v3.OrcaLoadReportRequest"
+      },
+      "type": "com.google.protobuf.ExtensionRegistry",
+      "methods": [
+        {
+          "name": "getEmptyRegistry",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.config.core.v3.Node"
+      },
+      "type": "com.google.protobuf.ExtensionRegistry",
+      "methods": [
+        {
+          "name": "getEmptyRegistry",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "com.google.protobuf.ExtensionRegistry",
+      "methods": [
+        {
+          "name": "getEmptyRegistry",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.service.rate_limit_quota.v3.BucketId"
+      },
+      "type": "com.google.protobuf.ExtensionRegistry",
+      "methods": [
+        {
+          "name": "getEmptyRegistry",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.service.status.v3.ClientStatusRequest"
+      },
+      "type": "com.google.protobuf.ExtensionRegistry",
+      "methods": [
+        {
+          "name": "getEmptyRegistry",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.XdsChannelCredentials"
+      },
+      "type": "java.util.concurrent.atomic.LongAdder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.XdsServerBuilder"
+      },
+      "type": "java.util.concurrent.atomic.LongAdder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     }
   ]
 }

--- a/tests/src/com.google.cloud/grpc-gcp/1.10.0/build.gradle
+++ b/tests/src/com.google.cloud/grpc-gcp/1.10.0/build.gradle
@@ -22,6 +22,14 @@ dependencies {
 }
 
 graalvmNative {
+    binaries {
+        test {
+            excludeConfig.put("io.grpc:grpc-netty-shaded", [
+                    ".*/netty-codec-http/native-image\\.properties",
+                    ".*/netty-codec-http2/native-image\\.properties"
+            ])
+        }
+    }
     agent {
         defaultMode = "conditional"
         modes {

--- a/tests/src/io.grpc/grpc-googleapis/1.80.0/build.gradle
+++ b/tests/src/io.grpc/grpc-googleapis/1.80.0/build.gradle
@@ -16,6 +16,14 @@ dependencies {
 }
 
 graalvmNative {
+    binaries {
+        test {
+            excludeConfig.put("io.grpc:grpc-netty-shaded", [
+                    ".*/netty-codec-http/native-image\\.properties",
+                    ".*/netty-codec-http2/native-image\\.properties"
+            ])
+        }
+    }
     agent {
         defaultMode = "conditional"
         modes {

--- a/tests/src/io.grpc/grpc-xds/1.68.0/build.gradle
+++ b/tests/src/io.grpc/grpc-xds/1.68.0/build.gradle
@@ -16,6 +16,14 @@ dependencies {
 }
 
 graalvmNative {
+    binaries {
+        test {
+            excludeConfig.put("io.grpc:grpc-netty-shaded", [
+                    ".*/netty-codec-http/native-image\\.properties",
+                    ".*/netty-codec-http2/native-image\\.properties"
+            ])
+        }
+    }
     agent {
         defaultMode = "conditional"
         modes {


### PR DESCRIPTION
## Summary

This PR fixes the native-image build failures reported for:

- Fixes #6834
- Fixes #6836
- Fixes #6838

The changes are intentionally split into two commits:

1. Exclude the upstream shaded Netty HTTP/HTTP2 `native-image.properties` files from the affected test builds.
2. Add the additional runtime reachability metadata needed by `io.grpc:grpc-xds:1.68.0` after the native image can build successfully.

## Why the properties exclusions are needed

The affected test coordinates all pull in `io.grpc:grpc-netty-shaded` transitively:

- `com.google.cloud:grpc-gcp:1.10.0` pulls `grpc-netty-shaded:1.69.0`
- `io.grpc:grpc-googleapis:1.80.0` pulls `grpc-netty-shaded:1.80.0`
- `io.grpc:grpc-xds:1.68.0` pulls `grpc-netty-shaded:1.68.0`

Those upstream jars contain Netty-provided configuration at:

- `META-INF/native-image/io.grpc.netty.shaded.io.netty/netty-codec-http/native-image.properties`
- `META-INF/native-image/io.grpc.netty.shaded.io.netty/netty-codec-http2/native-image.properties`

Both files include a broad directive:

```text
--initialize-at-build-time=io.grpc.netty.shaded.io.netty
```

That directive asks native-image to initialize the shaded Netty package at image build time. Once the recently added `grpc-netty-shaded` metadata makes shaded Netty/tcnative/OpenSSL classes reachable, image building can try to initialize classes such as `SSL`, `SSLPrivateKeyMethod`, `CertificateVerifier`, or `CertificateCompressionAlgo`. Their class initialization calls native tcnative/OpenSSL methods, which are not available in the image build phase, so the build fails with `UnsatisfiedLinkError` wrapped as class-initialization failures.

The repository metadata policy avoids shipping class-initialization directives. Excluding only these two upstream properties files in the affected tests removes the problematic package-wide build-time initialization while leaving the rest of the upstream Netty native-image resources and JSON metadata available.

## Why grpc-xds also needs metadata

After the build-time initialization issue is removed, `io.grpc:grpc-xds:1.68.0` can build its native image, but native runtime tests expose missing metadata that is separate from the properties problem.

The xDS proto paths need reflective access to `com.google.protobuf.ExtensionRegistry.getEmptyRegistry()`. Newer `grpc-xds` metadata versions already contain equivalent entries, so this PR backfills the same pattern for `1.68.0`.

The xDS channel credentials path also creates shaded Netty event loops. That path initializes JCTools MPSC queue classes through Netty's `PlatformDependent`, which uses `Unsafe.objectFieldOffset(...)` for private queue index fields. Since those classes live in `io.grpc:grpc-netty-shaded`, the corresponding field metadata belongs in `metadata/io.grpc/grpc-netty-shaded/1.68.0`, not in the downstream xDS artifact.

## Verification

- `./gradlew checkMetadataFiles -Pcoordinates=io.grpc:grpc-xds:1.68.0 --stacktrace`
- `./gradlew checkMetadataFiles -Pcoordinates=io.grpc:grpc-netty-shaded:1.68.0 --stacktrace`
- `GVM_TCK_NATIVE_IMAGE_MODE=current-defaults GVM_TCK_LV=1.10.0 ./gradlew test -Pcoordinates="com.google.cloud:grpc-gcp:1.10.0" --stacktrace`
- `GVM_TCK_NATIVE_IMAGE_MODE=current-defaults GVM_TCK_LV=1.80.0 ./gradlew test -Pcoordinates="io.grpc:grpc-googleapis:1.80.0" --stacktrace`
- `GVM_TCK_NATIVE_IMAGE_MODE=current-defaults GVM_TCK_LV=1.68.0 ./gradlew test -Pcoordinates="io.grpc:grpc-xds:1.68.0" --stacktrace`
- `GVM_TCK_NATIVE_IMAGE_MODE=current-defaults GVM_TCK_LV=1.68.0 ./gradlew test -Pcoordinates="io.grpc:grpc-netty-shaded:1.68.0" --stacktrace`
- `git diff --check`