### PR TITLE
[Automation] Generated metadata for org.glassfish.hk2:hk2-api:2.5.0-b05

### DIFF
--- a/tests/src/org.glassfish.hk2/hk2-api/2.5.0-b05/src/test/java/org_glassfish_hk2/hk2_api/ClasspathDescriptorFileFinderTest.java
+++ b/tests/src/org.glassfish.hk2/hk2-api/2.5.0-b05/src/test/java/org_glassfish_hk2/hk2_api/ClasspathDescriptorFileFinderTest.java
@@ -28,12 +28,13 @@ public class ClasspathDescriptorFileFinderTest {
         final List<InputStream> descriptorFiles = finder.findDescriptorFiles();
 
         try {
-            assertThat(descriptorFiles).hasSize(1);
-            final InputStream descriptorFile = descriptorFiles.get(0);
-            final String descriptorText = new String(descriptorFile.readAllBytes(), StandardCharsets.UTF_8);
-            assertThat(descriptorText).contains("org.example.CoverageDescriptor");
+            assertThat(descriptorFiles).isNotEmpty();
+            for (InputStream descriptorFile : descriptorFiles) {
+                final String descriptorText = new String(descriptorFile.readAllBytes(), StandardCharsets.UTF_8);
+                assertThat(descriptorText).contains("org.example.CoverageDescriptor");
+            }
             assertThat(finder.getDescriptorFileInformation())
-                    .hasSize(1)
+                    .hasSize(descriptorFiles.size())
                     .allSatisfy(identifier -> assertThat(identifier).contains(DESCRIPTOR_RESOURCE));
         } finally {
             for (InputStream descriptorFile : descriptorFiles) {


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7354

This PR provides new metadata needed for the org.glassfish.hk2:hk2-api:2.5.0-b05, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.glassfish.hk2:hk2-api:2.5.0-b05`): 18
- Test-only metadata entries (previous `org.glassfish.hk2:hk2-api:2.5.0-b05`): 1
- Metadata entries (new `org.glassfish.hk2:hk2-api:2.5.0-b05`): 18
- Test-only metadata entries (new `org.glassfish.hk2:hk2-api:2.5.0-b05`): 1
- Library coverage (previous): 14.59%
- Library coverage (new): 14.59%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `d1332072d4c790e65c43ca7aed03672ae984da96`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `org.glassfish.hk2:hk2-api:2.5.0-b05` and `org.glassfish.hk2:hk2-api:2.5.0-b05`.

### Local CI Verification

- Status: `success`
- Commands run: 11
- Fixup attempts: 0
