### PR TITLE
[GenAI] Add support for org.springframework.boot:spring-boot-web-server:4.0.2 using gpt-5.5

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-web-server/4.0.2/reachability-metadata.json
+++ b/metadata/org.springframework.boot/spring-boot-web-server/4.0.2/reachability-metadata.json
@@ -15,6 +15,9 @@
   ],
   "resources" : [
     {
+      "glob" : "org/springframework/boot/web/server/mime-mappings.properties"
+    },
+    {
       "condition" : {
         "typeReached" : "org.springframework.boot.web.server.servlet.CookieSameSiteSupplier"
       },

--- a/stats/org.springframework.boot/spring-boot-web-server/4.0.2/execution-metrics.json
+++ b/stats/org.springframework.boot/spring-boot-web-server/4.0.2/execution-metrics.json
@@ -1,9 +1,9 @@
 {
   "add_new_library_support:2026-05-19": {
-    "timestamp": "2026-05-19T06:30:30.330326Z",
+    "timestamp": "2026-05-19T11:25:50.889977Z",
     "library": "org.springframework.boot:spring-boot-web-server:4.0.2",
-    "starting_commit": "b12516c75836fd987e22b2fb0192acbcda27a75c",
-    "ending_commit": "a545a93a257003463157315ffbca4bfa55642810",
+    "starting_commit": "6997c67dfb5965c478f05d9c0df89275adb79ca8",
+    "ending_commit": "cc31c0dd2d759ba663d303fe4c384d2acc04b67f",
     "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
     "agent": "pi",
     "model": "oca/gpt-5.5",
@@ -18,35 +18,35 @@
       },
       "libraryCoverage": {
         "instruction": {
-          "covered": 2944,
-          "missed": 3709,
-          "ratio": 0.442507,
+          "covered": 3723,
+          "missed": 2930,
+          "ratio": 0.559597,
           "total": 6653
         },
         "line": {
-          "covered": 835,
-          "missed": 833,
-          "ratio": 0.5006,
+          "covered": 993,
+          "missed": 675,
+          "ratio": 0.595324,
           "total": 1668
         },
         "method": {
-          "covered": 359,
-          "missed": 242,
-          "ratio": 0.597338,
+          "covered": 405,
+          "missed": 196,
+          "ratio": 0.673877,
           "total": 601
         }
       }
     },
     "metrics": {
-      "input_tokens_used": 228468,
-      "cached_input_tokens_used": 3533312,
-      "output_tokens_used": 35181,
+      "input_tokens_used": 188963,
+      "cached_input_tokens_used": 2536960,
+      "output_tokens_used": 23386,
       "iterations": 5,
-      "cost_usd": 2.8221,
-      "generated_loc": 540,
-      "tested_library_loc": 835,
-      "metadata_entries": 3,
-      "code_coverage_percent": 50.06
+      "cost_usd": 1.9701,
+      "generated_loc": 734,
+      "tested_library_loc": 993,
+      "metadata_entries": 4,
+      "code_coverage_percent": 59.53
     },
     "artifacts": {
       "test_file": "tests/src/org.springframework.boot/spring-boot-web-server/4.0.2/src/test/java/org_springframework_boot/spring_boot_web_server/Spring_boot_web_serverTest.java",

--- a/stats/org.springframework.boot/spring-boot-web-server/4.0.2/stats.json
+++ b/stats/org.springframework.boot/spring-boot-web-server/4.0.2/stats.json
@@ -9,21 +9,21 @@
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 2944,
-        "missed" : 3709,
-        "ratio" : 0.442507,
+        "covered" : 3723,
+        "missed" : 2930,
+        "ratio" : 0.559597,
         "total" : 6653
       },
       "line" : {
-        "covered" : 835,
-        "missed" : 833,
-        "ratio" : 0.5006,
+        "covered" : 993,
+        "missed" : 675,
+        "ratio" : 0.595324,
         "total" : 1668
       },
       "method" : {
-        "covered" : 359,
-        "missed" : 242,
-        "ratio" : 0.597338,
+        "covered" : 405,
+        "missed" : 196,
+        "ratio" : 0.673877,
         "total" : 601
       }
     }

--- a/tests/src/org.springframework.boot/spring-boot-web-server/4.0.2/build.gradle
+++ b/tests/src/org.springframework.boot/spring-boot-web-server/4.0.2/build.gradle
@@ -11,7 +11,9 @@ plugins {
 String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
+    testImplementation platform("org.springframework.boot:spring-boot-dependencies:$libraryVersion")
     testImplementation "org.springframework.boot:spring-boot-web-server:$libraryVersion"
+    testImplementation 'io.projectreactor:reactor-core'
     testImplementation 'jakarta.servlet:jakarta.servlet-api:6.0.0'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }

--- a/tests/src/org.springframework.boot/spring-boot-web-server/4.0.2/src/test/java/org_springframework_boot/spring_boot_web_server/Spring_boot_web_serverTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-web-server/4.0.2/src/test/java/org_springframework_boot/spring_boot_web_server/Spring_boot_web_serverTest.java
@@ -21,6 +21,9 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -29,6 +32,8 @@ import java.util.regex.Pattern;
 import org.apache.commons.logging.LogFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import reactor.core.publisher.Mono;
+
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.ssl.NoSuchSslBundleException;
@@ -50,10 +55,16 @@ import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.boot.web.server.WebServerFactoryCustomizerBeanPostProcessor;
 import org.springframework.boot.web.server.WebServerSslBundle;
 import org.springframework.boot.web.server.autoconfigure.ServerProperties;
+import org.springframework.boot.web.server.autoconfigure.reactive.ReactiveWebServerFactoryCustomizer;
+import org.springframework.boot.web.server.autoconfigure.servlet.ServletWebServerFactoryCustomizer;
 import org.springframework.boot.web.server.context.MissingWebServerFactoryBeanException;
 import org.springframework.boot.web.server.context.ServerPortInfoApplicationContextInitializer;
+import org.springframework.boot.web.server.context.WebServerApplicationContext;
+import org.springframework.boot.web.server.context.WebServerGracefulShutdownLifecycle;
 import org.springframework.boot.web.server.context.WebServerInitializedEvent;
 import org.springframework.boot.web.server.context.WebServerPortFileWriter;
+import org.springframework.boot.web.server.reactive.AbstractReactiveWebServerFactory;
+import org.springframework.boot.web.server.reactive.ConfigurableReactiveWebServerFactory;
 import org.springframework.boot.web.server.servlet.ConfigurableServletWebServerFactory;
 import org.springframework.boot.web.server.servlet.ContextPath;
 import org.springframework.boot.web.server.servlet.CookieSameSiteSupplier;
@@ -69,6 +80,7 @@ import org.springframework.boot.web.server.servlet.context.ServletWebServerAppli
 import org.springframework.boot.web.server.servlet.context.ServletWebServerInitializedEvent;
 import org.springframework.boot.web.servlet.ServletContextInitializer;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.HttpHandler;
 import org.springframework.util.unit.DataSize;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -344,6 +356,76 @@ public class Spring_boot_web_serverTest {
     }
 
     @Test
+    void autoConfigurationCustomizersApplyServerPropertiesToFactories() throws Exception {
+        ServerProperties properties = new ServerProperties();
+        properties.setPort(9090);
+        properties.setAddress(InetAddress.getLoopbackAddress());
+        properties.setServerHeader("customized-server");
+        properties.setShutdown(Shutdown.GRACEFUL);
+        properties.setMimeMappings(Map.of("br", "application/brotli"));
+        properties.getCompression().setEnabled(true);
+        properties.getCompression().setMinResponseSize(DataSize.ofBytes(512));
+        properties.getHttp2().setEnabled(true);
+        properties.setSsl(Ssl.forBundle("customizer-bundle"));
+        properties.getServlet().setContextPath("/custom");
+        properties.getServlet().setApplicationDisplayName("customized-app");
+        properties.getServlet().setRegisterDefaultServlet(true);
+        properties.getServlet().getContextParameters().put("from", "server-properties");
+        properties.getServlet().getJsp().setClassName("org.example.CustomJspServlet");
+        properties.getServlet().getSession().setTimeout(Duration.ofSeconds(45));
+        properties.getServlet().getSession().getCookie().setName("CUSTOMSESSION");
+        properties.getServlet().getEncoding().setMapping(Map.of(Locale.GERMAN, StandardCharsets.ISO_8859_1));
+        TestSslBundles sslBundles = new TestSslBundles();
+        CookieSameSiteSupplier sameSiteSupplier = CookieSameSiteSupplier.ofStrict().whenHasName("CUSTOMSESSION");
+
+        TestServletWebServerFactory servletFactory = new TestServletWebServerFactory();
+        ServletWebServerFactoryCustomizer servletCustomizer = new ServletWebServerFactoryCustomizer(properties,
+                List.of(registry -> registry.addWebListeners("org.example.CustomListener")),
+                List.of(sameSiteSupplier), sslBundles);
+        servletCustomizer.customize(servletFactory);
+
+        assertThat(servletCustomizer.getOrder()).isZero();
+        assertThat(servletFactory.getPort()).isEqualTo(9090);
+        assertThat(servletFactory.getAddress()).isEqualTo(InetAddress.getLoopbackAddress());
+        assertThat(servletFactory.getServerHeader()).isEqualTo("customized-server");
+        assertThat(servletFactory.getShutdown()).isEqualTo(Shutdown.GRACEFUL);
+        assertThat(servletFactory.getSsl().getBundle()).isEqualTo("customizer-bundle");
+        assertThat(servletFactory.getSslBundles()).isSameAs(sslBundles);
+        assertThat(servletFactory.getCompression().getEnabled()).isTrue();
+        assertThat(servletFactory.getCompression().getMinResponseSize()).isEqualTo(DataSize.ofBytes(512));
+        assertThat(servletFactory.getHttp2().isEnabled()).isTrue();
+        assertThat(servletFactory.getContextPath()).isEqualTo("/custom");
+        assertThat(servletFactory.getSettings().getDisplayName()).isEqualTo("customized-app");
+        assertThat(servletFactory.getSettings().isRegisterDefaultServlet()).isTrue();
+        assertThat(servletFactory.getSettings().getMimeMappings().get("br")).isEqualTo("application/brotli");
+        assertThat(servletFactory.getSettings().getInitParameters()).containsEntry("from", "server-properties");
+        assertThat(servletFactory.getSettings().getJsp().getClassName()).isEqualTo("org.example.CustomJspServlet");
+        assertThat(servletFactory.getSettings().getSession().getTimeout()).isEqualTo(Duration.ofSeconds(45));
+        assertThat(servletFactory.getSettings().getSession().getCookie().getName()).isEqualTo("CUSTOMSESSION");
+        assertThat(servletFactory.getSettings().getLocaleCharsetMappings())
+                .containsEntry(Locale.GERMAN, StandardCharsets.ISO_8859_1);
+        assertThat(servletFactory.getSettings().getCookieSameSiteSuppliers()).hasSize(1);
+        assertThat(servletFactory.getSettings().getCookieSameSiteSuppliers().get(0)).isSameAs(sameSiteSupplier);
+        assertThat(servletFactory.getSettings().getWebListenerClassNames())
+                .containsExactly("org.example.CustomListener");
+
+        TestReactiveWebServerFactory reactiveFactory = new TestReactiveWebServerFactory();
+        ReactiveWebServerFactoryCustomizer reactiveCustomizer = new ReactiveWebServerFactoryCustomizer(properties,
+                sslBundles);
+        reactiveCustomizer.customize(reactiveFactory);
+
+        assertThat(reactiveCustomizer.getOrder()).isZero();
+        assertThat(reactiveFactory.getPort()).isEqualTo(9090);
+        assertThat(reactiveFactory.getAddress()).isEqualTo(InetAddress.getLoopbackAddress());
+        assertThat(reactiveFactory.getServerHeader()).isNull();
+        assertThat(reactiveFactory.getShutdown()).isEqualTo(Shutdown.GRACEFUL);
+        assertThat(reactiveFactory.getSsl().getBundle()).isEqualTo("customizer-bundle");
+        assertThat(reactiveFactory.getSslBundles()).isSameAs(sslBundles);
+        assertThat(reactiveFactory.getCompression().getEnabled()).isTrue();
+        assertThat(reactiveFactory.getHttp2().isEnabled()).isTrue();
+    }
+
+    @Test
     void webServerSslBundleResolvesNamedBundlesAndInlineConfiguration(@TempDir File tempDir) throws Exception {
         SslBundle namedBundle = SslBundle.of(SslStoreBundle.NONE);
         Ssl namedSsl = Ssl.forBundle("test-bundle");
@@ -414,6 +496,67 @@ public class Spring_boot_web_serverTest {
         }
 
         assertThat(webServer.stopped).isTrue();
+    }
+
+    @Test
+    void webServerApplicationContextNamespaceUtilitiesInspectCurrentContext() {
+        TestServletWebServerFactory factory = new TestServletWebServerFactory();
+        factory.webServer = new RecordingWebServer(49200);
+
+        try (AnnotationConfigServletWebServerApplicationContext parent =
+                new AnnotationConfigServletWebServerApplicationContext()) {
+            parent.setServerNamespace("parent");
+            parent.registerBean(ServletWebServerFactory.class, () -> factory);
+            parent.refresh();
+
+            try (AnnotationConfigServletWebServerApplicationContext child =
+                    new AnnotationConfigServletWebServerApplicationContext()) {
+                child.setParent(parent);
+                child.setServerNamespace("child");
+
+                assertThat(WebServerApplicationContext.getServerNamespace(parent)).isEqualTo("parent");
+                assertThat(WebServerApplicationContext.getServerNamespace(child)).isEqualTo("child");
+                assertThat(WebServerApplicationContext.hasServerNamespace(child, "child")).isTrue();
+                assertThat(WebServerApplicationContext.hasServerNamespace(child, "parent")).isFalse();
+                assertThat(WebServerApplicationContext.hasServerNamespace(child, "missing")).isFalse();
+            }
+        }
+    }
+
+    @Test
+    void gracefulShutdownLifecycleStopsServerAndInvokesCallback() throws Exception {
+        RecordingWebServer server = new RecordingWebServer(0);
+        WebServerGracefulShutdownLifecycle lifecycle = new WebServerGracefulShutdownLifecycle(server);
+        CountDownLatch stopped = new CountDownLatch(1);
+
+        lifecycle.start();
+        lifecycle.stop(stopped::countDown);
+
+        assertThat(lifecycle.getPhase()).isEqualTo(WebServerApplicationContext.GRACEFUL_SHUTDOWN_PHASE);
+        assertThat(lifecycle.isPauseable()).isFalse();
+        assertThat(lifecycle.isRunning()).isFalse();
+        assertThat(stopped.await(1, TimeUnit.SECONDS)).isTrue();
+        assertThat(server.stopped).isFalse();
+    }
+
+    @Test
+    void reactiveWebServerFactoryCanCreateServerFromHttpHandler() {
+        TestReactiveWebServerFactory factory = new TestReactiveWebServerFactory();
+        RecordingWebServer webServer = new RecordingWebServer(49300);
+        factory.webServer = webServer;
+        AtomicBoolean handled = new AtomicBoolean();
+        HttpHandler handler = (request, response) -> {
+            handled.set(true);
+            return Mono.empty();
+        };
+
+        WebServer createdServer = factory.getWebServer(handler);
+        createdServer.start();
+
+        assertThat(createdServer).isSameAs(webServer);
+        assertThat(factory.httpHandler).isSameAs(handler);
+        assertThat(webServer.started).isTrue();
+        assertThat(handled).isFalse();
     }
 
     @Test
@@ -574,6 +717,18 @@ public class Spring_boot_web_serverTest {
         @Override
         public void addWebListeners(String... webListenerClassNames) {
             this.settings.addWebListenerClassNames(webListenerClassNames);
+        }
+    }
+
+    static final class TestReactiveWebServerFactory extends AbstractReactiveWebServerFactory
+            implements ConfigurableReactiveWebServerFactory {
+        private WebServer webServer = new RecordingWebServer(0);
+        private HttpHandler httpHandler;
+
+        @Override
+        public WebServer getWebServer(HttpHandler httpHandler) {
+            this.httpHandler = httpHandler;
+            return this.webServer;
         }
     }
 

--- a/tests/src/org.springframework.boot/spring-boot-web-server/4.0.2/src/test/java/org_springframework_boot/spring_boot_web_server/Spring_boot_web_serverTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-web-server/4.0.2/src/test/java/org_springframework_boot/spring_boot_web_server/Spring_boot_web_serverTest.java
@@ -67,6 +67,7 @@ import org.springframework.boot.web.server.reactive.AbstractReactiveWebServerFac
 import org.springframework.boot.web.server.reactive.ConfigurableReactiveWebServerFactory;
 import org.springframework.boot.web.server.reactive.ReactiveWebServerFactory;
 import org.springframework.boot.web.server.reactive.context.AnnotationConfigReactiveWebServerApplicationContext;
+import org.springframework.boot.web.server.reactive.context.ReactiveWebServerApplicationContext;
 import org.springframework.boot.web.server.reactive.context.ReactiveWebServerInitializedEvent;
 import org.springframework.boot.web.server.servlet.ConfigurableServletWebServerFactory;
 import org.springframework.boot.web.server.servlet.ContextPath;
@@ -540,6 +541,27 @@ public class Spring_boot_web_serverTest {
         }
 
         assertThat(webServer.stopped).isTrue();
+    }
+
+    @Test
+    void reactiveWebServerApplicationContextDelegatesToHttpHandlerAfterRefresh() {
+        TestReactiveWebServerFactory factory = new TestReactiveWebServerFactory();
+        factory.webServer = new RecordingWebServer(0);
+        AtomicBoolean handled = new AtomicBoolean();
+        HttpHandler handler = (request, response) -> {
+            handled.set(true);
+            return Mono.empty();
+        };
+
+        try (ReactiveWebServerApplicationContext context = new ReactiveWebServerApplicationContext()) {
+            context.registerBean(ReactiveWebServerFactory.class, () -> factory);
+            context.registerBean(HttpHandler.class, () -> handler);
+
+            context.refresh();
+            factory.httpHandler.handle(null, null).block(Duration.ofSeconds(1));
+
+            assertThat(handled).isTrue();
+        }
     }
 
     @Test

--- a/tests/src/org.springframework.boot/spring-boot-web-server/4.0.2/src/test/java/org_springframework_boot/spring_boot_web_server/Spring_boot_web_serverTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-web-server/4.0.2/src/test/java/org_springframework_boot/spring_boot_web_server/Spring_boot_web_serverTest.java
@@ -65,6 +65,9 @@ import org.springframework.boot.web.server.context.WebServerInitializedEvent;
 import org.springframework.boot.web.server.context.WebServerPortFileWriter;
 import org.springframework.boot.web.server.reactive.AbstractReactiveWebServerFactory;
 import org.springframework.boot.web.server.reactive.ConfigurableReactiveWebServerFactory;
+import org.springframework.boot.web.server.reactive.ReactiveWebServerFactory;
+import org.springframework.boot.web.server.reactive.context.AnnotationConfigReactiveWebServerApplicationContext;
+import org.springframework.boot.web.server.reactive.context.ReactiveWebServerInitializedEvent;
 import org.springframework.boot.web.server.servlet.ConfigurableServletWebServerFactory;
 import org.springframework.boot.web.server.servlet.ContextPath;
 import org.springframework.boot.web.server.servlet.CookieSameSiteSupplier;
@@ -493,6 +496,47 @@ public class Spring_boot_web_serverTest {
             assertThat(event.get().getWebServer()).isSameAs(webServer);
             assertThat(event.get().getApplicationContext()).isSameAs(context);
             assertThat(context.getEnvironment().getProperty("local.test.port", Integer.class)).isEqualTo(49152);
+        }
+
+        assertThat(webServer.stopped).isTrue();
+    }
+
+    @Test
+    void reactiveWebServerApplicationContextStartsFactoryServerAndPublishesPort() {
+        TestReactiveWebServerFactory factory = new TestReactiveWebServerFactory();
+        RecordingWebServer webServer = new RecordingWebServer(49500);
+        factory.webServer = webServer;
+        AtomicReference<ReactiveWebServerInitializedEvent> event = new AtomicReference<>();
+        AtomicBoolean handled = new AtomicBoolean();
+        HttpHandler handler = (request, response) -> {
+            handled.set(true);
+            return Mono.empty();
+        };
+
+        try (AnnotationConfigReactiveWebServerApplicationContext context =
+                new AnnotationConfigReactiveWebServerApplicationContext()) {
+            context.setServerNamespace("reactive");
+            context.registerBean(ReactiveWebServerFactory.class, () -> factory);
+            context.registerBean(HttpHandler.class, () -> handler);
+            context.addApplicationListener(applicationEvent -> {
+                if (applicationEvent instanceof ReactiveWebServerInitializedEvent webServerEvent) {
+                    event.set(webServerEvent);
+                }
+            });
+            new ServerPortInfoApplicationContextInitializer().initialize(context);
+
+            context.refresh();
+
+            assertThat(context.getServerNamespace()).isEqualTo("reactive");
+            assertThat(WebServerApplicationContext.getServerNamespace(context)).isEqualTo("reactive");
+            assertThat(context.getWebServer()).isSameAs(webServer);
+            assertThat(webServer.started).isTrue();
+            assertThat(factory.httpHandler).isNotNull();
+            assertThat(handled).isFalse();
+            assertThat(event.get()).isNotNull();
+            assertThat(event.get().getWebServer()).isSameAs(webServer);
+            assertThat(event.get().getApplicationContext()).isSameAs(context);
+            assertThat(context.getEnvironment().getProperty("local.reactive.port", Integer.class)).isEqualTo(49500);
         }
 
         assertThat(webServer.stopped).isTrue();


### PR DESCRIPTION

## What does this PR do?

Fixes: #7083

This PR introduces tests and metadata for org.springframework.boot:spring-boot-web-server:4.0.2, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 188963
- Cached input tokens: 2536960
- Output tokens: 23386
- Metadata entries: 4
- Iterations: 5
- Library coverage percentage: 59.53
- Generated lines of code: 734
- Tested library lines of code: 993

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `6997c67dfb5965c478f05d9c0df89275adb79ca8`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 3723/6653 (55.96%)
- Line: 993/1668 (59.53%)
- Method: 405/601 (67.39%)

### Local CI Verification

- Status: `success`
- Commands run: 12
- Fixup attempts: 0
