### PR TITLE
[GenAI] Test fix for org.springframework:spring-expression:6.2.7 using gpt-5.5

### DIFF
--- a/metadata/org.springframework/spring-expression/6.2.7/reachability-metadata.json
+++ b/metadata/org.springframework/spring-expression/6.2.7/reachability-metadata.json
@@ -1,318 +1,300 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org.springframework.util.ClassUtils"
+      "condition" : {
+        "typeReached" : "org.springframework.util.ClassUtils"
       },
-      "type": "String"
+      "type" : "String"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.expression.spel.ast.ConstructorReference"
+      "condition" : {
+        "typeReached" : "org.springframework.expression.spel.ast.ConstructorReference"
       },
-      "type": "int[]"
+      "type" : "int[]"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.expression.spel.ast.ConstructorReference"
+      "condition" : {
+        "typeReached" : "org.springframework.expression.spel.ast.ConstructorReference"
       },
-      "type": "int[][]"
+      "type" : "int[][]"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.ResolvableType"
+      "condition" : {
+        "typeReached" : "org.springframework.core.ResolvableType"
       },
-      "type": "java.io.Serializable"
+      "type" : "java.io.Serializable"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.convert.support.GenericConversionService$Converters"
+      "condition" : {
+        "typeReached" : "org.springframework.core.convert.support.GenericConversionService$Converters"
       },
-      "type": "java.io.Serializable[]"
+      "type" : "java.io.Serializable[]"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.ResolvableType"
+      "condition" : {
+        "typeReached" : "org.springframework.core.ResolvableType"
       },
-      "type": "java.lang.Boolean"
+      "type" : "java.lang.Boolean"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.convert.support.GenericConversionService$Converters"
+      "condition" : {
+        "typeReached" : "org.springframework.core.convert.support.GenericConversionService$Converters"
       },
-      "type": "java.lang.CharSequence[]"
+      "type" : "java.lang.CharSequence[]"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.ResolvableType"
+      "condition" : {
+        "typeReached" : "org.springframework.core.ResolvableType"
       },
-      "type": "java.lang.Character"
+      "type" : "java.lang.Character"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.convert.support.IdToEntityConverter"
+      "condition" : {
+        "typeReached" : "org.springframework.core.convert.support.IdToEntityConverter"
       },
-      "type": "java.lang.Class"
+      "type" : "java.lang.Class"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.ResolvableType"
+      "condition" : {
+        "typeReached" : "org.springframework.core.ResolvableType"
       },
-      "type": "java.lang.Cloneable"
+      "type" : "java.lang.Cloneable"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.convert.support.GenericConversionService$Converters"
+      "condition" : {
+        "typeReached" : "org.springframework.core.convert.support.GenericConversionService$Converters"
       },
-      "type": "java.lang.Cloneable[]"
+      "type" : "java.lang.Cloneable[]"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.convert.support.GenericConversionService$Converters"
+      "condition" : {
+        "typeReached" : "org.springframework.core.convert.support.GenericConversionService$Converters"
       },
-      "type": "java.lang.Comparable[]"
+      "type" : "java.lang.Comparable[]"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.ResolvableType"
+      "condition" : {
+        "typeReached" : "org.springframework.core.ResolvableType"
       },
-      "type": "java.lang.Enum"
+      "type" : "java.lang.Enum"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.ResolvableType"
+      "condition" : {
+        "typeReached" : "org.springframework.core.ResolvableType"
       },
-      "type": "java.lang.Integer"
+      "type" : "java.lang.Integer"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.expression.spel.ast.Projection"
+      "condition" : {
+        "typeReached" : "org.springframework.expression.spel.ast.Projection"
       },
-      "type": "java.lang.Integer[]"
+      "type" : "java.lang.Integer[]"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.expression.spel.ast.Selection"
+      "condition" : {
+        "typeReached" : "org.springframework.expression.spel.ast.Selection"
       },
-      "type": "java.lang.Integer[]"
+      "type" : "java.lang.Integer[]"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.util.ObjectUtils"
+      "condition" : {
+        "typeReached" : "org.springframework.util.ObjectUtils"
       },
-      "type": "java.lang.Integer[]"
+      "type" : "java.lang.Integer[]"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.ResolvableType"
+      "condition" : {
+        "typeReached" : "org.springframework.core.ResolvableType"
       },
-      "type": "java.lang.Number"
+      "type" : "java.lang.Number"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.convert.support.GenericConversionService$Converters"
+      "condition" : {
+        "typeReached" : "org.springframework.core.convert.support.GenericConversionService$Converters"
       },
-      "type": "java.lang.Object[]"
+      "type" : "java.lang.Object[]"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.SpringProperties"
+      "condition" : {
+        "typeReached" : "org.springframework.core.SpringProperties"
       },
-      "type": "java.lang.StackTraceElement[]"
+      "type" : "java.lang.StackTraceElement[]"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.expression.spel.ast.ConstructorReference"
+      "condition" : {
+        "typeReached" : "org.springframework.expression.spel.ast.ConstructorReference"
       },
-      "type": "java.lang.String[]"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.expression.spel.ast.TypeReference"
+      "condition" : {
+        "typeReached" : "org.springframework.expression.spel.ast.TypeReference"
       },
-      "type": "java.lang.String[][]"
+      "type" : "java.lang.String[][]"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.MethodParameter"
+      "condition" : {
+        "typeReached" : "org.springframework.core.MethodParameter"
       },
-      "type": "java.lang.annotation.Annotation[]"
+      "type" : "java.lang.annotation.Annotation[]"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.MethodParameter"
+      "condition" : {
+        "typeReached" : "org.springframework.core.MethodParameter"
       },
-      "type": "java.lang.annotation.Annotation[][]"
+      "type" : "java.lang.annotation.Annotation[][]"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.convert.support.GenericConversionService$Converters"
+      "condition" : {
+        "typeReached" : "org.springframework.core.convert.support.GenericConversionService$Converters"
       },
-      "type": "java.lang.constant.Constable[]"
+      "type" : "java.lang.constant.Constable[]"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.convert.support.GenericConversionService$Converters"
+      "condition" : {
+        "typeReached" : "org.springframework.core.convert.support.GenericConversionService$Converters"
       },
-      "type": "java.lang.constant.ConstantDesc[]"
+      "type" : "java.lang.constant.ConstantDesc[]"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.expression.spel.support.ReflectiveConstructorResolver"
+      "condition" : {
+        "typeReached" : "org.springframework.expression.spel.support.ReflectiveConstructorResolver"
       },
-      "type": "java.lang.reflect.Constructor[]"
+      "type" : "java.lang.reflect.Constructor[]"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.expression.spel.support.ReflectivePropertyAccessor"
+      "condition" : {
+        "typeReached" : "org.springframework.expression.spel.support.ReflectivePropertyAccessor"
       },
-      "type": "java.lang.reflect.Field[]"
+      "type" : "java.lang.reflect.Field[]"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.util.ReflectionUtils"
+      "condition" : {
+        "typeReached" : "org.springframework.util.ReflectionUtils"
       },
-      "type": "java.lang.reflect.Field[]"
+      "type" : "java.lang.reflect.Field[]"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.convert.support.IdToEntityConverter"
+      "condition" : {
+        "typeReached" : "org.springframework.core.convert.support.IdToEntityConverter"
       },
-      "type": "java.lang.reflect.Method[]"
+      "type" : "java.lang.reflect.Method[]"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.ResolvableType"
+      "condition" : {
+        "typeReached" : "org.springframework.core.ResolvableType"
       },
-      "type": "java.nio.charset.Charset"
+      "type" : "java.nio.charset.Charset"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.ResolvableType"
+      "condition" : {
+        "typeReached" : "org.springframework.core.ResolvableType"
       },
-      "type": "java.time.ZoneId"
+      "type" : "java.time.ZoneId"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.ResolvableType"
+      "condition" : {
+        "typeReached" : "org.springframework.core.ResolvableType"
       },
-      "type": "java.time.ZonedDateTime"
+      "type" : "java.time.ZonedDateTime"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.ResolvableType"
+      "condition" : {
+        "typeReached" : "org.springframework.core.ResolvableType"
       },
-      "type": "java.util.Calendar"
+      "type" : "java.util.Calendar"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.ResolvableType"
+      "condition" : {
+        "typeReached" : "org.springframework.core.ResolvableType"
       },
-      "type": "java.util.Collection"
+      "type" : "java.util.Collection"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.ResolvableType"
+      "condition" : {
+        "typeReached" : "org.springframework.core.ResolvableType"
       },
-      "type": "java.util.Currency"
+      "type" : "java.util.Currency"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.ResolvableType"
+      "condition" : {
+        "typeReached" : "org.springframework.core.ResolvableType"
       },
-      "type": "java.util.Locale"
+      "type" : "java.util.Locale"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.ResolvableType"
+      "condition" : {
+        "typeReached" : "org.springframework.core.ResolvableType"
       },
-      "type": "java.util.Properties"
+      "type" : "java.util.Properties"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.ResolvableType"
+      "condition" : {
+        "typeReached" : "org.springframework.core.ResolvableType"
       },
-      "type": "java.util.RandomAccess"
+      "type" : "java.util.RandomAccess"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.ResolvableType"
+      "condition" : {
+        "typeReached" : "org.springframework.core.ResolvableType"
       },
-      "type": "java.util.SequencedCollection"
+      "type" : "java.util.SequencedCollection"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.ResolvableType"
+      "condition" : {
+        "typeReached" : "org.springframework.core.ResolvableType"
       },
-      "type": "java.util.TimeZone"
+      "type" : "java.util.TimeZone"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.ResolvableType"
+      "condition" : {
+        "typeReached" : "org.springframework.core.ResolvableType"
       },
-      "type": "java.util.regex.Pattern"
+      "type" : "java.util.regex.Pattern"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.util.ClassUtils"
+      "condition" : {
+        "typeReached" : "org.springframework.util.ClassUtils"
       },
-      "type": "kotlin.Metadata"
+      "type" : "kotlin.Metadata"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.ResolvableType"
+      "condition" : {
+        "typeReached" : "org.springframework.core.ResolvableType"
       },
-      "type": "org.springframework.core.convert.converter.ConditionalConverter"
+      "type" : "org.springframework.core.convert.converter.ConditionalConverter"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.ResolvableType"
+      "condition" : {
+        "typeReached" : "org.springframework.core.ResolvableType"
       },
-      "type": "org.springframework.core.convert.converter.Converter"
+      "type" : "org.springframework.core.convert.converter.Converter"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.core.ResolvableType"
+      "condition" : {
+        "typeReached" : "org.springframework.core.ResolvableType"
       },
-      "type": "org.springframework.core.convert.converter.ConverterFactory"
+      "type" : "org.springframework.core.convert.converter.ConverterFactory"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.expression.spel.standard.InternalSpelExpressionParser"
+      "condition" : {
+        "typeReached" : "org.springframework.expression.spel.standard.InternalSpelExpressionParser"
       },
-      "type": "org.springframework.expression.spel.ast.SpelNodeImpl[]"
+      "type" : "org.springframework.expression.spel.ast.SpelNodeImpl[]"
     },
     {
-      "condition": {
-        "typeReached": "org.springframework.util.ConcurrentReferenceHashMap"
+      "condition" : {
+        "typeReached" : "org.springframework.util.ConcurrentReferenceHashMap"
       },
-      "type": "org.springframework.util.ConcurrentReferenceHashMap$Segment[]"
-    },
-    {
-      "condition": {
-        "typeReached": "org.springframework.util.ReflectionUtils"
-      },
-      "type": "org_springframework.spring_expression.IndexerInnerCollectionIndexingValueRefTest$LineItem"
-    },
-    {
-      "condition": {
-        "typeReached": "org.springframework.util.ReflectionUtils"
-      },
-      "type": "org_springframework.spring_expression.PropertyOrFieldReferenceTest$Profile"
-    },
-    {
-      "condition": {
-        "typeReached": "org.springframework.expression.spel.support.ReflectiveIndexAccessor"
-      },
-      "type": "org_springframework.spring_expression.ReflectiveIndexAccessorTest$FruitBasket"
+      "type" : "org.springframework.util.ConcurrentReferenceHashMap$Segment[]"
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "org.springframework.core.SpringProperties"
+      "condition" : {
+        "typeReached" : "org.springframework.core.SpringProperties"
       },
-      "glob": "spring.properties"
+      "glob" : "spring.properties"
     }
   ]
 }

--- a/metadata/org.springframework/spring-expression/6.2.7/reachability-metadata.json
+++ b/metadata/org.springframework/spring-expression/6.2.7/reachability-metadata.json
@@ -1,0 +1,318 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.springframework.util.ClassUtils"
+      },
+      "type": "String"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.expression.spel.ast.ConstructorReference"
+      },
+      "type": "int[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.expression.spel.ast.ConstructorReference"
+      },
+      "type": "int[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.ResolvableType"
+      },
+      "type": "java.io.Serializable"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.convert.support.GenericConversionService$Converters"
+      },
+      "type": "java.io.Serializable[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.ResolvableType"
+      },
+      "type": "java.lang.Boolean"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.convert.support.GenericConversionService$Converters"
+      },
+      "type": "java.lang.CharSequence[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.ResolvableType"
+      },
+      "type": "java.lang.Character"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.convert.support.IdToEntityConverter"
+      },
+      "type": "java.lang.Class"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.ResolvableType"
+      },
+      "type": "java.lang.Cloneable"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.convert.support.GenericConversionService$Converters"
+      },
+      "type": "java.lang.Cloneable[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.convert.support.GenericConversionService$Converters"
+      },
+      "type": "java.lang.Comparable[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.ResolvableType"
+      },
+      "type": "java.lang.Enum"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.ResolvableType"
+      },
+      "type": "java.lang.Integer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.expression.spel.ast.Projection"
+      },
+      "type": "java.lang.Integer[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.expression.spel.ast.Selection"
+      },
+      "type": "java.lang.Integer[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.util.ObjectUtils"
+      },
+      "type": "java.lang.Integer[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.ResolvableType"
+      },
+      "type": "java.lang.Number"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.convert.support.GenericConversionService$Converters"
+      },
+      "type": "java.lang.Object[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.SpringProperties"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.expression.spel.ast.ConstructorReference"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.expression.spel.ast.TypeReference"
+      },
+      "type": "java.lang.String[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.MethodParameter"
+      },
+      "type": "java.lang.annotation.Annotation[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.MethodParameter"
+      },
+      "type": "java.lang.annotation.Annotation[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.convert.support.GenericConversionService$Converters"
+      },
+      "type": "java.lang.constant.Constable[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.convert.support.GenericConversionService$Converters"
+      },
+      "type": "java.lang.constant.ConstantDesc[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.expression.spel.support.ReflectiveConstructorResolver"
+      },
+      "type": "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.expression.spel.support.ReflectivePropertyAccessor"
+      },
+      "type": "java.lang.reflect.Field[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.util.ReflectionUtils"
+      },
+      "type": "java.lang.reflect.Field[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.convert.support.IdToEntityConverter"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.ResolvableType"
+      },
+      "type": "java.nio.charset.Charset"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.ResolvableType"
+      },
+      "type": "java.time.ZoneId"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.ResolvableType"
+      },
+      "type": "java.time.ZonedDateTime"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.ResolvableType"
+      },
+      "type": "java.util.Calendar"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.ResolvableType"
+      },
+      "type": "java.util.Collection"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.ResolvableType"
+      },
+      "type": "java.util.Currency"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.ResolvableType"
+      },
+      "type": "java.util.Locale"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.ResolvableType"
+      },
+      "type": "java.util.Properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.ResolvableType"
+      },
+      "type": "java.util.RandomAccess"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.ResolvableType"
+      },
+      "type": "java.util.SequencedCollection"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.ResolvableType"
+      },
+      "type": "java.util.TimeZone"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.ResolvableType"
+      },
+      "type": "java.util.regex.Pattern"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.util.ClassUtils"
+      },
+      "type": "kotlin.Metadata"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.ResolvableType"
+      },
+      "type": "org.springframework.core.convert.converter.ConditionalConverter"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.ResolvableType"
+      },
+      "type": "org.springframework.core.convert.converter.Converter"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.ResolvableType"
+      },
+      "type": "org.springframework.core.convert.converter.ConverterFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.expression.spel.standard.InternalSpelExpressionParser"
+      },
+      "type": "org.springframework.expression.spel.ast.SpelNodeImpl[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.util.ConcurrentReferenceHashMap"
+      },
+      "type": "org.springframework.util.ConcurrentReferenceHashMap$Segment[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.util.ReflectionUtils"
+      },
+      "type": "org_springframework.spring_expression.IndexerInnerCollectionIndexingValueRefTest$LineItem"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.util.ReflectionUtils"
+      },
+      "type": "org_springframework.spring_expression.PropertyOrFieldReferenceTest$Profile"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.expression.spel.support.ReflectiveIndexAccessor"
+      },
+      "type": "org_springframework.spring_expression.ReflectiveIndexAccessorTest$FruitBasket"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.SpringProperties"
+      },
+      "glob": "spring.properties"
+    }
+  ]
+}

--- a/metadata/org.springframework/spring-expression/index.json
+++ b/metadata/org.springframework/spring-expression/index.json
@@ -89,6 +89,11 @@
   },
   {
     "metadata-version" : "6.2.7",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/spring-expression/$version$/spring-expression-$version$-sources.jar",
+    "repository-url" : "https://github.com/spring-projects/spring-framework",
+    "test-code-url" : "https://github.com/spring-projects/spring-framework/tree/v$version$/spring-expression/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/springframework/spring-expression/$version$/spring-expression-$version$-javadoc.jar",
+    "description" : "Spring Expression Language (SpEL) provides an expression parser and evaluation engine for querying and manipulating object graphs at runtime. The spring-expression artifact supplies the core SpEL API and implementation used by Spring Framework features such as bean definitions, annotations, and data binding.",
     "tested-versions" : [
       "6.2.7"
     ],

--- a/metadata/org.springframework/spring-expression/index.json
+++ b/metadata/org.springframework/spring-expression/index.json
@@ -88,6 +88,18 @@
     ]
   },
   {
+    "metadata-version" : "6.2.7",
+    "tested-versions" : [
+      "6.2.7"
+    ],
+    "allowed-packages" : [
+      "org.springframework.expression",
+      "org.springframework.core",
+      "org.springframework.core.convert.support",
+      "org.springframework.util"
+    ]
+  },
+  {
     "metadata-version" : "6.2.6",
     "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/spring-expression/$version$/spring-expression-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-framework",

--- a/stats/org.springframework/spring-expression/6.2.7/execution-metrics.json
+++ b/stats/org.springframework/spring-expression/6.2.7/execution-metrics.json
@@ -1,0 +1,101 @@
+{
+  "fix_javac_fail:2026-05-21": {
+    "timestamp": "2026-05-21T08:56:45.469257Z",
+    "library": "org.springframework:spring-expression:6.2.7",
+    "starting_commit": "f56e66996dd9bfdd193ebacf6ce028aa9541aeeb",
+    "ending_commit": "e4cb5fb499e389a8c0fbe1d99073f146887a6c76",
+    "previous_library": "org.springframework:spring-expression:5.3.15",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "6.2.7",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 25,
+            "totalCalls": 25
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 25,
+        "totalCalls": 25
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 7587,
+          "missed": 22034,
+          "ratio": 0.256136,
+          "total": 29621
+        },
+        "line": {
+          "covered": 1697,
+          "missed": 4449,
+          "ratio": 0.276115,
+          "total": 6146
+        },
+        "method": {
+          "covered": 330,
+          "missed": 635,
+          "ratio": 0.341969,
+          "total": 965
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "5.3.15",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 24,
+            "totalCalls": 24
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 24,
+        "totalCalls": 24
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 7671,
+          "missed": 21181,
+          "ratio": 0.265874,
+          "total": 28852
+        },
+        "line": {
+          "covered": 1671,
+          "missed": 4217,
+          "ratio": 0.283798,
+          "total": 5888
+        },
+        "method": {
+          "covered": 307,
+          "missed": 583,
+          "ratio": 0.344944,
+          "total": 890
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 72826,
+      "cached_input_tokens_used": 376832,
+      "output_tokens_used": 5376,
+      "iterations": 3,
+      "cost_usd": 0.3497,
+      "tested_library_loc": 1697,
+      "metadata_entries": 49,
+      "test_only_metadata_entries": 4,
+      "previous_library_metadata_entries": 48,
+      "previous_library_test_only_metadata_entries": 3,
+      "code_coverage_percent": 27.61,
+      "previous_library_coverage_percent": 28.38
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/PropertyOrFieldReferenceTest.java",
+      "metadata_file": "metadata/org.springframework/spring-expression/6.2.7/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.springframework/spring-expression/6.2.7/stats.json
+++ b/stats/org.springframework/spring-expression/6.2.7/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "6.2.7",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 25,
+          "totalCalls" : 25
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 25,
+      "totalCalls" : 25
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 7587,
+        "missed" : 22034,
+        "ratio" : 0.256136,
+        "total" : 29621
+      },
+      "line" : {
+        "covered" : 1697,
+        "missed" : 4449,
+        "ratio" : 0.276115,
+        "total" : 6146
+      },
+      "method" : {
+        "covered" : 330,
+        "missed" : 635,
+        "ratio" : 0.341969,
+        "total" : 965
+      }
+    }
+  } ]
+}

--- a/tests/src/org.springframework/spring-expression/6.2.7/.gitignore
+++ b/tests/src/org.springframework/spring-expression/6.2.7/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.springframework/spring-expression/6.2.7/build.gradle
+++ b/tests/src/org.springframework/spring-expression/6.2.7/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.springframework:spring-expression:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-expression/6.2.7/gradle.properties
+++ b/tests/src/org.springframework/spring-expression/6.2.7/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.springframework:spring-expression:6.2.7
+library.version = 6.2.7
+metadata.dir = org.springframework/spring-expression/6.2.7/

--- a/tests/src/org.springframework/spring-expression/6.2.7/settings.gradle
+++ b/tests/src/org.springframework/spring-expression/6.2.7/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.springframework.spring-expression_tests'

--- a/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/ConstructorReferenceTest.java
+++ b/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/ConstructorReferenceTest.java
@@ -48,4 +48,14 @@ public class ConstructorReferenceTest {
         assertThat(values)
                 .containsExactly(1, 2, 3);
     }
+
+    @Test
+    void createsReferenceArrayFromInlineInitializer() {
+        Expression expression = this.parser.parseExpression("new String[] {'alpha', 'beta'}");
+
+        String[] values = expression.getValue(String[].class);
+
+        assertThat(values)
+                .containsExactly("alpha", "beta");
+    }
 }

--- a/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/ConstructorReferenceTest.java
+++ b/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/ConstructorReferenceTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_expression;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.expression.Expression;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConstructorReferenceTest {
+    private final SpelExpressionParser parser = new SpelExpressionParser();
+
+    @Test
+    void createsOneDimensionalPrimitiveArrayFromDeclaredSize() {
+        Expression expression = this.parser.parseExpression("new int[3]");
+
+        int[] values = expression.getValue(int[].class);
+
+        assertThat(values)
+                .containsExactly(0, 0, 0);
+    }
+
+    @Test
+    void createsMultiDimensionalPrimitiveArrayFromDeclaredSizes() {
+        Expression expression = this.parser.parseExpression("new int[2][3]");
+
+        int[][] values = expression.getValue(int[][].class);
+
+        assertThat(values.length)
+                .isEqualTo(2);
+        assertThat(values[0])
+                .containsExactly(0, 0, 0);
+        assertThat(values[1])
+                .containsExactly(0, 0, 0);
+    }
+
+    @Test
+    void createsPrimitiveArrayFromInlineInitializer() {
+        Expression expression = this.parser.parseExpression("new int[] {1, 2, 3}");
+
+        int[] values = expression.getValue(int[].class);
+
+        assertThat(values)
+                .containsExactly(1, 2, 3);
+    }
+}

--- a/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/FunctionReferenceTest.java
+++ b/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/FunctionReferenceTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_expression;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.expression.Expression;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FunctionReferenceTest {
+    private final SpelExpressionParser parser = new SpelExpressionParser();
+
+    @Test
+    void invokesRegisteredStaticMethodFunction() throws Exception {
+        Method method = FunctionReferenceTest.class.getDeclaredMethod("formatGreeting", String.class, int.class);
+        StandardEvaluationContext context = new StandardEvaluationContext();
+        context.registerFunction("formatGreeting", method);
+        Expression expression = this.parser.parseExpression("#formatGreeting('Spring', 3)");
+
+        String value = expression.getValue(context, String.class);
+
+        assertThat(value)
+                .isEqualTo("Hello Spring Hello Spring Hello Spring");
+    }
+
+    public static String formatGreeting(String name, int repetitions) {
+        return ("Hello " + name + " ").repeat(repetitions).trim();
+    }
+}

--- a/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/IndexerInnerCollectionIndexingValueRefTest.java
+++ b/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/IndexerInnerCollectionIndexingValueRefTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_expression;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.expression.Expression;
+import org.springframework.expression.spel.SpelParserConfiguration;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class IndexerInnerCollectionIndexingValueRefTest {
+    private final SpelExpressionParser parser = new SpelExpressionParser(new SpelParserConfiguration(true, true));
+
+    @Test
+    void growsTypedCollectionByConstructingMissingElements() {
+        Order order = new Order();
+        Expression expression = this.parser.parseExpression("items[2]");
+
+        LineItem item = expression.getValue(order, LineItem.class);
+
+        assertThat(item)
+                .isNotNull();
+        assertThat(order.getItems())
+                .hasSize(3)
+                .allSatisfy(lineItem -> assertThat(lineItem.getDescription()).isEqualTo("new item"));
+    }
+
+    public static class Order {
+        private final List<LineItem> items = new ArrayList<>();
+
+        public List<LineItem> getItems() {
+            return this.items;
+        }
+    }
+
+    public static class LineItem {
+        private final String description;
+
+        public LineItem() {
+            this.description = "new item";
+        }
+
+        public String getDescription() {
+            return this.description;
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/ProjectionTest.java
+++ b/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/ProjectionTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_expression;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.expression.Expression;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProjectionTest {
+    private final SpelExpressionParser parser = new SpelExpressionParser();
+
+    @Test
+    void projectsPrimitiveArrayToTypedResultArray() {
+        Expression expression = this.parser.parseExpression("![#this]");
+
+        Object value = expression.getValue(new int[] {1, 2, 3});
+
+        assertThat(value)
+                .isInstanceOf(Integer[].class);
+        assertThat((Integer[]) value)
+                .containsExactly(1, 2, 3);
+    }
+}

--- a/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/PropertyOrFieldReferenceTest.java
+++ b/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/PropertyOrFieldReferenceTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_expression;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.expression.Expression;
+import org.springframework.expression.spel.SpelParserConfiguration;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PropertyOrFieldReferenceTest {
+    private final SpelExpressionParser parser = new SpelExpressionParser(new SpelParserConfiguration(true, true));
+
+    @Test
+    void growsNullPropertyByConstructingNestedBean() {
+        Customer customer = new Customer();
+        Expression expression = this.parser.parseExpression("profile.status");
+
+        String status = expression.getValue(customer, String.class);
+
+        assertThat(status)
+                .isEqualTo("new profile");
+        assertThat(customer.getProfile())
+                .isNotNull();
+    }
+
+    public static class Customer {
+        private Profile profile;
+
+        public Profile getProfile() {
+            return this.profile;
+        }
+
+        public void setProfile(Profile profile) {
+            this.profile = profile;
+        }
+    }
+
+    public static class Profile {
+        private final String status;
+
+        public Profile() {
+            this.status = "new profile";
+        }
+
+        public String getStatus() {
+            return this.status;
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/ReflectionHelperTest.java
+++ b/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/ReflectionHelperTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_expression;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.expression.spel.support.ReflectionHelper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReflectionHelperTest {
+    @Test
+    void packagesTrailingArgumentsIntoVarargsArray() {
+        Class<?>[] requiredParameterTypes = {String.class, String[].class};
+
+        Object[] arguments = ReflectionHelper.setupArgumentsForVarargsInvocation(
+                requiredParameterTypes,
+                "message",
+                "hello",
+                "world");
+
+        assertThat(arguments)
+                .hasSize(2);
+        assertThat(arguments[0])
+                .isEqualTo("message");
+        assertThat(arguments[1])
+                .isInstanceOf(String[].class);
+        assertThat((String[]) arguments[1])
+                .containsExactly("hello", "world");
+    }
+}

--- a/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/ReflectiveConstructorExecutorTest.java
+++ b/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/ReflectiveConstructorExecutorTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_expression;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.expression.ConstructorExecutor;
+import org.springframework.expression.TypedValue;
+import org.springframework.expression.spel.support.ReflectiveConstructorExecutor;
+import org.springframework.expression.spel.support.ReflectiveConstructorResolver;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReflectiveConstructorExecutorTest {
+    @Test
+    void invokesResolvedPublicConstructor() throws Exception {
+        StandardEvaluationContext context = new StandardEvaluationContext();
+        ConstructorExecutor constructorExecutor = new ReflectiveConstructorResolver().resolve(
+                context,
+                ConstructedMessage.class.getName(),
+                List.of(TypeDescriptor.valueOf(String.class), TypeDescriptor.valueOf(String.class)));
+
+        assertThat(constructorExecutor)
+                .isInstanceOf(ReflectiveConstructorExecutor.class);
+
+        TypedValue result = constructorExecutor.execute(context, "Hello", "Spring");
+
+        assertThat(result.getValue())
+                .isInstanceOfSatisfying(ConstructedMessage.class, message -> {
+                    assertThat(message.greeting).isEqualTo("Hello");
+                    assertThat(message.subject).isEqualTo("Spring");
+                });
+    }
+
+    public static final class ConstructedMessage {
+        private final String greeting;
+        private final String subject;
+
+        public ConstructedMessage(String greeting, String subject) {
+            this.greeting = greeting;
+            this.subject = subject;
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/ReflectiveIndexAccessorTest.java
+++ b/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/ReflectiveIndexAccessorTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_expression;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.expression.TypedValue;
+import org.springframework.expression.spel.support.ReflectiveIndexAccessor;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReflectiveIndexAccessorTest {
+    @Test
+    void resolvesPublicReadMethodWhenConstructingReadOnlyAccessor() {
+        ReflectiveIndexAccessor accessor = new ReflectiveIndexAccessor(FruitBasket.class, Color.class, "getFruit");
+        StandardEvaluationContext context = new StandardEvaluationContext();
+        FruitBasket basket = new FruitBasket();
+
+        assertThat(accessor.getSpecificTargetClasses())
+                .containsExactly(FruitBasket.class);
+        assertThat(accessor.canRead(context, basket, Color.RED))
+                .isTrue();
+        TypedValue value = accessor.read(context, basket, Color.RED);
+        assertThat(value.getValue())
+                .isEqualTo("cherry");
+        assertThat(accessor.canWrite(context, basket, Color.RED))
+                .isFalse();
+    }
+
+    @Test
+    void resolvesPublicReadAndWriteMethodsWhenConstructingReadWriteAccessor() {
+        ReflectiveIndexAccessor accessor = new ReflectiveIndexAccessor(
+                FruitBasket.class, Color.class, "getFruit", "setFruit");
+        StandardEvaluationContext context = new StandardEvaluationContext();
+        FruitBasket basket = new FruitBasket();
+
+        assertThat(accessor.canRead(context, basket, Color.ORANGE))
+                .isTrue();
+        assertThat(accessor.canWrite(context, basket, Color.ORANGE))
+                .isTrue();
+
+        accessor.write(context, basket, Color.ORANGE, "tangerine");
+
+        assertThat(basket.getFruit(Color.ORANGE))
+                .isEqualTo("tangerine");
+        assertThat(accessor.read(context, basket, Color.ORANGE).getValue())
+                .isEqualTo("tangerine");
+    }
+
+    public enum Color {
+        RED, ORANGE
+    }
+
+    public static final class FruitBasket {
+        private final Map<Color, String> fruits = new EnumMap<>(Color.class);
+
+        public FruitBasket() {
+            this.fruits.put(Color.RED, "cherry");
+            this.fruits.put(Color.ORANGE, "orange");
+        }
+
+        public String getFruit(Color color) {
+            return this.fruits.get(color);
+        }
+
+        public void setFruit(Color color, String fruit) {
+            this.fruits.put(color, fruit);
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/ReflectiveMethodExecutorTest.java
+++ b/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/ReflectiveMethodExecutorTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_expression;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.expression.MethodExecutor;
+import org.springframework.expression.TypedValue;
+import org.springframework.expression.spel.support.ReflectiveMethodExecutor;
+import org.springframework.expression.spel.support.ReflectiveMethodResolver;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReflectiveMethodExecutorTest {
+    @Test
+    void invokesResolvedPublicMethodAndDiscoversPublicDeclaringClass() throws Exception {
+        StandardEvaluationContext context = new StandardEvaluationContext();
+        PublicGreeter greeter = new PublicGreeter("Hello");
+        MethodExecutor methodExecutor = new ReflectiveMethodResolver().resolve(
+                context,
+                greeter,
+                "greet",
+                List.of(TypeDescriptor.valueOf(String.class)));
+
+        assertThat(methodExecutor)
+                .isInstanceOf(ReflectiveMethodExecutor.class);
+        ReflectiveMethodExecutor executor = (ReflectiveMethodExecutor) methodExecutor;
+
+        assertThat(executor.getPublicDeclaringClass())
+                .isEqualTo(PublicGreeter.class);
+
+        TypedValue result = executor.execute(context, greeter, "Spring");
+
+        assertThat(result.getValue())
+                .isEqualTo("Hello, Spring");
+        assertThat(executor.didArgumentConversionOccur())
+                .isFalse();
+    }
+
+    public static final class PublicGreeter {
+        private final String salutation;
+
+        public PublicGreeter(String salutation) {
+            this.salutation = salutation;
+        }
+
+        public String greet(String name) {
+            return this.salutation + ", " + name;
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/ReflectivePropertyAccessorInnerOptimalPropertyAccessorTest.java
+++ b/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/ReflectivePropertyAccessorInnerOptimalPropertyAccessorTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_expression;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.expression.PropertyAccessor;
+import org.springframework.expression.TypedValue;
+import org.springframework.expression.spel.support.ReflectivePropertyAccessor;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReflectivePropertyAccessorInnerOptimalPropertyAccessorTest {
+    @Test
+    void readsMethodBackedPropertyThroughOptimalAccessor() throws Exception {
+        ReflectivePropertyAccessor reflectiveAccessor = new ReflectivePropertyAccessor();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+        MethodBackedSample sample = new MethodBackedSample("from getter");
+
+        PropertyAccessor accessor = reflectiveAccessor.createOptimalAccessor(context, sample, "name");
+
+        assertThat(accessor)
+                .isInstanceOf(ReflectivePropertyAccessor.OptimalPropertyAccessor.class);
+        assertThat(accessor.canRead(context, sample, "name"))
+                .isTrue();
+
+        TypedValue value = accessor.read(context, sample, "name");
+
+        assertThat(value.getValue())
+                .isEqualTo("from getter");
+    }
+
+    @Test
+    void readsFieldBackedPropertyThroughOptimalAccessor() throws Exception {
+        ReflectivePropertyAccessor reflectiveAccessor = new ReflectivePropertyAccessor();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+        FieldBackedSample sample = new FieldBackedSample();
+
+        PropertyAccessor accessor = reflectiveAccessor.createOptimalAccessor(context, sample, "message");
+
+        assertThat(accessor)
+                .isInstanceOf(ReflectivePropertyAccessor.OptimalPropertyAccessor.class);
+        assertThat(accessor.canRead(context, sample, "message"))
+                .isTrue();
+
+        TypedValue value = accessor.read(context, sample, "message");
+
+        assertThat(value.getValue())
+                .isEqualTo("from field");
+    }
+
+    public static final class MethodBackedSample {
+        private final String name;
+
+        public MethodBackedSample(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return this.name;
+        }
+    }
+
+    public static final class FieldBackedSample {
+        public String message = "from field";
+    }
+}

--- a/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/ReflectivePropertyAccessorInnerOptimalPropertyAccessorTest.java
+++ b/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/ReflectivePropertyAccessorInnerOptimalPropertyAccessorTest.java
@@ -9,6 +9,7 @@ package org_springframework.spring_expression;
 import org.junit.jupiter.api.Test;
 import org.springframework.expression.PropertyAccessor;
 import org.springframework.expression.TypedValue;
+import org.springframework.expression.spel.CompilablePropertyAccessor;
 import org.springframework.expression.spel.support.ReflectivePropertyAccessor;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 
@@ -24,7 +25,7 @@ public class ReflectivePropertyAccessorInnerOptimalPropertyAccessorTest {
         PropertyAccessor accessor = reflectiveAccessor.createOptimalAccessor(context, sample, "name");
 
         assertThat(accessor)
-                .isInstanceOf(ReflectivePropertyAccessor.OptimalPropertyAccessor.class);
+                .isInstanceOf(CompilablePropertyAccessor.class);
         assertThat(accessor.canRead(context, sample, "name"))
                 .isTrue();
 
@@ -43,7 +44,7 @@ public class ReflectivePropertyAccessorInnerOptimalPropertyAccessorTest {
         PropertyAccessor accessor = reflectiveAccessor.createOptimalAccessor(context, sample, "message");
 
         assertThat(accessor)
-                .isInstanceOf(ReflectivePropertyAccessor.OptimalPropertyAccessor.class);
+                .isInstanceOf(CompilablePropertyAccessor.class);
         assertThat(accessor.canRead(context, sample, "message"))
                 .isTrue();
 

--- a/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/ReflectivePropertyAccessorTest.java
+++ b/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/ReflectivePropertyAccessorTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_expression;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.expression.TypedValue;
+import org.springframework.expression.spel.support.ReflectivePropertyAccessor;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReflectivePropertyAccessorTest {
+    @Test
+    void readsAndWritesPropertiesThroughGetterAndSetterMethods() throws Exception {
+        ReflectivePropertyAccessor accessor = new ReflectivePropertyAccessor();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+        MethodBackedSample sample = new MethodBackedSample("initial");
+
+        assertThat(accessor.canRead(context, sample, "name"))
+                .isTrue();
+        TypedValue initialValue = accessor.read(context, sample, "name");
+        assertThat(initialValue.getValue())
+                .isEqualTo("initial");
+
+        assertThat(accessor.canWrite(context, sample, "name"))
+                .isTrue();
+        accessor.write(context, sample, "name", "updated");
+
+        assertThat(sample.getName())
+                .isEqualTo("updated");
+        assertThat(accessor.read(context, sample, "name").getValue())
+                .isEqualTo("updated");
+    }
+
+    @Test
+    void readsAndWritesPublicFieldsWhenAccessorMethodsAreAbsent() throws Exception {
+        ReflectivePropertyAccessor accessor = new ReflectivePropertyAccessor();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+        FieldBackedSample sample = new FieldBackedSample();
+
+        assertThat(accessor.canRead(context, sample, "message"))
+                .isTrue();
+        TypedValue initialValue = accessor.read(context, sample, "message");
+        assertThat(initialValue.getValue())
+                .isEqualTo("from field");
+
+        assertThat(accessor.canWrite(context, sample, "message"))
+                .isTrue();
+        accessor.write(context, sample, "message", "changed through field");
+
+        assertThat(sample.message)
+                .isEqualTo("changed through field");
+        assertThat(accessor.read(context, sample, "message").getValue())
+                .isEqualTo("changed through field");
+    }
+
+    public static final class MethodBackedSample {
+        private String name;
+
+        public MethodBackedSample(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return this.name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    public static final class FieldBackedSample {
+        public String message = "from field";
+    }
+}

--- a/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/SelectionTest.java
+++ b/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/SelectionTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_expression;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.expression.Expression;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SelectionTest {
+    private final SpelExpressionParser parser = new SpelExpressionParser();
+
+    @Test
+    void selectsPrimitiveArrayElementsToTypedResultArray() {
+        Expression expression = this.parser.parseExpression("?[#this > 1]");
+
+        Object value = expression.getValue(new int[] {1, 2, 3});
+
+        assertThat(value)
+                .isInstanceOf(Integer[].class);
+        assertThat((Integer[]) value)
+                .containsExactly(2, 3);
+    }
+}

--- a/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/SpelCompilerTest.java
+++ b/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/SpelCompilerTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_expression;
+
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+import org.springframework.expression.Expression;
+import org.springframework.expression.spel.standard.SpelCompiler;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SpelCompilerTest {
+    private final SpelExpressionParser parser = new SpelExpressionParser();
+
+    @Test
+    void compilesEvaluatedArithmeticExpressionAndEvaluatesCompiledForm() {
+        Expression expression = this.parser.parseExpression("1 + 2");
+
+        assertThat(expression.getValue(Integer.class))
+                .isEqualTo(3);
+        try {
+            assertThat(SpelCompiler.compile(expression))
+                    .isTrue();
+        } catch (Error error) {
+            if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                throw error;
+            }
+            return;
+        }
+
+        assertThat(expression.getValue(Integer.class))
+                .isEqualTo(3);
+    }
+}

--- a/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/TypeReferenceTest.java
+++ b/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/TypeReferenceTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_expression;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.expression.Expression;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TypeReferenceTest {
+    private final SpelExpressionParser parser = new SpelExpressionParser();
+
+    @Test
+    void resolvesPrimitiveArrayTypeReference() {
+        Expression expression = this.parser.parseExpression("T(int[])");
+
+        Class<?> type = expression.getValue(Class.class);
+
+        assertThat(type)
+                .isSameAs(int[].class);
+    }
+
+    @Test
+    void resolvesMultiDimensionalObjectArrayTypeReference() {
+        Expression expression = this.parser.parseExpression("T(java.lang.String[][])");
+
+        Class<?> type = expression.getValue(Class.class);
+
+        assertThat(type)
+                .isSameAs(String[][].class);
+    }
+}

--- a/tests/src/org.springframework/spring-expression/6.2.7/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.springframework/spring-expression/6.2.7/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -17,6 +17,12 @@
         "typeReached" : "org.springframework.expression.spel.support.ReflectiveMethodExecutor"
       },
       "type" : "org_springframework.spring_expression.ReflectiveMethodExecutorTest$PublicGreeter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.expression.spel.support.ReflectiveIndexAccessor"
+      },
+      "type" : "org_springframework.spring_expression.ReflectiveIndexAccessorTest$FruitBasket"
     }
   ]
 }

--- a/tests/src/org.springframework/spring-expression/6.2.7/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.springframework/spring-expression/6.2.7/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,22 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.util.ReflectionUtils"
+      },
+      "type" : "org_springframework.spring_expression.IndexerInnerCollectionIndexingValueRefTest$LineItem"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.util.ReflectionUtils"
+      },
+      "type" : "org_springframework.spring_expression.PropertyOrFieldReferenceTest$Profile"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.expression.spel.support.ReflectiveMethodExecutor"
+      },
+      "type" : "org_springframework.spring_expression.ReflectiveMethodExecutorTest$PublicGreeter"
+    }
+  ]
+}

--- a/tests/src/org.springframework/spring-expression/6.2.7/user-code-filter.json
+++ b/tests/src/org.springframework/spring-expression/6.2.7/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.springframework.expression.**"
+    },
+    {
+      "includeClasses" : "org_springframework.spring_expression.**"
+    }
+  ]
+}

--- a/tests/src/org.springframework/spring-expression/6.2.7/user-code-filter.json
+++ b/tests/src/org.springframework/spring-expression/6.2.7/user-code-filter.json
@@ -7,6 +7,15 @@
       "includeClasses" : "org.springframework.expression.**"
     },
     {
+      "includeClasses" : "org.springframework.core.**"
+    },
+    {
+      "includeClasses" : "org.springframework.core.convert.support.**"
+    },
+    {
+      "includeClasses" : "org.springframework.util.**"
+    },
+    {
       "includeClasses" : "org_springframework.spring_expression.**"
     }
   ]


### PR DESCRIPTION
## What does this PR do?

Fixes: #7467

This PR provides test fixes and new metadata for org.springframework:spring-expression:6.2.7, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 72826
- Cached input tokens: 376832
- Output tokens: 5376
- Metadata entries: 49
- Test-only metadata entries: 4
- Iterations: 3
- Library coverage percentage: 27.61
- Previous library version metadata entries: 48
- Previous library version test-only metadata entries: 3
- Previous library version coverage percentage: 28.38

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `8096ca1c2c460f841c064446336a5f5d83879f37`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.springframework:spring-expression:5.3.15: 24/24 covered calls (100.00%)
- org.springframework:spring-expression:6.2.7: 25/25 covered calls (100.00%)

**Reflection:**
- org.springframework:spring-expression:5.3.15: 24/24 covered calls (100.00%)
- org.springframework:spring-expression:6.2.7: 25/25 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.springframework:spring-expression:5.3.15: 7671/28852 (26.59%)
- org.springframework:spring-expression:6.2.7: 7587/29621 (25.61%)

**Line:**
- org.springframework:spring-expression:5.3.15: 1671/5888 (28.38%)
- org.springframework:spring-expression:6.2.7: 1697/6146 (27.61%)

**Method:**
- org.springframework:spring-expression:5.3.15: 307/890 (34.49%)
- org.springframework:spring-expression:6.2.7: 330/965 (34.20%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.springframework/spring-expression/5.3.15/src/test/java/org_springframework/spring_expression/ConstructorReferenceTest.java 2/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/ConstructorReferenceTest.java
index b6e2e1a6c4..5cb4575742 100644
--- 1/tests/src/org.springframework/spring-expression/5.3.15/src/test/java/org_springframework/spring_expression/ConstructorReferenceTest.java
+++ 2/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/ConstructorReferenceTest.java
@@ -48,4 +48,14 @@ public class ConstructorReferenceTest {
         assertThat(values)
                 .containsExactly(1, 2, 3);
     }
+
+    @Test
+    void createsReferenceArrayFromInlineInitializer() {
+        Expression expression = this.parser.parseExpression("new String[] {'alpha', 'beta'}");
+
+        String[] values = expression.getValue(String[].class);
+
+        assertThat(values)
+                .containsExactly("alpha", "beta");
+    }
 }
diff --git 1/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/ReflectiveIndexAccessorTest.java 2/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/ReflectiveIndexAccessorTest.java
new file mode 100644
index 0000000000..b2c52fe17b
--- /dev/null
+++ 2/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/ReflectiveIndexAccessorTest.java
@@ -0,0 +1,77 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_expression;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.expression.TypedValue;
+import org.springframework.expression.spel.support.ReflectiveIndexAccessor;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReflectiveIndexAccessorTest {
+    @Test
+    void resolvesPublicReadMethodWhenConstructingReadOnlyAccessor() {
+        ReflectiveIndexAccessor accessor = new ReflectiveIndexAccessor(FruitBasket.class, Color.class, "getFruit");
+        StandardEvaluationContext context = new StandardEvaluationContext();
+        FruitBasket basket = new FruitBasket();
+
+        assertThat(accessor.getSpecificTargetClasses())
+                .containsExactly(FruitBasket.class);
+        assertThat(accessor.canRead(context, basket, Color.RED))
+                .isTrue();
+        TypedValue value = accessor.read(context, basket, Color.RED);
+        assertThat(value.getValue())
+                .isEqualTo("cherry");
+        assertThat(accessor.canWrite(context, basket, Color.RED))
+                .isFalse();
+    }
+
+    @Test
+    void resolvesPublicReadAndWriteMethodsWhenConstructingReadWriteAccessor() {
+        ReflectiveIndexAccessor accessor = new ReflectiveIndexAccessor(
+                FruitBasket.class, Color.class, "getFruit", "setFruit");
+        StandardEvaluationContext context = new StandardEvaluationContext();
+        FruitBasket basket = new FruitBasket();
+
+        assertThat(accessor.canRead(context, basket, Color.ORANGE))
+                .isTrue();
+        assertThat(accessor.canWrite(context, basket, Color.ORANGE))
+                .isTrue();
+
+        accessor.write(context, basket, Color.ORANGE, "tangerine");
+
+        assertThat(basket.getFruit(Color.ORANGE))
+                .isEqualTo("tangerine");
+        assertThat(accessor.read(context, basket, Color.ORANGE).getValue())
+                .isEqualTo("tangerine");
+    }
+
+    public enum Color {
+        RED, ORANGE
+    }
+
+    public static final class FruitBasket {
+        private final Map<Color, String> fruits = new EnumMap<>(Color.class);
+
+        public FruitBasket() {
+            this.fruits.put(Color.RED, "cherry");
+            this.fruits.put(Color.ORANGE, "orange");
+        }
+
+        public String getFruit(Color color) {
+            return this.fruits.get(color);
+        }
+
+        public void setFruit(Color color, String fruit) {
+            this.fruits.put(color, fruit);
+        }
+    }
+}
diff --git 1/tests/src/org.springframework/spring-expression/5.3.15/src/test/java/org_springframework/spring_expression/ReflectivePropertyAccessorInnerOptimalPropertyAccessorTest.java 2/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/ReflectivePropertyAccessorInnerOptimalPropertyAccessorTest.java
index 3004fb8287..d6d2c4e351 100644
--- 1/tests/src/org.springframework/spring-expression/5.3.15/src/test/java/org_springframework/spring_expression/ReflectivePropertyAccessorInnerOptimalPropertyAccessorTest.java
+++ 2/tests/src/org.springframework/spring-expression/6.2.7/src/test/java/org_springframework/spring_expression/ReflectivePropertyAccessorInnerOptimalPropertyAccessorTest.java
@@ -9,6 +9,7 @@ package org_springframework.spring_expression;
 import org.junit.jupiter.api.Test;
 import org.springframework.expression.PropertyAccessor;
 import org.springframework.expression.TypedValue;
+import org.springframework.expression.spel.CompilablePropertyAccessor;
 import org.springframework.expression.spel.support.ReflectivePropertyAccessor;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 
@@ -24,7 +25,7 @@ public class ReflectivePropertyAccessorInnerOptimalPropertyAccessorTest {
         PropertyAccessor accessor = reflectiveAccessor.createOptimalAccessor(context, sample, "name");
 
         assertThat(accessor)
-                .isInstanceOf(ReflectivePropertyAccessor.OptimalPropertyAccessor.class);
+                .isInstanceOf(CompilablePropertyAccessor.class);
         assertThat(accessor.canRead(context, sample, "name"))
                 .isTrue();
 
@@ -43,7 +44,7 @@ public class ReflectivePropertyAccessorInnerOptimalPropertyAccessorTest {
         PropertyAccessor accessor = reflectiveAccessor.createOptimalAccessor(context, sample, "message");
 
         assertThat(accessor)
-                .isInstanceOf(ReflectivePropertyAccessor.OptimalPropertyAccessor.class);
+                .isInstanceOf(CompilablePropertyAccessor.class);
         assertThat(accessor.canRead(context, sample, "message"))
                 .isTrue();
 
diff --git 1/tests/src/org.springframework/spring-expression/5.3.15/user-code-filter.json 2/tests/src/org.springframework/spring-expression/6.2.7/user-code-filter.json
index 1e57bdf948..7e963d710c 100644
--- 1/tests/src/org.springframework/spring-expression/5.3.15/user-code-filter.json
+++ 2/tests/src/org.springframework/spring-expression/6.2.7/user-code-filter.json
@@ -6,6 +6,15 @@
     {
       "includeClasses" : "org.springframework.expression.**"
     },
+    {
+      "includeClasses" : "org.springframework.core.**"
+    },
+    {
+      "includeClasses" : "org.springframework.core.convert.support.**"
+    },
+    {
+      "includeClasses" : "org.springframework.util.**"
+    },
     {
       "includeClasses" : "org_springframework.spring_expression.**"
     }

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
