### PR TITLE
[GenAI] Test fix for org.apache.activemq:artemis-core-client:2.32.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.activemq/artemis-core-client/2.32.0/reachability-metadata.json
+++ b/metadata/org.apache.activemq/artemis-core-client/2.32.0/reachability-metadata.json
@@ -1,0 +1,309 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.api.core.JGroupsFileBroadcastEndpoint"
+      },
+      "type" : "byte[][]"
+    },
+    {
+      "type" : "java.lang.Object",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.api.core.ActiveMQBuffers"
+      },
+      "type" : "io.netty.buffer.AbstractReferenceCountedByteBuf"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.api.core.ActiveMQBuffers"
+      },
+      "type" : "java.nio.DirectByteBuffer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.core.protocol.core.impl.wireformat.FederationStreamConnectMessage"
+      },
+      "type" : "java.util.HashMap",
+      "methods" : [
+        {
+          "name" : "clone",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.api.core.JGroupsFileBroadcastEndpoint"
+      },
+      "type" : "java.lang.Thread",
+      "methods" : [
+        {
+          "name" : "ofVirtual",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.api.core.JGroupsFileBroadcastEndpoint"
+      },
+      "type" : "java.lang.Thread$Builder",
+      "methods" : [
+        {
+          "name" : "unstarted",
+          "parameterTypes" : [
+            "java.lang.Runnable"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.api.core.JGroupsFileBroadcastEndpoint"
+      },
+      "type" : "java.lang.Thread$Builder$OfVirtual"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.api.core.JGroupsFileBroadcastEndpoint"
+      },
+      "type" : "java.net.InetAddress[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.api.core.JGroupsFileBroadcastEndpoint"
+      },
+      "type" : "java.net.InterfaceAddress[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.api.core.JGroupsFileBroadcastEndpoint"
+      },
+      "type" : "java.net.NetworkInterface[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.api.core.ActiveMQBuffers"
+      },
+      "type" : "jdk.internal.misc.Unsafe"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.api.core.JGroupsFileBroadcastEndpoint"
+      },
+      "type" : "org.apache.logging.log4j.core.Logger"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.core.protocol.core.impl.wireformat.FederationStreamConnectMessage"
+      },
+      "type" : "org.apache.activemq.artemis.core.config.federation.FederationQueuePolicyConfiguration",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.logs.BundleFactory"
+      },
+      "type" : "org.apache.activemq.artemis.core.client.ActiveMQClientLogger_impl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.slf4j.Logger"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.api.core.JsonUtil"
+      },
+      "type" : "java.lang.Object",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.utils.ObjectInputStreamWithClassLoader"
+      },
+      "type" : "java.lang.Object",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.utils.ObjectInputStreamWithClassLoader"
+      },
+      "type" : "java.lang.String",
+      "serializable" : true,
+      "fields" : [
+        {
+          "name" : "serialVersionUID"
+        },
+        {
+          "name" : "serialPersistentFields"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.utils.ObjectInputStreamWithClassLoader"
+      },
+      "type" : "java.lang.reflect.Proxy",
+      "serializable" : true,
+      "fields" : [
+        {
+          "name" : "h"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.api.core.JsonUtil"
+      },
+      "type" : "java.lang.Number",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.api.core.JsonUtil"
+      },
+      "type" : "javax.management.openmbean.CompositeDataSupport",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.api.core.JsonUtil"
+      },
+      "type" : "javax.management.openmbean.CompositeType",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.api.core.JsonUtil"
+      },
+      "type" : "javax.management.openmbean.SimpleType",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.api.core.JsonUtil"
+      },
+      "type" : "javax.management.openmbean.OpenType",
+      "serializable" : true,
+      "methods" : [
+        {
+          "name" : "readObject",
+          "parameterTypes" : [
+            "java.io.ObjectInputStream"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.api.core.ActiveMQBuffers"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.Deprecated"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.api.core.ActiveMQBuffers"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.commons.shaded.johnzon.core.JsonProviderImpl"
+      },
+      "glob" : "META-INF/services/org.apache.activemq.artemis.commons.shaded.johnzon.core.spi.JsonPointerFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.api.core.JGroupsFileBroadcastEndpoint"
+      },
+      "bundle" : "jg-messages"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.api.core.JGroupsFileBroadcastEndpoint"
+      },
+      "glob" : "jgroups-test.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.utils.VersionLoader"
+      },
+      "glob" : "activemq-version.properties"
+    }
+  ],
+  "serialization" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.utils.ObjectInputStreamWithClassLoader"
+      },
+      "type" : "java.lang.String"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.utils.ObjectInputStreamWithClassLoader"
+      },
+      "type" : "java.lang.reflect.Proxy"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.utils.ObjectInputStreamWithClassLoader"
+      },
+      "type" : "java.lang.Number"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.utils.ObjectInputStreamWithClassLoader"
+      },
+      "type" : "javax.management.openmbean.CompositeDataSupport"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.utils.ObjectInputStreamWithClassLoader"
+      },
+      "type" : "javax.management.openmbean.CompositeType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.utils.ObjectInputStreamWithClassLoader"
+      },
+      "type" : "javax.management.openmbean.SimpleType"
+    }
+  ]
+}

--- a/metadata/org.apache.activemq/artemis-core-client/index.json
+++ b/metadata/org.apache.activemq/artemis-core-client/index.json
@@ -16,6 +16,11 @@
   },
   {
     "metadata-version" : "2.32.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/activemq/artemis-core-client/$version$/artemis-core-client-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/artemis",
+    "test-code-url" : "https://github.com/apache/artemis/tree/$version$/artemis-core-client/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/activemq/artemis-core-client/$version$/artemis-core-client-$version$-javadoc.jar",
+    "description" : "ActiveMQ Artemis Core Client is the Java client library that implements the native Artemis core messaging protocol for connecting applications to ActiveMQ Artemis brokers. It provides APIs and transport support for creating core sessions, producers, consumers, messages, and connection factories without using the JMS layer.",
     "tested-versions" : [
       "2.32.0"
     ],

--- a/metadata/org.apache.activemq/artemis-core-client/index.json
+++ b/metadata/org.apache.activemq/artemis-core-client/index.json
@@ -13,5 +13,14 @@
     "allowed-packages" : [
       "org.apache.activemq.artemis"
     ]
+  },
+  {
+    "metadata-version" : "2.32.0",
+    "tested-versions" : [
+      "2.32.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.activemq.artemis"
+    ]
   }
 ]

--- a/stats/org.apache.activemq/artemis-core-client/2.32.0/execution-metrics.json
+++ b/stats/org.apache.activemq/artemis-core-client/2.32.0/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_javac_fail:2026-05-21": {
+    "timestamp": "2026-05-21T06:05:14.951997Z",
+    "library": "org.apache.activemq:artemis-core-client:2.32.0",
+    "starting_commit": "4278b31ab75020105e1c3defa97cd872253e4d00",
+    "ending_commit": "3d8bcfdbb8478786a9c3919aacfe758ad0681f9a",
+    "previous_library": "org.apache.activemq:artemis-core-client:2.28.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.32.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.909091,
+            "coveredCalls": 10,
+            "totalCalls": 11
+          },
+          "resources": {
+            "coverageRatio": 0.5,
+            "coveredCalls": 1,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 0.846154,
+        "coveredCalls": 11,
+        "totalCalls": 13
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3116,
+          "missed": 69984,
+          "ratio": 0.042627,
+          "total": 73100
+        },
+        "line": {
+          "covered": 868,
+          "missed": 17269,
+          "ratio": 0.047858,
+          "total": 18137
+        },
+        "method": {
+          "covered": 151,
+          "missed": 4493,
+          "ratio": 0.032515,
+          "total": 4644
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.28.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.909091,
+            "coveredCalls": 10,
+            "totalCalls": 11
+          },
+          "resources": {
+            "coverageRatio": 0.5,
+            "coveredCalls": 1,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 0.846154,
+        "coveredCalls": 11,
+        "totalCalls": 13
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3067,
+          "missed": 67622,
+          "ratio": 0.043387,
+          "total": 70689
+        },
+        "line": {
+          "covered": 855,
+          "missed": 16912,
+          "ratio": 0.048123,
+          "total": 17767
+        },
+        "method": {
+          "covered": 148,
+          "missed": 4277,
+          "ratio": 0.033446,
+          "total": 4425
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 127111,
+      "cached_input_tokens_used": 1177600,
+      "output_tokens_used": 23571,
+      "iterations": 5,
+      "cost_usd": 1.2959,
+      "tested_library_loc": 868,
+      "metadata_entries": 49,
+      "test_only_metadata_entries": 18,
+      "previous_library_metadata_entries": 49,
+      "previous_library_test_only_metadata_entries": 17,
+      "code_coverage_percent": 4.79,
+      "previous_library_coverage_percent": 4.81
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.activemq/artemis-core-client/2.32.0/src/test/java/org_apache_activemq/artemis_core_client/VersionLoaderTest.java",
+      "metadata_file": "metadata/org.apache.activemq/artemis-core-client/2.32.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.activemq/artemis-core-client/2.32.0/stats.json
+++ b/stats/org.apache.activemq/artemis-core-client/2.32.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "2.32.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.909091,
+          "coveredCalls" : 10,
+          "totalCalls" : 11
+        },
+        "resources" : {
+          "coverageRatio" : 0.5,
+          "coveredCalls" : 1,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 0.846154,
+      "coveredCalls" : 11,
+      "totalCalls" : 13
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3116,
+        "missed" : 69984,
+        "ratio" : 0.042627,
+        "total" : 73100
+      },
+      "line" : {
+        "covered" : 868,
+        "missed" : 17269,
+        "ratio" : 0.047858,
+        "total" : 18137
+      },
+      "method" : {
+        "covered" : 151,
+        "missed" : 4493,
+        "ratio" : 0.032515,
+        "total" : 4644
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.activemq/artemis-core-client/2.32.0/.gitignore
+++ b/tests/src/org.apache.activemq/artemis-core-client/2.32.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.activemq/artemis-core-client/2.32.0/build.gradle
+++ b/tests/src/org.apache.activemq/artemis-core-client/2.32.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.activemq:artemis-core-client:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.activemq/artemis-core-client/2.32.0/build.gradle
+++ b/tests/src/org.apache.activemq/artemis-core-client/2.32.0/build.gradle
@@ -13,6 +13,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.apache.activemq:artemis-core-client:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.jgroups:jgroups:5.3.0.Final'
 }
 
 graalvmNative {

--- a/tests/src/org.apache.activemq/artemis-core-client/2.32.0/gradle.properties
+++ b/tests/src/org.apache.activemq/artemis-core-client/2.32.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.activemq:artemis-core-client:2.32.0
+library.version = 2.32.0
+metadata.dir = org.apache.activemq/artemis-core-client/2.32.0/

--- a/tests/src/org.apache.activemq/artemis-core-client/2.32.0/settings.gradle
+++ b/tests/src/org.apache.activemq/artemis-core-client/2.32.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.activemq.artemis-core-client_tests'

--- a/tests/src/org.apache.activemq/artemis-core-client/2.32.0/src/test/java/org_apache_activemq/artemis_core_client/FederationStreamConnectMessageTest.java
+++ b/tests/src/org.apache.activemq/artemis-core-client/2.32.0/src/test/java/org_apache_activemq/artemis_core_client/FederationStreamConnectMessageTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_activemq.artemis_core_client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
+import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
+import org.apache.activemq.artemis.core.config.federation.FederationDownstreamConfiguration;
+import org.apache.activemq.artemis.core.config.federation.FederationPolicy;
+import org.apache.activemq.artemis.core.config.federation.FederationQueuePolicyConfiguration;
+import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.FederationDownstreamConnectMessage;
+import org.junit.jupiter.api.Test;
+
+public class FederationStreamConnectMessageTest {
+    @Test
+    void decodesFederationPoliciesFromEncodedClassNames() {
+        FederationDownstreamConnectMessage source = new FederationDownstreamConnectMessage();
+        source.setName("downstream-connect");
+        source.setFederationPolicyMap(federationPolicies());
+        source.setStreamConfiguration(downstreamConfiguration());
+
+        ActiveMQBuffer buffer = ActiveMQBuffers.dynamicBuffer(512);
+        source.encodeRest(buffer);
+
+        FederationDownstreamConnectMessage decoded = new FederationDownstreamConnectMessage();
+        decoded.decodeRest(buffer);
+
+        assertThat(decoded.getName()).isEqualTo("downstream-connect");
+        assertThat(decoded.getStreamConfiguration().getName()).isEqualTo("downstream");
+        assertThat(decoded.getStreamConfiguration().getPolicyRefs()).containsExactly("orders");
+        assertThat(decoded.getStreamConfiguration().getUpstreamConfiguration())
+                .isEqualTo(source.getStreamConfiguration().getUpstreamConfiguration());
+        assertThat(decoded.getFederationPolicyMap())
+                .containsOnlyKeys("orders")
+                .containsEntry("orders", queuePolicy());
+    }
+
+    private static Map<String, FederationPolicy> federationPolicies() {
+        Map<String, FederationPolicy> policies = new HashMap<>();
+        FederationQueuePolicyConfiguration queuePolicy = queuePolicy();
+        policies.put(queuePolicy.getName(), queuePolicy);
+        return policies;
+    }
+
+    private static FederationQueuePolicyConfiguration queuePolicy() {
+        return new FederationQueuePolicyConfiguration()
+                .setName("orders")
+                .setIncludeFederated(true)
+                .setPriorityAdjustment(3)
+                .addInclude(new FederationQueuePolicyConfiguration.Matcher()
+                        .setAddressMatch("orders.#")
+                        .setQueueMatch("orders.queue"));
+    }
+
+    private static FederationDownstreamConfiguration downstreamConfiguration() {
+        FederationDownstreamConfiguration configuration = new FederationDownstreamConfiguration()
+                .setName("downstream")
+                .addPolicyRef("orders");
+        configuration.setUpstreamConfiguration(upstreamTransportConfiguration());
+        return configuration;
+    }
+
+    private static TransportConfiguration upstreamTransportConfiguration() {
+        Map<String, Object> params = new HashMap<>();
+        params.put("host", "127.0.0.1");
+        params.put("port", 61616);
+        return new TransportConfiguration("example.UpstreamConnectorFactory", params, "upstream-connector");
+    }
+}

--- a/tests/src/org.apache.activemq/artemis-core-client/2.32.0/src/test/java/org_apache_activemq/artemis_core_client/JGroupsFileBroadcastEndpointTest.java
+++ b/tests/src/org.apache.activemq/artemis-core-client/2.32.0/src/test/java/org_apache_activemq/artemis_core_client/JGroupsFileBroadcastEndpointTest.java
@@ -9,56 +9,23 @@ package org_apache_activemq.artemis_core_client;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-
 import org.apache.activemq.artemis.api.core.JGroupsFileBroadcastEndpoint;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 public class JGroupsFileBroadcastEndpointTest {
     @Test
-    void readsJGroupsConfigurationFromContextClassLoaderResource(@TempDir Path temporaryDirectory) throws Exception {
-        String resourceName = "jgroups-test.xml";
-        Files.writeString(temporaryDirectory.resolve(resourceName), "not a jgroups xml document", StandardCharsets.UTF_8);
-        ClassLoader originalContextClassLoader = Thread.currentThread().getContextClassLoader();
-        URL resourceUrl = temporaryDirectory.resolve(resourceName).toUri().toURL();
+    void readsJGroupsConfigurationFromContextClassLoaderResource() throws Exception {
+        String resourceName = "org_apache_activemq/artemis_core_client/jgroups-file-broadcast-endpoint.xml";
+        JGroupsFileBroadcastEndpoint endpoint = new JGroupsFileBroadcastEndpoint(
+                null,
+                resourceName,
+                "metadata-test-channel");
 
-        try {
-            Thread.currentThread().setContextClassLoader(new SingleResourceClassLoader(resourceName, resourceUrl));
-            JGroupsFileBroadcastEndpoint endpoint = new JGroupsFileBroadcastEndpoint(
-                    null,
-                    resourceName,
-                    "metadata-test-channel");
+        Throwable failure = catchThrowable(endpoint::createChannel);
 
-            Throwable failure = catchThrowable(endpoint::createChannel);
-
-            assertThat(failure).isNotNull();
-            assertThat(String.valueOf(failure.getMessage()))
-                    .doesNotContain("couldn't find JGroups configuration");
-        } finally {
-            Thread.currentThread().setContextClassLoader(originalContextClassLoader);
-        }
-    }
-
-    private static final class SingleResourceClassLoader extends ClassLoader {
-        private final String resourceName;
-        private final URL resourceUrl;
-
-        private SingleResourceClassLoader(String resourceName, URL resourceUrl) {
-            super(null);
-            this.resourceName = resourceName;
-            this.resourceUrl = resourceUrl;
-        }
-
-        @Override
-        protected URL findResource(String name) {
-            if (resourceName.equals(name)) {
-                return resourceUrl;
-            }
-            return null;
-        }
+        assertThat(failure).isNotNull();
+        assertThat(failure).isNotInstanceOf(NoClassDefFoundError.class);
+        assertThat(String.valueOf(failure.getMessage()))
+                .doesNotContain("couldn't find JGroups configuration");
     }
 }

--- a/tests/src/org.apache.activemq/artemis-core-client/2.32.0/src/test/java/org_apache_activemq/artemis_core_client/JGroupsFileBroadcastEndpointTest.java
+++ b/tests/src/org.apache.activemq/artemis-core-client/2.32.0/src/test/java/org_apache_activemq/artemis_core_client/JGroupsFileBroadcastEndpointTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_activemq.artemis_core_client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.activemq.artemis.api.core.JGroupsFileBroadcastEndpoint;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class JGroupsFileBroadcastEndpointTest {
+    @Test
+    void readsJGroupsConfigurationFromContextClassLoaderResource(@TempDir Path temporaryDirectory) throws Exception {
+        String resourceName = "jgroups-test.xml";
+        Files.writeString(temporaryDirectory.resolve(resourceName), "not a jgroups xml document", StandardCharsets.UTF_8);
+        ClassLoader originalContextClassLoader = Thread.currentThread().getContextClassLoader();
+        URL resourceUrl = temporaryDirectory.resolve(resourceName).toUri().toURL();
+
+        try {
+            Thread.currentThread().setContextClassLoader(new SingleResourceClassLoader(resourceName, resourceUrl));
+            JGroupsFileBroadcastEndpoint endpoint = new JGroupsFileBroadcastEndpoint(
+                    null,
+                    resourceName,
+                    "metadata-test-channel");
+
+            Throwable failure = catchThrowable(endpoint::createChannel);
+
+            assertThat(failure).isNotNull();
+            assertThat(String.valueOf(failure.getMessage()))
+                    .doesNotContain("couldn't find JGroups configuration");
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalContextClassLoader);
+        }
+    }
+
+    private static final class SingleResourceClassLoader extends ClassLoader {
+        private final String resourceName;
+        private final URL resourceUrl;
+
+        private SingleResourceClassLoader(String resourceName, URL resourceUrl) {
+            super(null);
+            this.resourceName = resourceName;
+            this.resourceUrl = resourceUrl;
+        }
+
+        @Override
+        protected URL findResource(String name) {
+            if (resourceName.equals(name)) {
+                return resourceUrl;
+            }
+            return null;
+        }
+    }
+}

--- a/tests/src/org.apache.activemq/artemis-core-client/2.32.0/src/test/java/org_apache_activemq/artemis_core_client/JsonUtilTest.java
+++ b/tests/src/org.apache.activemq/artemis-core-client/2.32.0/src/test/java/org_apache_activemq/artemis_core_client/JsonUtilTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_activemq.artemis_core_client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.management.openmbean.CompositeData;
+import javax.management.openmbean.CompositeDataSupport;
+import javax.management.openmbean.CompositeType;
+import javax.management.openmbean.OpenType;
+import javax.management.openmbean.SimpleType;
+
+import org.apache.activemq.artemis.api.core.JsonUtil;
+import org.apache.activemq.artemis.json.JsonArray;
+import org.junit.jupiter.api.Test;
+
+public class JsonUtilTest {
+    @Test
+    void restoresSerializedCompositeDataArraysFromJson() throws Exception {
+        CompositeDataSupport source = compositeData("orders", 12);
+
+        JsonArray jsonArray = JsonUtil.toJSONArray(new Object[] {new CompositeData[] {source}});
+        Object[] values = JsonUtil.fromJsonArray(jsonArray);
+
+        assertThat(values).hasSize(1);
+        assertThat(values[0]).isInstanceOf(Map.class);
+        Map<?, ?> restoredMap = (Map<?, ?>) values[0];
+        assertThat(restoredMap).hasSize(1);
+        assertThat(restoredMap.containsKey(CompositeData.class.getName())).isTrue();
+        assertThat(restoredMap.get(CompositeData.class.getName())).isInstanceOf(CompositeData[].class);
+        CompositeData[] restored = (CompositeData[]) restoredMap.get(CompositeData.class.getName());
+        assertThat(restored).hasSize(1);
+        assertThat(restored[0].get("queue")).isEqualTo("orders");
+        assertThat(restored[0].get("messageCount")).isEqualTo(12);
+        assertThat(restored[0].getCompositeType()).isEqualTo(source.getCompositeType());
+    }
+
+    @Test
+    void convertsObjectArrayElementsToDesiredArrayType() {
+        Object converted = JsonUtil.convertJsonValue(new Object[] {1L, 2L, 3L}, Integer.class);
+
+        assertThat(converted).isInstanceOf(Integer[].class);
+        assertThat((Integer[]) converted).containsExactly(1, 2, 3);
+    }
+
+    private static CompositeDataSupport compositeData(String queue, int messageCount) throws Exception {
+        String[] itemNames = {"queue", "messageCount"};
+        CompositeType compositeType = new CompositeType(
+                "QueueStats",
+                "Queue statistics",
+                itemNames,
+                itemNames,
+                new OpenType<?>[] {SimpleType.STRING, SimpleType.INTEGER});
+        Map<String, Object> values = new HashMap<>();
+        values.put("queue", queue);
+        values.put("messageCount", messageCount);
+        return new CompositeDataSupport(compositeType, values);
+    }
+}

--- a/tests/src/org.apache.activemq/artemis-core-client/2.32.0/src/test/java/org_apache_activemq/artemis_core_client/ObjectInputStreamWithClassLoaderTest.java
+++ b/tests/src/org.apache.activemq/artemis-core-client/2.32.0/src/test/java/org_apache_activemq/artemis_core_client/ObjectInputStreamWithClassLoaderTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_activemq.artemis_core_client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+import org.apache.activemq.artemis.utils.ObjectInputStreamWithClassLoader;
+import org.junit.jupiter.api.Test;
+
+public class ObjectInputStreamWithClassLoaderTest {
+    @Test
+    void readsSerializableObjectWithContextClassLoader() throws Exception {
+        SamplePayload payload = new SamplePayload("context-loader");
+
+        Object deserialized = deserializeWithContextClassLoader(
+                serialize(payload), ObjectInputStreamWithClassLoaderTest.class.getClassLoader());
+
+        assertThat(deserialized).isEqualTo(payload);
+    }
+
+    @Test
+    void fallsBackToDefaultObjectInputStreamResolutionWhenContextLoaderCannotLoadClass() throws Exception {
+        SamplePayload payload = new SamplePayload("fallback-loader");
+        ClassLoader rejectingContextLoader = new RejectingClassLoader(
+                ObjectInputStreamWithClassLoaderTest.class.getClassLoader(), SamplePayload.class.getName());
+
+        Object deserialized = deserializeWithContextClassLoader(serialize(payload), rejectingContextLoader);
+
+        assertThat(deserialized).isEqualTo(payload);
+    }
+
+    @Test
+    void readsSerializedDynamicProxyWithContextClassLoader() throws Exception {
+        Greeting proxy = (Greeting) Proxy.newProxyInstance(
+                ObjectInputStreamWithClassLoaderTest.class.getClassLoader(),
+                new Class<?>[] {Greeting.class},
+                new GreetingInvocationHandler());
+
+        Object deserialized = deserializeWithContextClassLoader(
+                serialize(proxy), ObjectInputStreamWithClassLoaderTest.class.getClassLoader());
+
+        assertThat(deserialized).isInstanceOf(Greeting.class);
+        assertThat(((Greeting) deserialized).greet("Artemis")).isEqualTo("Hello, Artemis");
+    }
+
+    private static byte[] serialize(Object value) throws IOException {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        try (ObjectOutputStream output = new ObjectOutputStream(buffer)) {
+            output.writeObject(value);
+        }
+        return buffer.toByteArray();
+    }
+
+    private static Object deserializeWithContextClassLoader(byte[] bytes, ClassLoader contextClassLoader)
+            throws Exception {
+        Thread thread = Thread.currentThread();
+        ClassLoader previousContextClassLoader = thread.getContextClassLoader();
+        thread.setContextClassLoader(contextClassLoader);
+        try (ObjectInputStreamWithClassLoader input = new ObjectInputStreamWithClassLoader(
+                new ByteArrayInputStream(bytes))) {
+            input.setBlackList(null);
+            input.setWhiteList(ObjectInputStreamWithClassLoader.CATCH_ALL_WILDCARD);
+            return input.readObject();
+        } finally {
+            thread.setContextClassLoader(previousContextClassLoader);
+        }
+    }
+
+    public interface Greeting extends Serializable {
+        String greet(String name);
+    }
+
+    private static final class GreetingInvocationHandler implements InvocationHandler, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) {
+            if ("toString".equals(method.getName())) {
+                return "Greeting proxy";
+            }
+            if ("hashCode".equals(method.getName())) {
+                return System.identityHashCode(proxy);
+            }
+            if ("equals".equals(method.getName())) {
+                return proxy == args[0];
+            }
+            if ("greet".equals(method.getName())) {
+                return "Hello, " + args[0];
+            }
+            throw new UnsupportedOperationException(method.toString());
+        }
+    }
+
+    private static final class RejectingClassLoader extends ClassLoader {
+        private final String rejectedClassName;
+
+        private RejectingClassLoader(ClassLoader parent, String rejectedClassName) {
+            super(parent);
+            this.rejectedClassName = rejectedClassName;
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (rejectedClassName.equals(name)) {
+                throw new ClassNotFoundException(name);
+            }
+            return super.loadClass(name, resolve);
+        }
+    }
+
+    private static final class SamplePayload implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private final String value;
+
+        private SamplePayload(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (!(other instanceof SamplePayload)) {
+                return false;
+            }
+            SamplePayload that = (SamplePayload) other;
+            return value.equals(that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return value.hashCode();
+        }
+    }
+}

--- a/tests/src/org.apache.activemq/artemis-core-client/2.32.0/src/test/java/org_apache_activemq/artemis_core_client/ObjectInputStreamWithClassLoaderTest.java
+++ b/tests/src/org.apache.activemq/artemis-core-client/2.32.0/src/test/java/org_apache_activemq/artemis_core_client/ObjectInputStreamWithClassLoaderTest.java
@@ -71,8 +71,8 @@ public class ObjectInputStreamWithClassLoaderTest {
         thread.setContextClassLoader(contextClassLoader);
         try (ObjectInputStreamWithClassLoader input = new ObjectInputStreamWithClassLoader(
                 new ByteArrayInputStream(bytes))) {
-            input.setBlackList(null);
-            input.setWhiteList(ObjectInputStreamWithClassLoader.CATCH_ALL_WILDCARD);
+            input.setDenyList(null);
+            input.setAllowList(ObjectInputStreamWithClassLoader.CATCH_ALL_WILDCARD);
             return input.readObject();
         } finally {
             thread.setContextClassLoader(previousContextClassLoader);

--- a/tests/src/org.apache.activemq/artemis-core-client/2.32.0/src/test/java/org_apache_activemq/artemis_core_client/ServerLocatorImplTest.java
+++ b/tests/src/org.apache.activemq/artemis-core-client/2.32.0/src/test/java/org_apache_activemq/artemis_core_client/ServerLocatorImplTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_activemq.artemis_core_client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.apache.activemq.artemis.api.core.Pair;
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
+import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
+import org.apache.activemq.artemis.api.core.client.ServerLocator;
+import org.apache.activemq.artemis.core.client.impl.ServerLocatorInternal;
+import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory;
+import org.junit.jupiter.api.Test;
+
+public class ServerLocatorImplTest {
+    @Test
+    void updatesTopologyArrayWhenClusterNodeIsAnnounced() {
+        TransportConfiguration initial = nettyConnector("initial-live");
+        TransportConfiguration live = nettyConnector("node-live");
+        TransportConfiguration backup = nettyConnector("node-backup");
+
+        try (ServerLocator locator = ActiveMQClient.createServerLocatorWithHA(initial)) {
+            ServerLocatorInternal internalLocator = (ServerLocatorInternal) locator;
+
+            internalLocator.notifyNodeUp(
+                    1L, "node-a", "backup-group", "scale-down-group", new Pair<>(live, backup), true);
+
+            assertThat(internalLocator.getTopology().getMembers()).hasSize(1);
+            assertThat(internalLocator.getTopology().getMember("node-a").getLive()).isEqualTo(live);
+            assertThat(internalLocator.getTopology().getMember("node-a").getBackup()).isEqualTo(backup);
+        }
+    }
+
+    private static TransportConfiguration nettyConnector(String name) {
+        return new TransportConfiguration(NettyConnectorFactory.class.getName(), Map.of("host", "127.0.0.1"), name);
+    }
+}

--- a/tests/src/org.apache.activemq/artemis-core-client/2.32.0/src/test/java/org_apache_activemq/artemis_core_client/VersionLoaderTest.java
+++ b/tests/src/org.apache.activemq/artemis-core-client/2.32.0/src/test/java/org_apache_activemq/artemis_core_client/VersionLoaderTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_activemq.artemis_core_client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.activemq.artemis.core.version.Version;
+import org.apache.activemq.artemis.utils.VersionLoader;
+import org.junit.jupiter.api.Test;
+
+public class VersionLoaderTest {
+    @Test
+    void loadsBundledVersionPropertiesFromClasspathResource() {
+        Version activeVersion = VersionLoader.getVersion();
+        Version[] clientVersions = VersionLoader.getClientVersions();
+
+        assertThat(clientVersions).isNotEmpty();
+        assertThat(activeVersion).isSameAs(clientVersions[0]);
+        assertThat(activeVersion.getVersionName()).isNotBlank();
+        assertThat(activeVersion.getFullVersion()).contains(activeVersion.getVersionName());
+        assertThat(activeVersion.getMajorVersion()).isPositive();
+        assertThat(activeVersion.getMinorVersion()).isNotNegative();
+        assertThat(activeVersion.getMicroVersion()).isNotNegative();
+        assertThat(activeVersion.getIncrementingVersion()).isPositive();
+    }
+}

--- a/tests/src/org.apache.activemq/artemis-core-client/2.32.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.activemq/artemis-core-client/2.32.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,92 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org_apache_activemq.artemis_core_client.ObjectInputStreamWithClassLoaderTest"
+      },
+      "type" : "java.lang.Object",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_activemq.artemis_core_client.ObjectInputStreamWithClassLoaderTest$Greeting"
+      },
+      "type" : "java.lang.Object",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_activemq.artemis_core_client.ObjectInputStreamWithClassLoaderTest"
+      },
+      "type" : "org_apache_activemq.artemis_core_client.ObjectInputStreamWithClassLoaderTest$GreetingInvocationHandler",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_activemq.artemis_core_client.ObjectInputStreamWithClassLoaderTest"
+      },
+      "type" : "org_apache_activemq.artemis_core_client.ObjectInputStreamWithClassLoaderTest$SamplePayload",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_activemq.artemis_core_client.JsonUtilTest"
+      },
+      "type" : "java.util.TreeMap",
+      "serializable" : true,
+      "fields" : [
+        {
+          "name" : "serialVersionUID"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_activemq.artemis_core_client.JsonUtilTest"
+      },
+      "type" : "java.lang.Integer",
+      "serializable" : true,
+      "fields" : [
+        {
+          "name" : "serialVersionUID"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.utils.ObjectInputStreamWithClassLoader"
+      },
+      "type" : {
+        "proxy" : [
+          "org_apache_activemq.artemis_core_client.ObjectInputStreamWithClassLoaderTest$Greeting"
+        ]
+      },
+      "serializable" : true,
+      "unsafeAllocated" : true
+    }
+  ],
+  "serialization" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.utils.ObjectInputStreamWithClassLoader"
+      },
+      "type" : "org_apache_activemq.artemis_core_client.ObjectInputStreamWithClassLoaderTest$GreetingInvocationHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.utils.ObjectInputStreamWithClassLoader"
+      },
+      "type" : "org_apache_activemq.artemis_core_client.ObjectInputStreamWithClassLoaderTest$SamplePayload"
+    }
+  ]
+}

--- a/tests/src/org.apache.activemq/artemis-core-client/2.32.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.activemq/artemis-core-client/2.32.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -88,5 +88,13 @@
       },
       "type" : "org_apache_activemq.artemis_core_client.ObjectInputStreamWithClassLoaderTest$SamplePayload"
     }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.activemq.artemis.api.core.JGroupsFileBroadcastEndpoint"
+      },
+      "glob" : "org_apache_activemq/artemis_core_client/jgroups-file-broadcast-endpoint.xml"
+    }
   ]
 }

--- a/tests/src/org.apache.activemq/artemis-core-client/2.32.0/src/test/resources/org_apache_activemq/artemis_core_client/jgroups-file-broadcast-endpoint.xml
+++ b/tests/src/org.apache.activemq/artemis-core-client/2.32.0/src/test/resources/org_apache_activemq/artemis_core_client/jgroups-file-broadcast-endpoint.xml
@@ -1,0 +1,1 @@
+not a jgroups xml document

--- a/tests/src/org.apache.activemq/artemis-core-client/2.32.0/user-code-filter.json
+++ b/tests/src/org.apache.activemq/artemis-core-client/2.32.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.activemq.artemis.**"
+    },
+    {
+      "includeClasses" : "org_apache_activemq.artemis_core_client.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7431

This PR provides test fixes and new metadata for org.apache.activemq:artemis-core-client:2.32.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 127111
- Cached input tokens: 1177600
- Output tokens: 23571
- Metadata entries: 49
- Test-only metadata entries: 18
- Iterations: 5
- Library coverage percentage: 4.79
- Previous library version metadata entries: 49
- Previous library version test-only metadata entries: 17
- Previous library version coverage percentage: 4.81

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `dad1e5c80e369dce42bc14ee78259d0d5693b582`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.activemq:artemis-core-client:2.28.0: 11/13 covered calls (84.62%)
- org.apache.activemq:artemis-core-client:2.32.0: 11/13 covered calls (84.62%)

**Reflection:**
- org.apache.activemq:artemis-core-client:2.28.0: 10/11 covered calls (90.91%)
- org.apache.activemq:artemis-core-client:2.32.0: 10/11 covered calls (90.91%)

**Resources:**
- org.apache.activemq:artemis-core-client:2.28.0: 1/2 covered calls (50.00%)
- org.apache.activemq:artemis-core-client:2.32.0: 1/2 covered calls (50.00%)

#### Library coverage

**Instruction:**
- org.apache.activemq:artemis-core-client:2.28.0: 3067/70689 (4.34%)
- org.apache.activemq:artemis-core-client:2.32.0: 3116/73100 (4.26%)

**Line:**
- org.apache.activemq:artemis-core-client:2.28.0: 855/17767 (4.81%)
- org.apache.activemq:artemis-core-client:2.32.0: 868/18137 (4.79%)

**Method:**
- org.apache.activemq:artemis-core-client:2.28.0: 148/4425 (3.34%)
- org.apache.activemq:artemis-core-client:2.32.0: 151/4644 (3.25%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.activemq/artemis-core-client/2.28.0/build.gradle 2/tests/src/org.apache.activemq/artemis-core-client/2.32.0/build.gradle
index 15560c0967..bdf8d0daa8 100644
--- 1/tests/src/org.apache.activemq/artemis-core-client/2.28.0/build.gradle
+++ 2/tests/src/org.apache.activemq/artemis-core-client/2.32.0/build.gradle
@@ -13,6 +13,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.apache.activemq:artemis-core-client:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.jgroups:jgroups:5.3.0.Final'
 }
 
 graalvmNative {
diff --git 1/tests/src/org.apache.activemq/artemis-core-client/2.28.0/src/test/java/org_apache_activemq/artemis_core_client/JGroupsFileBroadcastEndpointTest.java 2/tests/src/org.apache.activemq/artemis-core-client/2.32.0/src/test/java/org_apache_activemq/artemis_core_client/JGroupsFileBroadcastEndpointTest.java
index 70452540a5..21360c0ad2 100644
--- 1/tests/src/org.apache.activemq/artemis-core-client/2.28.0/src/test/java/org_apache_activemq/artemis_core_client/JGroupsFileBroadcastEndpointTest.java
+++ 2/tests/src/org.apache.activemq/artemis-core-client/2.32.0/src/test/java/org_apache_activemq/artemis_core_client/JGroupsFileBroadcastEndpointTest.java
@@ -9,56 +9,23 @@ package org_apache_activemq.artemis_core_client;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-
 import org.apache.activemq.artemis.api.core.JGroupsFileBroadcastEndpoint;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 public class JGroupsFileBroadcastEndpointTest {
     @Test
-    void readsJGroupsConfigurationFromContextClassLoaderResource(@TempDir Path temporaryDirectory) throws Exception {
-        String resourceName = "jgroups-test.xml";
-        Files.writeString(temporaryDirectory.resolve(resourceName), "not a jgroups xml document", StandardCharsets.UTF_8);
-        ClassLoader originalContextClassLoader = Thread.currentThread().getContextClassLoader();
-        URL resourceUrl = temporaryDirectory.resolve(resourceName).toUri().toURL();
-
-        try {
-            Thread.currentThread().setContextClassLoader(new SingleResourceClassLoader(resourceName, resourceUrl));
-            JGroupsFileBroadcastEndpoint endpoint = new JGroupsFileBroadcastEndpoint(
-                    null,
-                    resourceName,
-                    "metadata-test-channel");
-
-            Throwable failure = catchThrowable(endpoint::createChannel);
-
-            assertThat(failure).isNotNull();
-            assertThat(String.valueOf(failure.getMessage()))
-                    .doesNotContain("couldn't find JGroups configuration");
-        } finally {
-            Thread.currentThread().setContextClassLoader(originalContextClassLoader);
-        }
-    }
-
-    private static final class SingleResourceClassLoader extends ClassLoader {
-        private final String resourceName;
-        private final URL resourceUrl;
-
-        private SingleResourceClassLoader(String resourceName, URL resourceUrl) {
-            super(null);
-            this.resourceName = resourceName;
-            this.resourceUrl = resourceUrl;
-        }
-
-        @Override
-        protected URL findResource(String name) {
-            if (resourceName.equals(name)) {
-                return resourceUrl;
-            }
-            return null;
-        }
+    void readsJGroupsConfigurationFromContextClassLoaderResource() throws Exception {
+        String resourceName = "org_apache_activemq/artemis_core_client/jgroups-file-broadcast-endpoint.xml";
+        JGroupsFileBroadcastEndpoint endpoint = new JGroupsFileBroadcastEndpoint(
+                null,
+                resourceName,
+                "metadata-test-channel");
+
+        Throwable failure = catchThrowable(endpoint::createChannel);
+
+        assertThat(failure).isNotNull();
+        assertThat(failure).isNotInstanceOf(NoClassDefFoundError.class);
+        assertThat(String.valueOf(failure.getMessage()))
+                .doesNotContain("couldn't find JGroups configuration");
     }
 }
diff --git 1/tests/src/org.apache.activemq/artemis-core-client/2.28.0/src/test/java/org_apache_activemq/artemis_core_client/ObjectInputStreamWithClassLoaderTest.java 2/tests/src/org.apache.activemq/artemis-core-client/2.32.0/src/test/java/org_apache_activemq/artemis_core_client/ObjectInputStreamWithClassLoaderTest.java
index f5033da2af..00f0a81e38 100644
--- 1/tests/src/org.apache.activemq/artemis-core-client/2.28.0/src/test/java/org_apache_activemq/artemis_core_client/ObjectInputStreamWithClassLoaderTest.java
+++ 2/tests/src/org.apache.activemq/artemis-core-client/2.32.0/src/test/java/org_apache_activemq/artemis_core_client/ObjectInputStreamWithClassLoaderTest.java
@@ -71,8 +71,8 @@ public class ObjectInputStreamWithClassLoaderTest {
         thread.setContextClassLoader(contextClassLoader);
         try (ObjectInputStreamWithClassLoader input = new ObjectInputStreamWithClassLoader(
                 new ByteArrayInputStream(bytes))) {
-            input.setBlackList(null);
-            input.setWhiteList(ObjectInputStreamWithClassLoader.CATCH_ALL_WILDCARD);
+            input.setDenyList(null);
+            input.setAllowList(ObjectInputStreamWithClassLoader.CATCH_ALL_WILDCARD);
             return input.readObject();
         } finally {
             thread.setContextClassLoader(previousContextClassLoader);

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
