### PR TITLE
[Automation] Generated metadata for org.eclipse.jdt:ecj:3.27.0

### DIFF
--- a/stats/org.eclipse.jdt/ecj/3.27.0/stats.json
+++ b/stats/org.eclipse.jdt/ecj/3.27.0/stats.json
@@ -20,15 +20,15 @@
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 55234,
-        "missed" : 474505,
-        "ratio" : 0.104266,
+        "covered" : 55208,
+        "missed" : 474531,
+        "ratio" : 0.104217,
         "total" : 529739
       },
       "line" : {
-        "covered" : 12747,
-        "missed" : 107414,
-        "ratio" : 0.106083,
+        "covered" : 12743,
+        "missed" : 107418,
+        "ratio" : 0.106049,
         "total" : 120161
       },
       "method" : {


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7348

This PR provides new metadata needed for the org.eclipse.jdt:ecj:3.27.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.eclipse.jdt:ecj:3.26.0`): 1319
- Test-only metadata entries (previous `org.eclipse.jdt:ecj:3.26.0`): 17
- Metadata entries (new `org.eclipse.jdt:ecj:3.27.0`): 1325
- Test-only metadata entries (new `org.eclipse.jdt:ecj:3.27.0`): 17
- Library coverage (previous): 10.59%
- Library coverage (new): 10.60%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `108b6bc65a12913315690d8c973df0e3ee8f6818`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.eclipse.jdt:ecj:3.26.0: 55/55 covered calls (100.00%)
- org.eclipse.jdt:ecj:3.27.0: 56/56 covered calls (100.00%)

**Reflection:**
- org.eclipse.jdt:ecj:3.26.0: 29/29 covered calls (100.00%)
- org.eclipse.jdt:ecj:3.27.0: 30/30 covered calls (100.00%)

**Resources:**
- org.eclipse.jdt:ecj:3.26.0: 26/26 covered calls (100.00%)
- org.eclipse.jdt:ecj:3.27.0: 26/26 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.eclipse.jdt:ecj:3.26.0: 54997/528913 (10.40%)
- org.eclipse.jdt:ecj:3.27.0: 55208/529739 (10.42%)

**Line:**
- org.eclipse.jdt:ecj:3.26.0: 12705/119999 (10.59%)
- org.eclipse.jdt:ecj:3.27.0: 12743/120161 (10.60%)

**Method:**
- org.eclipse.jdt:ecj:3.26.0: 1630/10738 (15.18%)
- org.eclipse.jdt:ecj:3.27.0: 1657/10922 (15.17%)

### Local CI Verification

- Status: `success`
- Commands run: 5
- Fixup attempts: 0
