### PR TITLE
[GenAI] Test fix for org.mongodb:mongodb-driver-core:5.1.3 using gpt-5.5

### DIFF
--- a/metadata/org.mongodb/mongodb-driver-core/5.1.3/reachability-metadata.json
+++ b/metadata/org.mongodb/mongodb-driver-core/5.1.3/reachability-metadata.json
@@ -1,0 +1,63 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.mongodb.WriteConcern"
+      },
+      "type" : "com.mongodb.WriteConcern",
+      "fields" : [
+        {
+          "name" : "ACKNOWLEDGED"
+        },
+        {
+          "name" : "W1"
+        },
+        {
+          "name" : "W2"
+        },
+        {
+          "name" : "W3"
+        },
+        {
+          "name" : "UNACKNOWLEDGED"
+        },
+        {
+          "name" : "JOURNALED"
+        },
+        {
+          "name" : "MAJORITY"
+        }
+      ],
+      "allPublicFields" : true
+    },
+    {
+      "type" : "com.mongodb.internal.connection.tlschannel.util.DirectBufferDeallocator",
+      "fields" : [
+        {
+          "name" : "deallocator"
+        }
+      ],
+      "unsafeAllocated" : true
+    },
+    {
+      "type" : "com.mongodb.internal.connection.tlschannel.util.DirectBufferDeallocator$Java8Deallocator",
+      "fields" : [
+        {
+          "name" : "cleanerAccessor"
+        },
+        {
+          "name" : "clean"
+        }
+      ],
+      "unsafeAllocated" : true
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com.mongodb.internal.connection.ServerAddressWithResolver"
+      },
+      "glob" : "META-INF/services/com.mongodb.spi.dns.InetAddressResolverProvider"
+    }
+  ]
+}

--- a/metadata/org.mongodb/mongodb-driver-core/index.json
+++ b/metadata/org.mongodb/mongodb-driver-core/index.json
@@ -20,6 +20,11 @@
   },
   {
     "metadata-version" : "5.1.3",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/mongodb/mongodb-driver-core/$version$/mongodb-driver-core-$version$-sources.jar",
+    "repository-url" : "https://github.com/mongodb/mongo-java-driver",
+    "test-code-url" : "https://github.com/mongodb/mongo-java-driver/tree/r$version$/driver-core/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/mongodb/mongodb-driver-core/$version$/mongodb-driver-core-$version$-javadoc.jar",
+    "description" : "MongoDB Java Driver Core provides the shared protocol, cluster, connection, authentication, and operation infrastructure used by the synchronous and Reactive Streams MongoDB Java drivers. It handles low-level driver behavior such as server discovery, command execution, BSON codec integration, connection pooling, and optional compression or authentication integrations for JVM applications.",
     "tested-versions" : [
       "5.1.3"
     ],

--- a/metadata/org.mongodb/mongodb-driver-core/index.json
+++ b/metadata/org.mongodb/mongodb-driver-core/index.json
@@ -19,6 +19,15 @@
     ]
   },
   {
+    "metadata-version" : "5.1.3",
+    "tested-versions" : [
+      "5.1.3"
+    ],
+    "allowed-packages" : [
+      "com.mongodb"
+    ]
+  },
+  {
     "metadata-version" : "5.1.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/mongodb/mongodb-driver-core/$version$/mongodb-driver-core-$version$-sources.jar",
     "repository-url" : "https://github.com/mongodb/mongo-java-driver",

--- a/stats/org.mongodb/mongodb-driver-core/5.1.3/execution-metrics.json
+++ b/stats/org.mongodb/mongodb-driver-core/5.1.3/execution-metrics.json
@@ -1,0 +1,99 @@
+{
+  "fix_javac_fail:2026-05-21": {
+    "timestamp": "2026-05-21T04:02:50.758459Z",
+    "library": "org.mongodb:mongodb-driver-core:5.1.3",
+    "starting_commit": "38e618b5b0043d8092016d8eeb3ded10def20b8a",
+    "ending_commit": "83edc5fe67f86c627114edac598a3f0c2ac474e1",
+    "previous_library": "org.mongodb:mongodb-driver-core:4.11.1",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "5.1.3",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 13,
+            "totalCalls": 13
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 13,
+        "totalCalls": 13
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 13168,
+          "missed": 103033,
+          "ratio": 0.113321,
+          "total": 116201
+        },
+        "line": {
+          "covered": 3126,
+          "missed": 21986,
+          "ratio": 0.124482,
+          "total": 25112
+        },
+        "method": {
+          "covered": 1010,
+          "missed": 6672,
+          "ratio": 0.131476,
+          "total": 7682
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "4.11.1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 13,
+            "totalCalls": 13
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 13,
+        "totalCalls": 13
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 13219,
+          "missed": 101915,
+          "ratio": 0.114814,
+          "total": 115134
+        },
+        "line": {
+          "covered": 3142,
+          "missed": 21647,
+          "ratio": 0.12675,
+          "total": 24789
+        },
+        "method": {
+          "covered": 1002,
+          "missed": 6594,
+          "ratio": 0.131912,
+          "total": 7596
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 29006,
+      "cached_input_tokens_used": 314880,
+      "output_tokens_used": 3292,
+      "iterations": 1,
+      "cost_usd": 0.2562,
+      "tested_library_loc": 3126,
+      "metadata_entries": 17,
+      "previous_library_metadata_entries": 16,
+      "code_coverage_percent": 12.45,
+      "previous_library_coverage_percent": 12.68
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.mongodb/mongodb-driver-core/5.1.3/src/test/java/org_mongodb/mongodb_driver_core/DirectBufferDeallocatorInnerJava9DeallocatorTest.java",
+      "metadata_file": "metadata/org.mongodb/mongodb-driver-core/5.1.3/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.mongodb/mongodb-driver-core/5.1.3/stats.json
+++ b/stats/org.mongodb/mongodb-driver-core/5.1.3/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "5.1.3",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 13,
+          "totalCalls" : 13
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 13,
+      "totalCalls" : 13
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 13168,
+        "missed" : 103033,
+        "ratio" : 0.113321,
+        "total" : 116201
+      },
+      "line" : {
+        "covered" : 3126,
+        "missed" : 21986,
+        "ratio" : 0.124482,
+        "total" : 25112
+      },
+      "method" : {
+        "covered" : 1010,
+        "missed" : 6672,
+        "ratio" : 0.131476,
+        "total" : 7682
+      }
+    }
+  } ]
+}

--- a/tests/src/org.mongodb/mongodb-driver-core/5.1.3/.gitignore
+++ b/tests/src/org.mongodb/mongodb-driver-core/5.1.3/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.mongodb/mongodb-driver-core/5.1.3/build.gradle
+++ b/tests/src/org.mongodb/mongodb-driver-core/5.1.3/build.gradle
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.mongodb:mongodb-driver-core:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testRuntimeOnly 'software.amazon.awssdk:auth:2.34.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.mongodb/mongodb-driver-core/5.1.3/gradle.properties
+++ b/tests/src/org.mongodb/mongodb-driver-core/5.1.3/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.mongodb:mongodb-driver-core:5.1.3
+library.version = 5.1.3
+metadata.dir = org.mongodb/mongodb-driver-core/5.1.3/

--- a/tests/src/org.mongodb/mongodb-driver-core/5.1.3/settings.gradle
+++ b/tests/src/org.mongodb/mongodb-driver-core/5.1.3/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.mongodb.mongodb-driver-core_tests'

--- a/tests/src/org.mongodb/mongodb-driver-core/5.1.3/src/test/java/org_mongodb/mongodb_driver_core/AwsCredentialHelperTest.java
+++ b/tests/src/org.mongodb/mongodb-driver-core/5.1.3/src/test/java/org_mongodb/mongodb_driver_core/AwsCredentialHelperTest.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongodb_driver_core;
+
+import com.mongodb.internal.authentication.AwsCredentialHelper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AwsCredentialHelperTest {
+    @Test
+    void initializesAwsCredentialProviderSelection() {
+        assertThat(AwsCredentialHelper.LOGGER).isNotNull();
+        AwsCredentialHelper.requireBuiltInProvider();
+    }
+}

--- a/tests/src/org.mongodb/mongodb-driver-core/5.1.3/src/test/java/org_mongodb/mongodb_driver_core/ByteBufBsonArrayTest.java
+++ b/tests/src/org.mongodb/mongodb-driver-core/5.1.3/src/test/java/org_mongodb/mongodb_driver_core/ByteBufBsonArrayTest.java
@@ -16,8 +16,6 @@ import com.mongodb.connection.ClusterConnectionMode;
 import com.mongodb.connection.ClusterSettings;
 import com.mongodb.connection.ConnectionPoolSettings;
 import com.mongodb.connection.ServerSettings;
-import com.mongodb.connection.Stream;
-import com.mongodb.connection.StreamFactory;
 import com.mongodb.event.CommandListener;
 import com.mongodb.event.CommandStartedEvent;
 import com.mongodb.internal.IgnorableRequestContext;
@@ -26,6 +24,8 @@ import com.mongodb.internal.connection.Cluster;
 import com.mongodb.internal.connection.DefaultClusterFactory;
 import com.mongodb.internal.connection.InternalConnectionPoolSettings;
 import com.mongodb.internal.connection.PowerOfTwoBufferPool;
+import com.mongodb.internal.connection.Stream;
+import com.mongodb.internal.connection.StreamFactory;
 import com.mongodb.internal.operation.CommandReadOperation;
 import org.bson.BsonArray;
 import org.bson.BsonBinaryWriter;
@@ -84,7 +84,6 @@ public class ByteBufBsonArrayTest {
                 "byte-buf-bson-array-test",
                 MongoDriverInformation.builder().build(),
                 Collections.emptyList(),
-                null,
                 null,
                 null);
         final ClusterBinding binding = new ClusterBinding(cluster, ReadPreference.primary(), ReadConcern.DEFAULT, null,

--- a/tests/src/org.mongodb/mongodb-driver-core/5.1.3/src/test/java/org_mongodb/mongodb_driver_core/ByteBufBsonArrayTest.java
+++ b/tests/src/org.mongodb/mongodb-driver-core/5.1.3/src/test/java/org_mongodb/mongodb_driver_core/ByteBufBsonArrayTest.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongodb_driver_core;
+
+import com.mongodb.LoggerSettings;
+import com.mongodb.MongoDriverInformation;
+import com.mongodb.ReadConcern;
+import com.mongodb.ReadPreference;
+import com.mongodb.ServerAddress;
+import com.mongodb.connection.AsyncCompletionHandler;
+import com.mongodb.connection.ClusterConnectionMode;
+import com.mongodb.connection.ClusterSettings;
+import com.mongodb.connection.ConnectionPoolSettings;
+import com.mongodb.connection.ServerSettings;
+import com.mongodb.connection.Stream;
+import com.mongodb.connection.StreamFactory;
+import com.mongodb.event.CommandListener;
+import com.mongodb.event.CommandStartedEvent;
+import com.mongodb.internal.IgnorableRequestContext;
+import com.mongodb.internal.binding.ClusterBinding;
+import com.mongodb.internal.connection.Cluster;
+import com.mongodb.internal.connection.DefaultClusterFactory;
+import com.mongodb.internal.connection.InternalConnectionPoolSettings;
+import com.mongodb.internal.connection.PowerOfTwoBufferPool;
+import com.mongodb.internal.operation.CommandReadOperation;
+import org.bson.BsonArray;
+import org.bson.BsonBinaryWriter;
+import org.bson.BsonBoolean;
+import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+import org.bson.ByteBuf;
+import org.bson.codecs.BsonDocumentCodec;
+import org.bson.codecs.EncoderContext;
+import org.bson.io.BasicOutputBuffer;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ByteBufBsonArrayTest {
+    private static final int MESSAGE_HEADER_LENGTH = 16;
+    private static final int OP_REPLY = 1;
+    private static final int OP_QUERY = 2004;
+    private static final int OP_MSG = 2013;
+
+    @Test
+    void commandStartedEventConvertsByteBufferedArrayToTypedArray() {
+        final ServerAddress serverAddress = new ServerAddress("127.0.0.1", 27017);
+        final RecordingCommandListener commandListener = new RecordingCommandListener();
+        final RespondingStreamFactory streamFactory = new RespondingStreamFactory(serverAddress);
+        final Cluster cluster = new DefaultClusterFactory().createCluster(
+                ClusterSettings.builder()
+                        .hosts(Collections.singletonList(serverAddress))
+                        .mode(ClusterConnectionMode.SINGLE)
+                        .serverSelectionTimeout(5, TimeUnit.SECONDS)
+                        .build(),
+                ServerSettings.builder()
+                        .heartbeatFrequency(1, TimeUnit.HOURS)
+                        .minHeartbeatFrequency(1, TimeUnit.HOURS)
+                        .build(),
+                ConnectionPoolSettings.builder()
+                        .maxSize(1)
+                        .build(),
+                InternalConnectionPoolSettings.builder().build(),
+                streamFactory,
+                streamFactory,
+                null,
+                LoggerSettings.builder().build(),
+                commandListener,
+                "byte-buf-bson-array-test",
+                MongoDriverInformation.builder().build(),
+                Collections.emptyList(),
+                null,
+                null,
+                null);
+        final ClusterBinding binding = new ClusterBinding(cluster, ReadPreference.primary(), ReadConcern.DEFAULT, null,
+                IgnorableRequestContext.INSTANCE);
+        try {
+            final BsonDocument matchStage = new BsonDocument("$match",
+                    new BsonDocument("status", new BsonString("active")));
+            final BsonDocument limitStage = new BsonDocument("$limit", new BsonInt32(5));
+            final BsonDocument command = new BsonDocument("aggregate", new BsonString("widgets"))
+                    .append("pipeline", new BsonArray(Arrays.asList(matchStage, limitStage)))
+                    .append("cursor", new BsonDocument());
+            final CommandReadOperation<BsonDocument> operation = new CommandReadOperation<>("test", command,
+                    new BsonDocumentCodec());
+            final BsonDocument result = operation.execute(binding);
+
+            assertThat(result.getNumber("ok").doubleValue()).isEqualTo(1.0);
+            assertThat(commandListener.pipelineValues).containsExactly(matchStage, limitStage);
+            assertThat(commandListener.pipelineArrayClassName)
+                    .isEqualTo("com.mongodb.internal.connection.ByteBufBsonArray");
+        } finally {
+            binding.release();
+            cluster.close();
+        }
+    }
+
+    private static final class RecordingCommandListener implements CommandListener {
+        private List<BsonValue> pipelineValues = Collections.emptyList();
+        private String pipelineArrayClassName;
+
+        @Override
+        public void commandStarted(final CommandStartedEvent event) {
+            if (!"aggregate".equals(event.getCommandName())) {
+                return;
+            }
+            final BsonArray pipeline = event.getCommand().getArray("pipeline");
+            pipelineArrayClassName = pipeline.getClass().getName();
+            pipelineValues = Arrays.asList(pipeline.toArray(new BsonValue[0]));
+        }
+    }
+
+    private static final class RespondingStreamFactory implements StreamFactory {
+        private final ServerAddress serverAddress;
+
+        private RespondingStreamFactory(final ServerAddress serverAddress) {
+            this.serverAddress = serverAddress;
+        }
+
+        @Override
+        public Stream create(final ServerAddress address) {
+            return new RespondingStream(serverAddress);
+        }
+    }
+
+    private static final class RespondingStream implements Stream {
+        private final ServerAddress serverAddress;
+        private byte[] nextResponse;
+        private int nextResponsePosition;
+        private int lastRequestId;
+        private int lastOpCode;
+        private int responseRequestId = 1;
+        private int responsesCreated;
+        private boolean closed;
+
+        private RespondingStream(final ServerAddress serverAddress) {
+            this.serverAddress = serverAddress;
+        }
+
+        @Override
+        public void open() {
+            closed = false;
+        }
+
+        @Override
+        public void openAsync(final AsyncCompletionHandler<Void> handler) {
+            handler.completed(null);
+        }
+
+        @Override
+        public void write(final List<ByteBuf> byteBuffers) {
+            final byte[] header = new byte[MESSAGE_HEADER_LENGTH];
+            byteBuffers.get(0).get(byteBuffers.get(0).position(), header);
+            lastRequestId = getInt32LittleEndian(header, 4);
+            lastOpCode = getInt32LittleEndian(header, 12);
+            nextResponse = null;
+            nextResponsePosition = 0;
+        }
+
+        @Override
+        public ByteBuf read(final int numBytes) throws IOException {
+            return readResponseBytes(numBytes);
+        }
+
+        @Override
+        public ByteBuf read(final int numBytes, final int additionalTimeout) throws IOException {
+            return readResponseBytes(numBytes);
+        }
+
+        @Override
+        public void writeAsync(final List<ByteBuf> byteBuffers, final AsyncCompletionHandler<Void> handler) {
+            write(byteBuffers);
+            handler.completed(null);
+        }
+
+        @Override
+        public void readAsync(final int numBytes, final AsyncCompletionHandler<ByteBuf> handler) {
+            try {
+                handler.completed(read(numBytes));
+            } catch (IOException e) {
+                handler.failed(e);
+            }
+        }
+
+        @Override
+        public ServerAddress getAddress() {
+            return serverAddress;
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+
+        @Override
+        public boolean isClosed() {
+            return closed;
+        }
+
+        @Override
+        public ByteBuf getBuffer(final int size) {
+            return PowerOfTwoBufferPool.DEFAULT.getBuffer(size);
+        }
+
+        private ByteBuf readResponseBytes(final int numBytes) throws IOException {
+            if (nextResponse == null) {
+                nextResponse = createResponse(lastRequestId, lastOpCode, responseRequestId++, responsesCreated++ == 0);
+            }
+            if (nextResponsePosition + numBytes > nextResponse.length) {
+                throw new IOException("No response bytes remaining");
+            }
+            final ByteBuf buffer = getBuffer(numBytes);
+            buffer.put(nextResponse, nextResponsePosition, numBytes);
+            buffer.flip();
+            nextResponsePosition += numBytes;
+            if (nextResponsePosition == nextResponse.length) {
+                nextResponse = null;
+                nextResponsePosition = 0;
+            }
+            return buffer;
+        }
+
+        private static byte[] createResponse(final int responseTo, final int requestOpCode,
+                                             final int responseRequestId, final boolean handshake) {
+            final BsonDocument responseDocument = handshake ? helloResponse() : okResponse();
+            if (requestOpCode == OP_QUERY) {
+                return opReply(responseTo, responseRequestId, responseDocument);
+            }
+            return opMsg(responseTo, responseRequestId, responseDocument);
+        }
+
+        private static BsonDocument helloResponse() {
+            return new BsonDocument("ok", new BsonDouble(1.0))
+                    .append("isWritablePrimary", BsonBoolean.TRUE)
+                    .append("ismaster", BsonBoolean.TRUE)
+                    .append("helloOk", BsonBoolean.TRUE)
+                    .append("minWireVersion", new BsonInt32(0))
+                    .append("maxWireVersion", new BsonInt32(13))
+                    .append("maxBsonObjectSize", new BsonInt32(16 * 1024 * 1024))
+                    .append("maxMessageSizeBytes", new BsonInt32(48 * 1000 * 1000))
+                    .append("maxWriteBatchSize", new BsonInt32(100000))
+                    .append("logicalSessionTimeoutMinutes", new BsonInt32(30));
+        }
+
+        private static BsonDocument okResponse() {
+            return new BsonDocument("ok", new BsonDouble(1.0));
+        }
+
+        private static byte[] opReply(final int responseTo, final int requestId, final BsonDocument document) {
+            final byte[] documentBytes = toByteArray(document);
+            final int bodyLength = 4 + 8 + 4 + 4 + documentBytes.length;
+            final ByteBuffer buffer = messageBuffer(responseTo, requestId, OP_REPLY, bodyLength);
+            buffer.putInt(0);
+            buffer.putLong(0L);
+            buffer.putInt(0);
+            buffer.putInt(1);
+            buffer.put(documentBytes);
+            return buffer.array();
+        }
+
+        private static byte[] opMsg(final int responseTo, final int requestId, final BsonDocument document) {
+            final byte[] documentBytes = toByteArray(document);
+            final int bodyLength = 4 + 1 + documentBytes.length;
+            final ByteBuffer buffer = messageBuffer(responseTo, requestId, OP_MSG, bodyLength);
+            buffer.putInt(0);
+            buffer.put((byte) 0);
+            buffer.put(documentBytes);
+            return buffer.array();
+        }
+
+        private static ByteBuffer messageBuffer(final int responseTo, final int requestId, final int opCode,
+                                                final int bodyLength) {
+            final ByteBuffer buffer = ByteBuffer.allocate(MESSAGE_HEADER_LENGTH + bodyLength)
+                    .order(ByteOrder.LITTLE_ENDIAN);
+            buffer.putInt(MESSAGE_HEADER_LENGTH + bodyLength);
+            buffer.putInt(requestId);
+            buffer.putInt(responseTo);
+            buffer.putInt(opCode);
+            return buffer;
+        }
+
+        private static byte[] toByteArray(final BsonDocument document) {
+            final BasicOutputBuffer output = new BasicOutputBuffer();
+            try (BsonBinaryWriter writer = new BsonBinaryWriter(output)) {
+                new BsonDocumentCodec().encode(writer, document, EncoderContext.builder().build());
+            }
+            return output.toByteArray();
+        }
+
+        private static int getInt32LittleEndian(final byte[] bytes, final int offset) {
+            return ByteBuffer.wrap(bytes, offset, Integer.BYTES).order(ByteOrder.LITTLE_ENDIAN).getInt();
+        }
+    }
+}

--- a/tests/src/org.mongodb/mongodb-driver-core/5.1.3/src/test/java/org_mongodb/mongodb_driver_core/DirectBufferDeallocatorInnerJava8DeallocatorTest.java
+++ b/tests/src/org.mongodb/mongodb-driver-core/5.1.3/src/test/java/org_mongodb/mongodb_driver_core/DirectBufferDeallocatorInnerJava8DeallocatorTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongodb_driver_core;
+
+import com.mongodb.internal.connection.tlschannel.util.DirectBufferDeallocator;
+import org.junit.jupiter.api.Test;
+import sun.misc.Unsafe;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DirectBufferDeallocatorInnerJava8DeallocatorTest {
+    @Test
+    void deallocateInvokesCleanerThroughJava8Deallocator() throws Exception {
+        Java8DeallocatorState.reset();
+        final Unsafe unsafe = unsafe();
+        final Object java8Deallocator = unsafe.allocateInstance(java8DeallocatorClass());
+        setObjectField(
+                unsafe, java8Deallocator, "cleanerAccessor", accessibleMethod(Java8CleanerAccessor.class, "cleaner"));
+        setObjectField(unsafe, java8Deallocator, "clean", accessibleMethod(Java8Cleaner.class, "clean"));
+        final DirectBufferDeallocator deallocator =
+                (DirectBufferDeallocator) unsafe.allocateInstance(DirectBufferDeallocator.class);
+        setObjectField(unsafe, deallocator, "deallocator", java8Deallocator);
+        final ByteBuffer directBuffer = ByteBuffer.allocateDirect(Byte.BYTES);
+
+        deallocator.deallocate(directBuffer);
+
+        assertThat(Java8DeallocatorState.cleaned()).isTrue();
+    }
+
+    private static Class<?> java8DeallocatorClass() {
+        for (Class<?> nestedClass : DirectBufferDeallocator.class.getDeclaredClasses()) {
+            if ("Java8Deallocator".equals(nestedClass.getSimpleName())) {
+                return nestedClass;
+            }
+        }
+        throw new AssertionError("Java8Deallocator nested class not found");
+    }
+
+    private static Unsafe unsafe() throws ReflectiveOperationException {
+        final Field theUnsafe = Unsafe.class.getDeclaredField("theUnsafe");
+        theUnsafe.setAccessible(true);
+        return (Unsafe) theUnsafe.get(null);
+    }
+
+    private static Method accessibleMethod(final Class<?> declaringClass, final String methodName)
+            throws ReflectiveOperationException {
+        final Method method = declaringClass.getDeclaredMethod(methodName);
+        method.setAccessible(true);
+        return method;
+    }
+
+    private static void setObjectField(
+            final Unsafe unsafe, final Object target, final String fieldName, final Object value)
+            throws ReflectiveOperationException {
+        final Field field = target.getClass().getDeclaredField(fieldName);
+        unsafe.putObject(target, unsafe.objectFieldOffset(field), value);
+    }
+}
+
+final class Java8CleanerAccessor {
+    static Object cleaner() {
+        return new Java8Cleaner();
+    }
+}
+
+final class Java8Cleaner {
+    void clean() {
+        Java8DeallocatorState.markCleaned();
+    }
+}
+
+final class Java8DeallocatorState {
+    private static final AtomicBoolean CLEANED = new AtomicBoolean();
+
+    private Java8DeallocatorState() {
+    }
+
+    static void reset() {
+        CLEANED.set(false);
+    }
+
+    static void markCleaned() {
+        CLEANED.set(true);
+    }
+
+    static boolean cleaned() {
+        return CLEANED.get();
+    }
+}

--- a/tests/src/org.mongodb/mongodb-driver-core/5.1.3/src/test/java/org_mongodb/mongodb_driver_core/DirectBufferDeallocatorInnerJava9DeallocatorTest.java
+++ b/tests/src/org.mongodb/mongodb-driver-core/5.1.3/src/test/java/org_mongodb/mongodb_driver_core/DirectBufferDeallocatorInnerJava9DeallocatorTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongodb_driver_core;
+
+import com.mongodb.internal.connection.tlschannel.util.DirectBufferDeallocator;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+public class DirectBufferDeallocatorInnerJava9DeallocatorTest {
+    @Test
+    void deallocateReleasesDirectByteBufferWithJava9Deallocator() {
+        final ByteBuffer directBuffer = ByteBuffer.allocateDirect(Long.BYTES);
+        directBuffer.putLong(42L);
+        directBuffer.flip();
+
+        final DirectBufferDeallocator deallocator = new DirectBufferDeallocator();
+
+        assertThatCode(() -> deallocator.deallocate(directBuffer)).doesNotThrowAnyException();
+    }
+}

--- a/tests/src/org.mongodb/mongodb-driver-core/5.1.3/src/test/java/org_mongodb/mongodb_driver_core/SocketStreamHelperTest.java
+++ b/tests/src/org.mongodb/mongodb-driver-core/5.1.3/src/test/java/org_mongodb/mongodb_driver_core/SocketStreamHelperTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongodb_driver_core;
+
+import com.mongodb.ServerAddress;
+import com.mongodb.connection.SocketSettings;
+import com.mongodb.connection.SocketStreamFactory;
+import com.mongodb.connection.SslSettings;
+import com.mongodb.connection.Stream;
+import org.junit.jupiter.api.Test;
+
+import javax.net.SocketFactory;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketOption;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+public class SocketStreamHelperTest {
+    @Test
+    void socketStreamOpenConfiguresJava11ExtendedKeepAliveOptions() throws Exception {
+        final RecordingSocket socket = new RecordingSocket();
+        final SocketFactory socketFactory = new SingleSocketFactory(socket);
+        final SocketSettings socketSettings = SocketSettings.builder()
+                .connectTimeout(250, TimeUnit.MILLISECONDS)
+                .readTimeout(750, TimeUnit.MILLISECONDS)
+                .receiveBufferSize(1024)
+                .sendBufferSize(2048)
+                .build();
+        final SslSettings sslSettings = SslSettings.builder().build();
+        final SocketStreamFactory streamFactory = new SocketStreamFactory(socketSettings, sslSettings, socketFactory);
+        final Stream stream = streamFactory.create(new ServerAddress("127.0.0.1", 27017));
+
+        stream.open();
+        try {
+            assertThat(stream.isClosed()).isFalse();
+            assertThat(socket.connected).isTrue();
+            assertThat(socket.connectTimeout).isEqualTo(250);
+            assertThat(socket.tcpNoDelay).isTrue();
+            assertThat(socket.keepAlive).isTrue();
+            assertThat(socket.soTimeout).isEqualTo(750);
+            assertThat(socket.receiveBufferSize).isEqualTo(1024);
+            assertThat(socket.sendBufferSize).isEqualTo(2048);
+            assertThat(socket.extendedOptions)
+                    .containsEntry("TCP_KEEPCOUNT", 9)
+                    .containsEntry("TCP_KEEPIDLE", 120)
+                    .containsEntry("TCP_KEEPINTERVAL", 10);
+        } finally {
+            stream.close();
+        }
+
+        assertThat(socket.closed).isTrue();
+    }
+
+    private static final class SingleSocketFactory extends SocketFactory {
+        private final Socket socket;
+
+        private SingleSocketFactory(final Socket socket) {
+            this.socket = socket;
+        }
+
+        @Override
+        public Socket createSocket() {
+            return socket;
+        }
+
+        @Override
+        public Socket createSocket(final String host, final int port) {
+            return socket;
+        }
+
+        @Override
+        public Socket createSocket(final String host, final int port, final InetAddress localHost,
+                                   final int localPort) {
+            return socket;
+        }
+
+        @Override
+        public Socket createSocket(final InetAddress host, final int port) {
+            return socket;
+        }
+
+        @Override
+        public Socket createSocket(final InetAddress address, final int port, final InetAddress localAddress,
+                                   final int localPort) {
+            return socket;
+        }
+    }
+
+    private static final class RecordingSocket extends Socket {
+        private final Map<String, Object> extendedOptions = new LinkedHashMap<>();
+        private final ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[0]);
+        private final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        private boolean connected;
+        private boolean closed;
+        private boolean tcpNoDelay;
+        private boolean keepAlive;
+        private int soTimeout;
+        private int receiveBufferSize;
+        private int sendBufferSize;
+        private int connectTimeout;
+
+        @Override
+        public void connect(final SocketAddress endpoint, final int timeout) {
+            connected = true;
+            connectTimeout = timeout;
+        }
+
+        @Override
+        public void setTcpNoDelay(final boolean on) {
+            tcpNoDelay = on;
+        }
+
+        @Override
+        public void setSoTimeout(final int timeout) {
+            soTimeout = timeout;
+        }
+
+        @Override
+        public void setKeepAlive(final boolean on) {
+            keepAlive = on;
+        }
+
+        @Override
+        public void setReceiveBufferSize(final int size) {
+            receiveBufferSize = size;
+        }
+
+        @Override
+        public void setSendBufferSize(final int size) {
+            sendBufferSize = size;
+        }
+
+        @Override
+        public <T> Socket setOption(final SocketOption<T> name, final T value) throws IOException {
+            extendedOptions.put(name.name(), value);
+            return this;
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return inputStream;
+        }
+
+        @Override
+        public OutputStream getOutputStream() {
+            return outputStream;
+        }
+
+        @Override
+        public synchronized void close() {
+            closed = true;
+        }
+
+        @Override
+        public boolean isClosed() {
+            return closed;
+        }
+    }
+}

--- a/tests/src/org.mongodb/mongodb-driver-core/5.1.3/src/test/java/org_mongodb/mongodb_driver_core/SocketStreamHelperTest.java
+++ b/tests/src/org.mongodb/mongodb-driver-core/5.1.3/src/test/java/org_mongodb/mongodb_driver_core/SocketStreamHelperTest.java
@@ -8,9 +8,11 @@ package org_mongodb.mongodb_driver_core;
 
 import com.mongodb.ServerAddress;
 import com.mongodb.connection.SocketSettings;
-import com.mongodb.connection.SocketStreamFactory;
 import com.mongodb.connection.SslSettings;
-import com.mongodb.connection.Stream;
+import com.mongodb.internal.connection.DefaultInetAddressResolver;
+import com.mongodb.internal.connection.PowerOfTwoBufferPool;
+import com.mongodb.internal.connection.SocketStream;
+import com.mongodb.internal.connection.Stream;
 import org.junit.jupiter.api.Test;
 
 import javax.net.SocketFactory;
@@ -42,8 +44,8 @@ public class SocketStreamHelperTest {
                 .sendBufferSize(2048)
                 .build();
         final SslSettings sslSettings = SslSettings.builder().build();
-        final SocketStreamFactory streamFactory = new SocketStreamFactory(socketSettings, sslSettings, socketFactory);
-        final Stream stream = streamFactory.create(new ServerAddress("127.0.0.1", 27017));
+        final Stream stream = new SocketStream(new ServerAddress("127.0.0.1", 27017), new DefaultInetAddressResolver(),
+                socketSettings, sslSettings, socketFactory, PowerOfTwoBufferPool.DEFAULT);
 
         stream.open();
         try {

--- a/tests/src/org.mongodb/mongodb-driver-core/5.1.3/src/test/java/org_mongodb/mongodb_driver_core/WriteConcernTest.java
+++ b/tests/src/org.mongodb/mongodb-driver-core/5.1.3/src/test/java/org_mongodb/mongodb_driver_core/WriteConcernTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_mongodb.mongodb_driver_core;
+
+import com.mongodb.WriteConcern;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WriteConcernTest {
+    @Test
+    void valueOfFindsNamedWriteConcernsInitializedFromPublicConstants() {
+        final WriteConcern majority = WriteConcern.valueOf("majority");
+        final WriteConcern w1 = WriteConcern.valueOf("w1");
+        final WriteConcern acknowledged = WriteConcern.valueOf("acknowledged");
+
+        assertThat(majority).isSameAs(WriteConcern.MAJORITY);
+        assertThat(majority.getWString()).isEqualTo("majority");
+        assertThat(w1).isSameAs(WriteConcern.W1);
+        assertThat(w1.getW()).isEqualTo(1);
+        assertThat(acknowledged).isSameAs(WriteConcern.ACKNOWLEDGED);
+        assertThat(acknowledged.isServerDefault()).isTrue();
+    }
+
+    @Test
+    void writeConcernOptionsAreRenderedAsBsonDocument() {
+        final WriteConcern writeConcern = WriteConcern.MAJORITY
+                .withJournal(true)
+                .withWTimeout(2, TimeUnit.SECONDS);
+
+        assertThat(writeConcern.asDocument().toJson()).contains(
+                "\"w\": \"majority\"",
+                "\"wtimeout\": 2000",
+                "\"j\": true");
+        assertThat(writeConcern.isAcknowledged()).isTrue();
+    }
+}

--- a/tests/src/org.mongodb/mongodb-driver-core/5.1.3/user-code-filter.json
+++ b/tests/src/org.mongodb/mongodb-driver-core/5.1.3/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.mongodb.**"
+    },
+    {
+      "includeClasses" : "org_mongodb.mongodb_driver_core.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7438

This PR provides test fixes and new metadata for org.mongodb:mongodb-driver-core:5.1.3, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 29006
- Cached input tokens: 314880
- Output tokens: 3292
- Metadata entries: 17
- Iterations: 1
- Library coverage percentage: 12.45
- Previous library version metadata entries: 16
- Previous library version coverage percentage: 12.68

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `67bc8b0e70b11004840eb205c8af3d438a8aea88`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.mongodb:mongodb-driver-core:4.11.1: 13/13 covered calls (100.00%)
- org.mongodb:mongodb-driver-core:5.1.3: 13/13 covered calls (100.00%)

**Reflection:**
- org.mongodb:mongodb-driver-core:4.11.1: 13/13 covered calls (100.00%)
- org.mongodb:mongodb-driver-core:5.1.3: 13/13 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.mongodb:mongodb-driver-core:4.11.1: 13219/115134 (11.48%)
- org.mongodb:mongodb-driver-core:5.1.3: 13168/116201 (11.33%)

**Line:**
- org.mongodb:mongodb-driver-core:4.11.1: 3142/24789 (12.68%)
- org.mongodb:mongodb-driver-core:5.1.3: 3126/25112 (12.45%)

**Method:**
- org.mongodb:mongodb-driver-core:4.11.1: 1002/7596 (13.19%)
- org.mongodb:mongodb-driver-core:5.1.3: 1010/7682 (13.15%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.mongodb/mongodb-driver-core/4.11.1/src/test/java/org_mongodb/mongodb_driver_core/ByteBufBsonArrayTest.java 2/tests/src/org.mongodb/mongodb-driver-core/5.1.3/src/test/java/org_mongodb/mongodb_driver_core/ByteBufBsonArrayTest.java
index dc99818ba7..5d431d2021 100644
--- 1/tests/src/org.mongodb/mongodb-driver-core/4.11.1/src/test/java/org_mongodb/mongodb_driver_core/ByteBufBsonArrayTest.java
+++ 2/tests/src/org.mongodb/mongodb-driver-core/5.1.3/src/test/java/org_mongodb/mongodb_driver_core/ByteBufBsonArrayTest.java
@@ -16,8 +16,6 @@ import com.mongodb.connection.ClusterConnectionMode;
 import com.mongodb.connection.ClusterSettings;
 import com.mongodb.connection.ConnectionPoolSettings;
 import com.mongodb.connection.ServerSettings;
-import com.mongodb.connection.Stream;
-import com.mongodb.connection.StreamFactory;
 import com.mongodb.event.CommandListener;
 import com.mongodb.event.CommandStartedEvent;
 import com.mongodb.internal.IgnorableRequestContext;
@@ -26,6 +24,8 @@ import com.mongodb.internal.connection.Cluster;
 import com.mongodb.internal.connection.DefaultClusterFactory;
 import com.mongodb.internal.connection.InternalConnectionPoolSettings;
 import com.mongodb.internal.connection.PowerOfTwoBufferPool;
+import com.mongodb.internal.connection.Stream;
+import com.mongodb.internal.connection.StreamFactory;
 import com.mongodb.internal.operation.CommandReadOperation;
 import org.bson.BsonArray;
 import org.bson.BsonBinaryWriter;
@@ -85,7 +85,6 @@ public class ByteBufBsonArrayTest {
                 MongoDriverInformation.builder().build(),
                 Collections.emptyList(),
                 null,
-                null,
                 null);
         final ClusterBinding binding = new ClusterBinding(cluster, ReadPreference.primary(), ReadConcern.DEFAULT, null,
                 IgnorableRequestContext.INSTANCE);
diff --git 1/tests/src/org.mongodb/mongodb-driver-core/4.11.1/src/test/java/org_mongodb/mongodb_driver_core/SocketStreamHelperTest.java 2/tests/src/org.mongodb/mongodb-driver-core/5.1.3/src/test/java/org_mongodb/mongodb_driver_core/SocketStreamHelperTest.java
index 3171fc8809..84c9c1510e 100644
--- 1/tests/src/org.mongodb/mongodb-driver-core/4.11.1/src/test/java/org_mongodb/mongodb_driver_core/SocketStreamHelperTest.java
+++ 2/tests/src/org.mongodb/mongodb-driver-core/5.1.3/src/test/java/org_mongodb/mongodb_driver_core/SocketStreamHelperTest.java
@@ -8,9 +8,11 @@ package org_mongodb.mongodb_driver_core;
 
 import com.mongodb.ServerAddress;
 import com.mongodb.connection.SocketSettings;
-import com.mongodb.connection.SocketStreamFactory;
 import com.mongodb.connection.SslSettings;
-import com.mongodb.connection.Stream;
+import com.mongodb.internal.connection.DefaultInetAddressResolver;
+import com.mongodb.internal.connection.PowerOfTwoBufferPool;
+import com.mongodb.internal.connection.SocketStream;
+import com.mongodb.internal.connection.Stream;
 import org.junit.jupiter.api.Test;
 
 import javax.net.SocketFactory;
@@ -42,8 +44,8 @@ public class SocketStreamHelperTest {
                 .sendBufferSize(2048)
                 .build();
         final SslSettings sslSettings = SslSettings.builder().build();
-        final SocketStreamFactory streamFactory = new SocketStreamFactory(socketSettings, sslSettings, socketFactory);
-        final Stream stream = streamFactory.create(new ServerAddress("127.0.0.1", 27017));
+        final Stream stream = new SocketStream(new ServerAddress("127.0.0.1", 27017), new DefaultInetAddressResolver(),
+                socketSettings, sslSettings, socketFactory, PowerOfTwoBufferPool.DEFAULT);
 
         stream.open();
         try {

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
