### PR TITLE
[GenAI] Mark org.springframework.boot:spring-boot-starter-actuator as not for Native Image

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-starter-actuator/index.json
+++ b/metadata/org.springframework.boot/spring-boot-starter-actuator/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published 2.6.3 JAR contains only META-INF manifest, license, and notice files and no JVM .class files, so the starter itself has no library classes for Native Image reachability metadata.",
+    "replacement": "org.springframework.boot:spring-boot-actuator-autoconfigure:2.6.3 and org.springframework.boot:spring-boot-actuator:2.6.3"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #2208

This PR records `org.springframework.boot:spring-boot-starter-actuator` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published 2.6.3 JAR contains only META-INF manifest, license, and notice files and no JVM .class files, so the starter itself has no library classes for Native Image reachability metadata.

Replacement guidance:
- org.springframework.boot:spring-boot-actuator-autoconfigure:2.6.3 and org.springframework.boot:spring-boot-actuator:2.6.3

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `c3f234475560159f00bda2e75012103d3750cf3c`

### Local CI Verification

- Status: `success`
- Commands run: 6
- Fixup attempts: 0
