### PR TITLE
[GenAI] Mark org.springframework.boot:spring-boot-starter-web as not for Native Image

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-starter-web/index.json
+++ b/metadata/org.springframework.boot/spring-boot-starter-web/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published JAR for org.springframework.boot:spring-boot-starter-web:2.7.18 contains only META-INF files and no JVM class files; it is a dependency starter whose runtime classes are supplied by its dependencies.",
+    "replacement": "Use class-bearing dependencies such as org.springframework:spring-web:5.3.31, org.springframework:spring-webmvc:5.3.31, org.springframework.boot:spring-boot:2.7.18, org.springframework.boot:spring-boot-autoconfigure:2.7.18, and org.apache.tomcat.embed:tomcat-embed-core:9.0.83."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #2171

This PR records `org.springframework.boot:spring-boot-starter-web` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published JAR for org.springframework.boot:spring-boot-starter-web:2.7.18 contains only META-INF files and no JVM class files; it is a dependency starter whose runtime classes are supplied by its dependencies.

Replacement guidance:
- Use class-bearing dependencies such as org.springframework:spring-web:5.3.31, org.springframework:spring-webmvc:5.3.31, org.springframework.boot:spring-boot:2.7.18, org.springframework.boot:spring-boot-autoconfigure:2.7.18, and org.apache.tomcat.embed:tomcat-embed-core:9.0.83.

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3bc70b7373500f8aa5f681f9d52a165f4a8a3d55`

### Local CI Verification

- Status: `success`
- Commands run: 6
- Fixup attempts: 0
