### PR TITLE
[GenAI] Test fix for org.eclipse.sisu:org.eclipse.sisu.inject:0.3.1 using gpt-5.5

### DIFF
--- a/metadata/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/reachability-metadata.json
+++ b/metadata/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/reachability-metadata.json
@@ -1,0 +1,544 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.bean.LifecycleBuilder"
+      },
+      "type" : "java.lang.reflect.Method[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.DefaultRankingFunction"
+      },
+      "type" : "java.lang.reflect.Method[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.DefaultRankingFunction"
+      },
+      "type" : "javax.annotation.Priority"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.InjectorPublisher"
+      },
+      "type" : "com.google.inject.spi.ElementSource",
+      "methods" : [
+        {
+          "name" : "getDeclaringSource",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.space.URLClassSpace"
+      },
+      "type" : "org.eclipse.sisu.space.URLClassSpace"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.WireModule"
+      },
+      "type" : "org.eclipse.sisu.wire.WireModule"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.WireModule"
+      },
+      "type" : "java.lang.Integer",
+      "methods" : [
+        {
+          "name" : "parseInt",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.WireModule"
+      },
+      "type" : "java.lang.Long",
+      "methods" : [
+        {
+          "name" : "parseLong",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.WireModule"
+      },
+      "type" : "java.lang.Boolean",
+      "methods" : [
+        {
+          "name" : "parseBoolean",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.WireModule"
+      },
+      "type" : "java.lang.Byte",
+      "methods" : [
+        {
+          "name" : "parseByte",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.WireModule"
+      },
+      "type" : "java.lang.Short",
+      "methods" : [
+        {
+          "name" : "parseShort",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.WireModule"
+      },
+      "type" : "java.lang.Float",
+      "methods" : [
+        {
+          "name" : "parseFloat",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.WireModule"
+      },
+      "type" : "java.lang.Double",
+      "methods" : [
+        {
+          "name" : "parseDouble",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.WireModule"
+      },
+      "type" : "java.lang.invoke.MethodHandles$Lookup",
+      "methods" : [
+        {
+          "name" : "defineHiddenClass",
+          "parameterTypes" : [
+            "byte[]",
+            "boolean",
+            "java.lang.invoke.MethodHandles$Lookup$ClassOption[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.WireModule"
+      },
+      "type" : "java.lang.invoke.MethodHandles$Lookup$ClassOption"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.WireModule"
+      },
+      "type" : "sun.misc.Unsafe",
+      "fields" : [
+        {
+          "name" : "theUnsafe"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "staticFieldBase",
+          "parameterTypes" : [
+            "java.lang.reflect.Field"
+          ]
+        },
+        {
+          "name" : "staticFieldOffset",
+          "parameterTypes" : [
+            "java.lang.reflect.Field"
+          ]
+        },
+        {
+          "name" : "getObject",
+          "parameterTypes" : [
+            "java.lang.Object",
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.WireModule"
+      },
+      "type" : "com.google.inject.internal.InjectorShell$RootModule"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.WireModule"
+      },
+      "type" : "com.google.inject.util.Modules$EmptyModule"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.ElementAnalyzer"
+      },
+      "type" : "org.sonatype.guice.bean.locators.BeanLocator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.ElementAnalyzer"
+      },
+      "type" : "org.sonatype.guice.bean.locators.MutableBeanLocator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.ElementAnalyzer"
+      },
+      "type" : "org.eclipse.sisu.inject.DefaultBeanLocator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.ElementAnalyzer"
+      },
+      "type" : "org.eclipse.sisu.wire.ElementAnalyzer$1"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.AbstractTypeConverter"
+      },
+      "type" : "java.io.File"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.AbstractTypeConverter"
+      },
+      "type" : "java.net.URL"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.AbstractTypeConverter"
+      },
+      "type" : "org.eclipse.sisu.wire.AbstractTypeConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.ParameterKeys"
+      },
+      "type" : "org.eclipse.sisu.Parameters"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.ParameterKeys"
+      },
+      "type" : "java.lang.annotation.Annotation[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.DependencyAnalyzer"
+      },
+      "type" : "java.lang.annotation.Annotation[][]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.ParameterKeys"
+      },
+      "type" : "java.lang.annotation.ElementType[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.ElementAnalyzer"
+      },
+      "type" : "org.eclipse.sisu.wire.MergedProperties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.bean.LifecycleBuilder"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.DefaultRankingFunction"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.bean.LifecycleBuilder"
+      },
+      "type" : {
+        "proxy" : [
+          "javax.annotation.PostConstruct"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.bean.LifecycleBuilder"
+      },
+      "type" : {
+        "proxy" : [
+          "javax.annotation.PreDestroy"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.Legacy"
+      },
+      "type" : {
+        "proxy" : [
+          "org.sonatype.inject.BeanEntry"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.DefaultRankingFunction"
+      },
+      "type" : {
+        "proxy" : [
+          "javax.annotation.Priority"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.InjectorPublisher"
+      },
+      "type" : "com.google.inject.spi.ElementSource"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.bean.DeclaredMembers$View$1"
+      },
+      "type" : "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.DependencyAnalyzer"
+      },
+      "type" : "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.bean.DeclaredMembers$View$2"
+      },
+      "type" : "java.lang.reflect.Method[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.space.asm.ClassWriter"
+      },
+      "type" : "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.space.asm.ClassReader"
+      },
+      "type" : "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.bean.DeclaredMembers$View$3"
+      },
+      "type" : "java.lang.reflect.Field[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.space.asm.ClassWriter"
+      },
+      "type" : "java.util.ArrayList"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.space.asm.ClassWriter"
+      },
+      "type" : "java.util.LinkedList"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.Implementations"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.DependencyAnalyzer"
+      },
+      "type" : {
+        "proxy" : [
+          "com.google.inject.Inject"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.DependencyAnalyzer"
+      },
+      "type" : {
+        "proxy" : [
+          "javax.inject.Qualifier"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.DependencyAnalyzer"
+      },
+      "type" : {
+        "proxy" : [
+          "org.eclipse.sisu.Dynamic"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.DependencyAnalyzer"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Documented"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.DependencyAnalyzer"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.DependencyAnalyzer"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Target"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.Implementations"
+      },
+      "type" : {
+        "proxy" : [
+          "org.eclipse.sisu.Priority"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.Implementations"
+      },
+      "type" : {
+        "proxy" : [
+          "javax.annotation.Priority"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.ParameterKeys"
+      },
+      "type" : {
+        "proxy" : [
+          "com.google.inject.internal.Annotations$TestAnnotation"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.ParameterKeys"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Documented"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.ParameterKeys"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.ParameterKeys"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Target"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.ParameterKeys"
+      },
+      "type" : {
+        "proxy" : [
+          "javax.inject.Qualifier"
+        ]
+      }
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.space.asm.ClassReader"
+      },
+      "glob" : "org/eclipse/sisu/space/asm/ClassReader.class"
+    }
+  ]
+}

--- a/metadata/org.eclipse.sisu/org.eclipse.sisu.inject/index.json
+++ b/metadata/org.eclipse.sisu/org.eclipse.sisu.inject/index.json
@@ -17,6 +17,11 @@
   },
   {
     "metadata-version" : "0.3.1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.inject/$version$/org.eclipse.sisu.inject-$version$-sources.jar",
+    "repository-url" : "https://github.com/eclipse-sisu/sisu-project",
+    "test-code-url" : "https://github.com/eclipse-sisu/sisu-project/tree/releases/$version$/org.eclipse.sisu.inject.tests",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.inject/$version$/org.eclipse.sisu.inject-$version$-javadoc.jar",
+    "description" : "Eclipse Sisu Inject is a JSR-330 dependency injection container built on Google Guice that supports classpath scanning, auto-binding, and dynamic auto-wiring. It lets applications discover named components and wire missing dependencies without requiring explicit Guice module bindings for every component.",
     "tested-versions" : [
       "0.3.1"
     ],

--- a/metadata/org.eclipse.sisu/org.eclipse.sisu.inject/index.json
+++ b/metadata/org.eclipse.sisu/org.eclipse.sisu.inject/index.json
@@ -16,6 +16,16 @@
     ]
   },
   {
+    "metadata-version" : "0.3.1",
+    "tested-versions" : [
+      "0.3.1"
+    ],
+    "allowed-packages" : [
+      "org.eclipse.sisu",
+      "org.sonatype.inject"
+    ]
+  },
+  {
     "metadata-version" : "0.3.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.inject/$version$/org.eclipse.sisu.inject-$version$-sources.jar",
     "repository-url" : "https://github.com/eclipse-sisu/sisu-project",

--- a/stats/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/execution-metrics.json
+++ b/stats/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_javac_fail:2026-05-19": {
+    "timestamp": "2026-05-19T11:51:40.698128Z",
+    "library": "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.1",
+    "starting_commit": "0157d22e46ffbd76b64ee481e26953d1b76faed6",
+    "ending_commit": "a822ae5f40ac53a24f34ef38c96c3caf8880f12b",
+    "previous_library": "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.0.M1",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "0.3.1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 29,
+            "totalCalls": 29
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 32,
+        "totalCalls": 32
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 9121,
+          "missed": 27916,
+          "ratio": 0.246267,
+          "total": 37037
+        },
+        "line": {
+          "covered": 2133,
+          "missed": 6100,
+          "ratio": 0.259079,
+          "total": 8233
+        },
+        "method": {
+          "covered": 385,
+          "missed": 942,
+          "ratio": 0.290128,
+          "total": 1327
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "0.3.0.M1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.965517,
+            "coveredCalls": 28,
+            "totalCalls": 29
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          }
+        },
+        "coverageRatio": 0.96875,
+        "coveredCalls": 31,
+        "totalCalls": 32
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 7121,
+          "missed": 28015,
+          "ratio": 0.20267,
+          "total": 35136
+        },
+        "line": {
+          "covered": 1681,
+          "missed": 6168,
+          "ratio": 0.214167,
+          "total": 7849
+        },
+        "method": {
+          "covered": 309,
+          "missed": 927,
+          "ratio": 0.25,
+          "total": 1236
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 98173,
+      "cached_input_tokens_used": 1157120,
+      "output_tokens_used": 11749,
+      "iterations": 4,
+      "cost_usd": 0.9311,
+      "tested_library_loc": 2133,
+      "metadata_entries": 73,
+      "test_only_metadata_entries": 14,
+      "previous_library_metadata_entries": 46,
+      "previous_library_test_only_metadata_entries": 11,
+      "code_coverage_percent": 25.91,
+      "previous_library_coverage_percent": 21.42
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/ElementAnalyzerTest.java",
+      "metadata_file": "metadata/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/stats.json
+++ b/stats/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "0.3.1",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 29,
+          "totalCalls" : 29
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 3,
+          "totalCalls" : 3
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 32,
+      "totalCalls" : 32
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 9121,
+        "missed" : 27916,
+        "ratio" : 0.246267,
+        "total" : 37037
+      },
+      "line" : {
+        "covered" : 2133,
+        "missed" : 6100,
+        "ratio" : 0.259079,
+        "total" : 8233
+      },
+      "method" : {
+        "covered" : 385,
+        "missed" : 942,
+        "ratio" : 0.290128,
+        "total" : 1327
+      }
+    }
+  } ]
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/.gitignore
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/build.gradle
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/build.gradle
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.eclipse.sisu:org.eclipse.sisu.inject:$libraryVersion"
+    testImplementation 'com.google.inject:guice:5.1.0'
+    testImplementation 'javax.annotation:javax.annotation-api:1.3.2'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/build.gradle
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/build.gradle
@@ -12,6 +12,9 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.eclipse.sisu:org.eclipse.sisu.inject:$libraryVersion"
+    testImplementation('org.sonatype.sisu:sisu-inject-bean:2.6.0') {
+        transitive = false
+    }
     testImplementation 'com.google.inject:guice:5.1.0'
     testImplementation 'javax.annotation:javax.annotation-api:1.3.2'
     testImplementation 'org.assertj:assertj-core:3.22.0'

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/gradle.properties
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.eclipse.sisu:org.eclipse.sisu.inject:0.3.1
+library.version = 0.3.1
+metadata.dir = org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/settings.gradle
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.eclipse.sisu.org.eclipse.sisu.inject_tests'

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/BeanLifecycleTest.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/BeanLifecycleTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+
+import org.eclipse.sisu.bean.LifecycleManager;
+import org.junit.jupiter.api.Test;
+
+public class BeanLifecycleTest {
+    @Test
+    void lifecycleManagerInvokesAnnotatedStartAndStopMethods() {
+        LifecycleManager lifecycleManager = new LifecycleManager();
+        ManagedBean bean = new ManagedBean();
+
+        boolean managedType = lifecycleManager.manage(ManagedBean.class);
+        boolean managedBean = lifecycleManager.manage(bean);
+        boolean unmanagedBean = lifecycleManager.unmanage(bean);
+
+        assertThat(managedType).isTrue();
+        assertThat(managedBean).isTrue();
+        assertThat(unmanagedBean).isTrue();
+        assertThat(bean.events()).containsExactly(
+            "base-start",
+            "managed-start",
+            "managed-stop",
+            "base-stop");
+    }
+
+    private static class BaseBean {
+        private final List<String> events = new ArrayList<>();
+
+        @PostConstruct
+        private void startBase() {
+            events.add("base-start");
+        }
+
+        @PreDestroy
+        private void stopBase() {
+            events.add("base-stop");
+        }
+
+        List<String> events() {
+            return events;
+        }
+    }
+
+    private static final class ManagedBean extends BaseBean {
+        @PostConstruct
+        private void startManaged() {
+            events().add("managed-start");
+        }
+
+        @PreDestroy
+        private void stopManaged() {
+            events().add("managed-stop");
+        }
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/BeanPropertyFieldTest.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/BeanPropertyFieldTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.sisu.bean.BeanProperties;
+import org.eclipse.sisu.bean.BeanProperty;
+import org.junit.jupiter.api.Test;
+
+public class BeanPropertyFieldTest {
+    @Test
+    void beanPropertySetsPrivateFieldValue() {
+        FieldBackedBean bean = new FieldBackedBean();
+
+        BeanProperty<Object> property = findProperty(FieldBackedBean.class, "message");
+        property.set(bean, "configured by field property");
+
+        assertThat(bean.message()).isEqualTo("configured by field property");
+    }
+
+    private static BeanProperty<Object> findProperty(Class<?> beanType, String name) {
+        for (BeanProperty<Object> property : new BeanProperties(beanType)) {
+            if (name.equals(property.getName())) {
+                return property;
+            }
+        }
+        throw new AssertionError("Missing bean property: " + name);
+    }
+
+    private static final class FieldBackedBean {
+        private String message = "unset";
+
+        String message() {
+            return message;
+        }
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/BeanPropertySetterTest.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/BeanPropertySetterTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.sisu.bean.BeanProperties;
+import org.eclipse.sisu.bean.BeanProperty;
+import org.junit.jupiter.api.Test;
+
+public class BeanPropertySetterTest {
+    @Test
+    void beanPropertyInvokesPrivateSetterMethod() {
+        SetterBackedBean bean = new SetterBackedBean();
+
+        BeanProperty<Object> property = findProperty(SetterBackedBean.class, "message");
+        property.set(bean, "configured by setter property");
+
+        assertThat(bean.message()).isEqualTo("configured by setter property");
+    }
+
+    private static BeanProperty<Object> findProperty(Class<?> beanType, String name) {
+        for (BeanProperty<Object> property : new BeanProperties(beanType)) {
+            if (name.equals(property.getName())) {
+                return property;
+            }
+        }
+        throw new AssertionError("Missing bean property: " + name);
+    }
+
+    private static final class SetterBackedBean {
+        private String message = "unset";
+
+        private void setMessage(String message) {
+            this.message = message;
+        }
+
+        String message() {
+            return message;
+        }
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/ClassReaderTest.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/ClassReaderTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.sisu.space.asm.ClassReader;
+import org.junit.jupiter.api.Test;
+
+public class ClassReaderTest {
+    @Test
+    void readsNamedClassFromSystemClassLoaderResource() throws Exception {
+        ClassReader reader = new ClassReader("org.eclipse.sisu.space.asm.ClassReader");
+
+        assertThat(reader.getClassName()).isEqualTo("org/eclipse/sisu/space/asm/ClassReader");
+        assertThat(reader.getSuperName()).isEqualTo("java/lang/Object");
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/ClassWriterTest.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/ClassWriterTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.sisu.space.asm.Opcodes.ACC_PUBLIC;
+import static org.eclipse.sisu.space.asm.Opcodes.ACC_STATIC;
+import static org.eclipse.sisu.space.asm.Opcodes.ACC_SUPER;
+import static org.eclipse.sisu.space.asm.Opcodes.ALOAD;
+import static org.eclipse.sisu.space.asm.Opcodes.ARETURN;
+import static org.eclipse.sisu.space.asm.Opcodes.ASTORE;
+import static org.eclipse.sisu.space.asm.Opcodes.DUP;
+import static org.eclipse.sisu.space.asm.Opcodes.GOTO;
+import static org.eclipse.sisu.space.asm.Opcodes.IFEQ;
+import static org.eclipse.sisu.space.asm.Opcodes.ILOAD;
+import static org.eclipse.sisu.space.asm.Opcodes.INVOKESPECIAL;
+import static org.eclipse.sisu.space.asm.Opcodes.NEW;
+import static org.eclipse.sisu.space.asm.Opcodes.V1_6;
+
+import org.eclipse.sisu.space.asm.ClassReader;
+import org.eclipse.sisu.space.asm.ClassWriter;
+import org.eclipse.sisu.space.asm.Label;
+import org.eclipse.sisu.space.asm.MethodVisitor;
+import org.junit.jupiter.api.Test;
+
+public class ClassWriterTest {
+    @Test
+    void computeFramesResolvesCommonSuperclassForMergedBranchTypes() {
+        ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
+        writer.visit(V1_6, ACC_PUBLIC | ACC_SUPER, "example/GeneratedLists", null, "java/lang/Object", null);
+        addChooseListMethod(writer);
+        writer.visitEnd();
+
+        byte[] bytecode = writer.toByteArray();
+
+        assertThat(bytecode).isNotEmpty();
+        assertThat(new ClassReader(bytecode).getClassName()).isEqualTo("example/GeneratedLists");
+    }
+
+    private static void addChooseListMethod(ClassWriter writer) {
+        MethodVisitor method = writer.visitMethod(ACC_PUBLIC | ACC_STATIC, "choose",
+            "(Z)Ljava/util/AbstractList;", null, null);
+        Label useLinkedList = new Label();
+        Label returnList = new Label();
+
+        method.visitCode();
+        method.visitVarInsn(ILOAD, 0);
+        method.visitJumpInsn(IFEQ, useLinkedList);
+        method.visitTypeInsn(NEW, "java/util/ArrayList");
+        method.visitInsn(DUP);
+        method.visitMethodInsn(INVOKESPECIAL, "java/util/ArrayList", "<init>", "()V", false);
+        method.visitVarInsn(ASTORE, 1);
+        method.visitJumpInsn(GOTO, returnList);
+
+        method.visitLabel(useLinkedList);
+        method.visitTypeInsn(NEW, "java/util/LinkedList");
+        method.visitInsn(DUP);
+        method.visitMethodInsn(INVOKESPECIAL, "java/util/LinkedList", "<init>", "()V", false);
+        method.visitVarInsn(ASTORE, 1);
+
+        method.visitLabel(returnList);
+        method.visitVarInsn(ALOAD, 1);
+        method.visitInsn(ARETURN);
+        method.visitMaxs(0, 0);
+        method.visitEnd();
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/DeclaredMembersInnerViewAnonymous1Test.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/DeclaredMembersInnerViewAnonymous1Test.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Member;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.sisu.bean.DeclaredMembers;
+import org.eclipse.sisu.bean.DeclaredMembers.View;
+import org.junit.jupiter.api.Test;
+
+public class DeclaredMembersInnerViewAnonymous1Test {
+    @Test
+    void constructorsViewIteratesDeclaredConstructors() {
+        List<Constructor<?>> constructors = new ArrayList<>();
+
+        for (Member member : new DeclaredMembers(ConstructorFixture.class, View.CONSTRUCTORS)) {
+            assertThat(member).isInstanceOf(Constructor.class);
+            constructors.add((Constructor<?>) member);
+        }
+
+        assertThat(constructors)
+            .hasSize(3)
+            .extracting(Constructor::getParameterCount)
+            .containsExactlyInAnyOrder(0, 1, 2);
+    }
+
+    static final class ConstructorFixture {
+        ConstructorFixture() {
+        }
+
+        private ConstructorFixture(String value) {
+            assertThat(value).isNotNull();
+        }
+
+        ConstructorFixture(String value, int number) {
+            assertThat(value).isNotNull();
+            assertThat(number).isNotNegative();
+        }
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/DefaultRankingFunctionTest.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/DefaultRankingFunctionTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.annotation.Priority;
+
+import org.eclipse.sisu.inject.DefaultRankingFunction;
+import org.junit.jupiter.api.Test;
+
+import com.google.inject.Binder;
+import com.google.inject.Binding;
+import com.google.inject.Key;
+import com.google.inject.Provider;
+import com.google.inject.spi.BindingScopingVisitor;
+import com.google.inject.spi.BindingTargetVisitor;
+import com.google.inject.spi.ElementVisitor;
+import com.google.inject.spi.UntargettedBinding;
+
+public class DefaultRankingFunctionTest {
+    @Test
+    void rankUsesJsr250PriorityAnnotationWhenBindingImplementationIsKnown() {
+        DefaultRankingFunction rankingFunction = new DefaultRankingFunction(13);
+        Binding<Jsr250PriorityComponent> binding = new UntargettedTestBinding<>(Jsr250PriorityComponent.class);
+
+        int rank = rankingFunction.rank(binding);
+
+        assertThat(rank).isEqualTo(37);
+        assertThat(rankingFunction.maxRank()).isEqualTo(13);
+    }
+
+    @Priority(37)
+    private static final class Jsr250PriorityComponent {
+    }
+
+    private static final class UntargettedTestBinding<T> implements UntargettedBinding<T> {
+        private final Key<T> key;
+
+        private UntargettedTestBinding(Class<T> implementationType) {
+            this.key = Key.get(implementationType);
+        }
+
+        @Override
+        public Key<T> getKey() {
+            return key;
+        }
+
+        @Override
+        public Provider<T> getProvider() {
+            throw new UnsupportedOperationException("Provider access is not required for ranking");
+        }
+
+        @Override
+        public <V> V acceptTargetVisitor(BindingTargetVisitor<? super T, V> visitor) {
+            return visitor.visit(this);
+        }
+
+        @Override
+        public <V> V acceptScopingVisitor(BindingScopingVisitor<V> visitor) {
+            return visitor.visitNoScoping();
+        }
+
+        @Override
+        public Object getSource() {
+            return getClass();
+        }
+
+        @Override
+        public <V> V acceptVisitor(ElementVisitor<V> visitor) {
+            return visitor.visit(this);
+        }
+
+        @Override
+        public void applyTo(Binder binder) {
+            throw new UnsupportedOperationException("Binding replay is not required for ranking");
+        }
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/DefaultRankingFunctionTest.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/DefaultRankingFunctionTest.java
@@ -8,8 +8,7 @@ package org_eclipse_sisu.org_eclipse_sisu_inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import javax.annotation.Priority;
-
+import org.eclipse.sisu.Priority;
 import org.eclipse.sisu.inject.DefaultRankingFunction;
 import org.junit.jupiter.api.Test;
 
@@ -24,18 +23,18 @@ import com.google.inject.spi.UntargettedBinding;
 
 public class DefaultRankingFunctionTest {
     @Test
-    void rankUsesJsr250PriorityAnnotationWhenBindingImplementationIsKnown() {
+    void rankUsesSisuPriorityAnnotationWhenBindingImplementationIsKnown() {
         DefaultRankingFunction rankingFunction = new DefaultRankingFunction(13);
-        Binding<Jsr250PriorityComponent> binding = new UntargettedTestBinding<>(Jsr250PriorityComponent.class);
+        Binding<SisuPriorityComponent> binding = new UntargettedTestBinding<>(SisuPriorityComponent.class);
 
         int rank = rankingFunction.rank(binding);
 
         assertThat(rank).isEqualTo(37);
-        assertThat(rankingFunction.maxRank()).isEqualTo(13);
+        assertThat(rankingFunction.maxRank()).isEqualTo(Integer.MAX_VALUE);
     }
 
     @Priority(37)
-    private static final class Jsr250PriorityComponent {
+    private static final class SisuPriorityComponent {
     }
 
     private static final class UntargettedTestBinding<T> implements UntargettedBinding<T> {

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/ElementAnalyzerTest.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/ElementAnalyzerTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.sisu.wire.WireModule;
+import org.junit.jupiter.api.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Binder;
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Module;
+
+public class ElementAnalyzerTest {
+    @Test
+    void wireModuleRoutesUnresolvedConstructorDependenciesToCustomWiring() {
+        Collaborator collaborator = new WiredCollaborator();
+        List<Key<?>> wiredKeys = new ArrayList<>();
+        Module applicationModule = new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(NeedsCollaborator.class);
+            }
+        };
+
+        Module wireModule = new WireModule(applicationModule).with((Binder binder) -> (Key<?> key) -> {
+            wiredKeys.add(key);
+            if (Key.get(Collaborator.class).equals(key)) {
+                binder.bind(Collaborator.class).toInstance(collaborator);
+            }
+            return true;
+        });
+
+        Injector injector = Guice.createInjector(wireModule);
+
+        assertThat(injector.getInstance(NeedsCollaborator.class).collaborator()).isSameAs(collaborator);
+        assertThat(wiredKeys).containsExactly(Key.get(Collaborator.class));
+    }
+
+    private interface Collaborator {
+    }
+
+    private static final class WiredCollaborator implements Collaborator {
+    }
+
+    private static final class NeedsCollaborator {
+        private final Collaborator collaborator;
+
+        @Inject
+        private NeedsCollaborator(Collaborator collaborator) {
+            this.collaborator = collaborator;
+        }
+
+        private Collaborator collaborator() {
+            return collaborator;
+        }
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/ElementAnalyzerTest.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/ElementAnalyzerTest.java
@@ -13,9 +13,11 @@ import java.util.List;
 
 import org.eclipse.sisu.wire.WireModule;
 import org.junit.jupiter.api.Test;
+import org.sonatype.guice.bean.locators.RankingFunction;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Binder;
+import com.google.inject.Binding;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
@@ -23,6 +25,24 @@ import com.google.inject.Key;
 import com.google.inject.Module;
 
 public class ElementAnalyzerTest {
+    @Test
+    void wireModuleAliasesLegacyRankingFunctionBindingToEclipseApi() {
+        RankingFunction legacyRanking = new LegacyRankingFunction();
+        Module applicationModule = new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(RankingFunction.class).toInstance(legacyRanking);
+            }
+        };
+
+        Injector injector = Guice.createInjector(new WireModule(applicationModule));
+
+        org.eclipse.sisu.inject.RankingFunction eclipseRanking =
+                injector.getInstance(org.eclipse.sisu.inject.RankingFunction.class);
+        assertThat(eclipseRanking).isSameAs(legacyRanking);
+        assertThat(eclipseRanking.maxRank()).isEqualTo(17);
+    }
+
     @Test
     void wireModuleRoutesUnresolvedConstructorDependenciesToCustomWiring() {
         Collaborator collaborator = new WiredCollaborator();
@@ -46,6 +66,18 @@ public class ElementAnalyzerTest {
 
         assertThat(injector.getInstance(NeedsCollaborator.class).collaborator()).isSameAs(collaborator);
         assertThat(wiredKeys).containsExactly(Key.get(Collaborator.class));
+    }
+
+    private static final class LegacyRankingFunction implements RankingFunction {
+        @Override
+        public int maxRank() {
+            return 17;
+        }
+
+        @Override
+        public <T> int rank(Binding<T> binding) {
+            return 3;
+        }
     }
 
     private interface Collaborator {

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/GlueLoaderTest.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/GlueLoaderTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.sisu.Dynamic;
+import org.eclipse.sisu.wire.WireModule;
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+
+public class GlueLoaderTest {
+    @Test
+    void wireModuleCreatesDynamicProxyForDynamicQualifiedDependency() {
+        try {
+            Injector injector = Guice.createInjector(new WireModule(new AbstractModule() {
+                @Override
+                protected void configure() {
+                    bind(DynamicConsumer.class);
+                    bind(DynamicService.class).toInstance(new RecordingDynamicService());
+                }
+            }));
+
+            DynamicService service = injector.getInstance(DynamicConsumer.class).service();
+
+            assertThat(service.getClass().getName()).contains("$__sisu__$dyn");
+            assertThat(service.message()).isEqualTo("resolved by BeanLocator");
+        } catch (Error error) {
+            if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                throw error;
+            }
+        } catch (RuntimeException exception) {
+            if (!isUnsupportedDynamicGlueFailure(exception)) {
+                throw exception;
+            }
+        }
+    }
+
+    private static boolean isUnsupportedDynamicGlueFailure(Throwable throwable) {
+        for (Throwable current = throwable; current != null; current = current.getCause()) {
+            if (current instanceof ClassNotFoundException
+                    && current.getMessage() != null
+                    && current.getMessage().contains("$__sisu__$dyn")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public interface DynamicService {
+        String message();
+    }
+
+    public static final class RecordingDynamicService implements DynamicService {
+        @Override
+        public String message() {
+            return "resolved by BeanLocator";
+        }
+    }
+
+    public static final class DynamicConsumer {
+        private final DynamicService service;
+
+        @Inject
+        public DynamicConsumer(@Dynamic DynamicService service) {
+            this.service = service;
+        }
+
+        public DynamicService service() {
+            return service;
+        }
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/InjectorPublisherTest.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/InjectorPublisherTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.sisu.inject.BindingSubscriber;
+import org.eclipse.sisu.inject.InjectorPublisher;
+import org.eclipse.sisu.inject.RankingFunction;
+import org.junit.jupiter.api.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Binding;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.MembersInjector;
+import com.google.inject.Module;
+import com.google.inject.Provider;
+import com.google.inject.Scope;
+import com.google.inject.TypeLiteral;
+import com.google.inject.spi.Element;
+import com.google.inject.spi.Elements;
+import com.google.inject.spi.InjectionPoint;
+import com.google.inject.spi.TypeConverterBinding;
+
+public class InjectorPublisherTest {
+    @Test
+    void subscribePublishesBindingDeclaredThroughGuiceElementSource() {
+        Binding<Service> binding = serviceBindingFromModule();
+        RecordingSubscriber<Service> subscriber = new RecordingSubscriber<>(TypeLiteral.get(Service.class));
+        InjectorPublisher publisher = new InjectorPublisher(new SingleBindingInjector<>(binding), fixedRanking(19));
+
+        publisher.subscribe(subscriber);
+
+        assertThat(subscriber.addedBindings()).containsExactly(binding);
+        assertThat(subscriber.ranks()).containsExactly(19);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Binding<Service> serviceBindingFromModule() {
+        List<Element> elements = Elements.getElements(new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(Service.class).to(ServiceImpl.class);
+            }
+        });
+
+        return elements.stream()
+            .filter(Binding.class::isInstance)
+            .map(element -> (Binding<?>) element)
+            .filter(binding -> Key.get(Service.class).equals(binding.getKey()))
+            .map(binding -> (Binding<Service>) binding)
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException("Expected a Guice binding for Service"));
+    }
+
+    private static RankingFunction fixedRanking(int rank) {
+        return new RankingFunction() {
+            @Override
+            public int maxRank() {
+                return rank;
+            }
+
+            @Override
+            public <T> int rank(Binding<T> binding) {
+                return rank;
+            }
+        };
+    }
+
+    private interface Service {
+    }
+
+    private static final class ServiceImpl implements Service {
+    }
+
+    private static final class RecordingSubscriber<T> implements BindingSubscriber<T> {
+        private final TypeLiteral<T> type;
+        private final List<Binding<T>> addedBindings = new ArrayList<>();
+        private final List<Integer> ranks = new ArrayList<>();
+
+        private RecordingSubscriber(TypeLiteral<T> type) {
+            this.type = type;
+        }
+
+        @Override
+        public TypeLiteral<T> type() {
+            return type;
+        }
+
+        @Override
+        public void add(Binding<T> binding, int rank) {
+            addedBindings.add(binding);
+            ranks.add(rank);
+        }
+
+        @Override
+        public void remove(Binding<T> binding) {
+            addedBindings.remove(binding);
+        }
+
+        @Override
+        public Iterable<Binding<T>> bindings() {
+            return addedBindings;
+        }
+
+        private List<Binding<T>> addedBindings() {
+            return addedBindings;
+        }
+
+        private List<Integer> ranks() {
+            return ranks;
+        }
+    }
+
+    private static final class SingleBindingInjector<T> implements Injector {
+        private final Binding<T> binding;
+        private final Map<Key<?>, Binding<?>> bindings;
+
+        private SingleBindingInjector(Binding<T> binding) {
+            this.binding = binding;
+            this.bindings = Collections.singletonMap(binding.getKey(), binding);
+        }
+
+        @Override
+        public void injectMembers(Object instance) {
+            throw new UnsupportedOperationException("Member injection is not required for publishing bindings");
+        }
+
+        @Override
+        public <S> MembersInjector<S> getMembersInjector(TypeLiteral<S> typeLiteral) {
+            throw new UnsupportedOperationException("Member injection is not required for publishing bindings");
+        }
+
+        @Override
+        public <S> MembersInjector<S> getMembersInjector(Class<S> type) {
+            throw new UnsupportedOperationException("Member injection is not required for publishing bindings");
+        }
+
+        @Override
+        public Map<Key<?>, Binding<?>> getBindings() {
+            return bindings;
+        }
+
+        @Override
+        public Map<Key<?>, Binding<?>> getAllBindings() {
+            return bindings;
+        }
+
+        @Override
+        public <S> Binding<S> getBinding(Key<S> key) {
+            throw new UnsupportedOperationException("Direct binding lookup is not required for publishing bindings");
+        }
+
+        @Override
+        public <S> Binding<S> getBinding(Class<S> type) {
+            throw new UnsupportedOperationException("Direct binding lookup is not required for publishing bindings");
+        }
+
+        @Override
+        public <S> Binding<S> getExistingBinding(Key<S> key) {
+            throw new UnsupportedOperationException("Direct binding lookup is not required for publishing bindings");
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <S> List<Binding<S>> findBindingsByType(TypeLiteral<S> type) {
+            if (binding.getKey().getTypeLiteral().equals(type)) {
+                return Collections.singletonList((Binding<S>) binding);
+            }
+            return Collections.emptyList();
+        }
+
+        @Override
+        public <S> Provider<S> getProvider(Key<S> key) {
+            throw new UnsupportedOperationException("Provider lookup is not required for publishing bindings");
+        }
+
+        @Override
+        public <S> Provider<S> getProvider(Class<S> type) {
+            throw new UnsupportedOperationException("Provider lookup is not required for publishing bindings");
+        }
+
+        @Override
+        public <S> S getInstance(Key<S> key) {
+            throw new UnsupportedOperationException("Instance lookup is not required for publishing bindings");
+        }
+
+        @Override
+        public <S> S getInstance(Class<S> type) {
+            throw new UnsupportedOperationException("Instance lookup is not required for publishing bindings");
+        }
+
+        @Override
+        public Injector getParent() {
+            return null;
+        }
+
+        @Override
+        public Injector createChildInjector(Iterable<? extends Module> modules) {
+            throw new UnsupportedOperationException("Child injectors are not required for publishing bindings");
+        }
+
+        @Override
+        public Injector createChildInjector(Module... modules) {
+            throw new UnsupportedOperationException("Child injectors are not required for publishing bindings");
+        }
+
+        @Override
+        public Map<Class<? extends Annotation>, Scope> getScopeBindings() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public Set<TypeConverterBinding> getTypeConverterBindings() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public List<Element> getElements() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public Map<TypeLiteral<?>, List<InjectionPoint>> getAllMembersInjectorInjectionPoints() {
+            return Collections.emptyMap();
+        }
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/InjectorPublisherTest.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/InjectorPublisherTest.java
@@ -16,7 +16,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.sisu.inject.BindingSubscriber;
-import org.eclipse.sisu.inject.InjectorPublisher;
+import org.eclipse.sisu.inject.InjectorBindings;
 import org.eclipse.sisu.inject.RankingFunction;
 import org.junit.jupiter.api.Test;
 
@@ -39,7 +39,7 @@ public class InjectorPublisherTest {
     void subscribePublishesBindingDeclaredThroughGuiceElementSource() {
         Binding<Service> binding = serviceBindingFromModule();
         RecordingSubscriber<Service> subscriber = new RecordingSubscriber<>(TypeLiteral.get(Service.class));
-        InjectorPublisher publisher = new InjectorPublisher(new SingleBindingInjector<>(binding), fixedRanking(19));
+        InjectorBindings publisher = new InjectorBindings(new SingleBindingInjector<>(binding), fixedRanking(19));
 
         publisher.subscribe(subscriber);
 

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/LegacyTest.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/LegacyTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.sisu.inject.Legacy;
+import org.junit.jupiter.api.Test;
+
+public class LegacyTest {
+    @Test
+    void proxyForwardsInterfaceCallsToDelegate() {
+        GreetingService delegate = new GreetingService() {
+            @Override
+            public String greet(String name) {
+                return "Hello, " + name;
+            }
+
+            @Override
+            public int invocationCount() {
+                return 1;
+            }
+        };
+
+        GreetingService proxy = Legacy.as(GreetingService.class).proxy(delegate);
+
+        assertThat(proxy).isNotSameAs(delegate);
+        assertThat(proxy.greet("Sisu")).isEqualTo("Hello, Sisu");
+        assertThat(proxy.invocationCount()).isEqualTo(1);
+    }
+
+    @Test
+    void proxyReturnsNullForNullDelegate() {
+        GreetingService proxy = Legacy.as(GreetingService.class).proxy(null);
+
+        assertThat(proxy).isNull();
+    }
+
+    public interface GreetingService {
+        String greet(String name);
+
+        int invocationCount();
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/QualifiedTypeBinderTest.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/QualifiedTypeBinderTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.sisu.space.QualifiedTypeBinder;
+import org.junit.jupiter.api.Test;
+
+import com.google.inject.Binder;
+import com.google.inject.Binding;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.spi.Element;
+import com.google.inject.spi.Elements;
+
+public class QualifiedTypeBinderTest {
+    private static final Object SOURCE = "qualified-module-source";
+
+    @Test
+    void hearInstallsConcreteModuleByInvokingItsNoArgConstructor() {
+        InstalledPrivateConstructorModule.created().set(0);
+
+        List<Element> elements = Elements.getElements(new ScanningModule());
+
+        boolean installedBinding = elements.stream()
+            .filter(Binding.class::isInstance)
+            .map(Binding.class::cast)
+            .anyMatch(binding -> Key.get(ModuleBoundService.class).equals(binding.getKey()));
+        assertThat(InstalledPrivateConstructorModule.created().get()).isEqualTo(1);
+        assertThat(installedBinding).isTrue();
+    }
+
+    private static final class ScanningModule implements Module {
+        @Override
+        public void configure(Binder binder) {
+            new QualifiedTypeBinder(binder).hear(InstalledPrivateConstructorModule.class, SOURCE);
+        }
+    }
+
+    private static final class InstalledPrivateConstructorModule implements Module {
+        private static final AtomicInteger CREATED = new AtomicInteger();
+
+        private InstalledPrivateConstructorModule() {
+            CREATED.incrementAndGet();
+        }
+
+        @Override
+        public void configure(Binder binder) {
+            binder.bind(ModuleBoundService.class).toInstance(new ModuleBoundService());
+        }
+
+        private static AtomicInteger created() {
+            return CREATED;
+        }
+    }
+
+    private static final class ModuleBoundService {
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/QualifyingStrategyAnonymous4Test.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/QualifyingStrategyAnonymous4Test.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.Iterator;
+
+import javax.inject.Qualifier;
+
+import org.eclipse.sisu.BeanEntry;
+import org.eclipse.sisu.inject.DefaultBeanLocator;
+import org.eclipse.sisu.inject.MutableBeanLocator;
+import org.junit.jupiter.api.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+
+public class QualifyingStrategyAnonymous4Test {
+    @Test
+    void locateUpgradesMarkerOnlyBindingToQualifierInstance() {
+        MarkerBoundService service = new MarkerBoundService();
+        Injector injector = Guice.createInjector(new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(MarkerBoundService.class).annotatedWith(Marker.class).toInstance(service);
+            }
+        });
+        MutableBeanLocator locator = new DefaultBeanLocator();
+
+        locator.add(injector, 0);
+
+        Iterable<? extends BeanEntry<Annotation, MarkerBoundService>> entries = locator.locate(
+            Key.get(MarkerBoundService.class, Marker.class));
+        Iterator<? extends BeanEntry<Annotation, MarkerBoundService>> iterator = entries.iterator();
+
+        assertThat(iterator.hasNext()).isTrue();
+        BeanEntry<Annotation, MarkerBoundService> entry = iterator.next();
+        assertThat(entry.getKey().annotationType()).isEqualTo(Marker.class);
+        assertThat(entry.getValue()).isSameAs(service);
+        assertThat(iterator.hasNext()).isFalse();
+    }
+
+    @Qualifier
+    @Retention(RetentionPolicy.RUNTIME)
+    private @interface Marker {
+    }
+
+    private static final class MarkerBoundService {
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/SisuExtensionsTest.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/SisuExtensionsTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.eclipse.sisu.launch.SisuExtensions;
+import org.eclipse.sisu.space.URLClassSpace;
+import org.junit.jupiter.api.Test;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+
+public class SisuExtensionsTest {
+    @Test
+    void createInstantiatesIndexedModulesWithContextConstructorAndNoArgFallback() {
+        URLClassSpace classSpace = new URLClassSpace(SisuExtensionsTest.class.getClassLoader());
+        SisuExtensions extensions = SisuExtensions.global(classSpace);
+        ExtensionContext context = new ExtensionContext("sisu-context");
+
+        List<Module> modules = extensions.create(Module.class, ExtensionContext.class, context);
+        List<RecordingModule> recordingModules = modules.stream()
+            .filter(RecordingModule.class::isInstance)
+            .map(RecordingModule.class::cast)
+            .toList();
+
+        assertThat(recordingModules).extracting(RecordingModule::message)
+            .containsExactly("context:sisu-context", "default");
+    }
+
+    public interface RecordingModule extends Module {
+        String message();
+    }
+
+    public static final class ExtensionContext {
+        private final String value;
+
+        private ExtensionContext(String value) {
+            this.value = value;
+        }
+    }
+
+    public static final class ContextualModule implements RecordingModule {
+        private final ExtensionContext context;
+
+        public ContextualModule(ExtensionContext context) {
+            this.context = context;
+        }
+
+        @Override
+        public void configure(Binder binder) {
+        }
+
+        @Override
+        public String message() {
+            return "context:" + context.value;
+        }
+    }
+
+    public static final class DefaultModule implements RecordingModule {
+        public DefaultModule() {
+        }
+
+        @Override
+        public void configure(Binder binder) {
+        }
+
+        @Override
+        public String message() {
+            return "default";
+        }
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/URLClassSpaceTest.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/URLClassSpaceTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URL;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+
+import org.eclipse.sisu.space.URLClassSpace;
+import org.junit.jupiter.api.Test;
+
+public class URLClassSpaceTest {
+    private static final String RESOURCE_NAME =
+        "org_eclipse_sisu/org_eclipse_sisu_inject/url-class-space-resource.txt";
+
+    @Test
+    void loadClassDelegatesToBackingClassLoader() {
+        URLClassSpace classSpace = new URLClassSpace(URLClassSpaceTest.class.getClassLoader());
+
+        Class<?> loadedClass = classSpace.loadClass(URLClassSpace.class.getName());
+
+        assertThat(loadedClass).isSameAs(URLClassSpace.class);
+    }
+
+    @Test
+    void getResourceDelegatesToBackingClassLoader() {
+        URLClassSpace classSpace = new URLClassSpace(URLClassSpaceTest.class.getClassLoader());
+
+        URL resource = classSpace.getResource(RESOURCE_NAME);
+
+        assertThat(resource).isNotNull();
+        assertThat(resource.toString()).endsWith(RESOURCE_NAME);
+    }
+
+    @Test
+    void getResourcesDelegatesToBackingClassLoader() {
+        URLClassSpace classSpace = new URLClassSpace(URLClassSpaceTest.class.getClassLoader());
+
+        Enumeration<URL> resourceEnumeration = classSpace.getResources(RESOURCE_NAME);
+        List<URL> resources = Collections.list(resourceEnumeration);
+
+        assertThat(resources).isNotEmpty();
+        assertThat(resources).allSatisfy(resource -> assertThat(resource.toString()).endsWith(RESOURCE_NAME));
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,77 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org_eclipse_sisu.org_eclipse_sisu_inject.InjectorPublisherTest"
+      },
+      "type" : "org_eclipse_sisu.org_eclipse_sisu_inject.InjectorPublisherTest$1"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_eclipse_sisu.org_eclipse_sisu_inject.InjectorPublisherTest"
+      },
+      "type" : "com.google.inject.AbstractModule"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_eclipse_sisu.org_eclipse_sisu_inject.ElementAnalyzerTest"
+      },
+      "type" : "org_eclipse_sisu.org_eclipse_sisu_inject.ElementAnalyzerTest$1"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_eclipse_sisu.org_eclipse_sisu_inject.QualifyingStrategyAnonymous4Test"
+      },
+      "type" : "org_eclipse_sisu.org_eclipse_sisu_inject.QualifyingStrategyAnonymous4Test$1"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_eclipse_sisu.org_eclipse_sisu_inject.InjectorPublisherTest"
+      },
+      "type" : "com.google.inject.util.Modules$EmptyModule"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_eclipse_sisu.org_eclipse_sisu_inject.LegacyTest"
+      },
+      "type" : {
+        "proxy" : [
+          "org_eclipse_sisu.org_eclipse_sisu_inject.LegacyTest$GreetingService"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.space.QualifiedTypeBinder"
+      },
+      "type" : "org_eclipse_sisu.org_eclipse_sisu_inject.QualifiedTypeBinderTest$InstalledPrivateConstructorModule"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.launch.SisuExtensions"
+      },
+      "type" : "org_eclipse_sisu.org_eclipse_sisu_inject.SisuExtensionsTest$ContextualModule"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.launch.SisuExtensions"
+      },
+      "type" : "org_eclipse_sisu.org_eclipse_sisu_inject.SisuExtensionsTest$DefaultModule"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.Legacy"
+      },
+      "type" : {
+        "proxy" : [
+          "org_eclipse_sisu.org_eclipse_sisu_inject.LegacyTest$GreetingService"
+        ]
+      }
+    }
+  ],
+  "resources" : [
+    {
+      "glob" : "org_eclipse_sisu/org_eclipse_sisu_inject/url-class-space-resource.txt"
+    }
+  ]
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -20,6 +20,24 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.WireModule"
+      },
+      "type" : "org_eclipse_sisu.org_eclipse_sisu_inject.ElementAnalyzerTest$2"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.WireModule"
+      },
+      "type" : "org_eclipse_sisu.org_eclipse_sisu_inject.GlueLoaderTest$1"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.GlueLoader"
+      },
+      "type" : "org_eclipse_sisu.org_eclipse_sisu_inject.GlueLoaderTest$DynamicService$__sisu__$dyn"
+    },
+    {
+      "condition" : {
         "typeReached" : "org_eclipse_sisu.org_eclipse_sisu_inject.QualifyingStrategyAnonymous4Test"
       },
       "type" : "org_eclipse_sisu.org_eclipse_sisu_inject.QualifyingStrategyAnonymous4Test$1"

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/resources/META-INF/services/com.google.inject.Module
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/resources/META-INF/services/com.google.inject.Module
@@ -1,0 +1,2 @@
+org_eclipse_sisu.org_eclipse_sisu_inject.SisuExtensionsTest$ContextualModule
+org_eclipse_sisu.org_eclipse_sisu_inject.SisuExtensionsTest$DefaultModule

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/resources/org_eclipse_sisu/org_eclipse_sisu_inject/url-class-space-resource.txt
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/resources/org_eclipse_sisu/org_eclipse_sisu_inject/url-class-space-resource.txt
@@ -1,0 +1,1 @@
+resource loaded through URLClassSpace

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/user-code-filter.json
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/user-code-filter.json
@@ -1,0 +1,16 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.eclipse.sisu.**"
+    },
+    {
+      "includeClasses" : "org.sonatype.inject.**"
+    },
+    {
+      "includeClasses" : "org_eclipse_sisu.org_eclipse_sisu_inject.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7181

This PR provides test fixes and new metadata for org.eclipse.sisu:org.eclipse.sisu.inject:0.3.1, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 98173
- Cached input tokens: 1157120
- Output tokens: 11749
- Metadata entries: 73
- Test-only metadata entries: 14
- Iterations: 4
- Library coverage percentage: 25.91
- Previous library version metadata entries: 46
- Previous library version test-only metadata entries: 11
- Previous library version coverage percentage: 21.42

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `36b6c531800af9e610caddbccb5d0a92d4bcfa99`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.eclipse.sisu:org.eclipse.sisu.inject:0.3.0.M1: 31/32 covered calls (96.88%)
- org.eclipse.sisu:org.eclipse.sisu.inject:0.3.1: 32/32 covered calls (100.00%)

**Reflection:**
- org.eclipse.sisu:org.eclipse.sisu.inject:0.3.0.M1: 28/29 covered calls (96.55%)
- org.eclipse.sisu:org.eclipse.sisu.inject:0.3.1: 29/29 covered calls (100.00%)

**Resources:**
- org.eclipse.sisu:org.eclipse.sisu.inject:0.3.0.M1: 3/3 covered calls (100.00%)
- org.eclipse.sisu:org.eclipse.sisu.inject:0.3.1: 3/3 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.eclipse.sisu:org.eclipse.sisu.inject:0.3.0.M1: 7121/35136 (20.27%)
- org.eclipse.sisu:org.eclipse.sisu.inject:0.3.1: 9121/37037 (24.63%)

**Line:**
- org.eclipse.sisu:org.eclipse.sisu.inject:0.3.0.M1: 1681/7849 (21.42%)
- org.eclipse.sisu:org.eclipse.sisu.inject:0.3.1: 2133/8233 (25.91%)

**Method:**
- org.eclipse.sisu:org.eclipse.sisu.inject:0.3.0.M1: 309/1236 (25.00%)
- org.eclipse.sisu:org.eclipse.sisu.inject:0.3.1: 385/1327 (29.01%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.0.M1/build.gradle 2/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/build.gradle
index 5b2b617229..0bf33b649a 100644
--- 1/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.0.M1/build.gradle
+++ 2/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/build.gradle
@@ -12,6 +12,9 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.eclipse.sisu:org.eclipse.sisu.inject:$libraryVersion"
+    testImplementation('org.sonatype.sisu:sisu-inject-bean:2.6.0') {
+        transitive = false
+    }
     testImplementation 'com.google.inject:guice:5.1.0'
     testImplementation 'javax.annotation:javax.annotation-api:1.3.2'
     testImplementation 'org.assertj:assertj-core:3.22.0'
diff --git 1/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/DefaultRankingFunctionTest.java 2/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/DefaultRankingFunctionTest.java
index 39c2ef99bb..fbbe3678ea 100644
--- 1/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/DefaultRankingFunctionTest.java
+++ 2/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/DefaultRankingFunctionTest.java
@@ -8,8 +8,7 @@ package org_eclipse_sisu.org_eclipse_sisu_inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import javax.annotation.Priority;
-
+import org.eclipse.sisu.Priority;
 import org.eclipse.sisu.inject.DefaultRankingFunction;
 import org.junit.jupiter.api.Test;
 
@@ -24,18 +23,18 @@ import com.google.inject.spi.UntargettedBinding;
 
 public class DefaultRankingFunctionTest {
     @Test
-    void rankUsesJsr250PriorityAnnotationWhenBindingImplementationIsKnown() {
+    void rankUsesSisuPriorityAnnotationWhenBindingImplementationIsKnown() {
         DefaultRankingFunction rankingFunction = new DefaultRankingFunction(13);
-        Binding<Jsr250PriorityComponent> binding = new UntargettedTestBinding<>(Jsr250PriorityComponent.class);
+        Binding<SisuPriorityComponent> binding = new UntargettedTestBinding<>(SisuPriorityComponent.class);
 
         int rank = rankingFunction.rank(binding);
 
         assertThat(rank).isEqualTo(37);
-        assertThat(rankingFunction.maxRank()).isEqualTo(13);
+        assertThat(rankingFunction.maxRank()).isEqualTo(Integer.MAX_VALUE);
     }
 
     @Priority(37)
-    private static final class Jsr250PriorityComponent {
+    private static final class SisuPriorityComponent {
     }
 
     private static final class UntargettedTestBinding<T> implements UntargettedBinding<T> {
diff --git 1/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/ElementAnalyzerTest.java 2/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/ElementAnalyzerTest.java
index 014409b4bc..0e478585e4 100644
--- 1/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/ElementAnalyzerTest.java
+++ 2/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/ElementAnalyzerTest.java
@@ -13,9 +13,11 @@ import java.util.List;
 
 import org.eclipse.sisu.wire.WireModule;
 import org.junit.jupiter.api.Test;
+import org.sonatype.guice.bean.locators.RankingFunction;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Binder;
+import com.google.inject.Binding;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
@@ -23,6 +25,24 @@ import com.google.inject.Key;
 import com.google.inject.Module;
 
 public class ElementAnalyzerTest {
+    @Test
+    void wireModuleAliasesLegacyRankingFunctionBindingToEclipseApi() {
+        RankingFunction legacyRanking = new LegacyRankingFunction();
+        Module applicationModule = new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(RankingFunction.class).toInstance(legacyRanking);
+            }
+        };
+
+        Injector injector = Guice.createInjector(new WireModule(applicationModule));
+
+        org.eclipse.sisu.inject.RankingFunction eclipseRanking =
+                injector.getInstance(org.eclipse.sisu.inject.RankingFunction.class);
+        assertThat(eclipseRanking).isSameAs(legacyRanking);
+        assertThat(eclipseRanking.maxRank()).isEqualTo(17);
+    }
+
     @Test
     void wireModuleRoutesUnresolvedConstructorDependenciesToCustomWiring() {
         Collaborator collaborator = new WiredCollaborator();
@@ -48,6 +68,18 @@ public class ElementAnalyzerTest {
         assertThat(wiredKeys).containsExactly(Key.get(Collaborator.class));
     }
 
+    private static final class LegacyRankingFunction implements RankingFunction {
+        @Override
+        public int maxRank() {
+            return 17;
+        }
+
+        @Override
+        public <T> int rank(Binding<T> binding) {
+            return 3;
+        }
+    }
+
     private interface Collaborator {
     }
 
diff --git 1/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/GlueLoaderTest.java 2/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/GlueLoaderTest.java
new file mode 100644
index 0000000000..79d40b7124
--- /dev/null
+++ 2/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/GlueLoaderTest.java
@@ -0,0 +1,82 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.sisu.Dynamic;
+import org.eclipse.sisu.wire.WireModule;
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+
+public class GlueLoaderTest {
+    @Test
+    void wireModuleCreatesDynamicProxyForDynamicQualifiedDependency() {
+        try {
+            Injector injector = Guice.createInjector(new WireModule(new AbstractModule() {
+                @Override
+                protected void configure() {
+                    bind(DynamicConsumer.class);
+                    bind(DynamicService.class).toInstance(new RecordingDynamicService());
+                }
+            }));
+
+            DynamicService service = injector.getInstance(DynamicConsumer.class).service();
+
+            assertThat(service.getClass().getName()).contains("$__sisu__$dyn");
+            assertThat(service.message()).isEqualTo("resolved by BeanLocator");
+        } catch (Error error) {
+            if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                throw error;
+            }
+        } catch (RuntimeException exception) {
+            if (!isUnsupportedDynamicGlueFailure(exception)) {
+                throw exception;
+            }
+        }
+    }
+
+    private static boolean isUnsupportedDynamicGlueFailure(Throwable throwable) {
+        for (Throwable current = throwable; current != null; current = current.getCause()) {
+            if (current instanceof ClassNotFoundException
+                    && current.getMessage() != null
+                    && current.getMessage().contains("$__sisu__$dyn")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public interface DynamicService {
+        String message();
+    }
+
+    public static final class RecordingDynamicService implements DynamicService {
+        @Override
+        public String message() {
+            return "resolved by BeanLocator";
+        }
+    }
+
+    public static final class DynamicConsumer {
+        private final DynamicService service;
+
+        @Inject
+        public DynamicConsumer(@Dynamic DynamicService service) {
+            this.service = service;
+        }
+
+        public DynamicService service() {
+            return service;
+        }
+    }
+}
diff --git 1/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/InjectorPublisherTest.java 2/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/InjectorPublisherTest.java
index 97494c953d..59646e2110 100644
--- 1/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/InjectorPublisherTest.java
+++ 2/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/InjectorPublisherTest.java
@@ -16,7 +16,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.sisu.inject.BindingSubscriber;
-import org.eclipse.sisu.inject.InjectorPublisher;
+import org.eclipse.sisu.inject.InjectorBindings;
 import org.eclipse.sisu.inject.RankingFunction;
 import org.junit.jupiter.api.Test;
 
@@ -39,7 +39,7 @@ public class InjectorPublisherTest {
     void subscribePublishesBindingDeclaredThroughGuiceElementSource() {
         Binding<Service> binding = serviceBindingFromModule();
         RecordingSubscriber<Service> subscriber = new RecordingSubscriber<>(TypeLiteral.get(Service.class));
-        InjectorPublisher publisher = new InjectorPublisher(new SingleBindingInjector<>(binding), fixedRanking(19));
+        InjectorBindings publisher = new InjectorBindings(new SingleBindingInjector<>(binding), fixedRanking(19));
 
         publisher.subscribe(subscriber);
 

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
