### PR TITLE
[GenAI] Test fix for org.apache.directory.api:api-ldap-model:1.0.1 using gpt-5.5

### DIFF
--- a/metadata/org.apache.directory.api/api-ldap-model/1.0.1/reachability-metadata.json
+++ b/metadata/org.apache.directory.api/api-ldap-model/1.0.1/reachability-metadata.json
@@ -1,0 +1,28 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.directory.api.ldap.model.name.Rdn"
+      },
+      "type": "java.util.ArrayList",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.directory.api.ldap.model.name.AntlrDnLexer"
+      },
+      "type": "antlr.CommonToken",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.apache.directory.api/api-ldap-model/index.json
+++ b/metadata/org.apache.directory.api/api-ldap-model/index.json
@@ -15,6 +15,15 @@
     ]
   },
   {
+    "metadata-version" : "1.0.1",
+    "tested-versions" : [
+      "1.0.1"
+    ],
+    "allowed-packages" : [
+      "org.apache.directory.api.ldap.model"
+    ]
+  },
+  {
     "metadata-version" : "1.0.0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/apache/directory/api/api-ldap-model/$version$/api-ldap-model-$version$-sources.jar",
     "repository-url" : "https://svn.apache.org/repos/asf/directory/shared/",

--- a/metadata/org.apache.directory.api/api-ldap-model/index.json
+++ b/metadata/org.apache.directory.api/api-ldap-model/index.json
@@ -16,6 +16,11 @@
   },
   {
     "metadata-version" : "1.0.1",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/apache/directory/api/api-ldap-model/$version$/api-ldap-model-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/directory-ldap-api",
+    "test-code-url" : "https://github.com/apache/directory-ldap-api/tree/refs/tags/$version$/ldap/model/src/test/java/org/apache/directory/api/ldap/model",
+    "documentation-url" : "https://javadoc.io/doc/org.apache.directory.api/api-ldap-model/$version$/",
+    "description" : "Apache Directory LDAP API Model provides the common LDAP object model used by Apache Directory clients and servers, including entries, attributes, distinguished names, filters, controls, messages, schema objects, cursors, and LDAP exceptions. It supplies Java data structures and helpers for representing and manipulating LDAP protocol and directory data rather than implementing a standalone LDAP server or client.",
     "tested-versions" : [
       "1.0.1"
     ],

--- a/stats/org.apache.directory.api/api-ldap-model/1.0.1/execution-metrics.json
+++ b/stats/org.apache.directory.api/api-ldap-model/1.0.1/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_javac_fail:2026-05-19": {
+    "timestamp": "2026-05-19T18:49:19.759639Z",
+    "library": "org.apache.directory.api:api-ldap-model:1.0.1",
+    "starting_commit": "98fc0dfc6f3255a6f676242f7e0b00ab414f06fe",
+    "ending_commit": "b0ee680dd30f1f84b7ba3e6d5856d18045e910b2",
+    "previous_library": "org.apache.directory.api:api-ldap-model:1.0.0-M20",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.0.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 10577,
+          "missed": 112920,
+          "ratio": 0.085646,
+          "total": 123497
+        },
+        "line": {
+          "covered": 2513,
+          "missed": 24385,
+          "ratio": 0.093427,
+          "total": 26898
+        },
+        "method": {
+          "covered": 468,
+          "missed": 3260,
+          "ratio": 0.125536,
+          "total": 3728
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.0.0-M20",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 10353,
+          "missed": 99211,
+          "ratio": 0.094493,
+          "total": 109564
+        },
+        "line": {
+          "covered": 2452,
+          "missed": 22813,
+          "ratio": 0.097051,
+          "total": 25265
+        },
+        "method": {
+          "covered": 474,
+          "missed": 2908,
+          "ratio": 0.140154,
+          "total": 3382
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 33127,
+      "cached_input_tokens_used": 248320,
+      "output_tokens_used": 1704,
+      "iterations": 1,
+      "cost_usd": 0.1753,
+      "tested_library_loc": 2513,
+      "metadata_entries": 4,
+      "previous_library_metadata_entries": 2,
+      "code_coverage_percent": 9.34,
+      "previous_library_coverage_percent": 9.71
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.directory.api/api-ldap-model/1.0.1/src/test/java/org_apache_directory_api/api_ldap_model/Api_ldap_modelTest.java",
+      "metadata_file": "metadata/org.apache.directory.api/api-ldap-model/1.0.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.directory.api/api-ldap-model/1.0.1/stats.json
+++ b/stats/org.apache.directory.api/api-ldap-model/1.0.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.0.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 10577,
+        "missed" : 112920,
+        "ratio" : 0.085646,
+        "total" : 123497
+      },
+      "line" : {
+        "covered" : 2513,
+        "missed" : 24385,
+        "ratio" : 0.093427,
+        "total" : 26898
+      },
+      "method" : {
+        "covered" : 468,
+        "missed" : 3260,
+        "ratio" : 0.125536,
+        "total" : 3728
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.directory.api/api-ldap-model/1.0.1/.gitignore
+++ b/tests/src/org.apache.directory.api/api-ldap-model/1.0.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.directory.api/api-ldap-model/1.0.1/build.gradle
+++ b/tests/src/org.apache.directory.api/api-ldap-model/1.0.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.directory.api:api-ldap-model:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.directory.api/api-ldap-model/1.0.1/gradle.properties
+++ b/tests/src/org.apache.directory.api/api-ldap-model/1.0.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.directory.api:api-ldap-model:1.0.1
+library.version = 1.0.1
+metadata.dir = org.apache.directory.api/api-ldap-model/1.0.1/

--- a/tests/src/org.apache.directory.api/api-ldap-model/1.0.1/settings.gradle
+++ b/tests/src/org.apache.directory.api/api-ldap-model/1.0.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.directory.api.api-ldap-model_tests'

--- a/tests/src/org.apache.directory.api/api-ldap-model/1.0.1/src/test/java/org_apache_directory_api/api_ldap_model/Api_ldap_modelTest.java
+++ b/tests/src/org.apache.directory.api/api-ldap-model/1.0.1/src/test/java/org_apache_directory_api/api_ldap_model/Api_ldap_modelTest.java
@@ -1,0 +1,442 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_directory_api.api_ldap_model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.directory.api.ldap.model.cursor.ListCursor;
+import org.apache.directory.api.ldap.model.entry.Attribute;
+import org.apache.directory.api.ldap.model.entry.DefaultAttribute;
+import org.apache.directory.api.ldap.model.entry.DefaultEntry;
+import org.apache.directory.api.ldap.model.entry.DefaultModification;
+import org.apache.directory.api.ldap.model.entry.Entry;
+import org.apache.directory.api.ldap.model.entry.Modification;
+import org.apache.directory.api.ldap.model.entry.ModificationOperation;
+import org.apache.directory.api.ldap.model.entry.StringValue;
+import org.apache.directory.api.ldap.model.filter.AndNode;
+import org.apache.directory.api.ldap.model.filter.EqualityNode;
+import org.apache.directory.api.ldap.model.filter.ExprNode;
+import org.apache.directory.api.ldap.model.filter.NotNode;
+import org.apache.directory.api.ldap.model.filter.OrNode;
+import org.apache.directory.api.ldap.model.filter.PresenceNode;
+import org.apache.directory.api.ldap.model.filter.SubstringNode;
+import org.apache.directory.api.ldap.model.ldif.LdifEntry;
+import org.apache.directory.api.ldap.model.ldif.LdifReader;
+import org.apache.directory.api.ldap.model.ldif.LdifUtils;
+import org.apache.directory.api.ldap.model.message.AddRequestImpl;
+import org.apache.directory.api.ldap.model.message.AliasDerefMode;
+import org.apache.directory.api.ldap.model.message.BindRequest;
+import org.apache.directory.api.ldap.model.message.BindRequestImpl;
+import org.apache.directory.api.ldap.model.message.CompareRequest;
+import org.apache.directory.api.ldap.model.message.CompareRequestImpl;
+import org.apache.directory.api.ldap.model.message.Control;
+import org.apache.directory.api.ldap.model.message.DeleteRequest;
+import org.apache.directory.api.ldap.model.message.DeleteRequestImpl;
+import org.apache.directory.api.ldap.model.message.LdapResultImpl;
+import org.apache.directory.api.ldap.model.message.MessageTypeEnum;
+import org.apache.directory.api.ldap.model.message.ModifyDnRequest;
+import org.apache.directory.api.ldap.model.message.ModifyDnRequestImpl;
+import org.apache.directory.api.ldap.model.message.ModifyRequest;
+import org.apache.directory.api.ldap.model.message.ModifyRequestImpl;
+import org.apache.directory.api.ldap.model.message.ReferralImpl;
+import org.apache.directory.api.ldap.model.message.ResultCodeEnum;
+import org.apache.directory.api.ldap.model.message.SearchRequest;
+import org.apache.directory.api.ldap.model.message.SearchRequestImpl;
+import org.apache.directory.api.ldap.model.message.SearchScope;
+import org.apache.directory.api.ldap.model.message.controls.ChangeType;
+import org.apache.directory.api.ldap.model.message.controls.EntryChangeImpl;
+import org.apache.directory.api.ldap.model.message.controls.ManageDsaITImpl;
+import org.apache.directory.api.ldap.model.message.controls.OpaqueControl;
+import org.apache.directory.api.ldap.model.message.controls.PagedResultsImpl;
+import org.apache.directory.api.ldap.model.message.controls.PersistentSearchImpl;
+import org.apache.directory.api.ldap.model.message.controls.SortKey;
+import org.apache.directory.api.ldap.model.name.Dn;
+import org.apache.directory.api.ldap.model.name.Rdn;
+import org.apache.directory.api.ldap.model.url.LdapUrl;
+import org.junit.jupiter.api.Test;
+
+public class Api_ldap_modelTest {
+    @Test
+    void namesModelEscapingAndHierarchy() throws Exception {
+        Dn base = new Dn("dc=example,dc=com");
+        Dn people = new Dn("ou=People", "dc=example", "dc=com");
+        Dn person = new Dn("cn=John Doe,ou=People,dc=example,dc=com");
+        Rdn multiValuedRdn = new Rdn("cn=John Doe+sn=Doe");
+
+        assertThat(base.isAncestorOf(person)).isTrue();
+        assertThat(person.isDescendantOf(base)).isTrue();
+        assertThat(person.getParent()).isEqualTo(people);
+        assertThat(person.getRdn().getType()).isEqualTo("cn");
+        assertThat(person.getRdn().getValue().getString()).isEqualTo("John Doe");
+        assertThat(multiValuedRdn.size()).isEqualTo(2);
+        assertThat(multiValuedRdn.getAva("sn")).isNotNull();
+        assertThat(Dn.isValid(person.getName())).isTrue();
+        assertThat(Rdn.escapeValue(" leading,plus+hash# ")).contains("\\,", "\\+");
+        assertThat(Rdn.unescapeValue("John\\, Doe")).isEqualTo("John, Doe");
+        assertThat(Dn.getBytes(person)).containsSequence("cn=John Doe".getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void entriesAttributesValuesAndModificationsMaintainDirectoryData() throws Exception {
+        Dn dn = new Dn("cn=John Doe,ou=People,dc=example,dc=com");
+        Entry entry = new DefaultEntry(dn);
+        Attribute objectClass = new DefaultAttribute("objectClass", "top", "person", "inetOrgPerson");
+        Attribute cn = new DefaultAttribute("cn", new StringValue("John Doe"));
+        Attribute photo = new DefaultAttribute("jpegPhoto", new byte[] {1, 2, 3, 4});
+
+        entry.add(objectClass, cn, photo);
+        entry.add("sn", "Doe");
+        entry.put("mail", "john.doe@example.com", "jdoe@example.com");
+
+        assertThat(entry.getDn()).isEqualTo(dn);
+        assertThat(entry.size()).isEqualTo(5);
+        assertThat(entry.containsAttribute("objectClass", "cn", "sn", "mail", "jpegPhoto")).isTrue();
+        assertThat(entry.hasObjectClass("person", "inetOrgPerson")).isTrue();
+        assertThat(entry.contains("mail", "john.doe@example.com", "jdoe@example.com")).isTrue();
+        assertThat(entry.get("cn").getString()).isEqualTo("John Doe");
+        assertThat(entry.get("jpegPhoto").getBytes()).containsExactly((byte) 1, (byte) 2, (byte) 3, (byte) 4);
+
+        Entry cloned = entry.clone();
+        cloned.remove("mail", "jdoe@example.com");
+        cloned.removeAttributes("jpegPhoto");
+
+        assertThat(cloned).isNotSameAs(entry);
+        assertThat(cloned.contains("mail", "jdoe@example.com")).isFalse();
+        assertThat(cloned.containsAttribute("jpegPhoto")).isFalse();
+        assertThat(entry.contains("mail", "jdoe@example.com")).isTrue();
+        assertThat(entry.containsAttribute("jpegPhoto")).isTrue();
+
+        Modification addTelephone = new DefaultModification(
+                ModificationOperation.ADD_ATTRIBUTE,
+                "telephoneNumber",
+                "+1 555 0100");
+        Modification replaceMail = new DefaultModification(
+                ModificationOperation.REPLACE_ATTRIBUTE,
+                new DefaultAttribute("mail", "john@example.com"));
+
+        assertThat(addTelephone.getOperation()).isEqualTo(ModificationOperation.ADD_ATTRIBUTE);
+        assertThat(addTelephone.getAttribute().contains("+1 555 0100")).isTrue();
+        assertThat(replaceMail.getOperation().getValue()).isEqualTo(ModificationOperation.REPLACE_ATTRIBUTE.getValue());
+        assertThat(ModificationOperation.getOperation(addTelephone.getOperation().getValue()))
+                .isEqualTo(ModificationOperation.ADD_ATTRIBUTE);
+    }
+
+    @Test
+    void searchRequestsAcceptParsedAndProgrammaticFilters() throws Exception {
+        EqualityNode<String> mailEquals = new EqualityNode<>("mail", new StringValue("john@example.com"));
+        PresenceNode hasCn = new PresenceNode("cn");
+        SubstringNode surnameStartsWithDo = new SubstringNode("sn", "Do", null);
+        OrNode alternatives = new OrNode(mailEquals, surnameStartsWithDo);
+        AndNode filter = new AndNode(hasCn, alternatives);
+        NotNode negated = new NotNode(new PresenceNode("description"));
+        filter.addNode(negated);
+
+        SearchRequest search = new SearchRequestImpl()
+                .setMessageId(10)
+                .setBase(new Dn("ou=People,dc=example,dc=com"))
+                .setScope(SearchScope.SUBTREE)
+                .setDerefAliases(AliasDerefMode.DEREF_IN_SEARCHING)
+                .setSizeLimit(25)
+                .setTimeLimit(30)
+                .setTypesOnly(false)
+                .setFilter(filter)
+                .addAttributes("cn", "sn", "mail");
+
+        assertThat(search.getType()).isEqualTo(MessageTypeEnum.SEARCH_REQUEST);
+        assertThat(search.getResponseTypes()).contains(
+                MessageTypeEnum.SEARCH_RESULT_ENTRY,
+                MessageTypeEnum.SEARCH_RESULT_REFERENCE,
+                MessageTypeEnum.SEARCH_RESULT_DONE);
+        assertThat(search.getAttributes()).containsExactly("cn", "sn", "mail");
+        assertThat(search.getDerefAliases().isDerefInSearching()).isTrue();
+        assertThat(((AndNode) search.getFilter()).getChildren()).hasSize(3);
+        assertThat(search.removeAttribute("sn").getAttributes()).containsExactly("cn", "mail");
+
+        SearchRequest parsedSearch = new SearchRequestImpl()
+                .setBase(new Dn("dc=example,dc=com"))
+                .setFilter("(&(objectClass=person)(|(cn=John Doe)(mail=john@example.com)))");
+        ExprNode parsedFilter = parsedSearch.getFilter();
+
+        assertThat(parsedFilter).isInstanceOf(AndNode.class);
+        assertThat(((AndNode) parsedFilter).getChildren()).hasSize(2);
+        assertThat(parsedSearch.getResultResponse().getType()).isEqualTo(MessageTypeEnum.SEARCH_RESULT_DONE);
+    }
+
+    @Test
+    void requestMessagesExposeTypedStateControlsAndResponses() throws Exception {
+        Control manageDsaIt = new ManageDsaITImpl(true);
+        PagedResultsImpl pagedResults = new PagedResultsImpl();
+        pagedResults.setCritical(true);
+        pagedResults.setSize(100);
+        pagedResults.setCookie(new byte[] {9, 8, 7});
+
+        BindRequest bind = new BindRequestImpl()
+                .setMessageId(1)
+                .setDn(new Dn("uid=john,ou=People,dc=example,dc=com"))
+                .setSimple(true)
+                .setCredentials("secret")
+                .addControl(manageDsaIt)
+                .addControl(pagedResults);
+        AddRequestImpl add = new AddRequestImpl();
+        add.setMessageId(2);
+        add.setEntry(new DefaultEntry("cn=Jane Doe,ou=People,dc=example,dc=com"));
+        add.addAttributeType("objectClass");
+        add.addAttributeValue("top");
+        add.addAttributeValue("person");
+        add.addAttributeType("cn");
+        add.addAttributeValue("Jane Doe");
+
+        CompareRequest compare = new CompareRequestImpl()
+                .setMessageId(3)
+                .setName(new Dn("cn=Jane Doe,ou=People,dc=example,dc=com"))
+                .setAttributeId("cn")
+                .setAssertionValue("Jane Doe");
+        DeleteRequest delete = new DeleteRequestImpl()
+                .setMessageId(4)
+                .setName(new Dn("cn=Obsolete,ou=People,dc=example,dc=com"));
+        ModifyDnRequest rename = new ModifyDnRequestImpl()
+                .setMessageId(5)
+                .setName(new Dn("cn=Jane Doe,ou=People,dc=example,dc=com"))
+                .setNewRdn(new Rdn("cn=Jane Smith"))
+                .setNewSuperior(new Dn("ou=Alumni,dc=example,dc=com"))
+                .setDeleteOldRdn(true);
+
+        assertThat(bind.getType()).isEqualTo(MessageTypeEnum.BIND_REQUEST);
+        assertThat(bind.getResultResponse().getType()).isEqualTo(MessageTypeEnum.BIND_RESPONSE);
+        assertThat(bind.getCredentials()).containsExactly("secret".getBytes(StandardCharsets.UTF_8));
+        assertThat(bind.getControls()).containsKeys(manageDsaIt.getOid(), pagedResults.getOid());
+        assertThat(bind.getControl(pagedResults.getOid()).isCritical()).isTrue();
+        assertThat(pagedResults.getSize()).isEqualTo(100);
+        assertThat(pagedResults.getCookie()).containsExactly((byte) 9, (byte) 8, (byte) 7);
+
+        assertThat(add.getEntry().get("objectClass").contains("top", "person")).isTrue();
+        assertThat(add.getEntry().get("cn").contains("Jane Doe")).isTrue();
+        assertThat(add.getResponseType()).isEqualTo(MessageTypeEnum.ADD_RESPONSE);
+        assertThat(compare.getAssertionValue().getString()).isEqualTo("Jane Doe");
+        assertThat(compare.getResultResponse().getType()).isEqualTo(MessageTypeEnum.COMPARE_RESPONSE);
+        assertThat(delete.getName().getName()).isEqualTo("cn=Obsolete,ou=People,dc=example,dc=com");
+        assertThat(delete.getResponseType()).isEqualTo(MessageTypeEnum.DEL_RESPONSE);
+        assertThat(rename.getNewRdn().getValue().getString()).isEqualTo("Jane Smith");
+        assertThat(rename.getNewSuperior().getName()).isEqualTo("ou=Alumni,dc=example,dc=com");
+        assertThat(rename.isMove()).isTrue();
+        assertThat(rename.getDeleteOldRdn()).isTrue();
+    }
+
+    @Test
+    void ldifReaderParsesContentAndChangeRecords() throws Exception {
+        String contentLdif = """
+                version: 1
+
+                dn: cn=Jane Doe,ou=People,dc=example,dc=com
+                objectClass: top
+                objectClass: person
+                cn: Jane Doe
+                sn: Doe
+                jpegPhoto:: AQIDBA==
+                """;
+
+        List<LdifEntry> contentEntries = new ArrayList<>();
+        try (LdifReader reader = new LdifReader(new StringReader(contentLdif))) {
+            assertThat(reader.getVersion()).isEqualTo(1);
+            assertThat(reader.containsEntries()).isTrue();
+            for (LdifEntry entry : reader) {
+                contentEntries.add(entry);
+            }
+            assertThat(reader.hasError()).isFalse();
+        }
+
+        assertThat(contentEntries).hasSize(1);
+        LdifEntry contentEntry = contentEntries.get(0);
+        assertThat(contentEntry.isEntry()).isTrue();
+        assertThat(contentEntry.isLdifContent()).isTrue();
+        assertThat(contentEntry.getDn().getName()).isEqualTo("cn=Jane Doe,ou=People,dc=example,dc=com");
+        assertThat(contentEntry.get("objectClass").contains("top", "person")).isTrue();
+        assertThat(contentEntry.get("jpegPhoto").getBytes()).containsExactly((byte) 1, (byte) 2, (byte) 3, (byte) 4);
+
+        String renderedLdif = LdifUtils.convertToLdif(contentEntry.getEntry());
+        assertThat(renderedLdif).contains(
+                "dn: cn=Jane Doe,ou=People,dc=example,dc=com",
+                "objectclass: top",
+                "objectclass: person",
+                "cn: Jane Doe");
+
+        String changeLdif = """
+                version: 1
+
+                dn: cn=Jane Doe,ou=People,dc=example,dc=com
+                changetype: modify
+                replace: mail
+                mail: jane@example.com
+                -
+                add: telephoneNumber
+                telephoneNumber: +1 555 0110
+                -
+                """;
+        List<LdifEntry> changeEntries = new ArrayList<>();
+        try (LdifReader reader = new LdifReader(new StringReader(changeLdif))) {
+            assertThat(reader.getVersion()).isEqualTo(1);
+            for (LdifEntry entry : reader) {
+                changeEntries.add(entry);
+            }
+            assertThat(reader.hasError()).isFalse();
+        }
+
+        assertThat(changeEntries).hasSize(1);
+        LdifEntry changeEntry = changeEntries.get(0);
+        assertThat(changeEntry.isLdifChange()).isTrue();
+        assertThat(changeEntry.isChangeModify()).isTrue();
+        assertThat(changeEntry.getModifications()).hasSize(2);
+        assertThat(changeEntry.getModifications())
+                .extracting(Modification::getOperation)
+                .containsExactly(ModificationOperation.REPLACE_ATTRIBUTE, ModificationOperation.ADD_ATTRIBUTE);
+        assertThat(changeEntry.getModifications())
+                .extracting(modification -> modification.getAttribute().getUpId())
+                .containsExactly("mail", "telephoneNumber");
+        assertThat(changeEntry.getModifications().get(0).getAttribute().contains("jane@example.com")).isTrue();
+        assertThat(changeEntry.getModifications().get(1).getAttribute().contains("+1 555 0110")).isTrue();
+    }
+
+    @Test
+    void ldapUrlsParseDecodeAndRenderSearchLocations() throws Exception {
+        LdapUrl parsedUrl = new LdapUrl(
+                "ldaps://ldap.example.com:1636/ou=People,dc=example,dc=com?cn,sn,mail?sub?"
+                        + "(|(cn=John%20Doe)(mail=john@example.com))?!x-priority=high%2cmedium,x-empty");
+
+        assertThat(parsedUrl.getScheme()).isEqualTo(LdapUrl.LDAPS_SCHEME);
+        assertThat(parsedUrl.getHost()).isEqualTo("ldap.example.com");
+        assertThat(parsedUrl.getPort()).isEqualTo(1636);
+        assertThat(parsedUrl.getDn()).isEqualTo(new Dn("ou=People,dc=example,dc=com"));
+        assertThat(parsedUrl.getAttributes()).containsExactly("cn", "sn", "mail");
+        assertThat(parsedUrl.getScope()).isEqualTo(SearchScope.SUBTREE);
+        assertThat(parsedUrl.getFilter()).isEqualTo("(|(cn=John Doe)(mail=john@example.com))");
+        assertThat(parsedUrl.getExtensions()).hasSize(2);
+        assertThat(parsedUrl.getExtension("X-PRIORITY").isCritical()).isTrue();
+        assertThat(parsedUrl.getExtensionValue("x-priority")).isEqualTo("high,medium");
+        assertThat(parsedUrl.getExtension("x-empty").getValue()).isNull();
+        assertThat(parsedUrl.getBytesCopy()).containsExactly(
+                parsedUrl.getString().getBytes(StandardCharsets.UTF_8));
+        assertThat(parsedUrl.toString()).isEqualTo(
+                "ldaps://ldap.example.com:1636/ou=People,dc=example,dc=com?cn,sn,mail?sub?"
+                        + "(%7C(cn=John%20Doe)(mail=john@example.com))?!x-priority=high%2cmedium,x-empty");
+
+        LdapUrl builtUrl = new LdapUrl();
+        builtUrl.setScheme(LdapUrl.LDAP_SCHEME);
+        builtUrl.setHost("directory.example.org");
+        builtUrl.setPort(389);
+        builtUrl.setDn(new Dn("cn=Jane Smith,ou=People,dc=example,dc=com"));
+        builtUrl.setAttributes(Arrays.asList("cn", "mail"));
+        builtUrl.setScope(SearchScope.ONELEVEL);
+        builtUrl.setFilter("(mail=jane.smith@example.com)");
+        builtUrl.getExtensions().add(new LdapUrl.Extension(false, "x-note", "primary,secondary"));
+
+        assertThat(builtUrl.toString()).isEqualTo(
+                "ldap://directory.example.org:389/cn=Jane%20Smith,ou=People,dc=example,dc=com?cn,mail?one?"
+                        + "(mail=jane.smith@example.com)?x-note=primary%2csecondary");
+        assertThat(new LdapUrl(builtUrl.toString())).isEqualTo(builtUrl);
+    }
+
+    @Test
+    void modifyRequestsResultsReferralsControlsAndCursorsCoverModelUtilities() throws Exception {
+        ModifyRequest modify = new ModifyRequestImpl()
+                .setMessageId(20)
+                .setName(new Dn("cn=John Doe,ou=People,dc=example,dc=com"))
+                .add("telephoneNumber", "+1 555 0100")
+                .replace("mail", "john@example.com")
+                .remove(new DefaultAttribute("description"));
+
+        Collection<Modification> modifications = modify.getModifications();
+        List<ModificationOperation> operations = new ArrayList<>();
+        List<String> attributeIds = new ArrayList<>();
+        for (Modification modification : modifications) {
+            operations.add(modification.getOperation());
+            attributeIds.add(modification.getAttribute().getUpId());
+        }
+
+        assertThat(modify.getResponseType()).isEqualTo(MessageTypeEnum.MODIFY_RESPONSE);
+        assertThat(modify.getResultResponse().getType()).isEqualTo(MessageTypeEnum.MODIFY_RESPONSE);
+        assertThat(operations).containsExactly(
+                ModificationOperation.ADD_ATTRIBUTE,
+                ModificationOperation.REPLACE_ATTRIBUTE,
+                ModificationOperation.REMOVE_ATTRIBUTE);
+        assertThat(attributeIds).containsExactly("telephoneNumber", "mail", "description");
+
+        ReferralImpl referral = new ReferralImpl();
+        referral.addLdapUrl("ldap://ldap.example.com/ou=People,dc=example,dc=com");
+        referral.addLdapUrlBytes("ldap://backup.example.com/dc=example,dc=com".getBytes(StandardCharsets.UTF_8));
+        LdapResultImpl result = new LdapResultImpl();
+        result.setResultCode(ResultCodeEnum.REFERRAL);
+        result.setMatchedDn(new Dn("dc=example,dc=com"));
+        result.setDiagnosticMessage("Use referred directory");
+        result.setReferral(referral);
+
+        assertThat(result.isReferral()).isTrue();
+        assertThat(result.isDefaultSuccess()).isFalse();
+        assertThat(result.getReferral().getLdapUrls()).contains("ldap://ldap.example.com/ou=People,dc=example,dc=com");
+        Collection<byte[]> ldapUrlBytes = result.getReferral().getLdapUrlsBytes();
+        assertThat(ldapUrlBytes).hasSize(1);
+        assertThat(new String(ldapUrlBytes.iterator().next(), StandardCharsets.UTF_8))
+                .isEqualTo("ldap://backup.example.com/dc=example,dc=com");
+        assertThat(ResultCodeEnum.getResultCode(ResultCodeEnum.REFERRAL.getValue())).isEqualTo(ResultCodeEnum.REFERRAL);
+
+        EntryChangeImpl entryChange = new EntryChangeImpl();
+        entryChange.setChangeType(ChangeType.MODDN);
+        entryChange.setPreviousDn(new Dn("cn=John Doe,ou=People,dc=example,dc=com"));
+        entryChange.setChangeNumber(42L);
+        PersistentSearchImpl persistentSearch = new PersistentSearchImpl();
+        persistentSearch.setChangeTypes(0);
+        persistentSearch.enableNotification(ChangeType.ADD);
+        persistentSearch.enableNotification(ChangeType.MODIFY);
+        persistentSearch.setChangesOnly(true);
+        persistentSearch.setReturnECs(true);
+        OpaqueControl opaqueControl = new OpaqueControl("1.2.3.4", true);
+        opaqueControl.setEncodedValue(new byte[] {1, 3, 3, 7});
+        SortKey sortKey = new SortKey("sn", "caseIgnoreOrderingMatch", true);
+
+        assertThat(entryChange.getChangeType()).isEqualTo(ChangeType.MODDN);
+        assertThat(entryChange.getPreviousDn().getName()).isEqualTo("cn=John Doe,ou=People,dc=example,dc=com");
+        assertThat(entryChange.getChangeNumber()).isEqualTo(42L);
+        assertThat(persistentSearch.isNotificationEnabled(ChangeType.ADD)).isTrue();
+        assertThat(persistentSearch.isNotificationEnabled(ChangeType.DELETE)).isFalse();
+        assertThat(persistentSearch.isChangesOnly()).isTrue();
+        assertThat(persistentSearch.isReturnECs()).isTrue();
+        assertThat(opaqueControl.hasEncodedValue()).isTrue();
+        assertThat(opaqueControl.getEncodedValue()).containsExactly((byte) 1, (byte) 3, (byte) 3, (byte) 7);
+        assertThat(sortKey.getAttributeTypeOid()).isEqualTo("sn");
+        assertThat(sortKey.getMatchingRuleId()).isEqualTo("caseIgnoreOrderingMatch");
+        assertThat(sortKey.isReverseOrder()).isTrue();
+
+        Map<String, Control> controlsByOid = Map.of(
+                opaqueControl.getOid(), opaqueControl,
+                entryChange.getOid(), entryChange);
+        assertThat(controlsByOid).containsEntry(opaqueControl.getOid(), opaqueControl);
+
+        List<String> cursorValues = readCursor(new ListCursor<>(Arrays.asList("alpha", "bravo", "charlie")));
+        assertThat(cursorValues).containsExactly("alpha", "bravo", "charlie");
+    }
+
+    private static List<String> readCursor(ListCursor<String> cursor) throws Exception {
+        List<String> values = new ArrayList<>();
+        try {
+            cursor.beforeFirst();
+            while (cursor.next()) {
+                values.add(cursor.get());
+            }
+            assertThat(cursor.isAfterLast()).isTrue();
+        } finally {
+            cursor.close();
+        }
+        return values;
+    }
+}

--- a/tests/src/org.apache.directory.api/api-ldap-model/1.0.1/src/test/java/org_apache_directory_api/api_ldap_model/Api_ldap_modelTest.java
+++ b/tests/src/org.apache.directory.api/api-ldap-model/1.0.1/src/test/java/org_apache_directory_api/api_ldap_model/Api_ldap_modelTest.java
@@ -79,7 +79,7 @@ public class Api_ldap_modelTest {
         assertThat(person.isDescendantOf(base)).isTrue();
         assertThat(person.getParent()).isEqualTo(people);
         assertThat(person.getRdn().getType()).isEqualTo("cn");
-        assertThat(person.getRdn().getValue().getString()).isEqualTo("John Doe");
+        assertThat(person.getRdn().getValue()).isEqualTo("John Doe");
         assertThat(multiValuedRdn.size()).isEqualTo(2);
         assertThat(multiValuedRdn.getAva("sn")).isNotNull();
         assertThat(Dn.isValid(person.getName())).isTrue();
@@ -228,7 +228,7 @@ public class Api_ldap_modelTest {
         assertThat(compare.getResultResponse().getType()).isEqualTo(MessageTypeEnum.COMPARE_RESPONSE);
         assertThat(delete.getName().getName()).isEqualTo("cn=Obsolete,ou=People,dc=example,dc=com");
         assertThat(delete.getResponseType()).isEqualTo(MessageTypeEnum.DEL_RESPONSE);
-        assertThat(rename.getNewRdn().getValue().getString()).isEqualTo("Jane Smith");
+        assertThat(rename.getNewRdn().getValue()).isEqualTo("Jane Smith");
         assertThat(rename.getNewSuperior().getName()).isEqualTo("ou=Alumni,dc=example,dc=com");
         assertThat(rename.isMove()).isTrue();
         assertThat(rename.getDeleteOldRdn()).isTrue();
@@ -413,7 +413,7 @@ public class Api_ldap_modelTest {
         assertThat(persistentSearch.isReturnECs()).isTrue();
         assertThat(opaqueControl.hasEncodedValue()).isTrue();
         assertThat(opaqueControl.getEncodedValue()).containsExactly((byte) 1, (byte) 3, (byte) 3, (byte) 7);
-        assertThat(sortKey.getAttributeTypeOid()).isEqualTo("sn");
+        assertThat(sortKey.getAttributeTypeDesc()).isEqualTo("sn");
         assertThat(sortKey.getMatchingRuleId()).isEqualTo("caseIgnoreOrderingMatch");
         assertThat(sortKey.isReverseOrder()).isTrue();
 

--- a/tests/src/org.apache.directory.api/api-ldap-model/1.0.1/user-code-filter.json
+++ b/tests/src/org.apache.directory.api/api-ldap-model/1.0.1/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.directory.api.ldap.model.**"
+    },
+    {
+      "includeClasses" : "org_apache_directory_api.api_ldap_model.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6911

This PR provides test fixes and new metadata for org.apache.directory.api:api-ldap-model:1.0.1, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 33127
- Cached input tokens: 248320
- Output tokens: 1704
- Metadata entries: 4
- Iterations: 1
- Library coverage percentage: 9.34
- Previous library version metadata entries: 2
- Previous library version coverage percentage: 9.71

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `d386fabc5c663797bd4919a1cdca762f0085f4d1`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.directory.api:api-ldap-model:1.0.0-M20: 0/0 covered calls (100.00%)
- org.apache.directory.api:api-ldap-model:1.0.1: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.directory.api:api-ldap-model:1.0.0-M20: 10353/109564 (9.45%)
- org.apache.directory.api:api-ldap-model:1.0.1: 10577/123497 (8.56%)

**Line:**
- org.apache.directory.api:api-ldap-model:1.0.0-M20: 2452/25265 (9.71%)
- org.apache.directory.api:api-ldap-model:1.0.1: 2513/26898 (9.34%)

**Method:**
- org.apache.directory.api:api-ldap-model:1.0.0-M20: 474/3382 (14.02%)
- org.apache.directory.api:api-ldap-model:1.0.1: 468/3728 (12.55%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.directory.api/api-ldap-model/1.0.0-M20/src/test/java/org_apache_directory_api/api_ldap_model/Api_ldap_modelTest.java 2/tests/src/org.apache.directory.api/api-ldap-model/1.0.1/src/test/java/org_apache_directory_api/api_ldap_model/Api_ldap_modelTest.java
index 8e3f6a51a8..39ecf301ff 100644
--- 1/tests/src/org.apache.directory.api/api-ldap-model/1.0.0-M20/src/test/java/org_apache_directory_api/api_ldap_model/Api_ldap_modelTest.java
+++ 2/tests/src/org.apache.directory.api/api-ldap-model/1.0.1/src/test/java/org_apache_directory_api/api_ldap_model/Api_ldap_modelTest.java
@@ -79,7 +79,7 @@ public class Api_ldap_modelTest {
         assertThat(person.isDescendantOf(base)).isTrue();
         assertThat(person.getParent()).isEqualTo(people);
         assertThat(person.getRdn().getType()).isEqualTo("cn");
-        assertThat(person.getRdn().getValue().getString()).isEqualTo("John Doe");
+        assertThat(person.getRdn().getValue()).isEqualTo("John Doe");
         assertThat(multiValuedRdn.size()).isEqualTo(2);
         assertThat(multiValuedRdn.getAva("sn")).isNotNull();
         assertThat(Dn.isValid(person.getName())).isTrue();
@@ -228,7 +228,7 @@ public class Api_ldap_modelTest {
         assertThat(compare.getResultResponse().getType()).isEqualTo(MessageTypeEnum.COMPARE_RESPONSE);
         assertThat(delete.getName().getName()).isEqualTo("cn=Obsolete,ou=People,dc=example,dc=com");
         assertThat(delete.getResponseType()).isEqualTo(MessageTypeEnum.DEL_RESPONSE);
-        assertThat(rename.getNewRdn().getValue().getString()).isEqualTo("Jane Smith");
+        assertThat(rename.getNewRdn().getValue()).isEqualTo("Jane Smith");
         assertThat(rename.getNewSuperior().getName()).isEqualTo("ou=Alumni,dc=example,dc=com");
         assertThat(rename.isMove()).isTrue();
         assertThat(rename.getDeleteOldRdn()).isTrue();
@@ -413,7 +413,7 @@ public class Api_ldap_modelTest {
         assertThat(persistentSearch.isReturnECs()).isTrue();
         assertThat(opaqueControl.hasEncodedValue()).isTrue();
         assertThat(opaqueControl.getEncodedValue()).containsExactly((byte) 1, (byte) 3, (byte) 3, (byte) 7);
-        assertThat(sortKey.getAttributeTypeOid()).isEqualTo("sn");
+        assertThat(sortKey.getAttributeTypeDesc()).isEqualTo("sn");
         assertThat(sortKey.getMatchingRuleId()).isEqualTo("caseIgnoreOrderingMatch");
         assertThat(sortKey.isReverseOrder()).isTrue();
 

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
