### PR TITLE
[GenAI] Add support for org.springframework.boot:spring-boot-jdbc:4.0.6 using gpt-5.5

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-jdbc/4.0.6/reachability-metadata.json
+++ b/metadata/org.springframework.boot/spring-boot-jdbc/4.0.6/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.springframework.boot.jdbc.DataSourceBuilder"
+      },
+      "type": "org.springframework.jdbc.datasource.SimpleDriverDataSource",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.springframework.boot/spring-boot-jdbc/index.json
+++ b/metadata/org.springframework.boot/spring-boot-jdbc/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.0.6",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-jdbc/$version$/spring-boot-jdbc-$version$-sources.jar",
+    "repository-url" : "https://github.com/spring-projects/spring-boot",
+    "test-code-url" : "https://github.com/spring-projects/spring-boot/tree/v$version$/module/spring-boot-jdbc/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-jdbc/$version$/spring-boot-jdbc-$version$-javadoc.jar",
+    "description" : "Spring Boot JDBC provides auto-configuration and support classes for JDBC-based data access in Spring Boot applications. It configures data sources, JDBC templates, transaction managers, database initialization, health checks, connection pool metrics, and Docker Compose/Testcontainers connection details.",
+    "tested-versions" : [
+      "4.0.6"
+    ],
+    "allowed-packages" : [
+      "org.springframework.boot.jdbc"
+    ]
+  }
+]

--- a/stats/org.springframework.boot/spring-boot-jdbc/4.0.6/execution-metrics.json
+++ b/stats/org.springframework.boot/spring-boot-jdbc/4.0.6/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-19": {
+    "timestamp": "2026-05-19T21:45:54.515445Z",
+    "library": "org.springframework.boot:spring-boot-jdbc:4.0.6",
+    "starting_commit": "2c6ebabc9f91a526ea03a33b55a5de198726d9ad",
+    "ending_commit": "c80c6d5410a93d97e06bf9cdd69c75b9b5916ef9",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.0.6",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1124,
+          "missed": 5389,
+          "ratio": 0.172578,
+          "total": 6513
+        },
+        "line": {
+          "covered": 210,
+          "missed": 1313,
+          "ratio": 0.137886,
+          "total": 1523
+        },
+        "method": {
+          "covered": 67,
+          "missed": 476,
+          "ratio": 0.123389,
+          "total": 543
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 144564,
+      "cached_input_tokens_used": 2056704,
+      "output_tokens_used": 13012,
+      "iterations": 3,
+      "cost_usd": 1.4188,
+      "generated_loc": 49,
+      "tested_library_loc": 210,
+      "metadata_entries": 2,
+      "code_coverage_percent": 13.79
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.springframework.boot/spring-boot-jdbc/4.0.6/src/test/java/org_springframework_boot/spring_boot_jdbc/Spring_boot_jdbcTest.java",
+      "metadata_file": "metadata/org.springframework.boot/spring-boot-jdbc/4.0.6/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.springframework.boot/spring-boot-jdbc/4.0.6/stats.json
+++ b/stats/org.springframework.boot/spring-boot-jdbc/4.0.6/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.0.6",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1124,
+        "missed" : 5389,
+        "ratio" : 0.172578,
+        "total" : 6513
+      },
+      "line" : {
+        "covered" : 210,
+        "missed" : 1313,
+        "ratio" : 0.137886,
+        "total" : 1523
+      },
+      "method" : {
+        "covered" : 67,
+        "missed" : 476,
+        "ratio" : 0.123389,
+        "total" : 543
+      }
+    }
+  } ]
+}

--- a/tests/src/org.springframework.boot/spring-boot-jdbc/4.0.6/.gitignore
+++ b/tests/src/org.springframework.boot/spring-boot-jdbc/4.0.6/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.springframework.boot/spring-boot-jdbc/4.0.6/build.gradle
+++ b/tests/src/org.springframework.boot/spring-boot-jdbc/4.0.6/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.springframework.boot:spring-boot-jdbc:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.springframework.boot/spring-boot-jdbc/4.0.6/gradle.properties
+++ b/tests/src/org.springframework.boot/spring-boot-jdbc/4.0.6/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.springframework.boot:spring-boot-jdbc:4.0.6
+library.version = 4.0.6
+metadata.dir = org.springframework.boot/spring-boot-jdbc/4.0.6/

--- a/tests/src/org.springframework.boot/spring-boot-jdbc/4.0.6/settings.gradle
+++ b/tests/src/org.springframework.boot/spring-boot-jdbc/4.0.6/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.springframework.boot.spring-boot-jdbc_tests'

--- a/tests/src/org.springframework.boot/spring-boot-jdbc/4.0.6/src/test/java/org_springframework_boot/spring_boot_jdbc/Spring_boot_jdbcTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-jdbc/4.0.6/src/test/java/org_springframework_boot/spring_boot_jdbc/Spring_boot_jdbcTest.java
@@ -6,11 +6,43 @@
  */
 package org_springframework_boot.spring_boot_jdbc;
 
-import org.junit.jupiter.api.Test;
+import javax.sql.DataSource;
 
-class Spring_boot_jdbcTest {
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.jdbc.datasource.SimpleDriverDataSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Spring_boot_jdbcTest {
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void dataSourceBuilderCreatesSimpleDriverDataSourceWithConnectionSettings() {
+        SimpleDriverDataSource dataSource = DataSourceBuilder.create()
+            .type(SimpleDriverDataSource.class)
+            .url("jdbc:custom:orders")
+            .username("orders-user")
+            .password("orders-secret")
+            .build();
+
+        assertThat(dataSource.getUrl()).isEqualTo("jdbc:custom:orders");
+        assertThat(dataSource.getUsername()).isEqualTo("orders-user");
+        assertThat(dataSource.getPassword()).isEqualTo("orders-secret");
+    }
+
+    @Test
+    void dataSourceBuilderDerivesSettingsFromExistingDataSourceAndAppliesOverrides() {
+        SimpleDriverDataSource source = new SimpleDriverDataSource();
+        source.setUrl("jdbc:custom:inventory");
+        source.setUsername("source-user");
+        source.setPassword("source-secret");
+
+        DataSource dataSource = DataSourceBuilder.derivedFrom(source).username("derived-user").build();
+
+        assertThat(dataSource).isInstanceOfSatisfying(SimpleDriverDataSource.class, (derived) -> {
+            assertThat(derived.getUrl()).isEqualTo("jdbc:custom:inventory");
+            assertThat(derived.getUsername()).isEqualTo("derived-user");
+            assertThat(derived.getPassword()).isEqualTo("source-secret");
+        });
     }
 }

--- a/tests/src/org.springframework.boot/spring-boot-jdbc/4.0.6/src/test/java/org_springframework_boot/spring_boot_jdbc/Spring_boot_jdbcTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-jdbc/4.0.6/src/test/java/org_springframework_boot/spring_boot_jdbc/Spring_boot_jdbcTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework_boot.spring_boot_jdbc;
+
+import org.junit.jupiter.api.Test;
+
+class Spring_boot_jdbcTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.springframework.boot/spring-boot-jdbc/4.0.6/src/test/java/org_springframework_boot/spring_boot_jdbc/Spring_boot_jdbcTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-jdbc/4.0.6/src/test/java/org_springframework_boot/spring_boot_jdbc/Spring_boot_jdbcTest.java
@@ -10,6 +10,8 @@ import javax.sql.DataSource;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.boot.jdbc.DataSourceUnwrapper;
+import org.springframework.jdbc.datasource.DelegatingDataSource;
 import org.springframework.jdbc.datasource.SimpleDriverDataSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -44,5 +46,16 @@ public class Spring_boot_jdbcTest {
             assertThat(derived.getUsername()).isEqualTo("derived-user");
             assertThat(derived.getPassword()).isEqualTo("source-secret");
         });
+    }
+
+    @Test
+    void dataSourceUnwrapperFindsNestedDelegatingDataSourceTarget() {
+        SimpleDriverDataSource target = new SimpleDriverDataSource();
+        target.setUrl("jdbc:custom:warehouse");
+        DelegatingDataSource wrapped = new DelegatingDataSource(new DelegatingDataSource(target));
+
+        SimpleDriverDataSource unwrapped = DataSourceUnwrapper.unwrap(wrapped, SimpleDriverDataSource.class);
+
+        assertThat(unwrapped).isSameAs(target);
     }
 }

--- a/tests/src/org.springframework.boot/spring-boot-jdbc/4.0.6/user-code-filter.json
+++ b/tests/src/org.springframework.boot/spring-boot-jdbc/4.0.6/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.springframework.boot.jdbc.**"
+      "includeClasses" : "org.springframework.boot.jdbc.**"
+    },
+    {
+      "includeClasses" : "org_springframework_boot.spring_boot_jdbc.**"
     }
   ]
 }

--- a/tests/src/org.springframework.boot/spring-boot-jdbc/4.0.6/user-code-filter.json
+++ b/tests/src/org.springframework.boot/spring-boot-jdbc/4.0.6/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.springframework.boot.jdbc.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #7059

This PR introduces tests and metadata for org.springframework.boot:spring-boot-jdbc:4.0.6, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 144564
- Cached input tokens: 2056704
- Output tokens: 13012
- Metadata entries: 2
- Iterations: 3
- Library coverage percentage: 13.79
- Generated lines of code: 49
- Tested library lines of code: 210

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `6756ae459471d8cfe929ceac3cd34b92937f35fc`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1124/6513 (17.26%)
- Line: 210/1523 (13.79%)
- Method: 67/543 (12.34%)

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
