### PR TITLE
Block PRs with scaffold placeholder tests

### DIFF
--- a/forge/ai_workflows/add_new_library_support.py
+++ b/forge/ai_workflows/add_new_library_support.py
@@ -549,6 +549,7 @@ def main(argv=None):
         checkpoint_commit_hash=checkpoint_commit_hash,
     )
 
+    scaffold_placeholder_quality_gate_failed = False
     generated_test_validity_gate_failed = False
     if workflow_status in {RUN_STATUS_SUCCESS, RUN_STATUS_CHUNK_READY}:
         placeholder_cleanup = cleanup_scaffold_placeholder_tests(
@@ -565,9 +566,10 @@ def main(argv=None):
             for occurrence in placeholder_cleanup.remaining_placeholders:
                 log_stage(
                     "scaffold-cleanup",
-                    f"WARNING: Scaffold placeholder test remains in generated sources: "
+                    f"ERROR: Scaffold placeholder test remains in generated sources: "
                     f"{format_placeholder_occurrence(occurrence, reachability_repo_path)}",
                 )
+            scaffold_placeholder_quality_gate_failed = True
         generated_test_validity_issues = collect_generated_test_validity_issues(test_source_layout.source_root)
         for issue in generated_test_validity_issues:
             generated_test_validity_gate_failed = True
@@ -576,7 +578,7 @@ def main(argv=None):
                 "WARNING: Suspicious generated test target requires human review: "
                 f"{format_generated_test_validity_issue(issue, reachability_repo_path)}",
             )
-    if generated_test_validity_gate_failed:
+    if scaffold_placeholder_quality_gate_failed or generated_test_validity_gate_failed:
         workflow_status = RUN_STATUS_FAILURE
 
     if workflow_status in {RUN_STATUS_SUCCESS, RUN_STATUS_CHUNK_READY}:
@@ -612,7 +614,20 @@ def main(argv=None):
     else:
         log_stage("status", "Test generation failed")
 
-    if unittest_number == 0 and workflow_status != SUCCESS_WITH_INTERVENTION_STATUS:
+    if scaffold_placeholder_quality_gate_failed:
+        log_stage("status", "Generated tests failed scaffold placeholder quality gate")
+        run_metrics = create_failure_run_metrics_output(
+            package=package,
+            artifact=artifact,
+            library_version=library_version,
+            agent=agent,
+            model_name=model_name,
+            global_iterations=global_iterations,
+            strategy_name=strategy_name,
+            starting_commit=checkpoint_commit_hash,
+            ending_commit=ending_commit_hash,
+        )
+    elif unittest_number == 0 and workflow_status != SUCCESS_WITH_INTERVENTION_STATUS:
         log_stage("status", "No valid unit test generated")
         run_metrics = create_failure_run_metrics_output(
             package=package,

--- a/forge/git_scripts/make_pr_new_library_support.py
+++ b/forge/git_scripts/make_pr_new_library_support.py
@@ -45,7 +45,9 @@ from utility_scripts.local_ci_verification import (
 from utility_scripts.repo_path_resolver import resolve_repo_roots
 from utility_scripts.test_quality_checks import (
     collect_generated_test_validity_issues,
+    find_scaffold_placeholder_occurrences,
     format_generated_test_validity_issue,
+    format_placeholder_occurrence,
 )
 
 REPO = "oracle/graalvm-reachability-metadata"
@@ -627,6 +629,19 @@ def validate_run_quality(coordinates: str, metrics_repo_path: str, repo_path: st
         raise ValueError(f"Refusing to create PR for {coordinates}: {details}")
 
 
+def validate_no_scaffold_placeholders(coordinates: str, repo_path: str) -> None:
+    """Raise ValueError if generated tests still contain scaffold placeholder text."""
+    group, artifact, library_version = parse_coordinate_parts(coordinates)
+    module_dir = os.path.join(repo_path, "tests", "src", group, artifact, library_version)
+    occurrences = find_scaffold_placeholder_occurrences(module_dir)
+    if occurrences:
+        details = ", ".join(
+            format_placeholder_occurrence(occurrence, repo_path)
+            for occurrence in occurrences
+        )
+        raise ValueError(f"Refusing to create PR for {coordinates}: scaffold placeholder remains in {details}")
+
+
 def main(argv=None):
     (
         coordinates,
@@ -641,6 +656,7 @@ def main(argv=None):
 
     ensure_gh_authenticated()
     validate_run_quality(coordinates, metrics_repo_path, repo_path)
+    validate_no_scaffold_placeholders(coordinates, repo_path)
 
     branch = push_current_branch_to_origin(
         coordinates=coordinates,

--- a/forge/tests/test_make_pr_new_library_support.py
+++ b/forge/tests/test_make_pr_new_library_support.py
@@ -13,6 +13,7 @@ from git_scripts.make_pr_new_library_support import (
     DynamicAccessMetadataEvidence,
     build_pull_request_body,
     load_dynamic_access_metadata_evidence,
+    validate_no_scaffold_placeholders,
     validate_run_quality,
 )
 
@@ -233,6 +234,7 @@ class MakePrNewLibrarySupportTests(unittest.TestCase):
                     },
                     file,
                 )
+
             test_file = os.path.join(
                 repo_path,
                 "tests",
@@ -266,6 +268,39 @@ class ReflectorTest {
 
             with self.assertRaisesRegex(ValueError, "suspicious generated test target"):
                 validate_run_quality("plexus:plexus-utils:1.0.2", metrics_repo_path, repo_path)
+
+    def test_validate_no_scaffold_placeholders_rejects_placeholder_text(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path:
+            test_file = os.path.join(
+                repo_path,
+                "tests",
+                "src",
+                "org.example",
+                "demo",
+                "1.0.0",
+                "src",
+                "test",
+                "java",
+                "org_example",
+                "demo",
+                "DemoTest.java",
+            )
+            os.makedirs(os.path.dirname(test_file), exist_ok=True)
+            with open(test_file, "w", encoding="utf-8") as file:
+                file.write(
+                    """
+package org_example.demo;
+
+class DemoTest {
+    void test() {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}
+""",
+                )
+
+            with self.assertRaisesRegex(ValueError, "scaffold placeholder remains"):
+                validate_no_scaffold_placeholders("org.example:demo:1.0.0", repo_path)
 
 
 if __name__ == "__main__":

--- a/forge/tests/test_test_quality_checks.py
+++ b/forge/tests/test_test_quality_checks.py
@@ -12,6 +12,7 @@ from utility_scripts.test_quality_checks import (
     SCAFFOLD_PLACEHOLDER_TEXT,
     cleanup_scaffold_placeholder_tests,
     collect_generated_test_validity_issues,
+    find_scaffold_placeholder_occurrences,
     format_generated_test_validity_issue,
     format_placeholder_occurrence,
 )
@@ -111,6 +112,75 @@ public class ExampleTest {
 }
 """,
             )
+
+            result = cleanup_scaffold_placeholder_tests(tmp_dir, tmp_dir, scaffold_commit)
+
+            self.assertEqual(result.removed_files, [placeholder_file])
+            self.assertFalse(os.path.exists(placeholder_file))
+            self.assertEqual(result.remaining_placeholders, [])
+
+    def test_removes_changed_scaffold_when_throws_clause_is_removed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            self._init_git_repo(tmp_dir)
+            placeholder_file = os.path.join(tmp_dir, "ExampleTest.java")
+            self._write_file(
+                placeholder_file,
+                """
+package org.example;
+
+import org.junit.jupiter.api.Test;
+
+class ExampleTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}
+""",
+            )
+            scaffold_commit = self._commit_all(tmp_dir, "scaffold")
+            self._write_file(
+                placeholder_file,
+                """
+package org.example;
+
+import org.junit.jupiter.api.Test;
+
+public class ExampleTest {
+    @Test
+    void test() {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}
+""",
+            )
+
+            result = cleanup_scaffold_placeholder_tests(tmp_dir, tmp_dir, scaffold_commit)
+
+            self.assertEqual(result.removed_files, [placeholder_file])
+            self.assertFalse(os.path.exists(placeholder_file))
+            self.assertEqual(result.remaining_placeholders, [])
+
+    def test_removes_groovy_scaffold_placeholder(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            self._init_git_repo(tmp_dir)
+            placeholder_file = os.path.join(tmp_dir, "ExampleTest.groovy")
+            self._write_file(
+                placeholder_file,
+                """
+package org.example
+
+import org.junit.jupiter.api.Test
+
+class ExampleTest {
+    @Test
+    void test() {
+        println "This is just a placeholder, implement your test"
+    }
+}
+""",
+            )
+            scaffold_commit = self._commit_all(tmp_dir, "scaffold")
 
             result = cleanup_scaffold_placeholder_tests(tmp_dir, tmp_dir, scaffold_commit)
 
@@ -246,6 +316,71 @@ class ParserTest {
             issues = collect_generated_test_validity_issues(tmp_dir)
 
             self.assertEqual(issues, [])
+
+    def test_reports_placeholder_copied_after_scaffold_commit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            self._init_git_repo(tmp_dir)
+            scaffold_file = os.path.join(tmp_dir, "ExampleTest.java")
+            copied_file = os.path.join(tmp_dir, "CopiedTest.java")
+            self._write_file(
+                scaffold_file,
+                """
+package org.example;
+
+import org.junit.jupiter.api.Test;
+
+class ExampleTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}
+""",
+            )
+            scaffold_commit = self._commit_all(tmp_dir, "scaffold")
+            self._write_file(
+                copied_file,
+                """
+package org.example;
+
+import org.junit.jupiter.api.Test;
+
+class CopiedTest {
+    @Test
+    void copied() {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}
+""",
+            )
+
+            result = cleanup_scaffold_placeholder_tests(tmp_dir, tmp_dir, scaffold_commit)
+
+            self.assertEqual(result.removed_files, [scaffold_file])
+            self.assertFalse(os.path.exists(scaffold_file))
+            self.assertEqual(len(result.remaining_placeholders), 1)
+            self.assertEqual(result.remaining_placeholders[0].file_path, copied_file)
+
+    def test_finds_placeholders_without_scaffold_commit_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            placeholder_file = os.path.join(tmp_dir, "src", "ExampleTest.java")
+            self._write_file(
+                placeholder_file,
+                """
+package org.example;
+
+class ExampleTest {
+    void copied() {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}
+""",
+            )
+
+            occurrences = find_scaffold_placeholder_occurrences(tmp_dir)
+
+            self.assertEqual(len(occurrences), 1)
+            self.assertEqual(occurrences[0].file_path, placeholder_file)
 
     @staticmethod
     def _write_file(file_path: str, content: str) -> None:

--- a/forge/tests/test_test_quality_checks.py
+++ b/forge/tests/test_test_quality_checks.py
@@ -223,7 +223,7 @@ class MixedTest {{
             self.assertTrue(os.path.exists(placeholder_file))
             self.assertEqual(len(result.remaining_placeholders), 1)
 
-    def test_reports_placeholder_when_only_test_is_not_scaffold_method(self) -> None:
+    def test_removes_placeholder_when_only_test_method_is_renamed(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             self._init_git_repo(tmp_dir)
             placeholder_file = os.path.join(tmp_dir, "ExampleTest.java")
@@ -261,9 +261,9 @@ class ExampleTest {
 
             result = cleanup_scaffold_placeholder_tests(tmp_dir, tmp_dir, scaffold_commit)
 
-            self.assertEqual(result.removed_files, [])
-            self.assertTrue(os.path.exists(placeholder_file))
-            self.assertEqual(len(result.remaining_placeholders), 1)
+            self.assertEqual(result.removed_files, [placeholder_file])
+            self.assertFalse(os.path.exists(placeholder_file))
+            self.assertEqual(result.remaining_placeholders, [])
 
     def test_reports_version_specific_broken_behavior_exception_target(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/forge/utility_scripts/test_quality_checks.py
+++ b/forge/utility_scripts/test_quality_checks.py
@@ -10,10 +10,10 @@ import subprocess
 
 
 SCAFFOLD_PLACEHOLDER_TEXT = "This is just a placeholder, implement your test"
-TEST_SOURCE_EXTENSIONS = (".java", ".kt", ".scala")
+TEST_SOURCE_EXTENSIONS = (".java", ".kt", ".scala", ".groovy")
 SCAFFOLD_PLACEHOLDER_TEST_PATTERNS = (
     re.compile(
-        r"@Test\s+(?:public\s+)?void\s+test\s*\(\s*\)\s+throws\s+Exception\s*\{\s*"
+        r"@Test\s+(?:public\s+)?void\s+test\s*\(\s*\)\s*(?:throws\s+Exception\s*)?\{\s*"
         + re.escape(f'System.out.println("{SCAFFOLD_PLACEHOLDER_TEXT}");')
         + r"\s*\}"
     ),
@@ -25,6 +25,11 @@ SCAFFOLD_PLACEHOLDER_TEST_PATTERNS = (
     re.compile(
         r"@Test\s+def\s+test\s*\(\s*\)\s*:\s*Unit\s*=\s*\{\s*"
         + re.escape(f'println("{SCAFFOLD_PLACEHOLDER_TEXT}")')
+        + r"\s*\}"
+    ),
+    re.compile(
+        r"@Test\s+(?:public\s+)?void\s+test\s*\(\s*\)\s*\{\s*"
+        + re.escape(f'println "{SCAFFOLD_PLACEHOLDER_TEXT}"')
         + r"\s*\}"
     ),
 )
@@ -109,12 +114,11 @@ def cleanup_scaffold_placeholder_tests(
         os.remove(file_path)
         removed_files.append(file_path)
 
-    remaining_placeholders: list[PlaceholderOccurrence] = []
     removed_file_set = set(removed_files)
-    for file_path in placeholder_files:
-        if file_path in removed_file_set:
-            continue
-        remaining_placeholders.extend(_placeholder_occurrences(file_path))
+    remaining_placeholders = [
+        occurrence for occurrence in find_scaffold_placeholder_occurrences(test_source_root)
+        if occurrence.file_path not in removed_file_set
+    ]
 
     return ScaffoldPlaceholderCleanupResult(removed_files, remaining_placeholders)
 
@@ -124,6 +128,20 @@ def format_placeholder_occurrence(occurrence: PlaceholderOccurrence, repo_path: 
     if repo_path:
         display_path = os.path.relpath(occurrence.file_path, repo_path)
     return f"{display_path}:{occurrence.line_number}"
+
+
+def find_scaffold_placeholder_occurrences(test_source_root: str) -> list[PlaceholderOccurrence]:
+    """Return all scaffold placeholder text occurrences in generated test sources."""
+    if not os.path.isdir(test_source_root):
+        return []
+
+    occurrences: list[PlaceholderOccurrence] = []
+    for root_dir, _, file_names in os.walk(test_source_root):
+        for file_name in file_names:
+            if not file_name.endswith(TEST_SOURCE_EXTENSIONS):
+                continue
+            occurrences.extend(_placeholder_occurrences(os.path.join(root_dir, file_name)))
+    return occurrences
 
 
 def collect_generated_test_validity_issues(test_source_root: str) -> list[GeneratedTestValidityIssue]:

--- a/forge/utility_scripts/test_quality_checks.py
+++ b/forge/utility_scripts/test_quality_checks.py
@@ -11,28 +11,6 @@ import subprocess
 
 SCAFFOLD_PLACEHOLDER_TEXT = "This is just a placeholder, implement your test"
 TEST_SOURCE_EXTENSIONS = (".java", ".kt", ".scala", ".groovy")
-SCAFFOLD_PLACEHOLDER_TEST_PATTERNS = (
-    re.compile(
-        r"@Test\s+(?:public\s+)?void\s+test\s*\(\s*\)\s*(?:throws\s+Exception\s*)?\{\s*"
-        + re.escape(f'System.out.println("{SCAFFOLD_PLACEHOLDER_TEXT}");')
-        + r"\s*\}"
-    ),
-    re.compile(
-        r"@Test\s+fun\s+test\s*\(\s*\)\s*\{\s*"
-        + re.escape(f'println("{SCAFFOLD_PLACEHOLDER_TEXT}")')
-        + r"\s*\}"
-    ),
-    re.compile(
-        r"@Test\s+def\s+test\s*\(\s*\)\s*:\s*Unit\s*=\s*\{\s*"
-        + re.escape(f'println("{SCAFFOLD_PLACEHOLDER_TEXT}")')
-        + r"\s*\}"
-    ),
-    re.compile(
-        r"@Test\s+(?:public\s+)?void\s+test\s*\(\s*\)\s*\{\s*"
-        + re.escape(f'println "{SCAFFOLD_PLACEHOLDER_TEXT}"')
-        + r"\s*\}"
-    ),
-)
 TEST_ANNOTATION_PATTERN = re.compile(r"(?m)^\s*@Test\b")
 TEST_BLOCK_ANNOTATION_PATTERN = re.compile(
     r"(?m)^\s*@(?:Test|ParameterizedTest|RepeatedTest|TestFactory|TestTemplate)\b"
@@ -106,7 +84,7 @@ def cleanup_scaffold_placeholder_tests(
     ]
     scaffold_files = [
         file_path for file_path in placeholder_files
-        if _contains_only_scaffold_junit_placeholder_test(file_path)
+        if _contains_only_scaffold_placeholder_test(file_path)
     ]
 
     removed_files: list[str] = []
@@ -219,14 +197,14 @@ def _placeholder_occurrences(file_path: str) -> list[PlaceholderOccurrence]:
     return occurrences
 
 
-def _contains_only_scaffold_junit_placeholder_test(file_path: str) -> bool:
+def _contains_only_scaffold_placeholder_test(file_path: str) -> bool:
     try:
         with open(file_path, "r", encoding="utf-8") as source_file:
             source = source_file.read()
     except OSError:
         return False
     return (
-        any(pattern.search(source) for pattern in SCAFFOLD_PLACEHOLDER_TEST_PATTERNS)
+        SCAFFOLD_PLACEHOLDER_TEXT in source
         and len(TEST_ANNOTATION_PATTERN.findall(source)) == 1
     )
 


### PR DESCRIPTION
## Summary

- make remaining scaffold placeholder tests a fatal Forge quality gate
- scan generated test sources for placeholder text after cleanup
- add a PR creation backstop and regression coverage for escaped placeholder shapes

## Testing

- PYTHONPATH=$PWD/forge python3 -m unittest forge.tests.test_test_quality_checks forge.tests.test_make_pr_new_library_support
- python3 -m py_compile forge/utility_scripts/test_quality_checks.py forge/ai_workflows/add_new_library_support.py forge/git_scripts/make_pr_new_library_support.py forge/tests/test_test_quality_checks.py forge/tests/test_make_pr_new_library_support.py

Fixes #7521