### PR TITLE
[GenAI] Add support for org.springframework.cloud:spring-cloud-stream-binder-rabbit:5.0.1 using gpt-5.5

### DIFF
--- a/metadata/org.springframework.cloud/spring-cloud-stream-binder-rabbit/5.0.1/reachability-metadata.json
+++ b/metadata/org.springframework.cloud/spring-cloud-stream-binder-rabbit/5.0.1/reachability-metadata.json
@@ -1,0 +1,20 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.rabbit.RabbitExpressionEvaluatingInterceptor"
+      },
+      "type": "org.springframework.messaging.support.GenericMessage",
+      "methods": [
+        {
+          "name": "getPayload",
+          "parameterTypes": []
+        },
+        {
+          "name": "getHeaders",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.springframework.cloud/spring-cloud-stream-binder-rabbit/index.json
+++ b/metadata/org.springframework.cloud/spring-cloud-stream-binder-rabbit/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "5.0.1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/cloud/spring-cloud-stream-binder-rabbit/$version$/spring-cloud-stream-binder-rabbit-$version$-sources.jar",
+    "repository-url" : "https://github.com/spring-cloud/spring-cloud-stream",
+    "test-code-url" : "https://github.com/spring-cloud/spring-cloud-stream/tree/v$version$/binders/rabbit-binder/spring-cloud-stream-binder-rabbit/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/springframework/cloud/spring-cloud-stream-binder-rabbit/$version$/spring-cloud-stream-binder-rabbit-$version$-javadoc.jar",
+    "description" : "Spring Cloud Stream Binder Rabbit provides a RabbitMQ binder implementation for Spring Cloud Stream applications. It lets Spring Cloud Stream producers and consumers connect to RabbitMQ using Spring Boot and Spring Integration messaging infrastructure.",
+    "tested-versions" : [
+      "5.0.1"
+    ],
+    "allowed-packages" : [
+      "org.springframework.cloud.stream.binder.rabbit"
+    ]
+  }
+]

--- a/stats/org.springframework.cloud/spring-cloud-stream-binder-rabbit/5.0.1/execution-metrics.json
+++ b/stats/org.springframework.cloud/spring-cloud-stream-binder-rabbit/5.0.1/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-20": {
+    "timestamp": "2026-05-20T03:24:51.113865Z",
+    "library": "org.springframework.cloud:spring-cloud-stream-binder-rabbit:5.0.1",
+    "starting_commit": "13ee9947be3eaffc13bf8fc071f9285109acf9da",
+    "ending_commit": "3acac4fcb8ca40b24ca94b4263c27ace12dde582",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "5.0.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 394,
+          "missed": 2503,
+          "ratio": 0.136003,
+          "total": 2897
+        },
+        "line": {
+          "covered": 88,
+          "missed": 610,
+          "ratio": 0.126074,
+          "total": 698
+        },
+        "method": {
+          "covered": 37,
+          "missed": 94,
+          "ratio": 0.282443,
+          "total": 131
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 180834,
+      "cached_input_tokens_used": 2172416,
+      "output_tokens_used": 20893,
+      "iterations": 3,
+      "cost_usd": 1.713,
+      "generated_loc": 270,
+      "tested_library_loc": 88,
+      "metadata_entries": 3,
+      "code_coverage_percent": 12.61
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.springframework.cloud/spring-cloud-stream-binder-rabbit/5.0.1/src/test/java/org_springframework_cloud/spring_cloud_stream_binder_rabbit/Spring_cloud_stream_binder_rabbitTest.java",
+      "metadata_file": "metadata/org.springframework.cloud/spring-cloud-stream-binder-rabbit/5.0.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.springframework.cloud/spring-cloud-stream-binder-rabbit/5.0.1/stats.json
+++ b/stats/org.springframework.cloud/spring-cloud-stream-binder-rabbit/5.0.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "5.0.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 394,
+        "missed" : 2503,
+        "ratio" : 0.136003,
+        "total" : 2897
+      },
+      "line" : {
+        "covered" : 88,
+        "missed" : 610,
+        "ratio" : 0.126074,
+        "total" : 698
+      },
+      "method" : {
+        "covered" : 37,
+        "missed" : 94,
+        "ratio" : 0.282443,
+        "total" : 131
+      }
+    }
+  } ]
+}

--- a/tests/src/org.springframework.cloud/spring-cloud-stream-binder-rabbit/5.0.1/.gitignore
+++ b/tests/src/org.springframework.cloud/spring-cloud-stream-binder-rabbit/5.0.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.springframework.cloud/spring-cloud-stream-binder-rabbit/5.0.1/build.gradle
+++ b/tests/src/org.springframework.cloud/spring-cloud-stream-binder-rabbit/5.0.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.springframework.cloud:spring-cloud-stream-binder-rabbit:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.springframework.cloud/spring-cloud-stream-binder-rabbit/5.0.1/gradle.properties
+++ b/tests/src/org.springframework.cloud/spring-cloud-stream-binder-rabbit/5.0.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.springframework.cloud:spring-cloud-stream-binder-rabbit:5.0.1
+library.version = 5.0.1
+metadata.dir = org.springframework.cloud/spring-cloud-stream-binder-rabbit/5.0.1/

--- a/tests/src/org.springframework.cloud/spring-cloud-stream-binder-rabbit/5.0.1/settings.gradle
+++ b/tests/src/org.springframework.cloud/spring-cloud-stream-binder-rabbit/5.0.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.springframework.cloud.spring-cloud-stream-binder-rabbit_tests'

--- a/tests/src/org.springframework.cloud/spring-cloud-stream-binder-rabbit/5.0.1/src/test/java/org_springframework_cloud/spring_cloud_stream_binder_rabbit/Spring_cloud_stream_binder_rabbitTest.java
+++ b/tests/src/org.springframework.cloud/spring-cloud-stream-binder-rabbit/5.0.1/src/test/java/org_springframework_cloud/spring_cloud_stream_binder_rabbit/Spring_cloud_stream_binder_rabbitTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework_cloud.spring_cloud_stream_binder_rabbit;
+
+import org.junit.jupiter.api.Test;
+
+class Spring_cloud_stream_binder_rabbitTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.springframework.cloud/spring-cloud-stream-binder-rabbit/5.0.1/src/test/java/org_springframework_cloud/spring_cloud_stream_binder_rabbit/Spring_cloud_stream_binder_rabbitTest.java
+++ b/tests/src/org.springframework.cloud/spring-cloud-stream-binder-rabbit/5.0.1/src/test/java/org_springframework_cloud/spring_cloud_stream_binder_rabbit/Spring_cloud_stream_binder_rabbitTest.java
@@ -6,11 +6,267 @@
  */
 package org_springframework_cloud.spring_cloud_stream_binder_rabbit;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.net.ConnectException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.junit.jupiter.api.Test;
 
-class Spring_cloud_stream_binder_rabbitTest {
+import org.springframework.amqp.AmqpConnectException;
+import org.springframework.amqp.AmqpRejectAndDontRequeueException;
+import org.springframework.amqp.core.MessageDeliveryMode;
+import org.springframework.amqp.rabbit.connection.Connection;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionListener;
+import org.springframework.amqp.rabbit.support.ListenerExecutionFailedException;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.TypeHint;
+import org.springframework.boot.amqp.autoconfigure.RabbitProperties;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
+import org.springframework.cloud.function.context.config.MessageConverterHelper;
+import org.springframework.cloud.stream.binder.rabbit.BatchCapableRejectAndDontRequeueRecoverer;
+import org.springframework.cloud.stream.binder.rabbit.RabbitExpressionEvaluatingInterceptor;
+import org.springframework.cloud.stream.binder.rabbit.RabbitMessageChannelBinder;
+import org.springframework.cloud.stream.binder.rabbit.aot.RabbitBinderRuntimeHints;
+import org.springframework.cloud.stream.binder.rabbit.config.DefaultMessageConverterHelper;
+import org.springframework.cloud.stream.binder.rabbit.config.ExtendedBindingHandlerMappingsProviderConfiguration;
+import org.springframework.cloud.stream.binder.rabbit.config.MessageConverterHelperConfiguration;
+import org.springframework.cloud.stream.binder.rabbit.config.RabbitBinderConfiguration;
+import org.springframework.cloud.stream.binder.rabbit.properties.RabbitBindingProperties;
+import org.springframework.cloud.stream.binder.rabbit.properties.RabbitCommonProperties;
+import org.springframework.cloud.stream.binder.rabbit.properties.RabbitConsumerProperties;
+import org.springframework.cloud.stream.binder.rabbit.properties.RabbitExtendedBindingProperties;
+import org.springframework.cloud.stream.binder.rabbit.properties.RabbitProducerProperties;
+import org.springframework.cloud.stream.binder.rabbit.properties.RabbitProducerProperties.ProducerType;
+import org.springframework.cloud.stream.binder.rabbit.provisioning.RabbitExchangeQueueProvisioner;
+import org.springframework.cloud.stream.config.BindingHandlerAdvise.MappingsProvider;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+
+public class Spring_cloud_stream_binder_rabbitTest {
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void batchCapableRecovererRejectsSingleAndBatchMessagesWithoutRequeue() {
+        org.springframework.amqp.core.Message first = amqpMessage("first");
+        org.springframework.amqp.core.Message second = amqpMessage("second");
+        IllegalStateException cause = new IllegalStateException("poison payload");
+        BatchCapableRejectAndDontRequeueRecoverer recoverer =
+                new BatchCapableRejectAndDontRequeueRecoverer(() -> "retry attempts exhausted");
+
+        assertThatExceptionOfType(ListenerExecutionFailedException.class)
+                .isThrownBy(() -> recoverer.recover(first, cause))
+                .satisfies(ex -> {
+                    assertThat(ex).hasMessage("retry attempts exhausted");
+                    assertThat(ex.getFailedMessage()).isSameAs(first);
+                    assertThat(ex.getFailedMessages()).containsExactly(first);
+                    assertThat(ex.getCause()).isInstanceOf(AmqpRejectAndDontRequeueException.class);
+                    assertThat(ex.getCause().getCause()).isSameAs(cause);
+                });
+
+        assertThatExceptionOfType(ListenerExecutionFailedException.class)
+                .isThrownBy(() -> recoverer.recover(List.of(first, second), cause))
+                .satisfies(ex -> {
+                    assertThat(ex).hasMessage("retry attempts exhausted");
+                    assertThat(ex.getFailedMessages()).containsExactly(first, second);
+                    assertThat(ex.getCause()).isInstanceOf(AmqpRejectAndDontRequeueException.class);
+                    assertThat(ex.getCause().getCause()).isSameAs(cause);
+                });
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> new BatchCapableRejectAndDontRequeueRecoverer(null))
+                .withMessageContaining("messageSupplier");
+    }
+
+    @Test
+    void expressionInterceptorAddsRabbitRoutingAndDelayHeaders() {
+        RabbitExpressionEvaluatingInterceptor interceptor = new RabbitExpressionEvaluatingInterceptor(
+                RabbitExpressionEvaluatingInterceptor.PARSER.parseExpression(
+                        "payload['tenant'] + '.' + headers['eventType']"),
+                RabbitExpressionEvaluatingInterceptor.PARSER.parseExpression("headers['attempt'] * 125"),
+                new StandardEvaluationContext());
+        Message<Map<String, String>> message = MessageBuilder
+                .withPayload(Map.of("tenant", "tenant-a"))
+                .setHeader("eventType", "orders.created")
+                .setHeader("attempt", 2)
+                .build();
+
+        Message<?> result = interceptor.preSend(message, null);
+
+        assertThat(result.getPayload()).isSameAs(message.getPayload());
+        assertThat(result.getHeaders().get(RabbitExpressionEvaluatingInterceptor.ROUTING_KEY_HEADER))
+                .isEqualTo("tenant-a.orders.created");
+        assertThat(result.getHeaders().get(RabbitExpressionEvaluatingInterceptor.DELAY_HEADER)).isEqualTo(250);
+        assertThat(message.getHeaders()).doesNotContainKey(RabbitExpressionEvaluatingInterceptor.ROUTING_KEY_HEADER);
+
+        RabbitExpressionEvaluatingInterceptor routingOnly = new RabbitExpressionEvaluatingInterceptor(
+                RabbitExpressionEvaluatingInterceptor.PARSER.parseExpression("'fixed.key'"), null,
+                new StandardEvaluationContext());
+        assertThat(routingOnly.preSend(message, null).getHeaders())
+                .containsEntry(RabbitExpressionEvaluatingInterceptor.ROUTING_KEY_HEADER, "fixed.key")
+                .doesNotContainKey(RabbitExpressionEvaluatingInterceptor.DELAY_HEADER);
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> new RabbitExpressionEvaluatingInterceptor(null, null,
+                        new StandardEvaluationContext()))
+                .withMessageContaining("At least one expression");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> new RabbitExpressionEvaluatingInterceptor(
+                        RabbitExpressionEvaluatingInterceptor.PARSER.parseExpression("'key'"), null, null))
+                .withMessageContaining("evaluationContext");
+    }
+
+    @Test
+    void defaultMessageConverterHelperPrunesFailedBatchedHeaderOnlyOnFirstDeliveryAttempt() {
+        DefaultMessageConverterHelper helper = new DefaultMessageConverterHelper();
+        ArrayList<Map<String, Object>> batchedHeaders = new ArrayList<>();
+        batchedHeaders.add(new LinkedHashMap<>(Map.of("sequence", 1)));
+        batchedHeaders.add(new LinkedHashMap<>(Map.of("sequence", 2)));
+        Message<List<String>> firstDelivery = MessageBuilder
+                .withPayload(List.of("first", "second"))
+                .setHeader("deliveryAttempt", new AtomicInteger(1))
+                .setHeader("amqp_batchedHeaders", batchedHeaders)
+                .build();
+
+        assertThat(helper.shouldFailIfCantConvert(firstDelivery)).isFalse();
+        helper.postProcessBatchMessageOnFailure(firstDelivery, 0);
+
+        assertThat(batchedHeaders).hasSize(1);
+        assertThat(batchedHeaders.get(0)).containsEntry("sequence", 2);
+
+        ArrayList<Map<String, Object>> retryHeaders = new ArrayList<>();
+        retryHeaders.add(new LinkedHashMap<>(Map.of("sequence", 1)));
+        retryHeaders.add(new LinkedHashMap<>(Map.of("sequence", 2)));
+        Message<List<String>> retryDelivery = MessageBuilder
+                .withPayload(List.of("first", "second"))
+                .setHeader("deliveryAttempt", new AtomicInteger(2))
+                .setHeader("amqp_batchedHeaders", retryHeaders)
+                .build();
+
+        helper.postProcessBatchMessageOnFailure(retryDelivery, 0);
+
+        assertThat(retryHeaders).hasSize(2);
+    }
+
+    @Test
+    void configurationObjectsExposeBinderBeansAndDefaultPropertyMappings() {
+        RabbitBinderConfiguration binderConfiguration = new RabbitBinderConfiguration();
+        MessageConverterHelper converterHelper =
+                new MessageConverterHelperConfiguration().rabbitMessageConverterHelper();
+        MappingsProvider mappingsProvider = new ExtendedBindingHandlerMappingsProviderConfiguration()
+                .rabbitExtendedPropertiesDefaultMappingsProvider();
+
+        assertThat(binderConfiguration.binderName()).isEqualTo("rabbit");
+        assertThat(converterHelper).isInstanceOf(DefaultMessageConverterHelper.class);
+        assertThat(mappingsProvider.getDefaultMappings()).containsEntry(
+                ConfigurationPropertyName.of("spring.cloud.stream.rabbit.bindings"),
+                ConfigurationPropertyName.of("spring.cloud.stream.rabbit.default"));
+    }
+
+    @Test
+    void rabbitBinderRuntimeHintsRegisterExtendedBindingPropertyTypes() {
+        RuntimeHints hints = new RuntimeHints();
+
+        new RabbitBinderRuntimeHints().registerHints(hints, getClass().getClassLoader());
+
+        assertRegisteredBindingPropertyHint(hints, RabbitCommonProperties.class);
+        assertRegisteredBindingPropertyHint(hints, RabbitConsumerProperties.class);
+        assertRegisteredBindingPropertyHint(hints, RabbitProducerProperties.class);
+        assertRegisteredBindingPropertyHint(hints, RabbitExtendedBindingProperties.class);
+        assertRegisteredBindingPropertyHint(hints, RabbitBindingProperties.class);
+    }
+
+    @Test
+    void messageChannelBinderExposesConfiguredExtendedPropertiesWithoutBrokerConnection() throws Exception {
+        FailingConnectionFactory connectionFactory = new FailingConnectionFactory();
+        RabbitExchangeQueueProvisioner provisioner = new RabbitExchangeQueueProvisioner(connectionFactory);
+        RabbitMessageChannelBinder binder = new RabbitMessageChannelBinder(
+                connectionFactory, new RabbitProperties(), provisioner);
+        RabbitConsumerProperties consumer = new RabbitConsumerProperties();
+        consumer.setQueueNameGroupOnly(true);
+        RabbitProducerProperties producer = new RabbitProducerProperties();
+        producer.setDeliveryMode(MessageDeliveryMode.NON_PERSISTENT);
+        producer.setProducerType(ProducerType.STREAM_SYNC);
+        RabbitBindingProperties binding = new RabbitBindingProperties();
+        binding.setConsumer(consumer);
+        binding.setProducer(producer);
+        RabbitExtendedBindingProperties extendedProperties = new RabbitExtendedBindingProperties();
+        extendedProperties.setBindings(Map.of("orders-in", binding));
+
+        binder.setAdminAddresses(new String[] {"http://127.0.0.1:15672" });
+        binder.setNodes(new String[] {"rabbit@localhost" });
+        binder.setExtendedBindingProperties(extendedProperties);
+
+        assertThat(binder.getConnectionFactory()).isSameAs(connectionFactory);
+        assertThat(binder.getDefaultsPrefix()).isEqualTo("spring.cloud.stream.rabbit.default");
+        assertThat(binder.getExtendedPropertiesEntryClass()).isEqualTo(RabbitBindingProperties.class);
+        assertThat(binder.getExtendedConsumerProperties("orders-in")).isSameAs(consumer);
+        assertThat(binder.getExtendedProducerProperties("orders-in")).isSameAs(producer);
+        assertThat(binder.getBinderIdentity()).startsWith("rabbit-");
+
+        binder.destroy();
+    }
+
+    private static org.springframework.amqp.core.Message amqpMessage(String body) {
+        return new org.springframework.amqp.core.Message(body.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static void assertRegisteredBindingPropertyHint(RuntimeHints hints, Class<?> type) {
+        TypeHint typeHint = hints.reflection().getTypeHint(type);
+        assertThat(typeHint).as("runtime hint for %s", type.getName()).isNotNull();
+        assertThat(typeHint.getMemberCategories())
+                .contains(
+                        MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
+                        MemberCategory.INVOKE_DECLARED_METHODS,
+                        MemberCategory.INTROSPECT_PUBLIC_METHODS);
+    }
+
+    private static final class FailingConnectionFactory implements ConnectionFactory {
+
+        @Override
+        public Connection createConnection() {
+            throw new AmqpConnectException(new ConnectException("No broker is required for binder metadata tests"));
+        }
+
+        @Override
+        public String getHost() {
+            return "localhost";
+        }
+
+        @Override
+        public int getPort() {
+            return 5672;
+        }
+
+        @Override
+        public String getVirtualHost() {
+            return "/";
+        }
+
+        @Override
+        public String getUsername() {
+            return "guest";
+        }
+
+        @Override
+        public void addConnectionListener(ConnectionListener listener) {
+        }
+
+        @Override
+        public boolean removeConnectionListener(ConnectionListener listener) {
+            return false;
+        }
+
+        @Override
+        public void clearConnectionListeners() {
+        }
     }
 }

--- a/tests/src/org.springframework.cloud/spring-cloud-stream-binder-rabbit/5.0.1/src/test/java/org_springframework_cloud/spring_cloud_stream_binder_rabbit/Spring_cloud_stream_binder_rabbitTest.java
+++ b/tests/src/org.springframework.cloud/spring-cloud-stream-binder-rabbit/5.0.1/src/test/java/org_springframework_cloud/spring_cloud_stream_binder_rabbit/Spring_cloud_stream_binder_rabbitTest.java
@@ -33,6 +33,7 @@ import org.springframework.boot.amqp.autoconfigure.RabbitProperties;
 import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
 import org.springframework.cloud.function.context.config.MessageConverterHelper;
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
+import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
 import org.springframework.cloud.stream.binder.rabbit.BatchCapableRejectAndDontRequeueRecoverer;
 import org.springframework.cloud.stream.binder.rabbit.RabbitExpressionEvaluatingInterceptor;
 import org.springframework.cloud.stream.binder.rabbit.RabbitMessageChannelBinder;
@@ -50,6 +51,7 @@ import org.springframework.cloud.stream.binder.rabbit.properties.RabbitProducerP
 import org.springframework.cloud.stream.binder.rabbit.provisioning.RabbitExchangeQueueProvisioner;
 import org.springframework.cloud.stream.config.BindingHandlerAdvise.MappingsProvider;
 import org.springframework.cloud.stream.provisioning.ConsumerDestination;
+import org.springframework.cloud.stream.provisioning.ProducerDestination;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
@@ -205,6 +207,25 @@ public class Spring_cloud_stream_binder_rabbitTest {
 
         assertThat(destination.getName())
                 .isEqualTo("tenant.orders.analytics-2,tenant.invoices.analytics-2");
+    }
+
+    @Test
+    void provisionerBuildsPrefixedProducerDestinationWithoutBrokerConnection() {
+        FailingConnectionFactory connectionFactory = new FailingConnectionFactory();
+        RabbitExchangeQueueProvisioner provisioner = new RabbitExchangeQueueProvisioner(connectionFactory);
+        RabbitProducerProperties producerProperties = new RabbitProducerProperties();
+        producerProperties.setPrefix("tenant.");
+        producerProperties.setDeclareExchange(false);
+        producerProperties.setBindQueue(false);
+        ExtendedProducerProperties<RabbitProducerProperties> extendedProperties =
+                new ExtendedProducerProperties<>(producerProperties);
+        extendedProperties.setPartitionCount(3);
+
+        ProducerDestination destination = provisioner.provisionProducerDestination("orders", extendedProperties);
+
+        assertThat(destination.getName()).isEqualTo("tenant.orders");
+        assertThat(destination.getNameForPartition(0)).isEqualTo("tenant.orders");
+        assertThat(destination.getNameForPartition(2)).isEqualTo("tenant.orders");
     }
 
     @Test

--- a/tests/src/org.springframework.cloud/spring-cloud-stream-binder-rabbit/5.0.1/src/test/java/org_springframework_cloud/spring_cloud_stream_binder_rabbit/Spring_cloud_stream_binder_rabbitTest.java
+++ b/tests/src/org.springframework.cloud/spring-cloud-stream-binder-rabbit/5.0.1/src/test/java/org_springframework_cloud/spring_cloud_stream_binder_rabbit/Spring_cloud_stream_binder_rabbitTest.java
@@ -32,6 +32,7 @@ import org.springframework.aot.hint.TypeHint;
 import org.springframework.boot.amqp.autoconfigure.RabbitProperties;
 import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
 import org.springframework.cloud.function.context.config.MessageConverterHelper;
+import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.binder.rabbit.BatchCapableRejectAndDontRequeueRecoverer;
 import org.springframework.cloud.stream.binder.rabbit.RabbitExpressionEvaluatingInterceptor;
 import org.springframework.cloud.stream.binder.rabbit.RabbitMessageChannelBinder;
@@ -48,6 +49,7 @@ import org.springframework.cloud.stream.binder.rabbit.properties.RabbitProducerP
 import org.springframework.cloud.stream.binder.rabbit.properties.RabbitProducerProperties.ProducerType;
 import org.springframework.cloud.stream.binder.rabbit.provisioning.RabbitExchangeQueueProvisioner;
 import org.springframework.cloud.stream.config.BindingHandlerAdvise.MappingsProvider;
+import org.springframework.cloud.stream.provisioning.ConsumerDestination;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
@@ -182,6 +184,27 @@ public class Spring_cloud_stream_binder_rabbitTest {
         assertRegisteredBindingPropertyHint(hints, RabbitProducerProperties.class);
         assertRegisteredBindingPropertyHint(hints, RabbitExtendedBindingProperties.class);
         assertRegisteredBindingPropertyHint(hints, RabbitBindingProperties.class);
+    }
+
+    @Test
+    void provisionerBuildsPrefixedMultiplexConsumerDestinationsWithoutBrokerConnection() {
+        FailingConnectionFactory connectionFactory = new FailingConnectionFactory();
+        RabbitExchangeQueueProvisioner provisioner = new RabbitExchangeQueueProvisioner(connectionFactory);
+        RabbitConsumerProperties consumerProperties = new RabbitConsumerProperties();
+        consumerProperties.setPrefix("tenant.");
+        consumerProperties.setDeclareExchange(false);
+        consumerProperties.setBindQueue(false);
+        ExtendedConsumerProperties<RabbitConsumerProperties> extendedProperties =
+                new ExtendedConsumerProperties<>(consumerProperties);
+        extendedProperties.setMultiplex(true);
+        extendedProperties.setPartitioned(true);
+        extendedProperties.setInstanceIndex(2);
+
+        ConsumerDestination destination = provisioner.provisionConsumerDestination(
+                "orders, invoices", "analytics", extendedProperties);
+
+        assertThat(destination.getName())
+                .isEqualTo("tenant.orders.analytics-2,tenant.invoices.analytics-2");
     }
 
     @Test

--- a/tests/src/org.springframework.cloud/spring-cloud-stream-binder-rabbit/5.0.1/user-code-filter.json
+++ b/tests/src/org.springframework.cloud/spring-cloud-stream-binder-rabbit/5.0.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.springframework.cloud.stream.binder.rabbit.**"
+    }
+  ]
+}

--- a/tests/src/org.springframework.cloud/spring-cloud-stream-binder-rabbit/5.0.1/user-code-filter.json
+++ b/tests/src/org.springframework.cloud/spring-cloud-stream-binder-rabbit/5.0.1/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.springframework.cloud.stream.binder.rabbit.**"
+      "includeClasses" : "org.springframework.cloud.stream.binder.rabbit.**"
+    },
+    {
+      "includeClasses" : "org_springframework_cloud.spring_cloud_stream_binder_rabbit.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #7032

This PR introduces tests and metadata for org.springframework.cloud:spring-cloud-stream-binder-rabbit:5.0.1, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 180834
- Cached input tokens: 2172416
- Output tokens: 20893
- Metadata entries: 3
- Iterations: 3
- Library coverage percentage: 12.61
- Generated lines of code: 270
- Tested library lines of code: 88

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `1d0c503b4a12a09b0eb4fa08a43196f057d4dd63`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 394/2897 (13.60%)
- Line: 88/698 (12.61%)
- Method: 37/131 (28.24%)

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
