### PR TITLE
[Automation] Generated metadata for org.htrace:htrace-core:3.0.4

### DIFF
--- a/metadata/org.htrace/htrace-core/3.0.4/reachability-metadata.json
+++ b/metadata/org.htrace/htrace-core/3.0.4/reachability-metadata.json
@@ -1,1 +1,184 @@
-{ }
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.htrace.impl.LocalFileSpanReceiver$WriteSpanRunnable"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.htrace.Tracer"
+      },
+      "type" : "java.lang.String"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.htrace.HTraceConfiguration"
+      },
+      "type" : "java.lang.Thread",
+      "methods" : [
+        {
+          "name" : "getContextClassLoader",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.htrace.TraceTree"
+      },
+      "type" : "java.lang.Thread",
+      "methods" : [
+        {
+          "name" : "getContextClassLoader",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.htrace.Tracer"
+      },
+      "type" : "java.lang.Thread",
+      "methods" : [
+        {
+          "name" : "getContextClassLoader",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.htrace.impl.LocalFileSpanReceiver"
+      },
+      "type" : "java.lang.Thread",
+      "methods" : [
+        {
+          "name" : "getContextClassLoader",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.htrace.Tracer"
+      },
+      "type" : "org.apache.commons.logging.LogFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.htrace.HTraceConfiguration"
+      },
+      "type" : "org.apache.commons.logging.impl.Jdk14Logger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.htrace.Tracer"
+      },
+      "type" : "org.apache.commons.logging.impl.Jdk14Logger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.htrace.impl.LocalFileSpanReceiver"
+      },
+      "type" : "org.apache.commons.logging.impl.Jdk14Logger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.htrace.Tracer"
+      },
+      "type" : "org.apache.commons.logging.impl.Log4JLogger"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.htrace.Tracer"
+      },
+      "type" : "org.apache.commons.logging.impl.LogFactoryImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.htrace.Tracer"
+      },
+      "type" : "org.apache.commons.logging.impl.WeakHashtable",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.htrace.Trace"
+      },
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.htrace.Tracer"
+      },
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.htrace.Tracer"
+      },
+      "glob" : "META-INF/services/org.apache.commons.logging.LogFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.htrace.Tracer"
+      },
+      "glob" : "commons-logging.properties"
+    }
+  ]
+}

--- a/tests/src/org.htrace/htrace-core/3.0.4/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.htrace/htrace-core/3.0.4/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -9,6 +9,41 @@
           "org_htrace.htrace_core.Htrace_coreTest$GreetingService"
         ]
       }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.htrace.wrappers.TraceProxy$1"
+      },
+      "type" : "org_htrace.htrace_core.Htrace_coreTest$GreetingService",
+      "methods" : [
+        {
+          "name" : "greet",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "sum",
+          "parameterTypes" : [
+            "int",
+            "int"
+          ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org_htrace.htrace_core.Htrace_coreTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_htrace.htrace_core.Htrace_coreTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
     }
   ]
 }


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#6842

This PR provides new metadata needed for the org.htrace:htrace-core:3.0.4, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.htrace:htrace-core:3.0.4`): 28
- Test-only metadata entries (previous `org.htrace:htrace-core:3.0.4`): 6
- Metadata entries (new `org.htrace:htrace-core:3.0.4`): 28
- Test-only metadata entries (new `org.htrace:htrace-core:3.0.4`): 6
- Library coverage (previous): 80.49%
- Library coverage (new): 80.49%

### Metadata Forge

- Forge monitored branch: `master`
- Forge branch: `master`
- Forge commit hash: `6a95bc978e5444c203a5010df5d40d2e880033c3`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `org.htrace:htrace-core:3.0.4` and `org.htrace:htrace-core:3.0.4`.

### Local CI Verification

- Status: `skipped`
- Commands run: 0
- Fixup attempts: 0
