### PR TITLE
Fixes argument injection in the interactive contribute task.

### DIFF
--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/ContributionTask.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/ContributionTask.java
@@ -235,8 +235,11 @@ public abstract class ContributionTask extends DefaultTask {
 
     private void createStubs(boolean shouldUpdate) {
         InteractiveTaskUtils.printUserInfo("Generating stubs for: " + coordinates);
-        String opt = shouldUpdate ? "--update" : "";
-        GeneralUtils.invokeCommand(getExecOperations(), gradlewPath + " scaffold --coordinates " + coordinates + " --skipTests " + opt, "Cannot generate stubs for: " + coordinates);
+        List<String> args = new ArrayList<>(List.of("scaffold", "--coordinates", coordinates, "--skipTests"));
+        if (shouldUpdate) {
+            args.add("--update");
+        }
+        GeneralUtils.invokeCommand(getExecOperations(), gradlewPath.toString(), args, "Cannot generate stubs for: " + coordinates, null);
     }
 
     private void updateAllowedPackages(List<String> allowedPackages, boolean libraryAlreadyExists) throws IOException {
@@ -356,16 +359,16 @@ public abstract class ContributionTask extends DefaultTask {
 
     private void createPullRequest(String branch) {
         InteractiveTaskUtils.printUserInfo("Creating new branch: " + branch);
-        GeneralUtils.invokeCommand(getExecOperations(), "git switch -C " + branch, "Cannot create a new branch");
+        GeneralUtils.invokeCommand(getExecOperations(), "git", List.of("switch", "-C", branch), "Cannot create a new branch", null);
 
         InteractiveTaskUtils.printUserInfo("Staging changes");
-        GeneralUtils.invokeCommand(getExecOperations(), "git add .", "Cannot add changes");
+        GeneralUtils.invokeCommand(getExecOperations(), "git", List.of("add", "."), "Cannot add changes", null);
 
         InteractiveTaskUtils.printUserInfo("Committing changes");
         GeneralUtils.invokeCommand(getExecOperations(), "git", List.of("commit", "-m", "Add metadata for " + coordinates), "Cannot commit changes", null);
 
         InteractiveTaskUtils.printUserInfo("Pushing changes");
-        GeneralUtils.invokeCommand(getExecOperations(), "git push origin " + branch, "Cannot push to origin");
+        GeneralUtils.invokeCommand(getExecOperations(), "git", List.of("push", "origin", branch), "Cannot push to origin", null);
 
         InteractiveTaskUtils.printUserInfo("Complete pull request creation on the above link");
     }

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/GeneralUtils.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/GeneralUtils.java
@@ -15,7 +15,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -37,18 +36,6 @@ public final class GeneralUtils {
     public static void writeToFile(Path path, String content, StandardOpenOption writeOption) throws IOException {
         Files.createDirectories(path.getParent());
         Files.writeString(path, content, StandardCharsets.UTF_8, writeOption);
-    }
-
-    public static void invokeCommand(ExecOperations execOps, String command, String errorMessage) {
-        invokeCommand(execOps, command, errorMessage, null);
-    }
-
-    public static void invokeCommand(ExecOperations execOps, String command, String errorMessage, Path workingDirectory) {
-        String[] commandParts = command.split(" ");
-        String executable = commandParts[0];
-
-        List<String> args = List.of(Arrays.copyOfRange(commandParts, 1, commandParts.length));
-        invokeCommand(execOps, executable, args, errorMessage, workingDirectory);
     }
 
     /**


### PR DESCRIPTION
ContributionTask now invokes external commands using the existing executable-plus-argv `GeneralUtils.invokeCommand(...)` overload instead of building space-delimited command strings. This keeps user-provided values such as coordinates and branch names as single arguments when  passed to Gradle `ExecOperations.exec()`.

 Also removes the unsafe `GeneralUtils.invokeCommand(String command, ...)` overload that used `command.split(" ")`, preventing future callers from reintroducing the same issue.
