### PR TITLE
Add Kafka clients 4.2.0 metadata

### DIFF
--- a/metadata/org.apache.kafka/kafka-clients/4.2.0/reachability-metadata.json
+++ b/metadata/org.apache.kafka/kafka-clients/4.2.0/reachability-metadata.json
@@ -1,0 +1,675 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.clients.consumer.ConsumerPartitionAssignor"
+      },
+      "type": "org.apache.kafka.clients.consumer.CooperativeStickyAssignor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.clients.consumer.ConsumerPartitionAssignor"
+      },
+      "type": "org.apache.kafka.clients.consumer.RangeAssignor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.clients.consumer.ConsumerPartitionAssignor"
+      },
+      "type": "org.apache.kafka.clients.consumer.RoundRobinAssignor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.clients.consumer.ConsumerPartitionAssignor"
+      },
+      "type": "org.apache.kafka.clients.consumer.StickyAssignor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.clients.producer.KafkaProducer"
+      },
+      "type": "org.apache.kafka.clients.producer.RoundRobinPartitioner",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.common.utils.Utils"
+      },
+      "type": "org.apache.kafka.common.metrics.JmxReporter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.common.security.authenticator.LoginManager"
+      },
+      "type": "org.apache.kafka.common.security.authenticator.AbstractLogin$DefaultLoginCallbackHandler",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.common.security.authenticator.LoginManager"
+      },
+      "type": "org.apache.kafka.common.security.authenticator.DefaultLogin",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.common.security.authenticator.LoginManager"
+      },
+      "type": "javax.security.auth.Subject",
+      "allDeclaredMethods": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.common.network.SaslChannelBuilder"
+      },
+      "type": "org.apache.kafka.common.security.authenticator.SaslClientCallbackHandler",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.common.config.SaslConfigs"
+      },
+      "type": "org.apache.kafka.common.security.oauthbearer.DefaultJwtRetriever",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.common.config.SaslConfigs"
+      },
+      "type": "org.apache.kafka.common.security.oauthbearer.DefaultJwtValidator",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.common.security.authenticator.AbstractLogin"
+      },
+      "type": "org.apache.kafka.common.security.plain.PlainLoginModule",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.common.security.authenticator.AbstractLogin"
+      },
+      "type": "org.apache.kafka.common.security.scram.ScramLoginModule",
+      "allDeclaredMethods": true,
+      "allDeclaredConstructors": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.common.security.scram.internals.ScramSaslClientProvider"
+      },
+      "type": "org.apache.kafka.common.security.scram.internals.ScramSaslClient",
+      "allDeclaredMethods": true,
+      "allDeclaredConstructors": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.common.security.scram.internals.ScramSaslClientProvider"
+      },
+      "type": "org.apache.kafka.common.security.scram.internals.ScramSaslClient$ScramSaslClientFactory",
+      "allDeclaredMethods": true,
+      "allDeclaredConstructors": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.clients.consumer.KafkaConsumer"
+      },
+      "type": "org.apache.kafka.common.serialization.BooleanDeserializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.clients.producer.KafkaProducer"
+      },
+      "type": "org.apache.kafka.common.serialization.BooleanSerializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.clients.consumer.KafkaConsumer"
+      },
+      "type": "org.apache.kafka.common.serialization.ByteArrayDeserializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.clients.producer.KafkaProducer"
+      },
+      "type": "org.apache.kafka.common.serialization.ByteArraySerializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.clients.consumer.KafkaConsumer"
+      },
+      "type": "org.apache.kafka.common.serialization.ByteBufferDeserializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.clients.producer.KafkaProducer"
+      },
+      "type": "org.apache.kafka.common.serialization.ByteBufferSerializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.clients.consumer.KafkaConsumer"
+      },
+      "type": "org.apache.kafka.common.serialization.BytesDeserializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.clients.producer.KafkaProducer"
+      },
+      "type": "org.apache.kafka.common.serialization.BytesSerializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.clients.consumer.KafkaConsumer"
+      },
+      "type": "org.apache.kafka.common.serialization.DoubleDeserializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.clients.producer.KafkaProducer"
+      },
+      "type": "org.apache.kafka.common.serialization.DoubleSerializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.clients.consumer.KafkaConsumer"
+      },
+      "type": "org.apache.kafka.common.serialization.FloatDeserializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.clients.producer.KafkaProducer"
+      },
+      "type": "org.apache.kafka.common.serialization.FloatSerializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.clients.consumer.KafkaConsumer"
+      },
+      "type": "org.apache.kafka.common.serialization.IntegerDeserializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.clients.producer.KafkaProducer"
+      },
+      "type": "org.apache.kafka.common.serialization.IntegerSerializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.clients.consumer.KafkaConsumer"
+      },
+      "type": "org.apache.kafka.common.serialization.ListDeserializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.clients.producer.KafkaProducer"
+      },
+      "type": "org.apache.kafka.common.serialization.ListSerializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.clients.consumer.KafkaConsumer"
+      },
+      "type": "org.apache.kafka.common.serialization.LongDeserializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.clients.producer.KafkaProducer"
+      },
+      "type": "org.apache.kafka.common.serialization.LongSerializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.common.serialization.ListDeserializer"
+      },
+      "type": "org.apache.kafka.common.serialization.Serdes$BooleanSerde",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.common.serialization.ListSerializer"
+      },
+      "type": "org.apache.kafka.common.serialization.Serdes$BooleanSerde",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.common.serialization.ListSerializer"
+      },
+      "type": "org.apache.kafka.common.serialization.Serdes$ByteArraySerde",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.common.serialization.ListSerializer"
+      },
+      "type": "org.apache.kafka.common.serialization.Serdes$ByteBufferSerde",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.common.serialization.ListSerializer"
+      },
+      "type": "org.apache.kafka.common.serialization.Serdes$BytesSerde",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.common.serialization.ListSerializer"
+      },
+      "type": "org.apache.kafka.common.serialization.Serdes$DoubleSerde",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.common.serialization.ListSerializer"
+      },
+      "type": "org.apache.kafka.common.serialization.Serdes$FloatSerde",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.common.serialization.ListSerializer"
+      },
+      "type": "org.apache.kafka.common.serialization.Serdes$IntegerSerde",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.common.serialization.ListSerializer"
+      },
+      "type": "org.apache.kafka.common.serialization.Serdes$LongSerde",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.common.serialization.ListSerializer"
+      },
+      "type": "org.apache.kafka.common.serialization.Serdes$ShortSerde",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.common.serialization.ListSerializer"
+      },
+      "type": "org.apache.kafka.common.serialization.Serdes$StringSerde",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.common.serialization.ListSerializer"
+      },
+      "type": "org.apache.kafka.common.serialization.Serdes$UUIDSerde",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.common.serialization.ListSerializer"
+      },
+      "type": "org.apache.kafka.common.serialization.Serdes$VoidSerde",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.clients.consumer.KafkaConsumer"
+      },
+      "type": "org.apache.kafka.common.serialization.ShortDeserializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.clients.producer.KafkaProducer"
+      },
+      "type": "org.apache.kafka.common.serialization.ShortSerializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.clients.consumer.KafkaConsumer"
+      },
+      "type": "org.apache.kafka.common.serialization.StringDeserializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.clients.producer.KafkaProducer"
+      },
+      "type": "org.apache.kafka.common.serialization.StringSerializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.clients.consumer.KafkaConsumer"
+      },
+      "type": "org.apache.kafka.common.serialization.UUIDDeserializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.clients.producer.KafkaProducer"
+      },
+      "type": "org.apache.kafka.common.serialization.UUIDSerializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.clients.consumer.KafkaConsumer"
+      },
+      "type": "org.apache.kafka.common.serialization.VoidDeserializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.clients.producer.KafkaProducer"
+      },
+      "type": "org.apache.kafka.common.serialization.VoidSerializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.common.utils.AppInfoParser"
+      },
+      "type": "org.apache.kafka.common.utils.AppInfoParser$AppInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.common.utils.AppInfoParser"
+      },
+      "type": "org.apache.kafka.common.utils.AppInfoParser$AppInfoMBean"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.apache.kafka.common.utils.AppInfoParser"
+      },
+      "glob": "kafka/kafka-version.properties"
+    },
+    {
+      "bundle": "sun.security.util.Resources"
+    },
+    {
+      "bundle": "sun.security.util.resources.security"
+    }
+  ]
+}

--- a/metadata/org.apache.kafka/kafka-clients/index.json
+++ b/metadata/org.apache.kafka/kafka-clients/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest": true,
     "allowed-packages": [
       "org.apache.kafka"
     ],
@@ -13,6 +12,21 @@
     "tested-versions": [
       "3.5.1",
       "3.5.2"
+    ]
+  },
+  {
+    "latest": true,
+    "allowed-packages": [
+      "org.apache.kafka"
+    ],
+    "metadata-version": "4.2.0",
+    "source-code-url": "https://repo.maven.apache.org/maven2/org/apache/kafka/kafka-clients/$version$/kafka-clients-$version$-sources.jar",
+    "repository-url": "https://github.com/apache/kafka",
+    "test-code-url": "https://repo.maven.apache.org/maven2/org/apache/kafka/kafka-clients/$version$/kafka-clients-$version$-test-sources.jar",
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/apache/kafka/kafka-clients/$version$/kafka-clients-$version$-javadoc.jar",
+    "description": "Apache Kafka's Java client library provides APIs for producing records to Kafka, consuming records from Kafka, and administering Kafka clusters. It lets Java applications interact with Kafka brokers through the producer, consumer, and AdminClient APIs.",
+    "tested-versions": [
+      "4.2.0"
     ]
   }
 ]

--- a/stats/org.apache.kafka/kafka-clients/4.2.0/stats.json
+++ b/stats/org.apache.kafka/kafka-clients/4.2.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "4.2.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.132743,
+          "coveredCalls" : 15,
+          "totalCalls" : 113
+        },
+        "resources" : {
+          "coverageRatio" : 0.0,
+          "coveredCalls" : 0,
+          "totalCalls" : 3
+        }
+      },
+      "coverageRatio" : 0.12931,
+      "coveredCalls" : 15,
+      "totalCalls" : 116
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 76484,
+        "missed" : 1335026,
+        "ratio" : 0.054186,
+        "total" : 1411510
+      },
+      "line" : {
+        "covered" : 8660,
+        "missed" : 290621,
+        "ratio" : 0.028936,
+        "total" : 299281
+      },
+      "method" : {
+        "covered" : 1886,
+        "missed" : 52594,
+        "ratio" : 0.034618,
+        "total" : 54480
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.kafka/kafka-clients/4.2.0/.gitignore
+++ b/tests/src/org.apache.kafka/kafka-clients/4.2.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.kafka/kafka-clients/4.2.0/build.gradle
+++ b/tests/src/org.apache.kafka/kafka-clients/4.2.0/build.gradle
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.kafka:kafka-clients:$libraryVersion"
+    testImplementation "org.apache.kafka:kafka-clients:$libraryVersion:test"
+    testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.20.1'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'ch.qos.logback:logback-classic:1.4.5'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "metadata-user-code-filter.json"
+                extraFilterPath = "metadata-extra-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-clients/4.2.0/gradle.properties
+++ b/tests/src/org.apache.kafka/kafka-clients/4.2.0/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 4.2.0
+metadata.dir = org.apache.kafka/kafka-clients/4.2.0/

--- a/tests/src/org.apache.kafka/kafka-clients/4.2.0/metadata-extra-filter.json
+++ b/tests/src/org.apache.kafka/kafka-clients/4.2.0/metadata-extra-filter.json
@@ -1,0 +1,5 @@
+{
+  "rules": [
+    {"includeClasses": "org.apache.kafka.**"}
+  ]
+}

--- a/tests/src/org.apache.kafka/kafka-clients/4.2.0/metadata-user-code-filter.json
+++ b/tests/src/org.apache.kafka/kafka-clients/4.2.0/metadata-user-code-filter.json
@@ -1,0 +1,5 @@
+{
+  "rules": [
+    {"includeClasses": "org.apache.kafka.**"}
+  ]
+}

--- a/tests/src/org.apache.kafka/kafka-clients/4.2.0/settings.gradle
+++ b/tests/src/org.apache.kafka/kafka-clients/4.2.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.kafka.kafka-clients_tests'

--- a/tests/src/org.apache.kafka/kafka-clients/4.2.0/src/test/java/org_apache_kafka/kafka_clients/KafkaClientsTest.java
+++ b/tests/src/org.apache.kafka/kafka-clients/4.2.0/src/test/java/org_apache_kafka/kafka_clients/KafkaClientsTest.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_clients;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.CooperativeStickyAssignor;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.RangeAssignor;
+import org.apache.kafka.clients.consumer.RoundRobinAssignor;
+import org.apache.kafka.clients.consumer.StickyAssignor;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RoundRobinPartitioner;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.serialization.BooleanDeserializer;
+import org.apache.kafka.common.serialization.BooleanSerializer;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.ByteBufferDeserializer;
+import org.apache.kafka.common.serialization.ByteBufferSerializer;
+import org.apache.kafka.common.serialization.BytesDeserializer;
+import org.apache.kafka.common.serialization.BytesSerializer;
+import org.apache.kafka.common.serialization.DoubleDeserializer;
+import org.apache.kafka.common.serialization.DoubleSerializer;
+import org.apache.kafka.common.serialization.FloatDeserializer;
+import org.apache.kafka.common.serialization.FloatSerializer;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.ListDeserializer;
+import org.apache.kafka.common.serialization.ListSerializer;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.ShortDeserializer;
+import org.apache.kafka.common.serialization.ShortSerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.serialization.UUIDDeserializer;
+import org.apache.kafka.common.serialization.UUIDSerializer;
+import org.apache.kafka.common.serialization.VoidDeserializer;
+import org.apache.kafka.common.serialization.VoidSerializer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import javax.security.sasl.Sasl;
+import javax.security.sasl.SaslClient;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class KafkaClientsTest {
+
+    private static final String KAFKA_SERVER = "localhost:9092";
+
+    @Test
+    void testProduceAndConsume() throws Exception {
+        try (MockProducer<Integer, String> producer = new MockProducer<>(
+                true,
+                null,
+                new IntegerSerializer(),
+                new StringSerializer())) {
+            producer.send(new ProducerRecord<>("test_topic", 0, 0, "message0")).get();
+            producer.send(new ProducerRecord<>("test_topic", 0, 1, "message1")).get();
+
+            assertThat(producer.history())
+                    .extracting(ProducerRecord::value)
+                    .containsExactly("message0", "message1");
+        }
+
+        List<String> receivedMessages = new ArrayList<>();
+        TopicPartition partition = new TopicPartition("test_topic", 0);
+        try (MockConsumer<Integer, String> consumer = new MockConsumer<>("earliest")) {
+            consumer.assign(Collections.singletonList(partition));
+            consumer.updateBeginningOffsets(Collections.singletonMap(partition, 0L));
+            consumer.addRecord(new ConsumerRecord<>("test_topic", 0, 0L, 0, "message0"));
+            consumer.addRecord(new ConsumerRecord<>("test_topic", 0, 1L, 1, "message1"));
+
+            ConsumerRecords<Integer, String> records = consumer.poll(Duration.ofMillis(100));
+            for (ConsumerRecord<Integer, String> record : records) {
+                receivedMessages.add(record.value());
+            }
+        }
+
+        assertThat(receivedMessages)
+                .hasSize(2)
+                .containsExactly("message0", "message1");
+    }
+
+    @ParameterizedTest
+    @ValueSource(classes = {
+            BooleanSerializer.class,
+            BytesSerializer.class,
+            ByteArraySerializer.class,
+            ByteBufferSerializer.class,
+            DoubleSerializer.class,
+            FloatSerializer.class,
+            IntegerSerializer.class,
+            LongSerializer.class,
+            ShortSerializer.class,
+            StringSerializer.class,
+            UUIDSerializer.class,
+            VoidSerializer.class})
+    void testSerializers(Class valueSerializer) {
+        Map<String, Object> producerProperties = new HashMap<>();
+        producerProperties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA_SERVER);
+        producerProperties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
+        producerProperties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSerializer);
+        try (KafkaProducer producer = new KafkaProducer<>(producerProperties)) {
+            assertThat(producer).isNotNull();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(classes = {
+            BooleanDeserializer.class,
+            BytesDeserializer.class,
+            ByteArrayDeserializer.class,
+            ByteBufferDeserializer.class,
+            DoubleDeserializer.class,
+            FloatDeserializer.class,
+            IntegerDeserializer.class,
+            LongDeserializer.class,
+            ShortDeserializer.class,
+            StringDeserializer.class,
+            UUIDDeserializer.class,
+            VoidDeserializer.class})
+    void testDeserializers(Class valueDeserializer) {
+        Map<String, Object> consumerProperties = new HashMap<>();
+        consumerProperties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA_SERVER);
+        consumerProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, IntegerDeserializer.class);
+        consumerProperties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer);
+        try (KafkaConsumer consumer = new KafkaConsumer<>(consumerProperties)) {
+            assertThat(consumer).isNotNull();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(classes = {
+            Serdes.BooleanSerde.class,
+            Serdes.BytesSerde.class,
+            Serdes.ByteArraySerde.class,
+            Serdes.ByteBufferSerde.class,
+            Serdes.DoubleSerde.class,
+            Serdes.FloatSerde.class,
+            Serdes.IntegerSerde.class,
+            Serdes.LongSerde.class,
+            Serdes.ShortSerde.class,
+            Serdes.StringSerde.class,
+            Serdes.UUIDSerde.class,
+            Serdes.VoidSerde.class})
+    void testListSerializers(Class serdeInnerClass) {
+        Map<String, Object> producerProperties = new HashMap<>();
+        producerProperties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA_SERVER);
+        producerProperties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
+        producerProperties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ListSerializer.class);
+        producerProperties.put(CommonClientConfigs.DEFAULT_LIST_VALUE_SERDE_INNER_CLASS, serdeInnerClass);
+        try (KafkaProducer producer = new KafkaProducer<>(producerProperties)) {
+            assertThat(producer).isNotNull();
+        }
+    }
+
+    @Test
+    void testListDeserializers() {
+        Map<String, Object> consumerProperties = new HashMap<>();
+        consumerProperties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA_SERVER);
+        consumerProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, IntegerDeserializer.class);
+        consumerProperties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ListDeserializer.class);
+        consumerProperties.put(CommonClientConfigs.DEFAULT_LIST_VALUE_SERDE_TYPE_CLASS, ArrayList.class);
+        consumerProperties.put(CommonClientConfigs.DEFAULT_LIST_VALUE_SERDE_INNER_CLASS, Serdes.BooleanSerde.class);
+        try (KafkaConsumer consumer = new KafkaConsumer<>(consumerProperties)) {
+            assertThat(consumer).isNotNull();
+        }
+    }
+
+    @Test
+    void testRoundRobinPartitioner() {
+        Map<String, Object> producerProperties = new HashMap<>();
+        producerProperties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA_SERVER);
+        producerProperties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
+        producerProperties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        producerProperties.put(ProducerConfig.PARTITIONER_CLASS_CONFIG, RoundRobinPartitioner.class);
+        try (KafkaProducer producer = new KafkaProducer<>(producerProperties)) {
+            assertThat(producer).isNotNull();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(classes = {
+            RangeAssignor.class,
+            RoundRobinAssignor.class,
+            CooperativeStickyAssignor.class,
+            StickyAssignor.class})
+    void testPartitionAssignmentStrategy(Class assignor) {
+        Map<String, Object> consumerProperties = new HashMap<>();
+        consumerProperties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA_SERVER);
+        consumerProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, IntegerDeserializer.class);
+        consumerProperties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        consumerProperties.put(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, Arrays.asList(assignor));
+        try (KafkaConsumer consumer = new KafkaConsumer<>(consumerProperties)) {
+            assertThat(consumer).isNotNull();
+        }
+    }
+
+    @Test
+    void testSaslPlain() {
+        Map<String, Object> consumerProperties = new HashMap<>();
+        consumerProperties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA_SERVER);
+        consumerProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, IntegerDeserializer.class);
+        consumerProperties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        consumerProperties.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_PLAINTEXT");
+        consumerProperties.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+        consumerProperties.put(SaslConfigs.SASL_JAAS_CONFIG, "org.apache.kafka.common.security.plain.PlainLoginModule required username=admin password=admin-pass;");
+        // Keep the unreachable endpoint path bounded.
+        consumerProperties.put(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG, 5000);
+        consumerProperties.put(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, 5000);
+        try (KafkaConsumer consumer = new KafkaConsumer<>(consumerProperties)) {
+            assertThatThrownBy(() -> consumer.partitionsFor("non-existent-topic"))
+                    .isNotInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @Test
+    void testSaslScramSHA512() {
+        Map<String, Object> consumerProperties = new HashMap<>();
+        consumerProperties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA_SERVER);
+        consumerProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, IntegerDeserializer.class);
+        consumerProperties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        consumerProperties.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
+        consumerProperties.put(SaslConfigs.SASL_MECHANISM, "SCRAM-SHA-512");
+        consumerProperties.put(SaslConfigs.SASL_JAAS_CONFIG, "org.apache.kafka.common.security.scram.ScramLoginModule required username=admin password=admin-pass;");
+        // Keep the unreachable endpoint path bounded.
+        consumerProperties.put(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG, 5000);
+        consumerProperties.put(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, 5000);
+        try (KafkaConsumer consumer = new KafkaConsumer<>(consumerProperties)) {
+            assertThatThrownBy(() -> consumer.partitionsFor("non-existent-topic"))
+                    .isNotInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @Test
+    void testScramProviderCreatesClientFactory() throws Exception {
+        Class.forName("org.apache.kafka.common.security.scram.ScramLoginModule");
+
+        Map<String, String> saslProperties = new HashMap<>();
+        SaslClient client = Sasl.createSaslClient(
+                new String[] {"SCRAM-SHA-512"},
+                null,
+                "kafka",
+                "localhost",
+                saslProperties,
+                callbacks -> {
+                });
+
+        assertThat(client).isNotNull();
+        assertThat(client.getClass().getName())
+                .isEqualTo("org.apache.kafka.common.security.scram.internals.ScramSaslClient");
+    }
+
+}

--- a/tests/src/org.apache.kafka/kafka-clients/4.2.0/src/test/java/org_apache_kafka/kafka_clients/SaslOauthbearerDefaultsTest.java
+++ b/tests/src/org.apache.kafka/kafka-clients/4.2.0/src/test/java/org_apache_kafka/kafka_clients/SaslOauthbearerDefaultsTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_clients;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SaslOauthbearerDefaultsTest {
+
+    @Test
+    void producerConfigParsesDefaultOauthbearerJwtClasses() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+        ProducerConfig config = new ProducerConfig(properties);
+
+        assertThat(config.getClass(SaslConfigs.SASL_OAUTHBEARER_JWT_RETRIEVER_CLASS).getName())
+                .isEqualTo("org.apache.kafka.common.security.oauthbearer.DefaultJwtRetriever");
+        assertThat(config.getClass(SaslConfigs.SASL_OAUTHBEARER_JWT_VALIDATOR_CLASS).getName())
+                .isEqualTo("org.apache.kafka.common.security.oauthbearer.DefaultJwtValidator");
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-clients/4.2.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.kafka/kafka-clients/4.2.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,21 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "javax.security.auth.login.Configuration"
+      },
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ],
+      "type": "sun.security.provider.ConfigFile"
+    }
+  ],
+  "resources": [
+    {
+      "glob": "logback.xml"
+    }
+  ]
+}

--- a/tests/src/org.apache.kafka/kafka-clients/4.2.0/src/test/resources/logback.xml
+++ b/tests/src/org.apache.kafka/kafka-clients/4.2.0/src/test/resources/logback.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="KafkaClientsTest" level="INFO"/>
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
## Summary
- add a new latest metadata entry for org.apache.kafka:kafka-clients:4.2.0
- add focused Kafka client tests for OAuth bearer default class parsing and SCRAM client factory creation
- generate library stats for kafka-clients 4.2.0

## Testing
- GRAALVM_HOME=/home/jovan/ol/bb/master/graal/sdk/mxbuild/linux-amd64/GRAALVM_JAVA25/graalvm-25.1.0-dev+10.1 ./gradlew checkMetadataFiles compileTestJava -Pcoordinates=org.apache.kafka:kafka-clients:4.2.0 --stacktrace
- GRAALVM_HOME=/home/jovan/ol/bb/master/graal/sdk/mxbuild/linux-amd64/GRAALVM_JAVA25/graalvm-25.1.0-dev+10.1 ./gradlew checkstyle test -Pcoordinates=org.apache.kafka:kafka-clients:4.2.0 --stacktrace
- GRAALVM_HOME=/home/jovan/ol/bb/master/graal/sdk/mxbuild/linux-amd64/GRAALVM_JAVA25/graalvm-25.1.0-dev+10.1 ./gradlew generateLibraryStats validateLibraryStats -Pcoordinates=org.apache.kafka:kafka-clients:4.2.0 --stacktrace

Fixes #2110