### PR TITLE
[GenAI] Test fix for net.minidev:json-smart:2.1.1 using gpt-5.5

### DIFF
--- a/metadata/net.minidev/json-smart/2.1.1/reachability-metadata.json
+++ b/metadata/net.minidev/json-smart/2.1.1/reachability-metadata.json
@@ -1,106 +1,70 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "net.minidev.asm.ASMUtil"
+      "condition" : {
+        "typeReached" : "net.minidev.asm.ASMUtil"
       },
-      "type": "java.lang.StackTraceElement[]"
+      "type" : "java.lang.StackTraceElement[]"
     },
     {
-      "condition": {
-        "typeReached": "net.minidev.json.writer.ArraysMapper$GenericMapper"
+      "condition" : {
+        "typeReached" : "net.minidev.json.writer.ArraysMapper$GenericMapper"
       },
-      "type": "java.lang.String[]"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "net.minidev.asm.ASMUtil"
+      "condition" : {
+        "typeReached" : "net.minidev.asm.ASMUtil"
       },
-      "type": "java.lang.reflect.Field[]"
+      "type" : "java.lang.reflect.Field[]"
     },
     {
-      "condition": {
-        "typeReached": "net.minidev.json.reader.BeansWriter"
+      "condition" : {
+        "typeReached" : "net.minidev.json.reader.BeansWriter"
       },
-      "type": "java.lang.reflect.Field[]"
+      "type" : "java.lang.reflect.Field[]"
     },
     {
-      "condition": {
-        "typeReached": "net.minidev.asm.ASMUtil"
+      "condition" : {
+        "typeReached" : "net.minidev.asm.ASMUtil"
       },
-      "type": "java.util.AbstractMap"
+      "type" : "java.util.AbstractMap"
     },
     {
-      "condition": {
-        "typeReached": "net.minidev.json.writer.DefaultMapperCollection"
+      "condition" : {
+        "typeReached" : "net.minidev.json.writer.DefaultMapperCollection"
       },
-      "type": "java.util.ArrayList",
-      "methods": [
+      "type" : "java.util.ArrayList",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "net.minidev.asm.ASMUtil"
+      "condition" : {
+        "typeReached" : "net.minidev.asm.ASMUtil"
       },
-      "type": "java.util.HashMap"
+      "type" : "java.util.HashMap"
     },
     {
-      "condition": {
-        "typeReached": "net.minidev.asm.Accessor"
+      "condition" : {
+        "typeReached" : "net.minidev.asm.Accessor"
       },
-      "type": "java.util.HashMap"
+      "type" : "java.util.HashMap"
     },
     {
-      "condition": {
-        "typeReached": "net.minidev.json.writer.DefaultMapperCollection"
+      "condition" : {
+        "typeReached" : "net.minidev.json.writer.DefaultMapperCollection"
       },
-      "type": "java.util.HashMap",
-      "methods": [
+      "type" : "java.util.HashMap",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "net.minidev.json.reader.BeansWriter"
-      },
-      "type": "net_minidev.json_smart.BeansWriterTest$MixedAccessBean"
-    },
-    {
-      "condition": {
-        "typeReached": "net.minidev.json.writer.CollectionMapper$MapType"
-      },
-      "type": "net_minidev.json_smart.CollectionMapperInnerMapTypeTest$AccessibleJsonObject"
-    },
-    {
-      "condition": {
-        "typeReached": "net.minidev.asm.BeansAccess"
-      },
-      "type": "net_minidev.json_smart.CollectionMapperInnerMapTypeTest$AccessibleJsonObjectAccAccess"
-    },
-    {
-      "condition": {
-        "typeReached": "net.minidev.asm.Accessor"
-      },
-      "type": "net_minidev.json_smart.JsonWriterAnonymous8Test$BaseBean"
-    },
-    {
-      "condition": {
-        "typeReached": "net.minidev.asm.Accessor"
-      },
-      "type": "net_minidev.json_smart.JsonWriterAnonymous8Test$DerivedBean"
-    },
-    {
-      "condition": {
-        "typeReached": "net.minidev.asm.BeansAccess"
-      },
-      "type": "net_minidev.json_smart.JsonWriterAnonymous8Test$DerivedBeanAccAccess"
     }
   ]
 }

--- a/metadata/net.minidev/json-smart/2.1.1/reachability-metadata.json
+++ b/metadata/net.minidev/json-smart/2.1.1/reachability-metadata.json
@@ -1,0 +1,106 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "net.minidev.asm.ASMUtil"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "net.minidev.json.writer.ArraysMapper$GenericMapper"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "net.minidev.asm.ASMUtil"
+      },
+      "type": "java.lang.reflect.Field[]"
+    },
+    {
+      "condition": {
+        "typeReached": "net.minidev.json.reader.BeansWriter"
+      },
+      "type": "java.lang.reflect.Field[]"
+    },
+    {
+      "condition": {
+        "typeReached": "net.minidev.asm.ASMUtil"
+      },
+      "type": "java.util.AbstractMap"
+    },
+    {
+      "condition": {
+        "typeReached": "net.minidev.json.writer.DefaultMapperCollection"
+      },
+      "type": "java.util.ArrayList",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "net.minidev.asm.ASMUtil"
+      },
+      "type": "java.util.HashMap"
+    },
+    {
+      "condition": {
+        "typeReached": "net.minidev.asm.Accessor"
+      },
+      "type": "java.util.HashMap"
+    },
+    {
+      "condition": {
+        "typeReached": "net.minidev.json.writer.DefaultMapperCollection"
+      },
+      "type": "java.util.HashMap",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "net.minidev.json.reader.BeansWriter"
+      },
+      "type": "net_minidev.json_smart.BeansWriterTest$MixedAccessBean"
+    },
+    {
+      "condition": {
+        "typeReached": "net.minidev.json.writer.CollectionMapper$MapType"
+      },
+      "type": "net_minidev.json_smart.CollectionMapperInnerMapTypeTest$AccessibleJsonObject"
+    },
+    {
+      "condition": {
+        "typeReached": "net.minidev.asm.BeansAccess"
+      },
+      "type": "net_minidev.json_smart.CollectionMapperInnerMapTypeTest$AccessibleJsonObjectAccAccess"
+    },
+    {
+      "condition": {
+        "typeReached": "net.minidev.asm.Accessor"
+      },
+      "type": "net_minidev.json_smart.JsonWriterAnonymous8Test$BaseBean"
+    },
+    {
+      "condition": {
+        "typeReached": "net.minidev.asm.Accessor"
+      },
+      "type": "net_minidev.json_smart.JsonWriterAnonymous8Test$DerivedBean"
+    },
+    {
+      "condition": {
+        "typeReached": "net.minidev.asm.BeansAccess"
+      },
+      "type": "net_minidev.json_smart.JsonWriterAnonymous8Test$DerivedBeanAccAccess"
+    }
+  ]
+}

--- a/metadata/net.minidev/json-smart/index.json
+++ b/metadata/net.minidev/json-smart/index.json
@@ -17,6 +17,11 @@
   },
   {
     "metadata-version" : "2.1.1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/net/minidev/json-smart/$version$/json-smart-$version$-sources.jar",
+    "repository-url" : "https://github.com/netplex/json-smart-v2",
+    "test-code-url" : "N/A",
+    "documentation-url" : "N/A",
+    "description" : "json-smart is a lightweight Java library for parsing, generating, and serializing JSON data. It provides JSON object and array models, parser APIs, and mapper support for converting between JSON values and Java objects.",
     "tested-versions" : [
       "2.1.1"
     ],

--- a/metadata/net.minidev/json-smart/index.json
+++ b/metadata/net.minidev/json-smart/index.json
@@ -16,6 +16,16 @@
     ]
   },
   {
+    "metadata-version" : "2.1.1",
+    "tested-versions" : [
+      "2.1.1"
+    ],
+    "allowed-packages" : [
+      "net.minidev.asm",
+      "net.minidev.json"
+    ]
+  },
+  {
     "metadata-version" : "2.1.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/net/minidev/json-smart/$version$/json-smart-$version$-sources.jar",
     "repository-url" : "https://github.com/netplex/json-smart-v2",

--- a/stats/net.minidev/json-smart/2.1.1/execution-metrics.json
+++ b/stats/net.minidev/json-smart/2.1.1/execution-metrics.json
@@ -1,0 +1,101 @@
+{
+  "fix_javac_fail:2026-05-20": {
+    "timestamp": "2026-05-20T04:54:03.488033Z",
+    "library": "net.minidev:json-smart:2.1.1",
+    "starting_commit": "701af917e6809426581acaefc693b727cd8a234d",
+    "ending_commit": "7beb78ebdf01aae5b9854aaf46211648f4b56689",
+    "previous_library": "net.minidev:json-smart:2.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.1.1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 11,
+            "totalCalls": 11
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 11,
+        "totalCalls": 11
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2477,
+          "missed": 8227,
+          "ratio": 0.231409,
+          "total": 10704
+        },
+        "line": {
+          "covered": 536,
+          "missed": 1949,
+          "ratio": 0.215694,
+          "total": 2485
+        },
+        "method": {
+          "covered": 142,
+          "missed": 361,
+          "ratio": 0.282306,
+          "total": 503
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 6,
+            "totalCalls": 6
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 6,
+        "totalCalls": 6
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1603,
+          "missed": 7577,
+          "ratio": 0.174619,
+          "total": 9180
+        },
+        "line": {
+          "covered": 385,
+          "missed": 1812,
+          "ratio": 0.175239,
+          "total": 2197
+        },
+        "method": {
+          "covered": 96,
+          "missed": 309,
+          "ratio": 0.237037,
+          "total": 405
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 60909,
+      "cached_input_tokens_used": 457216,
+      "output_tokens_used": 4423,
+      "iterations": 2,
+      "cost_usd": 0.3613,
+      "tested_library_loc": 536,
+      "metadata_entries": 11,
+      "test_only_metadata_entries": 8,
+      "previous_library_metadata_entries": 9,
+      "previous_library_test_only_metadata_entries": 6,
+      "code_coverage_percent": 21.57,
+      "previous_library_coverage_percent": 17.52
+    },
+    "artifacts": {
+      "test_file": "tests/src/net.minidev/json-smart/2.1.1/src/test/java/net/minidev/asm/java/util/HashMapAccAccess.java",
+      "metadata_file": "metadata/net.minidev/json-smart/2.1.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/net.minidev/json-smart/2.1.1/stats.json
+++ b/stats/net.minidev/json-smart/2.1.1/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "2.1.1",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 11,
+          "totalCalls" : 11
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 11,
+      "totalCalls" : 11
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2477,
+        "missed" : 8227,
+        "ratio" : 0.231409,
+        "total" : 10704
+      },
+      "line" : {
+        "covered" : 536,
+        "missed" : 1949,
+        "ratio" : 0.215694,
+        "total" : 2485
+      },
+      "method" : {
+        "covered" : 142,
+        "missed" : 361,
+        "ratio" : 0.282306,
+        "total" : 503
+      }
+    }
+  } ]
+}

--- a/tests/src/net.minidev/json-smart/2.1.1/.gitignore
+++ b/tests/src/net.minidev/json-smart/2.1.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/net.minidev/json-smart/2.1.1/build.gradle
+++ b/tests/src/net.minidev/json-smart/2.1.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "net.minidev:json-smart:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/net.minidev/json-smart/2.1.1/gradle.properties
+++ b/tests/src/net.minidev/json-smart/2.1.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = net.minidev:json-smart:2.1.1
+library.version = 2.1.1
+metadata.dir = net.minidev/json-smart/2.1.1/

--- a/tests/src/net.minidev/json-smart/2.1.1/settings.gradle
+++ b/tests/src/net.minidev/json-smart/2.1.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'net.minidev.json-smart_tests'

--- a/tests/src/net.minidev/json-smart/2.1.1/src/test/java/net/minidev/asm/java/util/HashMapAccAccess.java
+++ b/tests/src/net.minidev/json-smart/2.1.1/src/test/java/net/minidev/asm/java/util/HashMapAccAccess.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net.minidev.asm.java.util;
+
+import java.util.HashMap;
+import net.minidev.asm.BeansAccess;
+
+public final class HashMapAccAccess extends BeansAccess<HashMap<Object, Object>> {
+    @Override
+    public void set(HashMap<Object, Object> object, int methodIndex, Object value) {
+        object.put(getAccessors()[methodIndex].getName(), value);
+    }
+
+    @Override
+    public Object get(HashMap<Object, Object> object, int methodIndex) {
+        return object.get(getAccessors()[methodIndex].getName());
+    }
+
+    @Override
+    public HashMap<Object, Object> newInstance() {
+        return new HashMap<>();
+    }
+}

--- a/tests/src/net.minidev/json-smart/2.1.1/src/test/java/net_minidev/json_smart/ArraysMapperInnerGenericMapperTest.java
+++ b/tests/src/net.minidev/json-smart/2.1.1/src/test/java/net_minidev/json_smart/ArraysMapperInnerGenericMapperTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_minidev.json_smart;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import net.minidev.json.JSONValue;
+import org.junit.jupiter.api.Test;
+
+public class ArraysMapperInnerGenericMapperTest {
+    @Test
+    void parsesJsonArrayIntoObjectArrayType() {
+        String[] values = JSONValue.parse("[\"alpha\",\"beta\",\"gamma\"]", String[].class);
+
+        assertThat(values)
+                .isInstanceOf(String[].class)
+                .containsExactly("alpha", "beta", "gamma");
+    }
+}

--- a/tests/src/net.minidev/json-smart/2.1.1/src/test/java/net_minidev/json_smart/BeansWriterTest.java
+++ b/tests/src/net.minidev/json-smart/2.1.1/src/test/java/net_minidev/json_smart/BeansWriterTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_minidev.json_smart;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import net.minidev.json.JSONObject;
+import net.minidev.json.JSONStyle;
+import net.minidev.json.JSONValue;
+import net.minidev.json.reader.BeansWriter;
+import org.junit.jupiter.api.Test;
+
+public class BeansWriterTest {
+    @Test
+    void writesPublicFieldsAndBeanGetterProperties() throws Exception {
+        StringBuilder out = new StringBuilder();
+
+        new BeansWriter().writeJSONString(new MixedAccessBean(), out, JSONStyle.NO_COMPRESS);
+
+        JSONObject parsed = (JSONObject) JSONValue.parse(out.toString());
+        assertThat(parsed)
+                .containsEntry("publicText", "visible")
+                .containsEntry("count", 3)
+                .containsEntry("active", true);
+    }
+
+    public static class MixedAccessBean {
+        public String publicText = "visible";
+        private int count = 3;
+        private boolean active = true;
+
+        public int getCount() {
+            return count;
+        }
+
+        public boolean isActive() {
+            return active;
+        }
+    }
+}

--- a/tests/src/net.minidev/json-smart/2.1.1/src/test/java/net_minidev/json_smart/CollectionMapperInnerMapTypeTest.java
+++ b/tests/src/net.minidev/json-smart/2.1.1/src/test/java/net_minidev/json_smart/CollectionMapperInnerMapTypeTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_minidev.json_smart;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import net.minidev.asm.BeansAccess;
+import net.minidev.json.JSONNavi;
+import net.minidev.json.JSONObject;
+import net.minidev.json.mapper.AMapper;
+import net.minidev.json.mapper.Mapper;
+import org.junit.jupiter.api.Test;
+
+public class CollectionMapperInnerMapTypeTest {
+    @Test
+    void parsesObjectIntoParameterizedMapType() {
+        ParameterizedType mapType =
+                new SimpleParameterizedType(AccessibleJsonObject.class, String.class, Integer.class);
+        AMapper<AccessibleJsonObject> mapper = Mapper.getMapper(mapType);
+
+        JSONNavi<AccessibleJsonObject> navi = new JSONNavi<>("{\"one\":1,\"two\":2}", mapper);
+
+        assertThat(navi.getCurrentObject())
+                .isInstanceOf(AccessibleJsonObject.class)
+                .isEqualTo(expectedMap());
+    }
+
+    private static AccessibleJsonObject expectedMap() {
+        AccessibleJsonObject expected = new AccessibleJsonObject();
+        expected.put("one", 1);
+        expected.put("two", 2);
+        return expected;
+    }
+
+    // json-smart resolves AccAccess helpers with the raw type's class loader.
+    public static class AccessibleJsonObject extends JSONObject {
+    }
+
+    public static class AccessibleJsonObjectAccAccess extends BeansAccess<AccessibleJsonObject> {
+        @Override
+        public void set(AccessibleJsonObject object, int methodIndex, Object value) {
+            object.put(getAccessors()[methodIndex].getName(), value);
+        }
+
+        @Override
+        public Object get(AccessibleJsonObject object, int methodIndex) {
+            return object.get(getAccessors()[methodIndex].getName());
+        }
+
+        @Override
+        public AccessibleJsonObject newInstance() {
+            return new AccessibleJsonObject();
+        }
+    }
+
+    private static final class SimpleParameterizedType implements ParameterizedType {
+        private final Type rawType;
+        private final Type[] actualTypeArguments;
+
+        private SimpleParameterizedType(Type rawType, Type... actualTypeArguments) {
+            this.rawType = rawType;
+            this.actualTypeArguments = actualTypeArguments.clone();
+        }
+
+        @Override
+        public Type[] getActualTypeArguments() {
+            return actualTypeArguments.clone();
+        }
+
+        @Override
+        public Type getRawType() {
+            return rawType;
+        }
+
+        @Override
+        public Type getOwnerType() {
+            return null;
+        }
+    }
+}

--- a/tests/src/net.minidev/json-smart/2.1.1/src/test/java/net_minidev/json_smart/CollectionMapperInnerMapTypeTest.java
+++ b/tests/src/net.minidev/json-smart/2.1.1/src/test/java/net_minidev/json_smart/CollectionMapperInnerMapTypeTest.java
@@ -13,8 +13,8 @@ import java.lang.reflect.Type;
 import net.minidev.asm.BeansAccess;
 import net.minidev.json.JSONNavi;
 import net.minidev.json.JSONObject;
-import net.minidev.json.mapper.AMapper;
-import net.minidev.json.mapper.Mapper;
+import net.minidev.json.JSONValue;
+import net.minidev.json.writer.JsonReaderI;
 import org.junit.jupiter.api.Test;
 
 public class CollectionMapperInnerMapTypeTest {
@@ -22,7 +22,7 @@ public class CollectionMapperInnerMapTypeTest {
     void parsesObjectIntoParameterizedMapType() {
         ParameterizedType mapType =
                 new SimpleParameterizedType(AccessibleJsonObject.class, String.class, Integer.class);
-        AMapper<AccessibleJsonObject> mapper = Mapper.getMapper(mapType);
+        JsonReaderI<AccessibleJsonObject> mapper = JSONValue.defaultReader.getMapper(mapType);
 
         JSONNavi<AccessibleJsonObject> navi = new JSONNavi<>("{\"one\":1,\"two\":2}", mapper);
 

--- a/tests/src/net.minidev/json-smart/2.1.1/src/test/java/net_minidev/json_smart/DefaultMapperCollectionTest.java
+++ b/tests/src/net.minidev/json-smart/2.1.1/src/test/java/net_minidev/json_smart/DefaultMapperCollectionTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_minidev.json_smart;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import net.minidev.json.JSONValue;
+import org.junit.jupiter.api.Test;
+
+public class DefaultMapperCollectionTest {
+    @Test
+    void parsesObjectIntoConcreteMapImplementation() {
+        HashMap<?, ?> parsed = JSONValue.parse(
+                "{\"name\":\"json-smart\",\"enabled\":true}", HashMap.class);
+
+        assertThat(parsed).isInstanceOf(HashMap.class);
+        assertThat(parsed.get("name")).isEqualTo("json-smart");
+        assertThat(parsed.get("enabled")).isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    void parsesArrayIntoConcreteListImplementation() {
+        ArrayList<?> parsed = JSONValue.parse("[\"alpha\",2,true]", ArrayList.class);
+
+        assertThat(parsed).isInstanceOf(ArrayList.class);
+        assertThat(parsed).hasSize(3);
+        assertThat(parsed.get(0)).isEqualTo("alpha");
+        assertThat(parsed.get(1)).isEqualTo(Integer.valueOf(2));
+        assertThat(parsed.get(2)).isEqualTo(Boolean.TRUE);
+    }
+}

--- a/tests/src/net.minidev/json-smart/2.1.1/src/test/java/net_minidev/json_smart/JsonWriterAnonymous8Test.java
+++ b/tests/src/net.minidev/json-smart/2.1.1/src/test/java/net_minidev/json_smart/JsonWriterAnonymous8Test.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_minidev.json_smart;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import net.minidev.asm.BeansAccess;
+import net.minidev.json.JSONObject;
+import net.minidev.json.JSONValue;
+import org.junit.jupiter.api.Test;
+
+public class JsonWriterAnonymous8Test {
+    @Test
+    void serializesAccessibleBeanFields() {
+        String json = JSONValue.toJSONString(new DerivedBean());
+
+        JSONObject parsed = (JSONObject) JSONValue.parse(json);
+        assertThat(parsed)
+                .containsEntry("publicText", "visible")
+                .containsEntry("enabled", true)
+                .containsEntry("count", 3)
+                .containsEntry("baseNumber", 7);
+    }
+
+    public static class BaseBean {
+        public int baseNumber = 7;
+    }
+
+    public static class DerivedBean extends BaseBean {
+        public String publicText = "visible";
+        public boolean enabled = true;
+        public int count = 3;
+    }
+
+    public static class DerivedBeanAccAccess extends BeansAccess<DerivedBean> {
+        @Override
+        public void set(DerivedBean object, int methodIndex, Object value) {
+            switch (getAccessors()[methodIndex].getName()) {
+                case "baseNumber" -> object.baseNumber = ((Integer) value).intValue();
+                case "count" -> object.count = ((Integer) value).intValue();
+                case "enabled" -> object.enabled = ((Boolean) value).booleanValue();
+                case "publicText" -> object.publicText = (String) value;
+                default -> throw new IllegalArgumentException("Unknown accessor index: " + methodIndex);
+            }
+        }
+
+        @Override
+        public Object get(DerivedBean object, int methodIndex) {
+            return switch (getAccessors()[methodIndex].getName()) {
+                case "baseNumber" -> Integer.valueOf(object.baseNumber);
+                case "count" -> Integer.valueOf(object.count);
+                case "enabled" -> Boolean.valueOf(object.enabled);
+                case "publicText" -> object.publicText;
+                default -> throw new IllegalArgumentException("Unknown accessor index: " + methodIndex);
+            };
+        }
+
+        @Override
+        public DerivedBean newInstance() {
+            return new DerivedBean();
+        }
+    }
+}

--- a/tests/src/net.minidev/json-smart/2.1.1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/net.minidev/json-smart/2.1.1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,40 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "net.minidev.json.mapper.CollectionMapper$MapType"
+      },
+      "type" : "net_minidev.json_smart.CollectionMapperInnerMapTypeTest$AccessibleJsonObject",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "net.minidev.asm.BeansAccess"
+      },
+      "type" : "net_minidev.json_smart.CollectionMapperInnerMapTypeTest$AccessibleJsonObjectAccAccess"
+    },
+    {
+      "condition" : {
+        "typeReached" : "net.minidev.asm.Accessor"
+      },
+      "type" : "net_minidev.json_smart.JsonWriterAnonymous8Test$BaseBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "net.minidev.asm.Accessor"
+      },
+      "type" : "net_minidev.json_smart.JsonWriterAnonymous8Test$DerivedBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "net.minidev.asm.BeansAccess"
+      },
+      "type" : "net_minidev.json_smart.JsonWriterAnonymous8Test$DerivedBeanAccAccess"
+    }
+  ]
+}

--- a/tests/src/net.minidev/json-smart/2.1.1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/net.minidev/json-smart/2.1.1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -35,6 +35,18 @@
         "typeReached" : "net.minidev.asm.BeansAccess"
       },
       "type" : "net_minidev.json_smart.JsonWriterAnonymous8Test$DerivedBeanAccAccess"
+    },
+    {
+      "condition" : {
+        "typeReached" : "net.minidev.json.reader.BeansWriter"
+      },
+      "type" : "net_minidev.json_smart.BeansWriterTest$MixedAccessBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "net.minidev.json.writer.CollectionMapper$MapType"
+      },
+      "type" : "net_minidev.json_smart.CollectionMapperInnerMapTypeTest$AccessibleJsonObject"
     }
   ]
 }

--- a/tests/src/net.minidev/json-smart/2.1.1/user-code-filter.json
+++ b/tests/src/net.minidev/json-smart/2.1.1/user-code-filter.json
@@ -4,7 +4,13 @@
       "excludeClasses" : "**"
     },
     {
+      "includeClasses" : "net.minidev.asm.**"
+    },
+    {
       "includeClasses" : "net.minidev.json.**"
+    },
+    {
+      "includeClasses" : "net.minidev.asm.java.util.**"
     },
     {
       "includeClasses" : "net_minidev.json_smart.**"

--- a/tests/src/net.minidev/json-smart/2.1.1/user-code-filter.json
+++ b/tests/src/net.minidev/json-smart/2.1.1/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "net.minidev.json.**"
+    },
+    {
+      "includeClasses" : "net_minidev.json_smart.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7287

This PR provides test fixes and new metadata for net.minidev:json-smart:2.1.1, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 60909
- Cached input tokens: 457216
- Output tokens: 4423
- Metadata entries: 11
- Test-only metadata entries: 8
- Iterations: 2
- Library coverage percentage: 21.57
- Previous library version metadata entries: 9
- Previous library version test-only metadata entries: 6
- Previous library version coverage percentage: 17.52

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `c3f234475560159f00bda2e75012103d3750cf3c`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- net.minidev:json-smart:2.0: 6/6 covered calls (100.00%)
- net.minidev:json-smart:2.1.1: 11/11 covered calls (100.00%)

**Reflection:**
- net.minidev:json-smart:2.0: 6/6 covered calls (100.00%)
- net.minidev:json-smart:2.1.1: 11/11 covered calls (100.00%)

#### Library coverage

**Instruction:**
- net.minidev:json-smart:2.0: 1603/9180 (17.46%)
- net.minidev:json-smart:2.1.1: 2477/10704 (23.14%)

**Line:**
- net.minidev:json-smart:2.0: 385/2197 (17.52%)
- net.minidev:json-smart:2.1.1: 536/2485 (21.57%)

**Method:**
- net.minidev:json-smart:2.0: 96/405 (23.70%)
- net.minidev:json-smart:2.1.1: 142/503 (28.23%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/net.minidev/json-smart/2.1.1/src/test/java/net_minidev/json_smart/BeansWriterTest.java 2/tests/src/net.minidev/json-smart/2.1.1/src/test/java/net_minidev/json_smart/BeansWriterTest.java
new file mode 100644
index 0000000000..c635b2496d
--- /dev/null
+++ 2/tests/src/net.minidev/json-smart/2.1.1/src/test/java/net_minidev/json_smart/BeansWriterTest.java
@@ -0,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_minidev.json_smart;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import net.minidev.json.JSONObject;
+import net.minidev.json.JSONStyle;
+import net.minidev.json.JSONValue;
+import net.minidev.json.reader.BeansWriter;
+import org.junit.jupiter.api.Test;
+
+public class BeansWriterTest {
+    @Test
+    void writesPublicFieldsAndBeanGetterProperties() throws Exception {
+        StringBuilder out = new StringBuilder();
+
+        new BeansWriter().writeJSONString(new MixedAccessBean(), out, JSONStyle.NO_COMPRESS);
+
+        JSONObject parsed = (JSONObject) JSONValue.parse(out.toString());
+        assertThat(parsed)
+                .containsEntry("publicText", "visible")
+                .containsEntry("count", 3)
+                .containsEntry("active", true);
+    }
+
+    public static class MixedAccessBean {
+        public String publicText = "visible";
+        private int count = 3;
+        private boolean active = true;
+
+        public int getCount() {
+            return count;
+        }
+
+        public boolean isActive() {
+            return active;
+        }
+    }
+}
diff --git 1/tests/src/net.minidev/json-smart/2.0/src/test/java/net_minidev/json_smart/CollectionMapperInnerMapTypeTest.java 2/tests/src/net.minidev/json-smart/2.1.1/src/test/java/net_minidev/json_smart/CollectionMapperInnerMapTypeTest.java
index 31a56ccf88..d75c73c36f 100644
--- 1/tests/src/net.minidev/json-smart/2.0/src/test/java/net_minidev/json_smart/CollectionMapperInnerMapTypeTest.java
+++ 2/tests/src/net.minidev/json-smart/2.1.1/src/test/java/net_minidev/json_smart/CollectionMapperInnerMapTypeTest.java
@@ -13,8 +13,8 @@ import java.lang.reflect.Type;
 import net.minidev.asm.BeansAccess;
 import net.minidev.json.JSONNavi;
 import net.minidev.json.JSONObject;
-import net.minidev.json.mapper.AMapper;
-import net.minidev.json.mapper.Mapper;
+import net.minidev.json.JSONValue;
+import net.minidev.json.writer.JsonReaderI;
 import org.junit.jupiter.api.Test;
 
 public class CollectionMapperInnerMapTypeTest {
@@ -22,7 +22,7 @@ public class CollectionMapperInnerMapTypeTest {
     void parsesObjectIntoParameterizedMapType() {
         ParameterizedType mapType =
                 new SimpleParameterizedType(AccessibleJsonObject.class, String.class, Integer.class);
-        AMapper<AccessibleJsonObject> mapper = Mapper.getMapper(mapType);
+        JsonReaderI<AccessibleJsonObject> mapper = JSONValue.defaultReader.getMapper(mapType);
 
         JSONNavi<AccessibleJsonObject> navi = new JSONNavi<>("{\"one\":1,\"two\":2}", mapper);
 
diff --git 1/tests/src/net.minidev/json-smart/2.0/user-code-filter.json 2/tests/src/net.minidev/json-smart/2.1.1/user-code-filter.json
index 3f7779409d..f939e164d2 100644
--- 1/tests/src/net.minidev/json-smart/2.0/user-code-filter.json
+++ 2/tests/src/net.minidev/json-smart/2.1.1/user-code-filter.json
@@ -3,9 +3,15 @@
     {
       "excludeClasses" : "**"
     },
+    {
+      "includeClasses" : "net.minidev.asm.**"
+    },
     {
       "includeClasses" : "net.minidev.json.**"
     },
+    {
+      "includeClasses" : "net.minidev.asm.java.util.**"
+    },
     {
       "includeClasses" : "net_minidev.json_smart.**"
     }

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
