### PR TITLE
[GenAI] Test fix for org.apache.maven.plugins:maven-source-plugin:3.1.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.maven.plugins/maven-source-plugin/3.1.0/reachability-metadata.json
+++ b/metadata/org.apache.maven.plugins/maven-source-plugin/3.1.0/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.plugins.source.HelpMojo"
+      },
+      "glob": "META-INF/maven/org.apache.maven.plugins/maven-source-plugin/plugin-help.xml"
+    }
+  ]
+}

--- a/metadata/org.apache.maven.plugins/maven-source-plugin/index.json
+++ b/metadata/org.apache.maven.plugins/maven-source-plugin/index.json
@@ -15,6 +15,15 @@
     ]
   },
   {
+    "metadata-version" : "3.1.0",
+    "tested-versions" : [
+      "3.1.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.maven.plugin.source"
+    ]
+  },
+  {
     "metadata-version" : "3.0.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-source-plugin/$version$/maven-source-plugin-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/maven-source-plugin",

--- a/metadata/org.apache.maven.plugins/maven-source-plugin/index.json
+++ b/metadata/org.apache.maven.plugins/maven-source-plugin/index.json
@@ -16,6 +16,11 @@
   },
   {
     "metadata-version" : "3.1.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-source-plugin/$version$/maven-source-plugin-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/maven-source-plugin",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-source-plugin/$version$/maven-source-plugin-$version$-source-release.zip",
+    "documentation-url" : "https://maven.apache.org/plugins-archives/maven-source-plugin-$version$/",
+    "description" : "Apache Maven Source Plugin creates source and test-source archive artifacts for Maven projects. It provides goals to package project sources into JARs and attach them to the build for installation or deployment.",
     "tested-versions" : [
       "3.1.0"
     ],

--- a/metadata/org.apache.maven.plugins/maven-source-plugin/index.json
+++ b/metadata/org.apache.maven.plugins/maven-source-plugin/index.json
@@ -25,7 +25,7 @@
       "3.1.0"
     ],
     "allowed-packages" : [
-      "org.apache.maven.plugin.source"
+      "org.apache.maven.plugins.source"
     ]
   },
   {

--- a/stats/org.apache.maven.plugins/maven-source-plugin/3.1.0/execution-metrics.json
+++ b/stats/org.apache.maven.plugins/maven-source-plugin/3.1.0/execution-metrics.json
@@ -1,0 +1,99 @@
+{
+  "fix_javac_fail:2026-05-21": {
+    "timestamp": "2026-05-21T20:28:55.321413Z",
+    "library": "org.apache.maven.plugins:maven-source-plugin:3.1.0",
+    "starting_commit": "3343b56ec350863efbc087feef47663d00c021f3",
+    "ending_commit": "c8dcbbef5a234b1de71a3142343d1edac9323b88",
+    "previous_library": "org.apache.maven.plugins:maven-source-plugin:2.2.1",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.1.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 559,
+          "missed": 962,
+          "ratio": 0.367521,
+          "total": 1521
+        },
+        "line": {
+          "covered": 106,
+          "missed": 191,
+          "ratio": 0.356902,
+          "total": 297
+        },
+        "method": {
+          "covered": 14,
+          "missed": 31,
+          "ratio": 0.311111,
+          "total": 45
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.2.1",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 462,
+          "missed": 863,
+          "ratio": 0.348679,
+          "total": 1325
+        },
+        "line": {
+          "covered": 78,
+          "missed": 170,
+          "ratio": 0.314516,
+          "total": 248
+        },
+        "method": {
+          "covered": 10,
+          "missed": 28,
+          "ratio": 0.263158,
+          "total": 38
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 10693,
+      "cached_input_tokens_used": 55296,
+      "output_tokens_used": 553,
+      "iterations": 1,
+      "cost_usd": 0.0442,
+      "tested_library_loc": 106,
+      "metadata_entries": 1,
+      "previous_library_metadata_entries": 1,
+      "code_coverage_percent": 35.69,
+      "previous_library_coverage_percent": 31.45
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.maven.plugins/maven-source-plugin/3.1.0/src/test/java/org_apache_maven_plugins/maven_source_plugin/HelpMojoTest.java",
+      "metadata_file": "metadata/org.apache.maven.plugins/maven-source-plugin/3.1.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.maven.plugins/maven-source-plugin/3.1.0/stats.json
+++ b/stats/org.apache.maven.plugins/maven-source-plugin/3.1.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "3.1.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 1,
+      "totalCalls" : 1
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 559,
+        "missed" : 962,
+        "ratio" : 0.367521,
+        "total" : 1521
+      },
+      "line" : {
+        "covered" : 106,
+        "missed" : 191,
+        "ratio" : 0.356902,
+        "total" : 297
+      },
+      "method" : {
+        "covered" : 14,
+        "missed" : 31,
+        "ratio" : 0.311111,
+        "total" : 45
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.maven.plugins/maven-source-plugin/3.1.0/.gitignore
+++ b/tests/src/org.apache.maven.plugins/maven-source-plugin/3.1.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.maven.plugins/maven-source-plugin/3.1.0/build.gradle
+++ b/tests/src/org.apache.maven.plugins/maven-source-plugin/3.1.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.maven.plugins:maven-source-plugin:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.maven.plugins/maven-source-plugin/3.1.0/gradle.properties
+++ b/tests/src/org.apache.maven.plugins/maven-source-plugin/3.1.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.maven.plugins:maven-source-plugin:3.1.0
+library.version = 3.1.0
+metadata.dir = org.apache.maven.plugins/maven-source-plugin/3.1.0/

--- a/tests/src/org.apache.maven.plugins/maven-source-plugin/3.1.0/settings.gradle
+++ b/tests/src/org.apache.maven.plugins/maven-source-plugin/3.1.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.maven.plugins.maven-source-plugin_tests'

--- a/tests/src/org.apache.maven.plugins/maven-source-plugin/3.1.0/src/test/java/org_apache_maven_plugins/maven_source_plugin/HelpMojoTest.java
+++ b/tests/src/org.apache.maven.plugins/maven-source-plugin/3.1.0/src/test/java/org_apache_maven_plugins/maven_source_plugin/HelpMojoTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_plugins.maven_source_plugin;
+
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugin.source.HelpMojo;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HelpMojoTest {
+    @Test
+    public void executeReadsBundledPluginHelpResource() throws Exception {
+        HelpMojo mojo = new HelpMojo();
+        CapturingLog log = new CapturingLog();
+        mojo.setLog(log);
+
+        mojo.execute();
+
+        assertThat(log.debugMessages()).contains("plugin-help.xml");
+        assertThat(log.infoMessages())
+                .contains("Maven Source Plugin")
+                .contains("source:jar")
+                .contains("source:test-jar");
+    }
+
+    private static final class CapturingLog implements Log {
+        private final StringBuilder debugMessages = new StringBuilder();
+        private final StringBuilder infoMessages = new StringBuilder();
+        private final StringBuilder warnMessages = new StringBuilder();
+        private final StringBuilder errorMessages = new StringBuilder();
+
+        String debugMessages() {
+            return debugMessages.toString();
+        }
+
+        String infoMessages() {
+            return infoMessages.toString();
+        }
+
+        @Override
+        public boolean isDebugEnabled() {
+            return true;
+        }
+
+        @Override
+        public void debug(CharSequence content) {
+            append(debugMessages, content);
+        }
+
+        @Override
+        public void debug(CharSequence content, Throwable error) {
+            append(debugMessages, content);
+            append(debugMessages, error);
+        }
+
+        @Override
+        public void debug(Throwable error) {
+            append(debugMessages, error);
+        }
+
+        @Override
+        public boolean isInfoEnabled() {
+            return true;
+        }
+
+        @Override
+        public void info(CharSequence content) {
+            append(infoMessages, content);
+        }
+
+        @Override
+        public void info(CharSequence content, Throwable error) {
+            append(infoMessages, content);
+            append(infoMessages, error);
+        }
+
+        @Override
+        public void info(Throwable error) {
+            append(infoMessages, error);
+        }
+
+        @Override
+        public boolean isWarnEnabled() {
+            return true;
+        }
+
+        @Override
+        public void warn(CharSequence content) {
+            append(warnMessages, content);
+        }
+
+        @Override
+        public void warn(CharSequence content, Throwable error) {
+            append(warnMessages, content);
+            append(warnMessages, error);
+        }
+
+        @Override
+        public void warn(Throwable error) {
+            append(warnMessages, error);
+        }
+
+        @Override
+        public boolean isErrorEnabled() {
+            return true;
+        }
+
+        @Override
+        public void error(CharSequence content) {
+            append(errorMessages, content);
+        }
+
+        @Override
+        public void error(CharSequence content, Throwable error) {
+            append(errorMessages, content);
+            append(errorMessages, error);
+        }
+
+        @Override
+        public void error(Throwable error) {
+            append(errorMessages, error);
+        }
+
+        private static void append(StringBuilder messages, CharSequence content) {
+            messages.append(content).append('\n');
+        }
+
+        private static void append(StringBuilder messages, Throwable error) {
+            messages.append(error.getClass().getName()).append(": ").append(error.getMessage()).append('\n');
+        }
+    }
+}

--- a/tests/src/org.apache.maven.plugins/maven-source-plugin/3.1.0/src/test/java/org_apache_maven_plugins/maven_source_plugin/HelpMojoTest.java
+++ b/tests/src/org.apache.maven.plugins/maven-source-plugin/3.1.0/src/test/java/org_apache_maven_plugins/maven_source_plugin/HelpMojoTest.java
@@ -7,7 +7,7 @@
 package org_apache_maven_plugins.maven_source_plugin;
 
 import org.apache.maven.plugin.logging.Log;
-import org.apache.maven.plugin.source.HelpMojo;
+import org.apache.maven.plugins.source.HelpMojo;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/tests/src/org.apache.maven.plugins/maven-source-plugin/3.1.0/user-code-filter.json
+++ b/tests/src/org.apache.maven.plugins/maven-source-plugin/3.1.0/user-code-filter.json
@@ -7,6 +7,9 @@
       "includeClasses" : "org.apache.maven.plugin.source.**"
     },
     {
+      "includeClasses" : "org.apache.maven.plugins.source.**"
+    },
+    {
       "includeClasses" : "org_apache_maven_plugins.maven_source_plugin.**"
     }
   ]

--- a/tests/src/org.apache.maven.plugins/maven-source-plugin/3.1.0/user-code-filter.json
+++ b/tests/src/org.apache.maven.plugins/maven-source-plugin/3.1.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.maven.plugin.source.**"
+    },
+    {
+      "includeClasses" : "org_apache_maven_plugins.maven_source_plugin.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7495

This PR provides test fixes and new metadata for org.apache.maven.plugins:maven-source-plugin:3.1.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 10693
- Cached input tokens: 55296
- Output tokens: 553
- Metadata entries: 1
- Iterations: 1
- Library coverage percentage: 35.69
- Previous library version metadata entries: 1
- Previous library version coverage percentage: 31.45

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `dfec64a575f274f3be2f56e9c7901af7b0fb4daa`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.maven.plugins:maven-source-plugin:2.2.1: 1/1 covered calls (100.00%)
- org.apache.maven.plugins:maven-source-plugin:3.1.0: 1/1 covered calls (100.00%)

**Resources:**
- org.apache.maven.plugins:maven-source-plugin:2.2.1: 1/1 covered calls (100.00%)
- org.apache.maven.plugins:maven-source-plugin:3.1.0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.maven.plugins:maven-source-plugin:2.2.1: 462/1325 (34.87%)
- org.apache.maven.plugins:maven-source-plugin:3.1.0: 559/1521 (36.75%)

**Line:**
- org.apache.maven.plugins:maven-source-plugin:2.2.1: 78/248 (31.45%)
- org.apache.maven.plugins:maven-source-plugin:3.1.0: 106/297 (35.69%)

**Method:**
- org.apache.maven.plugins:maven-source-plugin:2.2.1: 10/38 (26.32%)
- org.apache.maven.plugins:maven-source-plugin:3.1.0: 14/45 (31.11%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.maven.plugins/maven-source-plugin/2.2.1/src/test/java/org_apache_maven_plugins/maven_source_plugin/HelpMojoTest.java 2/tests/src/org.apache.maven.plugins/maven-source-plugin/3.1.0/src/test/java/org_apache_maven_plugins/maven_source_plugin/HelpMojoTest.java
index 4c7fa75479..c93051f471 100644
--- 1/tests/src/org.apache.maven.plugins/maven-source-plugin/2.2.1/src/test/java/org_apache_maven_plugins/maven_source_plugin/HelpMojoTest.java
+++ 2/tests/src/org.apache.maven.plugins/maven-source-plugin/3.1.0/src/test/java/org_apache_maven_plugins/maven_source_plugin/HelpMojoTest.java
@@ -7,7 +7,7 @@
 package org_apache_maven_plugins.maven_source_plugin;
 
 import org.apache.maven.plugin.logging.Log;
-import org.apache.maven.plugin.source.HelpMojo;
+import org.apache.maven.plugins.source.HelpMojo;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
diff --git 1/tests/src/org.apache.maven.plugins/maven-source-plugin/2.2.1/user-code-filter.json 2/tests/src/org.apache.maven.plugins/maven-source-plugin/3.1.0/user-code-filter.json
index a26fe3c5b6..c3bff19b01 100644
--- 1/tests/src/org.apache.maven.plugins/maven-source-plugin/2.2.1/user-code-filter.json
+++ 2/tests/src/org.apache.maven.plugins/maven-source-plugin/3.1.0/user-code-filter.json
@@ -6,6 +6,9 @@
     {
       "includeClasses" : "org.apache.maven.plugin.source.**"
     },
+    {
+      "includeClasses" : "org.apache.maven.plugins.source.**"
+    },
     {
       "includeClasses" : "org_apache_maven_plugins.maven_source_plugin.**"
     }

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
