### PR TITLE
[Automation] Generated metadata for com.github.ben-manes.caffeine:caffeine:2.9.3

### DIFF
--- a/metadata/com.github.ben-manes.caffeine/caffeine/2.9.3/reachability-metadata.json
+++ b/metadata/com.github.ben-manes.caffeine/caffeine/2.9.3/reachability-metadata.json
@@ -510,6 +510,17 @@
           "name": "threadLocalRandomProbe"
         }
       ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.benmanes.caffeine.cache.UnsafeAccess"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ]
     }
   ]
 }

--- a/metadata/com.github.ben-manes.caffeine/caffeine/index.json
+++ b/metadata/com.github.ben-manes.caffeine/caffeine/index.json
@@ -28,7 +28,7 @@
   {
     "metadata-version" : "2.9.3",
     "source-code-url" : "https://repo1.maven.org/maven2/com/github/ben-manes/caffeine/caffeine/$version$/caffeine-$version$-sources.jar",
-    "repository-url" : "https://github.com/ben-manes/caffeine/tree/v2.9.3",
+    "repository-url" : "https://github.com/ben-manes/caffeine",
     "test-code-url" : "https://repo1.maven.org/maven2/com/github/ben-manes/caffeine/caffeine/$version$/caffeine-$version$-test.jar",
     "documentation-url" : "https://repo1.maven.org/maven2/com/github/ben-manes/caffeine/caffeine/$version$/caffeine-$version$-javadoc.jar",
     "description" : "Caffeine is a high-performance Java caching library that provides an in-memory cache with a Guava-inspired API. It supports automatic loading, size-based eviction, time-based expiration, refresh, reference-based entries, removal notifications, and cache statistics.",

--- a/stats/com.github.ben-manes.caffeine/caffeine/2.9.3/stats.json
+++ b/stats/com.github.ben-manes.caffeine/caffeine/2.9.3/stats.json
@@ -15,21 +15,21 @@
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 8754,
-        "missed" : 41144,
-        "ratio" : 0.175438,
+        "covered" : 8771,
+        "missed" : 41127,
+        "ratio" : 0.175779,
         "total" : 49898
       },
       "line" : {
-        "covered" : 2038,
-        "missed" : 11039,
-        "ratio" : 0.155846,
+        "covered" : 2047,
+        "missed" : 11030,
+        "ratio" : 0.156534,
         "total" : 13077
       },
       "method" : {
-        "covered" : 650,
-        "missed" : 5093,
-        "ratio" : 0.113181,
+        "covered" : 653,
+        "missed" : 5090,
+        "ratio" : 0.113704,
         "total" : 5743
       }
     }


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#6833

This PR provides new metadata needed for the com.github.ben-manes.caffeine:caffeine:2.9.3, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `com.github.ben-manes.caffeine:caffeine:3.1.2`): 121
- Metadata entries (new `com.github.ben-manes.caffeine:caffeine:2.9.3`): 82
- Library coverage (previous): 29.16%
- Library coverage (new): 15.65%

### Metadata Forge

- Forge monitored branch: `master`
- Forge branch: `master`
- Forge commit hash: `1c435bf718c410052040fc2ed2b120a824ad9295`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.github.ben-manes.caffeine:caffeine:3.1.2: 8/8 covered calls (100.00%)
- com.github.ben-manes.caffeine:caffeine:2.9.3: 14/21 covered calls (66.67%)

**Reflection:**
- com.github.ben-manes.caffeine:caffeine:3.1.2: 8/8 covered calls (100.00%)
- com.github.ben-manes.caffeine:caffeine:2.9.3: 14/21 covered calls (66.67%)

#### Library coverage

**Instruction:**
- com.github.ben-manes.caffeine:caffeine:3.1.2: 8461/52505 (16.11%)
- com.github.ben-manes.caffeine:caffeine:2.9.3: 8771/49898 (17.58%)

**Line:**
- com.github.ben-manes.caffeine:caffeine:3.1.2: 1602/5494 (29.16%)
- com.github.ben-manes.caffeine:caffeine:2.9.3: 2047/13077 (15.65%)

**Method:**
- com.github.ben-manes.caffeine:caffeine:3.1.2: 691/5855 (11.80%)
- com.github.ben-manes.caffeine:caffeine:2.9.3: 653/5743 (11.37%)

### Local CI Verification

- Status: `skipped`
- Commands run: 0
- Fixup attempts: 0
