### PR TITLE
[GenAI] Add support for org.apache.maven.plugins:maven-jar-plugin:3.2.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.maven.plugins/maven-jar-plugin/3.2.0/reachability-metadata.json
+++ b/metadata/org.apache.maven.plugins/maven-jar-plugin/3.2.0/reachability-metadata.json
@@ -1,0 +1,42 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.plugins.jar.HelpMojo"
+      },
+      "type": "com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.plugins.jar.HelpMojo"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.plugins.jar.HelpMojo"
+      },
+      "type": "short[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.plugins.jar.HelpMojo"
+      },
+      "type": "short[][]"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.plugins.jar.HelpMojo"
+      },
+      "glob": "META-INF/maven/org.apache.maven.plugins/maven-jar-plugin/plugin-help.xml"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.plugins.jar.HelpMojo"
+      },
+      "glob": "META-INF/services/javax.xml.parsers.DocumentBuilderFactory"
+    }
+  ]
+}

--- a/metadata/org.apache.maven.plugins/maven-jar-plugin/index.json
+++ b/metadata/org.apache.maven.plugins/maven-jar-plugin/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.2.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/$version$/maven-jar-plugin-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/maven-jar-plugin",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/$version$/maven-jar-plugin-$version$-source-release.zip",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/$version$/maven-jar-plugin-$version$-javadoc.jar",
+    "description" : "Apache Maven JAR Plugin builds Java Archive (JAR) files from a Maven project's compiled classes and resources. It also provides goals for packaging the main artifact and attaching a test JAR containing test classes.",
+    "tested-versions" : [
+      "3.2.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.maven.plugins.jar"
+    ]
+  }
+]

--- a/stats/org.apache.maven.plugins/maven-jar-plugin/3.2.0/execution-metrics.json
+++ b/stats/org.apache.maven.plugins/maven-jar-plugin/3.2.0/execution-metrics.json
@@ -1,0 +1,62 @@
+{
+  "add_new_library_support:2026-05-20": {
+    "timestamp": "2026-05-20T06:21:00.688210Z",
+    "library": "org.apache.maven.plugins:maven-jar-plugin:3.2.0",
+    "starting_commit": "deb4db90e0297041a9b1fb988de28e40c2eb8bc6",
+    "ending_commit": "75dec2feda9537c01db6b3a603c221cd99c42c81",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.2.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 559,
+          "missed": 684,
+          "ratio": 0.449718,
+          "total": 1243
+        },
+        "line": {
+          "covered": 107,
+          "missed": 129,
+          "ratio": 0.45339,
+          "total": 236
+        },
+        "method": {
+          "covered": 14,
+          "missed": 21,
+          "ratio": 0.4,
+          "total": 35
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 20793,
+      "cached_input_tokens_used": 190976,
+      "output_tokens_used": 4142,
+      "iterations": 1,
+      "cost_usd": 0.2198,
+      "generated_loc": 17,
+      "tested_library_loc": 107,
+      "metadata_entries": 6,
+      "code_coverage_percent": 45.34
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.maven.plugins/maven-jar-plugin/3.2.0/src/test/java/org_apache_maven_plugins/maven_jar_plugin/HelpMojoTest.java",
+      "metadata_file": "metadata/org.apache.maven.plugins/maven-jar-plugin/3.2.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.maven.plugins/maven-jar-plugin/3.2.0/stats.json
+++ b/stats/org.apache.maven.plugins/maven-jar-plugin/3.2.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "3.2.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 1,
+      "totalCalls" : 1
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 559,
+        "missed" : 684,
+        "ratio" : 0.449718,
+        "total" : 1243
+      },
+      "line" : {
+        "covered" : 107,
+        "missed" : 129,
+        "ratio" : 0.45339,
+        "total" : 236
+      },
+      "method" : {
+        "covered" : 14,
+        "missed" : 21,
+        "ratio" : 0.4,
+        "total" : 35
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.2.0/.gitignore
+++ b/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.2.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.2.0/build.gradle
+++ b/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.2.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.maven.plugins:maven-jar-plugin:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.2.0/gradle.properties
+++ b/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.2.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.maven.plugins:maven-jar-plugin:3.2.0
+library.version = 3.2.0
+metadata.dir = org.apache.maven.plugins/maven-jar-plugin/3.2.0/

--- a/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.2.0/settings.gradle
+++ b/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.2.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.maven.plugins.maven-jar-plugin_tests'

--- a/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.2.0/src/test/java/org_apache_maven_plugins/maven_jar_plugin/HelpMojoTest.java
+++ b/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.2.0/src/test/java/org_apache_maven_plugins/maven_jar_plugin/HelpMojoTest.java
@@ -6,11 +6,16 @@
  */
 package org_apache_maven_plugins.maven_jar_plugin;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.apache.maven.plugins.jar.HelpMojo;
 import org.junit.jupiter.api.Test;
 
-class Maven_jar_pluginTest {
+public class HelpMojoTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void executeLoadsPluginHelpResource() {
+        HelpMojo mojo = new HelpMojo();
+
+        assertThatCode(mojo::execute).doesNotThrowAnyException();
     }
 }

--- a/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.2.0/src/test/java/org_apache_maven_plugins/maven_jar_plugin/Maven_jar_pluginTest.java
+++ b/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.2.0/src/test/java/org_apache_maven_plugins/maven_jar_plugin/Maven_jar_pluginTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_plugins.maven_jar_plugin;
+
+import org.junit.jupiter.api.Test;
+
+class Maven_jar_pluginTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.2.0/user-code-filter.json
+++ b/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.2.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.apache.maven.plugins.jar.**"
+    }
+  ]
+}

--- a/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.2.0/user-code-filter.json
+++ b/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.2.0/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.apache.maven.plugins.jar.**"
+      "includeClasses" : "org.apache.maven.plugins.jar.**"
+    },
+    {
+      "includeClasses" : "org_apache_maven_plugins.maven_jar_plugin.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #2191

This PR introduces tests and metadata for org.apache.maven.plugins:maven-jar-plugin:3.2.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 20793
- Cached input tokens: 190976
- Output tokens: 4142
- Metadata entries: 6
- Iterations: 1
- Library coverage percentage: 45.34
- Generated lines of code: 17
- Tested library lines of code: 107

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `c3f234475560159f00bda2e75012103d3750cf3c`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 1/1 covered calls (100.00%)
- Resources: 1/1 covered calls (100.00%)

Library coverage:
- Instruction: 559/1243 (44.97%)
- Line: 107/236 (45.34%)
- Method: 14/35 (40.00%)

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
