### PR TITLE
[GenAI] Mark io.projectreactor.netty:reactor-netty as not for Native Image

### DIFF
--- a/metadata/io.projectreactor.netty/reactor-netty/index.json
+++ b/metadata/io.projectreactor.netty/reactor-netty/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published JAR for io.projectreactor.netty:reactor-netty:1.1.1 contains only META-INF/MANIFEST.MF and no JVM class files; implementation classes are supplied by its component dependencies.",
+    "replacement": "Use class-bearing dependencies such as io.projectreactor.netty:reactor-netty-core:1.1.1, io.projectreactor.netty:reactor-netty-http:1.1.1, and io.projectreactor.netty.incubator:reactor-netty-incubator-quic:0.1.1."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #1405

This PR records `io.projectreactor.netty:reactor-netty` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published JAR for io.projectreactor.netty:reactor-netty:1.1.1 contains only META-INF/MANIFEST.MF and no JVM class files; implementation classes are supplied by its component dependencies.

Replacement guidance:
- Use class-bearing dependencies such as io.projectreactor.netty:reactor-netty-core:1.1.1, io.projectreactor.netty:reactor-netty-http:1.1.1, and io.projectreactor.netty.incubator:reactor-netty-incubator-quic:0.1.1.

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `a043302631568d533705c10a2c6fa9e382757ad6`

### Local CI Verification

- Status: `success`
- Commands run: 6
- Fixup attempts: 0
