### PR TITLE
[GenAI] Mark org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j as not for Native Image

### DIFF
--- a/metadata/org.springframework.cloud/spring-cloud-starter-circuitbreaker-resilience4j/index.json
+++ b/metadata/org.springframework.cloud/spring-cloud-starter-circuitbreaker-resilience4j/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published JAR contains only Maven metadata and META-INF/spring.provides and has no JVM class files, so there is no class-bearing artifact for Native Image reachability metadata.",
+    "replacement": "org.springframework.cloud:spring-cloud-circuitbreaker-resilience4j:5.0.1"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #7029

This PR records `org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published JAR contains only Maven metadata and META-INF/spring.provides and has no JVM class files, so there is no class-bearing artifact for Native Image reachability metadata.

Replacement guidance:
- org.springframework.cloud:spring-cloud-circuitbreaker-resilience4j:5.0.1

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `1d0c503b4a12a09b0eb4fa08a43196f057d4dd63`

### Local CI Verification

- Status: `success`
- Commands run: 6
- Fixup attempts: 0
