### PR TITLE
[GenAI] Mark org.springframework.boot:spring-boot-starter-test as not for Native Image

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-starter-test/index.json
+++ b/metadata/org.springframework.boot/spring-boot-starter-test/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published JAR for org.springframework.boot:spring-boot-starter-test:2.7.18 contains only META-INF files and no JVM class files; it is a dependency starter whose test classes are supplied by its dependencies.",
+    "replacement": "Use class-bearing dependencies such as org.springframework.boot:spring-boot-test:2.7.18, org.springframework.boot:spring-boot-test-autoconfigure:2.7.18, org.junit.jupiter:junit-jupiter:5.8.2, org.mockito:mockito-core:4.5.1, and org.hamcrest:hamcrest:2.2."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #2170

This PR records `org.springframework.boot:spring-boot-starter-test` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published JAR for org.springframework.boot:spring-boot-starter-test:2.7.18 contains only META-INF files and no JVM class files; it is a dependency starter whose test classes are supplied by its dependencies.

Replacement guidance:
- Use class-bearing dependencies such as org.springframework.boot:spring-boot-test:2.7.18, org.springframework.boot:spring-boot-test-autoconfigure:2.7.18, org.junit.jupiter:junit-jupiter:5.8.2, org.mockito:mockito-core:4.5.1, and org.hamcrest:hamcrest:2.2.

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3bc70b7373500f8aa5f681f9d52a165f4a8a3d55`

### Local CI Verification

- Status: `success`
- Commands run: 6
- Fixup attempts: 0
