### PR TITLE
[GenAI] Mark org.springframework.boot:spring-boot-starter-data-jdbc as not for Native Image

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-starter-data-jdbc/index.json
+++ b/metadata/org.springframework.boot/spring-boot-starter-data-jdbc/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published spring-boot-starter-data-jdbc-4.0.6 JAR contains only META-INF/MANIFEST.MF, LICENSE.txt, and NOTICE.txt and no JVM class files; it is a dependency starter whose runtime classes are supplied by dependencies.",
+    "replacement": "Use class-bearing dependencies such as org.springframework.boot:spring-boot-data-jdbc:4.0.6 and org.springframework.boot:spring-boot-jdbc:4.0.6 for reachability metadata."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #7024

This PR records `org.springframework.boot:spring-boot-starter-data-jdbc` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published spring-boot-starter-data-jdbc-4.0.6 JAR contains only META-INF/MANIFEST.MF, LICENSE.txt, and NOTICE.txt and no JVM class files; it is a dependency starter whose runtime classes are supplied by dependencies.

Replacement guidance:
- Use class-bearing dependencies such as org.springframework.boot:spring-boot-data-jdbc:4.0.6 and org.springframework.boot:spring-boot-jdbc:4.0.6 for reachability metadata.

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `c3f234475560159f00bda2e75012103d3750cf3c`

### Local CI Verification

- Status: `success`
- Commands run: 6
- Fixup attempts: 0
