### PR TITLE
[Automation] Generated metadata for org.eclipse.jdt:ecj:3.28.0

### DIFF
--- a/stats/org.eclipse.jdt/ecj/3.28.0/stats.json
+++ b/stats/org.eclipse.jdt/ecj/3.28.0/stats.json
@@ -20,15 +20,15 @@
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 55365,
-        "missed" : 477574,
-        "ratio" : 0.103886,
+        "covered" : 55339,
+        "missed" : 477600,
+        "ratio" : 0.103837,
         "total" : 532939
       },
       "line" : {
-        "covered" : 12766,
-        "missed" : 108126,
-        "ratio" : 0.105598,
+        "covered" : 12762,
+        "missed" : 108130,
+        "ratio" : 0.105565,
         "total" : 120892
       },
       "method" : {


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7349

This PR provides new metadata needed for the org.eclipse.jdt:ecj:3.28.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.eclipse.jdt:ecj:3.26.0`): 1319
- Test-only metadata entries (previous `org.eclipse.jdt:ecj:3.26.0`): 17
- Metadata entries (new `org.eclipse.jdt:ecj:3.28.0`): 1345
- Test-only metadata entries (new `org.eclipse.jdt:ecj:3.28.0`): 17
- Library coverage (previous): 10.59%
- Library coverage (new): 10.56%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `bf0947e5bf2f1457918d26b5946e1e051d393df2`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.eclipse.jdt:ecj:3.26.0: 55/55 covered calls (100.00%)
- org.eclipse.jdt:ecj:3.28.0: 56/56 covered calls (100.00%)

**Reflection:**
- org.eclipse.jdt:ecj:3.26.0: 29/29 covered calls (100.00%)
- org.eclipse.jdt:ecj:3.28.0: 30/30 covered calls (100.00%)

**Resources:**
- org.eclipse.jdt:ecj:3.26.0: 26/26 covered calls (100.00%)
- org.eclipse.jdt:ecj:3.28.0: 26/26 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.eclipse.jdt:ecj:3.26.0: 54997/528913 (10.40%)
- org.eclipse.jdt:ecj:3.28.0: 55339/532939 (10.38%)

**Line:**
- org.eclipse.jdt:ecj:3.26.0: 12705/119999 (10.59%)
- org.eclipse.jdt:ecj:3.28.0: 12762/120892 (10.56%)

**Method:**
- org.eclipse.jdt:ecj:3.26.0: 1630/10738 (15.18%)
- org.eclipse.jdt:ecj:3.28.0: 1668/11040 (15.11%)

### Local CI Verification

- Status: `success`
- Commands run: 5
- Fixup attempts: 0
