### PR TITLE
[GenAI] Test fix for commons-configuration:commons-configuration:1.9 using gpt-5.5

### DIFF
--- a/metadata/commons-configuration/commons-configuration/1.9/reachability-metadata.json
+++ b/metadata/commons-configuration/commons-configuration/1.9/reachability-metadata.json
@@ -1,0 +1,278 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.ConfigurationUtils"
+      },
+      "type" : "org.apache.commons.configuration.ConfigurationUtils"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.ConfigurationFactory"
+      },
+      "type" : "org.apache.commons.configuration.ConfigurationFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.DefaultConfigurationBuilder"
+      },
+      "type" : "org.apache.commons.configuration.DefaultConfigurationBuilder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.DefaultConfigurationBuilder"
+      },
+      "type" : "org.apache.commons.configuration.XMLPropertiesConfiguration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.DefaultConfigurationBuilder"
+      },
+      "type" : "org.apache.commons.configuration.PropertiesConfiguration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.DefaultConfigurationBuilder"
+      },
+      "type" : "org.apache.commons.configuration.HierarchicalINIConfiguration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.DefaultConfigurationBuilder"
+      },
+      "type" : "org.apache.commons.configuration.JNDIConfiguration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.DefaultConfigurationBuilder"
+      },
+      "type" : "org.apache.commons.configuration.SystemConfiguration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.FileSystem"
+      },
+      "type" : "org.apache.commons.configuration.DefaultFileSystem",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.ConfigurationUtils"
+      },
+      "type" : "java.lang.Thread",
+      "methods" : [
+        {
+          "name" : "getContextClassLoader",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.ConfigurationFactory"
+      },
+      "type" : "java.lang.Thread",
+      "methods" : [
+        {
+          "name" : "getContextClassLoader",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.beanutils.ConfigurationDynaBean"
+      },
+      "type" : "java.lang.Thread",
+      "methods" : [
+        {
+          "name" : "getContextClassLoader",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.beanutils.ConfigurationDynaClass"
+      },
+      "type" : "java.lang.Thread",
+      "methods" : [
+        {
+          "name" : "getContextClassLoader",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.ConfigurationUtils"
+      },
+      "type" : "java.io.File",
+      "methods" : [
+        {
+          "name" : "toURI",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.ConfigurationUtils"
+      },
+      "type" : "java.net.URI",
+      "methods" : [
+        {
+          "name" : "toURL",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.ConfigurationUtils"
+      },
+      "type" : "org.apache.commons.collections.map.LinkedMap",
+      "methods" : [
+        {
+          "name" : "clone",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.ConfigurationUtils"
+      },
+      "type" : "java.util.LinkedHashMap",
+      "methods" : [
+        {
+          "name" : "clone",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.ConfigurationUtils"
+      },
+      "type" : "java.util.HashMap",
+      "methods" : [
+        {
+          "name" : "clone",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.EnvironmentConfiguration"
+      },
+      "type" : "java.lang.System",
+      "methods" : [
+        {
+          "name" : "getenv",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.PropertyConverter"
+      },
+      "type" : "java.lang.Class",
+      "methods" : [
+        {
+          "name" : "isEnum",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.PropertyConverter"
+      },
+      "type" : "java.lang.Integer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.beanutils.DefaultBeanFactory"
+      },
+      "type" : "java.util.Properties",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.interpol.ExprLookup$Variable"
+      },
+      "type" : "java.util.Properties",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.beanutils.ConfigurationDynaBean"
+      },
+      "type" : "org.apache.commons.logging.impl.Log4JLogger"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.beanutils.ConfigurationDynaBean"
+      },
+      "type" : "org.apache.commons.logging.impl.LogFactoryImpl"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.ConfigurationUtils"
+      },
+      "glob" : "commons-logging.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.beanutils.ConfigurationDynaBean"
+      },
+      "glob" : "commons-logging.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.beanutils.ConfigurationDynaBean"
+      },
+      "glob" : "META-INF/services/org.apache.commons.logging.LogFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.XMLPropertiesConfiguration"
+      },
+      "glob" : "META-INF/services/javax.xml.parsers.SAXParserFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.plist.XMLPropertyListConfiguration$1"
+      },
+      "glob" : "PropertyList-1.0.dtd"
+    }
+  ]
+}

--- a/metadata/commons-configuration/commons-configuration/index.json
+++ b/metadata/commons-configuration/commons-configuration/index.json
@@ -15,6 +15,15 @@
     ]
   },
   {
+    "metadata-version" : "1.9",
+    "tested-versions" : [
+      "1.9"
+    ],
+    "allowed-packages" : [
+      "org.apache.commons.configuration"
+    ]
+  },
+  {
     "metadata-version" : "1.8",
     "source-code-url" : "https://repo.maven.apache.org/maven2/commons-configuration/commons-configuration/$version$/commons-configuration-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/commons-configuration",

--- a/metadata/commons-configuration/commons-configuration/index.json
+++ b/metadata/commons-configuration/commons-configuration/index.json
@@ -16,6 +16,11 @@
   },
   {
     "metadata-version" : "1.9",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/commons-configuration/commons-configuration/$version$/commons-configuration-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/commons-configuration",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/commons-configuration/commons-configuration/$version$/commons-configuration-$version$-test-sources.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/commons-configuration/commons-configuration/$version$/commons-configuration-$version$-javadoc.jar",
+    "description" : "Apache Commons Configuration provides APIs for reading, writing, and combining configuration data from formats such as properties files, XML, INI, JNDI, and system properties. It supports interpolation, type conversion, reloading, and hierarchical configurations for Java applications.",
     "tested-versions" : [
       "1.9"
     ],

--- a/stats/commons-configuration/commons-configuration/1.9/execution-metrics.json
+++ b/stats/commons-configuration/commons-configuration/1.9/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_javac_fail:2026-05-20": {
+    "timestamp": "2026-05-20T02:00:59.135417Z",
+    "library": "commons-configuration:commons-configuration:1.9",
+    "starting_commit": "c35d35f7fc2235b2da62ec6a48caa699d5d22263",
+    "ending_commit": "8bc9258858be1968c4badc355822d3cb20b6571d",
+    "previous_library": "commons-configuration:commons-configuration:1.7",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.9",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 17,
+            "totalCalls": 17
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 21,
+        "totalCalls": 21
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 6140,
+          "missed": 29884,
+          "ratio": 0.170442,
+          "total": 36024
+        },
+        "line": {
+          "covered": 1625,
+          "missed": 6719,
+          "ratio": 0.194751,
+          "total": 8344
+        },
+        "method": {
+          "covered": 492,
+          "missed": 1485,
+          "ratio": 0.248862,
+          "total": 1977
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.7",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 41,
+            "totalCalls": 41
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 45,
+        "totalCalls": 45
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 6432,
+          "missed": 29432,
+          "ratio": 0.179344,
+          "total": 35864
+        },
+        "line": {
+          "covered": 1639,
+          "missed": 6684,
+          "ratio": 0.196924,
+          "total": 8323
+        },
+        "method": {
+          "covered": 487,
+          "missed": 1461,
+          "ratio": 0.25,
+          "total": 1948
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 29792,
+      "cached_input_tokens_used": 260608,
+      "output_tokens_used": 2948,
+      "iterations": 2,
+      "cost_usd": 0.2187,
+      "tested_library_loc": 1625,
+      "metadata_entries": 45,
+      "test_only_metadata_entries": 5,
+      "previous_library_metadata_entries": 39,
+      "previous_library_test_only_metadata_entries": 5,
+      "code_coverage_percent": 19.48,
+      "previous_library_coverage_percent": 19.69
+    },
+    "artifacts": {
+      "test_file": "tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/ConfigurationFactoryTest.java",
+      "metadata_file": "metadata/commons-configuration/commons-configuration/1.9/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/commons-configuration/commons-configuration/1.9/stats.json
+++ b/stats/commons-configuration/commons-configuration/1.9/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "1.9",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 17,
+          "totalCalls" : 17
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 4,
+          "totalCalls" : 4
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 21,
+      "totalCalls" : 21
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 6140,
+        "missed" : 29884,
+        "ratio" : 0.170442,
+        "total" : 36024
+      },
+      "line" : {
+        "covered" : 1625,
+        "missed" : 6719,
+        "ratio" : 0.194751,
+        "total" : 8344
+      },
+      "method" : {
+        "covered" : 492,
+        "missed" : 1485,
+        "ratio" : 0.248862,
+        "total" : 1977
+      }
+    }
+  } ]
+}

--- a/tests/src/commons-configuration/commons-configuration/1.9/.gitignore
+++ b/tests/src/commons-configuration/commons-configuration/1.9/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/commons-configuration/commons-configuration/1.9/build.gradle
+++ b/tests/src/commons-configuration/commons-configuration/1.9/build.gradle
@@ -1,0 +1,43 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "commons-configuration:commons-configuration:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+String defaultFileSystemClass = "org.apache.commons.configuration.DefaultFileSystem"
+
+tasks.withType(Test).configureEach {
+    systemProperty "org.apache.commons.configuration.filesystem", defaultFileSystemClass
+}
+
+tasks.named("nativeTest") {
+    runtimeArgs.add("-Dorg.apache.commons.configuration.filesystem=$defaultFileSystemClass")
+}
+
+graalvmNative {
+    binaries {
+        test {
+            buildArgs.add("-Dorg.apache.commons.configuration.filesystem=$defaultFileSystemClass")
+        }
+    }
+
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/commons-configuration/commons-configuration/1.9/build.gradle
+++ b/tests/src/commons-configuration/commons-configuration/1.9/build.gradle
@@ -12,6 +12,8 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "commons-configuration:commons-configuration:$libraryVersion"
+    testImplementation 'commons-beanutils:commons-beanutils:1.8.3'
+    testImplementation 'commons-digester:commons-digester:1.8.1'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/commons-configuration/commons-configuration/1.9/gradle.properties
+++ b/tests/src/commons-configuration/commons-configuration/1.9/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = commons-configuration:commons-configuration:1.9
+library.version = 1.9
+metadata.dir = commons-configuration/commons-configuration/1.9/

--- a/tests/src/commons-configuration/commons-configuration/1.9/settings.gradle
+++ b/tests/src/commons-configuration/commons-configuration/1.9/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'commons-configuration.commons-configuration_tests'

--- a/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/ConfigurationDynaBeanTest.java
+++ b/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/ConfigurationDynaBeanTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package commons_configuration.commons_configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import java.util.Arrays;
+
+import org.apache.commons.configuration.BaseConfiguration;
+import org.apache.commons.configuration.beanutils.ConfigurationDynaBean;
+import org.junit.jupiter.api.Test;
+
+public class ConfigurationDynaBeanTest {
+    @Test
+    public void constructorInitializesBeanAndSupportsDynaPropertyAccess() {
+        BaseConfiguration configuration = new BaseConfiguration();
+        ConfigurationDynaBean bean = new ConfigurationDynaBean(configuration);
+
+        bean.set("server.host", "localhost");
+        bean.set("server.ports", Arrays.asList("8080", "8443"));
+        bean.set("server.aliases", new String[] {"primary", "secondary"});
+        bean.set("database", "url", "jdbc:test");
+
+        assertThat(bean.get("server.host")).isEqualTo("localhost");
+        assertThat(bean.get("server.ports", 0)).isEqualTo("8080");
+        assertThat(bean.get("server.ports", 1)).isEqualTo("8443");
+        assertThat(bean.get("server.aliases", 0)).isEqualTo("primary");
+        assertThat(bean.contains("database", "url")).isTrue();
+        assertThat(bean.get("database", "url")).isEqualTo("jdbc:test");
+
+        Object server = bean.get("server");
+        assertThat(server).isInstanceOf(ConfigurationDynaBean.class);
+        assertThat(((ConfigurationDynaBean) server).get("host")).isEqualTo("localhost");
+    }
+
+    @Test
+    public void invalidPropertyOperationsReportClearFailures() {
+        ConfigurationDynaBean bean = new ConfigurationDynaBean(new BaseConfiguration());
+
+        assertThatNullPointerException()
+                .isThrownBy(() -> bean.set("missing", null))
+                .withMessage("Error trying to set property to null.");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> bean.get("missing"))
+                .withMessage("Property 'missing' does not exist.");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> bean.get("missing", 0))
+                .withMessage("Property 'missing' does not exist.");
+    }
+}

--- a/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/ConfigurationDynaClassTest.java
+++ b/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/ConfigurationDynaClassTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package commons_configuration.commons_configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.beanutils.DynaBean;
+import org.apache.commons.beanutils.DynaProperty;
+import org.apache.commons.configuration.BaseConfiguration;
+import org.apache.commons.configuration.beanutils.ConfigurationDynaBean;
+import org.apache.commons.configuration.beanutils.ConfigurationDynaClass;
+import org.junit.jupiter.api.Test;
+
+public class ConfigurationDynaClassTest {
+    @Test
+    public void constructorCreatesDynaClassForConfigurationProperties() throws Exception {
+        BaseConfiguration configuration = new BaseConfiguration();
+        configuration.setProperty("host", "localhost");
+        configuration.setProperty("enabled", Boolean.TRUE);
+        configuration.setProperty("port", Integer.valueOf(8080));
+        configuration.setProperty("weight", Double.valueOf(1.25));
+        configuration.setProperty("grade", Character.valueOf('A'));
+        configuration.setProperty("attempts", Short.valueOf((short) 3));
+
+        ConfigurationDynaClass dynaClass = new ConfigurationDynaClass(configuration);
+
+        assertThat(dynaClass.getName()).isEqualTo(ConfigurationDynaBean.class.getName());
+        assertThat(dynaClass.getDynaProperty("host").getType()).isEqualTo(String.class);
+        assertThat(dynaClass.getDynaProperty("enabled").getType()).isEqualTo(Boolean.TYPE);
+        assertThat(dynaClass.getDynaProperty("port").getType()).isEqualTo(Integer.TYPE);
+        assertThat(dynaClass.getDynaProperty("weight").getType()).isEqualTo(Double.TYPE);
+        assertThat(dynaClass.getDynaProperty("grade").getType()).isEqualTo(Character.TYPE);
+        assertThat(dynaClass.getDynaProperty("attempts").getType()).isEqualTo(Short.TYPE);
+        assertThat(dynaClass.getDynaProperty("missing")).isNull();
+
+        Map<String, Class<?>> propertyTypes = new HashMap<String, Class<?>>();
+        for (DynaProperty property : dynaClass.getDynaProperties()) {
+            propertyTypes.put(property.getName(), property.getType());
+        }
+
+        assertThat(propertyTypes)
+                .containsEntry("host", String.class)
+                .containsEntry("enabled", Boolean.TYPE)
+                .containsEntry("port", Integer.TYPE)
+                .containsEntry("weight", Double.TYPE)
+                .containsEntry("grade", Character.TYPE)
+                .containsEntry("attempts", Short.TYPE);
+
+        DynaBean bean = dynaClass.newInstance();
+        assertThat(bean).isInstanceOf(ConfigurationDynaBean.class);
+        assertThat(bean.get("host")).isEqualTo("localhost");
+    }
+
+    @Test
+    public void getDynaPropertyRejectsNullPropertyName() {
+        ConfigurationDynaClass dynaClass = new ConfigurationDynaClass(new BaseConfiguration());
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> dynaClass.getDynaProperty(null))
+                .withMessage("Property name must not be null!");
+    }
+}

--- a/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/ConfigurationFactoryInnerDigesterConfigurationFactoryTest.java
+++ b/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/ConfigurationFactoryInnerDigesterConfigurationFactoryTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package commons_configuration.commons_configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.commons.configuration.BaseConfiguration;
+import org.apache.commons.configuration.ConfigurationFactory;
+import org.junit.jupiter.api.Test;
+
+public class ConfigurationFactoryInnerDigesterConfigurationFactoryTest {
+    @Test
+    public void createObjectInstantiatesConfiguredConfigurationClass() throws Exception {
+        ConfigurationFactory configurationFactory = new ConfigurationFactory();
+        ConfigurationFactory.DigesterConfigurationFactory digesterFactory =
+                configurationFactory.new DigesterConfigurationFactory(BaseConfiguration.class);
+
+        Object configuration = digesterFactory.createObject(null);
+
+        assertThat(configuration).isInstanceOf(BaseConfiguration.class);
+        assertThat(((BaseConfiguration) configuration).isEmpty()).isTrue();
+    }
+}

--- a/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/ConfigurationFactoryTest.java
+++ b/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/ConfigurationFactoryTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package commons_configuration.commons_configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.commons.configuration.ConfigurationFactory;
+import org.junit.jupiter.api.Test;
+
+public class ConfigurationFactoryTest {
+    @Test
+    public void constructorWithConfigurationFileNameDerivesImplicitBasePath() throws Exception {
+        Path directory = Files.createTempDirectory("configuration-factory");
+        Path configurationFile = directory.resolve("factory.xml");
+        Files.write(configurationFile, "<configuration/>".getBytes(StandardCharsets.UTF_8));
+        try {
+            ConfigurationFactory factory = new ConfigurationFactory(configurationFile.toString());
+
+            assertThat(factory.getConfigurationFileName()).isEqualTo(configurationFile.getFileName().toString());
+            assertThat(factory.getBasePath()).isEqualTo(directory.toFile().getAbsolutePath());
+        } finally {
+            Files.deleteIfExists(configurationFile);
+            Files.deleteIfExists(directory);
+        }
+    }
+
+    @Test
+    public void defaultConstructorUsesCurrentDirectoryBasePathUntilConfigurationIsSet() {
+        ConfigurationFactory factory = new ConfigurationFactory();
+
+        assertThat(factory.getBasePath()).isEqualTo(".");
+    }
+}

--- a/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/ConfigurationUtilsTest.java
+++ b/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/ConfigurationUtilsTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package commons_configuration.commons_configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+
+import org.apache.commons.configuration.BaseConfiguration;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.ConfigurationUtils;
+import org.junit.jupiter.api.Test;
+
+public class ConfigurationUtilsTest {
+    private static final String CLASSPATH_RESOURCE = "commons-configuration/configuration-utils-resource.properties";
+
+    @Test
+    public void cloneConfigurationInvokesPublicCloneMethod() {
+        BaseConfiguration original = new BaseConfiguration();
+        original.addProperty("message", "copied");
+
+        Configuration cloned = ConfigurationUtils.cloneConfiguration(original);
+
+        assertThat(cloned).isNotSameAs(original);
+        assertThat(cloned.getString("message")).isEqualTo("copied");
+    }
+
+    @Test
+    public void getUrlConvertsAbsoluteFileThroughUriReflection() throws Exception {
+        Path file = Files.createTempFile("configuration-utils", ".properties");
+        String originalJavaVersion = useLegacyJavaVersionString();
+        try {
+            URL url = ConfigurationUtils.getURL(null, file.toString());
+
+            assertThat(url).isEqualTo(file.toUri().toURL());
+        } finally {
+            restoreJavaVersionString(originalJavaVersion);
+            Files.deleteIfExists(file);
+        }
+    }
+
+    @Test
+    public void locateConvertsAbsoluteFileThroughUriReflection() throws Exception {
+        Path file = Files.createTempFile("configuration-utils-locate", ".properties");
+        String originalJavaVersion = useLegacyJavaVersionString();
+        try {
+            URL url = ConfigurationUtils.locate(null, file.toString());
+
+            assertThat(url).isEqualTo(file.toUri().toURL());
+        } finally {
+            restoreJavaVersionString(originalJavaVersion);
+            Files.deleteIfExists(file);
+        }
+    }
+
+    @Test
+    public void locateLoadsResourceFromContextClassLoader() throws Exception {
+        Path file = Files.createTempFile("configuration-utils-context", ".properties");
+        URL expectedUrl = file.toUri().toURL();
+        Thread currentThread = Thread.currentThread();
+        ClassLoader originalClassLoader = currentThread.getContextClassLoader();
+        currentThread.setContextClassLoader(new SingleResourceClassLoader(CLASSPATH_RESOURCE, expectedUrl));
+        try {
+            URL url = ConfigurationUtils.locate(null, CLASSPATH_RESOURCE);
+
+            assertThat(url).isEqualTo(expectedUrl);
+        } finally {
+            currentThread.setContextClassLoader(originalClassLoader);
+            Files.deleteIfExists(file);
+        }
+    }
+
+    @Test
+    public void locateLoadsResourceFromSystemClassLoaderWhenContextClassLoaderIsUnavailable() throws Exception {
+        Thread currentThread = Thread.currentThread();
+        ClassLoader originalClassLoader = currentThread.getContextClassLoader();
+        currentThread.setContextClassLoader(null);
+        try {
+            URL url = ConfigurationUtils.locate(null, CLASSPATH_RESOURCE);
+            assertThat(url).isNotNull();
+
+            Properties properties = new Properties();
+            try (InputStream input = url.openStream()) {
+                properties.load(input);
+            }
+            assertThat(properties.getProperty("loaded")).isEqualTo("true");
+        } finally {
+            currentThread.setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    private static String useLegacyJavaVersionString() {
+        // Commons Lang 2.x only recognizes pre-Java-9 version strings in this compatibility check.
+        String originalJavaVersion = System.getProperty("java.version");
+        System.setProperty("java.version", "1.8.0");
+        return originalJavaVersion;
+    }
+
+    private static void restoreJavaVersionString(String originalJavaVersion) {
+        if (originalJavaVersion == null) {
+            System.clearProperty("java.version");
+        } else {
+            System.setProperty("java.version", originalJavaVersion);
+        }
+    }
+
+    private static final class SingleResourceClassLoader extends ClassLoader {
+        private final String resourceName;
+        private final URL resourceUrl;
+
+        private SingleResourceClassLoader(String resourceName, URL resourceUrl) {
+            super(null);
+            this.resourceName = resourceName;
+            this.resourceUrl = resourceUrl;
+        }
+
+        @Override
+        public URL getResource(String name) {
+            if (resourceName.equals(name)) {
+                return resourceUrl;
+            }
+            return null;
+        }
+    }
+}

--- a/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/DataConfigurationTest.java
+++ b/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/DataConfigurationTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package commons_configuration.commons_configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+
+import org.apache.commons.configuration.BaseConfiguration;
+import org.apache.commons.configuration.DataConfiguration;
+import org.junit.jupiter.api.Test;
+
+public class DataConfigurationTest {
+    @Test
+    public void getArrayCreatesEmptyDefaultArrayForMissingObjectProperty() {
+        DataConfiguration dataConfiguration = new DataConfiguration(new BaseConfiguration());
+
+        String[] names = (String[]) dataConfiguration.getArray(String.class, "missing.names");
+
+        assertThat(names).isEmpty();
+    }
+
+    @Test
+    public void getArrayCreatesTypedObjectArrayFromListProperty() {
+        BaseConfiguration configuration = new BaseConfiguration();
+        configuration.setProperty("ports", Arrays.asList("8080", "8443"));
+        DataConfiguration dataConfiguration = new DataConfiguration(configuration);
+
+        Integer[] ports = (Integer[]) dataConfiguration.getArray(Integer.class, "ports");
+
+        assertThat(ports).containsExactly(Integer.valueOf(8080), Integer.valueOf(8443));
+    }
+
+    @Test
+    public void getArrayCreatesPrimitiveArrayFromWrapperArrayProperty() {
+        RawValueConfiguration configuration = new RawValueConfiguration();
+        configuration.putRaw("ports", new Integer[] {Integer.valueOf(8080), Integer.valueOf(8443)});
+        DataConfiguration dataConfiguration = new DataConfiguration(configuration);
+
+        int[] ports = (int[]) dataConfiguration.getArray(Integer.TYPE, "ports");
+
+        assertThat(ports).containsExactly(8080, 8443);
+    }
+
+    @Test
+    public void getArrayCreatesPrimitiveArrayFromCollectionProperty() {
+        BaseConfiguration configuration = new BaseConfiguration();
+        configuration.setProperty("feature.enabled", Arrays.asList("true", "false"));
+        DataConfiguration dataConfiguration = new DataConfiguration(configuration);
+
+        boolean[] enabled = (boolean[]) dataConfiguration.getArray(Boolean.TYPE, "feature.enabled");
+
+        assertThat(enabled).containsExactly(true, false);
+    }
+
+    @Test
+    public void getArrayCreatesSingleElementPrimitiveArrayFromScalarProperty() {
+        BaseConfiguration configuration = new BaseConfiguration();
+        configuration.setProperty("maximum.connections", "12");
+        DataConfiguration dataConfiguration = new DataConfiguration(configuration);
+
+        int[] maximumConnections = (int[]) dataConfiguration.getArray(Integer.TYPE, "maximum.connections");
+
+        assertThat(maximumConnections).containsExactly(12);
+    }
+
+    private static final class RawValueConfiguration extends BaseConfiguration {
+        private void putRaw(String key, Object value) {
+            addPropertyDirect(key, value);
+        }
+    }
+}

--- a/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/DefaultBeanFactoryTest.java
+++ b/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/DefaultBeanFactoryTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package commons_configuration.commons_configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.commons.configuration.beanutils.BeanDeclaration;
+import org.apache.commons.configuration.beanutils.DefaultBeanFactory;
+import org.junit.jupiter.api.Test;
+
+public class DefaultBeanFactoryTest {
+    @Test
+    public void createBeanInstantiatesPublicClassWithDefaultConstructor() throws Exception {
+        DefaultBeanFactory factory = DefaultBeanFactory.INSTANCE;
+        BeanDeclaration declaration = new EmptyBeanDeclaration();
+
+        Object bean = factory.createBean(Properties.class, declaration, "ignored parameter");
+
+        assertThat(bean).isInstanceOf(Properties.class);
+        assertThat(((Properties) bean)).isEmpty();
+        assertThat(factory.getDefaultBeanClass()).isNull();
+    }
+
+    private static final class EmptyBeanDeclaration implements BeanDeclaration {
+        @Override
+        public String getBeanFactoryName() {
+            return null;
+        }
+
+        @Override
+        public Object getBeanFactoryParameter() {
+            return null;
+        }
+
+        @Override
+        public String getBeanClassName() {
+            return null;
+        }
+
+        @Override
+        public Map getBeanProperties() {
+            return null;
+        }
+
+        @Override
+        public Map getNestedBeanDeclarations() {
+            return null;
+        }
+    }
+}

--- a/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/DefaultConfigurationBuilderInnerConfigurationProviderTest.java
+++ b/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/DefaultConfigurationBuilderInnerConfigurationProviderTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package commons_configuration.commons_configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.commons.configuration.BaseConfiguration;
+import org.apache.commons.configuration.DefaultConfigurationBuilder;
+import org.junit.jupiter.api.Test;
+
+public class DefaultConfigurationBuilderInnerConfigurationProviderTest {
+    @Test
+    public void fetchConfigurationClassResolvesConfiguredClassName() throws Exception {
+        ExposedConfigurationProvider provider =
+                new ExposedConfigurationProvider(BaseConfiguration.class.getName());
+
+        Class configurationClass = provider.resolveConfigurationClass();
+
+        assertThat(configurationClass).isEqualTo(BaseConfiguration.class);
+        assertThat(provider.getConfigurationClass()).isSameAs(BaseConfiguration.class);
+    }
+
+    private static final class ExposedConfigurationProvider
+            extends DefaultConfigurationBuilder.ConfigurationProvider {
+        ExposedConfigurationProvider(String configurationClassName) {
+            super(configurationClassName);
+        }
+
+        Class resolveConfigurationClass() throws Exception {
+            return fetchConfigurationClass();
+        }
+    }
+}

--- a/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/DefaultConfigurationBuilderTest.java
+++ b/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/DefaultConfigurationBuilderTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package commons_configuration.commons_configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.commons.configuration.DefaultConfigurationBuilder;
+import org.junit.jupiter.api.Test;
+
+public class DefaultConfigurationBuilderTest {
+    @Test
+    public void constructorRegistersBuiltInConfigurationProviders() {
+        DefaultConfigurationBuilder builder = new DefaultConfigurationBuilder();
+
+        assertThat(DefaultConfigurationBuilder.ADDITIONAL_NAME)
+                .isEqualTo(DefaultConfigurationBuilder.class.getName() + "/ADDITIONAL_CONFIG");
+        assertThat(builder.providerForTag("properties")).isNotNull();
+        assertThat(builder.providerForTag("xml"))
+                .isInstanceOf(DefaultConfigurationBuilder.XMLConfigurationProvider.class);
+        assertThat(builder.providerForTag("system")).isNotNull();
+        assertThat(builder.providerForTag("configuration")).isNotNull();
+    }
+}

--- a/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/DynamicCombinedConfigurationTest.java
+++ b/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/DynamicCombinedConfigurationTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package commons_configuration.commons_configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.commons.configuration.BaseConfiguration;
+import org.apache.commons.configuration.DynamicCombinedConfiguration;
+import org.apache.commons.configuration.tree.UnionCombiner;
+import org.junit.jupiter.api.Test;
+
+public class DynamicCombinedConfigurationTest {
+    @Test
+    public void constructorWithCombinerInitializesDynamicConfiguration() {
+        DynamicCombinedConfiguration configuration = new DynamicCombinedConfiguration(new UnionCombiner());
+
+        configuration.setKeyPattern("default-tenant");
+
+        assertThat(configuration.getKeyPattern()).isEqualTo("default-tenant");
+        assertThat(configuration.getNodeCombiner()).isInstanceOf(UnionCombiner.class);
+    }
+
+    @Test
+    public void propertyAccessUsesConfigurationSelectedByKeyPattern() {
+        DynamicCombinedConfiguration configuration = new DynamicCombinedConfiguration(new UnionCombiner());
+        configuration.setKeyPattern("tenant-a");
+        BaseConfiguration child = new BaseConfiguration();
+        child.addProperty("service.url", "https://service.example.test");
+
+        configuration.addConfiguration(child, "service", null);
+
+        assertThat(configuration.getNumberOfConfigurations()).isEqualTo(1);
+        assertThat(configuration.getConfiguration("service")).isSameAs(child);
+        assertThat(configuration.getString("service.url")).isEqualTo("https://service.example.test");
+    }
+}

--- a/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/EnvironmentConfigurationTest.java
+++ b/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/EnvironmentConfigurationTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package commons_configuration.commons_configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Iterator;
+import java.util.Map;
+
+import org.apache.commons.configuration.EnvironmentConfiguration;
+import org.apache.commons.lang.SystemUtils;
+import org.junit.jupiter.api.Test;
+
+public class EnvironmentConfigurationTest {
+    private static final int JAVA_1_5 = 150;
+
+    @Test
+    public void constructorReadsProcessEnvironmentThroughSystemGetenv() {
+        String originalJavaVersion = useJavaVersionRecognizedByCommonsLang();
+        try {
+            assertThat(SystemUtils.isJavaVersionAtLeast(JAVA_1_5)).isTrue();
+
+            EnvironmentConfiguration configuration = new EnvironmentConfiguration();
+
+            assertThat(configuration.isEmpty()).isEqualTo(System.getenv().isEmpty());
+            assertThat(configuration.getKeys().hasNext()).isEqualTo(!System.getenv().isEmpty());
+            for (Map.Entry<String, String> entry : System.getenv().entrySet()) {
+                assertThat(configuration.containsKey(entry.getKey())).isTrue();
+                assertThat(configuration.getProperty(entry.getKey())).isEqualTo(entry.getValue());
+            }
+        } finally {
+            restoreJavaVersionString(originalJavaVersion);
+        }
+    }
+
+    @Test
+    public void environmentConfigurationIsReadOnly() {
+        String originalJavaVersion = useJavaVersionRecognizedByCommonsLang();
+        try {
+            EnvironmentConfiguration configuration = new EnvironmentConfiguration();
+
+            assertThatThrownBy(configuration::clear).isInstanceOf(UnsupportedOperationException.class)
+                    .hasMessage("Configuration is read-only!");
+            assertThatThrownBy(() -> configuration.clearProperty("PATH"))
+                    .isInstanceOf(UnsupportedOperationException.class)
+                    .hasMessage("Configuration is read-only!");
+        } finally {
+            restoreJavaVersionString(originalJavaVersion);
+        }
+    }
+
+    @Test
+    public void getKeysReturnsEachEnvironmentVariableName() {
+        String originalJavaVersion = useJavaVersionRecognizedByCommonsLang();
+        try {
+            EnvironmentConfiguration configuration = new EnvironmentConfiguration();
+            Iterator keys = configuration.getKeys();
+
+            while (keys.hasNext()) {
+                assertThat(System.getenv()).containsKey((String) keys.next());
+            }
+        } finally {
+            restoreJavaVersionString(originalJavaVersion);
+        }
+    }
+
+    private static String useJavaVersionRecognizedByCommonsLang() {
+        // Commons Lang 2.x recognizes pre-Java-9 version strings in this compatibility check.
+        String originalJavaVersion = System.getProperty("java.version");
+        System.setProperty("java.version", "1.8.0");
+        return originalJavaVersion;
+    }
+
+    private static void restoreJavaVersionString(String originalJavaVersion) {
+        if (originalJavaVersion == null) {
+            System.clearProperty("java.version");
+        } else {
+            System.setProperty("java.version", originalJavaVersion);
+        }
+    }
+}

--- a/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/EnvironmentConfigurationTest.java
+++ b/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/EnvironmentConfigurationTest.java
@@ -26,6 +26,7 @@ public class EnvironmentConfigurationTest {
             assertThat(SystemUtils.isJavaVersionAtLeast(JAVA_1_5)).isTrue();
 
             EnvironmentConfiguration configuration = new EnvironmentConfiguration();
+            configuration.setDelimiterParsingDisabled(true);
 
             assertThat(configuration.isEmpty()).isEqualTo(System.getenv().isEmpty());
             assertThat(configuration.getKeys().hasNext()).isEqualTo(!System.getenv().isEmpty());
@@ -45,10 +46,10 @@ public class EnvironmentConfigurationTest {
             EnvironmentConfiguration configuration = new EnvironmentConfiguration();
 
             assertThatThrownBy(configuration::clear).isInstanceOf(UnsupportedOperationException.class)
-                    .hasMessage("Configuration is read-only!");
+                    .hasMessage("EnvironmentConfiguration is read-only!");
             assertThatThrownBy(() -> configuration.clearProperty("PATH"))
                     .isInstanceOf(UnsupportedOperationException.class)
-                    .hasMessage("Configuration is read-only!");
+                    .hasMessage("EnvironmentConfiguration is read-only!");
         } finally {
             restoreJavaVersionString(originalJavaVersion);
         }

--- a/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/FileChangedReloadingStrategyTest.java
+++ b/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/FileChangedReloadingStrategyTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package commons_configuration.commons_configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration.reloading.FileChangedReloadingStrategy;
+import org.junit.jupiter.api.Test;
+
+public class FileChangedReloadingStrategyTest {
+    @Test
+    public void detectsModifiedConfigurationFile() throws Exception {
+        Path file = Files.createTempFile("file-changed-reloading", ".properties");
+        try {
+            Files.write(file, "message=initial\n".getBytes(StandardCharsets.UTF_8));
+            PropertiesConfiguration configuration = new PropertiesConfiguration(file.toFile());
+            FileChangedReloadingStrategy strategy = new FileChangedReloadingStrategy();
+            strategy.setConfiguration(configuration);
+            strategy.setRefreshDelay(0);
+            strategy.init();
+
+            Files.write(file, "message=updated\n".getBytes(StandardCharsets.UTF_8));
+            long modifiedTime = Math.max(file.toFile().lastModified() + 2_000, System.currentTimeMillis() + 2_000);
+            assertThat(file.toFile().setLastModified(modifiedTime)).isTrue();
+
+            assertThat(strategy.reloadingRequired()).isTrue();
+
+            strategy.reloadingPerformed();
+
+            assertThat(strategy.reloadingRequired()).isFalse();
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
+}

--- a/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/FileSystemTest.java
+++ b/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/FileSystemTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package commons_configuration.commons_configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.commons.configuration.DefaultFileSystem;
+import org.apache.commons.configuration.FileSystem;
+import org.junit.jupiter.api.Test;
+
+public class FileSystemTest {
+    @Test
+    public void defaultFileSystemCanBeConfiguredWithSystemProperty() {
+        FileSystem defaultFileSystem = FileSystem.getDefaultFileSystem();
+
+        assertThat(defaultFileSystem).isInstanceOf(DefaultFileSystem.class);
+    }
+}

--- a/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/ManagedReloadingStrategyTest.java
+++ b/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/ManagedReloadingStrategyTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package commons_configuration.commons_configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration.reloading.ManagedReloadingStrategy;
+import org.junit.jupiter.api.Test;
+
+public class ManagedReloadingStrategyTest {
+    @Test
+    public void refreshMarksReloadingAsRequiredUntilReloadingIsPerformed() {
+        ManagedReloadingStrategy strategy = new ManagedReloadingStrategy();
+        PropertiesConfiguration configuration = new PropertiesConfiguration();
+        configuration.addProperty("application.name", "test");
+        strategy.setConfiguration(configuration);
+
+        assertThat(strategy.reloadingRequired()).isFalse();
+
+        strategy.refresh();
+
+        assertThat(strategy.reloadingRequired()).isTrue();
+
+        strategy.reloadingPerformed();
+
+        assertThat(strategy.reloadingRequired()).isFalse();
+    }
+}

--- a/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/MultiFileHierarchicalConfigurationTest.java
+++ b/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/MultiFileHierarchicalConfigurationTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package commons_configuration.commons_configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.commons.configuration.MultiFileHierarchicalConfiguration;
+import org.junit.jupiter.api.Test;
+
+public class MultiFileHierarchicalConfigurationTest {
+    @Test
+    public void propertyAccessUsesCachedConfigurationForFilePattern() {
+        MultiFileHierarchicalConfiguration configuration = new MultiFileHierarchicalConfiguration();
+        configuration.setFilePattern("tenant-a.xml");
+
+        configuration.addProperty("service.name", "orders");
+
+        assertThat(configuration.containsKey("service.name")).isTrue();
+        assertThat(configuration.getString("service.name")).isEqualTo("orders");
+    }
+
+    @Test
+    public void constructorWithFilePatternInitializesConfigurationAccess() {
+        MultiFileHierarchicalConfiguration configuration = new MultiFileHierarchicalConfiguration("tenant-b.xml");
+
+        configuration.addProperty("service.port", 8080);
+
+        assertThat(configuration.getInt("service.port")).isEqualTo(8080);
+    }
+}

--- a/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/PropertyConverterTest.java
+++ b/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/PropertyConverterTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package commons_configuration.commons_configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.commons.configuration.BaseConfiguration;
+import org.apache.commons.configuration.DataConfiguration;
+import org.apache.commons.configuration.PropertyConverter;
+import org.junit.jupiter.api.Test;
+
+public class PropertyConverterTest {
+    @Test
+    public void toIntegerCreatesNumberFromStringConstructor() {
+        assertThat(PropertyConverter.toInteger("8080")).isEqualTo(Integer.valueOf(8080));
+    }
+
+    @Test
+    public void dataConfigurationConvertsStringValueToEnumByValueOf() {
+        String originalJavaVersion = useLegacyJavaVersionString();
+        try {
+            BaseConfiguration configuration = new BaseConfiguration();
+            configuration.addProperty("mode", "PRODUCTION");
+            DataConfiguration dataConfiguration = new DataConfiguration(configuration);
+
+            assertThat(dataConfiguration.get(DeploymentMode.class, "mode")).isEqualTo(DeploymentMode.PRODUCTION);
+        } finally {
+            restoreJavaVersionString(originalJavaVersion);
+        }
+    }
+
+    @Test
+    public void dataConfigurationConvertsNumericValueToEnumByValuesArray() {
+        String originalJavaVersion = useLegacyJavaVersionString();
+        try {
+            BaseConfiguration configuration = new BaseConfiguration();
+            configuration.addProperty("mode", Integer.valueOf(2));
+            DataConfiguration dataConfiguration = new DataConfiguration(configuration);
+
+            assertThat(dataConfiguration.get(DeploymentMode.class, "mode")).isEqualTo(DeploymentMode.MAINTENANCE);
+        } finally {
+            restoreJavaVersionString(originalJavaVersion);
+        }
+    }
+
+    private static String useLegacyJavaVersionString() {
+        // Commons Lang 2.x only recognizes pre-Java-9 version strings in this compatibility check.
+        String originalJavaVersion = System.getProperty("java.version");
+        System.setProperty("java.version", "1.8.0");
+        return originalJavaVersion;
+    }
+
+    private static void restoreJavaVersionString(String originalJavaVersion) {
+        if (originalJavaVersion == null) {
+            System.clearProperty("java.version");
+        } else {
+            System.setProperty("java.version", originalJavaVersion);
+        }
+    }
+
+    public enum DeploymentMode {
+        DEVELOPMENT,
+        PRODUCTION,
+        MAINTENANCE
+    }
+}

--- a/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/XMLPropertiesConfigurationAnonymous1Test.java
+++ b/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/XMLPropertiesConfigurationAnonymous1Test.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package commons_configuration.commons_configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.StringReader;
+
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.XMLPropertiesConfiguration;
+import org.junit.jupiter.api.Test;
+
+public class XMLPropertiesConfigurationAnonymous1Test {
+    @Test
+    public void loadResolvesBundledPropertiesDtdFromClasspath() throws ConfigurationException {
+        final XMLPropertiesConfiguration configuration = new XMLPropertiesConfiguration();
+        final String xml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+                <properties>\
+                <comment>Integration settings</comment>\
+                <entry key="endpoint">https://example.invalid/service</entry>\
+                <entry key="retries">3</entry>\
+                </properties>
+                """.stripLeading();
+
+        configuration.load(new StringReader(xml));
+
+        assertThat(configuration.getHeader()).isEqualTo("Integration settings");
+        assertThat(configuration.getString("endpoint")).isEqualTo("https://example.invalid/service");
+        assertThat(configuration.getInt("retries")).isEqualTo(3);
+    }
+}

--- a/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/interpol/ConstantLookupTest.java
+++ b/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/interpol/ConstantLookupTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package commons_configuration.commons_configuration.interpol;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.commons.configuration.interpol.ConstantLookup;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ConstantLookupTest {
+    public static final String LOOKUP_VALUE = "constant lookup value";
+
+    private final ConstantLookup lookup = new ConstantLookup();
+
+    @BeforeEach
+    public void clearConstantCache() {
+        ConstantLookup.clear();
+    }
+
+    @Test
+    public void resolvesPublicConstantFieldByFullyQualifiedName() {
+        final String variableName = ConstantLookupTest.class.getName() + ".LOOKUP_VALUE";
+
+        final String value = lookup.lookup(variableName);
+
+        assertThat(value).isEqualTo(LOOKUP_VALUE);
+    }
+}

--- a/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/interpol/ExprLookupInnerVariableTest.java
+++ b/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/interpol/ExprLookupInnerVariableTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package commons_configuration.commons_configuration.interpol;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+
+import org.apache.commons.configuration.interpol.ExprLookup;
+import org.junit.jupiter.api.Test;
+
+public class ExprLookupInnerVariableTest {
+    @Test
+    public void setValueInstantiatesClassNamedByString() {
+        ExprLookup.Variable variable = new ExprLookup.Variable("properties", Properties.class.getName());
+
+        Object value = variable.getValue();
+
+        assertThat(value).isInstanceOf(Properties.class);
+        assertThat((Properties) value).isEmpty();
+    }
+}

--- a/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/plist/XMLPropertyListConfigurationAnonymous1Test.java
+++ b/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/plist/XMLPropertyListConfigurationAnonymous1Test.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package commons_configuration.commons_configuration.plist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.StringReader;
+import java.math.BigInteger;
+
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.plist.XMLPropertyListConfiguration;
+import org.junit.jupiter.api.Test;
+
+public class XMLPropertyListConfigurationAnonymous1Test {
+    @Test
+    public void loadResolvesBundledPropertyListDtdFromClasspath() throws ConfigurationException {
+        final XMLPropertyListConfiguration configuration = new XMLPropertyListConfiguration();
+        final String xml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+                <plist version="1.0">
+                  <dict>
+                    <key>serviceName</key>
+                    <string>orders</string>
+                    <key>enabled</key>
+                    <true/>
+                    <key>ports</key>
+                    <array>
+                      <integer>8080</integer>
+                      <integer>8443</integer>
+                    </array>
+                  </dict>
+                </plist>
+                """.stripLeading();
+
+        configuration.load(new StringReader(xml));
+
+        assertThat(configuration.getString("serviceName")).isEqualTo("orders");
+        assertThat(configuration.getBoolean("enabled")).isTrue();
+        assertThat(configuration.getList("ports"))
+                .containsExactly(new BigInteger("8080"), new BigInteger("8443"));
+    }
+}

--- a/tests/src/commons-configuration/commons-configuration/1.9/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/commons-configuration/commons-configuration/1.9/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,36 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.PropertyConverter"
+      },
+      "type" : "commons_configuration.commons_configuration.PropertyConverterTest$DeploymentMode",
+      "methods" : [
+        {
+          "name" : "valueOf",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "values",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.ConfigurationUtils"
+      },
+      "glob" : "commons-configuration/configuration-utils-resource.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.configuration.XMLPropertiesConfiguration$1"
+      },
+      "glob" : "properties.dtd"
+    }
+  ]
+}

--- a/tests/src/commons-configuration/commons-configuration/1.9/src/test/resources/commons-configuration/configuration-utils-resource.properties
+++ b/tests/src/commons-configuration/commons-configuration/1.9/src/test/resources/commons-configuration/configuration-utils-resource.properties
@@ -1,0 +1,1 @@
+loaded=true

--- a/tests/src/commons-configuration/commons-configuration/1.9/src/test/resources/properties.dtd
+++ b/tests/src/commons-configuration/commons-configuration/1.9/src/test/resources/properties.dtd
@@ -1,0 +1,8 @@
+<!--
+  DTD for XML properties files as expected by XMLPropertiesConfiguration.
+-->
+<!ELEMENT properties (comment?, entry*)>
+<!ATTLIST properties version CDATA #FIXED "1.0">
+<!ELEMENT comment (#PCDATA)>
+<!ELEMENT entry (#PCDATA)>
+<!ATTLIST entry key CDATA #REQUIRED>

--- a/tests/src/commons-configuration/commons-configuration/1.9/user-code-filter.json
+++ b/tests/src/commons-configuration/commons-configuration/1.9/user-code-filter.json
@@ -1,0 +1,19 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.commons.configuration.**"
+    },
+    {
+      "includeClasses" : "commons_configuration.commons_configuration.**"
+    },
+    {
+      "includeClasses" : "commons_configuration.commons_configuration.plist.**"
+    },
+    {
+      "includeClasses" : "commons_configuration.commons_configuration.interpol.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7241

This PR provides test fixes and new metadata for commons-configuration:commons-configuration:1.9, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 29792
- Cached input tokens: 260608
- Output tokens: 2948
- Metadata entries: 45
- Test-only metadata entries: 5
- Iterations: 2
- Library coverage percentage: 19.48
- Previous library version metadata entries: 39
- Previous library version test-only metadata entries: 5
- Previous library version coverage percentage: 19.69

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `1d0c503b4a12a09b0eb4fa08a43196f057d4dd63`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- commons-configuration:commons-configuration:1.7: 45/45 covered calls (100.00%)
- commons-configuration:commons-configuration:1.9: 21/21 covered calls (100.00%)

**Reflection:**
- commons-configuration:commons-configuration:1.7: 41/41 covered calls (100.00%)
- commons-configuration:commons-configuration:1.9: 17/17 covered calls (100.00%)

**Resources:**
- commons-configuration:commons-configuration:1.7: 4/4 covered calls (100.00%)
- commons-configuration:commons-configuration:1.9: 4/4 covered calls (100.00%)

#### Library coverage

**Instruction:**
- commons-configuration:commons-configuration:1.7: 6432/35864 (17.93%)
- commons-configuration:commons-configuration:1.9: 6140/36024 (17.04%)

**Line:**
- commons-configuration:commons-configuration:1.7: 1639/8323 (19.69%)
- commons-configuration:commons-configuration:1.9: 1625/8344 (19.48%)

**Method:**
- commons-configuration:commons-configuration:1.7: 487/1948 (25.00%)
- commons-configuration:commons-configuration:1.9: 492/1977 (24.89%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/commons-configuration/commons-configuration/1.7/build.gradle 2/tests/src/commons-configuration/commons-configuration/1.9/build.gradle
index 0cdfe2dbbe..44479e9dc0 100644
--- 1/tests/src/commons-configuration/commons-configuration/1.7/build.gradle
+++ 2/tests/src/commons-configuration/commons-configuration/1.9/build.gradle
@@ -12,6 +12,8 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "commons-configuration:commons-configuration:$libraryVersion"
+    testImplementation 'commons-beanutils:commons-beanutils:1.8.3'
+    testImplementation 'commons-digester:commons-digester:1.8.1'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
diff --git 1/tests/src/commons-configuration/commons-configuration/1.7/src/test/java/commons_configuration/commons_configuration/EnvironmentConfigurationTest.java 2/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/EnvironmentConfigurationTest.java
index c060cbb4c4..7dab708111 100644
--- 1/tests/src/commons-configuration/commons-configuration/1.7/src/test/java/commons_configuration/commons_configuration/EnvironmentConfigurationTest.java
+++ 2/tests/src/commons-configuration/commons-configuration/1.9/src/test/java/commons_configuration/commons_configuration/EnvironmentConfigurationTest.java
@@ -26,6 +26,7 @@ public class EnvironmentConfigurationTest {
             assertThat(SystemUtils.isJavaVersionAtLeast(JAVA_1_5)).isTrue();
 
             EnvironmentConfiguration configuration = new EnvironmentConfiguration();
+            configuration.setDelimiterParsingDisabled(true);
 
             assertThat(configuration.isEmpty()).isEqualTo(System.getenv().isEmpty());
             assertThat(configuration.getKeys().hasNext()).isEqualTo(!System.getenv().isEmpty());
@@ -45,10 +46,10 @@ public class EnvironmentConfigurationTest {
             EnvironmentConfiguration configuration = new EnvironmentConfiguration();
 
             assertThatThrownBy(configuration::clear).isInstanceOf(UnsupportedOperationException.class)
-                    .hasMessage("Configuration is read-only!");
+                    .hasMessage("EnvironmentConfiguration is read-only!");
             assertThatThrownBy(() -> configuration.clearProperty("PATH"))
                     .isInstanceOf(UnsupportedOperationException.class)
-                    .hasMessage("Configuration is read-only!");
+                    .hasMessage("EnvironmentConfiguration is read-only!");
         } finally {
             restoreJavaVersionString(originalJavaVersion);
         }

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
