### PR TITLE
[GenAI] Test fix for org.clojure:google-closure-library-third-party:0.0-20160609-f42b4a24 using gpt-5.5

### DIFF
--- a/metadata/org.clojure/google-closure-library-third-party/0.0-20160609-f42b4a24/reachability-metadata.json
+++ b/metadata/org.clojure/google-closure-library-third-party/0.0-20160609-f42b4a24/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "resources" : [
+    {
+      "glob" : "goog/**"
+    },
+    {
+      "glob" : "README.md"
+    },
+    {
+      "glob" : "AUTHORS"
+    },
+    {
+      "glob" : "LICENSE"
+    }
+  ]
+}

--- a/metadata/org.clojure/google-closure-library-third-party/index.json
+++ b/metadata/org.clojure/google-closure-library-third-party/index.json
@@ -15,6 +15,15 @@
     ]
   },
   {
+    "metadata-version" : "0.0-20160609-f42b4a24",
+    "tested-versions" : [
+      "0.0-20160609-f42b4a24"
+    ],
+    "allowed-packages" : [
+      "org.clojure"
+    ]
+  },
+  {
     "metadata-version" : "0.0-20150505-021ed5b3",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/clojure/google-closure-library-third-party/$version$/google-closure-library-third-party-$version$-sources.jar",
     "repository-url" : "https://github.com/google/closure-library",

--- a/metadata/org.clojure/google-closure-library-third-party/index.json
+++ b/metadata/org.clojure/google-closure-library-third-party/index.json
@@ -16,6 +16,11 @@
   },
   {
     "metadata-version" : "0.0-20160609-f42b4a24",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/clojure/google-closure-library-third-party/$version$/google-closure-library-third-party-$version$-sources.jar",
+    "repository-url" : "https://github.com/google/closure-library",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/clojure/google-closure-library-third-party/$version$/google-closure-library-third-party-$version$-sources.jar",
+    "documentation-url" : "https://github.com/google/closure-library/blob/f42b4a24f312b9e8db04b558167b0e03e386338e/README.md",
+    "description" : "Google Closure Library Third-Party Extensions packages optional third-party JavaScript modules used with the Google Closure Library, including browser-side utilities such as Caja HTML handling, MochiKit async helpers, lorem ipsum data, SVG pan support, and Dojo DOM query code. This Maven artifact is a non-official ClojureScript-maintained distribution of those files for consumers that resolve Closure Library dependencies through Maven.",
     "tested-versions" : [
       "0.0-20160609-f42b4a24"
     ],

--- a/stats/org.clojure/google-closure-library-third-party/0.0-20160609-f42b4a24/execution-metrics.json
+++ b/stats/org.clojure/google-closure-library-third-party/0.0-20160609-f42b4a24/execution-metrics.json
@@ -1,0 +1,47 @@
+{
+  "fix_java_run_fail:2026-05-22": {
+    "timestamp": "2026-05-22T13:00:59.134770Z",
+    "library": "org.clojure:google-closure-library-third-party:0.0-20160609-f42b4a24",
+    "starting_commit": "be28ec310ed7820687640bfc825813b37d22a762",
+    "ending_commit": "73710cda33dc14e7eeeeda6a643a56f22ccdd6d1",
+    "previous_library": "org.clojure:google-closure-library-third-party:0.0-20250515-f04e4c0e",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "0.0-20160609-f42b4a24",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      }
+    },
+    "previous_library_stats": {
+      "version": "0.0-20250515-f04e4c0e",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 87648,
+      "cached_input_tokens_used": 629760,
+      "output_tokens_used": 6049,
+      "iterations": 1,
+      "cost_usd": 0.4964,
+      "tested_library_loc": 0,
+      "metadata_entries": 4,
+      "previous_library_metadata_entries": 4,
+      "code_coverage_percent": 100.0,
+      "previous_library_coverage_percent": 100.0
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.clojure/google-closure-library-third-party/0.0-20160609-f42b4a24/src/test/java/org_clojure/google_closure_library_third_party/Google_closure_library_third_partyTest.java",
+      "metadata_file": "metadata/org.clojure/google-closure-library-third-party/0.0-20160609-f42b4a24/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.clojure/google-closure-library-third-party/0.0-20160609-f42b4a24/stats.json
+++ b/stats/org.clojure/google-closure-library-third-party/0.0-20160609-f42b4a24/stats.json
@@ -1,0 +1,16 @@
+{
+  "versions" : [ {
+    "version" : "0.0-20160609-f42b4a24",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : "N/A",
+      "line" : "N/A",
+      "method" : "N/A"
+    }
+  } ]
+}

--- a/tests/src/org.clojure/google-closure-library-third-party/0.0-20160609-f42b4a24/.gitignore
+++ b/tests/src/org.clojure/google-closure-library-third-party/0.0-20160609-f42b4a24/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.clojure/google-closure-library-third-party/0.0-20160609-f42b4a24/build.gradle
+++ b/tests/src/org.clojure/google-closure-library-third-party/0.0-20160609-f42b4a24/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.clojure:google-closure-library-third-party:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.clojure/google-closure-library-third-party/0.0-20160609-f42b4a24/gradle.properties
+++ b/tests/src/org.clojure/google-closure-library-third-party/0.0-20160609-f42b4a24/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.clojure:google-closure-library-third-party:0.0-20160609-f42b4a24
+library.version = 0.0-20160609-f42b4a24
+metadata.dir = org.clojure/google-closure-library-third-party/0.0-20160609-f42b4a24/

--- a/tests/src/org.clojure/google-closure-library-third-party/0.0-20160609-f42b4a24/settings.gradle
+++ b/tests/src/org.clojure/google-closure-library-third-party/0.0-20160609-f42b4a24/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.clojure.google-closure-library-third-party_tests'

--- a/tests/src/org.clojure/google-closure-library-third-party/0.0-20160609-f42b4a24/src/test/java/org_clojure/google_closure_library_third_party/Google_closure_library_third_partyTest.java
+++ b/tests/src/org.clojure/google-closure-library-third-party/0.0-20160609-f42b4a24/src/test/java/org_clojure/google_closure_library_third_party/Google_closure_library_third_partyTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_clojure.google_closure_library_third_party;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+public class Google_closure_library_third_partyTest {
+    private static final List<String> DISTRIBUTED_RESOURCES = List.of(
+            "goog/dojo/dom/query.js",
+            "goog/dojo/dom/query_test.js",
+            "goog/dojo/dom/query_test_dom.html",
+            "goog/mochikit/BUILD",
+            "goog/mochikit/LICENSE",
+            "goog/mochikit/async/BUILD",
+            "goog/mochikit/async/deferred.js",
+            "goog/mochikit/async/deferred_async_test.js",
+            "goog/mochikit/async/deferred_async_test_dom.html",
+            "goog/mochikit/async/deferred_test.js",
+            "goog/mochikit/async/deferredlist.js",
+            "goog/mochikit/async/deferredlist_test.js",
+            "README.md",
+            "AUTHORS",
+            "LICENSE");
+
+    private static final Map<String, List<String>> MODULE_PROVIDES = Map.of(
+            "goog/mochikit/async/deferred.js",
+            List.of(
+                    "goog.async.Deferred",
+                    "goog.async.Deferred.AlreadyCalledError",
+                    "goog.async.Deferred.CanceledError"),
+            "goog/mochikit/async/deferredlist.js",
+            List.of("goog.async.DeferredList"),
+            "goog/dojo/dom/query.js",
+            List.of("goog.dom.query"));
+
+    @Test
+    void distributedResourceSetIsAvailableOnTheClasspath() throws IOException {
+        for (String resourcePath : DISTRIBUTED_RESOURCES) {
+            String resource = readResource(resourcePath);
+
+            assertThat(resource)
+                    .as("resource %s should be packaged and readable", resourcePath)
+                    .isNotBlank();
+        }
+    }
+
+    @Test
+    void closureModulesDeclareExpectedPublicNamespaces() throws IOException {
+        for (Map.Entry<String, List<String>> module : MODULE_PROVIDES.entrySet()) {
+            String source = readResource(module.getKey());
+
+            for (String providedNamespace : module.getValue()) {
+                assertThat(source)
+                        .as("%s should provide %s", module.getKey(), providedNamespace)
+                        .contains("goog.provide('" + providedNamespace + "')");
+            }
+        }
+    }
+
+    @Test
+    void closureModulesKeepExpectedThirdPartyIntegrationPoints() throws IOException {
+        assertThat(readResource("goog/mochikit/async/deferred.js"))
+                .contains("goog.require('goog.Promise')")
+                .contains("goog.async.Deferred.prototype.callback")
+                .contains("goog.async.Deferred.prototype.errback")
+                .contains("goog.async.Deferred.prototype.cancel")
+                .contains("goog.async.Deferred.prototype.then")
+                .contains("goog.async.Deferred.fromPromise")
+                .contains("goog.async.Deferred.when");
+
+        assertThat(readResource("goog/mochikit/async/deferredlist.js"))
+                .contains("goog.require('goog.async.Deferred')")
+                .contains("goog.async.DeferredList.prototype.handleCallback_")
+                .contains("goog.async.DeferredList.prototype.errback")
+                .contains("goog.async.DeferredList.gatherResults");
+
+        assertThat(readResource("goog/dojo/dom/query.js"))
+                .contains("goog.dom.query = (function()")
+                .contains("This code was ported from the Dojo Toolkit")
+                .contains("querySelectorAll")
+                .contains("goog.exportSymbol('goog.dom.query', goog.dom.query)")
+                .contains("goog.exportSymbol('goog.dom.query.pseudos', goog.dom.query.pseudos)");
+    }
+
+    @Test
+    void deferredModuleCoversCancellationErrorsAndPromiseIntegration() throws IOException {
+        assertThat(readResource("goog/mochikit/async/deferred.js"))
+                .contains("goog.define('goog.async.Deferred.STRICT_ERRORS', false)")
+                .contains("goog.define('goog.async.Deferred.LONG_STACK_TRACES', false)")
+                .contains("goog.async.Deferred.prototype.makeStackTraceLong_")
+                .contains("goog.async.Deferred.AlreadyCalledError.prototype.name = 'AlreadyCalledError'")
+                .contains("goog.async.Deferred.CanceledError.prototype.name = 'CanceledError'")
+                .contains("goog.Thenable.addImplementation(goog.async.Deferred)")
+                .contains("goog.async.Deferred.assertNoErrors = function()");
+    }
+
+    @Test
+    void dojoQuerySelectorEngineSupportsCssSelectorsAttributesAndPseudos() throws IOException {
+        assertThat(readResource("goog/dojo/dom/query.js"))
+                .contains("'*=': function(attr, value)")
+                .contains("'^=': function(attr, value)")
+                .contains("'$=': function(attr, value)")
+                .contains("'~=': function(attr, value)")
+                .contains("'|=': function(attr, value)")
+                .contains("'=': function(attr, value)")
+                .contains("'first-child': function()")
+                .contains("'last-child': function()")
+                .contains("'only-child': function(name, condition)")
+                .contains("'empty': function(name, condition)")
+                .contains("'contains': function(name, condition)")
+                .contains("'not': function(name, condition)")
+                .contains("'nth-child': function(name, condition)");
+    }
+
+    @Test
+    void bundledJavascriptFixturesReferenceThePackagedModules() throws IOException {
+        assertThat(readResource("goog/mochikit/async/deferred_test.js"))
+                .contains("goog.module('goog.async.deferredTest')")
+                .contains("const Deferred = goog.require('goog.async.Deferred')")
+                .contains("testNormal()")
+                .contains("testCancel()")
+                .contains("testDeferredDependencies()");
+
+        assertThat(readResource("goog/mochikit/async/deferred_async_test.js"))
+                .contains("goog.module('goog.async.deferredAsyncTest')")
+                .contains("const Deferred = goog.require('goog.async.Deferred')")
+                .contains("testErrorStack()");
+
+        assertThat(readResource("goog/mochikit/async/deferredlist_test.js"))
+                .contains("goog.module('goog.async.deferredListTest')")
+                .contains("const DeferredList = goog.require('goog.async.DeferredList')")
+                .contains("testDeferredList()")
+                .contains("testGatherResults()");
+
+        assertThat(readResource("goog/mochikit/async/deferred_async_test_dom.html"))
+                .contains("goog.async.Deferred.LONG_STACK_TRACES = true;");
+
+        assertThat(readResource("goog/dojo/dom/query_test.js"))
+                .contains("function testBasicSelectors()")
+                .contains("function testNthChild()")
+                .contains("function testAttributes()");
+
+        assertThat(readResource("goog/dojo/dom/query_test_dom.html"))
+                .contains("<h1>testing goog.dom.query()</h1>")
+                .contains("id=iframe-test");
+    }
+
+    @Test
+    void projectDocumentationAndLicenseArePackaged() throws IOException {
+        assertThat(readResource("README.md"))
+                .contains("# Closure Library")
+                .contains("*actively* maintained by the Clojure team")
+                .contains("Google stopped contributing to Closure Library on August 2024")
+                .contains("Previous version of this README can be found here");
+
+        assertThat(readResource("AUTHORS"))
+                .contains("Closure Library")
+                .contains("Google Inc.");
+
+        assertThat(readResource("LICENSE"))
+                .contains("Apache License")
+                .contains("Version 2.0, January 2004")
+                .contains("TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION");
+    }
+
+    @Test
+    void packagedModulesRemainInExpectedThirdPartyGroups() {
+        Map<String, Long> resourceCountsByGroup = DISTRIBUTED_RESOURCES.stream()
+                .filter(resourcePath -> resourcePath.startsWith("goog/"))
+                .collect(Collectors.groupingBy(
+                        resourcePath -> resourcePath.substring(0, resourcePath.indexOf('/', "goog/".length())),
+                        Collectors.counting()));
+
+        assertThat(resourceCountsByGroup)
+                .contains(
+                        entry("goog/dojo", 3L),
+                        entry("goog/mochikit", 9L));
+    }
+
+    private static String readResource(String resourcePath) throws IOException {
+        ClassLoader classLoader = Google_closure_library_third_partyTest.class.getClassLoader();
+        try (InputStream resourceStream = classLoader.getResourceAsStream(resourcePath)) {
+            assertThat(resourceStream)
+                    .as("resource %s should exist", resourcePath)
+                    .isNotNull();
+            return new String(resourceStream.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/tests/src/org.clojure/google-closure-library-third-party/0.0-20160609-f42b4a24/src/test/java/org_clojure/google_closure_library_third_party/Google_closure_library_third_partyTest.java
+++ b/tests/src/org.clojure/google-closure-library-third-party/0.0-20160609-f42b4a24/src/test/java/org_clojure/google_closure_library_third_party/Google_closure_library_third_partyTest.java
@@ -19,23 +19,36 @@ import org.junit.jupiter.api.Test;
 
 public class Google_closure_library_third_partyTest {
     private static final List<String> DISTRIBUTED_RESOURCES = List.of(
+            "goog/caja/string/html/htmlparser.js",
+            "goog/caja/string/html/htmlsanitizer.js",
             "goog/dojo/dom/query.js",
             "goog/dojo/dom/query_test.js",
-            "goog/dojo/dom/query_test_dom.html",
-            "goog/mochikit/BUILD",
-            "goog/mochikit/LICENSE",
-            "goog/mochikit/async/BUILD",
+            "goog/dojo/dom/query_test.html",
+            "goog/loremipsum/text/loremipsum.js",
+            "goog/loremipsum/text/loremipsum_test.html",
             "goog/mochikit/async/deferred.js",
-            "goog/mochikit/async/deferred_async_test.js",
-            "goog/mochikit/async/deferred_async_test_dom.html",
-            "goog/mochikit/async/deferred_test.js",
+            "goog/mochikit/async/deferred_async_test.html",
+            "goog/mochikit/async/deferred_test.html",
             "goog/mochikit/async/deferredlist.js",
-            "goog/mochikit/async/deferredlist_test.js",
+            "goog/mochikit/async/deferredlist_test.html",
+            "goog/osapi/osapi.js",
+            "goog/svgpan/svgpan.js",
             "README.md",
             "AUTHORS",
             "LICENSE");
 
     private static final Map<String, List<String>> MODULE_PROVIDES = Map.of(
+            "goog/caja/string/html/htmlparser.js",
+            List.of(
+                    "goog.string.html",
+                    "goog.string.html.HtmlParser",
+                    "goog.string.html.HtmlSaxHandler"),
+            "goog/caja/string/html/htmlsanitizer.js",
+            List.of(
+                    "goog.string.html.HtmlSanitizer",
+                    "goog.string.html.htmlSanitize"),
+            "goog/loremipsum/text/loremipsum.js",
+            List.of("goog.text.LoremIpsum"),
             "goog/mochikit/async/deferred.js",
             List.of(
                     "goog.async.Deferred",
@@ -43,6 +56,10 @@ public class Google_closure_library_third_partyTest {
                     "goog.async.Deferred.CanceledError"),
             "goog/mochikit/async/deferredlist.js",
             List.of("goog.async.DeferredList"),
+            "goog/osapi/osapi.js",
+            List.of("goog.osapi"),
+            "goog/svgpan/svgpan.js",
+            List.of("svgpan.SvgPan"),
             "goog/dojo/dom/query.js",
             List.of("goog.dom.query"));
 
@@ -127,33 +144,31 @@ public class Google_closure_library_third_partyTest {
 
     @Test
     void bundledJavascriptFixturesReferenceThePackagedModules() throws IOException {
-        assertThat(readResource("goog/mochikit/async/deferred_test.js"))
-                .contains("goog.module('goog.async.deferredTest')")
-                .contains("const Deferred = goog.require('goog.async.Deferred')")
-                .contains("testNormal()")
-                .contains("testCancel()")
-                .contains("testDeferredDependencies()");
+        assertThat(readResource("goog/mochikit/async/deferred_test.html"))
+                .contains("goog.require('goog.async.Deferred')")
+                .contains("var Deferred = goog.async.Deferred")
+                .contains("function testNormal()")
+                .contains("function testCancel()")
+                .contains("function testDeferredDependencies()");
 
-        assertThat(readResource("goog/mochikit/async/deferred_async_test.js"))
-                .contains("goog.module('goog.async.deferredAsyncTest')")
-                .contains("const Deferred = goog.require('goog.async.Deferred')")
-                .contains("testErrorStack()");
+        assertThat(readResource("goog/mochikit/async/deferred_async_test.html"))
+                .contains("goog.require('goog.async.Deferred')")
+                .contains("goog.async.Deferred.LONG_STACK_TRACES = true;")
+                .contains("function testErrorStack()")
+                .contains("function testErrorStack_forErrback()");
 
-        assertThat(readResource("goog/mochikit/async/deferredlist_test.js"))
-                .contains("goog.module('goog.async.deferredListTest')")
-                .contains("const DeferredList = goog.require('goog.async.DeferredList')")
-                .contains("testDeferredList()")
-                .contains("testGatherResults()");
-
-        assertThat(readResource("goog/mochikit/async/deferred_async_test_dom.html"))
-                .contains("goog.async.Deferred.LONG_STACK_TRACES = true;");
+        assertThat(readResource("goog/mochikit/async/deferredlist_test.html"))
+                .contains("goog.require('goog.async.DeferredList')")
+                .contains("var DeferredList = goog.async.DeferredList")
+                .contains("function testDeferredList()")
+                .contains("function testGatherResults()");
 
         assertThat(readResource("goog/dojo/dom/query_test.js"))
                 .contains("function testBasicSelectors()")
                 .contains("function testNthChild()")
                 .contains("function testAttributes()");
 
-        assertThat(readResource("goog/dojo/dom/query_test_dom.html"))
+        assertThat(readResource("goog/dojo/dom/query_test.html"))
                 .contains("<h1>testing goog.dom.query()</h1>")
                 .contains("id=iframe-test");
     }
@@ -162,9 +177,9 @@ public class Google_closure_library_third_partyTest {
     void projectDocumentationAndLicenseArePackaged() throws IOException {
         assertThat(readResource("README.md"))
                 .contains("# Closure Library")
-                .contains("*actively* maintained by the Clojure team")
-                .contains("Google stopped contributing to Closure Library on August 2024")
-                .contains("Previous version of this README can be found here");
+                .contains("Closure Library is a powerful, low-level JavaScript library")
+                .contains("https://developers.google.com/closure/library")
+                .contains("npm install google-closure-library");
 
         assertThat(readResource("AUTHORS"))
                 .contains("Closure Library")
@@ -186,8 +201,12 @@ public class Google_closure_library_third_partyTest {
 
         assertThat(resourceCountsByGroup)
                 .contains(
+                        entry("goog/caja", 2L),
                         entry("goog/dojo", 3L),
-                        entry("goog/mochikit", 9L));
+                        entry("goog/loremipsum", 2L),
+                        entry("goog/mochikit", 5L),
+                        entry("goog/osapi", 1L),
+                        entry("goog/svgpan", 1L));
     }
 
     private static String readResource(String resourcePath) throws IOException {

--- a/tests/src/org.clojure/google-closure-library-third-party/0.0-20160609-f42b4a24/user-code-filter.json
+++ b/tests/src/org.clojure/google-closure-library-third-party/0.0-20160609-f42b4a24/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.clojure.**"
+    }
+  ]
+}

--- a/tests/src/org.clojure/google-closure-library-third-party/0.0-20160609-f42b4a24/user-code-filter.json
+++ b/tests/src/org.clojure/google-closure-library-third-party/0.0-20160609-f42b4a24/user-code-filter.json
@@ -5,6 +5,9 @@
     },
     {
       "includeClasses" : "org.clojure.**"
+    },
+    {
+      "includeClasses" : "org_clojure.google_closure_library_third_party.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #3952

This PR provides test fixes and new metadata for org.clojure:google-closure-library-third-party:0.0-20160609-f42b4a24, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 87648
- Cached input tokens: 629760
- Output tokens: 6049
- Metadata entries: 4
- Iterations: 1
- Library coverage percentage: 100.0
- Previous library version metadata entries: 4
- Previous library version coverage percentage: 100.0

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `67e0a73e34f50e997dae71850b04af6b566e0366`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.clojure:google-closure-library-third-party:0.0-20250515-f04e4c0e: 0/0 covered calls (100.00%)
- org.clojure:google-closure-library-third-party:0.0-20160609-f42b4a24: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.clojure:google-closure-library-third-party:0.0-20250515-f04e4c0e: N/A
- org.clojure:google-closure-library-third-party:0.0-20160609-f42b4a24: N/A

**Line:**
- org.clojure:google-closure-library-third-party:0.0-20250515-f04e4c0e: N/A
- org.clojure:google-closure-library-third-party:0.0-20160609-f42b4a24: N/A

**Method:**
- org.clojure:google-closure-library-third-party:0.0-20250515-f04e4c0e: N/A
- org.clojure:google-closure-library-third-party:0.0-20160609-f42b4a24: N/A

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.clojure/google-closure-library-third-party/0.0-20250515-f04e4c0e/src/test/java/org_clojure/google_closure_library_third_party/Google_closure_library_third_partyTest.java 2/tests/src/org.clojure/google-closure-library-third-party/0.0-20160609-f42b4a24/src/test/java/org_clojure/google_closure_library_third_party/Google_closure_library_third_partyTest.java
index 7f5b276578..55b950097e 100644
--- 1/tests/src/org.clojure/google-closure-library-third-party/0.0-20250515-f04e4c0e/src/test/java/org_clojure/google_closure_library_third_party/Google_closure_library_third_partyTest.java
+++ 2/tests/src/org.clojure/google-closure-library-third-party/0.0-20160609-f42b4a24/src/test/java/org_clojure/google_closure_library_third_party/Google_closure_library_third_partyTest.java
@@ -19,23 +19,36 @@ import org.junit.jupiter.api.Test;
 
 public class Google_closure_library_third_partyTest {
     private static final List<String> DISTRIBUTED_RESOURCES = List.of(
+            "goog/caja/string/html/htmlparser.js",
+            "goog/caja/string/html/htmlsanitizer.js",
             "goog/dojo/dom/query.js",
             "goog/dojo/dom/query_test.js",
-            "goog/dojo/dom/query_test_dom.html",
-            "goog/mochikit/BUILD",
-            "goog/mochikit/LICENSE",
-            "goog/mochikit/async/BUILD",
+            "goog/dojo/dom/query_test.html",
+            "goog/loremipsum/text/loremipsum.js",
+            "goog/loremipsum/text/loremipsum_test.html",
             "goog/mochikit/async/deferred.js",
-            "goog/mochikit/async/deferred_async_test.js",
-            "goog/mochikit/async/deferred_async_test_dom.html",
-            "goog/mochikit/async/deferred_test.js",
+            "goog/mochikit/async/deferred_async_test.html",
+            "goog/mochikit/async/deferred_test.html",
             "goog/mochikit/async/deferredlist.js",
-            "goog/mochikit/async/deferredlist_test.js",
+            "goog/mochikit/async/deferredlist_test.html",
+            "goog/osapi/osapi.js",
+            "goog/svgpan/svgpan.js",
             "README.md",
             "AUTHORS",
             "LICENSE");
 
     private static final Map<String, List<String>> MODULE_PROVIDES = Map.of(
+            "goog/caja/string/html/htmlparser.js",
+            List.of(
+                    "goog.string.html",
+                    "goog.string.html.HtmlParser",
+                    "goog.string.html.HtmlSaxHandler"),
+            "goog/caja/string/html/htmlsanitizer.js",
+            List.of(
+                    "goog.string.html.HtmlSanitizer",
+                    "goog.string.html.htmlSanitize"),
+            "goog/loremipsum/text/loremipsum.js",
+            List.of("goog.text.LoremIpsum"),
             "goog/mochikit/async/deferred.js",
             List.of(
                     "goog.async.Deferred",
@@ -43,6 +56,10 @@ public class Google_closure_library_third_partyTest {
                     "goog.async.Deferred.CanceledError"),
             "goog/mochikit/async/deferredlist.js",
             List.of("goog.async.DeferredList"),
+            "goog/osapi/osapi.js",
+            List.of("goog.osapi"),
+            "goog/svgpan/svgpan.js",
+            List.of("svgpan.SvgPan"),
             "goog/dojo/dom/query.js",
             List.of("goog.dom.query"));
 
@@ -127,33 +144,31 @@ public class Google_closure_library_third_partyTest {
 
     @Test
     void bundledJavascriptFixturesReferenceThePackagedModules() throws IOException {
-        assertThat(readResource("goog/mochikit/async/deferred_test.js"))
-                .contains("goog.module('goog.async.deferredTest')")
-                .contains("const Deferred = goog.require('goog.async.Deferred')")
-                .contains("testNormal()")
-                .contains("testCancel()")
-                .contains("testDeferredDependencies()");
-
-        assertThat(readResource("goog/mochikit/async/deferred_async_test.js"))
-                .contains("goog.module('goog.async.deferredAsyncTest')")
-                .contains("const Deferred = goog.require('goog.async.Deferred')")
-                .contains("testErrorStack()");
-
-        assertThat(readResource("goog/mochikit/async/deferredlist_test.js"))
-                .contains("goog.module('goog.async.deferredListTest')")
-                .contains("const DeferredList = goog.require('goog.async.DeferredList')")
-                .contains("testDeferredList()")
-                .contains("testGatherResults()");
-
-        assertThat(readResource("goog/mochikit/async/deferred_async_test_dom.html"))
-                .contains("goog.async.Deferred.LONG_STACK_TRACES = true;");
+        assertThat(readResource("goog/mochikit/async/deferred_test.html"))
+                .contains("goog.require('goog.async.Deferred')")
+                .contains("var Deferred = goog.async.Deferred")
+                .contains("function testNormal()")
+                .contains("function testCancel()")
+                .contains("function testDeferredDependencies()");
+
+        assertThat(readResource("goog/mochikit/async/deferred_async_test.html"))
+                .contains("goog.require('goog.async.Deferred')")
+                .contains("goog.async.Deferred.LONG_STACK_TRACES = true;")
+                .contains("function testErrorStack()")
+                .contains("function testErrorStack_forErrback()");
+
+        assertThat(readResource("goog/mochikit/async/deferredlist_test.html"))
+                .contains("goog.require('goog.async.DeferredList')")
+                .contains("var DeferredList = goog.async.DeferredList")
+                .contains("function testDeferredList()")
+                .contains("function testGatherResults()");
 
         assertThat(readResource("goog/dojo/dom/query_test.js"))
                 .contains("function testBasicSelectors()")
                 .contains("function testNthChild()")
                 .contains("function testAttributes()");
 
-        assertThat(readResource("goog/dojo/dom/query_test_dom.html"))
+        assertThat(readResource("goog/dojo/dom/query_test.html"))
                 .contains("<h1>testing goog.dom.query()</h1>")
                 .contains("id=iframe-test");
     }
@@ -162,9 +177,9 @@ public class Google_closure_library_third_partyTest {
     void projectDocumentationAndLicenseArePackaged() throws IOException {
         assertThat(readResource("README.md"))
                 .contains("# Closure Library")
-                .contains("*actively* maintained by the Clojure team")
-                .contains("Google stopped contributing to Closure Library on August 2024")
-                .contains("Previous version of this README can be found here");
+                .contains("Closure Library is a powerful, low-level JavaScript library")
+                .contains("https://developers.google.com/closure/library")
+                .contains("npm install google-closure-library");
 
         assertThat(readResource("AUTHORS"))
                 .contains("Closure Library")
@@ -186,8 +201,12 @@ public class Google_closure_library_third_partyTest {
 
         assertThat(resourceCountsByGroup)
                 .contains(
+                        entry("goog/caja", 2L),
                         entry("goog/dojo", 3L),
-                        entry("goog/mochikit", 9L));
+                        entry("goog/loremipsum", 2L),
+                        entry("goog/mochikit", 5L),
+                        entry("goog/osapi", 1L),
+                        entry("goog/svgpan", 1L));
     }
 
     private static String readResource(String resourcePath) throws IOException {
diff --git 1/tests/src/org.clojure/google-closure-library-third-party/0.0-20250515-f04e4c0e/user-code-filter.json 2/tests/src/org.clojure/google-closure-library-third-party/0.0-20160609-f42b4a24/user-code-filter.json
index cc4014406a..58fe65064a 100644
--- 1/tests/src/org.clojure/google-closure-library-third-party/0.0-20250515-f04e4c0e/user-code-filter.json
+++ 2/tests/src/org.clojure/google-closure-library-third-party/0.0-20160609-f42b4a24/user-code-filter.json
@@ -5,6 +5,9 @@
     },
     {
       "includeClasses" : "org.clojure.**"
+    },
+    {
+      "includeClasses" : "org_clojure.google_closure_library_third_party.**"
     }
   ]
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 14
- Fixup attempts: 0
