### PR TITLE
Fix stale latest metadata index markers

### DIFF
--- a/metadata/ch.qos.logback/logback-classic/index.json
+++ b/metadata/ch.qos.logback/logback-classic/index.json
@@ -90,7 +90,6 @@
     ]
   },
   {
-    "latest" : true,
     "metadata-version" : "1.5.26",
     "source-code-url" : "https://repo1.maven.org/maven2/ch/qos/logback/logback-classic/$version$/logback-classic-$version$-sources.jar",
     "repository-url" : "https://github.com/qos-ch/logback",
@@ -106,6 +105,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "1.5.28",
     "source-code-url" : "https://repo1.maven.org/maven2/ch/qos/logback/logback-classic/$version$/logback-classic-$version$-sources.jar",
     "repository-url" : "https://github.com/qos-ch/logback",

--- a/metadata/ch.qos.logback/logback-core/index.json
+++ b/metadata/ch.qos.logback/logback-core/index.json
@@ -28,7 +28,6 @@
     ]
   },
   {
-    "latest" : true,
     "metadata-version" : "1.5.26",
     "source-code-url" : "https://repo1.maven.org/maven2/ch/qos/logback/logback-core/$version$/logback-core-$version$-sources.jar",
     "repository-url" : "https://github.com/qos-ch/logback",
@@ -46,6 +45,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "1.5.32",
     "source-code-url" : "https://repo1.maven.org/maven2/ch/qos/logback/logback-core/$version$/logback-core-$version$-sources.jar",
     "repository-url" : "https://github.com/qos-ch/logback",

--- a/metadata/com.beust/jcommander/index.json
+++ b/metadata/com.beust/jcommander/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "metadata-version" : "1.72",
     "source-code-url" : "https://repo1.maven.org/maven2/com/beust/jcommander/$version$/jcommander-$version$-sources.jar",
     "repository-url" : "https://github.com/cbeust/jcommander",
@@ -15,6 +14,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "1.82",
     "source-code-url" : "https://repo1.maven.org/maven2/com/beust/jcommander/$version$/jcommander-$version$-sources.jar",
     "repository-url" : "https://github.com/cbeust/jcommander",

--- a/metadata/com.graphql-java/graphql-java-extended-validation/index.json
+++ b/metadata/com.graphql-java/graphql-java-extended-validation/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest": true,
     "allowed-packages": [
       "graphql"
     ],
@@ -22,6 +21,7 @@
     "allowed-packages": [
       "graphql"
     ],
+    "latest": true,
     "metadata-version": "19.2",
     "tested-versions": [
       "19.2"

--- a/metadata/com.squareup.okhttp3/okhttp/index.json
+++ b/metadata/com.squareup.okhttp3/okhttp/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "metadata-version" : "3.6.0",
     "source-code-url" : "https://repo1.maven.org/maven2/com/squareup/okhttp3/okhttp/$version$/okhttp-$version$-sources.jar",
     "repository-url" : "https://github.com/square/okhttp",
@@ -15,6 +14,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "3.8.0",
     "source-code-url" : "https://repo1.maven.org/maven2/com/squareup/okhttp3/okhttp/$version$/okhttp-$version$-sources.jar",
     "repository-url" : "https://github.com/square/okhttp",

--- a/metadata/commons-configuration/commons-configuration/index.json
+++ b/metadata/commons-configuration/commons-configuration/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "metadata-version" : "1.7",
     "source-code-url" : "https://repo.maven.apache.org/maven2/commons-configuration/commons-configuration/$version$/commons-configuration-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/commons-configuration",
@@ -15,6 +14,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "1.8",
     "source-code-url" : "https://repo.maven.apache.org/maven2/commons-configuration/commons-configuration/$version$/commons-configuration-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/commons-configuration",

--- a/metadata/io.grpc/grpc-xds/index.json
+++ b/metadata/io.grpc/grpc-xds/index.json
@@ -14,7 +14,6 @@
     ]
   },
   {
-    "latest" : true,
     "metadata-version" : "1.71.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/grpc/grpc-xds/$version$/grpc-xds-$version$-sources.jar",
     "repository-url" : "https://github.com/grpc/grpc-java",
@@ -40,6 +39,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "1.81.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/grpc/grpc-xds/$version$/grpc-xds-$version$-sources.jar",
     "repository-url" : "https://github.com/grpc/grpc-java",

--- a/metadata/io.vertx/vertx-core/index.json
+++ b/metadata/io.vertx/vertx-core/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "metadata-version" : "4.4.2",
     "source-code-url" : "https://repo1.maven.org/maven2/io/vertx/vertx-core/$version$/vertx-core-$version$-sources.jar",
     "repository-url" : "https://github.com/eclipse-vertx/vert.x",
@@ -50,6 +49,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "5.0.4",
     "source-code-url" : "https://repo1.maven.org/maven2/io/vertx/vertx-core/$version$/vertx-core-$version$-sources.jar",
     "repository-url" : "https://github.com/eclipse-vertx/vert.x",

--- a/metadata/jakarta.servlet.jsp.jstl/jakarta.servlet.jsp.jstl-api/index.json
+++ b/metadata/jakarta.servlet.jsp.jstl/jakarta.servlet.jsp.jstl-api/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "metadata-version" : "3.0.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/jakarta/servlet/jsp/jstl/jakarta.servlet.jsp.jstl-api/$version$/jakarta.servlet.jsp.jstl-api-$version$-sources.jar",
     "repository-url" : "https://github.com/jakartaee/tags",
@@ -17,6 +16,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "3.1.0-M1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/jakarta/servlet/jsp/jstl/jakarta.servlet.jsp.jstl-api/$version$/jakarta.servlet.jsp.jstl-api-$version$-sources.jar",
     "repository-url" : "https://github.com/jakartaee/tags",

--- a/metadata/jakarta.ws.rs/jakarta.ws.rs-api/index.json
+++ b/metadata/jakarta.ws.rs/jakarta.ws.rs-api/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "metadata-version" : "2.1.6",
     "source-code-url" : "https://repo.maven.apache.org/maven2/jakarta/ws/rs/jakarta.ws.rs-api/$version$/jakarta.ws.rs-api-$version$-sources.jar",
     "repository-url" : "https://github.com/jakartaee/rest",
@@ -15,6 +14,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "3.0.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/jakarta/ws/rs/jakarta.ws.rs-api/$version$/jakarta.ws.rs-api-$version$-sources.jar",
     "repository-url" : "https://github.com/jakartaee/rest",

--- a/metadata/net.minidev/json-smart/index.json
+++ b/metadata/net.minidev/json-smart/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "metadata-version" : "2.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/net/minidev/json-smart/$version$/json-smart-$version$-sources.jar",
     "repository-url" : "https://github.com/netplex/json-smart-v2",
@@ -16,6 +15,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "2.1.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/net/minidev/json-smart/$version$/json-smart-$version$-sources.jar",
     "repository-url" : "https://github.com/netplex/json-smart-v2",

--- a/metadata/org.aesh/readline/index.json
+++ b/metadata/org.aesh/readline/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "metadata-version" : "2.6",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/aesh/readline/$version$/readline-$version$-sources.jar",
     "repository-url" : "https://github.com/aeshell/aesh-readline",
@@ -15,6 +14,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "3.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/aesh/readline/$version$/readline-$version$-sources.jar",
     "repository-url" : "https://github.com/aeshell/aesh-readline",

--- a/metadata/org.apache.activemq/artemis-core-client/index.json
+++ b/metadata/org.apache.activemq/artemis-core-client/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "metadata-version" : "2.28.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/activemq/artemis-core-client/$version$/artemis-core-client-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/artemis",
@@ -15,6 +14,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "2.33.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/activemq/artemis-core-client/$version$/artemis-core-client-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/artemis",

--- a/metadata/org.apache.directory.api/api-ldap-model/index.json
+++ b/metadata/org.apache.directory.api/api-ldap-model/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "metadata-version" : "1.0.0-M20",
     "source-code-url" : "https://repo1.maven.org/maven2/org/apache/directory/api/api-ldap-model/$version$/api-ldap-model-$version$-sources.jar",
     "repository-url" : "https://svn.apache.org/repos/asf/directory/shared/",
@@ -29,6 +28,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "2.0.0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/apache/directory/api/api-ldap-model/$version$/api-ldap-model-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/directory-ldap-api",

--- a/metadata/org.apache.hadoop/hadoop-yarn-api/index.json
+++ b/metadata/org.apache.hadoop/hadoop-yarn-api/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "metadata-version" : "2.2.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/hadoop/hadoop-yarn-api/$version$/hadoop-yarn-api-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/hadoop",
@@ -15,6 +14,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "2.6.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/hadoop/hadoop-yarn-api/$version$/hadoop-yarn-api-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/hadoop",

--- a/metadata/org.apache.hadoop/hadoop-yarn-server-common/index.json
+++ b/metadata/org.apache.hadoop/hadoop-yarn-server-common/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "metadata-version" : "2.7.3",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/hadoop/hadoop-yarn-server-common/$version$/hadoop-yarn-server-common-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/hadoop",
@@ -16,6 +15,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "2.8.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/hadoop/hadoop-yarn-server-common/$version$/hadoop-yarn-server-common-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/hadoop",

--- a/metadata/org.apache.maven.doxia/doxia-core/index.json
+++ b/metadata/org.apache.maven.doxia/doxia-core/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "metadata-version" : "1.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-core/$version$/doxia-core-$version$-sources.jar",
     "repository-url" : "https://svn.apache.org/repos/asf/maven/doxia/doxia",
@@ -25,6 +24,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "1.7",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-core/$version$/doxia-core-$version$-sources.jar",
     "repository-url" : "https://svn.apache.org/repos/asf/maven/doxia/doxia",

--- a/metadata/org.apache.maven.plugins/maven-jar-plugin/index.json
+++ b/metadata/org.apache.maven.plugins/maven-jar-plugin/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "metadata-version" : "3.2.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/$version$/maven-jar-plugin-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/maven-jar-plugin",
@@ -15,6 +14,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "3.2.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/$version$/maven-jar-plugin-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/maven-jar-plugin",

--- a/metadata/org.apache.maven.plugins/maven-source-plugin/index.json
+++ b/metadata/org.apache.maven.plugins/maven-source-plugin/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "metadata-version" : "2.2.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-source-plugin/$version$/maven-source-plugin-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/maven-source-plugin",
@@ -15,6 +14,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "3.1.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-source-plugin/$version$/maven-source-plugin-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/maven-source-plugin",

--- a/metadata/org.apache.orc/orc-mapreduce/index.json
+++ b/metadata/org.apache.orc/orc-mapreduce/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "metadata-version" : "1.7.8",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/orc/orc-mapreduce/$version$/orc-mapreduce-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/orc",
@@ -29,6 +28,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "1.9.5",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/orc/orc-mapreduce/$version$/orc-mapreduce-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/orc",

--- a/metadata/org.apache.pekko/pekko-protobuf-v3_2.13/index.json
+++ b/metadata/org.apache.pekko/pekko-protobuf-v3_2.13/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "metadata-version" : "1.6.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/pekko/pekko-protobuf-v3_2.13/$version$/pekko-protobuf-v3_2.13-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/pekko",
@@ -20,6 +19,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "2.0.0-M2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/pekko/pekko-protobuf-v3_2.13/$version$/pekko-protobuf-v3_2.13-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/pekko",

--- a/metadata/org.codehaus.plexus/plexus-container-default/index.json
+++ b/metadata/org.codehaus.plexus/plexus-container-default/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "metadata-version" : "1.0-alpha-7",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/$version$/plexus-container-default-$version$-sources.jar",
     "repository-url" : "https://github.com/codehaus-plexus/plexus-containers",
@@ -15,6 +14,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "1.0-alpha-8",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/$version$/plexus-container-default-$version$-sources.jar",
     "repository-url" : "https://github.com/codehaus-plexus/plexus-containers",

--- a/metadata/org.codehaus.plexus/plexus-java/index.json
+++ b/metadata/org.codehaus.plexus/plexus-java/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "metadata-version" : "0.9.10",
     "source-code-url" : "https://repo1.maven.org/maven2/org/codehaus/plexus/plexus-java/$version$/plexus-java-$version$-sources.jar",
     "repository-url" : "https://github.com/codehaus-plexus/plexus-languages",
@@ -15,6 +14,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "1.0.0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/codehaus/plexus/plexus-java/$version$/plexus-java-$version$-sources.jar",
     "repository-url" : "https://github.com/codehaus-plexus/plexus-languages",

--- a/metadata/org.codehaus.plexus/plexus-utils/index.json
+++ b/metadata/org.codehaus.plexus/plexus-utils/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "metadata-version" : "1.5.7",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/$version$/plexus-utils-$version$-sources.jar",
     "repository-url" : "https://github.com/codehaus-plexus/plexus-utils",
@@ -15,6 +14,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "3.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/$version$/plexus-utils-$version$-sources.jar",
     "repository-url" : "https://github.com/sonatype/plexus-utils",

--- a/metadata/org.eclipse.sisu/org.eclipse.sisu.inject/index.json
+++ b/metadata/org.eclipse.sisu/org.eclipse.sisu.inject/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "metadata-version" : "0.3.0.M1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.inject/$version$/org.eclipse.sisu.inject-$version$-sources.jar",
     "repository-url" : "https://github.com/eclipse-sisu/sisu-project",
@@ -16,6 +15,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "0.3.4",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.inject/$version$/org.eclipse.sisu.inject-$version$-sources.jar",
     "repository-url" : "https://github.com/eclipse-sisu/sisu-project",

--- a/metadata/org.glassfish.grizzly/grizzly-http-servlet/index.json
+++ b/metadata/org.glassfish.grizzly/grizzly-http-servlet/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "metadata-version" : "2.1.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/glassfish/grizzly/grizzly-http-servlet/$version$/grizzly-http-servlet-$version$-sources.jar",
     "repository-url" : "https://github.com/javaee/grizzly",
@@ -19,6 +18,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "2.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/glassfish/grizzly/grizzly-http-servlet/$version$/grizzly-http-servlet-$version$-sources.jar",
     "repository-url" : "https://github.com/javaee/grizzly",

--- a/metadata/org.glassfish.jersey.containers/jersey-container-servlet/index.json
+++ b/metadata/org.glassfish.jersey.containers/jersey-container-servlet/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "metadata-version" : "2.34",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/glassfish/jersey/containers/jersey-container-servlet/$version$/jersey-container-servlet-$version$-sources.jar",
     "repository-url" : "https://github.com/eclipse-ee4j/jersey",
@@ -61,6 +60,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "5.0.0-M1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/glassfish/jersey/containers/jersey-container-servlet/$version$/jersey-container-servlet-$version$-sources.jar",
     "repository-url" : "https://github.com/eclipse-ee4j/jersey",

--- a/metadata/org.hibernate.orm/hibernate-core/index.json
+++ b/metadata/org.hibernate.orm/hibernate-core/index.json
@@ -11,6 +11,7 @@
       "org.mariadb.jdbc.Driver",
       "org.postgresql.Driver"
     ],
+    "latest": true,
     "metadata-version": "8.0.0.Alpha1",
     "test-version": "7.1.0.Final",
     "tested-versions": [
@@ -23,7 +24,6 @@
     "description": "Hibernate ORM maps Java objects to relational database tables and provides the core runtime for persistence, querying, and transaction management. It implements Jakarta Persistence (JPA) while also exposing native Hibernate APIs and extension points for advanced ORM use cases."
   },
   {
-    "latest": true,
     "default-for": "7\\.3\\..*",
     "allowed-packages": [
       "com.microsoft.sqlserver.jdbc.SQLServerDriver",

--- a/metadata/org.jboss.threads/jboss-threads/index.json
+++ b/metadata/org.jboss.threads/jboss-threads/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "metadata-version" : "2.3.6.Final",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/jboss/threads/jboss-threads/$version$/jboss-threads-$version$-sources.jar",
     "repository-url" : "https://github.com/jboss/jboss-threads",
@@ -15,6 +14,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "3.1.1.Final",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/jboss/threads/jboss-threads/$version$/jboss-threads-$version$-sources.jar",
     "repository-url" : "https://github.com/jboss/jboss-threads",

--- a/metadata/org.jetbrains.exposed/exposed-core/index.json
+++ b/metadata/org.jetbrains.exposed/exposed-core/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "metadata-version" : "1.0.0-beta-4",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/jetbrains/exposed/exposed-core/$version$/exposed-core-$version$-sources.jar",
     "repository-url" : "https://github.com/JetBrains/Exposed",
@@ -19,6 +18,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "1.3.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/jetbrains/exposed/exposed-core/$version$/exposed-core-$version$-sources.jar",
     "repository-url" : "https://github.com/JetBrains/Exposed",

--- a/metadata/org.mongodb/mongodb-driver-core/index.json
+++ b/metadata/org.mongodb/mongodb-driver-core/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "metadata-version" : "4.11.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/mongodb/mongodb-driver-core/$version$/mongodb-driver-core-$version$-sources.jar",
     "repository-url" : "https://github.com/mongodb/mongo-java-driver",
@@ -19,6 +18,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "5.2.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/mongodb/mongodb-driver-core/$version$/mongodb-driver-core-$version$-sources.jar",
     "repository-url" : "https://github.com/mongodb/mongo-java-driver",

--- a/metadata/org.seleniumhq.selenium/selenium-manager/index.json
+++ b/metadata/org.seleniumhq.selenium/selenium-manager/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "metadata-version" : "4.9.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/seleniumhq/selenium/selenium-manager/$version$/selenium-manager-$version$-sources.jar",
     "repository-url" : "https://github.com/SeleniumHQ/selenium/",
@@ -15,6 +14,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "4.12.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/seleniumhq/selenium/selenium-manager/$version$/selenium-manager-$version$-sources.jar",
     "repository-url" : "https://github.com/SeleniumHQ/selenium/",

--- a/metadata/org.seleniumhq.selenium/selenium-support/index.json
+++ b/metadata/org.seleniumhq.selenium/selenium-support/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "metadata-version" : "3.141.59",
     "source-code-url" : "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-support/$version$/selenium-support-$version$-sources.jar",
     "repository-url" : "https://github.com/SeleniumHQ/selenium",
@@ -50,6 +49,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "4.19.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/seleniumhq/selenium/selenium-support/$version$/selenium-support-$version$-sources.jar",
     "repository-url" : "https://github.com/SeleniumHQ/selenium",

--- a/metadata/org.springframework/spring-expression/index.json
+++ b/metadata/org.springframework/spring-expression/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "metadata-version" : "5.3.15",
     "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/spring-expression/$version$/spring-expression-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-framework",
@@ -88,6 +87,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "6.2.7",
     "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/spring-expression/$version$/spring-expression-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-framework",

--- a/metadata/org.springframework/spring-tx/index.json
+++ b/metadata/org.springframework/spring-tx/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "metadata-version" : "5.3.18",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/spring-tx/$version$/spring-tx-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-framework",
@@ -36,6 +35,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "6.0.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/spring-tx/$version$/spring-tx-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-framework",

--- a/metadata/redis.clients/jedis/index.json
+++ b/metadata/redis.clients/jedis/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "metadata-version" : "4.4.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/redis/clients/jedis/$version$/jedis-$version$-sources.jar",
     "repository-url" : "https://github.com/redis/jedis",
@@ -23,6 +22,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "5.0.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/redis/clients/jedis/$version$/jedis-$version$-sources.jar",
     "repository-url" : "https://github.com/redis/jedis",


### PR DESCRIPTION
Moves stale latest markers to the newest parseable supported metadata-version in affected metadata index.json files.

Validation:
- stale latest scan: stale=0, multiple_latest=0
- targeted checkMetadataFiles passed for all 36 updated latest coordinates
- git diff --check

Note: full checkMetadataFiles -Pcoordinates=all crashed the Gradle daemon with Java heap space on unrelated org.playframework:play-configuration_3:3.0.0.

Fixes #7538