### PR TITLE
[GenAI] Test fix for org.eclipse.jetty:jetty-servlet:9.4.0.RC1 using gpt-5.5

### DIFF
--- a/metadata/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/reachability-metadata.json
+++ b/metadata/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/reachability-metadata.json
@@ -1,0 +1,105 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.server.handler.ContextHandler$Context"
+      },
+      "type" : "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.DateCache"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.servlet.ServletHolder"
+      },
+      "type" : "java.lang.reflect.Method[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.servlet.listener.ELContextCleaner"
+      },
+      "type" : "javax.el.BeanELResolver",
+      "fields" : [
+        {
+          "name" : "properties"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.Loader"
+      },
+      "type" : "javax.el.BeanELResolver"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.http.PreEncodedHttpField"
+      },
+      "type" : "org.eclipse.jetty.http.Http1FieldPreEncoder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.servlet.ServletContextHandler"
+      },
+      "type" : "org.eclipse.jetty.security.ConstraintSecurityHandler",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.server.handler.ContextHandler$Context"
+      },
+      "type" : "org.eclipse.jetty.servlet.DefaultServlet",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.LazyList"
+      },
+      "type" : "org.eclipse.jetty.servlet.FilterHolder[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.LazyList"
+      },
+      "type" : "org.eclipse.jetty.servlet.FilterMapping[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.LazyList"
+      },
+      "type" : "org.eclipse.jetty.servlet.ListenerHolder[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.ArrayUtil"
+      },
+      "type" : "org.eclipse.jetty.servlet.ServletHolder[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.ArrayUtil"
+      },
+      "type" : "org.eclipse.jetty.servlet.ServletMapping[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.DateCache"
+      },
+      "type" : "sun.util.resources.cldr.CalendarData"
+    }
+  ]
+}

--- a/metadata/org.eclipse.jetty/jetty-servlet/index.json
+++ b/metadata/org.eclipse.jetty/jetty-servlet/index.json
@@ -31,6 +31,18 @@
     ]
   },
   {
+    "metadata-version" : "9.4.0.RC1",
+    "tested-versions" : [
+      "9.4.0.RC1"
+    ],
+    "allowed-packages" : [
+      "org.eclipse.jetty.servlet",
+      "org.eclipse.jetty.http",
+      "org.eclipse.jetty.server.handler",
+      "org.eclipse.jetty.util"
+    ]
+  },
+  {
     "metadata-version" : "9.4.0.RC0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-servlet/$version$/jetty-servlet-$version$-sources.jar",
     "repository-url" : "https://github.com/jetty/jetty.project",

--- a/metadata/org.eclipse.jetty/jetty-servlet/index.json
+++ b/metadata/org.eclipse.jetty/jetty-servlet/index.json
@@ -32,6 +32,11 @@
   },
   {
     "metadata-version" : "9.4.0.RC1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-servlet/$version$/jetty-servlet-$version$-sources.jar",
+    "repository-url" : "https://github.com/jetty/jetty.project",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-servlet/$version$/jetty-servlet-$version$-tests.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-servlet/$version$/jetty-servlet-$version$-javadoc.jar",
+    "description" : "Jetty Servlet provides the servlet container layer for Eclipse Jetty, including servlet holders, contexts, filters, mappings, and session integration. It lets Jetty applications host and manage Java Servlet API components inside embedded or standalone Jetty servers.",
     "tested-versions" : [
       "9.4.0.RC1"
     ],

--- a/stats/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/execution-metrics.json
+++ b/stats/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_javac_fail:2026-05-20": {
+    "timestamp": "2026-05-20T03:52:14.582998Z",
+    "library": "org.eclipse.jetty:jetty-servlet:9.4.0.RC1",
+    "starting_commit": "4de9b097086ce938a468f504dd49e1276e1dfd5c",
+    "ending_commit": "329538adb00fa0a450d7aca527d94f56f520fa3c",
+    "previous_library": "org.eclipse.jetty:jetty-servlet:9.3.19.v20170502",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "9.4.0.RC1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 9,
+            "totalCalls": 9
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 10,
+        "totalCalls": 10
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2432,
+          "missed": 9223,
+          "ratio": 0.208666,
+          "total": 11655
+        },
+        "line": {
+          "covered": 621,
+          "missed": 2048,
+          "ratio": 0.232671,
+          "total": 2669
+        },
+        "method": {
+          "covered": 135,
+          "missed": 308,
+          "ratio": 0.30474,
+          "total": 443
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "9.3.19.v20170502",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 9,
+            "totalCalls": 9
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 10,
+        "totalCalls": 10
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2255,
+          "missed": 11128,
+          "ratio": 0.168497,
+          "total": 13383
+        },
+        "line": {
+          "covered": 576,
+          "missed": 2501,
+          "ratio": 0.187195,
+          "total": 3077
+        },
+        "method": {
+          "covered": 119,
+          "missed": 328,
+          "ratio": 0.266219,
+          "total": 447
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 30745,
+      "cached_input_tokens_used": 176640,
+      "output_tokens_used": 2226,
+      "iterations": 1,
+      "cost_usd": 0.1551,
+      "tested_library_loc": 621,
+      "metadata_entries": 17,
+      "test_only_metadata_entries": 2,
+      "previous_library_metadata_entries": 18,
+      "previous_library_test_only_metadata_entries": 6,
+      "code_coverage_percent": 23.27,
+      "previous_library_coverage_percent": 18.72
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/src/test/java/org/apache/jasper/compiler/JspUtil.java",
+      "metadata_file": "metadata/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/stats.json
+++ b/stats/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "9.4.0.RC1",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 9,
+          "totalCalls" : 9
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 10,
+      "totalCalls" : 10
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2432,
+        "missed" : 9223,
+        "ratio" : 0.208666,
+        "total" : 11655
+      },
+      "line" : {
+        "covered" : 621,
+        "missed" : 2048,
+        "ratio" : 0.232671,
+        "total" : 2669
+      },
+      "method" : {
+        "covered" : 135,
+        "missed" : 308,
+        "ratio" : 0.30474,
+        "total" : 443
+      }
+    }
+  } ]
+}

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/.gitignore
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/build.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/build.gradle
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.eclipse.jetty:jetty-servlet:$libraryVersion"
+    testImplementation 'javax.el:javax.el-api:3.0.0'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/gradle.properties
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.eclipse.jetty:jetty-servlet:9.4.0.RC1
+library.version = 9.4.0.RC1
+metadata.dir = org.eclipse.jetty/jetty-servlet/9.4.0.RC1/

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/settings.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.eclipse.jetty.jetty-servlet_tests'

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/src/test/java/org/apache/jasper/compiler/JspUtil.java
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/src/test/java/org/apache/jasper/compiler/JspUtil.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.apache.jasper.compiler;
+
+public final class JspUtil {
+    private JspUtil() {
+    }
+
+    public static String makeJavaIdentifier(String jsp) {
+        return "javaIdentifier:" + jsp;
+    }
+
+    public static String makeJavaPackage(String jsp) {
+        return "javaPackage:" + jsp;
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/src/test/java/org_eclipse_jetty/jetty_servlet/DefaultServletTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/src/test/java/org_eclipse_jetty/jetty_servlet/DefaultServletTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_servlet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+
+import javax.servlet.Servlet;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class DefaultServletTest {
+    @TempDir
+    Path resourceBase;
+
+    @Test
+    public void initLoadsDefaultDirectoryStylesheet() throws Exception {
+        Server server = new Server();
+        ServletContextHandler context = new ServletContextHandler(ServletContextHandler.NO_SESSIONS);
+        context.setContextPath("/");
+        context.setResourceBase(resourceBase.toUri().toASCIIString());
+        ServletHolder holder = context.addServlet(DefaultServlet.class, "/");
+        server.setHandler(context);
+
+        try {
+            server.start();
+
+            Servlet servlet = holder.getServlet();
+            assertThat(servlet).isInstanceOf(DefaultServlet.class);
+            assertThat(servlet.getServletConfig()).isNotNull();
+        } finally {
+            server.stop();
+            server.destroy();
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/src/test/java/org_eclipse_jetty/jetty_servlet/ELContextCleanerTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/src/test/java/org_eclipse_jetty/jetty_servlet/ELContextCleanerTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_servlet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import javax.el.BeanELResolver;
+
+import org.eclipse.jetty.servlet.listener.ELContextCleaner;
+import org.junit.jupiter.api.Test;
+
+public class ELContextCleanerTest {
+    @Test
+    public void contextDestroyedInspectsBeanELResolverPropertiesCache() {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(ELContextCleanerTest.class.getClassLoader());
+        try {
+            BeanELResolver resolver = new BeanELResolver();
+            ELContextCleaner cleaner = new ELContextCleaner();
+
+            assertThat(resolver).isNotNull();
+            assertThatCode(() -> cleaner.contextDestroyed(null)).doesNotThrowAnyException();
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/src/test/java/org_eclipse_jetty/jetty_servlet/FilterHolderTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/src/test/java/org_eclipse_jetty/jetty_servlet/FilterHolderTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_servlet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+import org.eclipse.jetty.servlet.FilterHolder;
+import org.eclipse.jetty.servlet.ServletHandler;
+import org.junit.jupiter.api.Test;
+
+public class FilterHolderTest {
+    @Test
+    public void initializeCreatesFilterInstanceFromHeldClass() throws Exception {
+        FilterHolder holder = new FilterHolder(RecordingFilter.class);
+        holder.setName("recording");
+        holder.setInitParameter("mode", "test");
+        holder.setServletHandler(new ServletHandler());
+        holder.start();
+        try {
+            holder.initialize();
+
+            Filter filter = holder.getFilter();
+            assertThat(filter).isInstanceOf(RecordingFilter.class);
+            RecordingFilter recordingFilter = (RecordingFilter) filter;
+            assertThat(recordingFilter.getFilterName()).isEqualTo("recording");
+            assertThat(recordingFilter.getMode()).isEqualTo("test");
+            assertThat(recordingFilter.isInitialized()).isTrue();
+        } finally {
+            holder.stop();
+        }
+    }
+
+    public static class RecordingFilter implements Filter {
+        private boolean initialized;
+        private String filterName;
+        private String mode;
+
+        @Override
+        public void init(FilterConfig filterConfig) throws ServletException {
+            initialized = true;
+            filterName = filterConfig.getFilterName();
+            mode = filterConfig.getInitParameter("mode");
+        }
+
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+                throws IOException, ServletException {
+            chain.doFilter(request, response);
+        }
+
+        @Override
+        public void destroy() {
+            initialized = false;
+        }
+
+        public boolean isInitialized() {
+            return initialized;
+        }
+
+        public String getFilterName() {
+            return filterName;
+        }
+
+        public String getMode() {
+            return mode;
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/src/test/java/org_eclipse_jetty/jetty_servlet/ServletContextHandlerTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/src/test/java/org_eclipse_jetty/jetty_servlet/ServletContextHandlerTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_servlet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.jetty.security.ConstraintSecurityHandler;
+import org.eclipse.jetty.security.SecurityHandler;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.junit.jupiter.api.Test;
+
+public class ServletContextHandlerTest {
+    @Test
+    public void getSecurityHandlerCreatesDefaultSecurityHandlerWhenSecurityIsEnabled() {
+        ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SECURITY);
+
+        SecurityHandler securityHandler = context.getSecurityHandler();
+
+        assertThat(securityHandler).isInstanceOf(ConstraintSecurityHandler.class);
+        assertThat(context.getHandler()).isSameAs(securityHandler);
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/src/test/java/org_eclipse_jetty/jetty_servlet/ServletHolderTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/src/test/java/org_eclipse_jetty/jetty_servlet/ServletHolderTest.java
@@ -19,21 +19,25 @@ import org.junit.jupiter.api.Test;
 
 public class ServletHolderTest {
     @Test
-    public void getNameOfJspClassUsesAvailableJasperUtility() {
+    public void doStartUsesAvailableJasperUtilityToFindPrecompiledJspServlet() throws Exception {
+        ServletHandler handler = new ServletHandler();
+        handler.setEnsureDefaultServlet(false);
+        ServletHolder precompiledJsp = new ServletHolder();
+        precompiledJsp.setName("org.apache.jsp.javaPackage:/WEB-INF/pages.javaIdentifier:monthly-report.jsp");
+        precompiledJsp.setClassName(CountingServlet.class.getName());
+
         ServletHolder holder = new ServletHolder();
+        holder.setName("monthlyReport");
+        holder.setForcedPath("/WEB-INF/pages/monthly-report.jsp");
+        handler.setServlets(new ServletHolder[] {precompiledJsp, holder});
 
-        String jspClassName = holder.getNameOfJspClass("/WEB-INF/pages/monthly-report.jsp");
+        try {
+            handler.start();
 
-        assertThat(jspClassName).isEqualTo("javaIdentifier:monthly-report.jsp");
-    }
-
-    @Test
-    public void getPackageOfJspClassUsesAvailableJasperUtility() {
-        ServletHolder holder = new ServletHolder();
-
-        String jspPackage = holder.getPackageOfJspClass("/WEB-INF/pages/monthly-report.jsp");
-
-        assertThat(jspPackage).isEqualTo("javaPackage:/WEB-INF/pages");
+            assertThat(holder.getClassName()).isEqualTo(CountingServlet.class.getName());
+        } finally {
+            handler.stop();
+        }
     }
 
     @Test

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/src/test/java/org_eclipse_jetty/jetty_servlet/ServletHolderTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/src/test/java/org_eclipse_jetty/jetty_servlet/ServletHolderTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_servlet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.servlet.Servlet;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+
+import org.eclipse.jetty.servlet.ServletHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.junit.jupiter.api.Test;
+
+public class ServletHolderTest {
+    @Test
+    public void getNameOfJspClassUsesAvailableJasperUtility() {
+        ServletHolder holder = new ServletHolder();
+
+        String jspClassName = holder.getNameOfJspClass("/WEB-INF/pages/monthly-report.jsp");
+
+        assertThat(jspClassName).isEqualTo("javaIdentifier:monthly-report.jsp");
+    }
+
+    @Test
+    public void getPackageOfJspClassUsesAvailableJasperUtility() {
+        ServletHolder holder = new ServletHolder();
+
+        String jspPackage = holder.getPackageOfJspClass("/WEB-INF/pages/monthly-report.jsp");
+
+        assertThat(jspPackage).isEqualTo("javaPackage:/WEB-INF/pages");
+    }
+
+    @Test
+    public void getServletCreatesServletInstanceFromHeldClass() throws ServletException {
+        ServletHolder holder = new ServletHolder("counting", CountingServlet.class);
+        holder.setServletHandler(new ServletHandler());
+
+        Servlet servlet = holder.getServlet();
+
+        assertThat(servlet).isInstanceOf(CountingServlet.class);
+        assertThat(((CountingServlet) servlet).getServletConfig()).isNotNull();
+    }
+
+    public static class CountingServlet extends HttpServlet {
+        private static final long serialVersionUID = 1L;
+
+        private ServletConfig servletConfig;
+
+        @Override
+        public void init(ServletConfig config) throws ServletException {
+            super.init(config);
+            servletConfig = config;
+        }
+
+        @Override
+        public ServletConfig getServletConfig() {
+            return servletConfig;
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -2,32 +2,6 @@
   "reflection" : [
     {
       "condition" : {
-        "typeReached" : "org.eclipse.jetty.servlet.ServletHolder"
-      },
-      "type" : "org.apache.jasper.compiler.JspUtil",
-      "methods" : [
-        {
-          "name" : "makeJavaIdentifier",
-          "parameterTypes" : [
-            "java.lang.String"
-          ]
-        },
-        {
-          "name" : "makeJavaPackage",
-          "parameterTypes" : [
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.eclipse.jetty.util.Loader"
-      },
-      "type" : "org.apache.jasper.compiler.JspUtil"
-    },
-    {
-      "condition" : {
         "typeReached" : "org.eclipse.jetty.servlet.FilterHolder"
       },
       "type" : "org_eclipse_jetty.jetty_servlet.FilterHolderTest$RecordingFilter"

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -2,6 +2,26 @@
   "reflection" : [
     {
       "condition" : {
+        "typeReached" : "org.eclipse.jetty.servlet.ServletHolder"
+      },
+      "type" : "org.apache.jasper.compiler.JspUtil",
+      "methods" : [
+        {
+          "name" : "makeJavaIdentifier",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "makeJavaPackage",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
         "typeReached" : "org.eclipse.jetty.servlet.FilterHolder"
       },
       "type" : "org_eclipse_jetty.jetty_servlet.FilterHolderTest$RecordingFilter"

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,42 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.servlet.ServletHolder"
+      },
+      "type" : "org.apache.jasper.compiler.JspUtil",
+      "methods" : [
+        {
+          "name" : "makeJavaIdentifier",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "makeJavaPackage",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.Loader"
+      },
+      "type" : "org.apache.jasper.compiler.JspUtil"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.servlet.FilterHolder"
+      },
+      "type" : "org_eclipse_jetty.jetty_servlet.FilterHolderTest$RecordingFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.servlet.ServletHolder"
+      },
+      "type" : "org_eclipse_jetty.jetty_servlet.ServletHolderTest$CountingServlet"
+    }
+  ]
+}

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/user-code-filter.json
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/user-code-filter.json
@@ -7,6 +7,15 @@
       "includeClasses" : "org.eclipse.jetty.servlet.**"
     },
     {
+      "includeClasses" : "org.eclipse.jetty.http.**"
+    },
+    {
+      "includeClasses" : "org.eclipse.jetty.server.handler.**"
+    },
+    {
+      "includeClasses" : "org.eclipse.jetty.util.**"
+    },
+    {
       "includeClasses" : "org.apache.jasper.compiler.**"
     },
     {

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/user-code-filter.json
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/user-code-filter.json
@@ -1,0 +1,16 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.eclipse.jetty.servlet.**"
+    },
+    {
+      "includeClasses" : "org.apache.jasper.compiler.**"
+    },
+    {
+      "includeClasses" : "org_eclipse_jetty.jetty_servlet.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7289

This PR provides test fixes and new metadata for org.eclipse.jetty:jetty-servlet:9.4.0.RC1, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 30745
- Cached input tokens: 176640
- Output tokens: 2226
- Metadata entries: 17
- Test-only metadata entries: 2
- Iterations: 1
- Library coverage percentage: 23.27
- Previous library version metadata entries: 18
- Previous library version test-only metadata entries: 6
- Previous library version coverage percentage: 18.72

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `c3f234475560159f00bda2e75012103d3750cf3c`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.eclipse.jetty:jetty-servlet:9.3.19.v20170502: 10/10 covered calls (100.00%)
- org.eclipse.jetty:jetty-servlet:9.4.0.RC1: 10/10 covered calls (100.00%)

**Reflection:**
- org.eclipse.jetty:jetty-servlet:9.3.19.v20170502: 9/9 covered calls (100.00%)
- org.eclipse.jetty:jetty-servlet:9.4.0.RC1: 9/9 covered calls (100.00%)

**Resources:**
- org.eclipse.jetty:jetty-servlet:9.3.19.v20170502: 1/1 covered calls (100.00%)
- org.eclipse.jetty:jetty-servlet:9.4.0.RC1: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.eclipse.jetty:jetty-servlet:9.3.19.v20170502: 2255/13383 (16.85%)
- org.eclipse.jetty:jetty-servlet:9.4.0.RC1: 2432/11655 (20.87%)

**Line:**
- org.eclipse.jetty:jetty-servlet:9.3.19.v20170502: 576/3077 (18.72%)
- org.eclipse.jetty:jetty-servlet:9.4.0.RC1: 621/2669 (23.27%)

**Method:**
- org.eclipse.jetty:jetty-servlet:9.3.19.v20170502: 119/447 (26.62%)
- org.eclipse.jetty:jetty-servlet:9.4.0.RC1: 135/443 (30.47%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.eclipse.jetty/jetty-servlet/9.3.19.v20170502/src/test/java/org_eclipse_jetty/jetty_servlet/ServletHolderTest.java 2/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/src/test/java/org_eclipse_jetty/jetty_servlet/ServletHolderTest.java
index b02b42e536..f289148598 100644
--- 1/tests/src/org.eclipse.jetty/jetty-servlet/9.3.19.v20170502/src/test/java/org_eclipse_jetty/jetty_servlet/ServletHolderTest.java
+++ 2/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/src/test/java/org_eclipse_jetty/jetty_servlet/ServletHolderTest.java
@@ -19,21 +19,25 @@ import org.junit.jupiter.api.Test;
 
 public class ServletHolderTest {
     @Test
-    public void getNameOfJspClassUsesAvailableJasperUtility() {
-        ServletHolder holder = new ServletHolder();
-
-        String jspClassName = holder.getNameOfJspClass("/WEB-INF/pages/monthly-report.jsp");
-
-        assertThat(jspClassName).isEqualTo("javaIdentifier:monthly-report.jsp");
-    }
+    public void doStartUsesAvailableJasperUtilityToFindPrecompiledJspServlet() throws Exception {
+        ServletHandler handler = new ServletHandler();
+        handler.setEnsureDefaultServlet(false);
+        ServletHolder precompiledJsp = new ServletHolder();
+        precompiledJsp.setName("org.apache.jsp.javaPackage:/WEB-INF/pages.javaIdentifier:monthly-report.jsp");
+        precompiledJsp.setClassName(CountingServlet.class.getName());
 
-    @Test
-    public void getPackageOfJspClassUsesAvailableJasperUtility() {
         ServletHolder holder = new ServletHolder();
+        holder.setName("monthlyReport");
+        holder.setForcedPath("/WEB-INF/pages/monthly-report.jsp");
+        handler.setServlets(new ServletHolder[] {precompiledJsp, holder});
 
-        String jspPackage = holder.getPackageOfJspClass("/WEB-INF/pages/monthly-report.jsp");
+        try {
+            handler.start();
 
-        assertThat(jspPackage).isEqualTo("javaPackage:/WEB-INF/pages");
+            assertThat(holder.getClassName()).isEqualTo(CountingServlet.class.getName());
+        } finally {
+            handler.stop();
+        }
     }
 
     @Test
diff --git 1/tests/src/org.eclipse.jetty/jetty-servlet/9.3.19.v20170502/user-code-filter.json 2/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/user-code-filter.json
index d82667e887..d11ddde121 100644
--- 1/tests/src/org.eclipse.jetty/jetty-servlet/9.3.19.v20170502/user-code-filter.json
+++ 2/tests/src/org.eclipse.jetty/jetty-servlet/9.4.0.RC1/user-code-filter.json
@@ -6,6 +6,15 @@
     {
       "includeClasses" : "org.eclipse.jetty.servlet.**"
     },
+    {
+      "includeClasses" : "org.eclipse.jetty.http.**"
+    },
+    {
+      "includeClasses" : "org.eclipse.jetty.server.handler.**"
+    },
+    {
+      "includeClasses" : "org.eclipse.jetty.util.**"
+    },
     {
       "includeClasses" : "org.apache.jasper.compiler.**"
     },

```

### Local CI Verification

- Status: `success`
- Commands run: 23
- Fixup attempts: 1
