### PR TITLE
[GenAI] Add support for org.springframework.integration:spring-integration-core:7.0.2 using gpt-5.5

### DIFF
--- a/stats/org.springframework.integration/spring-integration-core/7.0.2/execution-metrics.json
+++ b/stats/org.springframework.integration/spring-integration-core/7.0.2/execution-metrics.json
@@ -1,9 +1,9 @@
 {
   "add_new_library_support:2026-05-19": {
-    "timestamp": "2026-05-19T07:11:48.003559Z",
+    "timestamp": "2026-05-19T12:52:34.305523Z",
     "library": "org.springframework.integration:spring-integration-core:7.0.2",
-    "starting_commit": "ca038ea5c5e479915cac7df353634125ea179a85",
-    "ending_commit": "130fdf8c1673d0134a32d19036c3caed7af82132",
+    "starting_commit": "6a95bc978e5444c203a5010df5d40d2e880033c3",
+    "ending_commit": "b1dce76e331a142d346fbfe0310bfa6decf2b2cf",
     "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
     "agent": "pi",
     "model": "oca/gpt-5.5",
@@ -12,35 +12,35 @@
       "version": "7.0.2",
       "libraryCoverage": {
         "instruction": {
-          "covered": 4358,
-          "missed": 90297,
-          "ratio": 0.046041,
+          "covered": 6546,
+          "missed": 88109,
+          "ratio": 0.069156,
           "total": 94655
         },
         "line": {
-          "covered": 1205,
-          "missed": 22603,
-          "ratio": 0.050613,
+          "covered": 1821,
+          "missed": 21987,
+          "ratio": 0.076487,
           "total": 23808
         },
         "method": {
-          "covered": 333,
-          "missed": 6092,
-          "ratio": 0.051829,
+          "covered": 489,
+          "missed": 5936,
+          "ratio": 0.076109,
           "total": 6425
         }
       }
     },
     "metrics": {
-      "input_tokens_used": 181013,
-      "cached_input_tokens_used": 1953792,
-      "output_tokens_used": 23983,
-      "iterations": 5,
-      "cost_usd": 1.6964,
-      "generated_loc": 338,
-      "tested_library_loc": 1205,
+      "input_tokens_used": 204166,
+      "cached_input_tokens_used": 2140672,
+      "output_tokens_used": 23225,
+      "iterations": 6,
+      "cost_usd": 1.767,
+      "generated_loc": 630,
+      "tested_library_loc": 1821,
       "metadata_entries": 0,
-      "code_coverage_percent": 5.06
+      "code_coverage_percent": 7.65
     },
     "artifacts": {
       "test_file": "tests/src/org.springframework.integration/spring-integration-core/7.0.2/src/test/java/org_springframework_integration/spring_integration_core/Spring_integration_coreTest.java",

--- a/stats/org.springframework.integration/spring-integration-core/7.0.2/stats.json
+++ b/stats/org.springframework.integration/spring-integration-core/7.0.2/stats.json
@@ -4,21 +4,21 @@
     "dynamicAccess" : "N/A",
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 4358,
-        "missed" : 90297,
-        "ratio" : 0.046041,
+        "covered" : 6546,
+        "missed" : 88109,
+        "ratio" : 0.069156,
         "total" : 94655
       },
       "line" : {
-        "covered" : 1205,
-        "missed" : 22603,
-        "ratio" : 0.050613,
+        "covered" : 1821,
+        "missed" : 21987,
+        "ratio" : 0.076487,
         "total" : 23808
       },
       "method" : {
-        "covered" : 333,
-        "missed" : 6092,
-        "ratio" : 0.051829,
+        "covered" : 489,
+        "missed" : 5936,
+        "ratio" : 0.076109,
         "total" : 6425
       }
     }

--- a/tests/src/org.springframework.integration/spring-integration-core/7.0.2/src/test/java/org_springframework_integration/spring_integration_core/Spring_integration_coreTest.java
+++ b/tests/src/org.springframework.integration/spring-integration-core/7.0.2/src/test/java/org_springframework_integration/spring_integration_core/Spring_integration_coreTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -36,6 +37,7 @@ import org.springframework.integration.channel.ExecutorChannel;
 import org.springframework.integration.channel.FixedSubscriberChannel;
 import org.springframework.integration.channel.FluxMessageChannel;
 import org.springframework.integration.channel.NullChannel;
+import org.springframework.integration.channel.PartitionedChannel;
 import org.springframework.integration.channel.PriorityChannel;
 import org.springframework.integration.channel.PublishSubscribeChannel;
 import org.springframework.integration.channel.QueueChannel;
@@ -575,6 +577,54 @@ public class Spring_integration_coreTest {
             adapter.stop();
             adapter.destroy();
             taskScheduler.shutdown();
+        }
+    }
+
+    @Test
+    void partitionedChannelSerializesMessagesByPartitionKeyOnDedicatedWorkers() throws Exception {
+        AtomicInteger threadCounter = new AtomicInteger();
+        PartitionedChannel channel = new PartitionedChannel(2, message -> message.getHeaders().get("partitionKey"));
+        channel.setThreadFactory(task -> {
+            Thread thread = new Thread(task, "partition-worker-" + threadCounter.incrementAndGet());
+            thread.setDaemon(true);
+            return thread;
+        });
+        initialize(channel);
+
+        CountDownLatch handledMessages = new CountDownLatch(4);
+        List<String> handledPayloads = new CopyOnWriteArrayList<>();
+        Map<Object, String> threadsByPartition = new ConcurrentHashMap<>();
+        AtomicReference<Throwable> handlerFailure = new AtomicReference<>();
+        channel.subscribe(message -> {
+            Object partitionKey = message.getHeaders().get("partitionKey");
+            String threadName = Thread.currentThread().getName();
+            String previousThreadName = threadsByPartition.putIfAbsent(partitionKey, threadName);
+            if (previousThreadName != null && !previousThreadName.equals(threadName)) {
+                handlerFailure.compareAndSet(null, new AssertionError(
+                        "Partition " + partitionKey + " moved from " + previousThreadName + " to " + threadName));
+            }
+            handledPayloads.add(message.getPayload().toString());
+            handledMessages.countDown();
+        });
+
+        try {
+            assertThat(channel.send(MessageBuilder.withPayload("zero-one").setHeader("partitionKey", 0).build()))
+                    .isTrue();
+            assertThat(channel.send(MessageBuilder.withPayload("one-one").setHeader("partitionKey", 1).build()))
+                    .isTrue();
+            assertThat(channel.send(MessageBuilder.withPayload("zero-two").setHeader("partitionKey", 0).build()))
+                    .isTrue();
+            assertThat(channel.send(MessageBuilder.withPayload("one-two").setHeader("partitionKey", 1).build()))
+                    .isTrue();
+
+            assertThat(handledMessages.await(2, TimeUnit.SECONDS)).isTrue();
+            assertThat(handlerFailure.get()).isNull();
+            assertThat(threadsByPartition).containsOnlyKeys(0, 1);
+            assertThat(threadsByPartition.get(0)).isNotEqualTo(threadsByPartition.get(1));
+            assertThat(handledPayloads.indexOf("zero-one")).isLessThan(handledPayloads.indexOf("zero-two"));
+            assertThat(handledPayloads.indexOf("one-one")).isLessThan(handledPayloads.indexOf("one-two"));
+        } finally {
+            channel.destroy();
         }
     }
 

--- a/tests/src/org.springframework.integration/spring-integration-core/7.0.2/src/test/java/org_springframework_integration/spring_integration_core/Spring_integration_coreTest.java
+++ b/tests/src/org.springframework.integration/spring-integration-core/7.0.2/src/test/java/org_springframework_integration/spring_integration_core/Spring_integration_coreTest.java
@@ -19,6 +19,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 
@@ -42,8 +43,10 @@ import org.springframework.integration.channel.RendezvousChannel;
 import org.springframework.integration.channel.interceptor.WireTap;
 import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.context.IntegrationObjectSupport;
+import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.core.MessagingTemplate;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
+import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
 import org.springframework.integration.filter.MessageFilter;
 import org.springframework.integration.handler.MessageProcessor;
 import org.springframework.integration.handler.ServiceActivatingHandler;
@@ -73,6 +76,7 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.support.PeriodicTrigger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -529,6 +533,49 @@ public class Spring_integration_coreTest {
         Lock reacquired = registry.obtain("customer-42");
         assertThat(reacquired.tryLock(1, TimeUnit.SECONDS)).isTrue();
         reacquired.unlock();
+    }
+
+    @Test
+    void sourcePollingChannelAdapterPollsMessageSourceIntoOutputChannel() {
+        ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+        taskScheduler.setPoolSize(1);
+        taskScheduler.initialize();
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        beanFactory.registerSingleton(IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME, taskScheduler);
+        QueueChannel output = new QueueChannel();
+        AtomicInteger counter = new AtomicInteger();
+        MessageSource<String> source = () -> {
+            int value = counter.incrementAndGet();
+            if (value > 2) {
+                return null;
+            }
+            return MessageBuilder.withPayload("poll-" + value)
+                    .setHeader("pollNumber", value)
+                    .build();
+        };
+        SourcePollingChannelAdapter adapter = new SourcePollingChannelAdapter();
+        adapter.setSource(source);
+        adapter.setOutputChannel(output);
+        adapter.setTrigger(new PeriodicTrigger(Duration.ofMillis(10)));
+        adapter.setMaxMessagesPerPoll(1);
+        initialize(adapter, beanFactory);
+
+        adapter.start();
+        try {
+            Message<?> first = output.receive(2_000);
+            Message<?> second = output.receive(2_000);
+
+            assertThat(first).isNotNull();
+            assertThat(first.getPayload()).isEqualTo("poll-1");
+            assertThat(first.getHeaders().get("pollNumber")).isEqualTo(1);
+            assertThat(second).isNotNull();
+            assertThat(second.getPayload()).isEqualTo("poll-2");
+            assertThat(second.getHeaders().get("pollNumber")).isEqualTo(2);
+        } finally {
+            adapter.stop();
+            adapter.destroy();
+            taskScheduler.shutdown();
+        }
     }
 
     @Test

--- a/tests/src/org.springframework.integration/spring-integration-core/7.0.2/src/test/java/org_springframework_integration/spring_integration_core/Spring_integration_coreTest.java
+++ b/tests/src/org.springframework.integration/spring-integration-core/7.0.2/src/test/java/org_springframework_integration/spring_integration_core/Spring_integration_coreTest.java
@@ -11,13 +11,16 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
 
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
@@ -26,31 +29,50 @@ import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.aggregator.DefaultAggregatingMessageGroupProcessor;
 import org.springframework.integration.aggregator.MessageCountReleaseStrategy;
+import org.springframework.integration.channel.DefaultHeaderChannelRegistry;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.ExecutorChannel;
+import org.springframework.integration.channel.FixedSubscriberChannel;
 import org.springframework.integration.channel.FluxMessageChannel;
+import org.springframework.integration.channel.NullChannel;
 import org.springframework.integration.channel.PriorityChannel;
 import org.springframework.integration.channel.PublishSubscribeChannel;
 import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.channel.RendezvousChannel;
 import org.springframework.integration.channel.interceptor.WireTap;
+import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.context.IntegrationObjectSupport;
+import org.springframework.integration.core.MessagingTemplate;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.filter.MessageFilter;
 import org.springframework.integration.handler.MessageProcessor;
 import org.springframework.integration.handler.ServiceActivatingHandler;
+import org.springframework.integration.metadata.SimpleMetadataStore;
+import org.springframework.integration.router.HeaderValueRouter;
+import org.springframework.integration.router.PayloadTypeRouter;
 import org.springframework.integration.router.RecipientListRouter;
+import org.springframework.integration.selector.MessageSelectorChain;
+import org.springframework.integration.selector.MetadataStoreSelector;
+import org.springframework.integration.selector.PayloadTypeSelector;
+import org.springframework.integration.selector.UnexpiredMessageSelector;
 import org.springframework.integration.splitter.DefaultMessageSplitter;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.SimpleMessageStore;
 import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.support.locks.DefaultLockRegistry;
 import org.springframework.integration.transformer.ClaimCheckInTransformer;
 import org.springframework.integration.transformer.ClaimCheckOutTransformer;
+import org.springframework.integration.transformer.HeaderEnricher;
+import org.springframework.integration.transformer.HeaderFilter;
 import org.springframework.integration.transformer.MessageTransformingHandler;
+import org.springframework.integration.transformer.ObjectToStringTransformer;
 import org.springframework.integration.transformer.PayloadTypeConvertingTransformer;
+import org.springframework.integration.transformer.support.StaticHeaderValueMessageProcessor;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -303,6 +325,213 @@ public class Spring_integration_coreTest {
     }
 
     @Test
+    void messagingTemplateSupportsRequestReplyAndPollableReceives() {
+        DirectChannel requests = new DirectChannel();
+        QueueChannel replies = new QueueChannel();
+        requests.subscribe(message -> {
+            MessageChannel replyChannel = (MessageChannel) message.getHeaders().getReplyChannel();
+            replyChannel.send(MessageBuilder.withPayload("processed-" + message.getPayload())
+                    .setHeader("requestId", message.getHeaders().get("requestId"))
+                    .build());
+        });
+        MessagingTemplate template = new MessagingTemplate();
+        template.setSendTimeout(1_000);
+        template.setReceiveTimeout(1_000);
+
+        Message<?> reply = template.sendAndReceive(requests, MessageBuilder.withPayload("template")
+                .setHeader("requestId", "r-1")
+                .build());
+
+        assertThat(reply).isNotNull();
+        assertThat(reply.getPayload()).isEqualTo("processed-template");
+        assertThat(reply.getHeaders().get("requestId")).isEqualTo("r-1");
+
+        replies.send(MessageBuilder.withPayload(42).build());
+        assertThat(template.receiveAndConvert(replies, 0)).isEqualTo(42);
+    }
+
+    @Test
+    void rendezvousFixedSubscriberNullAndHeaderRegistryChannelsUsePublicChannelContracts() throws Exception {
+        RendezvousChannel rendezvous = new RendezvousChannel();
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<Boolean> sender = executor.submit(() -> rendezvous.send(MessageBuilder.withPayload("handoff")
+                .build(), 2_000));
+        try {
+            Message<?> received = rendezvous.receive(2_000);
+
+            assertThat(received).isNotNull();
+            assertThat(received.getPayload()).isEqualTo("handoff");
+            assertThat(sender.get(2, TimeUnit.SECONDS)).isTrue();
+        } finally {
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(2, TimeUnit.SECONDS)).isTrue();
+        }
+
+        AtomicReference<Message<?>> fixedSubscriberMessage = new AtomicReference<>();
+        FixedSubscriberChannel fixedSubscriberChannel = new FixedSubscriberChannel(fixedSubscriberMessage::set);
+        assertThat(fixedSubscriberChannel.send(MessageBuilder.withPayload("fixed").build())).isTrue();
+        assertThat(fixedSubscriberMessage.get().getPayload()).isEqualTo("fixed");
+
+        NullChannel nullChannel = new NullChannel();
+        assertThat(nullChannel.send(MessageBuilder.withPayload("discard").build())).isTrue();
+        assertThat(nullChannel.receive(0)).isNull();
+
+        ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+        taskScheduler.setPoolSize(1);
+        taskScheduler.initialize();
+        DefaultListableBeanFactory registryBeanFactory = new DefaultListableBeanFactory();
+        registryBeanFactory.registerSingleton(IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME, taskScheduler);
+        DefaultHeaderChannelRegistry registry = initialize(
+                new DefaultHeaderChannelRegistry(10_000), registryBeanFactory);
+        try {
+            registry.setRemoveOnGet(true);
+            Object channelName = registry.channelToChannelName(fixedSubscriberChannel);
+            assertThat(channelName).isInstanceOf(String.class);
+            assertThat(registry.size()).isEqualTo(1);
+            assertThat(registry.channelNameToChannel((String) channelName)).isSameAs(fixedSubscriberChannel);
+            assertThat(registry.size()).isZero();
+        } finally {
+            registry.stop();
+            taskScheduler.shutdown();
+        }
+    }
+
+    @Test
+    void payloadAndHeaderRoutersResolveMappedChannelsFromBeanFactory() {
+        QueueChannel stringPayloads = new QueueChannel();
+        QueueChannel numberPayloads = new QueueChannel();
+        QueueChannel standardPriority = new QueueChannel();
+        QueueChannel expressPriority = new QueueChannel();
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        beanFactory.registerSingleton("stringPayloads", stringPayloads);
+        beanFactory.registerSingleton("numberPayloads", numberPayloads);
+        beanFactory.registerSingleton("standardPriority", standardPriority);
+        beanFactory.registerSingleton("expressPriority", expressPriority);
+
+        PayloadTypeRouter payloadTypeRouter = new PayloadTypeRouter();
+        payloadTypeRouter.setChannelMapping(String.class.getName(), "stringPayloads");
+        payloadTypeRouter.setChannelMapping(Integer.class.getName(), "numberPayloads");
+        initialize(payloadTypeRouter, beanFactory);
+
+        payloadTypeRouter.handleMessage(MessageBuilder.withPayload("text").build());
+        payloadTypeRouter.handleMessage(MessageBuilder.withPayload(99).build());
+
+        assertThat(stringPayloads.receive(0).getPayload()).isEqualTo("text");
+        assertThat(numberPayloads.receive(0).getPayload()).isEqualTo(99);
+
+        HeaderValueRouter headerValueRouter = new HeaderValueRouter("shippingPriority");
+        headerValueRouter.setChannelMapping("standard", "standardPriority");
+        headerValueRouter.setChannelMapping("express", "expressPriority");
+        initialize(headerValueRouter, beanFactory);
+
+        headerValueRouter.handleMessage(MessageBuilder.withPayload("first")
+                .setHeader("shippingPriority", "standard")
+                .build());
+        headerValueRouter.handleMessage(MessageBuilder.withPayload("second")
+                .setHeader("shippingPriority", "express")
+                .build());
+
+        assertThat(standardPriority.receive(0).getPayload()).isEqualTo("first");
+        assertThat(expressPriority.receive(0).getPayload()).isEqualTo("second");
+    }
+
+    @Test
+    void headerTransformersEnrichFilterAndRenderPayloads() {
+        HeaderEnricher enricher = new HeaderEnricher(Map.of(
+                "tenant", new StaticHeaderValueMessageProcessor<>("north"),
+                "internalTrace", new StaticHeaderValueMessageProcessor<>("trace-1")));
+        enricher.setDefaultOverwrite(true);
+        initialize(enricher);
+
+        Message<?> enriched = enricher.transform(MessageBuilder.withPayload(List.of("a", "b"))
+                .setHeader("tenant", "original")
+                .build());
+
+        assertThat(enriched.getHeaders().get("tenant")).isEqualTo("north");
+        assertThat(enriched.getHeaders().get("internalTrace")).isEqualTo("trace-1");
+
+        HeaderFilter headerFilter = new HeaderFilter("internal*");
+        headerFilter.setPatternMatch(true);
+        initialize(headerFilter);
+        Message<?> filtered = headerFilter.transform(enriched);
+
+        assertThat(filtered.getHeaders()).containsEntry("tenant", "north");
+        assertThat(filtered.getHeaders()).doesNotContainKey("internalTrace");
+
+        ObjectToStringTransformer objectToStringTransformer = initialize(new ObjectToStringTransformer());
+        Message<?> rendered = objectToStringTransformer.transform(filtered);
+
+        assertThat(rendered.getPayload()).isEqualTo("[a, b]");
+        assertThat(rendered.getHeaders().get("tenant")).isEqualTo("north");
+    }
+
+    @Test
+    void metadataStoreSelectorsAndSelectorChainsFilterMessagesDeterministically() {
+        SimpleMetadataStore metadataStore = new SimpleMetadataStore();
+        MessageProcessor<String> keyProcessor = message -> message.getHeaders().get("businessKey", String.class);
+        MessageProcessor<String> valueProcessor = message -> message.getPayload().toString();
+        MetadataStoreSelector selector = new MetadataStoreSelector(keyProcessor, valueProcessor, metadataStore);
+        selector.setCompareValues((oldValue, newValue) -> newValue.compareTo(oldValue) > 0);
+
+        Message<String> firstVersion = MessageBuilder.withPayload("v1")
+                .setHeader("businessKey", "order-1")
+                .build();
+        Message<String> duplicateVersion = MessageBuilder.withPayload("v1")
+                .setHeader("businessKey", "order-1")
+                .build();
+        Message<String> laterVersion = MessageBuilder.withPayload("v2")
+                .setHeader("businessKey", "order-1")
+                .build();
+
+        assertThat(selector.accept(firstVersion)).isTrue();
+        assertThat(selector.accept(duplicateVersion)).isFalse();
+        assertThat(selector.accept(laterVersion)).isTrue();
+        assertThat(metadataStore.get("order-1")).isEqualTo("v2");
+
+        MessageSelectorChain chain = new MessageSelectorChain();
+        chain.add(new PayloadTypeSelector(String.class));
+        chain.add(new UnexpiredMessageSelector());
+
+        assertThat(chain.accept(MessageBuilder.withPayload("fresh")
+                .setExpirationDate(System.currentTimeMillis() + 60_000)
+                .build())).isTrue();
+        assertThat(chain.accept(MessageBuilder.withPayload(7)
+                .setExpirationDate(System.currentTimeMillis() + 60_000)
+                .build())).isFalse();
+        assertThat(chain.accept(MessageBuilder.withPayload("expired")
+                .setExpirationDate(System.currentTimeMillis() - 1_000)
+                .build())).isFalse();
+    }
+
+    @Test
+    void defaultLockRegistryCoordinatesAccessAcrossThreads() throws Exception {
+        DefaultLockRegistry registry = new DefaultLockRegistry();
+        Lock lock = registry.obtain("customer-42");
+        lock.lock();
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<Boolean> contender = executor.submit(() -> {
+                Lock contenderLock = registry.obtain("customer-42");
+                boolean acquired = contenderLock.tryLock(100, TimeUnit.MILLISECONDS);
+                if (acquired) {
+                    contenderLock.unlock();
+                }
+                return acquired;
+            });
+
+            assertThat(contender.get(2, TimeUnit.SECONDS)).isFalse();
+        } finally {
+            lock.unlock();
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(2, TimeUnit.SECONDS)).isTrue();
+        }
+
+        Lock reacquired = registry.obtain("customer-42");
+        assertThat(reacquired.tryLock(1, TimeUnit.SECONDS)).isTrue();
+        reacquired.unlock();
+    }
+
+    @Test
     void executorAndFluxChannelsDeliverMessagesAsynchronouslyWithinBoundedWaits() throws Exception {
         ExecutorService executor = Executors.newSingleThreadExecutor();
         ExecutorChannel executorChannel = new ExecutorChannel(executor);
@@ -368,7 +597,12 @@ public class Spring_integration_coreTest {
     }
 
     private static <T extends IntegrationObjectSupport> T initialize(T component) {
-        component.setBeanFactory(BEAN_FACTORY);
+        return initialize(component, BEAN_FACTORY);
+    }
+
+    private static <T extends IntegrationObjectSupport> T initialize(
+            T component, DefaultListableBeanFactory beanFactory) {
+        component.setBeanFactory(beanFactory);
         component.afterPropertiesSet();
         return component;
     }


### PR DESCRIPTION

## What does this PR do?

Fixes: #7080

This PR introduces tests and metadata for org.springframework.integration:spring-integration-core:7.0.2, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 204166
- Cached input tokens: 2140672
- Output tokens: 23225
- Metadata entries: 0
- Iterations: 6
- Library coverage percentage: 7.65
- Generated lines of code: 630
- Tested library lines of code: 1821

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `6a95bc978e5444c203a5010df5d40d2e880033c3`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Library coverage:
- Instruction: 6546/94655 (6.92%)
- Line: 1821/23808 (7.65%)
- Method: 489/6425 (7.61%)

### Local CI Verification

- Status: `success`
- Commands run: 12
- Fixup attempts: 0
