### PR TITLE
[GenAI] Add support for org.jboss.xnio:xnio-api:3.8.7.Final using gpt-5.5

### DIFF
--- a/metadata/org.jboss.xnio/xnio-api/3.8.7.Final/reachability-metadata.json
+++ b/metadata/org.jboss.xnio/xnio-api/3.8.7.Final/reachability-metadata.json
@@ -1,0 +1,18 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.xnio.Xnio"
+      },
+      "type": "org.xnio._private.Messages_$logger",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.jboss.logging.Logger"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.jboss.xnio/xnio-api/index.json
+++ b/metadata/org.jboss.xnio/xnio-api/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.8.7.Final",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/jboss/xnio/xnio-api/$version$/xnio-api-$version$-sources.jar",
+    "repository-url" : "https://github.com/xnio/xnio",
+    "test-code-url" : "https://github.com/xnio/xnio/tree/$version$/api/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/jboss/xnio/xnio-api/$version$/xnio-api-$version$-javadoc.jar",
+    "description" : "XNIO API provides Java NIO-based abstractions for blocking and non-blocking I/O. It defines the public channel, worker, option, conduit, and utility APIs used by XNIO implementations and JBoss/WildFly networking components.",
+    "tested-versions" : [
+      "3.8.7.Final"
+    ],
+    "allowed-packages" : [
+      "org.xnio"
+    ]
+  }
+]

--- a/stats/org.jboss.xnio/xnio-api/3.8.7.Final/execution-metrics.json
+++ b/stats/org.jboss.xnio/xnio-api/3.8.7.Final/execution-metrics.json
@@ -1,0 +1,62 @@
+{
+  "add_new_library_support:2026-05-20": {
+    "timestamp": "2026-05-20T13:22:57.799906Z",
+    "library": "org.jboss.xnio:xnio-api:3.8.7.Final",
+    "starting_commit": "392070b78426ac4cd3f2677e98c2b46e0b5857f6",
+    "ending_commit": "d4db723ce341e851323f0f8fba08d2ddfbbb669a",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.8.7.Final",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.0,
+            "coveredCalls": 0,
+            "totalCalls": 10
+          }
+        },
+        "coverageRatio": 0.0,
+        "coveredCalls": 0,
+        "totalCalls": 10
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3306,
+          "missed": 46498,
+          "ratio": 0.06638,
+          "total": 49804
+        },
+        "line": {
+          "covered": 775,
+          "missed": 11297,
+          "ratio": 0.064198,
+          "total": 12072
+        },
+        "method": {
+          "covered": 229,
+          "missed": 2818,
+          "ratio": 0.075156,
+          "total": 3047
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 370970,
+      "cached_input_tokens_used": 6015488,
+      "output_tokens_used": 35234,
+      "iterations": 9,
+      "cost_usd": 4.0647,
+      "generated_loc": 187,
+      "tested_library_loc": 775,
+      "metadata_entries": 2,
+      "code_coverage_percent": 6.42
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/src/test/java/org_jboss_xnio/xnio_api/Xnio_apiTest.java",
+      "metadata_file": "metadata/org.jboss.xnio/xnio-api/3.8.7.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.jboss.xnio/xnio-api/3.8.7.Final/stats.json
+++ b/stats/org.jboss.xnio/xnio-api/3.8.7.Final/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "3.8.7.Final",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.0,
+          "coveredCalls" : 0,
+          "totalCalls" : 10
+        }
+      },
+      "coverageRatio" : 0.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 10
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3306,
+        "missed" : 46498,
+        "ratio" : 0.06638,
+        "total" : 49804
+      },
+      "line" : {
+        "covered" : 775,
+        "missed" : 11297,
+        "ratio" : 0.064198,
+        "total" : 12072
+      },
+      "method" : {
+        "covered" : 229,
+        "missed" : 2818,
+        "ratio" : 0.075156,
+        "total" : 3047
+      }
+    }
+  } ]
+}

--- a/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/.gitignore
+++ b/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/build.gradle
+++ b/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.jboss.xnio:xnio-api:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/build.gradle
+++ b/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/build.gradle
@@ -12,6 +12,9 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.jboss.xnio:xnio-api:$libraryVersion"
+    testImplementation('org.wildfly.common:wildfly-common:1.7.0.Final') {
+        because 'wildfly-common 1.5.4.Final contains substitutions for removed Graal compiler classes'
+    }
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/gradle.properties
+++ b/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.jboss.xnio:xnio-api:3.8.7.Final
+library.version = 3.8.7.Final
+metadata.dir = org.jboss.xnio/xnio-api/3.8.7.Final/

--- a/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/settings.gradle
+++ b/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.jboss.xnio.xnio-api_tests'

--- a/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/src/test/java/org_jboss_xnio/xnio_api/Xnio_apiTest.java
+++ b/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/src/test/java/org_jboss_xnio/xnio_api/Xnio_apiTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_xnio.xnio_api;
+
+import org.junit.jupiter.api.Test;
+
+class Xnio_apiTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/src/test/java/org_jboss_xnio/xnio_api/Xnio_apiTest.java
+++ b/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/src/test/java/org_jboss_xnio/xnio_api/Xnio_apiTest.java
@@ -6,11 +6,146 @@
  */
 package org_jboss_xnio.xnio_api;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-class Xnio_apiTest {
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.xnio.BufferAllocator;
+import org.xnio.FailedIoFuture;
+import org.xnio.FileAccess;
+import org.xnio.FinishedIoFuture;
+import org.xnio.FutureResult;
+import org.xnio.IoFuture;
+import org.xnio.Option;
+import org.xnio.OptionMap;
+import org.xnio.Options;
+import org.xnio.Property;
+import org.xnio.Sequence;
+import org.xnio.sasl.SaslQop;
+import org.xnio.sasl.SaslStrength;
+import org.xnio.streams.LimitedInputStream;
+import org.xnio.streams.LimitedOutputStream;
+import org.xnio.streams.WriterOutputStream;
+
+public class Xnio_apiTest {
+    public static final Option<Class<? extends Number>> NUMBER_TYPE =
+            Option.type(Xnio_apiTest.class, "NUMBER_TYPE", Number.class);
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void optionsCanBeParsedCastedAndStoredInImmutableMaps() {
+        Sequence<SaslQop> qopSequence = Options.SASL_QOP.parseValue("AUTH,AUTH_INT", null);
+        Sequence<Property> saslProperties = Options.SASL_PROPERTIES.parseValue("realm=example.org,trace=true", null);
+
+        OptionMap optionMap = OptionMap.builder()
+                .parse(Options.TCP_NODELAY, "true")
+                .parse(Options.WORKER_IO_THREADS, "3")
+                .set(Options.SASL_STRENGTH, SaslStrength.HIGH)
+                .set(Options.SASL_QOP, qopSequence)
+                .set(Options.SASL_PROPERTIES, saslProperties)
+                .set(Options.WORKER_NAME, "metadata-worker")
+                .set(NUMBER_TYPE, Integer.class)
+                .getMap();
+
+        assertThat(Options.TCP_NODELAY.cast(Boolean.TRUE)).isTrue();
+        assertThat(optionMap.get(Options.TCP_NODELAY, false)).isTrue();
+        assertThat(optionMap.get(Options.WORKER_IO_THREADS, 0)).isEqualTo(3);
+        assertThat(optionMap.get(Options.WORKER_NAME)).isEqualTo("metadata-worker");
+        assertThat(optionMap.get(Options.SASL_STRENGTH)).isEqualTo(SaslStrength.HIGH);
+        assertThat(optionMap.get(Options.SASL_QOP)).containsExactly(SaslQop.AUTH, SaslQop.AUTH_INT);
+        assertThat(optionMap.get(NUMBER_TYPE)).isSameAs(Integer.class);
+        assertThat(saslProperties).containsExactly(Property.of("realm", "example.org"), Property.of("trace", "true"));
+
+        OptionMap fileOptions = OptionMap.create(Options.FILE_ACCESS, FileAccess.READ_ONLY);
+        assertThat(fileOptions.get(Options.FILE_ACCESS)).isEqualTo(FileAccess.READ_ONLY);
+        assertThat(optionMap).contains(Options.TCP_NODELAY, Options.SASL_QOP, NUMBER_TYPE);
     }
+
+    @Test
+    void bufferAllocatorsCreateHeapAndDirectBuffers() {
+        ByteBuffer heapBuffer = BufferAllocator.BYTE_BUFFER_ALLOCATOR.allocate(8);
+        heapBuffer.put("xnio".getBytes(StandardCharsets.US_ASCII));
+        heapBuffer.flip();
+
+        byte[] bytes = new byte[heapBuffer.remaining()];
+        heapBuffer.get(bytes);
+        assertThat(bytes).containsExactly((byte) 'x', (byte) 'n', (byte) 'i', (byte) 'o');
+
+        ByteBuffer directBuffer = BufferAllocator.DIRECT_BYTE_BUFFER_ALLOCATOR.allocate(4);
+        assertThat(directBuffer.isDirect()).isTrue();
+        assertThat(directBuffer.capacity()).isEqualTo(4);
+    }
+
+    @Test
+    void ioFuturesNotifyCompletionFailureAndCancellation() throws Exception {
+        FinishedIoFuture<String> finished = new FinishedIoFuture<>("ready");
+        AtomicReference<String> finishedAttachment = new AtomicReference<>("notified");
+        finished.addNotifier(
+                (future, attachment) -> attachment.set(future.getStatus() + ":" + attachment.get()),
+                finishedAttachment);
+        assertThat(finished.get()).isEqualTo("ready");
+        assertThat(finished.getStatus()).isEqualTo(IoFuture.Status.DONE);
+        assertThat(finishedAttachment).hasValue("DONE:notified");
+
+        IOException failure = new IOException("boom");
+        FailedIoFuture<String> failed = new FailedIoFuture<>(failure);
+        assertThat(failed.await(10, TimeUnit.MILLISECONDS)).isEqualTo(IoFuture.Status.FAILED);
+        assertThat(failed.getException()).isSameAs(failure);
+
+        FutureResult<String> result = new FutureResult<>();
+        IoFuture<String> future = result.getIoFuture();
+        AtomicBoolean cancelHandlerCalled = new AtomicBoolean();
+        AtomicReference<IoFuture.Status> observedStatus = new AtomicReference<>();
+        result.addCancelHandler(() -> {
+            cancelHandlerCalled.set(true);
+            return null;
+        });
+        future.addNotifier((notifiedFuture, attachment) -> attachment.set(notifiedFuture.getStatus()), observedStatus);
+
+        assertThat(future.await(1, TimeUnit.MILLISECONDS)).isEqualTo(IoFuture.Status.WAITING);
+        assertThat(result.setResult("complete")).isTrue();
+        assertThat(future.awaitInterruptibly(10, TimeUnit.MILLISECONDS)).isEqualTo(IoFuture.Status.DONE);
+        assertThat(future.getInterruptibly()).isEqualTo("complete");
+        assertThat(observedStatus).hasValue(IoFuture.Status.DONE);
+        assertThat(result.setCancelled()).isFalse();
+        assertThat(cancelHandlerCalled).isFalse();
+    }
+
+    @Test
+    void streamAdaptersEnforceLimitsAndDecodeBytes() throws Exception {
+        ByteArrayInputStream bytes = new ByteArrayInputStream("abcdef".getBytes(StandardCharsets.UTF_8));
+        LimitedInputStream input = new LimitedInputStream(bytes, 4);
+        assertThat(input.read()).isEqualTo('a');
+        input.mark(10);
+        assertThat(input.read(new byte[2])).isEqualTo(2);
+        input.reset();
+        assertThat(input.readAllBytes()).containsExactly((byte) 'b', (byte) 'c', (byte) 'd');
+        assertThat(input.read()).isEqualTo(-1);
+
+        ByteArrayOutputStream outputBytes = new ByteArrayOutputStream();
+        LimitedOutputStream output = new LimitedOutputStream(outputBytes, 5);
+        output.write("xnio".getBytes(StandardCharsets.UTF_8));
+        output.write('!');
+        assertThrows(IOException.class, () -> output.write('?'));
+        output.close();
+        assertThat(outputBytes.toString(StandardCharsets.UTF_8)).isEqualTo("xnio!");
+
+        StringWriter decoded = new StringWriter();
+        try (WriterOutputStream writerOutputStream = new WriterOutputStream(
+                decoded,
+                StandardCharsets.UTF_8.newDecoder(),
+                4)) {
+            writerOutputStream.write("Grüße".getBytes(StandardCharsets.UTF_8));
+        }
+        assertThat(decoded).hasToString("Grüße");
+    }
+
 }

--- a/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/src/test/java/org_jboss_xnio/xnio_api/Xnio_apiTest.java
+++ b/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/src/test/java/org_jboss_xnio/xnio_api/Xnio_apiTest.java
@@ -207,9 +207,9 @@ public class Xnio_apiTest {
                 decoded,
                 StandardCharsets.UTF_8.newDecoder(),
                 4)) {
-            writerOutputStream.write("Grüße".getBytes(StandardCharsets.UTF_8));
+            writerOutputStream.write("Gr\u00fc\u00dfe".getBytes(StandardCharsets.UTF_8));
         }
-        assertThat(decoded).hasToString("Grüße");
+        assertThat(decoded).hasToString("Gr\u00fc\u00dfe");
     }
 
 }

--- a/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/src/test/java/org_jboss_xnio/xnio_api/Xnio_apiTest.java
+++ b/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/src/test/java/org_jboss_xnio/xnio_api/Xnio_apiTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import org.xnio.BufferAllocator;
+import org.xnio.ByteString;
 import org.xnio.FailedIoFuture;
 import org.xnio.FileAccess;
 import org.xnio.FinishedIoFuture;
@@ -82,6 +83,31 @@ public class Xnio_apiTest {
         ByteBuffer directBuffer = BufferAllocator.DIRECT_BYTE_BUFFER_ALLOCATOR.allocate(4);
         assertThat(directBuffer.isDirect()).isTrue();
         assertThat(directBuffer.capacity()).isEqualTo(4);
+    }
+
+    @Test
+    void byteStringsSupportImmutableAsciiSearchAndNumericConversion() throws Exception {
+        byte[] bytes = "Content-Length: 42".getBytes(StandardCharsets.ISO_8859_1);
+        ByteString header = ByteString.copyOf(bytes, 0, bytes.length);
+        bytes[0] = 'x';
+
+        assertThat(header.toString()).isEqualTo("Content-Length: 42");
+        assertThat(header.startsWithIgnoreCase(ByteString.getBytes("content"))).isTrue();
+        assertThat(header.containsIgnoreCase(ByteString.getBytes("length"))).isTrue();
+        assertThat(header.indexOf(':')).isEqualTo("Content-Length".length());
+        assertThat(header.toInt("Content-Length: ".length())).isEqualTo(42);
+        assertThat(header.substring(0, "Content".length()).toString()).isEqualTo("Content");
+
+        ByteBuffer target = ByteBuffer.allocate(8);
+        int appended = header.tryAppendTo(0, target);
+        assertThat(appended).isEqualTo(8);
+        target.flip();
+        assertThat(ByteString.getBytes(target).toString()).isEqualTo("Content-");
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        ByteString statusLinePrefix = ByteString.concat("HTTP/", ByteString.fromInt(2));
+        statusLinePrefix.concat(".0").writeTo(output);
+        assertThat(output.toString(StandardCharsets.ISO_8859_1)).isEqualTo("HTTP/2.0");
     }
 
     @Test

--- a/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/src/test/java/org_jboss_xnio/xnio_api/Xnio_apiTest.java
+++ b/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/src/test/java/org_jboss_xnio/xnio_api/Xnio_apiTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import org.xnio.BufferAllocator;
+import org.xnio.ByteBufferPool;
 import org.xnio.ByteString;
 import org.xnio.FailedIoFuture;
 import org.xnio.FileAccess;
@@ -83,6 +84,43 @@ public class Xnio_apiTest {
         ByteBuffer directBuffer = BufferAllocator.DIRECT_BYTE_BUFFER_ALLOCATOR.allocate(4);
         assertThat(directBuffer.isDirect()).isTrue();
         assertThat(directBuffer.capacity()).isEqualTo(4);
+    }
+
+    @Test
+    void byteBufferPoolsAllocateBulkBuffersAndUseScopedCaches() {
+        ByteBufferPool pool = ByteBufferPool.Set.HEAP.getSmall();
+        assertThat(pool.isDirect()).isFalse();
+        assertThat(pool.getSize()).isEqualTo(ByteBufferPool.SMALL_SIZE);
+
+        ByteBuffer[] buffers = new ByteBuffer[3];
+        pool.allocate(buffers, 1, 2);
+        assertThat(buffers[0]).isNull();
+        assertThat(buffers[1].capacity()).isEqualTo(ByteBufferPool.SMALL_SIZE);
+        assertThat(buffers[2].capacity()).isEqualTo(ByteBufferPool.SMALL_SIZE);
+        assertThat(buffers[1].isDirect()).isFalse();
+
+        buffers[1].put(0, (byte) 0x7f);
+        ByteBufferPool.zeroAndFree(buffers[1]);
+        assertThat(buffers[1].position()).isZero();
+        assertThat(buffers[1].limit()).isEqualTo(ByteBufferPool.SMALL_SIZE);
+        assertThat(buffers[1].get(0)).isZero();
+
+        ByteBufferPool.free(buffers, 2, 1);
+        assertThat(buffers[2]).isNull();
+
+        AtomicReference<ByteBuffer> firstAllocation = new AtomicReference<>();
+        AtomicReference<ByteBuffer> cachedAllocation = new AtomicReference<>();
+        pool.runWithCache(1, () -> {
+            ByteBuffer buffer = pool.allocate();
+            firstAllocation.set(buffer);
+            ByteBufferPool.free(buffer);
+            cachedAllocation.set(pool.allocate());
+        });
+
+        assertThat(cachedAllocation.get()).isSameAs(firstAllocation.get());
+        ByteBufferPool.free(cachedAllocation.get());
+        pool.flushCaches();
+        ByteBufferPool.flushAllCaches();
     }
 
     @Test

--- a/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/user-code-filter.json
+++ b/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.xnio.**"
+    }
+  ]
+}

--- a/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/user-code-filter.json
+++ b/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.xnio.**"
+      "includeClasses" : "org.xnio.**"
+    },
+    {
+      "includeClasses" : "org_jboss_xnio.xnio_api.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #1537

This PR introduces tests and metadata for org.jboss.xnio:xnio-api:3.8.7.Final, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 370970
- Cached input tokens: 6015488
- Output tokens: 35234
- Metadata entries: 2
- Iterations: 9
- Library coverage percentage: 6.42
- Generated lines of code: 187
- Tested library lines of code: 775

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `53127cfc0bfc6d8a07d43d8618bca90553445894`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/10 covered calls (0.00%)
- Reflection: 0/10 covered calls (0.00%)

Library coverage:
- Instruction: 3306/49804 (6.64%)
- Line: 775/12072 (6.42%)
- Method: 229/3047 (7.52%)

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
