### PR TITLE
[Automation] Generated metadata for org.eclipse.jdt:ecj:3.32.0

### DIFF
--- a/stats/org.eclipse.jdt/ecj/3.32.0/stats.json
+++ b/stats/org.eclipse.jdt/ecj/3.32.0/stats.json
@@ -20,15 +20,15 @@
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 55577,
-        "missed" : 486947,
-        "ratio" : 0.102442,
+        "covered" : 55551,
+        "missed" : 486973,
+        "ratio" : 0.102394,
         "total" : 542524
       },
       "line" : {
-        "covered" : 12837,
-        "missed" : 110496,
-        "ratio" : 0.104084,
+        "covered" : 12833,
+        "missed" : 110500,
+        "ratio" : 0.104052,
         "total" : 123333
       },
       "method" : {


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7352

This PR provides new metadata needed for the org.eclipse.jdt:ecj:3.32.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.eclipse.jdt:ecj:3.26.0`): 1319
- Test-only metadata entries (previous `org.eclipse.jdt:ecj:3.26.0`): 17
- Metadata entries (new `org.eclipse.jdt:ecj:3.32.0`): 1363
- Test-only metadata entries (new `org.eclipse.jdt:ecj:3.32.0`): 17
- Library coverage (previous): 10.59%
- Library coverage (new): 10.41%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `d1332072d4c790e65c43ca7aed03672ae984da96`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.eclipse.jdt:ecj:3.26.0: 55/55 covered calls (100.00%)
- org.eclipse.jdt:ecj:3.32.0: 56/56 covered calls (100.00%)

**Reflection:**
- org.eclipse.jdt:ecj:3.26.0: 29/29 covered calls (100.00%)
- org.eclipse.jdt:ecj:3.32.0: 30/30 covered calls (100.00%)

**Resources:**
- org.eclipse.jdt:ecj:3.26.0: 26/26 covered calls (100.00%)
- org.eclipse.jdt:ecj:3.32.0: 26/26 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.eclipse.jdt:ecj:3.26.0: 54997/528913 (10.40%)
- org.eclipse.jdt:ecj:3.32.0: 55551/542524 (10.24%)

**Line:**
- org.eclipse.jdt:ecj:3.26.0: 12705/119999 (10.59%)
- org.eclipse.jdt:ecj:3.32.0: 12833/123333 (10.41%)

**Method:**
- org.eclipse.jdt:ecj:3.26.0: 1630/10738 (15.18%)
- org.eclipse.jdt:ecj:3.32.0: 1682/11218 (14.99%)

### Local CI Verification

- Status: `success`
- Commands run: 5
- Fixup attempts: 0
