### PR TITLE
[GenAI] Add support for org.springframework.cloud:spring-cloud-context:5.0.1 using gpt-5.5

### DIFF
--- a/metadata/org.springframework.cloud/spring-cloud-context/5.0.1/reachability-metadata.json
+++ b/metadata/org.springframework.cloud/spring-cloud-context/5.0.1/reachability-metadata.json
@@ -1,0 +1,172 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.cloud.endpoint.event.RefreshEventListener"
+      },
+      "type" : "org.springframework.boot.ClearCachesApplicationListener",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.cloud.endpoint.event.RefreshEventListener"
+      },
+      "type" : "org.springframework.boot.builder.ParentContextCloserApplicationListener",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.cloud.endpoint.event.RefreshEventListener"
+      },
+      "type" : "org.springframework.boot.context.ConfigurationWarningsApplicationContextInitializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.cloud.endpoint.event.RefreshEventListener"
+      },
+      "type" : "org.springframework.boot.context.ContextIdApplicationContextInitializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.cloud.endpoint.event.RefreshEventListener"
+      },
+      "type" : "org.springframework.boot.context.FileEncodingApplicationListener",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.cloud.endpoint.event.RefreshEventListener"
+      },
+      "type" : "org.springframework.boot.context.logging.LoggingApplicationListener",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.cloud.endpoint.event.RefreshEventListener"
+      },
+      "type" : "org.springframework.boot.io.ProtocolResolverApplicationContextInitializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.cloud.endpoint.event.RefreshEventListener"
+      },
+      "type" : "org.springframework.cloud.bootstrap.BootstrapApplicationListener",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.cloud.endpoint.event.RefreshEventListener"
+      },
+      "type" : "org.springframework.cloud.bootstrap.LoggingSystemShutdownListener",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.cloud.endpoint.event.RefreshEventListener"
+      },
+      "type" : "org.springframework.cloud.bootstrap.RefreshBootstrapRegistryInitializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.cloud.endpoint.event.RefreshEventListener"
+      },
+      "type" : "org.springframework.cloud.context.restart.RestartListener",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.cloud.endpoint.event.RefreshEventListener"
+      },
+      "type" : "org.springframework.cloud.bootstrap.TextEncryptorConfigBootstrapper",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.cloud.endpoint.event.RefreshEventListener"
+      },
+      "type" : "org.springframework.boot.support.AnsiOutputApplicationListener",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.cloud.endpoint.event.RefreshEventListener"
+      },
+      "type" : "org.springframework.boot.support.EnvironmentPostProcessorApplicationListener",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.springframework.cloud/spring-cloud-context/index.json
+++ b/metadata/org.springframework.cloud/spring-cloud-context/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "5.0.1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/cloud/spring-cloud-context/$version$/spring-cloud-context-$version$-sources.jar",
+    "repository-url" : "https://github.com/spring-cloud/spring-cloud-commons",
+    "test-code-url" : "https://github.com/spring-cloud/spring-cloud-commons/tree/v$version$/spring-cloud-context/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/springframework/cloud/spring-cloud-context/$version$/spring-cloud-context-$version$-javadoc.jar",
+    "description" : "Spring Cloud Context provides utilities and services for a Spring Cloud application's ApplicationContext, including bootstrap context, encryption, refresh scope, and environment endpoints. It supports runtime configuration refresh and context-related infrastructure used by Spring Cloud applications.",
+    "tested-versions" : [
+      "5.0.1"
+    ],
+    "allowed-packages" : [
+      "org.springframework.cloud"
+    ]
+  }
+]

--- a/stats/org.springframework.cloud/spring-cloud-context/5.0.1/execution-metrics.json
+++ b/stats/org.springframework.cloud/spring-cloud-context/5.0.1/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-19": {
+    "timestamp": "2026-05-19T15:48:10.860480Z",
+    "library": "org.springframework.cloud:spring-cloud-context:5.0.1",
+    "starting_commit": "5c238d3215d53bd438a68c52a56b9e55a60eed5d",
+    "ending_commit": "0c46717a65272ac16550dcd5bfd3de585f7cef7f",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "5.0.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1497,
+          "missed": 7614,
+          "ratio": 0.164307,
+          "total": 9111
+        },
+        "line": {
+          "covered": 383,
+          "missed": 1876,
+          "ratio": 0.169544,
+          "total": 2259
+        },
+        "method": {
+          "covered": 127,
+          "missed": 453,
+          "ratio": 0.218966,
+          "total": 580
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 220850,
+      "cached_input_tokens_used": 2347520,
+      "output_tokens_used": 22626,
+      "iterations": 5,
+      "cost_usd": 1.8526,
+      "generated_loc": 301,
+      "tested_library_loc": 383,
+      "metadata_entries": 28,
+      "code_coverage_percent": 16.95
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.springframework.cloud/spring-cloud-context/5.0.1/src/test/java/org_springframework_cloud/spring_cloud_context/Spring_cloud_contextTest.java",
+      "metadata_file": "metadata/org.springframework.cloud/spring-cloud-context/5.0.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.springframework.cloud/spring-cloud-context/5.0.1/stats.json
+++ b/stats/org.springframework.cloud/spring-cloud-context/5.0.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "5.0.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1497,
+        "missed" : 7614,
+        "ratio" : 0.164307,
+        "total" : 9111
+      },
+      "line" : {
+        "covered" : 383,
+        "missed" : 1876,
+        "ratio" : 0.169544,
+        "total" : 2259
+      },
+      "method" : {
+        "covered" : 127,
+        "missed" : 453,
+        "ratio" : 0.218966,
+        "total" : 580
+      }
+    }
+  } ]
+}

--- a/tests/src/org.springframework.cloud/spring-cloud-context/5.0.1/.gitignore
+++ b/tests/src/org.springframework.cloud/spring-cloud-context/5.0.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.springframework.cloud/spring-cloud-context/5.0.1/build.gradle
+++ b/tests/src/org.springframework.cloud/spring-cloud-context/5.0.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.springframework.cloud:spring-cloud-context:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.springframework.cloud/spring-cloud-context/5.0.1/gradle.properties
+++ b/tests/src/org.springframework.cloud/spring-cloud-context/5.0.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.springframework.cloud:spring-cloud-context:5.0.1
+library.version = 5.0.1
+metadata.dir = org.springframework.cloud/spring-cloud-context/5.0.1/

--- a/tests/src/org.springframework.cloud/spring-cloud-context/5.0.1/settings.gradle
+++ b/tests/src/org.springframework.cloud/spring-cloud-context/5.0.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.springframework.cloud.spring-cloud-context_tests'

--- a/tests/src/org.springframework.cloud/spring-cloud-context/5.0.1/src/test/java/org_springframework_cloud/spring_cloud_context/Spring_cloud_contextTest.java
+++ b/tests/src/org.springframework.cloud/spring-cloud-context/5.0.1/src/test/java/org_springframework_cloud/spring_cloud_context/Spring_cloud_contextTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -20,6 +21,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.cloud.bootstrap.config.BootstrapPropertySource;
 import org.springframework.cloud.bootstrap.config.PropertySourceBootstrapProperties;
 import org.springframework.cloud.bootstrap.config.SimpleBootstrapPropertySource;
@@ -33,6 +36,8 @@ import org.springframework.cloud.context.scope.StandardScopeCache;
 import org.springframework.cloud.context.scope.refresh.RefreshScope;
 import org.springframework.cloud.context.scope.thread.ThreadScope;
 import org.springframework.cloud.endpoint.RefreshEndpoint;
+import org.springframework.cloud.endpoint.event.RefreshEvent;
+import org.springframework.cloud.endpoint.event.RefreshEventListener;
 import org.springframework.cloud.util.PropertyUtils;
 import org.springframework.cloud.util.random.CachedRandomPropertySource;
 import org.springframework.context.ApplicationContextInitializer;
@@ -184,6 +189,34 @@ public class Spring_cloud_contextTest {
         }
 
         assertThat(factory.getContextNames()).isEmpty();
+    }
+
+    @Test
+    void refreshEventListenerRefreshesOnlyAfterApplicationIsReady() {
+        try (GenericApplicationContext context = new GenericApplicationContext()) {
+            context.refresh();
+            RefreshScope refreshScope = new RefreshScope();
+            refreshScope.setApplicationContext(context);
+            RefreshEventListener listener = new RefreshEventListener(new StubContextRefresher(context, refreshScope,
+                    Map.of("spring.cloud.context.test.refresh.event", "ready")));
+            RefreshEvent refreshEvent = new RefreshEvent(this, Map.of("trigger", "test"), "test refresh event");
+
+            assertThat(listener.supportsEventType(RefreshEvent.class)).isTrue();
+            assertThat(listener.supportsEventType(ApplicationReadyEvent.class)).isTrue();
+            assertThat(refreshEvent.getEvent()).isEqualTo(Map.of("trigger", "test"));
+            assertThat(refreshEvent.getEventDesc()).isEqualTo("test refresh event");
+
+            listener.onApplicationEvent(refreshEvent);
+
+            assertThat(context.getEnvironment().getProperty("spring.cloud.context.test.refresh.event")).isNull();
+
+            listener.onApplicationEvent(new ApplicationReadyEvent(new SpringApplication(Spring_cloud_contextTest.class),
+                    new String[0], context, Duration.ZERO));
+            listener.onApplicationEvent(refreshEvent);
+
+            assertThat(context.getEnvironment().getProperty("spring.cloud.context.test.refresh.event"))
+                    .isEqualTo("ready");
+        }
     }
 
     @Test

--- a/tests/src/org.springframework.cloud/spring-cloud-context/5.0.1/src/test/java/org_springframework_cloud/spring_cloud_context/Spring_cloud_contextTest.java
+++ b/tests/src/org.springframework.cloud/spring-cloud-context/5.0.1/src/test/java/org_springframework_cloud/spring_cloud_context/Spring_cloud_contextTest.java
@@ -200,8 +200,7 @@ public class Spring_cloud_contextTest {
             assertThat(services).containsKeys("clientService", "preferredClientService");
             assertThat(factory.getConfigurations()).containsKey("default.shared");
             assertThat(factory.getContextNames()).containsExactlyInAnyOrder("alpha", "beta");
-        }
-        finally {
+        } finally {
             factory.destroy();
         }
 

--- a/tests/src/org.springframework.cloud/spring-cloud-context/5.0.1/src/test/java/org_springframework_cloud/spring_cloud_context/Spring_cloud_contextTest.java
+++ b/tests/src/org.springframework.cloud/spring-cloud-context/5.0.1/src/test/java/org_springframework_cloud/spring_cloud_context/Spring_cloud_contextTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework_cloud.spring_cloud_context;
+
+import org.junit.jupiter.api.Test;
+
+class Spring_cloud_contextTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.springframework.cloud/spring-cloud-context/5.0.1/src/test/java/org_springframework_cloud/spring_cloud_context/Spring_cloud_contextTest.java
+++ b/tests/src/org.springframework.cloud/spring-cloud-context/5.0.1/src/test/java/org_springframework_cloud/spring_cloud_context/Spring_cloud_contextTest.java
@@ -6,11 +6,311 @@
  */
 package org_springframework_cloud.spring_cloud_context;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
-class Spring_cloud_contextTest {
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.cloud.bootstrap.config.BootstrapPropertySource;
+import org.springframework.cloud.bootstrap.config.PropertySourceBootstrapProperties;
+import org.springframework.cloud.bootstrap.config.SimpleBootstrapPropertySource;
+import org.springframework.cloud.context.environment.EnvironmentChangeEvent;
+import org.springframework.cloud.context.environment.EnvironmentManager;
+import org.springframework.cloud.context.named.NamedContextFactory;
+import org.springframework.cloud.context.named.NamedContextFactory.Specification;
+import org.springframework.cloud.context.refresh.ContextRefresher;
+import org.springframework.cloud.context.scope.GenericScope;
+import org.springframework.cloud.context.scope.StandardScopeCache;
+import org.springframework.cloud.context.scope.refresh.RefreshScope;
+import org.springframework.cloud.context.scope.thread.ThreadScope;
+import org.springframework.cloud.endpoint.RefreshEndpoint;
+import org.springframework.cloud.util.PropertyUtils;
+import org.springframework.cloud.util.random.CachedRandomPropertySource;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+
+public class Spring_cloud_contextTest {
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void environmentManagerPublishesChangesAndResetsManagedPropertySource() {
+        StandardEnvironment environment = new StandardEnvironment();
+        EnvironmentManager manager = new EnvironmentManager(environment);
+        List<ApplicationEvent> events = new ArrayList<>();
+        manager.setApplicationEventPublisher(event -> events.add((ApplicationEvent) event));
+
+        manager.setProperty("spring.cloud.context.test.feature.flag", "enabled");
+        manager.setProperty("spring.cloud.context.test.feature.flag", "enabled");
+        manager.setProperty("spring.cloud.context.test.service.timeout", "PT1S");
+
+        assertThat(manager.getProperty("spring.cloud.context.test.feature.flag")).isEqualTo("enabled");
+        assertThat(environment.getPropertySources().contains("manager")).isTrue();
+        assertThat(events).hasSize(2);
+        assertThat(environmentChangeKeys(events.get(0))).containsExactly("spring.cloud.context.test.feature.flag");
+        assertThat(environmentChangeKeys(events.get(1))).containsExactly("spring.cloud.context.test.service.timeout");
+
+        Map<String, Object> removedProperties = manager.reset();
+
+        assertThat(removedProperties).containsEntry("spring.cloud.context.test.feature.flag", "enabled")
+                .containsEntry("spring.cloud.context.test.service.timeout", "PT1S");
+        assertThat(manager.getProperty("spring.cloud.context.test.feature.flag")).isNull();
+        assertThat(events).hasSize(3);
+        assertThat(environmentChangeKeys(events.get(2))).containsExactlyInAnyOrder(
+                "spring.cloud.context.test.feature.flag", "spring.cloud.context.test.service.timeout");
+    }
+
+    @Test
+    void bootstrapPropertySourcesDelegateNamesValuesAndPropertyEnumeration() {
+        MapPropertySource mapPropertySource = new MapPropertySource("testSource", Map.of(
+                "alpha", "one",
+                "bravo", "two"));
+        BootstrapPropertySource<Map<String, Object>> enumerableBootstrapSource = new BootstrapPropertySource<>(
+                mapPropertySource);
+        SimpleBootstrapPropertySource<Map<String, Object>> simpleBootstrapSource = new SimpleBootstrapPropertySource<>(
+                mapPropertySource);
+
+        assertThat(enumerableBootstrapSource.getName()).isEqualTo("bootstrapProperties-testSource");
+        assertThat(enumerableBootstrapSource.getDelegate()).isSameAs(mapPropertySource);
+        assertThat(enumerableBootstrapSource.getProperty("alpha")).isEqualTo("one");
+        assertThat(enumerableBootstrapSource.getPropertyNames()).containsExactlyInAnyOrder("alpha", "bravo");
+        assertThat(simpleBootstrapSource.getName()).isEqualTo("bootstrapProperties-testSource");
+        assertThat(simpleBootstrapSource.getDelegate()).isSameAs(mapPropertySource);
+        assertThat(simpleBootstrapSource.getProperty("bravo")).isEqualTo("two");
+    }
+
+    @Test
+    void cachedRandomPropertySourceCachesValuesPerKeyUntilCacheIsCleared() {
+        CachedRandomPropertySource.clearCache();
+        Map<String, Object> randomValues = new HashMap<>();
+        randomValues.put("random.int", 4);
+        CachedRandomPropertySource cachedRandom = new CachedRandomPropertySource(
+                new MapPropertySource("random", randomValues));
+
+        Object first = cachedRandom.getProperty("cachedrandom.cacheA.int");
+        randomValues.put("random.int", 8);
+        Object cached = cachedRandom.getProperty("cachedrandom.cacheA.int");
+        Object secondKey = cachedRandom.getProperty("cachedrandom.cacheB.int");
+        CachedRandomPropertySource.clearCache();
+        Object refreshed = cachedRandom.getProperty("cachedrandom.cacheA.int");
+
+        assertThat(first).isEqualTo(4);
+        assertThat(cached).isEqualTo(4);
+        assertThat(secondKey).isEqualTo(8);
+        assertThat(refreshed).isEqualTo(8);
+        assertThat(cachedRandom.getProperty("random.int")).isNull();
+        assertThat(cachedRandom.getProperty("cachedrandom.int")).isNull();
+        CachedRandomPropertySource.clearCache();
+    }
+
+    @Test
+    void scopeCacheAndGenericScopesReuseAndDestroyScopedObjects() {
+        StandardScopeCache cache = new StandardScopeCache();
+        assertThat(cache.put("name", "first")).isEqualTo("first");
+        assertThat(cache.put("name", "second")).isEqualTo("first");
+        assertThat(cache.get("name")).isEqualTo("first");
+        assertThat(cache.remove("name")).isEqualTo("first");
+        assertThat(cache.clear()).isEmpty();
+
+        GenericScope scope = new GenericScope();
+        scope.setName("scenario");
+        AtomicInteger created = new AtomicInteger();
+        AtomicInteger destroyed = new AtomicInteger();
+        Object first = scope.get("scopedBean", () -> "instance-" + created.incrementAndGet());
+        Object second = scope.get("scopedBean", () -> "instance-" + created.incrementAndGet());
+        scope.registerDestructionCallback("scopedBean", destroyed::incrementAndGet);
+
+        assertThat(scope.getConversationId()).isEqualTo("scenario");
+        assertThat(first).isEqualTo("instance-1");
+        assertThat(second).isSameAs(first);
+        assertThat(created).hasValue(1);
+
+        scope.destroy();
+
+        assertThat(destroyed).hasValue(1);
+        assertThat(scope.getErrors()).isEmpty();
+        assertThat(scope.get("scopedBean", () -> "instance-" + created.incrementAndGet())).isEqualTo("instance-2");
+
+        ThreadScope threadScope = new ThreadScope();
+        assertThat(threadScope.getConversationId()).isEqualTo("thread");
+        assertThat(threadScope.get("threadBean", () -> "thread-instance")).isEqualTo("thread-instance");
+        assertThat(threadScope.remove("threadBean")).isEqualTo("thread-instance");
+    }
+
+    @Test
+    void namedContextFactoryCreatesIsolatedContextsWithProvidersAndResolvableTypes() {
+        Map<String, ApplicationContextInitializer<GenericApplicationContext>> initializers = Map.of(
+                "alpha", Spring_cloud_contextTest::initializeNamedContext,
+                "beta", Spring_cloud_contextTest::initializeNamedContext);
+        TestNamedContextFactory factory = new TestNamedContextFactory(initializers);
+
+        try (GenericApplicationContext parent = new GenericApplicationContext()) {
+            parent.refresh();
+            factory.setApplicationContext(parent);
+            factory.setConfigurations(
+                    List.of(new TestSpecification("default.shared", DefaultNamedContextConfiguration.class)));
+
+            ClientSettings alphaSettings = factory.getInstance("alpha", ClientSettings.class);
+            ClientSettings betaSettings = factory.getProvider("beta", ClientSettings.class).getObject();
+            ObjectProvider<ClientSettings> lazyAlphaProvider = factory.getLazyProvider("alpha", ClientSettings.class);
+            ClientService resolvedService = factory.getInstance("alpha", ClientService.class, new Class<?>[0]);
+            ClientService annotatedService = factory.getAnnotatedInstance("alpha",
+                    ResolvableType.forClass(ClientService.class), PreferredClient.class);
+            Map<String, ClientService> services = factory.getInstances("alpha", ClientService.class);
+
+            assertThat(factory.getParent()).isSameAs(parent);
+            assertThat(alphaSettings.name()).isEqualTo("alpha");
+            assertThat(betaSettings.name()).isEqualTo("beta");
+            assertThat(lazyAlphaProvider.getObject().name()).isEqualTo("alpha");
+            assertThat(resolvedService.description()).isIn("service-alpha", "preferred-alpha");
+            assertThat(annotatedService.description()).isEqualTo("preferred-alpha");
+            assertThat(services).containsKeys("clientService", "preferredClientService");
+            assertThat(factory.getConfigurations()).containsKey("default.shared");
+            assertThat(factory.getContextNames()).containsExactlyInAnyOrder("alpha", "beta");
+        }
+        finally {
+            factory.destroy();
+        }
+
+        assertThat(factory.getContextNames()).isEmpty();
+    }
+
+    @Test
+    void propertyUtilitiesPropertiesAndRefreshEndpointExposeSimplePublicContracts() {
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources().addFirst(new MapPropertySource("defaults", Map.of(
+                "spring.config.use-legacy-processing", "false")));
+        assertThat(PropertyUtils.useLegacyProcessing(environment)).isFalse();
+
+        environment.getPropertySources().addFirst(new MapPropertySource("cloud", Map.of(
+                "spring.cloud.bootstrap.enabled", "true",
+                "spring.config.use-legacy-processing", "true")));
+
+        assertThat(PropertyUtils.bootstrapEnabled(environment)).isTrue();
+        assertThat(PropertyUtils.useLegacyProcessing(environment)).isTrue();
+
+        PropertySourceBootstrapProperties properties = new PropertySourceBootstrapProperties();
+        properties.setAllowOverride(true);
+        properties.setOverrideNone(true);
+        properties.setOverrideSystemProperties(false);
+        properties.setInitializeOnContextRefresh(true);
+
+        assertThat(properties.isAllowOverride()).isTrue();
+        assertThat(properties.isOverrideNone()).isTrue();
+        assertThat(properties.isOverrideSystemProperties()).isFalse();
+        assertThat(properties.isInitializeOnContextRefresh()).isTrue();
+
+        try (GenericApplicationContext context = new GenericApplicationContext()) {
+            context.refresh();
+            RefreshScope refreshScope = new RefreshScope();
+            refreshScope.setApplicationContext(context);
+            RefreshEndpoint endpoint = new RefreshEndpoint(new StubContextRefresher(context, refreshScope,
+                    Map.of("spring.cloud.context.test.alpha", "one", "spring.cloud.context.test.bravo", "two")));
+
+            assertThat(endpoint.refresh()).containsExactlyInAnyOrder("spring.cloud.context.test.alpha",
+                    "spring.cloud.context.test.bravo");
+        }
+    }
+
+    private static Set<String> environmentChangeKeys(ApplicationEvent event) {
+        assertThat(event).isInstanceOf(EnvironmentChangeEvent.class);
+        return ((EnvironmentChangeEvent) event).getKeys();
+    }
+
+    private static void initializeNamedContext(GenericApplicationContext context) {
+        String name = context.getEnvironment().getRequiredProperty("client.name");
+        context.registerBean(ClientSettings.class, () -> new ClientSettings(name));
+        context.registerBean("clientService", ClientService.class, () -> new ClientService("service-" + name));
+        context.registerBean("preferredClientService", AnnotatedClientService.class,
+                () -> new AnnotatedClientService("preferred-" + name));
+    }
+
+    private static final class StubContextRefresher extends ContextRefresher {
+
+        private final Map<String, Object> updatedProperties;
+
+        private StubContextRefresher(GenericApplicationContext context, RefreshScope scope,
+                Map<String, Object> updatedProperties) {
+            super(context, scope);
+            this.updatedProperties = updatedProperties;
+        }
+
+        @Override
+        protected void updateEnvironment() {
+            getContext().getEnvironment().getPropertySources()
+                    .addFirst(new MapPropertySource("refreshed", this.updatedProperties));
+        }
+    }
+
+    private static final class TestNamedContextFactory extends NamedContextFactory<TestSpecification> {
+
+        private TestNamedContextFactory(
+                Map<String, ApplicationContextInitializer<GenericApplicationContext>> initializers) {
+            super(DefaultNamedContextConfiguration.class, "testClients", "client.name", initializers);
+        }
+    }
+
+    private static final class TestSpecification implements Specification {
+
+        private final String name;
+
+        private final Class<?>[] configuration;
+
+        private TestSpecification(String name, Class<?>... configuration) {
+            this.name = name;
+            this.configuration = Arrays.copyOf(configuration, configuration.length);
+        }
+
+        @Override
+        public String getName() {
+            return this.name;
+        }
+
+        @Override
+        public Class<?>[] getConfiguration() {
+            return Arrays.copyOf(this.configuration, this.configuration.length);
+        }
+    }
+
+    private static final class DefaultNamedContextConfiguration {
+    }
+
+    private record ClientSettings(String name) {
+    }
+
+    private static class ClientService {
+
+        private final String description;
+
+        private ClientService(String description) {
+            this.description = description;
+        }
+
+        private String description() {
+            return this.description;
+        }
+    }
+
+    @PreferredClient
+    private static final class AnnotatedClientService extends ClientService {
+
+        private AnnotatedClientService(String description) {
+            super(description);
+        }
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    private @interface PreferredClient {
     }
 }

--- a/tests/src/org.springframework.cloud/spring-cloud-context/5.0.1/src/test/java/org_springframework_cloud/spring_cloud_context/Spring_cloud_contextTest.java
+++ b/tests/src/org.springframework.cloud/spring-cloud-context/5.0.1/src/test/java/org_springframework_cloud/spring_cloud_context/Spring_cloud_contextTest.java
@@ -7,6 +7,7 @@
 package org_springframework_cloud.spring_cloud_context;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -26,6 +27,8 @@ import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.cloud.bootstrap.config.BootstrapPropertySource;
 import org.springframework.cloud.bootstrap.config.PropertySourceBootstrapProperties;
 import org.springframework.cloud.bootstrap.config.SimpleBootstrapPropertySource;
+import org.springframework.cloud.context.encrypt.EncryptorFactory;
+import org.springframework.cloud.context.encrypt.KeyFormatException;
 import org.springframework.cloud.context.environment.EnvironmentChangeEvent;
 import org.springframework.cloud.context.environment.EnvironmentManager;
 import org.springframework.cloud.context.named.NamedContextFactory;
@@ -46,6 +49,7 @@ import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.StandardEnvironment;
+import org.springframework.security.crypto.encrypt.TextEncryptor;
 
 public class Spring_cloud_contextTest {
 
@@ -117,6 +121,19 @@ public class Spring_cloud_contextTest {
         assertThat(cachedRandom.getProperty("random.int")).isNull();
         assertThat(cachedRandom.getProperty("cachedrandom.int")).isNull();
         CachedRandomPropertySource.clearCache();
+    }
+
+    @Test
+    void encryptorFactoryCreatesSymmetricTextEncryptorAndRejectsPublicKeys() {
+        EncryptorFactory factory = new EncryptorFactory("01234567");
+        TextEncryptor encryptor = factory.create("test-password");
+
+        String encrypted = encryptor.encrypt("spring-cloud-context secret");
+
+        assertThat(encrypted).isNotEqualTo("spring-cloud-context secret");
+        assertThat(encryptor.decrypt(encrypted)).isEqualTo("spring-cloud-context secret");
+        assertThatThrownBy(() -> factory.create("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCtest"))
+                .isInstanceOf(KeyFormatException.class);
     }
 
     @Test

--- a/tests/src/org.springframework.cloud/spring-cloud-context/5.0.1/user-code-filter.json
+++ b/tests/src/org.springframework.cloud/spring-cloud-context/5.0.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.springframework.cloud.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #7075

This PR introduces tests and metadata for org.springframework.cloud:spring-cloud-context:5.0.1, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 220850
- Cached input tokens: 2347520
- Output tokens: 22626
- Metadata entries: 28
- Iterations: 5
- Library coverage percentage: 16.95
- Generated lines of code: 301
- Tested library lines of code: 383

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `bc0d4df1c271ed1ca7ec4111066a1015d5416a7d`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1497/9111 (16.43%)
- Line: 383/2259 (16.95%)
- Method: 127/580 (21.90%)

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
