### PR TITLE
[GenAI] Add support for com.github.waffle:waffle-jna:3.5.0 using gpt-5.5

### DIFF
--- a/metadata/com.github.waffle/waffle-jna/3.5.0/reachability-metadata.json
+++ b/metadata/com.github.waffle/waffle-jna/3.5.0/reachability-metadata.json
@@ -1,0 +1,26 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "waffle.windows.auth.impl.WindowsSecurityContextImpl"
+      },
+      "type": "com.sun.jna.platform.win32.Sspi$SecBufferDesc",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "waffle.windows.auth.impl.WindowsSecurityContextImpl"
+      },
+      "type": "com.sun.jna.platform.win32.Sspi$SecBuffer",
+      "allDeclaredFields": true
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "waffle.jaas.WindowsLoginModule"
+      },
+      "bundle": "sun.security.util.resources.security"
+    }
+  ]
+}

--- a/metadata/com.github.waffle/waffle-jna/index.json
+++ b/metadata/com.github.waffle/waffle-jna/index.json
@@ -1,0 +1,20 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.5.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/github/waffle/waffle-jna/$version$/waffle-jna-$version$-sources.jar",
+    "repository-url" : "https://github.com/Waffle/waffle",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/com/github/waffle/waffle-jna/$version$/waffle-jna-$version$-test-sources.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/github/waffle/waffle-jna/$version$/waffle-jna-$version$-javadoc.jar",
+    "description" : "WAFFLE is a native Windows authentication framework for Java and .NET that supports Negotiate, NTLM, and Kerberos. The waffle-jna module provides the Java JNA implementation used for Windows authentication APIs, Java web server single sign-on integrations, and related JAAS or servlet authentication support.",
+    "tested-versions" : [
+      "3.5.0"
+    ],
+    "allowed-packages" : [
+      "waffle.jaas",
+      "waffle.servlet",
+      "waffle.util",
+      "waffle.windows.auth"
+    ]
+  }
+]

--- a/stats/com.github.waffle/waffle-jna/3.5.0/execution-metrics.json
+++ b/stats/com.github.waffle/waffle-jna/3.5.0/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-21": {
+    "timestamp": "2026-05-21T03:45:32.131852Z",
+    "library": "com.github.waffle:waffle-jna:3.5.0",
+    "starting_commit": "96d14fc792f63df4dd2864165f79a6e5b7382545",
+    "ending_commit": "6388c2764265a24b40f03a90b4893de7b78b6e47",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.5.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1055,
+          "missed": 3653,
+          "ratio": 0.224087,
+          "total": 4708
+        },
+        "line": {
+          "covered": 239,
+          "missed": 925,
+          "ratio": 0.205326,
+          "total": 1164
+        },
+        "method": {
+          "covered": 73,
+          "missed": 148,
+          "ratio": 0.330317,
+          "total": 221
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 147194,
+      "cached_input_tokens_used": 1707008,
+      "output_tokens_used": 19370,
+      "iterations": 4,
+      "cost_usd": 1.4346,
+      "generated_loc": 359,
+      "tested_library_loc": 239,
+      "metadata_entries": 5,
+      "code_coverage_percent": 20.53
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.github.waffle/waffle-jna/3.5.0/src/test/java/com_github_waffle/waffle_jna/Waffle_jnaTest.java",
+      "metadata_file": "metadata/com.github.waffle/waffle-jna/3.5.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.github.waffle/waffle-jna/3.5.0/stats.json
+++ b/stats/com.github.waffle/waffle-jna/3.5.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.5.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1055,
+        "missed" : 3653,
+        "ratio" : 0.224087,
+        "total" : 4708
+      },
+      "line" : {
+        "covered" : 239,
+        "missed" : 925,
+        "ratio" : 0.205326,
+        "total" : 1164
+      },
+      "method" : {
+        "covered" : 73,
+        "missed" : 148,
+        "ratio" : 0.330317,
+        "total" : 221
+      }
+    }
+  } ]
+}

--- a/tests/src/com.github.waffle/waffle-jna/3.5.0/.gitignore
+++ b/tests/src/com.github.waffle/waffle-jna/3.5.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.github.waffle/waffle-jna/3.5.0/build.gradle
+++ b/tests/src/com.github.waffle/waffle-jna/3.5.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.github.waffle:waffle-jna:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.github.waffle/waffle-jna/3.5.0/gradle.properties
+++ b/tests/src/com.github.waffle/waffle-jna/3.5.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.github.waffle:waffle-jna:3.5.0
+library.version = 3.5.0
+metadata.dir = com.github.waffle/waffle-jna/3.5.0/

--- a/tests/src/com.github.waffle/waffle-jna/3.5.0/settings.gradle
+++ b/tests/src/com.github.waffle/waffle-jna/3.5.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.github.waffle.waffle-jna_tests'

--- a/tests/src/com.github.waffle/waffle-jna/3.5.0/src/test/java/com_github_waffle/waffle_jna/Waffle_jnaTest.java
+++ b/tests/src/com.github.waffle/waffle-jna/3.5.0/src/test/java/com_github_waffle/waffle_jna/Waffle_jnaTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_github_waffle.waffle_jna;
+
+import org.junit.jupiter.api.Test;
+
+class Waffle_jnaTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/com.github.waffle/waffle-jna/3.5.0/src/test/java/com_github_waffle/waffle_jna/Waffle_jnaTest.java
+++ b/tests/src/com.github.waffle/waffle-jna/3.5.0/src/test/java/com_github_waffle/waffle_jna/Waffle_jnaTest.java
@@ -14,6 +14,7 @@ import org.w3c.dom.Element;
 
 import waffle.jaas.RolePrincipal;
 import waffle.jaas.UserPrincipal;
+import waffle.jaas.WindowsLoginModule;
 import waffle.servlet.WindowsPrincipal;
 import waffle.util.NtlmMessage;
 import waffle.util.SPNegoMessage;
@@ -23,15 +24,26 @@ import waffle.util.cache.CacheSupplier;
 import waffle.util.cache.CaffeineCache;
 import waffle.util.cache.CaffeineCacheSupplier;
 import waffle.windows.auth.IWindowsAccount;
+import waffle.windows.auth.IWindowsAuthProvider;
+import waffle.windows.auth.IWindowsComputer;
+import waffle.windows.auth.IWindowsDomain;
 import waffle.windows.auth.IWindowsIdentity;
 import waffle.windows.auth.IWindowsImpersonationContext;
+import waffle.windows.auth.IWindowsSecurityContext;
 import waffle.windows.auth.PrincipalFormat;
 import waffle.windows.auth.WindowsAccount;
 import waffle.windows.auth.impl.WindowsAuthProviderImpl;
 
 import java.util.Arrays;
+import java.util.Map;
 import java.util.ServiceLoader;
 
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.xml.parsers.DocumentBuilderFactory;
 
 public class Waffle_jnaTest {
@@ -133,6 +145,50 @@ public class Waffle_jnaTest {
     }
 
     @Test
+    void windowsLoginModuleAuthenticatesWithCallbackCredentialsAndPopulatesSubjectPrincipals() throws Exception {
+        TrackingWindowsIdentity identity = new TrackingWindowsIdentity("S-1-5-21-1000", new byte[] { 1, 2, 3, 4 },
+                "DOMAIN\\alice",
+                new TestWindowsAccount("S-1-5-32-544", "DOMAIN\\Admins", "Admins", "DOMAIN"),
+                new TestWindowsAccount("S-1-5-32-545", "DOMAIN\\Users", "Users", "DOMAIN"));
+        TestWindowsAuthProvider authProvider = new TestWindowsAuthProvider(identity);
+        Subject subject = new Subject();
+        WindowsLoginModule loginModule = new WindowsLoginModule();
+        CallbackHandler callbackHandler = callbacks -> {
+            for (Callback callback : callbacks) {
+                if (callback instanceof NameCallback nameCallback) {
+                    nameCallback.setName("DOMAIN\\alice");
+                } else if (callback instanceof PasswordCallback passwordCallback) {
+                    passwordCallback.setPassword("secret".toCharArray());
+                } else {
+                    throw new UnsupportedCallbackException(callback);
+                }
+            }
+        };
+
+        loginModule.setAuth(authProvider);
+        loginModule.setAllowGuestLogin(false);
+        loginModule.initialize(subject, callbackHandler, Map.of(), Map.of("debug", "true", "principalFormat", "both",
+                "roleFormat", "sid"));
+
+        assertThat(loginModule.isDebug()).isTrue();
+        assertThat(loginModule.isAllowGuestLogin()).isFalse();
+        assertThat(loginModule.getAuth()).isSameAs(authProvider);
+        assertThat(loginModule.login()).isTrue();
+        assertThat(authProvider.getLastUsername()).isEqualTo("DOMAIN\\alice");
+        assertThat(authProvider.getLastPassword()).isEqualTo("secret");
+        assertThat(identity.isDisposed()).isTrue();
+
+        assertThat(loginModule.commit()).isTrue();
+        assertThat(subject.getPrincipals()).contains(new UserPrincipal("DOMAIN\\alice"),
+                new UserPrincipal("S-1-5-21-1000"), new RolePrincipal("S-1-5-32-544"),
+                new RolePrincipal("S-1-5-32-545"));
+        assertThat(subject.getPrincipals()).doesNotContain(new RolePrincipal("DOMAIN\\Admins"));
+
+        assertThat(loginModule.logout()).isTrue();
+        assertThat(subject.getPrincipals()).isEmpty();
+    }
+
+    @Test
     void waffleInfoFormatsExceptionDetailsAsXml() throws Exception {
         Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
         IllegalArgumentException failure = new IllegalArgumentException("bad account");
@@ -178,6 +234,123 @@ public class Waffle_jnaTest {
         @Override
         public String getDomain() {
             return domain;
+        }
+    }
+
+    private static final class TestWindowsAuthProvider implements IWindowsAuthProvider {
+        private final IWindowsIdentity identity;
+        private String lastUsername;
+        private String lastPassword;
+
+        private TestWindowsAuthProvider(IWindowsIdentity identity) {
+            this.identity = identity;
+        }
+
+        @Override
+        public IWindowsIdentity logonUser(String username, String password) {
+            this.lastUsername = username;
+            this.lastPassword = password;
+            return identity;
+        }
+
+        @Override
+        public IWindowsIdentity logonDomainUser(String username, String domain, String password) {
+            throw new UnsupportedOperationException("Domain logon is not used by this test.");
+        }
+
+        @Override
+        public IWindowsIdentity logonDomainUserEx(String username, String domain, String password, int logonType,
+                int logonProvider) {
+            throw new UnsupportedOperationException("Extended domain logon is not used by this test.");
+        }
+
+        @Override
+        public IWindowsAccount lookupAccount(String accountName) {
+            throw new UnsupportedOperationException("Account lookup is not used by this test.");
+        }
+
+        @Override
+        public IWindowsComputer getCurrentComputer() {
+            throw new UnsupportedOperationException("Computer lookup is not used by this test.");
+        }
+
+        @Override
+        public IWindowsDomain[] getDomains() {
+            throw new UnsupportedOperationException("Domain enumeration is not used by this test.");
+        }
+
+        @Override
+        public IWindowsSecurityContext acceptSecurityToken(String connectionId, byte[] token, String securityPackage) {
+            throw new UnsupportedOperationException("Security token acceptance is not used by this test.");
+        }
+
+        @Override
+        public void resetSecurityToken(String connectionId) {
+            throw new UnsupportedOperationException("Security token reset is not used by this test.");
+        }
+
+        private String getLastUsername() {
+            return lastUsername;
+        }
+
+        private String getLastPassword() {
+            return lastPassword;
+        }
+    }
+
+    private static final class TrackingWindowsIdentity implements IWindowsIdentity {
+        private final String sidString;
+        private final byte[] sid;
+        private final String fqn;
+        private final IWindowsAccount[] groups;
+        private boolean disposed;
+
+        private TrackingWindowsIdentity(String sidString, byte[] sid, String fqn, IWindowsAccount... groups) {
+            this.sidString = sidString;
+            this.sid = Arrays.copyOf(sid, sid.length);
+            this.fqn = fqn;
+            this.groups = Arrays.copyOf(groups, groups.length);
+        }
+
+        @Override
+        public String getSidString() {
+            return sidString;
+        }
+
+        @Override
+        public byte[] getSid() {
+            return Arrays.copyOf(sid, sid.length);
+        }
+
+        @Override
+        public String getFqn() {
+            return fqn;
+        }
+
+        @Override
+        public IWindowsAccount[] getGroups() {
+            return Arrays.copyOf(groups, groups.length);
+        }
+
+        @Override
+        public IWindowsImpersonationContext impersonate() {
+            return () -> {
+                // Test identity does not hold a native impersonation context.
+            };
+        }
+
+        @Override
+        public void dispose() {
+            disposed = true;
+        }
+
+        @Override
+        public boolean isGuest() {
+            return false;
+        }
+
+        private boolean isDisposed() {
+            return disposed;
         }
     }
 

--- a/tests/src/com.github.waffle/waffle-jna/3.5.0/src/test/java/com_github_waffle/waffle_jna/Waffle_jnaTest.java
+++ b/tests/src/com.github.waffle/waffle-jna/3.5.0/src/test/java/com_github_waffle/waffle_jna/Waffle_jnaTest.java
@@ -50,10 +50,10 @@ import javax.xml.parsers.DocumentBuilderFactory;
 public class Waffle_jnaTest {
     @Test
     void ntlmAndSpnegoMessagesAreRecognizedFromWireBytes() {
-        byte[] ntlmTypeOne = new byte[] { 'N', 'T', 'L', 'M', 'S', 'S', 'P', 0, 1, 0, 0, 0 };
-        byte[] nonNtlm = new byte[] { 'N', 'T', 'L', 'M', 'x' };
-        byte[] spnegoNegTokenInit = new byte[] { 0x60, 0x08, 0x06, 0x06, 0x2b, 0x06, 0x01, 0x05, 0x05, 0x02 };
-        byte[] spnegoNegTokenArg = new byte[] { (byte) 0xa1, 0x03, 0x01, 0x02, 0x03 };
+        byte[] ntlmTypeOne = new byte[] {'N', 'T', 'L', 'M', 'S', 'S', 'P', 0, 1, 0, 0, 0 };
+        byte[] nonNtlm = new byte[] {'N', 'T', 'L', 'M', 'x' };
+        byte[] spnegoNegTokenInit = new byte[] {0x60, 0x08, 0x06, 0x06, 0x2b, 0x06, 0x01, 0x05, 0x05, 0x02 };
+        byte[] spnegoNegTokenArg = new byte[] {(byte) 0xa1, 0x03, 0x01, 0x02, 0x03 };
 
         assertThat(NtlmMessage.isNtlmMessage(ntlmTypeOne)).isTrue();
         assertThat(NtlmMessage.getMessageType(ntlmTypeOne)).isEqualTo(1);
@@ -61,9 +61,9 @@ public class Waffle_jnaTest {
         assertThat(NtlmMessage.isNtlmMessage(null)).isFalse();
 
         assertThat(SPNegoMessage.isNegTokenInit(spnegoNegTokenInit)).isTrue();
-        assertThat(SPNegoMessage.isNegTokenInit(new byte[] { 0x60, 0x01 })).isFalse();
+        assertThat(SPNegoMessage.isNegTokenInit(new byte[] {0x60, 0x01 })).isFalse();
         assertThat(SPNegoMessage.isNegTokenArg(spnegoNegTokenArg)).isTrue();
-        assertThat(SPNegoMessage.isNegTokenArg(new byte[] { (byte) 0xa1, 0x04, 0x01 })).isFalse();
+        assertThat(SPNegoMessage.isNegTokenArg(new byte[] {(byte) 0xa1, 0x04, 0x01 })).isFalse();
     }
 
     @Test
@@ -95,7 +95,7 @@ public class Waffle_jnaTest {
     void windowsPrincipalBuildsRolesForRequestedPrincipalAndGroupFormats() {
         TestWindowsAccount admins = new TestWindowsAccount("S-1-5-32-544", "DOMAIN\\Admins", "Admins", "DOMAIN");
         TestWindowsAccount users = new TestWindowsAccount("S-1-5-32-545", "DOMAIN\\Users", "Users", "DOMAIN");
-        TestWindowsIdentity identity = new TestWindowsIdentity("S-1-5-21-1000", new byte[] { 1, 2, 3, 4 },
+        TestWindowsIdentity identity = new TestWindowsIdentity("S-1-5-21-1000", new byte[] {1, 2, 3, 4 },
                 "DOMAIN\\alice", admins, users);
 
         WindowsPrincipal principal = new WindowsPrincipal(identity, PrincipalFormat.BOTH, PrincipalFormat.SID);
@@ -118,7 +118,7 @@ public class Waffle_jnaTest {
     @Test
     void windowsSecurityContextStoresNegotiationStateAndDefensivelyCopiesToken() {
         WindowsSecurityContextImpl context = new WindowsSecurityContextImpl();
-        byte[] token = new byte[] { 1, 2, 3, 4 };
+        byte[] token = new byte[] {1, 2, 3, 4 };
 
         context.setPrincipalName("DOMAIN\\alice");
         context.setSecurityPackage("Negotiate");
@@ -168,7 +168,7 @@ public class Waffle_jnaTest {
 
     @Test
     void windowsLoginModuleAuthenticatesWithCallbackCredentialsAndPopulatesSubjectPrincipals() throws Exception {
-        TrackingWindowsIdentity identity = new TrackingWindowsIdentity("S-1-5-21-1000", new byte[] { 1, 2, 3, 4 },
+        TrackingWindowsIdentity identity = new TrackingWindowsIdentity("S-1-5-21-1000", new byte[] {1, 2, 3, 4 },
                 "DOMAIN\\alice",
                 new TestWindowsAccount("S-1-5-32-544", "DOMAIN\\Admins", "Admins", "DOMAIN"),
                 new TestWindowsAccount("S-1-5-32-545", "DOMAIN\\Users", "Users", "DOMAIN"));

--- a/tests/src/com.github.waffle/waffle-jna/3.5.0/src/test/java/com_github_waffle/waffle_jna/Waffle_jnaTest.java
+++ b/tests/src/com.github.waffle/waffle-jna/3.5.0/src/test/java/com_github_waffle/waffle_jna/Waffle_jnaTest.java
@@ -6,11 +6,229 @@
  */
 package com_github_waffle.waffle_jna;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
-class Waffle_jnaTest {
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import waffle.jaas.RolePrincipal;
+import waffle.jaas.UserPrincipal;
+import waffle.servlet.WindowsPrincipal;
+import waffle.util.NtlmMessage;
+import waffle.util.SPNegoMessage;
+import waffle.util.WaffleInfo;
+import waffle.util.cache.Cache;
+import waffle.util.cache.CacheSupplier;
+import waffle.util.cache.CaffeineCache;
+import waffle.util.cache.CaffeineCacheSupplier;
+import waffle.windows.auth.IWindowsAccount;
+import waffle.windows.auth.IWindowsIdentity;
+import waffle.windows.auth.IWindowsImpersonationContext;
+import waffle.windows.auth.PrincipalFormat;
+import waffle.windows.auth.WindowsAccount;
+import waffle.windows.auth.impl.WindowsAuthProviderImpl;
+
+import java.util.Arrays;
+import java.util.ServiceLoader;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+public class Waffle_jnaTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void ntlmAndSpnegoMessagesAreRecognizedFromWireBytes() {
+        byte[] ntlmTypeOne = new byte[] { 'N', 'T', 'L', 'M', 'S', 'S', 'P', 0, 1, 0, 0, 0 };
+        byte[] nonNtlm = new byte[] { 'N', 'T', 'L', 'M', 'x' };
+        byte[] spnegoNegTokenInit = new byte[] { 0x60, 0x08, 0x06, 0x06, 0x2b, 0x06, 0x01, 0x05, 0x05, 0x02 };
+        byte[] spnegoNegTokenArg = new byte[] { (byte) 0xa1, 0x03, 0x01, 0x02, 0x03 };
+
+        assertThat(NtlmMessage.isNtlmMessage(ntlmTypeOne)).isTrue();
+        assertThat(NtlmMessage.getMessageType(ntlmTypeOne)).isEqualTo(1);
+        assertThat(NtlmMessage.isNtlmMessage(nonNtlm)).isFalse();
+        assertThat(NtlmMessage.isNtlmMessage(null)).isFalse();
+
+        assertThat(SPNegoMessage.isNegTokenInit(spnegoNegTokenInit)).isTrue();
+        assertThat(SPNegoMessage.isNegTokenInit(new byte[] { 0x60, 0x01 })).isFalse();
+        assertThat(SPNegoMessage.isNegTokenArg(spnegoNegTokenArg)).isTrue();
+        assertThat(SPNegoMessage.isNegTokenArg(new byte[] { (byte) 0xa1, 0x04, 0x01 })).isFalse();
+    }
+
+    @Test
+    void principalsAndAccountSnapshotsUseStableNamesAndIdentifiers() {
+        UserPrincipal user = new UserPrincipal("DOMAIN\\alice");
+        RolePrincipal role = new RolePrincipal("DOMAIN\\Admins");
+        WindowsAccount admins = new WindowsAccount(new TestWindowsAccount("S-1-5-32-544", "DOMAIN\\Admins", "Admins", "DOMAIN"));
+        WindowsAccount duplicateAdmins = new WindowsAccount(
+                new TestWindowsAccount("S-1-5-32-544", "OTHER\\Administrators", "Administrators", "OTHER"));
+        WindowsAccount users = new WindowsAccount(new TestWindowsAccount("S-1-5-32-545", "DOMAIN\\Users", "Users", "DOMAIN"));
+
+        assertThat(user.getName()).isEqualTo("DOMAIN\\alice");
+        assertThat(user).isEqualTo(new UserPrincipal("DOMAIN\\alice"));
+        assertThat(user).isNotEqualTo(new UserPrincipal("DOMAIN\\bob"));
+
+        assertThat(role.getName()).isEqualTo("DOMAIN\\Admins");
+        assertThat(role).isEqualTo(new RolePrincipal("DOMAIN\\Admins"));
+        assertThat(role).isNotEqualTo(new RolePrincipal("DOMAIN\\Users"));
+
+        assertThat(admins.getSidString()).isEqualTo("S-1-5-32-544");
+        assertThat(admins.getFqn()).isEqualTo("DOMAIN\\Admins");
+        assertThat(admins.getName()).isEqualTo("Admins");
+        assertThat(admins.getDomain()).isEqualTo("DOMAIN");
+        assertThat(admins).isEqualTo(duplicateAdmins);
+        assertThat(admins).isNotEqualTo(users);
+    }
+
+    @Test
+    void windowsPrincipalBuildsRolesForRequestedPrincipalAndGroupFormats() {
+        TestWindowsAccount admins = new TestWindowsAccount("S-1-5-32-544", "DOMAIN\\Admins", "Admins", "DOMAIN");
+        TestWindowsAccount users = new TestWindowsAccount("S-1-5-32-545", "DOMAIN\\Users", "Users", "DOMAIN");
+        TestWindowsIdentity identity = new TestWindowsIdentity("S-1-5-21-1000", new byte[] { 1, 2, 3, 4 },
+                "DOMAIN\\alice", admins, users);
+
+        WindowsPrincipal principal = new WindowsPrincipal(identity, PrincipalFormat.BOTH, PrincipalFormat.SID);
+
+        assertThat(principal.getName()).isEqualTo("DOMAIN\\alice");
+        assertThat(principal.toString()).isEqualTo("DOMAIN\\alice");
+        assertThat(principal.getSidString()).isEqualTo("S-1-5-21-1000");
+        assertThat(principal.getSid()).containsExactly((byte) 1, (byte) 2, (byte) 3, (byte) 4);
+        assertThat(principal.getSid()).isNotSameAs(identity.getSid());
+        assertThat(principal.getIdentity()).isSameAs(identity);
+        assertThat(principal.getGroups()).containsOnlyKeys("DOMAIN\\Admins", "DOMAIN\\Users");
+        assertThat(principal.hasRole("DOMAIN\\alice")).isTrue();
+        assertThat(principal.hasRole("S-1-5-21-1000")).isTrue();
+        assertThat(principal.hasRole("S-1-5-32-544")).isTrue();
+        assertThat(principal.hasRole("DOMAIN\\Admins")).isFalse();
+        assertThat(principal.getRolesString()).contains("DOMAIN\\alice", "S-1-5-21-1000", "S-1-5-32-544");
+        assertThat(principal).isEqualTo(new WindowsPrincipal(identity));
+    }
+
+    @Test
+    void cacheImplementationsStoreRemoveAndLoadThroughServiceProvider() {
+        Cache<String, String> directCache = new CaffeineCache<>(60);
+        directCache.put("connection", "token");
+        assertThat(directCache.get("connection")).isEqualTo("token");
+        assertThat(directCache.size()).isEqualTo(1);
+        directCache.remove("connection");
+        assertThat(directCache.get("connection")).isNull();
+        assertThat(directCache.size()).isZero();
+
+        Cache<String, Integer> suppliedCache = new CaffeineCacheSupplier().newCache(60);
+        suppliedCache.put("step", 1);
+        assertThat(suppliedCache.get("step")).isEqualTo(1);
+
+        ServiceLoader<CacheSupplier> cacheSuppliers = ServiceLoader.load(CacheSupplier.class);
+        assertThat(cacheSuppliers).anySatisfy(supplier -> assertThat(supplier).isInstanceOf(CaffeineCacheSupplier.class));
+
+        Cache<String, String> serviceLoadedCache = Cache.newCache(60);
+        serviceLoadedCache.put("service", "loaded");
+        assertThat(serviceLoadedCache.get("service")).isEqualTo("loaded");
+    }
+
+    @Test
+    void windowsAuthProviderStartsWithAnEmptyBoundedContinueContextCache() {
+        WindowsAuthProviderImpl authProvider = new WindowsAuthProviderImpl(60);
+
+        authProvider.resetSecurityToken("missing-connection");
+        assertThat(authProvider.getContinueContextsSize()).isZero();
+    }
+
+    @Test
+    void waffleInfoFormatsExceptionDetailsAsXml() throws Exception {
+        Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        IllegalArgumentException failure = new IllegalArgumentException("bad account");
+
+        Element exception = WaffleInfo.getException(document, failure);
+        document.appendChild(exception);
+        String xml = WaffleInfo.toPrettyXML(document);
+
+        assertThat(exception.getAttribute("class")).isEqualTo(IllegalArgumentException.class.getName());
+        assertThat(xml).contains("<exception class=\"java.lang.IllegalArgumentException\">");
+        assertThat(xml).contains("<message>bad account</message>");
+        assertThat(xml).contains("<trace>");
+    }
+
+    private static final class TestWindowsAccount implements IWindowsAccount {
+        private final String sidString;
+        private final String fqn;
+        private final String name;
+        private final String domain;
+
+        private TestWindowsAccount(String sidString, String fqn, String name, String domain) {
+            this.sidString = sidString;
+            this.fqn = fqn;
+            this.name = name;
+            this.domain = domain;
+        }
+
+        @Override
+        public String getSidString() {
+            return sidString;
+        }
+
+        @Override
+        public String getFqn() {
+            return fqn;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public String getDomain() {
+            return domain;
+        }
+    }
+
+    private static final class TestWindowsIdentity implements IWindowsIdentity {
+        private final String sidString;
+        private final byte[] sid;
+        private final String fqn;
+        private final IWindowsAccount[] groups;
+
+        private TestWindowsIdentity(String sidString, byte[] sid, String fqn, IWindowsAccount... groups) {
+            this.sidString = sidString;
+            this.sid = Arrays.copyOf(sid, sid.length);
+            this.fqn = fqn;
+            this.groups = Arrays.copyOf(groups, groups.length);
+        }
+
+        @Override
+        public String getSidString() {
+            return sidString;
+        }
+
+        @Override
+        public byte[] getSid() {
+            return Arrays.copyOf(sid, sid.length);
+        }
+
+        @Override
+        public String getFqn() {
+            return fqn;
+        }
+
+        @Override
+        public IWindowsAccount[] getGroups() {
+            return Arrays.copyOf(groups, groups.length);
+        }
+
+        @Override
+        public IWindowsImpersonationContext impersonate() {
+            return () -> {
+                // Test identity does not hold a native impersonation context.
+            };
+        }
+
+        @Override
+        public void dispose() {
+            // Test identity does not hold native resources.
+        }
+
+        @Override
+        public boolean isGuest() {
+            return false;
+        }
     }
 }

--- a/tests/src/com.github.waffle/waffle-jna/3.5.0/src/test/java/com_github_waffle/waffle_jna/Waffle_jnaTest.java
+++ b/tests/src/com.github.waffle/waffle-jna/3.5.0/src/test/java/com_github_waffle/waffle_jna/Waffle_jnaTest.java
@@ -33,6 +33,7 @@ import waffle.windows.auth.IWindowsSecurityContext;
 import waffle.windows.auth.PrincipalFormat;
 import waffle.windows.auth.WindowsAccount;
 import waffle.windows.auth.impl.WindowsAuthProviderImpl;
+import waffle.windows.auth.impl.WindowsSecurityContextImpl;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -112,6 +113,27 @@ public class Waffle_jnaTest {
         assertThat(principal.hasRole("DOMAIN\\Admins")).isFalse();
         assertThat(principal.getRolesString()).contains("DOMAIN\\alice", "S-1-5-21-1000", "S-1-5-32-544");
         assertThat(principal).isEqualTo(new WindowsPrincipal(identity));
+    }
+
+    @Test
+    void windowsSecurityContextStoresNegotiationStateAndDefensivelyCopiesToken() {
+        WindowsSecurityContextImpl context = new WindowsSecurityContextImpl();
+        byte[] token = new byte[] { 1, 2, 3, 4 };
+
+        context.setPrincipalName("DOMAIN\\alice");
+        context.setSecurityPackage("Negotiate");
+        context.setToken(token);
+        context.setContinue(true);
+        token[0] = 9;
+
+        assertThat(context.getPrincipalName()).isEqualTo("DOMAIN\\alice");
+        assertThat(context.getSecurityPackage()).isEqualTo("Negotiate");
+        assertThat(context.isContinue()).isTrue();
+        assertThat(context.getToken()).containsExactly((byte) 1, (byte) 2, (byte) 3, (byte) 4);
+
+        byte[] returnedToken = context.getToken();
+        returnedToken[1] = 9;
+        assertThat(context.getToken()).containsExactly((byte) 1, (byte) 2, (byte) 3, (byte) 4);
     }
 
     @Test

--- a/tests/src/com.github.waffle/waffle-jna/3.5.0/user-code-filter.json
+++ b/tests/src/com.github.waffle/waffle-jna/3.5.0/user-code-filter.json
@@ -1,19 +1,22 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "waffle.jaas.**"
+      "includeClasses" : "waffle.jaas.**"
     },
     {
-      "includeClasses": "waffle.servlet.**"
+      "includeClasses" : "waffle.servlet.**"
     },
     {
-      "includeClasses": "waffle.util.**"
+      "includeClasses" : "waffle.util.**"
     },
     {
-      "includeClasses": "waffle.windows.auth.**"
+      "includeClasses" : "waffle.windows.auth.**"
+    },
+    {
+      "includeClasses" : "com_github_waffle.waffle_jna.**"
     }
   ]
 }

--- a/tests/src/com.github.waffle/waffle-jna/3.5.0/user-code-filter.json
+++ b/tests/src/com.github.waffle/waffle-jna/3.5.0/user-code-filter.json
@@ -1,0 +1,19 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "waffle.jaas.**"
+    },
+    {
+      "includeClasses": "waffle.servlet.**"
+    },
+    {
+      "includeClasses": "waffle.util.**"
+    },
+    {
+      "includeClasses": "waffle.windows.auth.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #1315

This PR introduces tests and metadata for com.github.waffle:waffle-jna:3.5.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 147194
- Cached input tokens: 1707008
- Output tokens: 19370
- Metadata entries: 5
- Iterations: 4
- Library coverage percentage: 20.53
- Generated lines of code: 359
- Tested library lines of code: 239

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `99a95eed4c1dc3c8993bae6b6bfd1e049e3f2b00`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1055/4708 (22.41%)
- Line: 239/1164 (20.53%)
- Method: 73/221 (33.03%)

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
