### PR TITLE
Use maintainer team for repository CODEOWNERS entries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,10 @@
 metadata/*       @oracle/graalvm-reachability-maintainer
 tests/src/*      @oracle/graalvm-reachability-maintainer
-tests/tck-build-logic/* @vjovanov
+tests/tck-build-logic/* @oracle/graalvm-reachability-maintainer
 metadata/library-and-framework-list.json @fniephaus
-.github/* @vjovanov
-docs/*    @vjovanov
-README.md @vjovanov
-gradle/*  @vjovanov
-/*        @vjovanov
+.github/* @oracle/graalvm-reachability-maintainer
+docs/*    @oracle/graalvm-reachability-maintainer
+README.md @oracle/graalvm-reachability-maintainer
+gradle/*  @oracle/graalvm-reachability-maintainer
+/*        @oracle/graalvm-reachability-maintainer
 COVERAGE.md @oracle/graalvm-reachability-maintainer

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,4 @@ docs/*    @vjovanov
 README.md @vjovanov
 gradle/*  @vjovanov
 /*        @vjovanov
+COVERAGE.md @oracle/graalvm-reachability-maintainer


### PR DESCRIPTION
The CODEOWNERS file still had several repository infrastructure paths assigned to @vjovanov through specific rules and the root fallback. That meant broad repository changes, including automated updates that touch COVERAGE.md, could require approval from a single individual instead of the maintainer group.

This PR replaces the remaining @vjovanov CODEOWNERS entries with @oracle/graalvm-reachability-maintainer, keeping those paths under normal maintainer review while avoiding individual ownership requirements. COVERAGE.md is also explicitly assigned to the same maintainer team so library-bulk-update PRs do not fall through to an individual root owner.

Fixes #7477