### PR TITLE
Fix scheduled release output size

### DIFF
--- a/.github/workflows/create-scheduled-release.yml
+++ b/.github/workflows/create-scheduled-release.yml
@@ -65,7 +65,6 @@ jobs:
     runs-on: "ubuntu-22.04"
     timeout-minutes: 5
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
       none-found: ${{ steps.set-matrix.outputs.none-found }}
     steps:
       - name: "☁️ Checkout repository"
@@ -83,7 +82,10 @@ jobs:
         id: set-matrix
         run: |
           LATEST_TAG=$(git tag --list | sort -V | tail -1)
-          ./gradlew generateChangedCoordinatesMatrix -PbaseCommit="$(git show-ref -s "$LATEST_TAG")" -PnewCommit="$(git rev-parse HEAD)"
+          # Keep the expanded matrix out of job outputs; the release job only needs none-found.
+          GRADLE_OUTPUT=$(mktemp)
+          GITHUB_OUTPUT="$GRADLE_OUTPUT" ./gradlew generateChangedCoordinatesMatrix -PbaseCommit="$(git show-ref -s "$LATEST_TAG")" -PnewCommit="$(git rev-parse HEAD)"
+          grep '^none-found=' "$GRADLE_OUTPUT" >> "$GITHUB_OUTPUT"
 
   release:
     needs: get-changed-metadata


### PR DESCRIPTION
## Summary
- Avoid publishing the expanded changed-metadata matrix as a job output in the scheduled release workflow.
- Keep using the existing Gradle task to detect changed metadata, but forward only the `none-found` output that the release job consumes.
- Prevent large release diffs from hitting the GitHub Actions per-job output size limit.

## Verification
- Reproduced the failing release range locally and confirmed the workflow step now writes only `none-found=false` to the real GitHub output file.
- Ran `git diff --check`.

Fixes #7485