### PR TITLE
[Automation] Generated metadata for org.eclipse.jdt:ecj:3.26.0

### DIFF
--- a/metadata/org.eclipse.jdt/ecj/3.26.0/reachability-metadata.json
+++ b/metadata/org.eclipse.jdt/ecj/3.26.0/reachability-metadata.json
@@ -3793,6 +3793,18 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.lookup.SourceTypeBinding"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
         "typeReached" : "org.eclipse.jdt.internal.compiler.lookup.TypeBinding"
       },
       "type" : "sun.security.provider.SHA2$SHA256",

--- a/stats/org.eclipse.jdt/ecj/3.26.0/stats.json
+++ b/stats/org.eclipse.jdt/ecj/3.26.0/stats.json
@@ -20,15 +20,15 @@
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 54997,
-        "missed" : 473916,
-        "ratio" : 0.103981,
+        "covered" : 54971,
+        "missed" : 473942,
+        "ratio" : 0.103932,
         "total" : 528913
       },
       "line" : {
-        "covered" : 12705,
-        "missed" : 107294,
-        "ratio" : 0.105876,
+        "covered" : 12701,
+        "missed" : 107298,
+        "ratio" : 0.105843,
         "total" : 119999
       },
       "method" : {


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7347

This PR provides new metadata needed for the org.eclipse.jdt:ecj:3.26.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.eclipse.jdt:ecj:3.26.0`): 1321
- Test-only metadata entries (previous `org.eclipse.jdt:ecj:3.26.0`): 17
- Metadata entries (new `org.eclipse.jdt:ecj:3.26.0`): 1321
- Test-only metadata entries (new `org.eclipse.jdt:ecj:3.26.0`): 17
- Library coverage (previous): 10.58%
- Library coverage (new): 10.58%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `ca2d6d45611fadea909f0f50ccbfab3eb3e5b139`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `org.eclipse.jdt:ecj:3.26.0` and `org.eclipse.jdt:ecj:3.26.0`.

### Local CI Verification

- Status: `success`
- Commands run: 12
- Fixup attempts: 0
