### PR TITLE
[Automation] Generated metadata for org.eclipse.jdt:ecj:3.30.0

### DIFF
--- a/stats/org.eclipse.jdt/ecj/3.30.0/stats.json
+++ b/stats/org.eclipse.jdt/ecj/3.30.0/stats.json
@@ -20,15 +20,15 @@
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 55435,
-        "missed" : 483347,
-        "ratio" : 0.102889,
+        "covered" : 55409,
+        "missed" : 483373,
+        "ratio" : 0.102841,
         "total" : 538782
       },
       "line" : {
-        "covered" : 12790,
-        "missed" : 109632,
-        "ratio" : 0.104475,
+        "covered" : 12786,
+        "missed" : 109636,
+        "ratio" : 0.104442,
         "total" : 122422
       },
       "method" : {


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7351

This PR provides new metadata needed for the org.eclipse.jdt:ecj:3.30.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.eclipse.jdt:ecj:3.26.0`): 1319
- Test-only metadata entries (previous `org.eclipse.jdt:ecj:3.26.0`): 17
- Metadata entries (new `org.eclipse.jdt:ecj:3.30.0`): 1355
- Test-only metadata entries (new `org.eclipse.jdt:ecj:3.30.0`): 17
- Library coverage (previous): 10.59%
- Library coverage (new): 10.44%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `d1332072d4c790e65c43ca7aed03672ae984da96`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.eclipse.jdt:ecj:3.26.0: 55/55 covered calls (100.00%)
- org.eclipse.jdt:ecj:3.30.0: 56/56 covered calls (100.00%)

**Reflection:**
- org.eclipse.jdt:ecj:3.26.0: 29/29 covered calls (100.00%)
- org.eclipse.jdt:ecj:3.30.0: 30/30 covered calls (100.00%)

**Resources:**
- org.eclipse.jdt:ecj:3.26.0: 26/26 covered calls (100.00%)
- org.eclipse.jdt:ecj:3.30.0: 26/26 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.eclipse.jdt:ecj:3.26.0: 54997/528913 (10.40%)
- org.eclipse.jdt:ecj:3.30.0: 55409/538782 (10.28%)

**Line:**
- org.eclipse.jdt:ecj:3.26.0: 12705/119999 (10.59%)
- org.eclipse.jdt:ecj:3.30.0: 12786/122422 (10.44%)

**Method:**
- org.eclipse.jdt:ecj:3.26.0: 1630/10738 (15.18%)
- org.eclipse.jdt:ecj:3.30.0: 1673/11130 (15.03%)

### Local CI Verification

- Status: `success`
- Commands run: 5
- Fixup attempts: 0
