### PR TITLE
[GenAI] Mark org.springframework.cloud:spring-cloud-starter as not for Native Image

### DIFF
--- a/metadata/org.springframework.cloud/spring-cloud-starter/index.json
+++ b/metadata/org.springframework.cloud/spring-cloud-starter/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published JAR for 5.0.1 contains only Maven metadata and no JVM .class files, so there is no class-bearing artifact for Native Image reachability metadata.",
+    "replacement": "org.springframework.cloud:spring-cloud-context:5.0.1 and org.springframework.cloud:spring-cloud-commons:5.0.1"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #7079

This PR records `org.springframework.cloud:spring-cloud-starter` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published JAR for 5.0.1 contains only Maven metadata and no JVM .class files, so there is no class-bearing artifact for Native Image reachability metadata.

Replacement guidance:
- org.springframework.cloud:spring-cloud-context:5.0.1 and org.springframework.cloud:spring-cloud-commons:5.0.1

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `918d3413625a00510059678c3323ed4169729f59`

### Local CI Verification

- Status: `success`
- Commands run: 6
- Fixup attempts: 0
