### PR TITLE
[GenAI] Test fix for org.eclipse.angus:angus-mail:1.1.0 using gpt-5.5

### DIFF
--- a/metadata/org.eclipse.angus/angus-mail/1.1.0/reachability-metadata.json
+++ b/metadata/org.eclipse.angus/angus-mail/1.1.0/reachability-metadata.json
@@ -1,0 +1,238 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.sun.mail.util.logging.MailHandler"
+      },
+      "type" : "com.sun.mail.smtp.SMTPTransport",
+      "allDeclaredConstructors" : true,
+      "methods" : [
+        {
+          "name" : "getLocalHost",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.mail.util.logging.MailHandler"
+      },
+      "type" : "com.sun.mail.util.logging.CollectorFormatter",
+      "allDeclaredConstructors" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.mail.util.logging.MailHandler"
+      },
+      "type" : "java.util.logging.ErrorManager",
+      "allPublicConstructors" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.mail.util.logging.CollectorFormatter"
+      },
+      "type" : "com.sun.mail.util.logging.CompactFormatter",
+      "allDeclaredConstructors" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.mail.util.logging.CompactFormatter"
+      },
+      "type" : "java.lang.Math"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.mail.util.logging.CompactFormatter"
+      },
+      "type" : "java.lang.Throwable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.mail.util.logging.CollectorFormatter"
+      },
+      "type" : "com.sun.mail.util.logging.SeverityComparator",
+      "allDeclaredConstructors" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.mail.util.logging.CollectorFormatter"
+      },
+      "type" : "org.example.DoesNotExist"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.mail.util.logging.CollectorFormatter"
+      },
+      "type" : "org.example.ContextFormatter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.mail.util.logging.LogManagerProperties"
+      },
+      "type" : "com.sun.mail.handlers.image_gif",
+      "allDeclaredConstructors" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.mail.util.logging.LogManagerProperties"
+      },
+      "type" : "com.sun.mail.handlers.image_jpeg",
+      "allDeclaredConstructors" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.mail.util.logging.LogManagerProperties"
+      },
+      "type" : "com.sun.mail.handlers.message_rfc822",
+      "allDeclaredConstructors" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.mail.util.logging.LogManagerProperties"
+      },
+      "type" : "com.sun.mail.handlers.multipart_mixed",
+      "allDeclaredConstructors" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.mail.util.logging.LogManagerProperties"
+      },
+      "type" : "com.sun.mail.handlers.text_html",
+      "allDeclaredConstructors" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.mail.util.logging.LogManagerProperties"
+      },
+      "type" : "com.sun.mail.handlers.text_plain",
+      "allDeclaredConstructors" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.mail.util.logging.LogManagerProperties"
+      },
+      "type" : "com.sun.mail.handlers.text_xml",
+      "allDeclaredConstructors" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.mail.util.logging.LogManagerProperties"
+      },
+      "type" : "java.util.Comparator",
+      "methods" : [
+        {
+          "name" : "reversed",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.mail.util.logging.LogManagerProperties"
+      },
+      "type" : "java.time.Duration",
+      "methods" : [
+        {
+          "name" : "parse",
+          "parameterTypes" : [
+            "java.lang.CharSequence"
+          ]
+        },
+        {
+          "name" : "toMillis",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.mail.util.logging.LogManagerProperties"
+      },
+      "type" : "java.time.ZoneId",
+      "methods" : [
+        {
+          "name" : "systemDefault",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.mail.util.logging.LogManagerProperties"
+      },
+      "type" : "java.time.ZonedDateTime",
+      "methods" : [
+        {
+          "name" : "ofInstant",
+          "parameterTypes" : [
+            "java.time.Instant",
+            "java.time.ZoneId"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.mail.util.logging.LogManagerProperties"
+      },
+      "type" : "java.util.logging.LogRecord",
+      "methods" : [
+        {
+          "name" : "getInstant",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.mail.iap.Protocol"
+      },
+      "type" : "javax.net.ssl.SSLSocket",
+      "fields" : [
+        {
+          "name" : "socket"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.mail.iap.Protocol"
+      },
+      "type" : "java.net.Socket",
+      "fields" : [
+        {
+          "name" : "socket"
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "glob" : "META-INF/javamail.address.map"
+    },
+    {
+      "glob" : "META-INF/javamail.charset.map"
+    },
+    {
+      "glob" : "META-INF/javamail.default.address.map"
+    },
+    {
+      "glob" : "META-INF/javamail.default.providers"
+    },
+    {
+      "glob" : "META-INF/javamail.providers"
+    },
+    {
+      "glob" : "META-INF/mailcap"
+    },
+    {
+      "glob" : "META-INF/mailcap.default"
+    },
+    {
+      "glob" : "META-INF/mime.types"
+    },
+    {
+      "glob" : "META-INF/mimetypes.default"
+    }
+  ]
+}

--- a/metadata/org.eclipse.angus/angus-mail/index.json
+++ b/metadata/org.eclipse.angus/angus-mail/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.1.0",
+    "tested-versions" : [
+      "1.1.0"
+    ],
+    "allowed-packages" : [
+      "com.sun.mail"
+    ]
+  },
+  {
     "metadata-version" : "1.0.0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/eclipse/angus/angus-mail/$version$/angus-mail-$version$-sources.jar",
     "repository-url" : "https://github.com/eclipse-ee4j/angus-mail",

--- a/metadata/org.eclipse.angus/angus-mail/index.json
+++ b/metadata/org.eclipse.angus/angus-mail/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.1.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/eclipse/angus/angus-mail/$version$/angus-mail-$version$-sources.jar",
+    "repository-url" : "https://github.com/eclipse-ee4j/angus-mail",
+    "test-code-url" : "https://github.com/eclipse-ee4j/angus-mail/tree/$version$/providers/angus-mail/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/eclipse/angus/angus-mail/$version$/angus-mail-$version$-javadoc.jar",
+    "description" : "Angus Mail is the Eclipse implementation of the Jakarta Mail provider stack. The angus-mail artifact packages core utilities, SMTP, IMAP, POP3, MIME handlers, and logging mail handler classes used by Jakarta Mail clients.",
     "tested-versions" : [
       "1.1.0"
     ],

--- a/stats/org.eclipse.angus/angus-mail/1.1.0/execution-metrics.json
+++ b/stats/org.eclipse.angus/angus-mail/1.1.0/execution-metrics.json
@@ -1,0 +1,101 @@
+{
+  "fix_java_run_fail:2026-05-20": {
+    "timestamp": "2026-05-20T20:49:46.240107Z",
+    "library": "org.eclipse.angus:angus-mail:1.1.0",
+    "starting_commit": "f6f06ecf9545496942804550750a6d22b1348b57",
+    "ending_commit": "d8cde6a74a27283d5ea2c2f14e8f35060e3bcabd",
+    "previous_library": "org.eclipse.angus:angus-mail:1.0.0",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.1.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.978261,
+            "coveredCalls": 45,
+            "totalCalls": 46
+          }
+        },
+        "coverageRatio": 0.978261,
+        "coveredCalls": 45,
+        "totalCalls": 46
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 11547,
+          "missed": 53994,
+          "ratio": 0.17618,
+          "total": 65541
+        },
+        "line": {
+          "covered": 2705,
+          "missed": 12076,
+          "ratio": 0.183005,
+          "total": 14781
+        },
+        "method": {
+          "covered": 453,
+          "missed": 1451,
+          "ratio": 0.23792,
+          "total": 1904
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.0.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.978261,
+            "coveredCalls": 45,
+            "totalCalls": 46
+          }
+        },
+        "coverageRatio": 0.978261,
+        "coveredCalls": 45,
+        "totalCalls": 46
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 11600,
+          "missed": 53595,
+          "ratio": 0.177928,
+          "total": 65195
+        },
+        "line": {
+          "covered": 2726,
+          "missed": 11975,
+          "ratio": 0.18543,
+          "total": 14701
+        },
+        "method": {
+          "covered": 461,
+          "missed": 1428,
+          "ratio": 0.244044,
+          "total": 1889
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 136880,
+      "cached_input_tokens_used": 1341952,
+      "output_tokens_used": 26842,
+      "iterations": 3,
+      "cost_usd": 1.4763,
+      "tested_library_loc": 2705,
+      "metadata_entries": 53,
+      "test_only_metadata_entries": 2,
+      "previous_library_metadata_entries": 53,
+      "previous_library_test_only_metadata_entries": 2,
+      "code_coverage_percent": 18.3,
+      "previous_library_coverage_percent": 18.54
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.eclipse.angus/angus-mail/1.1.0/src/test/java/org_eclipse_angus/angus_mail/WriteTimeoutSocketTest.java",
+      "metadata_file": "metadata/org.eclipse.angus/angus-mail/1.1.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.eclipse.angus/angus-mail/1.1.0/stats.json
+++ b/stats/org.eclipse.angus/angus-mail/1.1.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "1.1.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.978261,
+          "coveredCalls" : 45,
+          "totalCalls" : 46
+        }
+      },
+      "coverageRatio" : 0.978261,
+      "coveredCalls" : 45,
+      "totalCalls" : 46
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 11547,
+        "missed" : 53994,
+        "ratio" : 0.17618,
+        "total" : 65541
+      },
+      "line" : {
+        "covered" : 2705,
+        "missed" : 12076,
+        "ratio" : 0.183005,
+        "total" : 14781
+      },
+      "method" : {
+        "covered" : 453,
+        "missed" : 1451,
+        "ratio" : 0.23792,
+        "total" : 1904
+      }
+    }
+  } ]
+}

--- a/tests/src/org.eclipse.angus/angus-mail/1.1.0/.gitignore
+++ b/tests/src/org.eclipse.angus/angus-mail/1.1.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.eclipse.angus/angus-mail/1.1.0/build.gradle
+++ b/tests/src/org.eclipse.angus/angus-mail/1.1.0/build.gradle
@@ -1,0 +1,37 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.eclipse.angus:angus-mail:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        binaries {
+            test {
+                buildArgs.add('--add-exports=java.base/sun.security.util=ALL-UNNAMED')
+            }
+        }
+
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}
+
+tasks.withType(Test).configureEach {
+    jvmArgs '--add-exports', 'java.base/sun.security.util=ALL-UNNAMED'
+}

--- a/tests/src/org.eclipse.angus/angus-mail/1.1.0/gradle.properties
+++ b/tests/src/org.eclipse.angus/angus-mail/1.1.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.eclipse.angus:angus-mail:1.1.0
+library.version = 1.1.0
+metadata.dir = org.eclipse.angus/angus-mail/1.1.0/

--- a/tests/src/org.eclipse.angus/angus-mail/1.1.0/settings.gradle
+++ b/tests/src/org.eclipse.angus/angus-mail/1.1.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.eclipse.angus.angus-mail_tests'

--- a/tests/src/org.eclipse.angus/angus-mail/1.1.0/src/test/java/org_eclipse_angus/angus_mail/IMAPProtocolTest.java
+++ b/tests/src/org.eclipse.angus/angus-mail/1.1.0/src/test/java/org_eclipse_angus/angus_mail/IMAPProtocolTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_angus.angus_mail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.mail.imap.protocol.IMAPProtocol;
+import com.sun.mail.imap.protocol.IMAPResponse;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+public class IMAPProtocolTest {
+    @Test
+    public void saslLoginInstantiatesDefaultSaslAuthenticator() throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty("mail.imap.reusetagprefix", "true");
+        ByteArrayOutputStream clientOutput = new ByteArrayOutputStream();
+        IMAPProtocol protocol = newProtocol(properties, clientOutput);
+
+        protocol.handleCapabilityResponse(new IMAPResponse[] {
+            new IMAPResponse("* CAPABILITY IMAP4rev1 AUTH=CRAM-MD5")
+        });
+
+        try {
+            try {
+                protocol.sasllogin(new String[] {"CRAM-MD5"}, null, null, "user", "password");
+            } catch (UnsupportedOperationException exception) {
+                assertThat(exception).hasMessageContaining("SASL");
+                return;
+            }
+
+            assertThat(protocol.isAuthenticated()).isTrue();
+            assertThat(clientOutput.toString(StandardCharsets.US_ASCII)).contains("A0 AUTHENTICATE CRAM-MD5");
+        } finally {
+            protocol.disconnect();
+        }
+    }
+
+    private static IMAPProtocol newProtocol(Properties properties, ByteArrayOutputStream clientOutput) throws Exception {
+        String serverResponses = "+ PDEyMzQ1Njc4OTA=\r\n"
+                + "A0 OK SASL authentication succeeded\r\n";
+        ByteArrayInputStream serverInput = new ByteArrayInputStream(serverResponses.getBytes(StandardCharsets.US_ASCII));
+        PrintStream clientPrintStream = new PrintStream(clientOutput, true, StandardCharsets.US_ASCII);
+        return new IMAPProtocol(serverInput, clientPrintStream, properties, false);
+    }
+}

--- a/tests/src/org.eclipse.angus/angus-mail/1.1.0/src/test/java/org_eclipse_angus/angus_mail/IMAPStoreTest.java
+++ b/tests/src/org.eclipse.angus/angus-mail/1.1.0/src/test/java/org_eclipse_angus/angus_mail/IMAPStoreTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_angus.angus_mail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.mail.imap.IMAPFolder;
+import com.sun.mail.imap.IMAPStore;
+import com.sun.mail.imap.protocol.IMAPResponse;
+import com.sun.mail.imap.protocol.ListInfo;
+import jakarta.mail.Session;
+import jakarta.mail.URLName;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+
+public class IMAPStoreTest {
+    @Test
+    public void configuredFolderClassCreatesFoldersFromNamesAndListResponses() throws Exception {
+        RecordingIMAPFolder.reset();
+        ExposedIMAPStore store = new ExposedIMAPStore(newSessionWithFolderClass());
+
+        IMAPFolder namedFolder = store.createFolder("Projects", '/');
+        IMAPFolder listedFolder = store.createFolder(newListInfo("Archive"));
+
+        assertThat(namedFolder).isInstanceOf(RecordingIMAPFolder.class);
+        assertThat(listedFolder).isInstanceOf(RecordingIMAPFolder.class);
+        assertThat(RecordingIMAPFolder.nameConstructorCalls).hasValue(1);
+        assertThat(RecordingIMAPFolder.listInfoConstructorCalls).hasValue(1);
+    }
+
+    @Test
+    public void configuredFolderClassFallsBackToImapStoreClassLoader() throws Exception {
+        try {
+            ClassLoader loader = new IsolatingStoreClassLoader();
+            Class<?> storeClass = loader.loadClass(IsolatedIMAPStore.class.getName());
+
+            Object store = storeClass
+                .getConstructor(Session.class, URLName.class)
+                .newInstance(newSessionWithFolderClass(), new URLName("imap://localhost"));
+
+            assertThat(store).isInstanceOf(IMAPStore.class);
+        } catch (InvocationTargetException exception) {
+            Throwable cause = exception.getCause();
+            if (cause instanceof Error error && NativeImageSupport.isUnsupportedFeatureError(error)) {
+                return;
+            }
+            throw exception;
+        } catch (Error error) {
+            if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                throw error;
+            }
+        }
+    }
+
+    private static Session newSessionWithFolderClass() {
+        Properties properties = new Properties();
+        properties.setProperty("mail.imap.folder.class", RecordingIMAPFolder.class.getName());
+        return Session.getInstance(properties);
+    }
+
+    private static ListInfo newListInfo(String name) throws Exception {
+        return new ListInfo(new IMAPResponse("* LIST (\\Marked) \"/\" " + name));
+    }
+
+    public static final class ExposedIMAPStore extends IMAPStore {
+        private ExposedIMAPStore(Session session) {
+            super(session, new URLName("imap://localhost"));
+        }
+
+        private IMAPFolder createFolder(String fullName, char separator) {
+            return newIMAPFolder(fullName, separator);
+        }
+
+        private IMAPFolder createFolder(ListInfo listInfo) {
+            return newIMAPFolder(listInfo);
+        }
+    }
+
+    public static final class IsolatedIMAPStore extends IMAPStore {
+        public IsolatedIMAPStore(Session session, URLName urlName) {
+            super(session, urlName);
+        }
+    }
+
+    public static final class RecordingIMAPFolder extends IMAPFolder {
+        private static final AtomicInteger nameConstructorCalls = new AtomicInteger();
+        private static final AtomicInteger listInfoConstructorCalls = new AtomicInteger();
+
+        public RecordingIMAPFolder(String fullName, char separator, IMAPStore store, Boolean isNamespace) {
+            super(fullName, separator, store, isNamespace);
+            nameConstructorCalls.incrementAndGet();
+        }
+
+        public RecordingIMAPFolder(ListInfo listInfo, IMAPStore store) {
+            super(listInfo, store);
+            listInfoConstructorCalls.incrementAndGet();
+        }
+
+        private static void reset() {
+            nameConstructorCalls.set(0);
+            listInfoConstructorCalls.set(0);
+        }
+    }
+
+    private static final class IsolatingStoreClassLoader extends ClassLoader {
+        private IsolatingStoreClassLoader() {
+            super(IMAPStore.class.getClassLoader());
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (RecordingIMAPFolder.class.getName().equals(name)) {
+                throw new ClassNotFoundException(name);
+            }
+            if (IsolatedIMAPStore.class.getName().equals(name)) {
+                Class<?> loadedClass = findLoadedClass(name);
+                if (loadedClass == null) {
+                    loadedClass = findClass(name);
+                }
+                if (resolve) {
+                    resolveClass(loadedClass);
+                }
+                return loadedClass;
+            }
+            return super.loadClass(name, resolve);
+        }
+
+        @Override
+        protected Class<?> findClass(String name) throws ClassNotFoundException {
+            if (!IsolatedIMAPStore.class.getName().equals(name)) {
+                throw new ClassNotFoundException(name);
+            }
+            byte[] bytes = readClassBytes(name);
+            return defineClass(name, bytes, 0, bytes.length);
+        }
+
+        private static byte[] readClassBytes(String name) throws ClassNotFoundException {
+            String resourceName = name.replace('.', '/') + ".class";
+            try (InputStream input = IMAPStoreTest.class.getClassLoader().getResourceAsStream(resourceName)) {
+                if (input == null) {
+                    throw new ClassNotFoundException(name);
+                }
+                ByteArrayOutputStream output = new ByteArrayOutputStream();
+                input.transferTo(output);
+                return output.toByteArray();
+            } catch (IOException exception) {
+                ClassNotFoundException classNotFoundException = new ClassNotFoundException(name);
+                classNotFoundException.initCause(exception);
+                throw classNotFoundException;
+            }
+        }
+    }
+}

--- a/tests/src/org.eclipse.angus/angus-mail/1.1.0/src/test/java/org_eclipse_angus/angus_mail/LogManagerPropertiesTest.java
+++ b/tests/src/org.eclipse.angus/angus-mail/1.1.0/src/test/java/org_eclipse_angus/angus_mail/LogManagerPropertiesTest.java
@@ -20,6 +20,7 @@ import java.lang.reflect.UndeclaredThrowableException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Properties;
+import java.util.logging.Formatter;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.LogRecord;
@@ -27,6 +28,19 @@ import org.graalvm.internal.tck.NativeImageSupport;
 import org.junit.jupiter.api.Test;
 
 public class LogManagerPropertiesTest {
+    private static final String CONTEXT_FORMATTER_NAME = "org.example.ContextFormatter";
+
+    private static final byte[] CONTEXT_FORMATTER_BYTES = Base64.getDecoder().decode("""
+        yv66vgAAADQAFQoAAgADBwAEDAAFAAYBABtqYXZhL3V0aWwvbG9nZ2luZy9Gb3JtYXR0ZXIB
+        AAY8aW5pdD4BAAMoKVYKAAgACQcACgwACwAMAQAbamF2YS91dGlsL2xvZ2dpbmcvTG9nUmVj
+        b3JkAQAKZ2V0TWVzc2FnZQEAFCgpTGphdmEvbGFuZy9TdHJpbmc7BwAOAQAcb3JnL2V4YW1w
+        bGUvQ29udGV4dEZvcm1hdHRlcgEABENvZGUBAA9MaW5lTnVtYmVyVGFibGUBAAZmb3JtYXQB
+        ADEoTGphdmEvdXRpbC9sb2dnaW5nL0xvZ1JlY29yZDspTGphdmEvbGFuZy9TdHJpbmc7AQAK
+        U291cmNlRmlsZQEAFUNvbnRleHRGb3JtYXR0ZXIuamF2YQAhAA0AAgAAAAAAAgABAAUABgAB
+        AA8AAAAdAAEAAQAAAAUqtwABsQAAAAEAEAAAAAYAAQAAAAQAAQARABIAAQAPAAAAHQABAAIA
+        AAAFK7YAB7AAAAABABAAAAAGAAEAAAAFAAEAEwAAAAIAFA==
+        """.replaceAll("\\s", ""));
+
     @Test
     public void compactFormatterFormatsZonedTimeAndClassifiesStackFrames() {
         LogRecord record = new LogRecord(Level.WARNING, "delivery failed");
@@ -102,7 +116,7 @@ public class LogManagerPropertiesTest {
     public void collectorFormatterLoadsFormatterThroughContextClassLoader() throws Exception {
         configureLogManager(
             "com.sun.mail.util.logging.CollectorFormatter.format={1}",
-            "com.sun.mail.util.logging.CollectorFormatter.formatter=org.example.ContextFormatter",
+            "com.sun.mail.util.logging.CollectorFormatter.formatter=" + CONTEXT_FORMATTER_NAME,
             "com.sun.mail.util.logging.CollectorFormatter.comparator=null");
 
         try {
@@ -121,6 +135,34 @@ public class LogManagerPropertiesTest {
                 throw error;
             }
         }
+    }
+
+    @Test
+    public void collectorFormatterLoadsJdkFormatterWhenContextClassLoaderIsUnset() throws Exception {
+        configureLogManager(
+            "com.sun.mail.util.logging.CollectorFormatter.format={1}",
+            "com.sun.mail.util.logging.CollectorFormatter.formatter=java.util.logging.SimpleFormatter",
+            "com.sun.mail.util.logging.CollectorFormatter.comparator=null");
+
+        CollectorFormatter formatter = withContextClassLoader(null, CollectorFormatter::new);
+        formatter.format(new LogRecord(Level.INFO, "simple formatter fallback"));
+
+        assertThat(formatter.getTail(null)).contains("simple formatter fallback");
+    }
+
+    @Test
+    public void collectorFormatterLoadsCallerVisibleFormatterWhenContextClassLoaderIsUnset()
+            throws Exception {
+        configureLogManager(
+            "com.sun.mail.util.logging.CollectorFormatter.format={1}",
+            "com.sun.mail.util.logging.CollectorFormatter.formatter="
+                + ClassForNameFallbackFormatter.class.getName(),
+            "com.sun.mail.util.logging.CollectorFormatter.comparator=null");
+
+        CollectorFormatter formatter = withContextClassLoader(null, CollectorFormatter::new);
+        formatter.format(new LogRecord(Level.INFO, "caller fallback"));
+
+        assertThat(formatter.getTail(null)).contains("fallback:caller fallback");
     }
 
     @Test
@@ -167,12 +209,19 @@ public class LogManagerPropertiesTest {
         Throwable current = throwable;
         while (current != null) {
             if (current instanceof ClassNotFoundException classNotFoundException
-                    && "org.example.ContextFormatter".equals(classNotFoundException.getMessage())) {
+                    && CONTEXT_FORMATTER_NAME.equals(classNotFoundException.getMessage())) {
                 return true;
             }
             current = current.getCause();
         }
         return false;
+    }
+
+    public static final class ClassForNameFallbackFormatter extends Formatter {
+        @Override
+        public String format(LogRecord record) {
+            return "fallback:" + record.getMessage();
+        }
     }
 
     @FunctionalInterface
@@ -181,27 +230,17 @@ public class LogManagerPropertiesTest {
     }
 
     private static final class FormatterContextClassLoader extends ClassLoader {
-        private static final byte[] FORMATTER_BYTES = Base64.getDecoder().decode("""
-            yv66vgAAADQAFQoAAgADBwAEDAAFAAYBABtqYXZhL3V0aWwvbG9nZ2luZy9Gb3JtYXR0ZXIB
-            AAY8aW5pdD4BAAMoKVYKAAgACQcACgwACwAMAQAbamF2YS91dGlsL2xvZ2dpbmcvTG9nUmVj
-            b3JkAQAKZ2V0TWVzc2FnZQEAFCgpTGphdmEvbGFuZy9TdHJpbmc7BwAOAQAcb3JnL2V4YW1w
-            bGUvQ29udGV4dEZvcm1hdHRlcgEABENvZGUBAA9MaW5lTnVtYmVyVGFibGUBAAZmb3JtYXQB
-            ADEoTGphdmEvdXRpbC9sb2dnaW5nL0xvZ1JlY29yZDspTGphdmEvbGFuZy9TdHJpbmc7AQAK
-            U291cmNlRmlsZQEAFUNvbnRleHRGb3JtYXR0ZXIuamF2YQAhAA0AAgAAAAAAAgABAAUABgAB
-            AA8AAAAdAAEAAQAAAAUqtwABsQAAAAEAEAAAAAYAAQAAAAQAAQARABIAAQAPAAAAHQABAAIA
-            AAAFK7YAB7AAAAABABAAAAAGAAEAAAAFAAEAEwAAAAIAFA==
-            """.replaceAll("\\s", ""));
-
         private FormatterContextClassLoader() {
             super(ClassLoader.getPlatformClassLoader());
         }
 
         @Override
         protected Class<?> findClass(String name) throws ClassNotFoundException {
-            if ("org.example.ContextFormatter".equals(name)) {
-                return defineClass(name, FORMATTER_BYTES, 0, FORMATTER_BYTES.length);
+            if (CONTEXT_FORMATTER_NAME.equals(name)) {
+                return defineClass(name, CONTEXT_FORMATTER_BYTES, 0, CONTEXT_FORMATTER_BYTES.length);
             }
             throw new ClassNotFoundException(name);
         }
     }
+
 }

--- a/tests/src/org.eclipse.angus/angus-mail/1.1.0/src/test/java/org_eclipse_angus/angus_mail/LogManagerPropertiesTest.java
+++ b/tests/src/org.eclipse.angus/angus-mail/1.1.0/src/test/java/org_eclipse_angus/angus_mail/LogManagerPropertiesTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_angus.angus_mail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.sun.mail.util.logging.CollectorFormatter;
+import com.sun.mail.util.logging.CompactFormatter;
+import com.sun.mail.util.logging.DurationFilter;
+import com.sun.mail.util.logging.MailHandler;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.UndeclaredThrowableException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.LogRecord;
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+
+public class LogManagerPropertiesTest {
+    @Test
+    public void compactFormatterFormatsZonedTimeAndClassifiesStackFrames() {
+        LogRecord record = new LogRecord(Level.WARNING, "delivery failed");
+        RuntimeException thrown = new RuntimeException("boom");
+        thrown.setStackTrace(new StackTraceElement[] {
+            new StackTraceElement("java.lang.Math", "abs", "Math.java", 123),
+            new StackTraceElement("java.lang.Throwable", "fillInStackTrace", "Throwable.java", 10),
+            new StackTraceElement("java.lang.String", "valueOf", "String.java", 42)
+        });
+        record.setThrown(thrown);
+
+        String formatted = new CompactFormatter("%1$tFT%1$tT %5$s %6$s%n").format(record);
+
+        assertThat(formatted)
+            .contains("delivery failed")
+            .contains("RuntimeException: boom")
+            .contains("Throwable.fillInStackTrace");
+    }
+
+    @Test
+    public void durationFilterParsesIsoDurationFromLogManager() throws Exception {
+        configureLogManager(
+            "com.sun.mail.util.logging.DurationFilter.records=2",
+            "com.sun.mail.util.logging.DurationFilter.duration=PT0.001S");
+
+        DurationFilter filter = new DurationFilter();
+        LogRecord first = new LogRecord(Level.INFO, "first");
+        LogRecord second = new LogRecord(Level.INFO, "second");
+
+        assertThat(filter.isLoggable(first)).isTrue();
+        assertThat(filter.isLoggable(second)).isTrue();
+    }
+
+    @Test
+    public void mailHandlerVerifiesLocalHostFromTransport() {
+        Properties properties = new Properties();
+        properties.setProperty("mail.transport.protocol", "smtp");
+        properties.setProperty("mail.smtp.host", "localhost");
+        properties.setProperty("mail.smtp.localhost", "localhost");
+        properties.setProperty("mail.to", "recipient@example.com");
+        properties.setProperty("mail.from", "sender@example.com");
+        properties.setProperty("verify", "local");
+
+        MailHandler handler = new MailHandler(properties);
+        try {
+            assertThat(handler.getLevel()).isNotNull();
+        } finally {
+            handler.close();
+        }
+    }
+
+    @Test
+    public void collectorFormatterLoadsConfiguredFormatterAndReversesComparator() throws Exception {
+        configureLogManager(
+            "com.sun.mail.util.logging.CollectorFormatter.format={1}",
+            "com.sun.mail.util.logging.CollectorFormatter.formatter="
+                + "com.sun.mail.util.logging.CompactFormatter",
+            "com.sun.mail.util.logging.CollectorFormatter.comparator="
+                + "com.sun.mail.util.logging.SeverityComparator",
+            "com.sun.mail.util.logging.CollectorFormatter.comparator.reverse=true",
+            "com.sun.mail.util.logging.CompactFormatter.format=%4$s:%5$s%n");
+
+        CollectorFormatter formatter = new CollectorFormatter();
+        formatter.format(new LogRecord(Level.SEVERE, "severe message"));
+        formatter.format(new LogRecord(Level.INFO, "info message"));
+
+        String tail = formatter.getTail(null);
+
+        assertThat(tail).contains("INFO:info message");
+    }
+
+    @Test
+    public void collectorFormatterLoadsFormatterThroughContextClassLoader() throws Exception {
+        configureLogManager(
+            "com.sun.mail.util.logging.CollectorFormatter.format={1}",
+            "com.sun.mail.util.logging.CollectorFormatter.formatter=org.example.ContextFormatter",
+            "com.sun.mail.util.logging.CollectorFormatter.comparator=null");
+
+        try {
+            CollectorFormatter formatter = withContextClassLoader(
+                new FormatterContextClassLoader(), CollectorFormatter::new);
+            formatter.format(new LogRecord(Level.INFO, "context message"));
+
+            assertThat(formatter.getTail(null)).contains("context message");
+        } catch (UndeclaredThrowableException exception) {
+            if (isUnsupportedNativeContextFormatterLoad(exception)) {
+                return;
+            }
+            throw exception;
+        } catch (Error error) {
+            if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                throw error;
+            }
+        }
+    }
+
+    @Test
+    public void collectorFormatterFailsWhenContextClassLoaderIsUnset() throws Exception {
+        configureLogManager(
+            "com.sun.mail.util.logging.CollectorFormatter.formatter="
+                + "org.example.DoesNotExist");
+
+        UndeclaredThrowableException thrown = withContextClassLoader(null,
+            () -> assertThrows(UndeclaredThrowableException.class, CollectorFormatter::new));
+
+        assertThat(thrown.getUndeclaredThrowable()).isInstanceOf(ClassNotFoundException.class);
+    }
+
+    private static <T> T withContextClassLoader(ClassLoader loader, ThrowingSupplier<T> supplier)
+            throws Exception {
+        Thread thread = Thread.currentThread();
+        ClassLoader previous = thread.getContextClassLoader();
+        thread.setContextClassLoader(loader);
+        try {
+            return supplier.get();
+        } finally {
+            thread.setContextClassLoader(previous);
+        }
+    }
+
+    private static void configureLogManager(String... entries) throws IOException {
+        StringBuilder builder = new StringBuilder();
+        builder.append(".level=INFO\n");
+        for (String entry : entries) {
+            builder.append(entry).append('\n');
+        }
+
+        byte[] bytes = builder.toString().getBytes(StandardCharsets.ISO_8859_1);
+        try (InputStream input = new ByteArrayInputStream(bytes)) {
+            LogManager.getLogManager().readConfiguration(input);
+        }
+    }
+
+    private static boolean isUnsupportedNativeContextFormatterLoad(Throwable throwable) {
+        if (!"runtime".equals(System.getProperty("org.graalvm.nativeimage.imagecode"))) {
+            return false;
+        }
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof ClassNotFoundException classNotFoundException
+                    && "org.example.ContextFormatter".equals(classNotFoundException.getMessage())) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    @FunctionalInterface
+    private interface ThrowingSupplier<T> {
+        T get() throws Exception;
+    }
+
+    private static final class FormatterContextClassLoader extends ClassLoader {
+        private static final byte[] FORMATTER_BYTES = Base64.getDecoder().decode("""
+            yv66vgAAADQAFQoAAgADBwAEDAAFAAYBABtqYXZhL3V0aWwvbG9nZ2luZy9Gb3JtYXR0ZXIB
+            AAY8aW5pdD4BAAMoKVYKAAgACQcACgwACwAMAQAbamF2YS91dGlsL2xvZ2dpbmcvTG9nUmVj
+            b3JkAQAKZ2V0TWVzc2FnZQEAFCgpTGphdmEvbGFuZy9TdHJpbmc7BwAOAQAcb3JnL2V4YW1w
+            bGUvQ29udGV4dEZvcm1hdHRlcgEABENvZGUBAA9MaW5lTnVtYmVyVGFibGUBAAZmb3JtYXQB
+            ADEoTGphdmEvdXRpbC9sb2dnaW5nL0xvZ1JlY29yZDspTGphdmEvbGFuZy9TdHJpbmc7AQAK
+            U291cmNlRmlsZQEAFUNvbnRleHRGb3JtYXR0ZXIuamF2YQAhAA0AAgAAAAAAAgABAAUABgAB
+            AA8AAAAdAAEAAQAAAAUqtwABsQAAAAEAEAAAAAYAAQAAAAQAAQARABIAAQAPAAAAHQABAAIA
+            AAAFK7YAB7AAAAABABAAAAAGAAEAAAAFAAEAEwAAAAIAFA==
+            """.replaceAll("\\s", ""));
+
+        private FormatterContextClassLoader() {
+            super(ClassLoader.getPlatformClassLoader());
+        }
+
+        @Override
+        protected Class<?> findClass(String name) throws ClassNotFoundException {
+            if ("org.example.ContextFormatter".equals(name)) {
+                return defineClass(name, FORMATTER_BYTES, 0, FORMATTER_BYTES.length);
+            }
+            throw new ClassNotFoundException(name);
+        }
+    }
+}

--- a/tests/src/org.eclipse.angus/angus-mail/1.1.0/src/test/java/org_eclipse_angus/angus_mail/POP3FolderTest.java
+++ b/tests/src/org.eclipse.angus/angus-mail/1.1.0/src/test/java/org_eclipse_angus/angus_mail/POP3FolderTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_angus.angus_mail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.mail.pop3.POP3Message;
+import com.sun.mail.pop3.POP3Store;
+import jakarta.mail.Folder;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.URLName;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+public class POP3FolderTest {
+    private static final int TIMEOUT_MILLIS = 5_000;
+
+    @Test
+    public void configuredMessageClassIsCreatedWhenMessageIsRead() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try (ServerSocket serverSocket = new ServerSocket(0, 1, InetAddress.getLoopbackAddress())) {
+            serverSocket.setSoTimeout(TIMEOUT_MILLIS);
+            Future<Void> served = executor.submit(() -> serveSingleMessageMailbox(serverSocket));
+
+            POP3Store store = new POP3Store(newSessionWithMessageClass(), new URLName("pop3://localhost"));
+            Folder folder = null;
+            boolean folderOpened = false;
+            try {
+                store.connect(serverSocket.getInetAddress().getHostAddress(), serverSocket.getLocalPort(), "user",
+                        "password");
+                folder = store.getFolder("INBOX");
+                folder.open(Folder.READ_ONLY);
+                folderOpened = true;
+
+                Message message = folder.getMessage(1);
+
+                assertThat(message).isInstanceOf(RecordingPOP3Message.class);
+                assertThat(((RecordingPOP3Message) message).constructedMessageNumber()).isEqualTo(1);
+            } finally {
+                if (folderOpened) {
+                    folder.close(false);
+                }
+                store.close();
+            }
+            served.get(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static Session newSessionWithMessageClass() {
+        Properties properties = new Properties();
+        properties.setProperty("mail.pop3.connectiontimeout", Integer.toString(TIMEOUT_MILLIS));
+        properties.setProperty("mail.pop3.timeout", Integer.toString(TIMEOUT_MILLIS));
+        properties.setProperty("mail.pop3.message.class", RecordingPOP3Message.class.getName());
+        return Session.getInstance(properties);
+    }
+
+    private static Void serveSingleMessageMailbox(ServerSocket serverSocket) throws IOException {
+        try (Socket socket = serverSocket.accept();
+                BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream(),
+                        StandardCharsets.ISO_8859_1));
+                BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream(),
+                        StandardCharsets.ISO_8859_1))) {
+            socket.setSoTimeout(TIMEOUT_MILLIS);
+            writeLine(writer, "+OK test POP3 server ready");
+
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.startsWith("CAPA")) {
+                    writeLine(writer, "-ERR capabilities unavailable");
+                } else if (line.startsWith("USER ") || line.startsWith("PASS ")) {
+                    writeLine(writer, "+OK");
+                } else if (line.equals("STAT")) {
+                    writeLine(writer, "+OK 1 42");
+                } else if (line.equals("QUIT")) {
+                    writeLine(writer, "+OK goodbye");
+                    return null;
+                } else {
+                    writeLine(writer, "-ERR unexpected command");
+                }
+            }
+        }
+        return null;
+    }
+
+    private static void writeLine(BufferedWriter writer, String line) throws IOException {
+        writer.write(line);
+        writer.write("\r\n");
+        writer.flush();
+    }
+
+    public static final class RecordingPOP3Message extends POP3Message {
+        private final int constructedMessageNumber;
+
+        public RecordingPOP3Message(Folder folder, int messageNumber) throws MessagingException {
+            super(folder, messageNumber);
+            this.constructedMessageNumber = messageNumber;
+        }
+
+        public int constructedMessageNumber() {
+            return constructedMessageNumber;
+        }
+    }
+}

--- a/tests/src/org.eclipse.angus/angus-mail/1.1.0/src/test/java/org_eclipse_angus/angus_mail/POP3StoreTest.java
+++ b/tests/src/org.eclipse.angus/angus-mail/1.1.0/src/test/java/org_eclipse_angus/angus_mail/POP3StoreTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_angus.angus_mail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.mail.pop3.POP3Message;
+import com.sun.mail.pop3.POP3Store;
+import jakarta.mail.Folder;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.URLName;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Properties;
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+
+public class POP3StoreTest {
+    @Test
+    public void configuredMessageClassIsResolvedWhenPop3StoreIsCreated() {
+        POP3Store store = new POP3Store(newSessionWithMessageClass(RecordingPOP3Message.class.getName()),
+                new URLName("pop3://localhost"));
+
+        assertThat(store).isNotNull();
+    }
+
+    @Test
+    public void configuredMessageClassFallsBackToSystemClassLoader() throws Exception {
+        try {
+            ClassLoader loader = new IsolatingStoreClassLoader();
+            Class<?> storeClass = loader.loadClass(IsolatedPOP3Store.class.getName());
+
+            Object store = storeClass
+                    .getConstructor(Session.class, URLName.class)
+                    .newInstance(newSessionWithMessageClass(RecordingPOP3Message.class.getName()),
+                            new URLName("pop3://localhost"));
+
+            assertThat(store).isInstanceOf(POP3Store.class);
+        } catch (InvocationTargetException exception) {
+            Throwable cause = exception.getCause();
+            if (cause instanceof Error error && NativeImageSupport.isUnsupportedFeatureError(error)) {
+                return;
+            }
+            throw exception;
+        } catch (Error error) {
+            if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                throw error;
+            }
+        }
+    }
+
+    private static Session newSessionWithMessageClass(String messageClassName) {
+        Properties properties = new Properties();
+        properties.setProperty("mail.pop3.message.class", messageClassName);
+        return Session.getInstance(properties);
+    }
+
+    public static final class RecordingPOP3Message extends POP3Message {
+        public RecordingPOP3Message(Folder folder, int messageNumber) throws MessagingException {
+            super(folder, messageNumber);
+        }
+    }
+
+    public static final class IsolatedPOP3Store extends POP3Store {
+        public IsolatedPOP3Store(Session session, URLName urlName) {
+            super(session, urlName);
+        }
+    }
+
+    private static final class IsolatingStoreClassLoader extends ClassLoader {
+        private IsolatingStoreClassLoader() {
+            super(POP3Store.class.getClassLoader());
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (RecordingPOP3Message.class.getName().equals(name)) {
+                throw new ClassNotFoundException(name);
+            }
+            if (IsolatedPOP3Store.class.getName().equals(name)) {
+                Class<?> loadedClass = findLoadedClass(name);
+                if (loadedClass == null) {
+                    loadedClass = findClass(name);
+                }
+                if (resolve) {
+                    resolveClass(loadedClass);
+                }
+                return loadedClass;
+            }
+            return super.loadClass(name, resolve);
+        }
+
+        @Override
+        protected Class<?> findClass(String name) throws ClassNotFoundException {
+            if (!IsolatedPOP3Store.class.getName().equals(name)) {
+                throw new ClassNotFoundException(name);
+            }
+            byte[] bytes = readClassBytes(name);
+            return defineClass(name, bytes, 0, bytes.length);
+        }
+
+        private static byte[] readClassBytes(String name) throws ClassNotFoundException {
+            String resourceName = name.replace('.', '/') + ".class";
+            try (InputStream input = POP3StoreTest.class.getClassLoader().getResourceAsStream(resourceName)) {
+                if (input == null) {
+                    throw new ClassNotFoundException(name);
+                }
+                ByteArrayOutputStream output = new ByteArrayOutputStream();
+                input.transferTo(output);
+                return output.toByteArray();
+            } catch (IOException exception) {
+                ClassNotFoundException classNotFoundException = new ClassNotFoundException(name);
+                classNotFoundException.initCause(exception);
+                throw classNotFoundException;
+            }
+        }
+    }
+}

--- a/tests/src/org.eclipse.angus/angus-mail/1.1.0/src/test/java/org_eclipse_angus/angus_mail/ProtocolTest.java
+++ b/tests/src/org.eclipse.angus/angus-mail/1.1.0/src/test/java/org_eclipse_angus/angus_mail/ProtocolTest.java
@@ -57,6 +57,8 @@ public class ProtocolTest {
             properties.setProperty("mail.test.connectiontimeout", Integer.toString(TIMEOUT_MILLIS));
             properties.setProperty("mail.test.timeout", Integer.toString(TIMEOUT_MILLIS));
             properties.setProperty("mail.test.usesocketchannels", "true");
+            properties.setProperty("mail.test.ssl.checkserveridentity", "false");
+            properties.setProperty("mail.test.socketFactory.fallback", "false");
             properties.put("mail.test.ssl.socketFactory", new DelegatingSslSocketFactory(socketCreator));
 
             ExposedProtocol protocol = new ExposedProtocol(serverSocket.getInetAddress().getHostAddress(),

--- a/tests/src/org.eclipse.angus/angus-mail/1.1.0/src/test/java/org_eclipse_angus/angus_mail/ProtocolTest.java
+++ b/tests/src/org.eclipse.angus/angus-mail/1.1.0/src/test/java/org_eclipse_angus/angus_mail/ProtocolTest.java
@@ -1,0 +1,345 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_angus.angus_mail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.mail.iap.Protocol;
+import com.sun.mail.util.MailLogger;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.nio.channels.SocketChannel;
+import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import javax.net.ssl.HandshakeCompletedListener;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import org.junit.jupiter.api.Test;
+
+public class ProtocolTest {
+    private static final int TIMEOUT_MILLIS = 5_000;
+
+    @Test
+    public void sslSocketChannelIsFoundThroughNamedWrappedSocketField() throws Exception {
+        SocketChannel channel = connectAndReadChannel(NamedSocketFieldSslSocketFactory::newSocket);
+
+        assertThat(channel).isNotNull();
+    }
+
+    @Test
+    public void sslSocketChannelIsFoundThroughAssignableWrappedSocketField() throws Exception {
+        SocketChannel channel = connectAndReadChannel(AssignableSocketFieldSslSocketFactory::newSocket);
+
+        assertThat(channel).isNotNull();
+    }
+
+    private static SocketChannel connectAndReadChannel(SslSocketCreator socketCreator) throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try (ServerSocket serverSocket = new ServerSocket(0, 1, InetAddress.getLoopbackAddress())) {
+            serverSocket.setSoTimeout(TIMEOUT_MILLIS);
+            Future<Void> accepted = executor.submit(() -> acceptProtocolConnection(serverSocket));
+
+            Properties properties = new Properties();
+            properties.setProperty("mail.test.connectiontimeout", Integer.toString(TIMEOUT_MILLIS));
+            properties.setProperty("mail.test.timeout", Integer.toString(TIMEOUT_MILLIS));
+            properties.setProperty("mail.test.usesocketchannels", "true");
+            properties.put("mail.test.ssl.socketFactory", new DelegatingSslSocketFactory(socketCreator));
+
+            ExposedProtocol protocol = new ExposedProtocol(serverSocket.getInetAddress().getHostAddress(),
+                    serverSocket.getLocalPort(), properties);
+            try {
+                return protocol.getChannel();
+            } finally {
+                protocol.close();
+                accepted.get(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static Void acceptProtocolConnection(ServerSocket serverSocket) throws IOException {
+        try (Socket socket = serverSocket.accept()) {
+            socket.setSoTimeout(TIMEOUT_MILLIS);
+            socket.getOutputStream().write("* OK test server ready\r\n".getBytes());
+            socket.getOutputStream().flush();
+        }
+        return null;
+    }
+
+    private interface SslSocketCreator {
+        SSLSocket create(Socket socket) throws IOException;
+    }
+
+    public static final class ExposedProtocol extends Protocol {
+        private ExposedProtocol(String host, int port, Properties properties) throws Exception {
+            super(host, port, properties, "mail.test", true,
+                    new MailLogger(ProtocolTest.class, "DEBUG", false, System.out));
+        }
+
+        @Override
+        public SocketChannel getChannel() {
+            return super.getChannel();
+        }
+
+        private void close() {
+            disconnect();
+        }
+    }
+
+    public static final class DelegatingSslSocketFactory extends SSLSocketFactory {
+        private final SslSocketCreator socketCreator;
+
+        private DelegatingSslSocketFactory(SslSocketCreator socketCreator) {
+            this.socketCreator = socketCreator;
+        }
+
+        @Override
+        public String[] getDefaultCipherSuites() {
+            return new String[] {"TLS_AES_128_GCM_SHA256"};
+        }
+
+        @Override
+        public String[] getSupportedCipherSuites() {
+            return getDefaultCipherSuites();
+        }
+
+        @Override
+        public Socket createSocket(Socket socket, String host, int port, boolean autoClose) throws IOException {
+            return socketCreator.create(socket);
+        }
+
+        @Override
+        public Socket createSocket(String host, int port) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Socket createSocket(String host, int port, InetAddress localHost, int localPort) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Socket createSocket(InetAddress host, int port) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    public static final class NamedSocketFieldSslSocketFactory {
+        private static SSLSocket newSocket(Socket socket) {
+            return new NamedSocketFieldSslSocket(socket);
+        }
+    }
+
+    public static final class AssignableSocketFieldSslSocketFactory {
+        private static SSLSocket newSocket(Socket socket) {
+            return new AssignableSocketFieldSslSocket(socket);
+        }
+    }
+
+    public static final class NamedSocketFieldSslSocket extends AbstractDelegatingSslSocket {
+        private final Socket socket;
+
+        private NamedSocketFieldSslSocket(Socket socket) {
+            super(socket);
+            this.socket = socket;
+        }
+    }
+
+    public static final class AssignableSocketFieldSslSocket extends AbstractDelegatingSslSocket {
+        private AssignableSocketFieldSslSocket(Socket socket) {
+            super(socket);
+        }
+    }
+
+    public abstract static class AbstractDelegatingSslSocket extends SSLSocket {
+        private final Socket delegate;
+        private boolean useClientMode = true;
+        private boolean enableSessionCreation = true;
+        private String[] enabledCipherSuites = new String[] {"TLS_AES_128_GCM_SHA256"};
+        private String[] enabledProtocols = new String[] {"TLSv1.3"};
+
+        private AbstractDelegatingSslSocket(Socket delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public InputStream getInputStream() throws IOException {
+            return delegate.getInputStream();
+        }
+
+        @Override
+        public OutputStream getOutputStream() throws IOException {
+            return delegate.getOutputStream();
+        }
+
+        @Override
+        public SocketChannel getChannel() {
+            return null;
+        }
+
+        @Override
+        public InetAddress getInetAddress() {
+            return delegate.getInetAddress();
+        }
+
+        @Override
+        public InetAddress getLocalAddress() {
+            return delegate.getLocalAddress();
+        }
+
+        @Override
+        public int getPort() {
+            return delegate.getPort();
+        }
+
+        @Override
+        public int getLocalPort() {
+            return delegate.getLocalPort();
+        }
+
+        @Override
+        public SocketAddress getRemoteSocketAddress() {
+            return delegate.getRemoteSocketAddress();
+        }
+
+        @Override
+        public SocketAddress getLocalSocketAddress() {
+            return delegate.getLocalSocketAddress();
+        }
+
+        @Override
+        public boolean isConnected() {
+            return delegate.isConnected();
+        }
+
+        @Override
+        public boolean isBound() {
+            return delegate.isBound();
+        }
+
+        @Override
+        public boolean isClosed() {
+            return delegate.isClosed();
+        }
+
+        @Override
+        public void setSoTimeout(int timeout) throws SocketException {
+            delegate.setSoTimeout(timeout);
+        }
+
+        @Override
+        public int getSoTimeout() throws SocketException {
+            return delegate.getSoTimeout();
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
+
+        @Override
+        public String[] getSupportedCipherSuites() {
+            return new String[] {"TLS_AES_128_GCM_SHA256"};
+        }
+
+        @Override
+        public String[] getEnabledCipherSuites() {
+            return enabledCipherSuites.clone();
+        }
+
+        @Override
+        public void setEnabledCipherSuites(String[] suites) {
+            enabledCipherSuites = suites.clone();
+        }
+
+        @Override
+        public String[] getSupportedProtocols() {
+            return new String[] {"TLSv1.3", "TLSv1.2"};
+        }
+
+        @Override
+        public String[] getEnabledProtocols() {
+            return enabledProtocols.clone();
+        }
+
+        @Override
+        public void setEnabledProtocols(String[] protocols) {
+            enabledProtocols = protocols.clone();
+        }
+
+        @Override
+        public SSLSession getSession() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void addHandshakeCompletedListener(HandshakeCompletedListener listener) {
+        }
+
+        @Override
+        public void removeHandshakeCompletedListener(HandshakeCompletedListener listener) {
+        }
+
+        @Override
+        public void startHandshake() {
+        }
+
+        @Override
+        public void setUseClientMode(boolean mode) {
+            useClientMode = mode;
+        }
+
+        @Override
+        public boolean getUseClientMode() {
+            return useClientMode;
+        }
+
+        @Override
+        public void setNeedClientAuth(boolean need) {
+        }
+
+        @Override
+        public boolean getNeedClientAuth() {
+            return false;
+        }
+
+        @Override
+        public void setWantClientAuth(boolean want) {
+        }
+
+        @Override
+        public boolean getWantClientAuth() {
+            return false;
+        }
+
+        @Override
+        public void setEnableSessionCreation(boolean flag) {
+            enableSessionCreation = flag;
+        }
+
+        @Override
+        public boolean getEnableSessionCreation() {
+            return enableSessionCreation;
+        }
+    }
+}

--- a/tests/src/org.eclipse.angus/angus-mail/1.1.0/src/test/java/org_eclipse_angus/angus_mail/SMTPTransportTest.java
+++ b/tests/src/org.eclipse.angus/angus-mail/1.1.0/src/test/java/org_eclipse_angus/angus_mail/SMTPTransportTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_angus.angus_mail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.mail.smtp.SMTPTransport;
+import jakarta.mail.Session;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+public class SMTPTransportTest {
+    private static final int TIMEOUT_MILLIS = 5_000;
+
+    @Test
+    public void saslEnabledAuthenticationCreatesSaslAuthenticator() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try (ServerSocket serverSocket = new ServerSocket(0, 1, InetAddress.getLoopbackAddress())) {
+            serverSocket.setSoTimeout(TIMEOUT_MILLIS);
+            Future<SmtpConversation> accepted = executor.submit(() -> acceptSmtpConnection(serverSocket));
+
+            SMTPTransport transport = (SMTPTransport) newSaslEnabledSession().getTransport("smtp");
+            try {
+                transport.connect(serverSocket.getInetAddress().getHostAddress(), serverSocket.getLocalPort(),
+                        "user", "password");
+
+                assertThat(transport.isConnected()).isTrue();
+            } finally {
+                transport.close();
+            }
+
+            SmtpConversation conversation = accepted.get(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+            assertThat(conversation.commands()).anySatisfy(command -> assertThat(command).startsWith("EHLO "));
+            assertThat(conversation.commands()).anySatisfy(command -> assertThat(command).startsWith("AUTH PLAIN"));
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static Session newSaslEnabledSession() {
+        Properties properties = new Properties();
+        properties.setProperty("mail.smtp.auth", "true");
+        properties.setProperty("mail.smtp.sasl.enable", "true");
+        properties.setProperty("mail.smtp.sasl.mechanisms", "PLAIN");
+        properties.setProperty("mail.smtp.auth.mechanisms", "PLAIN");
+        properties.setProperty("mail.smtp.connectiontimeout", Integer.toString(TIMEOUT_MILLIS));
+        properties.setProperty("mail.smtp.timeout", Integer.toString(TIMEOUT_MILLIS));
+        return Session.getInstance(properties);
+    }
+
+    private static SmtpConversation acceptSmtpConnection(ServerSocket serverSocket) throws IOException {
+        List<String> commands = new ArrayList<>();
+        try (Socket socket = serverSocket.accept();
+                BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream(),
+                        StandardCharsets.US_ASCII));
+                BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream(),
+                        StandardCharsets.US_ASCII))) {
+            socket.setSoTimeout(TIMEOUT_MILLIS);
+            writeLine(writer, "220 localhost test SMTP service ready");
+
+            String line;
+            while ((line = reader.readLine()) != null) {
+                commands.add(line);
+                String command = line.toUpperCase(Locale.ROOT);
+                if (command.startsWith("EHLO ")) {
+                    writeLine(writer, "250-localhost");
+                    writeLine(writer, "250-AUTH PLAIN LOGIN");
+                    writeLine(writer, "250 OK");
+                } else if (command.startsWith("AUTH ")) {
+                    writeLine(writer, "235 2.7.0 Authentication successful");
+                } else if (command.startsWith("QUIT")) {
+                    writeLine(writer, "221 2.0.0 Bye");
+                    break;
+                } else {
+                    writeLine(writer, "250 2.0.0 OK");
+                }
+            }
+        }
+        return new SmtpConversation(commands);
+    }
+
+    private static void writeLine(BufferedWriter writer, String line) throws IOException {
+        writer.write(line);
+        writer.write("\r\n");
+        writer.flush();
+    }
+
+    private record SmtpConversation(List<String> commands) {
+    }
+}

--- a/tests/src/org.eclipse.angus/angus-mail/1.1.0/src/test/java/org_eclipse_angus/angus_mail/SocketFetcherTest.java
+++ b/tests/src/org.eclipse.angus/angus-mail/1.1.0/src/test/java/org_eclipse_angus/angus_mail/SocketFetcherTest.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_angus.angus_mail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.mail.util.SocketFetcher;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.security.KeyFactory;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.SecureRandom;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.net.SocketFactory;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLSocket;
+import org.junit.jupiter.api.Test;
+
+public class SocketFetcherTest {
+    private static final int TIMEOUT_MILLIS = 5_000;
+    private static final char[] KEYSTORE_PASSWORD = "changeit".toCharArray();
+    private static final String LOCALHOST_CERTIFICATE = """
+        -----BEGIN CERTIFICATE-----
+        MIIC7TCCAdWgAwIBAgIUJ4hzJj01gI8FoidCDBGP9r0KFC0wDQYJKoZIhvcNAQEL
+        BQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI2MDUyMDE2MTMzN1oXDTM2MDUx
+        NzE2MTMzN1owFDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEF
+        AAOCAQ8AMIIBCgKCAQEAwQJQDoLJb+X5ZCglW5mGLEYkTx4BvNPI/idzmyEmqI4Y
+        Zzcspkg5SgCPoycEBHLjexG/Qq6UzTuit0kLc5lwkZbPm9P4IchvQbY4GWTa9YhQ
+        XXvZ4jm9YgjyD2BzG/eEYa+kKXhYhHdeypwThtmI1rVfIovuLJrS/xC3gP7FKQbB
+        lnSMhhAhmz40htgaj50ZwHJEQO6OoDpA+OoJC7OxldPIGYMykpl9aNSmEtdgfHdH
+        UDIPVqxD9/jldd1KyXVLrr7FMNgtw7V6wcCTwgP4VT+cxw+iqd4QXPuEa5aks3i5
+        P+jXfiNWwyoHmVLjFGdJR/JBXz5P4crk0mbVNAVKtQIDAQABozcwNTAUBgNVHREE
+        DTALgglsb2NhbGhvc3QwHQYDVR0OBBYEFEd1kou2IM62pN3p8Crxv8wTI7PhMA0G
+        CSqGSIb3DQEBCwUAA4IBAQA8Pr/YOEUVVvESc2xFyDS4pszghcU2pNBezPUDTbze
+        8imv2UJWHkD6UO/U2XWNsIr55CVFv+ollmjkp62XFI3JMoS9rwrpAe5UdRCDiiA0
+        l/A1MagQgRXpMIlahyoBwz3eoDyeWFhRl95VZpiG6zj6Ylu6bEJCKWdK3/DsXPTF
+        1t37phHFSyNgi8H3kVIG/gLLIIG37bzIXmnqy8fL0lrCpZ0tSKpNVO1y1hzlnHHF
+        sP8bQgCZmLxcwqCh6q/89+1HIUYXSdkTZzB6D1r/qjYXBNUzhElB1YTynuOIsClv
+        3yGIy0A6tLQEnxidpwTn6EL6j1q8n0ygQC6gEpXThTl1
+        -----END CERTIFICATE-----
+        """;
+    private static final String LOCALHOST_PRIVATE_KEY = """
+        -----BEGIN PRIVATE KEY-----
+        MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDBAlAOgslv5flk
+        KCVbmYYsRiRPHgG808j+J3ObISaojhhnNyymSDlKAI+jJwQEcuN7Eb9CrpTNO6K3
+        SQtzmXCRls+b0/ghyG9BtjgZZNr1iFBde9niOb1iCPIPYHMb94Rhr6QpeFiEd17K
+        nBOG2YjWtV8ii+4smtL/ELeA/sUpBsGWdIyGECGbPjSG2BqPnRnAckRA7o6gOkD4
+        6gkLs7GV08gZgzKSmX1o1KYS12B8d0dQMg9WrEP3+OV13UrJdUuuvsUw2C3DtXrB
+        wJPCA/hVP5zHD6Kp3hBc+4RrlqSzeLk/6Nd+I1bDKgeZUuMUZ0lH8kFfPk/hyuTS
+        ZtU0BUq1AgMBAAECggEACgl01dMDJtnyq+dy4o5Q3f0LdtTPOigDoq81BxXEf6Kc
+        uMNeWPWrtazioKqkU2yREVg/1g0jnlTyANjgKv5eo6eQJiDyB/m3IBeZ17zjrmiM
+        u1Z34xiQar3J2WGxOBID/5t6weWo/sHWu1pooTbZ85vCIIGz3Kce1AD6dfoUZoNv
+        oyeammEif7Op4USD8UqcsW/nhlaiTZmQufJh/Xm5VoJ7iPqvGIWiG0pIkqXI0+pq
+        o5QLf0H74mcikNMWnY3Kg+MIeZmgqbgdjMVk97sE4jXF5dO8eHoTc4faR9vX8L9U
+        xYsz6NWWlTeneqcI8Z9qd+/SgBvRXr3yn7C0wzTKuQKBgQDy6HH+Zd8W0XuetlMt
+        k2qilErKuvYD6QTyZ1Ngzz3UlOXY9aPoENZAI30/4So/d+vDNISiQHtuG7DApus3
+        mqjqFnl0WEps60OZMaaWLx9tY0ATkXTo+Ph3KDlHwNFBrQG6IWSHXDqGTVeffOYv
+        ZVeDq6pvX/7vDvVs4RutDrKkWQKBgQDLaWFM4gWY0Z9cxpSfIUABmbckbJnniN2V
+        w8ntooHu8E4I646C2/8sAAMCy9yULHG8G2z/EdxLcY2/N7hfNs4g9QDm9edXEbyx
+        2rIIDjiOokBT2d87wARB24R2XW4mIYrYKy6XRs9jPPKpCbN1sgbVI5+HVmBf0uQw
+        UNc+nKb9vQKBgQCoTSWufib0SHC+ptU63skjnFu125RZYTpsOesrSGwuvnwCty+5
+        uvC3v98oQ3piP1S7C8haIxNiVw1AbmbLP/2JM8kzM3ldviQ4II6rwDqmL/5VkJLQ
+        WLDO3q/RZ2eVeamYrUpZ/y0NoMj1WDSk4jKgqHCOepTITjT+G3pxjZ15AQKBgEH2
+        4aPyJEiDqj+G8omMWdprA/Ze9aYdP2ajAKf8rFBVQ6km4qdTOrQFKPTOMbEnnJaY
+        +kbZfuxEXehl5HeUKVKMwYcktaoJyXyP5G4yVmsC+QN4Qyl4QqkszA8qi174P7OM
+        hWZvgy+2gycIS1derVKPY9uaylQo6vE0NilK2eitAoGBAL9ggxBm95MZjKk43oso
+        4Vzw3awebMevkXMYtizl+NhzbAyPIR9SuaXmi74wSd4gXB2uSYDqVm3A30aovRHr
+        aCrDybcM0S9hbheV4SPUU9PVs4B6EjKGrtBZwlZGhFeD9NmOfLIc9763EFofniB1
+        e1k5F+Sazh9tk5b33fQY7mAs
+        -----END PRIVATE KEY-----
+        """;
+
+    @Test
+    public void socketFactoryClassLoadsThroughContextClassLoader() throws Exception {
+        RecordingSocketFactory.reset();
+
+        connectWithConfiguredSocketFactory(SocketFetcherTest.class.getClassLoader());
+
+        assertThat(RecordingSocketFactory.defaultCalls).hasValue(1);
+        assertThat(RecordingSocketFactory.unconnectedSocketCalls).hasValue(1);
+    }
+
+    @Test
+    public void socketFactoryClassFallsBackToSocketFetcherClassLoader() throws Exception {
+        RecordingSocketFactory.reset();
+
+        connectWithConfiguredSocketFactory(new RejectingFactoryClassLoader());
+
+        assertThat(RecordingSocketFactory.defaultCalls).hasValue(1);
+        assertThat(RecordingSocketFactory.unconnectedSocketCalls).hasValue(1);
+    }
+
+    @Test
+    public void sslServerIdentityCheckUsesJdkHostnameChecker() throws Exception {
+        SSLContext serverContext = newServerContext();
+        InetAddress loopback = InetAddress.getByName("localhost");
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try (SSLServerSocket serverSocket = (SSLServerSocket) serverContext.getServerSocketFactory()
+                .createServerSocket(0, 1, loopback)) {
+            serverSocket.setSoTimeout(TIMEOUT_MILLIS);
+            Future<Void> accepted = executor.submit(() -> acceptSslConnection(serverSocket));
+
+            Properties properties = timeoutProperties();
+            properties.setProperty("mail.test.ssl.trust", "*");
+            properties.setProperty("mail.test.ssl.checkserveridentity", "true");
+
+            try (Socket socket = SocketFetcher.getSocket("localhost", serverSocket.getLocalPort(),
+                    properties, "mail.test", true)) {
+                assertThat(socket).isInstanceOf(SSLSocket.class);
+            }
+
+            accepted.get(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static void connectWithConfiguredSocketFactory(ClassLoader contextClassLoader) throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try (ServerSocket serverSocket = new ServerSocket(0, 1, InetAddress.getLoopbackAddress())) {
+            serverSocket.setSoTimeout(TIMEOUT_MILLIS);
+            Future<Void> accepted = executor.submit(() -> acceptPlainConnection(serverSocket));
+
+            Properties properties = timeoutProperties();
+            properties.setProperty("mail.test.socketFactory.class", RecordingSocketFactory.class.getName());
+
+            withContextClassLoader(contextClassLoader, () -> {
+                try (Socket socket = SocketFetcher.getSocket(serverSocket.getInetAddress().getHostAddress(),
+                        serverSocket.getLocalPort(), properties, "mail.test")) {
+                    socket.getOutputStream().write(1);
+                }
+                return null;
+            });
+
+            accepted.get(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static Void acceptPlainConnection(ServerSocket serverSocket) throws IOException {
+        try (Socket socket = serverSocket.accept()) {
+            socket.setSoTimeout(TIMEOUT_MILLIS);
+            assertThat(socket.getInputStream().read()).isEqualTo(1);
+        }
+        return null;
+    }
+
+    private static Void acceptSslConnection(SSLServerSocket serverSocket) throws IOException {
+        try (SSLSocket socket = (SSLSocket) serverSocket.accept()) {
+            socket.setSoTimeout(TIMEOUT_MILLIS);
+            socket.startHandshake();
+            assertThat(socket.getInputStream().read()).isEqualTo(-1);
+        }
+        return null;
+    }
+
+    private static Properties timeoutProperties() {
+        Properties properties = new Properties();
+        properties.setProperty("mail.test.connectiontimeout", Integer.toString(TIMEOUT_MILLIS));
+        properties.setProperty("mail.test.timeout", Integer.toString(TIMEOUT_MILLIS));
+        return properties;
+    }
+
+    private static SSLContext newServerContext() throws Exception {
+        Certificate certificate = certificateFromPem(LOCALHOST_CERTIFICATE);
+        PrivateKey privateKey = privateKeyFromPem(LOCALHOST_PRIVATE_KEY);
+
+        KeyStore keyStore = KeyStore.getInstance("PKCS12");
+        keyStore.load(null, null);
+        keyStore.setKeyEntry("localhost", privateKey, KEYSTORE_PASSWORD, new Certificate[] {certificate});
+
+        KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        keyManagerFactory.init(keyStore, KEYSTORE_PASSWORD);
+
+        SSLContext context = SSLContext.getInstance("TLS");
+        context.init(keyManagerFactory.getKeyManagers(), null, new SecureRandom());
+        return context;
+    }
+
+    private static Certificate certificateFromPem(String pem) throws Exception {
+        CertificateFactory factory = CertificateFactory.getInstance("X.509");
+        return factory.generateCertificate(new ByteArrayInputStream(derBytes(pem)));
+    }
+
+    private static PrivateKey privateKeyFromPem(String pem) throws Exception {
+        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(derBytes(pem));
+        return KeyFactory.getInstance("RSA").generatePrivate(keySpec);
+    }
+
+    private static byte[] derBytes(String pem) {
+        String base64 = pem.replaceAll("-----BEGIN [^-]+-----", "")
+                .replaceAll("-----END [^-]+-----", "")
+                .replaceAll("\\s", "");
+        return Base64.getDecoder().decode(base64);
+    }
+
+    private static <T> T withContextClassLoader(ClassLoader loader, ThrowingSupplier<T> supplier) throws Exception {
+        Thread thread = Thread.currentThread();
+        ClassLoader previous = thread.getContextClassLoader();
+        thread.setContextClassLoader(loader);
+        try {
+            return supplier.get();
+        } finally {
+            thread.setContextClassLoader(previous);
+        }
+    }
+
+    @FunctionalInterface
+    private interface ThrowingSupplier<T> {
+        T get() throws Exception;
+    }
+
+    public static final class RecordingSocketFactory extends SocketFactory {
+        private static final AtomicInteger defaultCalls = new AtomicInteger();
+        private static final AtomicInteger unconnectedSocketCalls = new AtomicInteger();
+
+        public static SocketFactory getDefault() {
+            defaultCalls.incrementAndGet();
+            return new RecordingSocketFactory();
+        }
+
+        @Override
+        public Socket createSocket() {
+            unconnectedSocketCalls.incrementAndGet();
+            return new Socket();
+        }
+
+        @Override
+        public Socket createSocket(String host, int port) throws IOException {
+            return new Socket(host, port);
+        }
+
+        @Override
+        public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException {
+            return new Socket(host, port, localHost, localPort);
+        }
+
+        @Override
+        public Socket createSocket(InetAddress host, int port) throws IOException {
+            return new Socket(host, port);
+        }
+
+        @Override
+        public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort)
+                throws IOException {
+            return new Socket(address, port, localAddress, localPort);
+        }
+
+        private static void reset() {
+            defaultCalls.set(0);
+            unconnectedSocketCalls.set(0);
+        }
+    }
+
+    private static final class RejectingFactoryClassLoader extends ClassLoader {
+        private RejectingFactoryClassLoader() {
+            super(SocketFetcherTest.class.getClassLoader());
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (RecordingSocketFactory.class.getName().equals(name)) {
+                throw new ClassNotFoundException(name);
+            }
+            return super.loadClass(name, resolve);
+        }
+    }
+}

--- a/tests/src/org.eclipse.angus/angus-mail/1.1.0/src/test/java/org_eclipse_angus/angus_mail/WriteTimeoutSocketTest.java
+++ b/tests/src/org.eclipse.angus/angus-mail/1.1.0/src/test/java/org_eclipse_angus/angus_mail/WriteTimeoutSocketTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_angus.angus_mail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.mail.util.WriteTimeoutSocket;
+import java.io.FileDescriptor;
+import java.net.Socket;
+import org.junit.jupiter.api.Test;
+
+public class WriteTimeoutSocketTest {
+    @Test
+    public void getFileDescriptorInvokesDelegateAndroidCompatibilityMethod() throws Exception {
+        FileDescriptor fileDescriptor = new FileDescriptor();
+
+        try (WriteTimeoutSocket socket = new WriteTimeoutSocket(new FileDescriptorSocket(fileDescriptor), 1_000)) {
+            assertThat(socket.getFileDescriptor$()).isSameAs(fileDescriptor);
+        }
+    }
+
+    public static final class FileDescriptorSocket extends Socket {
+        private final FileDescriptor fileDescriptor;
+
+        public FileDescriptorSocket(FileDescriptor fileDescriptor) {
+            this.fileDescriptor = fileDescriptor;
+        }
+
+        public FileDescriptor getFileDescriptor$() {
+            return fileDescriptor;
+        }
+    }
+}

--- a/tests/src/org.eclipse.angus/angus-mail/1.1.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.eclipse.angus/angus-mail/1.1.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org_eclipse_angus.angus_mail.IMAPStoreTest"
+      },
+      "glob" : "org_eclipse_angus/angus_mail/IMAPStoreTest*.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_eclipse_angus.angus_mail.POP3StoreTest"
+      },
+      "glob" : "org_eclipse_angus/angus_mail/POP3StoreTest*.class"
+    }
+  ]
+}

--- a/tests/src/org.eclipse.angus/angus-mail/1.1.0/user-code-filter.json
+++ b/tests/src/org.eclipse.angus/angus-mail/1.1.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.sun.mail.**"
+    },
+    {
+      "includeClasses" : "org_eclipse_angus.angus_mail.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7391

This PR provides test fixes and new metadata for org.eclipse.angus:angus-mail:1.1.0, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 136880
- Cached input tokens: 1341952
- Output tokens: 26842
- Metadata entries: 53
- Test-only metadata entries: 2
- Iterations: 3
- Library coverage percentage: 18.3
- Previous library version metadata entries: 53
- Previous library version test-only metadata entries: 2
- Previous library version coverage percentage: 18.54

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `75c0c6cba42cd1c371bda654b8963184856bfdb2`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.eclipse.angus:angus-mail:1.0.0: 45/46 covered calls (97.83%)
- org.eclipse.angus:angus-mail:1.1.0: 45/46 covered calls (97.83%)

**Reflection:**
- org.eclipse.angus:angus-mail:1.0.0: 45/46 covered calls (97.83%)
- org.eclipse.angus:angus-mail:1.1.0: 45/46 covered calls (97.83%)

#### Library coverage

**Instruction:**
- org.eclipse.angus:angus-mail:1.0.0: 11600/65195 (17.79%)
- org.eclipse.angus:angus-mail:1.1.0: 11547/65541 (17.62%)

**Line:**
- org.eclipse.angus:angus-mail:1.0.0: 2726/14701 (18.54%)
- org.eclipse.angus:angus-mail:1.1.0: 2705/14781 (18.30%)

**Method:**
- org.eclipse.angus:angus-mail:1.0.0: 461/1889 (24.40%)
- org.eclipse.angus:angus-mail:1.1.0: 453/1904 (23.79%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.eclipse.angus/angus-mail/1.0.0/src/test/java/org_eclipse_angus/angus_mail/LogManagerPropertiesTest.java 2/tests/src/org.eclipse.angus/angus-mail/1.1.0/src/test/java/org_eclipse_angus/angus_mail/LogManagerPropertiesTest.java
index 853997604c..519db3ad14 100644
--- 1/tests/src/org.eclipse.angus/angus-mail/1.0.0/src/test/java/org_eclipse_angus/angus_mail/LogManagerPropertiesTest.java
+++ 2/tests/src/org.eclipse.angus/angus-mail/1.1.0/src/test/java/org_eclipse_angus/angus_mail/LogManagerPropertiesTest.java
@@ -20,6 +20,7 @@ import java.lang.reflect.UndeclaredThrowableException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Properties;
+import java.util.logging.Formatter;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.LogRecord;
@@ -27,6 +28,19 @@ import org.graalvm.internal.tck.NativeImageSupport;
 import org.junit.jupiter.api.Test;
 
 public class LogManagerPropertiesTest {
+    private static final String CONTEXT_FORMATTER_NAME = "org.example.ContextFormatter";
+
+    private static final byte[] CONTEXT_FORMATTER_BYTES = Base64.getDecoder().decode("""
+        yv66vgAAADQAFQoAAgADBwAEDAAFAAYBABtqYXZhL3V0aWwvbG9nZ2luZy9Gb3JtYXR0ZXIB
+        AAY8aW5pdD4BAAMoKVYKAAgACQcACgwACwAMAQAbamF2YS91dGlsL2xvZ2dpbmcvTG9nUmVj
+        b3JkAQAKZ2V0TWVzc2FnZQEAFCgpTGphdmEvbGFuZy9TdHJpbmc7BwAOAQAcb3JnL2V4YW1w
+        bGUvQ29udGV4dEZvcm1hdHRlcgEABENvZGUBAA9MaW5lTnVtYmVyVGFibGUBAAZmb3JtYXQB
+        ADEoTGphdmEvdXRpbC9sb2dnaW5nL0xvZ1JlY29yZDspTGphdmEvbGFuZy9TdHJpbmc7AQAK
+        U291cmNlRmlsZQEAFUNvbnRleHRGb3JtYXR0ZXIuamF2YQAhAA0AAgAAAAAAAgABAAUABgAB
+        AA8AAAAdAAEAAQAAAAUqtwABsQAAAAEAEAAAAAYAAQAAAAQAAQARABIAAQAPAAAAHQABAAIA
+        AAAFK7YAB7AAAAABABAAAAAGAAEAAAAFAAEAEwAAAAIAFA==
+        """.replaceAll("\\s", ""));
+
     @Test
     public void compactFormatterFormatsZonedTimeAndClassifiesStackFrames() {
         LogRecord record = new LogRecord(Level.WARNING, "delivery failed");
@@ -102,7 +116,7 @@ public class LogManagerPropertiesTest {
     public void collectorFormatterLoadsFormatterThroughContextClassLoader() throws Exception {
         configureLogManager(
             "com.sun.mail.util.logging.CollectorFormatter.format={1}",
-            "com.sun.mail.util.logging.CollectorFormatter.formatter=org.example.ContextFormatter",
+            "com.sun.mail.util.logging.CollectorFormatter.formatter=" + CONTEXT_FORMATTER_NAME,
             "com.sun.mail.util.logging.CollectorFormatter.comparator=null");
 
         try {
@@ -123,6 +137,34 @@ public class LogManagerPropertiesTest {
         }
     }
 
+    @Test
+    public void collectorFormatterLoadsJdkFormatterWhenContextClassLoaderIsUnset() throws Exception {
+        configureLogManager(
+            "com.sun.mail.util.logging.CollectorFormatter.format={1}",
+            "com.sun.mail.util.logging.CollectorFormatter.formatter=java.util.logging.SimpleFormatter",
+            "com.sun.mail.util.logging.CollectorFormatter.comparator=null");
+
+        CollectorFormatter formatter = withContextClassLoader(null, CollectorFormatter::new);
+        formatter.format(new LogRecord(Level.INFO, "simple formatter fallback"));
+
+        assertThat(formatter.getTail(null)).contains("simple formatter fallback");
+    }
+
+    @Test
+    public void collectorFormatterLoadsCallerVisibleFormatterWhenContextClassLoaderIsUnset()
+            throws Exception {
+        configureLogManager(
+            "com.sun.mail.util.logging.CollectorFormatter.format={1}",
+            "com.sun.mail.util.logging.CollectorFormatter.formatter="
+                + ClassForNameFallbackFormatter.class.getName(),
+            "com.sun.mail.util.logging.CollectorFormatter.comparator=null");
+
+        CollectorFormatter formatter = withContextClassLoader(null, CollectorFormatter::new);
+        formatter.format(new LogRecord(Level.INFO, "caller fallback"));
+
+        assertThat(formatter.getTail(null)).contains("fallback:caller fallback");
+    }
+
     @Test
     public void collectorFormatterFailsWhenContextClassLoaderIsUnset() throws Exception {
         configureLogManager(
@@ -167,7 +209,7 @@ public class LogManagerPropertiesTest {
         Throwable current = throwable;
         while (current != null) {
             if (current instanceof ClassNotFoundException classNotFoundException
-                    && "org.example.ContextFormatter".equals(classNotFoundException.getMessage())) {
+                    && CONTEXT_FORMATTER_NAME.equals(classNotFoundException.getMessage())) {
                 return true;
             }
             current = current.getCause();
@@ -175,33 +217,30 @@ public class LogManagerPropertiesTest {
         return false;
     }
 
+    public static final class ClassForNameFallbackFormatter extends Formatter {
+        @Override
+        public String format(LogRecord record) {
+            return "fallback:" + record.getMessage();
+        }
+    }
+
     @FunctionalInterface
     private interface ThrowingSupplier<T> {
         T get() throws Exception;
     }
 
     private static final class FormatterContextClassLoader extends ClassLoader {
-        private static final byte[] FORMATTER_BYTES = Base64.getDecoder().decode("""
-            yv66vgAAADQAFQoAAgADBwAEDAAFAAYBABtqYXZhL3V0aWwvbG9nZ2luZy9Gb3JtYXR0ZXIB
-            AAY8aW5pdD4BAAMoKVYKAAgACQcACgwACwAMAQAbamF2YS91dGlsL2xvZ2dpbmcvTG9nUmVj
-            b3JkAQAKZ2V0TWVzc2FnZQEAFCgpTGphdmEvbGFuZy9TdHJpbmc7BwAOAQAcb3JnL2V4YW1w
-            bGUvQ29udGV4dEZvcm1hdHRlcgEABENvZGUBAA9MaW5lTnVtYmVyVGFibGUBAAZmb3JtYXQB
-            ADEoTGphdmEvdXRpbC9sb2dnaW5nL0xvZ1JlY29yZDspTGphdmEvbGFuZy9TdHJpbmc7AQAK
-            U291cmNlRmlsZQEAFUNvbnRleHRGb3JtYXR0ZXIuamF2YQAhAA0AAgAAAAAAAgABAAUABgAB
-            AA8AAAAdAAEAAQAAAAUqtwABsQAAAAEAEAAAAAYAAQAAAAQAAQARABIAAQAPAAAAHQABAAIA
-            AAAFK7YAB7AAAAABABAAAAAGAAEAAAAFAAEAEwAAAAIAFA==
-            """.replaceAll("\\s", ""));
-
         private FormatterContextClassLoader() {
             super(ClassLoader.getPlatformClassLoader());
         }
 
         @Override
         protected Class<?> findClass(String name) throws ClassNotFoundException {
-            if ("org.example.ContextFormatter".equals(name)) {
-                return defineClass(name, FORMATTER_BYTES, 0, FORMATTER_BYTES.length);
+            if (CONTEXT_FORMATTER_NAME.equals(name)) {
+                return defineClass(name, CONTEXT_FORMATTER_BYTES, 0, CONTEXT_FORMATTER_BYTES.length);
             }
             throw new ClassNotFoundException(name);
         }
     }
+
 }
diff --git 1/tests/src/org.eclipse.angus/angus-mail/1.0.0/src/test/java/org_eclipse_angus/angus_mail/ProtocolTest.java 2/tests/src/org.eclipse.angus/angus-mail/1.1.0/src/test/java/org_eclipse_angus/angus_mail/ProtocolTest.java
index 3ac316fcfa..a59b33f4a4 100644
--- 1/tests/src/org.eclipse.angus/angus-mail/1.0.0/src/test/java/org_eclipse_angus/angus_mail/ProtocolTest.java
+++ 2/tests/src/org.eclipse.angus/angus-mail/1.1.0/src/test/java/org_eclipse_angus/angus_mail/ProtocolTest.java
@@ -57,6 +57,8 @@ public class ProtocolTest {
             properties.setProperty("mail.test.connectiontimeout", Integer.toString(TIMEOUT_MILLIS));
             properties.setProperty("mail.test.timeout", Integer.toString(TIMEOUT_MILLIS));
             properties.setProperty("mail.test.usesocketchannels", "true");
+            properties.setProperty("mail.test.ssl.checkserveridentity", "false");
+            properties.setProperty("mail.test.socketFactory.fallback", "false");
             properties.put("mail.test.ssl.socketFactory", new DelegatingSslSocketFactory(socketCreator));
 
             ExposedProtocol protocol = new ExposedProtocol(serverSocket.getInetAddress().getHostAddress(),

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
