### PR TITLE
[GenAI] Test fix for org.glassfish.grizzly:grizzly-http-servlet:2.1.11 using gpt-5.5

### DIFF
--- a/metadata/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/reachability-metadata.json
+++ b/metadata/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/reachability-metadata.json
@@ -1,0 +1,152 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.nio.SelectorRunner"
+      },
+      "type": "java.nio.channels.SelectionKey[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.utils.DataStructures"
+      },
+      "type": "java.util.concurrent.LinkedTransferQueue"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.http.server.NetworkListener"
+      },
+      "type": "java.util.logging.ConsoleHandler"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.http.server.HttpServer"
+      },
+      "type": "java.util.logging.Handler[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.http.server.NetworkListener"
+      },
+      "type": "java.util.logging.Handler[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.http.server.NetworkListener"
+      },
+      "type": "java.util.logging.SimpleFormatter"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.filterchain.DefaultFilterChain$FiltersStateFactory"
+      },
+      "type": "org.glassfish.grizzly.filterchain.DefaultFilterChain$FilterStateElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.filterchain.DefaultFilterChain$FiltersStateFactory"
+      },
+      "type": "org.glassfish.grizzly.filterchain.DefaultFilterChain$FilterStateElement[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.utils.ArraySet"
+      },
+      "type": "org.glassfish.grizzly.http.ContentEncoding[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.utils.ArraySet"
+      },
+      "type": "org.glassfish.grizzly.http.HttpProbe[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.utils.ArraySet"
+      },
+      "type": "org.glassfish.grizzly.http.KeepAliveProbe[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.utils.ArraySet"
+      },
+      "type": "org.glassfish.grizzly.http.TransferEncoding[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.utils.ArrayUtils"
+      },
+      "type": "org.glassfish.grizzly.http.TransferEncoding[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.utils.ArraySet"
+      },
+      "type": "org.glassfish.grizzly.http.server.AddOn[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.utils.ArraySet"
+      },
+      "type": "org.glassfish.grizzly.http.server.HttpServerProbe[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.utils.ArraySet"
+      },
+      "type": "org.glassfish.grizzly.http.server.filecache.FileCacheProbe[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.NIOTransportBuilder"
+      },
+      "type": "org.glassfish.grizzly.nio.transport.TCPNIOTransport"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.servlet.ServletContextImpl"
+      },
+      "type": "org_glassfish_grizzly.grizzly_http_servlet.Grizzly_http_servletTest$ServletEventRecorder"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.http.server.NetworkListener"
+      },
+      "type": "sun.util.logging.resources.logging"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.http.util.CookieUtils$1"
+      },
+      "type": "sun.util.resources.cldr.CalendarData"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.http.util.CookieUtils"
+      },
+      "type": "sun.util.resources.cldr.TimeZoneNames"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.http.util.CookieUtils"
+      },
+      "type": "sun.util.resources.cldr.TimeZoneNames_en"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.http.server.NetworkListener"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.glassfish.grizzly.http.server.NetworkListener"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en_US.properties"
+    }
+  ]
+}

--- a/metadata/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/reachability-metadata.json
+++ b/metadata/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/reachability-metadata.json
@@ -1,152 +1,146 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.nio.SelectorRunner"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.nio.SelectorRunner"
       },
-      "type": "java.nio.channels.SelectionKey[]"
+      "type" : "java.nio.channels.SelectionKey[]"
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.utils.DataStructures"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.utils.DataStructures"
       },
-      "type": "java.util.concurrent.LinkedTransferQueue"
+      "type" : "java.util.concurrent.LinkedTransferQueue"
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.http.server.NetworkListener"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.http.server.NetworkListener"
       },
-      "type": "java.util.logging.ConsoleHandler"
+      "type" : "java.util.logging.ConsoleHandler"
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.http.server.HttpServer"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.http.server.HttpServer"
       },
-      "type": "java.util.logging.Handler[]"
+      "type" : "java.util.logging.Handler[]"
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.http.server.NetworkListener"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.http.server.NetworkListener"
       },
-      "type": "java.util.logging.Handler[]"
+      "type" : "java.util.logging.Handler[]"
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.http.server.NetworkListener"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.http.server.NetworkListener"
       },
-      "type": "java.util.logging.SimpleFormatter"
+      "type" : "java.util.logging.SimpleFormatter"
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.filterchain.DefaultFilterChain$FiltersStateFactory"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.filterchain.DefaultFilterChain$FiltersStateFactory"
       },
-      "type": "org.glassfish.grizzly.filterchain.DefaultFilterChain$FilterStateElement[]"
+      "type" : "org.glassfish.grizzly.filterchain.DefaultFilterChain$FilterStateElement[]"
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.filterchain.DefaultFilterChain$FiltersStateFactory"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.filterchain.DefaultFilterChain$FiltersStateFactory"
       },
-      "type": "org.glassfish.grizzly.filterchain.DefaultFilterChain$FilterStateElement[][]"
+      "type" : "org.glassfish.grizzly.filterchain.DefaultFilterChain$FilterStateElement[][]"
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.utils.ArraySet"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.utils.ArraySet"
       },
-      "type": "org.glassfish.grizzly.http.ContentEncoding[]"
+      "type" : "org.glassfish.grizzly.http.ContentEncoding[]"
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.utils.ArraySet"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.utils.ArraySet"
       },
-      "type": "org.glassfish.grizzly.http.HttpProbe[]"
+      "type" : "org.glassfish.grizzly.http.HttpProbe[]"
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.utils.ArraySet"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.utils.ArraySet"
       },
-      "type": "org.glassfish.grizzly.http.KeepAliveProbe[]"
+      "type" : "org.glassfish.grizzly.http.KeepAliveProbe[]"
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.utils.ArraySet"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.utils.ArraySet"
       },
-      "type": "org.glassfish.grizzly.http.TransferEncoding[]"
+      "type" : "org.glassfish.grizzly.http.TransferEncoding[]"
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.utils.ArrayUtils"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.utils.ArrayUtils"
       },
-      "type": "org.glassfish.grizzly.http.TransferEncoding[]"
+      "type" : "org.glassfish.grizzly.http.TransferEncoding[]"
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.utils.ArraySet"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.utils.ArraySet"
       },
-      "type": "org.glassfish.grizzly.http.server.AddOn[]"
+      "type" : "org.glassfish.grizzly.http.server.AddOn[]"
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.utils.ArraySet"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.utils.ArraySet"
       },
-      "type": "org.glassfish.grizzly.http.server.HttpServerProbe[]"
+      "type" : "org.glassfish.grizzly.http.server.HttpServerProbe[]"
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.utils.ArraySet"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.utils.ArraySet"
       },
-      "type": "org.glassfish.grizzly.http.server.filecache.FileCacheProbe[]"
+      "type" : "org.glassfish.grizzly.http.server.filecache.FileCacheProbe[]"
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.NIOTransportBuilder"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.NIOTransportBuilder"
       },
-      "type": "org.glassfish.grizzly.nio.transport.TCPNIOTransport"
+      "type" : "org.glassfish.grizzly.nio.transport.TCPNIOTransport"
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.servlet.ServletContextImpl"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.http.server.NetworkListener"
       },
-      "type": "org_glassfish_grizzly.grizzly_http_servlet.Grizzly_http_servletTest$ServletEventRecorder"
+      "type" : "sun.util.logging.resources.logging"
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.http.server.NetworkListener"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.http.util.CookieUtils$1"
       },
-      "type": "sun.util.logging.resources.logging"
+      "type" : "sun.util.resources.cldr.CalendarData"
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.http.util.CookieUtils$1"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.http.util.CookieUtils"
       },
-      "type": "sun.util.resources.cldr.CalendarData"
+      "type" : "sun.util.resources.cldr.TimeZoneNames"
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.http.util.CookieUtils"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.http.util.CookieUtils"
       },
-      "type": "sun.util.resources.cldr.TimeZoneNames"
-    },
-    {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.http.util.CookieUtils"
-      },
-      "type": "sun.util.resources.cldr.TimeZoneNames_en"
+      "type" : "sun.util.resources.cldr.TimeZoneNames_en"
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.http.server.NetworkListener"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.http.server.NetworkListener"
       },
-      "module": "java.logging",
-      "glob": "sun/util/logging/resources/logging_en.properties"
+      "module" : "java.logging",
+      "glob" : "sun/util/logging/resources/logging_en.properties"
     },
     {
-      "condition": {
-        "typeReached": "org.glassfish.grizzly.http.server.NetworkListener"
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.http.server.NetworkListener"
       },
-      "module": "java.logging",
-      "glob": "sun/util/logging/resources/logging_en_US.properties"
+      "module" : "java.logging",
+      "glob" : "sun/util/logging/resources/logging_en_US.properties"
     }
   ]
 }

--- a/metadata/org.glassfish.grizzly/grizzly-http-servlet/index.json
+++ b/metadata/org.glassfish.grizzly/grizzly-http-servlet/index.json
@@ -20,6 +20,11 @@
   },
   {
     "metadata-version" : "2.1.11",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/glassfish/grizzly/grizzly-http-servlet/$version$/grizzly-http-servlet-$version$-sources.jar",
+    "repository-url" : "https://github.com/javaee/grizzly",
+    "test-code-url" : "https://github.com/javaee/grizzly/tree/2_1_11/modules/http-servlet/src/test?version=$version$",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/glassfish/grizzly/grizzly-http-servlet/$version$/grizzly-http-servlet-$version$-javadoc.jar",
+    "description" : "Grizzly HTTP Servlet provides a servlet integration layer for Grizzly's HTTP server, including servlet request, response, context, session, filter, and dispatcher support. It lets JVM applications register and run Java Servlet components on top of Grizzly while also serving static resources through the HTTP server.",
     "tested-versions" : [
       "2.1.11"
     ],

--- a/metadata/org.glassfish.grizzly/grizzly-http-servlet/index.json
+++ b/metadata/org.glassfish.grizzly/grizzly-http-servlet/index.json
@@ -19,6 +19,17 @@
     ]
   },
   {
+    "metadata-version" : "2.1.11",
+    "tested-versions" : [
+      "2.1.11"
+    ],
+    "allowed-packages" : [
+      "org.glassfish.grizzly.servlet",
+      "org.glassfish.grizzly",
+      "org.glassfish.grizzly.utils"
+    ]
+  },
+  {
     "metadata-version" : "2.1.10",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/glassfish/grizzly/grizzly-http-servlet/$version$/grizzly-http-servlet-$version$-sources.jar",
     "repository-url" : "https://github.com/javaee/grizzly",

--- a/stats/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/execution-metrics.json
+++ b/stats/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/execution-metrics.json
@@ -1,0 +1,110 @@
+{
+  "fix_javac_fail:2026-05-21": {
+    "timestamp": "2026-05-21T08:53:59.925630Z",
+    "library": "org.glassfish.grizzly:grizzly-http-servlet:2.1.11",
+    "starting_commit": "f9f799ba28a0f99b1c77b9723cbe9685584b6f4b",
+    "ending_commit": "94bed7b06dda2c0035f204bbb282dde9eae18c28",
+    "previous_library": "org.glassfish.grizzly:grizzly-http-servlet:2.1.2",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.1.11",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 4,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3163,
+          "missed": 4086,
+          "ratio": 0.436336,
+          "total": 7249
+        },
+        "line": {
+          "covered": 896,
+          "missed": 1091,
+          "ratio": 0.450931,
+          "total": 1987
+        },
+        "method": {
+          "covered": 185,
+          "missed": 250,
+          "ratio": 0.425287,
+          "total": 435
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.1.2",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          },
+          "resources": {
+            "coverageRatio": 0.0,
+            "coveredCalls": 0,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 0.5,
+        "coveredCalls": 2,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3133,
+          "missed": 11232,
+          "ratio": 0.2181,
+          "total": 14365
+        },
+        "line": {
+          "covered": 887,
+          "missed": 3323,
+          "ratio": 0.210689,
+          "total": 4210
+        },
+        "method": {
+          "covered": 183,
+          "missed": 1692,
+          "ratio": 0.0976,
+          "total": 1875
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 82824,
+      "cached_input_tokens_used": 503296,
+      "output_tokens_used": 6657,
+      "iterations": 2,
+      "cost_usd": 0.4513,
+      "tested_library_loc": 896,
+      "metadata_entries": 25,
+      "test_only_metadata_entries": 1,
+      "previous_library_metadata_entries": 12,
+      "code_coverage_percent": 45.09,
+      "previous_library_coverage_percent": 21.07
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/src/test/java/org_glassfish_grizzly/grizzly_http_servlet/ServletContextImplTest.java",
+      "metadata_file": "metadata/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/stats.json
+++ b/stats/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "2.1.11",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 4,
+      "totalCalls" : 4
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3163,
+        "missed" : 4086,
+        "ratio" : 0.436336,
+        "total" : 7249
+      },
+      "line" : {
+        "covered" : 896,
+        "missed" : 1091,
+        "ratio" : 0.450931,
+        "total" : 1987
+      },
+      "method" : {
+        "covered" : 185,
+        "missed" : 250,
+        "ratio" : 0.425287,
+        "total" : 435
+      }
+    }
+  } ]
+}

--- a/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/.gitignore
+++ b/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/build.gradle
+++ b/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/build.gradle
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.glassfish.grizzly:grizzly-http-servlet:$libraryVersion"
+    testImplementation 'javax.servlet:servlet-api:2.5'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/gradle.properties
+++ b/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.glassfish.grizzly:grizzly-http-servlet:2.1.11
+library.version = 2.1.11
+metadata.dir = org.glassfish.grizzly/grizzly-http-servlet/2.1.11/

--- a/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/settings.gradle
+++ b/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.glassfish.grizzly.grizzly-http-servlet_tests'

--- a/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/src/test/java/org_glassfish_grizzly/grizzly_http_servlet/Grizzly_http_servletTest.java
+++ b/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/src/test/java/org_glassfish_grizzly/grizzly_http_servlet/Grizzly_http_servletTest.java
@@ -1,0 +1,609 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_grizzly.grizzly_http_servlet;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.ServerSocket;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletContextAttributeEvent;
+import javax.servlet.ServletContextAttributeListener;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletRequestAttributeEvent;
+import javax.servlet.ServletRequestAttributeListener;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpSessionAttributeListener;
+import javax.servlet.http.HttpSessionBindingEvent;
+import javax.servlet.http.HttpSessionEvent;
+import javax.servlet.http.HttpSessionListener;
+
+import org.glassfish.grizzly.http.server.HttpServer;
+import org.glassfish.grizzly.http.server.NetworkListener;
+import org.glassfish.grizzly.servlet.CookieWrapper;
+import org.glassfish.grizzly.servlet.ServletHandler;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Grizzly_http_servletTest {
+    private static final String HOST = "127.0.0.1";
+    private static final int TIMEOUT_MILLIS = 3_000;
+
+    @Test
+    void servletHandlerServesRequestsThroughFiltersSessionsAndCookies() throws Exception {
+        EchoServlet servlet = new EchoServlet();
+        CapturingFilter filter = new CapturingFilter();
+        ServletHandler handler = new ServletHandler(servlet);
+        handler.setContextPath("/sample");
+        handler.setServletPath("/echo");
+        handler.addInitParameter("greeting", "hello");
+        handler.addContextParameter("application", "grizzly-servlet-test");
+        handler.addFilter(filter, "capturingFilter", Collections.singletonMap("role", "observed"));
+
+        ServerHandle server = startServer(handler, "/sample/echo/*");
+        try {
+            HttpResponse response = get(server.port(),
+                    "/sample/echo/details?name=GraalVM&multi=one&multi=two",
+                    Map.of("X-Test-Header", "present", "Cookie", "client=browser"));
+
+            assertThat(response.status).isEqualTo(HttpURLConnection.HTTP_OK);
+            assertThat(response.header("X-Filter-Role")).isEqualTo("observed");
+            assertThat(response.headersWithName("Set-Cookie"))
+                    .anySatisfy(value -> assertThat(value).contains("server=grizzly"));
+
+            Map<String, String> lines = parseBody(response.body);
+            assertThat(lines).containsEntry("initGreeting", "hello");
+            assertThat(lines).containsEntry("contextApplication", "grizzly-servlet-test");
+            assertThat(lines).containsEntry("contextPath", "/sample");
+            assertThat(lines).containsEntry("servletPath", "/echo");
+            assertThat(lines).containsEntry("pathInfo", "/details");
+            assertThat(lines).containsEntry("queryName", "GraalVM");
+            assertThat(lines).containsEntry("multiValues", "one,two");
+            assertThat(lines).containsEntry("requestHeader", "present");
+            assertThat(lines).containsEntry("clientCookie", "browser");
+            assertThat(lines).containsEntry("filterAttribute", "observed");
+            assertThat(lines).containsEntry("sessionAttribute", "created");
+            assertThat(lines).containsEntry("method", "GET");
+            assertThat(lines).containsEntry("localeLanguage", Locale.US.getLanguage());
+            assertThat(Integer.parseInt(lines.get("sessionIdLength"))).isPositive();
+
+            assertThat(servlet.initCount).hasValue(1);
+            assertThat(servlet.requestCount).hasValue(1);
+            assertThat(filter.initCount).hasValue(1);
+            assertThat(filter.requestCount).hasValue(1);
+        } finally {
+            server.close();
+        }
+
+        assertThat(servlet.destroyCount.get()).isGreaterThanOrEqualTo(1);
+        assertThat(filter.destroyCount.get()).isGreaterThanOrEqualTo(1);
+    }
+
+    @Test
+    void requestDispatcherIncludesAndForwardsWithinServletContext() throws Exception {
+        DispatchingServlet servlet = new DispatchingServlet();
+        ServletHandler handler = new ServletHandler(servlet);
+        handler.setContextPath("");
+        handler.setServletPath("/dispatch");
+
+        ServerHandle server = startServer(handler, "/dispatch/*");
+        try {
+            HttpResponse includeResponse = get(server.port(), "/dispatch/include", Collections.emptyMap());
+
+            assertThat(includeResponse.status).isEqualTo(HttpURLConnection.HTTP_OK);
+            assertThat(includeResponse.body).contains("before-include");
+            assertThat(includeResponse.body).contains("targetPath=/target");
+            assertThat(includeResponse.body).contains("includedAttribute=from-include");
+            assertThat(includeResponse.body).contains("after-include");
+
+            HttpResponse forwardResponse = get(server.port(), "/dispatch/forward", Collections.emptyMap());
+
+            assertThat(forwardResponse.status).isEqualTo(HttpURLConnection.HTTP_OK);
+            assertThat(forwardResponse.body).doesNotContain("before-forward");
+            assertThat(forwardResponse.body).contains("targetPath=/target");
+            assertThat(forwardResponse.body).contains("includedAttribute=from-forward");
+        } finally {
+            server.close();
+        }
+    }
+
+    @Test
+    void postRequestBodyAndFormParametersAreAvailableToServlet() throws Exception {
+        ServletHandler handler = new ServletHandler(new FormServlet());
+        handler.setContextPath("/forms");
+        handler.setServletPath("/submit");
+
+        ServerHandle server = startServer(handler, "/forms/submit");
+        try {
+            HttpResponse response = post(server.port(), "/forms/submit", "alpha=one&beta=two&beta=three");
+
+            assertThat(response.status).isEqualTo(HttpURLConnection.HTTP_OK);
+            Map<String, String> lines = parseBody(response.body);
+            assertThat(lines).containsEntry("contentType", "application/x-www-form-urlencoded");
+            assertThat(lines).containsEntry("alpha", "one");
+            assertThat(lines).containsEntry("beta", "two,three");
+            assertThat(lines).containsEntry("contentLength", "29");
+        } finally {
+            server.close();
+        }
+    }
+
+    @Test
+    void servletHandlerNotifiesServletEventListenersRegisteredByClassName() throws Exception {
+        ServletEventRecorder.reset();
+        ServletHandler handler = new ServletHandler(new ListenerDrivenServlet());
+        handler.setContextPath("/events");
+        handler.setServletPath("/capture");
+        handler.addServletListener(ServletEventRecorder.class.getName());
+
+        ServerHandle server = startServer(handler, "/events/capture");
+        try {
+            assertThat(ServletEventRecorder.events()).containsExactly("contextInitialized:/events");
+
+            HttpResponse response = get(server.port(), "/events/capture", Collections.emptyMap());
+
+            assertThat(response.status).isEqualTo(HttpURLConnection.HTTP_OK);
+            assertThat(response.body).contains("eventsRecorded=");
+            assertThat(ServletEventRecorder.events()).containsSubsequence(
+                    "contextInitialized:/events",
+                    "contextAttributeAdded:context.flag=one",
+                    "contextAttributeReplaced:context.flag=one",
+                    "contextAttributeRemoved:context.flag=two",
+                    "requestAttributeAdded:request.flag=one",
+                    "requestAttributeReplaced:request.flag=one",
+                    "requestAttributeRemoved:request.flag=two",
+                    "sessionAttributeAdded:session.flag=one",
+                    "sessionAttributeReplaced:session.flag=one",
+                    "sessionAttributeRemoved:session.flag=two",
+                    "sessionDestroyed");
+        } finally {
+            server.close();
+        }
+
+        assertThat(ServletEventRecorder.events()).endsWith("contextDestroyed:/events");
+    }
+
+    @Test
+    void servletHandlersCreatedFromExistingHandlerShareServletContext() throws Exception {
+        ServletHandler writerHandler = new ServletHandler(new SharedContextWriterServlet());
+        writerHandler.setContextPath("/shared");
+        writerHandler.setServletPath("/write");
+        writerHandler.addContextParameter("scope", "application");
+
+        ServletHandler readerHandler = writerHandler.newServletHandler(new SharedContextReaderServlet());
+        readerHandler.setServletPath("/read");
+
+        Map<String, ServletHandler> handlersByMapping = new LinkedHashMap<>();
+        handlersByMapping.put("/shared/write", writerHandler);
+        handlersByMapping.put("/shared/read", readerHandler);
+
+        ServerHandle server = startServer(handlersByMapping);
+        try {
+            HttpResponse writeResponse = get(server.port(), "/shared/write?name=color&value=blue",
+                    Collections.emptyMap());
+
+            assertThat(writeResponse.status).isEqualTo(HttpURLConnection.HTTP_OK);
+            assertThat(parseBody(writeResponse.body)).containsEntry("stored", "color=blue");
+
+            HttpResponse readResponse = get(server.port(), "/shared/read?name=color", Collections.emptyMap());
+
+            assertThat(readResponse.status).isEqualTo(HttpURLConnection.HTTP_OK);
+            Map<String, String> lines = parseBody(readResponse.body);
+            assertThat(lines).containsEntry("contextPath", "/shared");
+            assertThat(lines).containsEntry("servletPath", "/read");
+            assertThat(lines).containsEntry("contextParameter", "application");
+            assertThat(lines).containsEntry("sharedValue", "blue");
+        } finally {
+            server.close();
+        }
+    }
+
+    @Test
+    void cookieWrapperDelegatesToWrappedServletCookie() {
+        Cookie servletCookie = new Cookie("theme", "light");
+        CookieWrapper wrapper = new CookieWrapper("ignored", "ignored");
+        wrapper.setWrappedCookie(servletCookie);
+
+        wrapper.setValue("dark");
+        wrapper.setComment("ui preference");
+        wrapper.setDomain("example.test");
+        wrapper.setPath("/ui");
+        wrapper.setMaxAge(120);
+        wrapper.setSecure(true);
+        wrapper.setVersion(1);
+
+        assertThat(wrapper.getName()).isEqualTo("theme");
+        assertThat(wrapper.getValue()).isEqualTo("dark");
+        assertThat(wrapper.getComment()).isEqualTo("ui preference");
+        assertThat(wrapper.getDomain()).isEqualTo("example.test");
+        assertThat(wrapper.getPath()).isEqualTo("/ui");
+        assertThat(wrapper.getMaxAge()).isEqualTo(120);
+        assertThat(wrapper.isSecure()).isTrue();
+        assertThat(wrapper.getVersion()).isEqualTo(1);
+        assertThat(wrapper.getWrappedCookie()).isSameAs(servletCookie);
+
+        Cookie clone = (Cookie) wrapper.clone();
+        assertThat(clone).isNotSameAs(servletCookie);
+        assertThat(clone.getName()).isEqualTo("theme");
+        assertThat(clone.getValue()).isEqualTo("dark");
+    }
+
+    private static ServerHandle startServer(ServletHandler handler, String mapping) throws IOException {
+        int port = availablePort();
+        HttpServer server = new HttpServer();
+        server.addListener(new NetworkListener("test-listener", HOST, port));
+        server.getServerConfiguration().addHttpHandler(handler, mapping);
+        server.start();
+        return new ServerHandle(server, port);
+    }
+
+    private static ServerHandle startServer(Map<String, ServletHandler> handlersByMapping) throws IOException {
+        int port = availablePort();
+        HttpServer server = new HttpServer();
+        server.addListener(new NetworkListener("test-listener", HOST, port));
+        handlersByMapping.forEach((mapping, handler) ->
+                server.getServerConfiguration().addHttpHandler(handler, mapping));
+        server.start();
+        return new ServerHandle(server, port);
+    }
+
+    private static int availablePort() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+
+    private static HttpResponse get(int port, String path, Map<String, String> headers) throws IOException {
+        HttpURLConnection connection = openConnection(port, path);
+        headers.forEach(connection::setRequestProperty);
+        return readResponse(connection);
+    }
+
+    private static HttpResponse post(int port, String path, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        HttpURLConnection connection = openConnection(port, path);
+        connection.setRequestMethod("POST");
+        connection.setDoOutput(true);
+        connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+        connection.setFixedLengthStreamingMode(bytes.length);
+        try (OutputStream output = connection.getOutputStream()) {
+            output.write(bytes);
+        }
+        return readResponse(connection);
+    }
+
+    private static HttpURLConnection openConnection(int port, String path) throws IOException {
+        URL url = new URL("http", HOST, port, path);
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setConnectTimeout(TIMEOUT_MILLIS);
+        connection.setReadTimeout(TIMEOUT_MILLIS);
+        connection.setInstanceFollowRedirects(false);
+        connection.setRequestProperty("Connection", "close");
+        return connection;
+    }
+
+    private static HttpResponse readResponse(HttpURLConnection connection) throws IOException {
+        try {
+            int status = connection.getResponseCode();
+            InputStream input = status >= HttpURLConnection.HTTP_BAD_REQUEST
+                    ? connection.getErrorStream()
+                    : connection.getInputStream();
+            String body = input == null ? "" : new String(input.readAllBytes(), StandardCharsets.UTF_8);
+            return new HttpResponse(status, body, connection.getHeaderFields());
+        } finally {
+            connection.disconnect();
+        }
+    }
+
+    private static Map<String, String> parseBody(String body) {
+        Map<String, String> values = new LinkedHashMap<>();
+        for (String line : body.split("\\R")) {
+            int separator = line.indexOf('=');
+            if (separator > 0) {
+                values.put(line.substring(0, separator), line.substring(separator + 1));
+            }
+        }
+        return values;
+    }
+
+    private static String cookieValue(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return "";
+        }
+        for (Cookie cookie : cookies) {
+            if (name.equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return "";
+    }
+
+    private static String join(String[] values) {
+        return values == null ? "" : String.join(",", values);
+    }
+
+    private record ServerHandle(HttpServer server, int port) implements AutoCloseable {
+        @Override
+        public void close() {
+            server.stop();
+        }
+    }
+
+    private record HttpResponse(int status, String body, Map<String, List<String>> headers) {
+        private String header(String name) {
+            List<String> values = headersWithName(name);
+            return values.isEmpty() ? null : values.get(0);
+        }
+
+        private List<String> headersWithName(String name) {
+            return headers.entrySet().stream()
+                    .filter(entry -> entry.getKey() != null && entry.getKey().equalsIgnoreCase(name))
+                    .flatMap(entry -> entry.getValue().stream())
+                    .toList();
+        }
+    }
+
+    private static final class CapturingFilter implements Filter {
+        private final AtomicInteger initCount = new AtomicInteger();
+        private final AtomicInteger requestCount = new AtomicInteger();
+        private final AtomicInteger destroyCount = new AtomicInteger();
+        private String role;
+
+        @Override
+        public void init(FilterConfig filterConfig) {
+            role = filterConfig.getInitParameter("role");
+            initCount.incrementAndGet();
+        }
+
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+                throws IOException, ServletException {
+            requestCount.incrementAndGet();
+            request.setAttribute("filter.role", role);
+            ((HttpServletResponse) response).setHeader("X-Filter-Role", role);
+            chain.doFilter(request, response);
+        }
+
+        @Override
+        public void destroy() {
+            destroyCount.incrementAndGet();
+        }
+    }
+
+    private static final class EchoServlet extends HttpServlet {
+        private final AtomicInteger initCount = new AtomicInteger();
+        private final AtomicInteger requestCount = new AtomicInteger();
+        private final AtomicInteger destroyCount = new AtomicInteger();
+
+        @Override
+        public void init() {
+            initCount.incrementAndGet();
+        }
+
+        @Override
+        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+            requestCount.incrementAndGet();
+            HttpSession session = request.getSession(true);
+            session.setAttribute("state", "created");
+            response.addCookie(new Cookie("server", "grizzly"));
+            response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+            response.setContentType("text/plain");
+            response.setLocale(Locale.US);
+            response.getWriter().println("initGreeting=" + getInitParameter("greeting"));
+            response.getWriter().println("contextApplication=" + getServletContext().getInitParameter("application"));
+            response.getWriter().println("contextPath=" + request.getContextPath());
+            response.getWriter().println("servletPath=" + request.getServletPath());
+            response.getWriter().println("pathInfo=" + request.getPathInfo());
+            response.getWriter().println("queryName=" + request.getParameter("name"));
+            response.getWriter().println("multiValues=" + join(request.getParameterValues("multi")));
+            response.getWriter().println("requestHeader=" + request.getHeader("X-Test-Header"));
+            response.getWriter().println("clientCookie=" + cookieValue(request, "client"));
+            response.getWriter().println("filterAttribute=" + request.getAttribute("filter.role"));
+            response.getWriter().println("sessionAttribute=" + session.getAttribute("state"));
+            response.getWriter().println("sessionIdLength=" + session.getId().length());
+            response.getWriter().println("method=" + request.getMethod());
+            response.getWriter().println("localeLanguage=" + response.getLocale().getLanguage());
+        }
+
+        @Override
+        public void destroy() {
+            destroyCount.incrementAndGet();
+        }
+    }
+
+    private static final class DispatchingServlet extends HttpServlet {
+        @Override
+        protected void doGet(HttpServletRequest request, HttpServletResponse response)
+                throws IOException, ServletException {
+            response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+            response.setContentType("text/plain");
+            if (request.getAttribute("dispatch.attribute") != null || "/target".equals(request.getPathInfo())) {
+                response.getWriter().println("targetPath=/target");
+                response.getWriter().println("includedAttribute=" + request.getAttribute("dispatch.attribute"));
+                return;
+            }
+            if ("/include".equals(request.getPathInfo())) {
+                request.setAttribute("dispatch.attribute", "from-include");
+                response.getWriter().println("before-include");
+                request.getRequestDispatcher("/dispatch/target").include(request, response);
+                response.getWriter().println("after-include");
+            } else if ("/forward".equals(request.getPathInfo())) {
+                request.setAttribute("dispatch.attribute", "from-forward");
+                response.getWriter().println("before-forward");
+                RequestDispatcher dispatcher = request.getRequestDispatcher("/dispatch/target");
+                dispatcher.forward(request, response);
+            }
+        }
+    }
+
+    private static final class FormServlet extends HttpServlet {
+        @Override
+        protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+            response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+            response.setContentType("text/plain");
+            response.getWriter().println("contentType=" + request.getContentType());
+            response.getWriter().println("alpha=" + request.getParameter("alpha"));
+            response.getWriter().println("beta=" + join(request.getParameterValues("beta")));
+            response.getWriter().println("contentLength=" + request.getContentLength());
+        }
+    }
+
+    private static final class SharedContextWriterServlet extends HttpServlet {
+        @Override
+        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+            String name = request.getParameter("name");
+            String value = request.getParameter("value");
+            getServletContext().setAttribute("shared." + name, value);
+
+            response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+            response.setContentType("text/plain");
+            response.getWriter().println("stored=" + name + "=" + value);
+        }
+    }
+
+    private static final class SharedContextReaderServlet extends HttpServlet {
+        @Override
+        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+            String name = request.getParameter("name");
+            Object sharedValue = getServletContext().getAttribute("shared." + name);
+
+            response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+            response.setContentType("text/plain");
+            response.getWriter().println("contextPath=" + request.getContextPath());
+            response.getWriter().println("servletPath=" + request.getServletPath());
+            response.getWriter().println("contextParameter=" + getServletContext().getInitParameter("scope"));
+            response.getWriter().println("sharedValue=" + sharedValue);
+        }
+    }
+
+    private static final class ListenerDrivenServlet extends HttpServlet {
+        @Override
+        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+            getServletContext().setAttribute("context.flag", "one");
+            getServletContext().setAttribute("context.flag", "two");
+            getServletContext().removeAttribute("context.flag");
+
+            request.setAttribute("request.flag", "one");
+            request.setAttribute("request.flag", "two");
+            request.removeAttribute("request.flag");
+
+            HttpSession session = request.getSession(true);
+            session.setAttribute("session.flag", "one");
+            session.setAttribute("session.flag", "two");
+            session.removeAttribute("session.flag");
+            session.invalidate();
+
+            response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+            response.setContentType("text/plain");
+            response.getWriter().println("eventsRecorded=" + ServletEventRecorder.events().size());
+        }
+    }
+
+    public static final class ServletEventRecorder implements ServletContextListener, ServletContextAttributeListener,
+            ServletRequestAttributeListener, HttpSessionListener, HttpSessionAttributeListener {
+        private static final CopyOnWriteArrayList<String> EVENTS = new CopyOnWriteArrayList<>();
+
+        public ServletEventRecorder() {
+        }
+
+        private static void reset() {
+            EVENTS.clear();
+        }
+
+        private static List<String> events() {
+            return List.copyOf(EVENTS);
+        }
+
+        @Override
+        public void contextInitialized(ServletContextEvent event) {
+            EVENTS.add("contextInitialized:" + event.getServletContext().getContextPath());
+        }
+
+        @Override
+        public void contextDestroyed(ServletContextEvent event) {
+            EVENTS.add("contextDestroyed:" + event.getServletContext().getContextPath());
+        }
+
+        @Override
+        public void attributeAdded(ServletContextAttributeEvent event) {
+            EVENTS.add("contextAttributeAdded:" + event.getName() + "=" + event.getValue());
+        }
+
+        @Override
+        public void attributeReplaced(ServletContextAttributeEvent event) {
+            EVENTS.add("contextAttributeReplaced:" + event.getName() + "=" + event.getValue());
+        }
+
+        @Override
+        public void attributeRemoved(ServletContextAttributeEvent event) {
+            EVENTS.add("contextAttributeRemoved:" + event.getName() + "=" + event.getValue());
+        }
+
+        @Override
+        public void attributeAdded(ServletRequestAttributeEvent event) {
+            EVENTS.add("requestAttributeAdded:" + event.getName() + "=" + event.getValue());
+        }
+
+        @Override
+        public void attributeReplaced(ServletRequestAttributeEvent event) {
+            EVENTS.add("requestAttributeReplaced:" + event.getName() + "=" + event.getValue());
+        }
+
+        @Override
+        public void attributeRemoved(ServletRequestAttributeEvent event) {
+            EVENTS.add("requestAttributeRemoved:" + event.getName() + "=" + event.getValue());
+        }
+
+        @Override
+        public void sessionCreated(HttpSessionEvent event) {
+            EVENTS.add("sessionCreated");
+        }
+
+        @Override
+        public void sessionDestroyed(HttpSessionEvent event) {
+            EVENTS.add("sessionDestroyed");
+        }
+
+        @Override
+        public void attributeAdded(HttpSessionBindingEvent event) {
+            EVENTS.add("sessionAttributeAdded:" + event.getName() + "=" + event.getValue());
+        }
+
+        @Override
+        public void attributeReplaced(HttpSessionBindingEvent event) {
+            EVENTS.add("sessionAttributeReplaced:" + event.getName() + "=" + event.getValue());
+        }
+
+        @Override
+        public void attributeRemoved(HttpSessionBindingEvent event) {
+            EVENTS.add("sessionAttributeRemoved:" + event.getName() + "=" + event.getValue());
+        }
+    }
+}

--- a/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/src/test/java/org_glassfish_grizzly/grizzly_http_servlet/Grizzly_http_servletTest.java
+++ b/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/src/test/java/org_glassfish_grizzly/grizzly_http_servlet/Grizzly_http_servletTest.java
@@ -248,7 +248,7 @@ public class Grizzly_http_servletTest {
         assertThat(wrapper.getVersion()).isEqualTo(1);
         assertThat(wrapper.getWrappedCookie()).isSameAs(servletCookie);
 
-        Cookie clone = (Cookie) wrapper.clone();
+        Cookie clone = (Cookie) wrapper.cloneCookie();
         assertThat(clone).isNotSameAs(servletCookie);
         assertThat(clone.getName()).isEqualTo("theme");
         assertThat(clone.getValue()).isEqualTo("dark");

--- a/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/src/test/java/org_glassfish_grizzly/grizzly_http_servlet/ServletContextImplTest.java
+++ b/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/src/test/java/org_glassfish_grizzly/grizzly_http_servlet/ServletContextImplTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_grizzly.grizzly_http_servlet;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.glassfish.grizzly.servlet.ServletContextImpl;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ServletContextImplTest {
+    private static final String RESOURCE_NAME = "org_glassfish_grizzly/grizzly_http_servlet/context-resource.txt";
+    private static final String RESOURCE_PATH = "/" + RESOURCE_NAME;
+    private static final String RESOURCE_CONTENT = "resource loaded by the thread context class loader";
+
+    @Test
+    void getResourceDelegatesToThreadContextClassLoader() throws Exception {
+        ResourceClassLoader classLoader = new ResourceClassLoader(
+                Thread.currentThread().getContextClassLoader(), RESOURCE_NAME, RESOURCE_CONTENT);
+
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(classLoader);
+        try {
+            ServletContextImpl servletContext = new ServletContextImpl();
+
+            URL resource = servletContext.getResource(RESOURCE_PATH);
+
+            assertThat(resource).isNotNull();
+            try (InputStream input = resource.openStream()) {
+                assertThat(new String(input.readAllBytes(), StandardCharsets.UTF_8)).isEqualTo(RESOURCE_CONTENT);
+            }
+            assertThat(classLoader.resourceRequests()).containsExactly(RESOURCE_NAME);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    @Test
+    void getResourceAsStreamDelegatesToThreadContextClassLoader() throws IOException {
+        ResourceClassLoader classLoader = new ResourceClassLoader(
+                Thread.currentThread().getContextClassLoader(), RESOURCE_NAME, RESOURCE_CONTENT);
+
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(classLoader);
+        try {
+            ServletContextImpl servletContext = new ServletContextImpl();
+
+            try (InputStream resourceStream = servletContext.getResourceAsStream(RESOURCE_PATH)) {
+                assertThat(resourceStream).isNotNull();
+                assertThat(new String(resourceStream.readAllBytes(), StandardCharsets.UTF_8))
+                        .isEqualTo(RESOURCE_CONTENT);
+            }
+            assertThat(classLoader.resourceStreamRequests()).containsExactly(RESOURCE_NAME);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    private static final class ResourceClassLoader extends ClassLoader {
+        private final String resourceName;
+        private final byte[] resourceContent;
+        private final List<String> resourceRequests = new ArrayList<>();
+        private final List<String> resourceStreamRequests = new ArrayList<>();
+
+        ResourceClassLoader(ClassLoader parent, String resourceName, String resourceContent) {
+            super(parent);
+            this.resourceName = resourceName;
+            this.resourceContent = resourceContent.getBytes(StandardCharsets.UTF_8);
+        }
+
+        @Override
+        public URL getResource(String name) {
+            resourceRequests.add(name);
+            if (!resourceName.equals(name)) {
+                return super.getResource(name);
+            }
+            try {
+                return inMemoryResourceUrl();
+            } catch (MalformedURLException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            resourceStreamRequests.add(name);
+            if (!resourceName.equals(name)) {
+                return super.getResourceAsStream(name);
+            }
+            return new ByteArrayInputStream(resourceContent);
+        }
+
+        List<String> resourceRequests() {
+            return resourceRequests;
+        }
+
+        List<String> resourceStreamRequests() {
+            return resourceStreamRequests;
+        }
+
+        private URL inMemoryResourceUrl() throws MalformedURLException {
+            return new URL(null, "memory://servlet-context-resource", new URLStreamHandler() {
+                @Override
+                protected URLConnection openConnection(URL url) {
+                    return new URLConnection(url) {
+                        @Override
+                        public void connect() {
+                        }
+
+                        @Override
+                        public InputStream getInputStream() {
+                            return new ByteArrayInputStream(resourceContent);
+                        }
+                    };
+                }
+            });
+        }
+    }
+}

--- a/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/src/test/resources/META-INF/native-image/org.glassfish.grizzly/grizzly-http-servlet-tests/native-image.properties
+++ b/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/src/test/resources/META-INF/native-image/org.glassfish.grizzly/grizzly-http-servlet-tests/native-image.properties
@@ -1,0 +1,1 @@
+Args = --enable-url-protocols=http

--- a/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.glassfish.grizzly.servlet.ServletContextImpl"
+      },
+      "type" : "org_glassfish_grizzly.grizzly_http_servlet.Grizzly_http_servletTest$ServletEventRecorder"
+    }
+  ]
+}

--- a/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/user-code-filter.json
+++ b/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/user-code-filter.json
@@ -7,6 +7,12 @@
       "includeClasses" : "org.glassfish.grizzly.servlet.**"
     },
     {
+      "includeClasses" : "org.glassfish.grizzly.**"
+    },
+    {
+      "includeClasses" : "org.glassfish.grizzly.utils.**"
+    },
+    {
       "includeClasses" : "org_glassfish_grizzly.grizzly_http_servlet.**"
     }
   ]

--- a/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/user-code-filter.json
+++ b/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.glassfish.grizzly.servlet.**"
+    },
+    {
+      "includeClasses" : "org_glassfish_grizzly.grizzly_http_servlet.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7466

This PR provides test fixes and new metadata for org.glassfish.grizzly:grizzly-http-servlet:2.1.11, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 82824
- Cached input tokens: 503296
- Output tokens: 6657
- Metadata entries: 25
- Test-only metadata entries: 1
- Iterations: 2
- Library coverage percentage: 45.09
- Previous library version metadata entries: 12
- Previous library version coverage percentage: 21.07

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `8096ca1c2c460f841c064446336a5f5d83879f37`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.glassfish.grizzly:grizzly-http-servlet:2.1.2: 2/4 covered calls (50.00%)
- org.glassfish.grizzly:grizzly-http-servlet:2.1.11: 4/4 covered calls (100.00%)

**Reflection:**
- org.glassfish.grizzly:grizzly-http-servlet:2.1.2: 2/2 covered calls (100.00%)
- org.glassfish.grizzly:grizzly-http-servlet:2.1.11: 2/2 covered calls (100.00%)

**Resources:**
- org.glassfish.grizzly:grizzly-http-servlet:2.1.2: 0/2 covered calls (0.00%)
- org.glassfish.grizzly:grizzly-http-servlet:2.1.11: 2/2 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.glassfish.grizzly:grizzly-http-servlet:2.1.2: 3133/14365 (21.81%)
- org.glassfish.grizzly:grizzly-http-servlet:2.1.11: 3163/7249 (43.63%)

**Line:**
- org.glassfish.grizzly:grizzly-http-servlet:2.1.2: 887/4210 (21.07%)
- org.glassfish.grizzly:grizzly-http-servlet:2.1.11: 896/1987 (45.09%)

**Method:**
- org.glassfish.grizzly:grizzly-http-servlet:2.1.2: 183/1875 (9.76%)
- org.glassfish.grizzly:grizzly-http-servlet:2.1.11: 185/435 (42.53%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.2/src/test/java/org_glassfish_grizzly/grizzly_http_servlet/Grizzly_http_servletTest.java 2/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/src/test/java/org_glassfish_grizzly/grizzly_http_servlet/Grizzly_http_servletTest.java
index 2f51fc80c0..136cfcc904 100644
--- 1/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.2/src/test/java/org_glassfish_grizzly/grizzly_http_servlet/Grizzly_http_servletTest.java
+++ 2/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/src/test/java/org_glassfish_grizzly/grizzly_http_servlet/Grizzly_http_servletTest.java
@@ -248,7 +248,7 @@ public class Grizzly_http_servletTest {
         assertThat(wrapper.getVersion()).isEqualTo(1);
         assertThat(wrapper.getWrappedCookie()).isSameAs(servletCookie);
 
-        Cookie clone = (Cookie) wrapper.clone();
+        Cookie clone = (Cookie) wrapper.cloneCookie();
         assertThat(clone).isNotSameAs(servletCookie);
         assertThat(clone.getName()).isEqualTo("theme");
         assertThat(clone.getValue()).isEqualTo("dark");
diff --git 1/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/src/test/java/org_glassfish_grizzly/grizzly_http_servlet/ServletContextImplTest.java 2/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/src/test/java/org_glassfish_grizzly/grizzly_http_servlet/ServletContextImplTest.java
new file mode 100644
index 0000000000..265ca0b2d2
--- /dev/null
+++ 2/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/src/test/java/org_glassfish_grizzly/grizzly_http_servlet/ServletContextImplTest.java
@@ -0,0 +1,133 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_glassfish_grizzly.grizzly_http_servlet;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.glassfish.grizzly.servlet.ServletContextImpl;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ServletContextImplTest {
+    private static final String RESOURCE_NAME = "org_glassfish_grizzly/grizzly_http_servlet/context-resource.txt";
+    private static final String RESOURCE_PATH = "/" + RESOURCE_NAME;
+    private static final String RESOURCE_CONTENT = "resource loaded by the thread context class loader";
+
+    @Test
+    void getResourceDelegatesToThreadContextClassLoader() throws Exception {
+        ResourceClassLoader classLoader = new ResourceClassLoader(
+                Thread.currentThread().getContextClassLoader(), RESOURCE_NAME, RESOURCE_CONTENT);
+
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(classLoader);
+        try {
+            ServletContextImpl servletContext = new ServletContextImpl();
+
+            URL resource = servletContext.getResource(RESOURCE_PATH);
+
+            assertThat(resource).isNotNull();
+            try (InputStream input = resource.openStream()) {
+                assertThat(new String(input.readAllBytes(), StandardCharsets.UTF_8)).isEqualTo(RESOURCE_CONTENT);
+            }
+            assertThat(classLoader.resourceRequests()).containsExactly(RESOURCE_NAME);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    @Test
+    void getResourceAsStreamDelegatesToThreadContextClassLoader() throws IOException {
+        ResourceClassLoader classLoader = new ResourceClassLoader(
+                Thread.currentThread().getContextClassLoader(), RESOURCE_NAME, RESOURCE_CONTENT);
+
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(classLoader);
+        try {
+            ServletContextImpl servletContext = new ServletContextImpl();
+
+            try (InputStream resourceStream = servletContext.getResourceAsStream(RESOURCE_PATH)) {
+                assertThat(resourceStream).isNotNull();
+                assertThat(new String(resourceStream.readAllBytes(), StandardCharsets.UTF_8))
+                        .isEqualTo(RESOURCE_CONTENT);
+            }
+            assertThat(classLoader.resourceStreamRequests()).containsExactly(RESOURCE_NAME);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    private static final class ResourceClassLoader extends ClassLoader {
+        private final String resourceName;
+        private final byte[] resourceContent;
+        private final List<String> resourceRequests = new ArrayList<>();
+        private final List<String> resourceStreamRequests = new ArrayList<>();
+
+        ResourceClassLoader(ClassLoader parent, String resourceName, String resourceContent) {
+            super(parent);
+            this.resourceName = resourceName;
+            this.resourceContent = resourceContent.getBytes(StandardCharsets.UTF_8);
+        }
+
+        @Override
+        public URL getResource(String name) {
+            resourceRequests.add(name);
+            if (!resourceName.equals(name)) {
+                return super.getResource(name);
+            }
+            try {
+                return inMemoryResourceUrl();
+            } catch (MalformedURLException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            resourceStreamRequests.add(name);
+            if (!resourceName.equals(name)) {
+                return super.getResourceAsStream(name);
+            }
+            return new ByteArrayInputStream(resourceContent);
+        }
+
+        List<String> resourceRequests() {
+            return resourceRequests;
+        }
+
+        List<String> resourceStreamRequests() {
+            return resourceStreamRequests;
+        }
+
+        private URL inMemoryResourceUrl() throws MalformedURLException {
+            return new URL(null, "memory://servlet-context-resource", new URLStreamHandler() {
+                @Override
+                protected URLConnection openConnection(URL url) {
+                    return new URLConnection(url) {
+                        @Override
+                        public void connect() {
+                        }
+
+                        @Override
+                        public InputStream getInputStream() {
+                            return new ByteArrayInputStream(resourceContent);
+                        }
+                    };
+                }
+            });
+        }
+    }
+}
diff --git 1/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.2/user-code-filter.json 2/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/user-code-filter.json
index 0da1030a08..40b178fb2a 100644
--- 1/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.2/user-code-filter.json
+++ 2/tests/src/org.glassfish.grizzly/grizzly-http-servlet/2.1.11/user-code-filter.json
@@ -6,6 +6,12 @@
     {
       "includeClasses" : "org.glassfish.grizzly.servlet.**"
     },
+    {
+      "includeClasses" : "org.glassfish.grizzly.**"
+    },
+    {
+      "includeClasses" : "org.glassfish.grizzly.utils.**"
+    },
     {
       "includeClasses" : "org_glassfish_grizzly.grizzly_http_servlet.**"
     }

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
