### PR TITLE
[Automation] Generated metadata for io.mockk:mockk-agent-jvm:1.14.9

### DIFF
--- a/tests/src/io.mockk/mockk-agent-jvm/1.14.9/src/test/kotlin/io_mockk/mockk_agent_jvm/MockkNativeImageSupport.kt
+++ b/tests/src/io.mockk/mockk-agent-jvm/1.14.9/src/test/kotlin/io_mockk/mockk_agent_jvm/MockkNativeImageSupport.kt
@@ -31,7 +31,10 @@ internal object MockkNativeImageSupport {
 
     private fun hasByteBuddyAttachmentFailure(throwable: Throwable): Boolean =
         throwable.causeSequence().any { current: Throwable ->
-            current is IllegalStateException && current.message?.startsWith("Error during attachment using:") == true
+            current is IllegalStateException && (
+                current.message?.startsWith("Error during attachment using:") == true ||
+                    current.message == "No compatible attachment provider is available"
+                )
         }
 
     private fun hasJavaDispatcherInitializationFailure(throwable: Throwable): Boolean =

--- a/tests/src/io.mockk/mockk-agent-jvm/1.14.9/src/test/kotlin/io_mockk/mockk_agent_jvm/MockkNativeImageSupportTest.kt
+++ b/tests/src/io.mockk/mockk-agent-jvm/1.14.9/src/test/kotlin/io_mockk/mockk_agent_jvm/MockkNativeImageSupportTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_mockk.mockk_agent_jvm
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+public class MockkNativeImageSupportTest {
+    @Test
+    fun treatsByteBuddyAttachmentProviderFailureAsExpectedInNativeImageRuntime(): Unit {
+        withNativeImageRuntimeProperty {
+            val throwable: Throwable = IllegalStateException("No compatible attachment provider is available")
+
+            assertThat(MockkNativeImageSupport.isExpectedNativeImageFailure(throwable)).isTrue()
+        }
+    }
+
+    private fun withNativeImageRuntimeProperty(block: () -> Unit): Unit {
+        val key: String = "org.graalvm.nativeimage.imagecode"
+        val previousValue: String? = System.getProperty(key)
+        System.setProperty(key, "runtime")
+
+        try {
+            block()
+        } finally {
+            if (previousValue == null) {
+                System.clearProperty(key)
+            } else {
+                System.setProperty(key, previousValue)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7158

This PR provides new metadata needed for the io.mockk:mockk-agent-jvm:1.14.9, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `io.mockk:mockk-agent-jvm:1.14.9`): 19
- Test-only metadata entries (previous `io.mockk:mockk-agent-jvm:1.14.9`): 1
- Metadata entries (new `io.mockk:mockk-agent-jvm:1.14.9`): 19
- Test-only metadata entries (new `io.mockk:mockk-agent-jvm:1.14.9`): 1
- Library coverage (previous): 62.95%
- Library coverage (new): 62.95%

### Metadata Forge

- Forge monitored branch: `master`
- Forge branch: `master`
- Forge commit hash: `41f048d9398fd5b3b3636762ab9663985e255f68`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `io.mockk:mockk-agent-jvm:1.14.9` and `io.mockk:mockk-agent-jvm:1.14.9`.

### Local CI Verification

- Status: `skipped`
- Commands run: 0
- Fixup attempts: 0
