### PR TITLE
Stage JVM test sources in native-image-run finalizer

### DIFF
--- a/forge/git_scripts/make_pr_ni_run_fix.py
+++ b/forge/git_scripts/make_pr_ni_run_fix.py
@@ -40,6 +40,7 @@ REPO = "oracle/graalvm-reachability-metadata"
 BASE_BRANCH = 'master'
 REVIEWERS = get_configured_reviewers()
 SEVERE_METADATA_DROP_RATIO = 0.25
+TEST_SOURCE_DIR_NAMES: tuple[str, ...] = ("java", "kotlin", "groovy", "scala")
 
 
 def is_severe_metadata_drop(previous_entries: int, new_entries: int) -> bool:
@@ -78,7 +79,6 @@ def stage_and_commit(
 ) -> None:
     """Stage the expected files/directories and commit with the required message."""
     test_version_dir = os.path.join("tests", "src", group, artifact, test_version)
-    test_sources_dir = os.path.join(test_version_dir, "src", "test", "java")
     test_native_image_metadata_dir = os.path.join(
         test_version_dir,
         "src",
@@ -94,8 +94,10 @@ def stage_and_commit(
         str(os.path.relpath(stats_artifact_dir(repo_path, group, artifact), repo_path)),
     ]
 
-    if os.path.exists(os.path.join(repo_path, test_sources_dir)):
-        candidate_paths.append(str(test_sources_dir))
+    for test_source_dir_name in TEST_SOURCE_DIR_NAMES:
+        test_sources_dir = os.path.join(test_version_dir, "src", "test", test_source_dir_name)
+        if os.path.exists(os.path.join(repo_path, test_sources_dir)):
+            candidate_paths.append(str(test_sources_dir))
     if os.path.exists(os.path.join(repo_path, test_native_image_metadata_dir)):
         candidate_paths.append(str(test_native_image_metadata_dir))
 

--- a/forge/tests/test_make_pr_ni_run_fix.py
+++ b/forge/tests/test_make_pr_ni_run_fix.py
@@ -62,6 +62,50 @@ class SevereMetadataDropGuardrailTests(unittest.TestCase):
 
 
 class NativeImageRunFinalizationTests(unittest.TestCase):
+    def test_stage_and_commit_includes_jvm_test_source_directories(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path:
+            test_version_dir = os.path.join(
+                repo_path,
+                "tests",
+                "src",
+                "org.example",
+                "demo",
+                "1.0.0",
+            )
+            for test_source_dir_name in ("java", "kotlin", "groovy", "scala"):
+                os.makedirs(os.path.join(test_version_dir, "src", "test", test_source_dir_name))
+
+            with patch.object(make_pr_ni_run_fix, "stage_and_commit_common") as stage_and_commit, \
+                    patch.object(
+                        make_pr_ni_run_fix,
+                        "stats_artifact_dir",
+                        return_value=os.path.join(repo_path, "stats", "org.example", "demo"),
+                    ):
+                make_pr_ni_run_fix.stage_and_commit(
+                    group="org.example",
+                    artifact="demo",
+                    test_version="1.0.0",
+                    metadata_version="2.0.0",
+                    coordinates="org.example:demo:2.0.0",
+                    repo_path=repo_path,
+                )
+
+        staged_paths = stage_and_commit.call_args.args[0]
+        for test_source_dir_name in ("java", "kotlin", "groovy", "scala"):
+            self.assertIn(
+                os.path.join(
+                    "tests",
+                    "src",
+                    "org.example",
+                    "demo",
+                    "1.0.0",
+                    "src",
+                    "test",
+                    test_source_dir_name,
+                ),
+                staged_paths,
+            )
+
     def test_stage_and_commit_includes_test_native_image_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as repo_path:
             native_image_metadata_dir = os.path.join(


### PR DESCRIPTION
Fixes #7213

The native-image-run PR finalizer previously only staged `src/test/java`, so generated or modified Kotlin/Groovy/Scala tests could be left out of the final commit.

This stages all existing JVM test source directories used by Forge test projects:

- `src/test/java`
- `src/test/kotlin`
- `src/test/groovy`
- `src/test/scala`

Verification:

```text
python3 -m unittest tests/test_make_pr_ni_run_fix.py
Ran 5 tests in 0.034s

OK
```