### PR TITLE
[GenAI] Mark org.springframework.boot:spring-boot-starter-aspectj as not for Native Image

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-starter-aspectj/index.json
+++ b/metadata/org.springframework.boot/spring-boot-starter-aspectj/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published spring-boot-starter-aspectj-4.0.6 JAR contains only META-INF/MANIFEST.MF, LICENSE.txt, and NOTICE.txt and no JVM class files; it is a dependency starter whose runtime classes are supplied by dependencies.",
+    "replacement": "Use class-bearing dependencies such as org.springframework:spring-aop:7.0.7 and org.aspectj:aspectjweaver:1.9.25.1 for reachability metadata."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #7023

This PR records `org.springframework.boot:spring-boot-starter-aspectj` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published spring-boot-starter-aspectj-4.0.6 JAR contains only META-INF/MANIFEST.MF, LICENSE.txt, and NOTICE.txt and no JVM class files; it is a dependency starter whose runtime classes are supplied by dependencies.

Replacement guidance:
- Use class-bearing dependencies such as org.springframework:spring-aop:7.0.7 and org.aspectj:aspectjweaver:1.9.25.1 for reachability metadata.

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `62e06e0c82495b7d0965fd8483f62f09af93d77f`

### Local CI Verification

- Status: `success`
- Commands run: 6
- Fixup attempts: 0
