### PR TITLE
[Automation] Generated metadata for org.glassfish.hk2:hk2-api:2.6.0

### DIFF
--- a/metadata/org.glassfish.hk2/hk2-api/index.json
+++ b/metadata/org.glassfish.hk2/hk2-api/index.json
@@ -1,21 +1,6 @@
 [
   {
     "latest" : true,
-    "metadata-version" : "2.5.0-b05",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/org/glassfish/hk2/hk2-api/$version$/hk2-api-$version$-sources.jar",
-    "repository-url" : "https://github.com/javaee/hk2",
-    "test-code-url" : "https://github.com/javaee/hk2/tree/$version$/hk2-api/src/test",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/org/glassfish/hk2/hk2-api/$version$/hk2-api-$version$-javadoc.jar",
-    "description" : "HK2 API provides the core contracts, annotations, descriptors, and service locator interfaces for the HK2 dependency injection framework. It lets applications and HK2 extensions describe services, manage dynamic configurations, resolve injections, define scopes, and observe service lifecycle events.",
-    "tested-versions" : [
-      "2.5.0-b05"
-    ],
-    "allowed-packages" : [
-      "org.glassfish.hk2",
-      "org.jvnet.hk2.annotations"
-    ]
-  },
-  {
     "metadata-version" : "2.6.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/glassfish/hk2/hk2-api/$version$/hk2-api-$version$-sources.jar",
     "repository-url" : "https://github.com/eclipse-ee4j/glassfish-hk2",
@@ -39,6 +24,21 @@
     "description" : "HK2 API provides the core contracts, annotations, descriptors, and service locator interfaces for the HK2 dependency injection framework. It lets applications and HK2 extensions describe services, manage dynamic configurations, resolve injections, define scopes, and observe service lifecycle events.",
     "tested-versions" : [
       "2.5.0"
+    ],
+    "allowed-packages" : [
+      "org.glassfish.hk2",
+      "org.jvnet.hk2.annotations"
+    ]
+  },
+  {
+    "metadata-version" : "2.5.0-b05",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/glassfish/hk2/hk2-api/$version$/hk2-api-$version$-sources.jar",
+    "repository-url" : "https://github.com/javaee/hk2",
+    "test-code-url" : "https://github.com/javaee/hk2/tree/$version$/hk2-api/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/glassfish/hk2/hk2-api/$version$/hk2-api-$version$-javadoc.jar",
+    "description" : "HK2 API provides the core contracts, annotations, descriptors, and service locator interfaces for the HK2 dependency injection framework. It lets applications and HK2 extensions describe services, manage dynamic configurations, resolve injections, define scopes, and observe service lifecycle events.",
+    "tested-versions" : [
+      "2.5.0-b05"
     ],
     "allowed-packages" : [
       "org.glassfish.hk2",


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7355

This PR provides new metadata needed for the org.glassfish.hk2:hk2-api:2.6.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.glassfish.hk2:hk2-api:2.5.0-b05`): 18
- Test-only metadata entries (previous `org.glassfish.hk2:hk2-api:2.5.0-b05`): 1
- Metadata entries (new `org.glassfish.hk2:hk2-api:2.6.0`): 18
- Test-only metadata entries (new `org.glassfish.hk2:hk2-api:2.6.0`): 1
- Library coverage (previous): 14.59%
- Library coverage (new): 14.17%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `53127cfc0bfc6d8a07d43d8618bca90553445894`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.glassfish.hk2:hk2-api:2.5.0-b05: 7/7 covered calls (100.00%)
- org.glassfish.hk2:hk2-api:2.6.0: 7/7 covered calls (100.00%)

**Reflection:**
- org.glassfish.hk2:hk2-api:2.5.0-b05: 6/6 covered calls (100.00%)
- org.glassfish.hk2:hk2-api:2.6.0: 6/6 covered calls (100.00%)

**Resources:**
- org.glassfish.hk2:hk2-api:2.5.0-b05: 1/1 covered calls (100.00%)
- org.glassfish.hk2:hk2-api:2.6.0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.glassfish.hk2:hk2-api:2.5.0-b05: 1309/10677 (12.26%)
- org.glassfish.hk2:hk2-api:2.6.0: 1309/11143 (11.75%)

**Line:**
- org.glassfish.hk2:hk2-api:2.5.0-b05: 345/2365 (14.59%)
- org.glassfish.hk2:hk2-api:2.6.0: 356/2513 (14.17%)

**Method:**
- org.glassfish.hk2:hk2-api:2.5.0-b05: 85/554 (15.34%)
- org.glassfish.hk2:hk2-api:2.6.0: 85/586 (14.51%)

### Local CI Verification

- Status: `success`
- Commands run: 6
- Fixup attempts: 0
