### PR TITLE
[GenAI] Test fix for org.glassfish.jersey.containers:jersey-container-servlet:5.0.0-M1 using gpt-5.5

### DIFF
--- a/metadata/org.glassfish.jersey.containers/jersey-container-servlet/5.0.0-M1/reachability-metadata.json
+++ b/metadata/org.glassfish.jersey.containers/jersey-container-servlet/5.0.0-M1/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.glassfish.jersey.servlet.internal.l10n.LocalizationMessages$BundleSupplier"
+      },
+      "bundle": "org.glassfish.jersey.servlet.internal.l10n.localization"
+    }
+  ]
+}

--- a/metadata/org.glassfish.jersey.containers/jersey-container-servlet/index.json
+++ b/metadata/org.glassfish.jersey.containers/jersey-container-servlet/index.json
@@ -61,6 +61,15 @@
     ]
   },
   {
+    "metadata-version" : "5.0.0-M1",
+    "tested-versions" : [
+      "5.0.0-M1"
+    ],
+    "allowed-packages" : [
+      "org.glassfish.jersey.servlet"
+    ]
+  },
+  {
     "metadata-version" : "4.0.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/glassfish/jersey/containers/jersey-container-servlet/$version$/jersey-container-servlet-$version$-sources.jar",
     "repository-url" : "https://github.com/eclipse-ee4j/jersey",

--- a/metadata/org.glassfish.jersey.containers/jersey-container-servlet/index.json
+++ b/metadata/org.glassfish.jersey.containers/jersey-container-servlet/index.json
@@ -62,6 +62,11 @@
   },
   {
     "metadata-version" : "5.0.0-M1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/glassfish/jersey/containers/jersey-container-servlet/$version$/jersey-container-servlet-$version$-sources.jar",
+    "repository-url" : "https://github.com/eclipse-ee4j/jersey",
+    "test-code-url" : "https://github.com/eclipse-ee4j/jersey/tree/$version$-RELEASE/tests/integration/servlet-3-init-provider/src/test",
+    "documentation-url" : "https://github.com/eclipse-ee4j/jersey/tree/$version$-RELEASE/docs/src/main/docbook",
+    "description" : "Jersey Container Servlet integrates Eclipse Jersey's Jakarta REST server runtime with Jakarta Servlet containers. It provides servlet registration, request handling, and async-context support so Jersey REST resources can run in WAR-based web applications.",
     "tested-versions" : [
       "5.0.0-M1"
     ],

--- a/stats/org.glassfish.jersey.containers/jersey-container-servlet/5.0.0-M1/execution-metrics.json
+++ b/stats/org.glassfish.jersey.containers/jersey-container-servlet/5.0.0-M1/execution-metrics.json
@@ -1,0 +1,104 @@
+{
+  "fix_javac_fail:2026-05-19": {
+    "timestamp": "2026-05-19T22:13:20.611284Z",
+    "library": "org.glassfish.jersey.containers:jersey-container-servlet:5.0.0-M1",
+    "starting_commit": "bb4a48d3a03a36164d64eaab9781fb6ef722a06b",
+    "ending_commit": "6d03e3df8a0e83c9a590384aff46b9738de43cd6",
+    "previous_library": "org.glassfish.jersey.containers:jersey-container-servlet:2.34",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "5.0.0-M1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 2,
+        "totalCalls": 2
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 51,
+          "missed": 3760,
+          "ratio": 0.013382,
+          "total": 3811
+        },
+        "line": {
+          "covered": 10,
+          "missed": 862,
+          "ratio": 0.011468,
+          "total": 872
+        },
+        "method": {
+          "covered": 6,
+          "missed": 230,
+          "ratio": 0.025424,
+          "total": 236
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.34",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 28,
+          "missed": 937,
+          "ratio": 0.029016,
+          "total": 965
+        },
+        "line": {
+          "covered": 4,
+          "missed": 195,
+          "ratio": 0.020101,
+          "total": 199
+        },
+        "method": {
+          "covered": 3,
+          "missed": 39,
+          "ratio": 0.071429,
+          "total": 42
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 26730,
+      "cached_input_tokens_used": 185856,
+      "output_tokens_used": 2882,
+      "iterations": 2,
+      "cost_usd": 0.1794,
+      "tested_library_loc": 10,
+      "metadata_entries": 1,
+      "previous_library_metadata_entries": 1,
+      "code_coverage_percent": 1.15,
+      "previous_library_coverage_percent": 2.01
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.glassfish.jersey.containers/jersey-container-servlet/5.0.0-M1/src/test/java/org_glassfish_jersey_containers/jersey_container_servlet/LocalizationMessagesInnerBundleSupplierTest.java",
+      "metadata_file": "metadata/org.glassfish.jersey.containers/jersey-container-servlet/5.0.0-M1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.glassfish.jersey.containers/jersey-container-servlet/5.0.0-M1/stats.json
+++ b/stats/org.glassfish.jersey.containers/jersey-container-servlet/5.0.0-M1/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "5.0.0-M1",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 2,
+      "totalCalls" : 2
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 51,
+        "missed" : 3760,
+        "ratio" : 0.013382,
+        "total" : 3811
+      },
+      "line" : {
+        "covered" : 10,
+        "missed" : 862,
+        "ratio" : 0.011468,
+        "total" : 872
+      },
+      "method" : {
+        "covered" : 6,
+        "missed" : 230,
+        "ratio" : 0.025424,
+        "total" : 236
+      }
+    }
+  } ]
+}

--- a/tests/src/org.glassfish.jersey.containers/jersey-container-servlet/5.0.0-M1/.gitignore
+++ b/tests/src/org.glassfish.jersey.containers/jersey-container-servlet/5.0.0-M1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.glassfish.jersey.containers/jersey-container-servlet/5.0.0-M1/build.gradle
+++ b/tests/src/org.glassfish.jersey.containers/jersey-container-servlet/5.0.0-M1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.glassfish.jersey.containers:jersey-container-servlet:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.glassfish.jersey.containers/jersey-container-servlet/5.0.0-M1/gradle.properties
+++ b/tests/src/org.glassfish.jersey.containers/jersey-container-servlet/5.0.0-M1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.glassfish.jersey.containers:jersey-container-servlet:5.0.0-M1
+library.version = 5.0.0-M1
+metadata.dir = org.glassfish.jersey.containers/jersey-container-servlet/5.0.0-M1/

--- a/tests/src/org.glassfish.jersey.containers/jersey-container-servlet/5.0.0-M1/settings.gradle
+++ b/tests/src/org.glassfish.jersey.containers/jersey-container-servlet/5.0.0-M1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.glassfish.jersey.containers.jersey-container-servlet_tests'

--- a/tests/src/org.glassfish.jersey.containers/jersey-container-servlet/5.0.0-M1/src/test/java/org_glassfish_jersey_containers/jersey_container_servlet/LocalizationMessagesInnerBundleSupplierTest.java
+++ b/tests/src/org.glassfish.jersey.containers/jersey-container-servlet/5.0.0-M1/src/test/java/org_glassfish_jersey_containers/jersey_container_servlet/LocalizationMessagesInnerBundleSupplierTest.java
@@ -10,7 +10,7 @@ import java.util.Locale;
 import java.util.ResourceBundle;
 
 import org.glassfish.jersey.internal.l10n.Localizable;
-import org.glassfish.jersey.servlet.init.internal.LocalizationMessages;
+import org.glassfish.jersey.servlet.internal.l10n.LocalizationMessages;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/tests/src/org.glassfish.jersey.containers/jersey-container-servlet/5.0.0-M1/src/test/java/org_glassfish_jersey_containers/jersey_container_servlet/LocalizationMessagesInnerBundleSupplierTest.java
+++ b/tests/src/org.glassfish.jersey.containers/jersey-container-servlet/5.0.0-M1/src/test/java/org_glassfish_jersey_containers/jersey_container_servlet/LocalizationMessagesInnerBundleSupplierTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_jersey_containers.jersey_container_servlet;
+
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+import org.glassfish.jersey.internal.l10n.Localizable;
+import org.glassfish.jersey.servlet.init.internal.LocalizationMessages;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LocalizationMessagesInnerBundleSupplierTest {
+    @Test
+    void localizableMessageExposesServletInitializationResourceBundle() {
+        Localizable message = LocalizationMessages.localizableJERSEY_APP_NO_MAPPING("SampleApplication");
+
+        ResourceBundle bundle = message.getResourceBundle(Locale.ROOT);
+
+        assertThat(bundle.getString("jersey.app.no.mapping"))
+                .isEqualTo("The Jersey servlet application, named {0}, has no servlet mapping.");
+    }
+}

--- a/tests/src/org.glassfish.jersey.containers/jersey-container-servlet/5.0.0-M1/src/test/java/org_glassfish_jersey_containers/jersey_container_servlet/ThreadLocalInvokerTest.java
+++ b/tests/src/org.glassfish.jersey.containers/jersey-container-servlet/5.0.0-M1/src/test/java/org_glassfish_jersey_containers/jersey_container_servlet/ThreadLocalInvokerTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_jersey_containers.jersey_container_servlet;
+
+import java.lang.reflect.Proxy;
+
+import org.glassfish.jersey.servlet.internal.ThreadLocalInvoker;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ThreadLocalInvokerTest {
+    @Test
+    void proxyMethodInvocationDelegatesToThreadLocalInstance() {
+        ThreadLocalInvoker<CharSequence> invoker = new ThreadLocalInvoker<>();
+        invoker.set("Jersey servlet");
+        CharSequence proxy = (CharSequence) Proxy.newProxyInstance(
+                ThreadLocalInvokerTest.class.getClassLoader(),
+                new Class<?>[] {CharSequence.class},
+                invoker);
+
+        int length = proxy.length();
+        char firstCharacter = proxy.charAt(0);
+        CharSequence prefix = proxy.subSequence(0, 6);
+
+        assertThat(length).isEqualTo("Jersey servlet".length());
+        assertThat(firstCharacter).isEqualTo('J');
+        assertThat(prefix).hasToString("Jersey");
+    }
+}

--- a/tests/src/org.glassfish.jersey.containers/jersey-container-servlet/5.0.0-M1/user-code-filter.json
+++ b/tests/src/org.glassfish.jersey.containers/jersey-container-servlet/5.0.0-M1/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.glassfish.jersey.servlet.**"
+    },
+    {
+      "includeClasses" : "org_glassfish_jersey_containers.jersey_container_servlet.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7250

This PR provides test fixes and new metadata for org.glassfish.jersey.containers:jersey-container-servlet:5.0.0-M1, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 26730
- Cached input tokens: 185856
- Output tokens: 2882
- Metadata entries: 1
- Iterations: 2
- Library coverage percentage: 1.15
- Previous library version metadata entries: 1
- Previous library version coverage percentage: 2.01

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `071c34eac05e95255f8e525514209236affbdc7e`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.glassfish.jersey.containers:jersey-container-servlet:2.34: 1/1 covered calls (100.00%)
- org.glassfish.jersey.containers:jersey-container-servlet:5.0.0-M1: 2/2 covered calls (100.00%)

**Reflection:**
- org.glassfish.jersey.containers:jersey-container-servlet:2.34: N/A
- org.glassfish.jersey.containers:jersey-container-servlet:5.0.0-M1: 1/1 covered calls (100.00%)

**Resources:**
- org.glassfish.jersey.containers:jersey-container-servlet:2.34: 1/1 covered calls (100.00%)
- org.glassfish.jersey.containers:jersey-container-servlet:5.0.0-M1: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.glassfish.jersey.containers:jersey-container-servlet:2.34: 28/965 (2.90%)
- org.glassfish.jersey.containers:jersey-container-servlet:5.0.0-M1: 51/3811 (1.34%)

**Line:**
- org.glassfish.jersey.containers:jersey-container-servlet:2.34: 4/199 (2.01%)
- org.glassfish.jersey.containers:jersey-container-servlet:5.0.0-M1: 10/872 (1.15%)

**Method:**
- org.glassfish.jersey.containers:jersey-container-servlet:2.34: 3/42 (7.14%)
- org.glassfish.jersey.containers:jersey-container-servlet:5.0.0-M1: 6/236 (2.54%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.glassfish.jersey.containers/jersey-container-servlet/2.34/src/test/java/org_glassfish_jersey_containers/jersey_container_servlet/LocalizationMessagesInnerBundleSupplierTest.java 2/tests/src/org.glassfish.jersey.containers/jersey-container-servlet/5.0.0-M1/src/test/java/org_glassfish_jersey_containers/jersey_container_servlet/LocalizationMessagesInnerBundleSupplierTest.java
index b3e0a5e2e2..3fd980af7a 100644
--- 1/tests/src/org.glassfish.jersey.containers/jersey-container-servlet/2.34/src/test/java/org_glassfish_jersey_containers/jersey_container_servlet/LocalizationMessagesInnerBundleSupplierTest.java
+++ 2/tests/src/org.glassfish.jersey.containers/jersey-container-servlet/5.0.0-M1/src/test/java/org_glassfish_jersey_containers/jersey_container_servlet/LocalizationMessagesInnerBundleSupplierTest.java
@@ -10,7 +10,7 @@ import java.util.Locale;
 import java.util.ResourceBundle;
 
 import org.glassfish.jersey.internal.l10n.Localizable;
-import org.glassfish.jersey.servlet.init.internal.LocalizationMessages;
+import org.glassfish.jersey.servlet.internal.l10n.LocalizationMessages;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
diff --git 1/tests/src/org.glassfish.jersey.containers/jersey-container-servlet/5.0.0-M1/src/test/java/org_glassfish_jersey_containers/jersey_container_servlet/ThreadLocalInvokerTest.java 2/tests/src/org.glassfish.jersey.containers/jersey-container-servlet/5.0.0-M1/src/test/java/org_glassfish_jersey_containers/jersey_container_servlet/ThreadLocalInvokerTest.java
new file mode 100644
index 0000000000..4dba330a40
--- /dev/null
+++ 2/tests/src/org.glassfish.jersey.containers/jersey-container-servlet/5.0.0-M1/src/test/java/org_glassfish_jersey_containers/jersey_container_servlet/ThreadLocalInvokerTest.java
@@ -0,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_jersey_containers.jersey_container_servlet;
+
+import java.lang.reflect.Proxy;
+
+import org.glassfish.jersey.servlet.internal.ThreadLocalInvoker;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ThreadLocalInvokerTest {
+    @Test
+    void proxyMethodInvocationDelegatesToThreadLocalInstance() {
+        ThreadLocalInvoker<CharSequence> invoker = new ThreadLocalInvoker<>();
+        invoker.set("Jersey servlet");
+        CharSequence proxy = (CharSequence) Proxy.newProxyInstance(
+                ThreadLocalInvokerTest.class.getClassLoader(),
+                new Class<?>[] {CharSequence.class},
+                invoker);
+
+        int length = proxy.length();
+        char firstCharacter = proxy.charAt(0);
+        CharSequence prefix = proxy.subSequence(0, 6);
+
+        assertThat(length).isEqualTo("Jersey servlet".length());
+        assertThat(firstCharacter).isEqualTo('J');
+        assertThat(prefix).hasToString("Jersey");
+    }
+}

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
