### PR TITLE
[Automation] Generated metadata for org.glassfish.hk2:hk2-api:2.6.0

### DIFF
--- a/metadata/org.glassfish.hk2/hk2-api/2.6.0/reachability-metadata.json
+++ b/metadata/org.glassfish.hk2/hk2-api/2.6.0/reachability-metadata.json
@@ -62,6 +62,18 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.glassfish.hk2.api.AnnotationLiteral"
+      },
+      "type" : "org.glassfish.hk2.api.Rank",
+      "methods" : [
+        {
+          "name" : "value",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
         "typeReached" : "org.glassfish.hk2.utilities.binding.AbstractBinder$2"
       },
       "type" : "org.glassfish.hk2.utilities.DescriptorImpl"


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7480

This PR provides new metadata needed for the org.glassfish.hk2:hk2-api:2.6.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.glassfish.hk2:hk2-api:2.6.0`): 20
- Test-only metadata entries (previous `org.glassfish.hk2:hk2-api:2.6.0`): 1
- Metadata entries (new `org.glassfish.hk2:hk2-api:2.6.0`): 20
- Test-only metadata entries (new `org.glassfish.hk2:hk2-api:2.6.0`): 1
- Library coverage (previous): 14.17%
- Library coverage (new): 14.17%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `beffdda71fa596fcf4ad943df5c7344379f2ce54`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `org.glassfish.hk2:hk2-api:2.6.0` and `org.glassfish.hk2:hk2-api:2.6.0`.

### Local CI Verification

- Status: `success`
- Commands run: 12
- Fixup attempts: 0
