### PR TITLE
[GenAI] Test fix for org.apache.maven.plugins:maven-jar-plugin:3.3.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.maven.plugins/maven-jar-plugin/3.3.0/reachability-metadata.json
+++ b/metadata/org.apache.maven.plugins/maven-jar-plugin/3.3.0/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.plugins.jar.HelpMojo"
+      },
+      "glob": "META-INF/maven/org.apache.maven.plugins/maven-jar-plugin/plugin-help.xml"
+    }
+  ]
+}

--- a/metadata/org.apache.maven.plugins/maven-jar-plugin/index.json
+++ b/metadata/org.apache.maven.plugins/maven-jar-plugin/index.json
@@ -1,5 +1,15 @@
 [
   {
+    "latest" : true,
+    "metadata-version" : "3.3.0",
+    "tested-versions" : [
+      "3.3.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.maven.plugins.jar"
+    ]
+  },
+  {
     "metadata-version" : "3.2.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/$version$/maven-jar-plugin-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/maven-jar-plugin",
@@ -14,7 +24,6 @@
     ]
   },
   {
-    "latest" : true,
     "metadata-version" : "3.2.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/$version$/maven-jar-plugin-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/maven-jar-plugin",

--- a/metadata/org.apache.maven.plugins/maven-jar-plugin/index.json
+++ b/metadata/org.apache.maven.plugins/maven-jar-plugin/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "3.3.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/$version$/maven-jar-plugin-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/maven-jar-plugin",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/$version$/maven-jar-plugin-$version$-source-release.zip",
+    "documentation-url" : "https://maven.apache.org/plugins-archives/maven-jar-plugin-$version$/",
+    "description" : "Apache Maven JAR Plugin builds Java Archive (JAR) files from a Maven project's compiled classes and resources. It also provides goals for packaging the main artifact and attaching a test JAR containing test classes.",
     "tested-versions" : [
       "3.3.0"
     ],

--- a/stats/org.apache.maven.plugins/maven-jar-plugin/3.3.0/execution-metrics.json
+++ b/stats/org.apache.maven.plugins/maven-jar-plugin/3.3.0/execution-metrics.json
@@ -1,0 +1,99 @@
+{
+  "fix_javac_fail:2026-05-22": {
+    "timestamp": "2026-05-22T10:44:43.615764Z",
+    "library": "org.apache.maven.plugins:maven-jar-plugin:3.3.0",
+    "starting_commit": "dd96c8456f9bf265d499ddf11d252b572f7dc96d",
+    "ending_commit": "b112509efb5f45e631a23c450980e542fb8cc055",
+    "previous_library": "org.apache.maven.plugins:maven-jar-plugin:3.2.2",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.3.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 538,
+          "missed": 671,
+          "ratio": 0.444996,
+          "total": 1209
+        },
+        "line": {
+          "covered": 102,
+          "missed": 125,
+          "ratio": 0.449339,
+          "total": 227
+        },
+        "method": {
+          "covered": 14,
+          "missed": 21,
+          "ratio": 0.4,
+          "total": 35
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.2.2",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 559,
+          "missed": 687,
+          "ratio": 0.448636,
+          "total": 1246
+        },
+        "line": {
+          "covered": 106,
+          "missed": 132,
+          "ratio": 0.445378,
+          "total": 238
+        },
+        "method": {
+          "covered": 14,
+          "missed": 21,
+          "ratio": 0.4,
+          "total": 35
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 18784,
+      "cached_input_tokens_used": 168448,
+      "output_tokens_used": 1872,
+      "iterations": 1,
+      "cost_usd": 0.1404,
+      "tested_library_loc": 102,
+      "metadata_entries": 1,
+      "previous_library_metadata_entries": 6,
+      "code_coverage_percent": 44.93,
+      "previous_library_coverage_percent": 44.54
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.maven.plugins/maven-jar-plugin/3.3.0/src/test/java/org_apache_maven_plugins/maven_jar_plugin/HelpMojoTest.java",
+      "metadata_file": "metadata/org.apache.maven.plugins/maven-jar-plugin/3.3.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.maven.plugins/maven-jar-plugin/3.3.0/stats.json
+++ b/stats/org.apache.maven.plugins/maven-jar-plugin/3.3.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "3.3.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 1,
+      "totalCalls" : 1
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 538,
+        "missed" : 671,
+        "ratio" : 0.444996,
+        "total" : 1209
+      },
+      "line" : {
+        "covered" : 102,
+        "missed" : 125,
+        "ratio" : 0.449339,
+        "total" : 227
+      },
+      "method" : {
+        "covered" : 14,
+        "missed" : 21,
+        "ratio" : 0.4,
+        "total" : 35
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.3.0/.gitignore
+++ b/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.3.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.3.0/build.gradle
+++ b/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.3.0/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     testImplementation("org.apache.maven.plugins:maven-jar-plugin:$libraryVersion") {
         exclude group: "org.sonatype.sisu", module: "sisu-guice"
     }
+    testImplementation 'org.apache.maven:maven-plugin-api:3.2.5'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.3.0/build.gradle
+++ b/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.3.0/build.gradle
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation("org.apache.maven.plugins:maven-jar-plugin:$libraryVersion") {
+        exclude group: "org.sonatype.sisu", module: "sisu-guice"
+    }
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.3.0/gradle.properties
+++ b/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.3.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.maven.plugins:maven-jar-plugin:3.3.0
+library.version = 3.3.0
+metadata.dir = org.apache.maven.plugins/maven-jar-plugin/3.3.0/

--- a/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.3.0/settings.gradle
+++ b/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.3.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.maven.plugins.maven-jar-plugin_tests'

--- a/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.3.0/src/test/java/org_apache_maven_plugins/maven_jar_plugin/HelpMojoTest.java
+++ b/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.3.0/src/test/java/org_apache_maven_plugins/maven_jar_plugin/HelpMojoTest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_plugins.maven_jar_plugin;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.apache.maven.plugins.jar.HelpMojo;
+import org.junit.jupiter.api.Test;
+
+public class HelpMojoTest {
+    @Test
+    void executeLoadsPluginHelpResource() {
+        HelpMojo mojo = new HelpMojo();
+
+        assertThatCode(mojo::execute).doesNotThrowAnyException();
+    }
+}

--- a/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.3.0/user-code-filter.json
+++ b/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.3.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.maven.plugins.jar.**"
+    },
+    {
+      "includeClasses" : "org_apache_maven_plugins.maven_jar_plugin.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7462

This PR provides test fixes and new metadata for org.apache.maven.plugins:maven-jar-plugin:3.3.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 18784
- Cached input tokens: 168448
- Output tokens: 1872
- Metadata entries: 1
- Iterations: 1
- Library coverage percentage: 44.93
- Previous library version metadata entries: 6
- Previous library version coverage percentage: 44.54

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `d06b204e57b2b5ac6de5167e5d1cf9b9e06bee35`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.maven.plugins:maven-jar-plugin:3.2.2: 1/1 covered calls (100.00%)
- org.apache.maven.plugins:maven-jar-plugin:3.3.0: 1/1 covered calls (100.00%)

**Resources:**
- org.apache.maven.plugins:maven-jar-plugin:3.2.2: 1/1 covered calls (100.00%)
- org.apache.maven.plugins:maven-jar-plugin:3.3.0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.maven.plugins:maven-jar-plugin:3.2.2: 559/1246 (44.86%)
- org.apache.maven.plugins:maven-jar-plugin:3.3.0: 538/1209 (44.50%)

**Line:**
- org.apache.maven.plugins:maven-jar-plugin:3.2.2: 106/238 (44.54%)
- org.apache.maven.plugins:maven-jar-plugin:3.3.0: 102/227 (44.93%)

**Method:**
- org.apache.maven.plugins:maven-jar-plugin:3.2.2: 14/35 (40.00%)
- org.apache.maven.plugins:maven-jar-plugin:3.3.0: 14/35 (40.00%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.2.2/build.gradle 2/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.3.0/build.gradle
index 8f55f54f4f..0ee61ac065 100644
--- 1/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.2.2/build.gradle
+++ 2/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.3.0/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     testImplementation("org.apache.maven.plugins:maven-jar-plugin:$libraryVersion") {
         exclude group: "org.sonatype.sisu", module: "sisu-guice"
     }
+    testImplementation 'org.apache.maven:maven-plugin-api:3.2.5'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

```

### Local CI Verification

- Status: `success`
- Commands run: 14
- Fixup attempts: 0
