### PR TITLE
[GenAI] Add support for org.apache.activemq:artemis-selector:2.28.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.activemq/artemis-selector/2.28.0/reachability-metadata.json
+++ b/metadata/org.apache.activemq/artemis-selector/2.28.0/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.selector.impl.LRUCache"
+      },
+      "type" : "java.util.HashMap",
+      "methods" : [
+        {
+          "name" : "clone",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.apache.activemq/artemis-selector/index.json
+++ b/metadata/org.apache.activemq/artemis-selector/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.28.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/activemq/artemis-selector/$version$/artemis-selector-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/artemis",
+    "test-code-url" : "https://github.com/apache/artemis/tree/$version$/artemis-selector/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/activemq/artemis-selector/$version$/artemis-selector-$version$-javadoc.jar",
+    "description" : "ActiveMQ Artemis Selector provides the parser and expression model used to evaluate JMS selector-style filter expressions against Artemis messages. It includes JavaCC-generated strict and hyphenated-property parsers plus filter expression implementations for boolean, comparison, arithmetic, XPath, and XQuery predicates.",
+    "tested-versions" : [
+      "2.28.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.activemq.artemis.selector"
+    ]
+  }
+]

--- a/stats/org.apache.activemq/artemis-selector/2.28.0/execution-metrics.json
+++ b/stats/org.apache.activemq/artemis-selector/2.28.0/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-20": {
+    "timestamp": "2026-05-20T16:50:35.127707Z",
+    "library": "org.apache.activemq:artemis-selector:2.28.0",
+    "starting_commit": "2455d676a95fbcad47b02195428b5f882fc6c05b",
+    "ending_commit": "5a5afa3232522520fad278f9f9f3a4732650f9d6",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.28.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 6676,
+          "missed": 9939,
+          "ratio": 0.401806,
+          "total": 16615
+        },
+        "line": {
+          "covered": 1430,
+          "missed": 2275,
+          "ratio": 0.385965,
+          "total": 3705
+        },
+        "method": {
+          "covered": 253,
+          "missed": 276,
+          "ratio": 0.478261,
+          "total": 529
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 146824,
+      "cached_input_tokens_used": 1693696,
+      "output_tokens_used": 15635,
+      "iterations": 3,
+      "cost_usd": 1.3158,
+      "generated_loc": 186,
+      "tested_library_loc": 1430,
+      "metadata_entries": 2,
+      "code_coverage_percent": 38.6
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.activemq/artemis-selector/2.28.0/src/test/java/org_apache_activemq/artemis_selector/Artemis_selectorTest.java",
+      "metadata_file": "metadata/org.apache.activemq/artemis-selector/2.28.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.activemq/artemis-selector/2.28.0/stats.json
+++ b/stats/org.apache.activemq/artemis-selector/2.28.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.28.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 6676,
+        "missed" : 9939,
+        "ratio" : 0.401806,
+        "total" : 16615
+      },
+      "line" : {
+        "covered" : 1430,
+        "missed" : 2275,
+        "ratio" : 0.385965,
+        "total" : 3705
+      },
+      "method" : {
+        "covered" : 253,
+        "missed" : 276,
+        "ratio" : 0.478261,
+        "total" : 529
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.activemq/artemis-selector/2.28.0/.gitignore
+++ b/tests/src/org.apache.activemq/artemis-selector/2.28.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.activemq/artemis-selector/2.28.0/build.gradle
+++ b/tests/src/org.apache.activemq/artemis-selector/2.28.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.activemq:artemis-selector:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.activemq/artemis-selector/2.28.0/gradle.properties
+++ b/tests/src/org.apache.activemq/artemis-selector/2.28.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.activemq:artemis-selector:2.28.0
+library.version = 2.28.0
+metadata.dir = org.apache.activemq/artemis-selector/2.28.0/

--- a/tests/src/org.apache.activemq/artemis-selector/2.28.0/settings.gradle
+++ b/tests/src/org.apache.activemq/artemis-selector/2.28.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.activemq.artemis-selector_tests'

--- a/tests/src/org.apache.activemq/artemis-selector/2.28.0/src/test/java/org_apache_activemq/artemis_selector/Artemis_selectorTest.java
+++ b/tests/src/org.apache.activemq/artemis-selector/2.28.0/src/test/java/org_apache_activemq/artemis_selector/Artemis_selectorTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_activemq.artemis_selector;
+
+import org.junit.jupiter.api.Test;
+
+class Artemis_selectorTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.apache.activemq/artemis-selector/2.28.0/src/test/java/org_apache_activemq/artemis_selector/Artemis_selectorTest.java
+++ b/tests/src/org.apache.activemq/artemis-selector/2.28.0/src/test/java/org_apache_activemq/artemis_selector/Artemis_selectorTest.java
@@ -9,11 +9,13 @@ package org_apache_activemq.artemis_selector;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.selector.filter.BooleanExpression;
 import org.apache.activemq.artemis.selector.filter.FilterException;
 import org.apache.activemq.artemis.selector.filter.Filterable;
+import org.apache.activemq.artemis.selector.filter.XPathExpression;
 import org.apache.activemq.artemis.selector.impl.LRUCache;
 import org.apache.activemq.artemis.selector.impl.SelectorParser;
 import org.junit.jupiter.api.Test;
@@ -108,6 +110,31 @@ public class Artemis_selectorTest {
         assertThatExceptionOfType(FilterException.class)
                 .isThrownBy(() -> SelectorParser.parse("priority >"))
                 .withMessageContaining("priority >");
+    }
+
+    @Test
+    void delegatesXPathSelectorsToConfiguredEvaluatorFactory() throws Exception {
+        XPathExpression.XPathEvaluatorFactory originalFactory = XPathExpression.XPATH_EVALUATOR_FACTORY;
+        AtomicReference<String> requestedXPath = new AtomicReference<>();
+
+        try {
+            XPathExpression.XPATH_EVALUATOR_FACTORY = xpath -> {
+                requestedXPath.set(xpath);
+                return message -> "accepted".equals(message.getProperty(SimpleString.toSimpleString("routing")));
+            };
+
+            BooleanExpression selector = SelectorParser.parse("XPATH 'routing-check'");
+            TestFilterable accepted = filterable(Map.of("routing", "accepted"));
+            TestFilterable rejected = filterable(Map.of("routing", "rejected"));
+
+            assertThat(requestedXPath).hasValue("routing-check");
+            assertThat(selector.evaluate(accepted)).isEqualTo(Boolean.TRUE);
+            assertThat(selector.matches(accepted)).isTrue();
+            assertThat(selector.matches(rejected)).isFalse();
+            assertThat(selector.toString()).isEqualTo("XPATH 'routing-check'");
+        } finally {
+            XPathExpression.XPATH_EVALUATOR_FACTORY = originalFactory;
+        }
     }
 
     @Test

--- a/tests/src/org.apache.activemq/artemis-selector/2.28.0/src/test/java/org_apache_activemq/artemis_selector/Artemis_selectorTest.java
+++ b/tests/src/org.apache.activemq/artemis-selector/2.28.0/src/test/java/org_apache_activemq/artemis_selector/Artemis_selectorTest.java
@@ -89,6 +89,17 @@ public class Artemis_selectorTest {
     }
 
     @Test
+    void decodesEscapedApostrophesInStringLiterals() throws Exception {
+        TestFilterable message = filterable(Map.of("customer", "Bob's Bikes"));
+
+        BooleanExpression selector = SelectorParser.parse("customer = 'Bob''s Bikes'");
+
+        assertThat(selector.evaluate(message)).isEqualTo(Boolean.TRUE);
+        assertThat(selector.matches(message)).isTrue();
+        assertThat(SelectorParser.parse("customer = 'Bobs Bikes'").matches(message)).isFalse();
+    }
+
+    @Test
     void supportsQuotedIdentifiersAndXmlBodySelectors() throws Exception {
         TestFilterable message = filterable(
                 Map.of("quoted property", "expected"),

--- a/tests/src/org.apache.activemq/artemis-selector/2.28.0/src/test/java/org_apache_activemq/artemis_selector/Artemis_selectorTest.java
+++ b/tests/src/org.apache.activemq/artemis-selector/2.28.0/src/test/java/org_apache_activemq/artemis_selector/Artemis_selectorTest.java
@@ -6,11 +6,179 @@
  */
 package org_apache_activemq.artemis_selector;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.selector.filter.BooleanExpression;
+import org.apache.activemq.artemis.selector.filter.FilterException;
+import org.apache.activemq.artemis.selector.filter.Filterable;
+import org.apache.activemq.artemis.selector.impl.LRUCache;
+import org.apache.activemq.artemis.selector.impl.SelectorParser;
 import org.junit.jupiter.api.Test;
 
-class Artemis_selectorTest {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+public class Artemis_selectorTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void evaluatesComparisonsLogicAndArithmeticSelectors() throws Exception {
+        TestFilterable message = filterable(Map.of(
+                "priority", 8,
+                "category", "orders",
+                "price", 10,
+                "quantity", 7,
+                "adjustment", 5,
+                "active", true));
+
+        BooleanExpression selector = SelectorParser.parse("""
+                priority >= 5
+                AND category = 'orders'
+                AND active = TRUE
+                AND ((price * quantity) + adjustment) / 2 >= 37.5
+                AND price % 2 = 0
+                """);
+
+        assertThat(selector.evaluate(message)).isEqualTo(Boolean.TRUE);
+        assertThat(selector.matches(message)).isTrue();
+        assertThat(SelectorParser.parse("NOT (priority < 10 OR category <> 'orders')").matches(message)).isFalse();
+    }
+
+    @Test
+    void evaluatesSetRangePatternAndNullOperators() throws Exception {
+        TestFilterable matching = filterable(Map.of(
+                "status", "S5",
+                "symbol", "A_2024",
+                "score", 42,
+                "name", "consumer"));
+        TestFilterable nonMatching = filterable(Map.of(
+                "status", "S7",
+                "symbol", "AB2024",
+                "score", 101,
+                "name", "consumer"));
+
+        BooleanExpression selector = SelectorParser.parse("""
+                status IN ('S1', 'S2', 'S3', 'S4', 'S5')
+                AND symbol LIKE 'A!_%' ESCAPE '!'
+                AND score BETWEEN 40 AND 50
+                AND name IS NOT NULL
+                AND missing IS NULL
+                """);
+
+        assertThat(selector.matches(matching)).isTrue();
+        assertThat(selector.matches(nonMatching)).isFalse();
+        assertThat(SelectorParser.parse("status NOT IN ('S1', 'S2') AND score NOT BETWEEN 1 AND 10")
+                .matches(matching)).isTrue();
+        assertThat(SelectorParser.parse("missing = 'value'").evaluate(matching)).isNull();
+    }
+
+    @Test
+    void honorsParserPrefixesForStringConversionAndHyphenatedProperties() throws Exception {
+        TestFilterable message = filterable(Map.of(
+                "age", "30",
+                "enabled", "true",
+                "order-id", "A-42"));
+
+        assertThat(SelectorParser.parse("age > 20 OR enabled = TRUE").matches(message)).isFalse();
+        assertThat(SelectorParser.parse("convert_string_expressions:age > 20 AND enabled = TRUE")
+                .matches(message)).isTrue();
+        assertThat(SelectorParser.parse("hyphenated_props:order-id = 'A-42'").matches(message)).isTrue();
+    }
+
+    @Test
+    void supportsQuotedIdentifiersAndXmlBodySelectors() throws Exception {
+        TestFilterable message = filterable(
+                Map.of("quoted property", "expected"),
+                """
+                        <order>
+                            <customer tier="gold">Ada</customer>
+                            <total>19.99</total>
+                        </order>
+                        """);
+
+        assertThat(SelectorParser.parse("\"quoted property\" = 'expected'").matches(message)).isTrue();
+        assertThat(SelectorParser.parse("XPATH '/order/customer[@tier=\"gold\"]'").matches(message)).isTrue();
+        assertThat(SelectorParser.parse("XPATH '/order/customer[@tier=\"silver\"]'").matches(message)).isFalse();
+        assertThat(SelectorParser.parse("XQUERY '/order/customer'").matches(message)).isFalse();
+    }
+
+    @Test
+    void reportsInvalidSelectorsAsFilterExceptions() {
+        assertThatExceptionOfType(FilterException.class)
+                .isThrownBy(() -> SelectorParser.parse("priority >"))
+                .withMessageContaining("priority >");
+    }
+
+    @Test
+    void evictsLeastRecentlyUsedEntriesFromCache() {
+        RecordingCache<String, Integer> cache = new RecordingCache<>(2, true);
+
+        cache.put("one", 1);
+        cache.put("two", 2);
+        assertThat(cache.get("one")).isEqualTo(1);
+        cache.put("three", 3);
+
+        assertThat(cache).containsOnlyKeys("one", "three");
+        assertThat(cache.evictedKeys).containsExactly("two");
+        assertThat(cache.getMaxCacheSize()).isEqualTo(2);
+
+        cache.setMaxCacheSize(1);
+        cache.clear();
+        cache.put("four", 4);
+        cache.put("five", 5);
+
+        assertThat(cache).containsOnlyKeys("five");
+        assertThat(cache.evictedKeys).containsExactly("two", "four");
+    }
+
+    private static TestFilterable filterable(Map<String, Object> properties) {
+        return filterable(properties, null);
+    }
+
+    private static TestFilterable filterable(Map<String, Object> properties, String body) {
+        return new TestFilterable(properties, body);
+    }
+
+    private static final class TestFilterable implements Filterable {
+        private final Map<String, Object> properties;
+        private final String body;
+
+        private TestFilterable(Map<String, Object> properties, String body) {
+            this.properties = properties;
+            this.body = body;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getBodyAs(Class<T> type) {
+            if (type == String.class) {
+                return (T) body;
+            }
+            return null;
+        }
+
+        @Override
+        public Object getProperty(SimpleString name) {
+            return properties.get(name.toString());
+        }
+
+        @Override
+        public Object getLocalConnectionId() {
+            return "test-connection";
+        }
+    }
+
+    private static final class RecordingCache<K, V> extends LRUCache<K, V> {
+        private final List<K> evictedKeys = new ArrayList<>();
+
+        private RecordingCache(int maximumCacheSize, boolean accessOrder) {
+            super(0, maximumCacheSize, 0.75f, accessOrder);
+        }
+
+        @Override
+        protected void onCacheEviction(Map.Entry<K, V> eldest) {
+            evictedKeys.add(eldest.getKey());
+        }
     }
 }

--- a/tests/src/org.apache.activemq/artemis-selector/2.28.0/user-code-filter.json
+++ b/tests/src/org.apache.activemq/artemis-selector/2.28.0/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.apache.activemq.artemis.selector.**"
+      "includeClasses" : "org.apache.activemq.artemis.selector.**"
+    },
+    {
+      "includeClasses" : "org_apache_activemq.artemis_selector.**"
     }
   ]
 }

--- a/tests/src/org.apache.activemq/artemis-selector/2.28.0/user-code-filter.json
+++ b/tests/src/org.apache.activemq/artemis-selector/2.28.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.apache.activemq.artemis.selector.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #1475

This PR introduces tests and metadata for org.apache.activemq:artemis-selector:2.28.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 146824
- Cached input tokens: 1693696
- Output tokens: 15635
- Metadata entries: 2
- Iterations: 3
- Library coverage percentage: 38.6
- Generated lines of code: 186
- Tested library lines of code: 1430

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `bf0947e5bf2f1457918d26b5946e1e051d393df2`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 6676/16615 (40.18%)
- Line: 1430/3705 (38.60%)
- Method: 253/529 (47.83%)

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
