### PR TITLE
[Automation] Generated metadata for jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api:3.0.0

### DIFF
--- a/metadata/jakarta.servlet.jsp.jstl/jakarta.servlet.jsp.jstl-api/3.0.0/reachability-metadata.json
+++ b/metadata/jakarta.servlet.jsp.jstl/jakarta.servlet.jsp.jstl-api/3.0.0/reachability-metadata.json
@@ -70,13 +70,28 @@
       "condition": {
         "typeReached": "jakarta.servlet.jsp.jstl.fmt.LocaleSupport"
       },
-      "bundle": "jakarta_servlet_jsp_jstl.jakarta_servlet_jsp_jstl_api.Jakarta_servlet_jsp_jstl_apiTest$MessagesBundle"
+      "bundle": "jakarta_servlet_jsp_jstl.jakarta_servlet_jsp_jstl_api.LocaleSupportTest$MessagesBundle"
     },
     {
       "condition": {
         "typeReached": "jakarta.servlet.jsp.jstl.fmt.LocaleSupport"
       },
-      "bundle": "jakarta_servlet_jsp_jstl.jakarta_servlet_jsp_jstl_api.Jakarta_servlet_jsp_jstl_apiTest$NamedLocaleMessages"
+      "bundle": "jakarta_servlet_jsp_jstl.jakarta_servlet_jsp_jstl_api.LocaleSupportTest$NamedLocaleMessages"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.servlet.jsp.jstl.fmt.LocaleSupport"
+      },
+      "bundle": "jakarta_servlet_jsp_jstl.jakarta_servlet_jsp_jstl_api.LocaleSupportTest$RootMessages"
+    },
+    {
+      "glob": "META-INF/services/javax.sql.rowset.RowSetFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.servlet.jsp.jstl.tlv.PermittedTaglibsTLV"
+      },
+      "glob": "META-INF/services/javax.xml.parsers.SAXParserFactory"
     },
     {
       "module": "java.sql.rowset",

--- a/metadata/jakarta.servlet.jsp.jstl/jakarta.servlet.jsp.jstl-api/index.json
+++ b/metadata/jakarta.servlet.jsp.jstl/jakarta.servlet.jsp.jstl-api/index.json
@@ -4,7 +4,7 @@
     "metadata-version" : "3.0.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/jakarta/servlet/jsp/jstl/jakarta.servlet.jsp.jstl-api/$version$/jakarta.servlet.jsp.jstl-api-$version$-sources.jar",
     "repository-url" : "https://github.com/jakartaee/tags",
-    "test-code-url" : "https://download.eclipse.org/jakartaee/tags/3.0/jakarta-tags-tck-$version$.zip",
+    "test-code-url" : "https://github.com/jakartaee/tags/tree/$version$-RELEASE/impl/src/test",
     "documentation-url" : "https://repo.maven.apache.org/maven2/jakarta/servlet/jsp/jstl/jakarta.servlet.jsp.jstl-api/$version$/jakarta.servlet.jsp.jstl-api-$version$-javadoc.jar",
     "description" : "Jakarta Standard Tag Library API defines the standard tag interfaces, support classes, validators, and utility APIs used by JSP tag libraries. It provides the API surface for core, formatting, SQL, XML, and tag-library validation features that application servers and JSTL implementations expose to Jakarta Servlet and JSP applications.",
     "tested-versions" : [

--- a/stats/jakarta.servlet.jsp.jstl/jakarta.servlet.jsp.jstl-api/3.0.0/stats.json
+++ b/stats/jakarta.servlet.jsp.jstl/jakarta.servlet.jsp.jstl-api/3.0.0/stats.json
@@ -4,32 +4,32 @@
     "dynamicAccess" : {
       "breakdown" : {
         "resources" : {
-          "coverageRatio" : 0.5,
-          "coveredCalls" : 1,
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
           "totalCalls" : 2
         }
       },
-      "coverageRatio" : 0.5,
-      "coveredCalls" : 1,
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 2,
       "totalCalls" : 2
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 1725,
-        "missed" : 557,
-        "ratio" : 0.755916,
+        "covered" : 1758,
+        "missed" : 524,
+        "ratio" : 0.770377,
         "total" : 2282
       },
       "line" : {
-        "covered" : 465,
-        "missed" : 147,
-        "ratio" : 0.759804,
+        "covered" : 472,
+        "missed" : 140,
+        "ratio" : 0.771242,
         "total" : 612
       },
       "method" : {
-        "covered" : 104,
-        "missed" : 22,
-        "ratio" : 0.825397,
+        "covered" : 105,
+        "missed" : 21,
+        "ratio" : 0.833333,
         "total" : 126
       }
     }

--- a/tests/src/jakarta.servlet.jsp.jstl/jakarta.servlet.jsp.jstl-api/3.0.0/src/test/java/jakarta_servlet_jsp_jstl/jakarta_servlet_jsp_jstl_api/Jakarta_servlet_jsp_jstl_apiTest.java
+++ b/tests/src/jakarta.servlet.jsp.jstl/jakarta.servlet.jsp.jstl-api/3.0.0/src/test/java/jakarta_servlet_jsp_jstl/jakarta_servlet_jsp_jstl_api/Jakarta_servlet_jsp_jstl_apiTest.java
@@ -24,10 +24,8 @@ import java.util.EventListener;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.ListResourceBundle;
 import java.util.Locale;
 import java.util.Map;
-import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.SortedMap;
 
@@ -69,8 +67,6 @@ import jakarta.servlet.jsp.jstl.core.IteratedExpression;
 import jakarta.servlet.jsp.jstl.core.IteratedValueExpression;
 import jakarta.servlet.jsp.jstl.core.LoopTagStatus;
 import jakarta.servlet.jsp.jstl.core.LoopTagSupport;
-import jakarta.servlet.jsp.jstl.fmt.LocaleSupport;
-import jakarta.servlet.jsp.jstl.fmt.LocalizationContext;
 import jakarta.servlet.jsp.jstl.sql.Result;
 import jakarta.servlet.jsp.jstl.sql.ResultSupport;
 import jakarta.servlet.jsp.jstl.tlv.PermittedTaglibsTLV;
@@ -82,9 +78,6 @@ import jakarta.servlet.jsp.tagext.ValidationMessage;
 import org.junit.jupiter.api.Test;
 
 public class Jakarta_servlet_jsp_jstl_apiTest {
-    private static final String NAMED_MESSAGES_BUNDLE = "jakarta_servlet_jsp_jstl.jakarta_servlet_jsp_jstl_api"
-            + ".Jakarta_servlet_jsp_jstl_apiTest$NamedLocaleMessages";
-
     @Test
     void configStoresScopedValuesAndFindsThemInStandardOrder() {
         TestPageContext pageContext = new TestPageContext();
@@ -117,35 +110,6 @@ public class Jakarta_servlet_jsp_jstl_apiTest {
 
         assertThat(Config.get(pageContext.getServletContext(), Config.FMT_LOCALE)).isNull();
         assertThat(Config.find(pageContext, Config.FMT_LOCALE)).isEqualTo("en-US");
-    }
-
-    @Test
-    void localizationContextAndLocaleSupportResolveAndFormatMessages() {
-        TestPageContext pageContext = new TestPageContext();
-        ResourceBundle bundle = new MessagesBundle();
-        LocalizationContext context = new LocalizationContext(bundle, Locale.US);
-
-        Config.set(pageContext, Config.FMT_LOCALIZATION_CONTEXT, context, PageContext.PAGE_SCOPE);
-
-        assertThat(context.getResourceBundle()).isSameAs(bundle);
-        assertThat(context.getLocale()).isEqualTo(Locale.US);
-        assertThat(LocaleSupport.getLocalizedMessage(pageContext, "plain")).isEqualTo("Plain text");
-        assertThat(LocaleSupport.getLocalizedMessage(pageContext, "welcome", new Object[] {"Ada"}))
-                .isEqualTo("Welcome Ada");
-        assertThat(LocaleSupport.getLocalizedMessage(pageContext, "missing")).isEqualTo("???missing???");
-        assertThat(new LocalizationContext().getResourceBundle()).isNull();
-        assertThat(new LocalizationContext(bundle).getLocale()).isNull();
-    }
-
-    @Test
-    void localeSupportLoadsBundleByBasenameAndAppliesConfiguredLocale() {
-        TestPageContext pageContext = new TestPageContext();
-
-        Config.set(pageContext, Config.FMT_LOCALE, "en-US", PageContext.PAGE_SCOPE);
-
-        assertThat(LocaleSupport.getLocalizedMessage(pageContext, "salutation", new Object[] {"Ada"},
-                NAMED_MESSAGES_BUNDLE)).isEqualTo("Howdy Ada");
-        assertThat(pageContext.getResponse().getLocale()).isEqualTo(Locale.US);
     }
 
     @Test
@@ -565,42 +529,14 @@ public class Jakarta_servlet_jsp_jstl_apiTest {
         }
     }
 
-    private static final class MessagesBundle extends ListResourceBundle {
-        @Override
-        protected Object[][] getContents() {
-            return new Object[][] {
-                    {"plain", "Plain text"},
-                    {"welcome", "Welcome {0}"}
-            };
-        }
-    }
-
-    public static final class NamedLocaleMessages extends ListResourceBundle {
-        @Override
-        protected Object[][] getContents() {
-            return new Object[][] {
-                    {"salutation", "Hello {0}"}
-            };
-        }
-    }
-
-    public static final class NamedLocaleMessages_en_US extends ListResourceBundle {
-        @Override
-        protected Object[][] getContents() {
-            return new Object[][] {
-                    {"salutation", "Howdy {0}"}
-            };
-        }
-    }
-
-    private static final class TestPageContext extends PageContext {
+    static final class TestPageContext extends PageContext {
         private final Map<Integer, Map<String, Object>> scopedAttributes = new HashMap<>();
         private final TestServletContext servletContext = new TestServletContext();
         private final TestHttpSession session = new TestHttpSession(servletContext);
         private final TestServletResponse response = new TestServletResponse();
         private final TestELContext elContext = new TestELContext();
 
-        private TestPageContext() {
+        TestPageContext() {
             scopedAttributes.put(PAGE_SCOPE, new HashMap<>());
             scopedAttributes.put(REQUEST_SCOPE, new HashMap<>());
             scopedAttributes.put(SESSION_SCOPE, new HashMap<>());

--- a/tests/src/jakarta.servlet.jsp.jstl/jakarta.servlet.jsp.jstl-api/3.0.0/src/test/java/jakarta_servlet_jsp_jstl/jakarta_servlet_jsp_jstl_api/LocaleSupportTest.java
+++ b/tests/src/jakarta.servlet.jsp.jstl/jakarta.servlet.jsp.jstl-api/3.0.0/src/test/java/jakarta_servlet_jsp_jstl/jakarta_servlet_jsp_jstl_api/LocaleSupportTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_servlet_jsp_jstl.jakarta_servlet_jsp_jstl_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ListResourceBundle;
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+import jakarta.servlet.jsp.PageContext;
+import jakarta.servlet.jsp.jstl.core.Config;
+import jakarta.servlet.jsp.jstl.fmt.LocaleSupport;
+import jakarta.servlet.jsp.jstl.fmt.LocalizationContext;
+import org.junit.jupiter.api.Test;
+
+public class LocaleSupportTest {
+    private static final String NAMED_MESSAGES_BUNDLE = "jakarta_servlet_jsp_jstl.jakarta_servlet_jsp_jstl_api"
+            + ".LocaleSupportTest$NamedLocaleMessages";
+    private static final String ROOT_MESSAGES_BUNDLE = "jakarta_servlet_jsp_jstl.jakarta_servlet_jsp_jstl_api"
+            + ".LocaleSupportTest$RootMessages";
+
+    @Test
+    void localizationContextAndLocaleSupportResolveAndFormatMessages() {
+        Jakarta_servlet_jsp_jstl_apiTest.TestPageContext pageContext =
+                new Jakarta_servlet_jsp_jstl_apiTest.TestPageContext();
+        ResourceBundle bundle = new MessagesBundle();
+        LocalizationContext context = new LocalizationContext(bundle, Locale.US);
+
+        Config.set(pageContext, Config.FMT_LOCALIZATION_CONTEXT, context, PageContext.PAGE_SCOPE);
+
+        assertThat(context.getResourceBundle()).isSameAs(bundle);
+        assertThat(context.getLocale()).isEqualTo(Locale.US);
+        assertThat(LocaleSupport.getLocalizedMessage(pageContext, "plain")).isEqualTo("Plain text");
+        assertThat(LocaleSupport.getLocalizedMessage(pageContext, "welcome", new Object[] {"Ada"}))
+                .isEqualTo("Welcome Ada");
+        assertThat(LocaleSupport.getLocalizedMessage(pageContext, "missing")).isEqualTo("???missing???");
+        assertThat(new LocalizationContext().getResourceBundle()).isNull();
+        assertThat(new LocalizationContext(bundle).getLocale()).isNull();
+    }
+
+    @Test
+    void localeSupportLoadsBundleByBasenameAndAppliesConfiguredLocale() {
+        Jakarta_servlet_jsp_jstl_apiTest.TestPageContext pageContext =
+                new Jakarta_servlet_jsp_jstl_apiTest.TestPageContext();
+
+        Config.set(pageContext, Config.FMT_LOCALE, "en-US", PageContext.PAGE_SCOPE);
+
+        assertThat(LocaleSupport.getLocalizedMessage(pageContext, "salutation", new Object[] {"Ada"},
+                NAMED_MESSAGES_BUNDLE)).isEqualTo("Howdy Ada");
+        assertThat(pageContext.getResponse().getLocale()).isEqualTo(Locale.US);
+    }
+
+    @Test
+    void loadsRootBundleWhenConfiguredLocaleDoesNotMatchAvailableBundles() {
+        Jakarta_servlet_jsp_jstl_apiTest.TestPageContext pageContext =
+                new Jakarta_servlet_jsp_jstl_apiTest.TestPageContext();
+
+        Config.set(pageContext, Config.FMT_LOCALE, "zz-ZZ", PageContext.PAGE_SCOPE);
+
+        assertThat(LocaleSupport.getLocalizedMessage(pageContext, "rootOnly", ROOT_MESSAGES_BUNDLE))
+                .isEqualTo("Resolved from the root bundle");
+    }
+
+    private static final class MessagesBundle extends ListResourceBundle {
+        @Override
+        protected Object[][] getContents() {
+            return new Object[][] {
+                    {"plain", "Plain text"},
+                    {"welcome", "Welcome {0}"}
+            };
+        }
+    }
+
+    public static final class NamedLocaleMessages extends ListResourceBundle {
+        @Override
+        protected Object[][] getContents() {
+            return new Object[][] {
+                    {"salutation", "Hello {0}"}
+            };
+        }
+    }
+
+    public static final class NamedLocaleMessages_en_US extends ListResourceBundle {
+        @Override
+        protected Object[][] getContents() {
+            return new Object[][] {
+                    {"salutation", "Howdy {0}"}
+            };
+        }
+    }
+
+    public static final class RootMessages extends ListResourceBundle {
+        @Override
+        protected Object[][] getContents() {
+            return new Object[][] {
+                    {"rootOnly", "Resolved from the root bundle"}
+            };
+        }
+    }
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7340

This PR provides new metadata needed for the jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api:3.0.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api:3.0.0`): 32
- Metadata entries (new `jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api:3.0.0`): 32
- Library coverage (previous): 77.12%
- Library coverage (new): 77.12%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `2092ee0386858841e6525060b6699ef91669eeca`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api:3.0.0` and `jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api:3.0.0`.

### Local CI Verification

- Status: `success`
- Commands run: 14
- Fixup attempts: 0
