### PR TITLE
[GenAI] Test fix for org.codehaus.plexus:plexus-java:1.0.0 using gpt-5.5

### DIFF
--- a/metadata/org.codehaus.plexus/plexus-java/1.0.0/reachability-metadata.json
+++ b/metadata/org.codehaus.plexus/plexus-java/1.0.0/reachability-metadata.json
@@ -1,0 +1,54 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.codehaus.plexus.languages.java.jpms.MainClassModuleNameExtractor"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.plexus.languages.java.jpms.MainClassModuleNameExtractor"
+      },
+      "type": "java.lang.module.ModuleDescriptor",
+      "methods": [
+        {
+          "name": "name",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.plexus.languages.java.jpms.MainClassModuleNameExtractor"
+      },
+      "type": "java.lang.module.ModuleReference",
+      "methods": [
+        {
+          "name": "descriptor",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.plexus.languages.java.jpms.MainClassModuleNameExtractor"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.plexus.languages.java.jpms.MainClassModuleNameExtractor"
+      },
+      "type": "jdk.internal.module.ModuleReferenceImpl"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.codehaus.plexus.languages.java.jpms.MainClassModuleNameExtractor"
+      },
+      "glob": "META-INF/versions/9/org/codehaus/plexus/languages/java/jpms/CmdModuleNameExtractor.class"
+    }
+  ]
+}

--- a/metadata/org.codehaus.plexus/plexus-java/index.json
+++ b/metadata/org.codehaus.plexus/plexus-java/index.json
@@ -15,6 +15,15 @@
     ]
   },
   {
+    "metadata-version" : "1.0.0",
+    "tested-versions" : [
+      "1.0.0"
+    ],
+    "allowed-packages" : [
+      "org.codehaus.plexus.languages.java"
+    ]
+  },
+  {
     "metadata-version" : "0.9.11",
     "source-code-url" : "https://repo1.maven.org/maven2/org/codehaus/plexus/plexus-java/$version$/plexus-java-$version$-sources.jar",
     "repository-url" : "https://github.com/codehaus-plexus/plexus-languages",

--- a/metadata/org.codehaus.plexus/plexus-java/index.json
+++ b/metadata/org.codehaus.plexus/plexus-java/index.json
@@ -16,6 +16,11 @@
   },
   {
     "metadata-version" : "1.0.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/codehaus/plexus/plexus-java/$version$/plexus-java-$version$-sources.jar",
+    "repository-url" : "https://github.com/codehaus-plexus/plexus-languages",
+    "test-code-url" : "https://github.com/codehaus-plexus/plexus-languages/tree/plexus-languages-$version$/plexus-java/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/codehaus/plexus/plexus-java/$version$/plexus-java-$version$-javadoc.jar",
+    "description" : "Plexus Java is the Java-language module of Plexus Languages, providing JVM utilities for reading JPMS module descriptors and deriving module names from Java artifacts. It also includes Java version parsing helpers used by Maven and Plexus tooling when inspecting Java libraries.",
     "tested-versions" : [
       "1.0.0"
     ],

--- a/stats/org.codehaus.plexus/plexus-java/1.0.0/execution-metrics.json
+++ b/stats/org.codehaus.plexus/plexus-java/1.0.0/execution-metrics.json
@@ -1,0 +1,104 @@
+{
+  "fix_javac_fail:2026-05-19": {
+    "timestamp": "2026-05-19T11:43:04.580255Z",
+    "library": "org.codehaus.plexus:plexus-java:1.0.0",
+    "starting_commit": "b4e62aac9c05784b3041640e94656ed74d6acc55",
+    "ending_commit": "e54fa46663ecb1d73c43d611c2910371e22bd792",
+    "previous_library": "org.codehaus.plexus:plexus-java:0.9.10",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.0.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 199,
+          "missed": 2278,
+          "ratio": 0.080339,
+          "total": 2477
+        },
+        "line": {
+          "covered": 41,
+          "missed": 519,
+          "ratio": 0.073214,
+          "total": 560
+        },
+        "method": {
+          "covered": 5,
+          "missed": 138,
+          "ratio": 0.034965,
+          "total": 143
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "0.9.10",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 6,
+            "totalCalls": 6
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 7,
+        "totalCalls": 7
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 291,
+          "missed": 1534,
+          "ratio": 0.159452,
+          "total": 1825
+        },
+        "line": {
+          "covered": 55,
+          "missed": 371,
+          "ratio": 0.129108,
+          "total": 426
+        },
+        "method": {
+          "covered": 6,
+          "missed": 91,
+          "ratio": 0.061856,
+          "total": 97
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 26102,
+      "cached_input_tokens_used": 124928,
+      "output_tokens_used": 1982,
+      "iterations": 1,
+      "cost_usd": 0.122,
+      "tested_library_loc": 41,
+      "metadata_entries": 8,
+      "previous_library_metadata_entries": 8,
+      "code_coverage_percent": 7.32,
+      "previous_library_coverage_percent": 12.91
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.codehaus.plexus/plexus-java/1.0.0/src/test/java/org_codehaus_plexus/plexus_java/MainClassModuleNameExtractorTest.java",
+      "metadata_file": "metadata/org.codehaus.plexus/plexus-java/1.0.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.codehaus.plexus/plexus-java/1.0.0/stats.json
+++ b/stats/org.codehaus.plexus/plexus-java/1.0.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "1.0.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 1,
+      "totalCalls" : 1
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 199,
+        "missed" : 2278,
+        "ratio" : 0.080339,
+        "total" : 2477
+      },
+      "line" : {
+        "covered" : 41,
+        "missed" : 519,
+        "ratio" : 0.073214,
+        "total" : 560
+      },
+      "method" : {
+        "covered" : 5,
+        "missed" : 138,
+        "ratio" : 0.034965,
+        "total" : 143
+      }
+    }
+  } ]
+}

--- a/tests/src/org.codehaus.plexus/plexus-java/1.0.0/.gitignore
+++ b/tests/src/org.codehaus.plexus/plexus-java/1.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.codehaus.plexus/plexus-java/1.0.0/build.gradle
+++ b/tests/src/org.codehaus.plexus/plexus-java/1.0.0/build.gradle
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.codehaus.plexus:plexus-java:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+tasks.named("nativeTest") {
+    runtimeArgs.add("-Djava.home=${System.getenv('JAVA_HOME')}")
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-java/1.0.0/gradle.properties
+++ b/tests/src/org.codehaus.plexus/plexus-java/1.0.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.codehaus.plexus:plexus-java:1.0.0
+library.version = 1.0.0
+metadata.dir = org.codehaus.plexus/plexus-java/1.0.0/

--- a/tests/src/org.codehaus.plexus/plexus-java/1.0.0/settings.gradle
+++ b/tests/src/org.codehaus.plexus/plexus-java/1.0.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.codehaus.plexus.plexus-java_tests'

--- a/tests/src/org.codehaus.plexus/plexus-java/1.0.0/src/test/java/org_codehaus_plexus/plexus_java/MainClassModuleNameExtractorTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-java/1.0.0/src/test/java/org_codehaus_plexus/plexus_java/MainClassModuleNameExtractorTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_java;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import org.codehaus.plexus.languages.java.jpms.MainClassModuleNameExtractor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class MainClassModuleNameExtractorTest {
+    private static final String MODULE_NAME = "org.example.plexus.fixture";
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void getsAutomaticModuleNameFromJarManifest() throws Exception {
+        Path moduleJar = createAutomaticModuleJar();
+
+        String moduleName = MainClassModuleNameExtractor.getModuleName(moduleJar);
+
+        assertThat(moduleName).isEqualTo(MODULE_NAME);
+    }
+
+    @Test
+    void extractsModuleNamesThroughForkedMainClass() throws Exception {
+        Path moduleJar = createAutomaticModuleJar();
+        MainClassModuleNameExtractor extractor =
+                new MainClassModuleNameExtractor(Path.of(System.getProperty("java.home")));
+
+        Map<String, String> moduleNames = extractor.extract(Map.of("fixture", moduleJar));
+
+        assertThat(moduleNames).containsEntry("fixture", MODULE_NAME);
+    }
+
+    private Path createAutomaticModuleJar() throws IOException {
+        Path moduleJar = Files.createTempFile(temporaryDirectory, "automatic-module", ".jar");
+        Manifest manifest = new Manifest();
+        Attributes attributes = manifest.getMainAttributes();
+        attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        attributes.putValue("Automatic-Module-Name", MODULE_NAME);
+
+        try (OutputStream outputStream = Files.newOutputStream(moduleJar);
+                JarOutputStream jarOutputStream = new JarOutputStream(outputStream, manifest)) {
+            JarEntry resourceEntry = new JarEntry("org/example/plexus/fixture/resource.txt");
+            jarOutputStream.putNextEntry(resourceEntry);
+            jarOutputStream.write("fixture".getBytes(StandardCharsets.UTF_8));
+            jarOutputStream.closeEntry();
+        }
+        return moduleJar;
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-java/1.0.0/src/test/java/org_codehaus_plexus/plexus_java/MainClassModuleNameExtractorTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-java/1.0.0/src/test/java/org_codehaus_plexus/plexus_java/MainClassModuleNameExtractorTest.java
@@ -31,10 +31,12 @@ public class MainClassModuleNameExtractorTest {
     @Test
     void getsAutomaticModuleNameFromJarManifest() throws Exception {
         Path moduleJar = createAutomaticModuleJar();
+        MainClassModuleNameExtractor extractor =
+                new MainClassModuleNameExtractor(Path.of(System.getProperty("java.home")));
 
-        String moduleName = MainClassModuleNameExtractor.getModuleName(moduleJar);
+        Map<Path, String> moduleNames = extractor.extract(Map.of(moduleJar, moduleJar));
 
-        assertThat(moduleName).isEqualTo(MODULE_NAME);
+        assertThat(moduleNames).containsEntry(moduleJar, MODULE_NAME);
     }
 
     @Test

--- a/tests/src/org.codehaus.plexus/plexus-java/1.0.0/user-code-filter.json
+++ b/tests/src/org.codehaus.plexus/plexus-java/1.0.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.codehaus.plexus.languages.java.**"
+    },
+    {
+      "includeClasses" : "org_codehaus_plexus.plexus_java.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7180

This PR provides test fixes and new metadata for org.codehaus.plexus:plexus-java:1.0.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 26102
- Cached input tokens: 124928
- Output tokens: 1982
- Metadata entries: 8
- Iterations: 1
- Library coverage percentage: 7.32
- Previous library version metadata entries: 8
- Previous library version coverage percentage: 12.91

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `36b6c531800af9e610caddbccb5d0a92d4bcfa99`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.codehaus.plexus:plexus-java:0.9.10: 7/7 covered calls (100.00%)
- org.codehaus.plexus:plexus-java:1.0.0: 1/1 covered calls (100.00%)

**Reflection:**
- org.codehaus.plexus:plexus-java:0.9.10: 6/6 covered calls (100.00%)
- org.codehaus.plexus:plexus-java:1.0.0: N/A

**Resources:**
- org.codehaus.plexus:plexus-java:0.9.10: 1/1 covered calls (100.00%)
- org.codehaus.plexus:plexus-java:1.0.0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.codehaus.plexus:plexus-java:0.9.10: 291/1825 (15.95%)
- org.codehaus.plexus:plexus-java:1.0.0: 199/2477 (8.03%)

**Line:**
- org.codehaus.plexus:plexus-java:0.9.10: 55/426 (12.91%)
- org.codehaus.plexus:plexus-java:1.0.0: 41/560 (7.32%)

**Method:**
- org.codehaus.plexus:plexus-java:0.9.10: 6/97 (6.19%)
- org.codehaus.plexus:plexus-java:1.0.0: 5/143 (3.50%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.codehaus.plexus/plexus-java/0.9.10/src/test/java/org_codehaus_plexus/plexus_java/MainClassModuleNameExtractorTest.java 2/tests/src/org.codehaus.plexus/plexus-java/1.0.0/src/test/java/org_codehaus_plexus/plexus_java/MainClassModuleNameExtractorTest.java
index 5587d86f74..5c4a80e866 100644
--- 1/tests/src/org.codehaus.plexus/plexus-java/0.9.10/src/test/java/org_codehaus_plexus/plexus_java/MainClassModuleNameExtractorTest.java
+++ 2/tests/src/org.codehaus.plexus/plexus-java/1.0.0/src/test/java/org_codehaus_plexus/plexus_java/MainClassModuleNameExtractorTest.java
@@ -31,10 +31,12 @@ public class MainClassModuleNameExtractorTest {
     @Test
     void getsAutomaticModuleNameFromJarManifest() throws Exception {
         Path moduleJar = createAutomaticModuleJar();
+        MainClassModuleNameExtractor extractor =
+                new MainClassModuleNameExtractor(Path.of(System.getProperty("java.home")));
 
-        String moduleName = MainClassModuleNameExtractor.getModuleName(moduleJar);
+        Map<Path, String> moduleNames = extractor.extract(Map.of(moduleJar, moduleJar));
 
-        assertThat(moduleName).isEqualTo(MODULE_NAME);
+        assertThat(moduleNames).containsEntry(moduleJar, MODULE_NAME);
     }
 
     @Test

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
