### PR TITLE
[GenAI] Test fix for org.eclipse.jetty:jetty-servlet:9.4.20.v20190813 using gpt-5.5

### DIFF
--- a/metadata/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/reachability-metadata.json
+++ b/metadata/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/reachability-metadata.json
@@ -1,0 +1,193 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.util.ProcessorUtils"
+      },
+      "type": "byte[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.servlet.DecoratingListener$DynamicDecorator"
+      },
+      "type": "java.lang.Class[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.server.handler.ContextHandler$Context"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.servlet.ServletHolder"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.servlet.DecoratingListener$DynamicDecorator"
+      },
+      "type": "java.lang.invoke.LambdaForm$Name[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.servlet.ServletHolder"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.util.DateCache"
+      },
+      "type": "java.time.format.DateTimeFormatterBuilder$DateTimePrinterParser[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.servlet.listener.ELContextCleaner"
+      },
+      "type": "javax.el.BeanELResolver",
+      "fields": [
+        {
+          "name": "properties"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.util.Loader"
+      },
+      "type": "javax.el.BeanELResolver"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.servlet.ServletHolder"
+      },
+      "type": "org.apache.jasper.compiler.JspUtil",
+      "methods": [
+        {
+          "name": "makeJavaIdentifier",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "makeJavaPackage",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.util.Loader"
+      },
+      "type": "org.apache.jasper.compiler.JspUtil"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.PreEncodedHttpField"
+      },
+      "type": "org.eclipse.jetty.http.Http1FieldPreEncoder"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.servlet.ServletContextHandler"
+      },
+      "type": "org.eclipse.jetty.security.ConstraintSecurityHandler",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.server.handler.ContextHandler$Context"
+      },
+      "type": "org.eclipse.jetty.servlet.DefaultServlet",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.util.LazyList"
+      },
+      "type": "org.eclipse.jetty.servlet.FilterHolder[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.util.LazyList"
+      },
+      "type": "org.eclipse.jetty.servlet.FilterMapping[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.util.LazyList"
+      },
+      "type": "org.eclipse.jetty.servlet.ListenerHolder[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.util.ArrayUtil"
+      },
+      "type": "org.eclipse.jetty.servlet.ServletHolder[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.util.ArrayUtil"
+      },
+      "type": "org.eclipse.jetty.servlet.ServletMapping[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.util.log.Log"
+      },
+      "type": "org.eclipse.jetty.util.log.Slf4jLog"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.servlet.DecoratingListener"
+      },
+      "type": "org_eclipse_jetty.jetty_servlet.DecoratingListenerTest$MethodBasedDecorator"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.servlet.FilterHolder"
+      },
+      "type": "org_eclipse_jetty.jetty_servlet.FilterHolderTest$RecordingFilter"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.servlet.ListenerHolder"
+      },
+      "type": "org_eclipse_jetty.jetty_servlet.ListenerHolderTest$RecordingContextListener"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.server.handler.ContextHandler$Context"
+      },
+      "type": "org_eclipse_jetty.jetty_servlet.ServletHolderTest$CountingServlet"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.servlet.ServletHolder"
+      },
+      "type": "org_eclipse_jetty.jetty_servlet.ServletHolderTest$CountingServlet"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.servlet.DefaultServlet"
+      },
+      "glob": "jetty-dir.css"
+    }
+  ]
+}

--- a/metadata/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/reachability-metadata.json
+++ b/metadata/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/reachability-metadata.json
@@ -1,193 +1,163 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org.eclipse.jetty.util.ProcessorUtils"
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.ProcessorUtils"
       },
-      "type": "byte[][]"
+      "type" : "byte[][]"
     },
     {
-      "condition": {
-        "typeReached": "org.eclipse.jetty.servlet.DecoratingListener$DynamicDecorator"
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.servlet.DecoratingListener$DynamicDecorator"
       },
-      "type": "java.lang.Class[]"
+      "type" : "java.lang.Class[]"
     },
     {
-      "condition": {
-        "typeReached": "org.eclipse.jetty.server.handler.ContextHandler$Context"
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.server.handler.ContextHandler$Context"
       },
-      "type": "java.lang.StackTraceElement[]"
+      "type" : "java.lang.StackTraceElement[]"
     },
     {
-      "condition": {
-        "typeReached": "org.eclipse.jetty.servlet.ServletHolder"
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.servlet.ServletHolder"
       },
-      "type": "java.lang.String[]"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "org.eclipse.jetty.servlet.DecoratingListener$DynamicDecorator"
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.servlet.DecoratingListener$DynamicDecorator"
       },
-      "type": "java.lang.invoke.LambdaForm$Name[]"
+      "type" : "java.lang.invoke.LambdaForm$Name[]"
     },
     {
-      "condition": {
-        "typeReached": "org.eclipse.jetty.servlet.ServletHolder"
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.servlet.ServletHolder"
       },
-      "type": "java.lang.reflect.Method[]"
+      "type" : "java.lang.reflect.Method[]"
     },
     {
-      "condition": {
-        "typeReached": "org.eclipse.jetty.util.DateCache"
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.DateCache"
       },
-      "type": "java.time.format.DateTimeFormatterBuilder$DateTimePrinterParser[]"
+      "type" : "java.time.format.DateTimeFormatterBuilder$DateTimePrinterParser[]"
     },
     {
-      "condition": {
-        "typeReached": "org.eclipse.jetty.servlet.listener.ELContextCleaner"
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.servlet.listener.ELContextCleaner"
       },
-      "type": "javax.el.BeanELResolver",
-      "fields": [
+      "type" : "javax.el.BeanELResolver",
+      "fields" : [
         {
-          "name": "properties"
+          "name" : "properties"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.eclipse.jetty.util.Loader"
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.Loader"
       },
-      "type": "javax.el.BeanELResolver"
+      "type" : "javax.el.BeanELResolver"
     },
     {
-      "condition": {
-        "typeReached": "org.eclipse.jetty.servlet.ServletHolder"
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.servlet.ServletHolder"
       },
-      "type": "org.apache.jasper.compiler.JspUtil",
-      "methods": [
+      "type" : "org.apache.jasper.compiler.JspUtil",
+      "methods" : [
         {
-          "name": "makeJavaIdentifier",
-          "parameterTypes": [
+          "name" : "makeJavaIdentifier",
+          "parameterTypes" : [
             "java.lang.String"
           ]
         },
         {
-          "name": "makeJavaPackage",
-          "parameterTypes": [
+          "name" : "makeJavaPackage",
+          "parameterTypes" : [
             "java.lang.String"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.eclipse.jetty.util.Loader"
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.Loader"
       },
-      "type": "org.apache.jasper.compiler.JspUtil"
+      "type" : "org.apache.jasper.compiler.JspUtil"
     },
     {
-      "condition": {
-        "typeReached": "org.eclipse.jetty.http.PreEncodedHttpField"
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.http.PreEncodedHttpField"
       },
-      "type": "org.eclipse.jetty.http.Http1FieldPreEncoder"
+      "type" : "org.eclipse.jetty.http.Http1FieldPreEncoder"
     },
     {
-      "condition": {
-        "typeReached": "org.eclipse.jetty.servlet.ServletContextHandler"
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.servlet.ServletContextHandler"
       },
-      "type": "org.eclipse.jetty.security.ConstraintSecurityHandler",
-      "methods": [
+      "type" : "org.eclipse.jetty.security.ConstraintSecurityHandler",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.eclipse.jetty.server.handler.ContextHandler$Context"
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.server.handler.ContextHandler$Context"
       },
-      "type": "org.eclipse.jetty.servlet.DefaultServlet",
-      "methods": [
+      "type" : "org.eclipse.jetty.servlet.DefaultServlet",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.eclipse.jetty.util.LazyList"
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.LazyList"
       },
-      "type": "org.eclipse.jetty.servlet.FilterHolder[]"
+      "type" : "org.eclipse.jetty.servlet.FilterHolder[]"
     },
     {
-      "condition": {
-        "typeReached": "org.eclipse.jetty.util.LazyList"
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.LazyList"
       },
-      "type": "org.eclipse.jetty.servlet.FilterMapping[]"
+      "type" : "org.eclipse.jetty.servlet.FilterMapping[]"
     },
     {
-      "condition": {
-        "typeReached": "org.eclipse.jetty.util.LazyList"
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.LazyList"
       },
-      "type": "org.eclipse.jetty.servlet.ListenerHolder[]"
+      "type" : "org.eclipse.jetty.servlet.ListenerHolder[]"
     },
     {
-      "condition": {
-        "typeReached": "org.eclipse.jetty.util.ArrayUtil"
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.ArrayUtil"
       },
-      "type": "org.eclipse.jetty.servlet.ServletHolder[]"
+      "type" : "org.eclipse.jetty.servlet.ServletHolder[]"
     },
     {
-      "condition": {
-        "typeReached": "org.eclipse.jetty.util.ArrayUtil"
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.ArrayUtil"
       },
-      "type": "org.eclipse.jetty.servlet.ServletMapping[]"
+      "type" : "org.eclipse.jetty.servlet.ServletMapping[]"
     },
     {
-      "condition": {
-        "typeReached": "org.eclipse.jetty.util.log.Log"
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.util.log.Log"
       },
-      "type": "org.eclipse.jetty.util.log.Slf4jLog"
-    },
-    {
-      "condition": {
-        "typeReached": "org.eclipse.jetty.servlet.DecoratingListener"
-      },
-      "type": "org_eclipse_jetty.jetty_servlet.DecoratingListenerTest$MethodBasedDecorator"
-    },
-    {
-      "condition": {
-        "typeReached": "org.eclipse.jetty.servlet.FilterHolder"
-      },
-      "type": "org_eclipse_jetty.jetty_servlet.FilterHolderTest$RecordingFilter"
-    },
-    {
-      "condition": {
-        "typeReached": "org.eclipse.jetty.servlet.ListenerHolder"
-      },
-      "type": "org_eclipse_jetty.jetty_servlet.ListenerHolderTest$RecordingContextListener"
-    },
-    {
-      "condition": {
-        "typeReached": "org.eclipse.jetty.server.handler.ContextHandler$Context"
-      },
-      "type": "org_eclipse_jetty.jetty_servlet.ServletHolderTest$CountingServlet"
-    },
-    {
-      "condition": {
-        "typeReached": "org.eclipse.jetty.servlet.ServletHolder"
-      },
-      "type": "org_eclipse_jetty.jetty_servlet.ServletHolderTest$CountingServlet"
+      "type" : "org.eclipse.jetty.util.log.Slf4jLog"
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "org.eclipse.jetty.servlet.DefaultServlet"
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.servlet.DefaultServlet"
       },
-      "glob": "jetty-dir.css"
+      "glob" : "jetty-dir.css"
     }
   ]
 }

--- a/metadata/org.eclipse.jetty/jetty-servlet/index.json
+++ b/metadata/org.eclipse.jetty/jetty-servlet/index.json
@@ -18,6 +18,18 @@
     ]
   },
   {
+    "metadata-version" : "9.4.20.v20190813",
+    "tested-versions" : [
+      "9.4.20.v20190813"
+    ],
+    "allowed-packages" : [
+      "org.eclipse.jetty.servlet",
+      "org.eclipse.jetty.http",
+      "org.eclipse.jetty.server.handler",
+      "org.eclipse.jetty.util"
+    ]
+  },
+  {
     "metadata-version" : "9.3.19.v20170502",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-servlet/$version$/jetty-servlet-$version$-sources.jar",
     "repository-url" : "https://github.com/jetty/jetty.project",

--- a/metadata/org.eclipse.jetty/jetty-servlet/index.json
+++ b/metadata/org.eclipse.jetty/jetty-servlet/index.json
@@ -55,22 +55,7 @@
       "9.3.27.v20190418",
       "9.3.28.v20191105",
       "9.3.29.v20201019",
-      "9.3.30.v20211001",
-      "9.4.1.v20170120",
-      "9.4.1.v20180619",
-      "9.4.2.v20170220",
-      "9.4.2.v20180619",
-      "9.4.3.v20170317",
-      "9.4.3.v20180619",
-      "9.4.4.v20170414",
-      "9.4.4.v20180619",
-      "9.4.5.v20170502",
-      "9.4.5.v20180619",
-      "9.4.6.v20170531",
-      "9.4.6.v20180619",
-      "9.4.7.RC0",
-      "9.4.7.v20170914",
-      "9.4.7.v20180619"
+      "9.3.30.v20211001"
     ],
     "allowed-packages" : [
       "org.eclipse.jetty.servlet",
@@ -87,7 +72,22 @@
     "documentation-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-servlet/$version$/jetty-servlet-$version$-javadoc.jar",
     "description" : "Jetty Servlet provides the servlet container layer for Eclipse Jetty, including servlet holders, contexts, filters, mappings, and session integration. It lets Jetty applications host and manage Java Servlet API components inside embedded or standalone Jetty servers.",
     "tested-versions" : [
-      "9.4.0.v20180619"
+      "9.4.0.v20180619",
+      "9.4.1.v20170120",
+      "9.4.1.v20180619",
+      "9.4.2.v20170220",
+      "9.4.2.v20180619",
+      "9.4.3.v20170317",
+      "9.4.3.v20180619",
+      "9.4.4.v20170414",
+      "9.4.4.v20180619",
+      "9.4.5.v20170502",
+      "9.4.5.v20180619",
+      "9.4.6.v20170531",
+      "9.4.6.v20180619",
+      "9.4.7.RC0",
+      "9.4.7.v20170914",
+      "9.4.7.v20180619"
     ],
     "allowed-packages" : [
       "org.eclipse.jetty.servlet",

--- a/metadata/org.eclipse.jetty/jetty-servlet/index.json
+++ b/metadata/org.eclipse.jetty/jetty-servlet/index.json
@@ -19,6 +19,11 @@
   },
   {
     "metadata-version" : "9.4.20.v20190813",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-servlet/$version$/jetty-servlet-$version$-sources.jar",
+    "repository-url" : "https://github.com/jetty/jetty.project",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-servlet/$version$/jetty-servlet-$version$-tests.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-servlet/$version$/jetty-servlet-$version$-javadoc.jar",
+    "description" : "Jetty Servlet provides the servlet container layer for Eclipse Jetty, including servlet holders, contexts, filters, mappings, and session integration. It lets Jetty applications host and manage Java Servlet API components inside embedded or standalone Jetty servers.",
     "tested-versions" : [
       "9.4.20.v20190813"
     ],

--- a/stats/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/execution-metrics.json
+++ b/stats/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_java_run_fail:2026-05-22": {
+    "timestamp": "2026-05-22T14:37:44.872721Z",
+    "library": "org.eclipse.jetty:jetty-servlet:9.4.20.v20190813",
+    "starting_commit": "f3c41a6233f7e6f9f4ed8f965bcb981c904dc079",
+    "ending_commit": "b060a8870b4cb33c533f794d54154feae41456fe",
+    "previous_library": "org.eclipse.jetty:jetty-servlet:9.4.8.v20171121",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "9.4.20.v20190813",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 17,
+            "totalCalls": 17
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 18,
+        "totalCalls": 18
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2632,
+          "missed": 9743,
+          "ratio": 0.212687,
+          "total": 12375
+        },
+        "line": {
+          "covered": 691,
+          "missed": 2180,
+          "ratio": 0.240683,
+          "total": 2871
+        },
+        "method": {
+          "covered": 148,
+          "missed": 331,
+          "ratio": 0.308977,
+          "total": 479
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "9.4.8.v20171121",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 9,
+            "totalCalls": 9
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 10,
+        "totalCalls": 10
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2445,
+          "missed": 9492,
+          "ratio": 0.204825,
+          "total": 11937
+        },
+        "line": {
+          "covered": 628,
+          "missed": 2119,
+          "ratio": 0.228613,
+          "total": 2747
+        },
+        "method": {
+          "covered": 131,
+          "missed": 316,
+          "ratio": 0.293065,
+          "total": 447
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 202590,
+      "cached_input_tokens_used": 2551296,
+      "output_tokens_used": 22127,
+      "iterations": 5,
+      "cost_usd": 1.9394,
+      "tested_library_loc": 691,
+      "metadata_entries": 26,
+      "test_only_metadata_entries": 5,
+      "previous_library_metadata_entries": 22,
+      "previous_library_test_only_metadata_entries": 3,
+      "code_coverage_percent": 24.07,
+      "previous_library_coverage_percent": 22.86
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/java/org/apache/jasper/compiler/JspUtil.java",
+      "metadata_file": "metadata/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/stats.json
+++ b/stats/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "9.4.20.v20190813",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 17,
+          "totalCalls" : 17
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 18,
+      "totalCalls" : 18
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2632,
+        "missed" : 9743,
+        "ratio" : 0.212687,
+        "total" : 12375
+      },
+      "line" : {
+        "covered" : 691,
+        "missed" : 2180,
+        "ratio" : 0.240683,
+        "total" : 2871
+      },
+      "method" : {
+        "covered" : 148,
+        "missed" : 331,
+        "ratio" : 0.308977,
+        "total" : 479
+      }
+    }
+  } ]
+}

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/.gitignore
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/build.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/build.gradle
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.eclipse.jetty:jetty-servlet:$libraryVersion"
+    testImplementation 'javax.el:javax.el-api:3.0.0'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/gradle.properties
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.eclipse.jetty:jetty-servlet:9.4.20.v20190813
+library.version = 9.4.20.v20190813
+metadata.dir = org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/settings.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.eclipse.jetty.jetty-servlet_tests'

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/java/org/apache/jasper/compiler/JspUtil.java
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/java/org/apache/jasper/compiler/JspUtil.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.apache.jasper.compiler;
+
+public final class JspUtil {
+    private JspUtil() {
+    }
+
+    public static String makeJavaIdentifier(String jsp) {
+        return "javaIdentifier:" + jsp;
+    }
+
+    public static String makeJavaPackage(String jsp) {
+        return "javaPackage:" + jsp;
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/java/org_eclipse_jetty/jetty_servlet/ContainerInitializerInnerServletContainerInitializerServletContextListenerTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/java/org_eclipse_jetty/jetty_servlet/ContainerInitializerInnerServletContainerInitializerServletContextListenerTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_servlet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.servlet.ServletContainerInitializer;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.listener.ContainerInitializer;
+import org.eclipse.jetty.servlet.listener.ContainerInitializer.ServletContainerInitializerServletContextListener;
+import org.junit.jupiter.api.Test;
+
+public class ContainerInitializerInnerServletContainerInitializerServletContextListenerTest {
+    @Test
+    public void contextInitializedLoadsConfiguredClassNamesWithThreadContextClassLoader() {
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.NO_SESSIONS);
+        ServletContext servletContext = contextHandler.getServletContext();
+        AtomicReference<Set<Class<?>>> startupClasses = new AtomicReference<>();
+        AtomicReference<ServletContext> startupContext = new AtomicReference<>();
+        AtomicBoolean afterStartupCalled = new AtomicBoolean();
+        ServletContainerInitializer initializer = (classes, context) -> {
+            startupClasses.set(classes);
+            startupContext.set(context);
+        };
+        ServletContainerInitializerServletContextListener listener = ContainerInitializer.asContextListener(initializer)
+                .addClasses(StartupTarget.class.getName())
+                .afterStartup(context -> afterStartupCalled.set(context == servletContext));
+
+        listener.contextInitialized(new ServletContextEvent(servletContext));
+
+        assertThat(startupClasses.get()).containsExactly(StartupTarget.class);
+        assertThat(startupContext.get()).isSameAs(servletContext);
+        assertThat(afterStartupCalled).isTrue();
+    }
+
+    public static class StartupTarget {
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/java/org_eclipse_jetty/jetty_servlet/DecoratingListenerTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/java/org_eclipse_jetty/jetty_servlet/DecoratingListenerTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_servlet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.jetty.servlet.DecoratingListener;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.junit.jupiter.api.Test;
+
+public class DecoratingListenerTest {
+    private static final String DECORATOR_ATTRIBUTE = "test.decorator";
+
+    @Test
+    public void constructorAdaptsExistingAttributeWithDecoratorMethods() {
+        ServletContextHandler context = new ServletContextHandler(ServletContextHandler.NO_SESSIONS);
+        MethodBasedDecorator decorator = new MethodBasedDecorator();
+        context.setAttribute(DECORATOR_ATTRIBUTE, decorator);
+
+        DecoratingListener listener = new DecoratingListener(context, DECORATOR_ATTRIBUTE);
+        Payload payload = new Payload();
+
+        Payload decorated = context.getObjectFactory().decorate(payload);
+        context.getObjectFactory().destroy(decorated);
+
+        assertThat(listener.getAttributeName()).isEqualTo(DECORATOR_ATTRIBUTE);
+        assertThat(decorated).isSameAs(payload);
+        assertThat(payload.isDecorated()).isTrue();
+        assertThat(payload.isDestroyed()).isTrue();
+    }
+
+    public static class MethodBasedDecorator {
+        public Object decorate(Object object) {
+            if (object instanceof Payload) {
+                ((Payload) object).markDecorated();
+            }
+            return object;
+        }
+
+        public void destroy(Object object) {
+            if (object instanceof Payload) {
+                ((Payload) object).markDestroyed();
+            }
+        }
+    }
+
+    public static class Payload {
+        private boolean decorated;
+        private boolean destroyed;
+
+        public void markDecorated() {
+            decorated = true;
+        }
+
+        public void markDestroyed() {
+            destroyed = true;
+        }
+
+        public boolean isDecorated() {
+            return decorated;
+        }
+
+        public boolean isDestroyed() {
+            return destroyed;
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/java/org_eclipse_jetty/jetty_servlet/DefaultServletTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/java/org_eclipse_jetty/jetty_servlet/DefaultServletTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_servlet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+
+import javax.servlet.Servlet;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class DefaultServletTest {
+    @TempDir
+    Path resourceBase;
+
+    @Test
+    public void initLoadsDefaultDirectoryStylesheet() throws Exception {
+        Server server = new Server();
+        ServletContextHandler context = new ServletContextHandler(ServletContextHandler.NO_SESSIONS);
+        context.setContextPath("/");
+        context.setResourceBase(resourceBase.toUri().toASCIIString());
+        ServletHolder holder = context.addServlet(DefaultServlet.class, "/");
+        server.setHandler(context);
+
+        try {
+            server.start();
+
+            Servlet servlet = holder.getServlet();
+            assertThat(servlet).isInstanceOf(DefaultServlet.class);
+            assertThat(servlet.getServletConfig()).isNotNull();
+        } finally {
+            server.stop();
+            server.destroy();
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/java/org_eclipse_jetty/jetty_servlet/ELContextCleanerTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/java/org_eclipse_jetty/jetty_servlet/ELContextCleanerTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_servlet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import javax.el.BeanELResolver;
+
+import org.eclipse.jetty.servlet.listener.ELContextCleaner;
+import org.junit.jupiter.api.Test;
+
+public class ELContextCleanerTest {
+    @Test
+    public void contextDestroyedInspectsBeanELResolverPropertiesCache() {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(ELContextCleanerTest.class.getClassLoader());
+        try {
+            BeanELResolver resolver = new BeanELResolver();
+            ELContextCleaner cleaner = new ELContextCleaner();
+
+            assertThat(resolver).isNotNull();
+            assertThatCode(() -> cleaner.contextDestroyed(null)).doesNotThrowAnyException();
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/java/org_eclipse_jetty/jetty_servlet/FilterHolderTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/java/org_eclipse_jetty/jetty_servlet/FilterHolderTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_servlet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+import org.eclipse.jetty.servlet.FilterHolder;
+import org.eclipse.jetty.servlet.ServletHandler;
+import org.junit.jupiter.api.Test;
+
+public class FilterHolderTest {
+    @Test
+    public void initializeCreatesFilterInstanceFromHeldClass() throws Exception {
+        FilterHolder holder = new FilterHolder(RecordingFilter.class);
+        holder.setName("recording");
+        holder.setInitParameter("mode", "test");
+        holder.setServletHandler(new ServletHandler());
+        holder.start();
+        try {
+            holder.initialize();
+
+            Filter filter = holder.getFilter();
+            assertThat(filter).isInstanceOf(RecordingFilter.class);
+            RecordingFilter recordingFilter = (RecordingFilter) filter;
+            assertThat(recordingFilter.getFilterName()).isEqualTo("recording");
+            assertThat(recordingFilter.getMode()).isEqualTo("test");
+            assertThat(recordingFilter.isInitialized()).isTrue();
+        } finally {
+            holder.stop();
+        }
+    }
+
+    public static class RecordingFilter implements Filter {
+        private boolean initialized;
+        private String filterName;
+        private String mode;
+
+        @Override
+        public void init(FilterConfig filterConfig) throws ServletException {
+            initialized = true;
+            filterName = filterConfig.getFilterName();
+            mode = filterConfig.getInitParameter("mode");
+        }
+
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+                throws IOException, ServletException {
+            chain.doFilter(request, response);
+        }
+
+        @Override
+        public void destroy() {
+            initialized = false;
+        }
+
+        public boolean isInitialized() {
+            return initialized;
+        }
+
+        public String getFilterName() {
+            return filterName;
+        }
+
+        public String getMode() {
+            return mode;
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/java/org_eclipse_jetty/jetty_servlet/ListenerHolderTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/java/org_eclipse_jetty/jetty_servlet/ListenerHolderTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_servlet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.servlet.ListenerHolder;
+import org.junit.jupiter.api.Test;
+
+public class ListenerHolderTest {
+    @Test
+    public void startCreatesListenerInstanceFromHeldClassInContextHandler() throws Exception {
+        ContextHandler contextHandler = new ContextHandler("/");
+        ListenerHolder holder = new ListenerHolder(RecordingContextListener.class);
+
+        try {
+            runInContext(contextHandler, holder::start);
+
+            assertThat(holder.getListener()).isInstanceOf(RecordingContextListener.class);
+            RecordingContextListener listener = (RecordingContextListener) holder.getListener();
+            assertThat(listener.isInitialized()).isFalse();
+            assertThat(listener.isDestroyed()).isFalse();
+            assertThat(contextHandler.getEventListeners()).contains(listener);
+        } finally {
+            holder.stop();
+            contextHandler.destroy();
+        }
+    }
+
+    private static void runInContext(ContextHandler contextHandler, ThrowingRunnable action) throws Exception {
+        Throwable[] failure = new Throwable[1];
+        contextHandler.handle(() -> {
+            try {
+                action.run();
+            } catch (Throwable throwable) {
+                failure[0] = throwable;
+            }
+        });
+
+        if (failure[0] instanceof Exception) {
+            throw (Exception) failure[0];
+        }
+        if (failure[0] instanceof Error) {
+            throw (Error) failure[0];
+        }
+        if (failure[0] != null) {
+            throw new Exception(failure[0]);
+        }
+    }
+
+    private interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+
+    public static class RecordingContextListener implements ServletContextListener {
+        private boolean initialized;
+        private boolean destroyed;
+
+        @Override
+        public void contextInitialized(ServletContextEvent event) {
+            initialized = true;
+        }
+
+        @Override
+        public void contextDestroyed(ServletContextEvent event) {
+            destroyed = true;
+        }
+
+        public boolean isInitialized() {
+            return initialized;
+        }
+
+        public boolean isDestroyed() {
+            return destroyed;
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/java/org_eclipse_jetty/jetty_servlet/ServletContextHandlerTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/java/org_eclipse_jetty/jetty_servlet/ServletContextHandlerTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_servlet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.jetty.security.ConstraintSecurityHandler;
+import org.eclipse.jetty.security.SecurityHandler;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.junit.jupiter.api.Test;
+
+public class ServletContextHandlerTest {
+    @Test
+    public void getSecurityHandlerCreatesDefaultSecurityHandlerWhenSecurityIsEnabled() {
+        ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SECURITY);
+
+        SecurityHandler securityHandler = context.getSecurityHandler();
+
+        assertThat(securityHandler).isInstanceOf(ConstraintSecurityHandler.class);
+        assertThat(context.getHandler()).isSameAs(securityHandler);
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/java/org_eclipse_jetty/jetty_servlet/ServletHolderTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/java/org_eclipse_jetty/jetty_servlet/ServletHolderTest.java
@@ -61,21 +61,21 @@ public class ServletHolderTest {
     }
 
     @Test
-    public void standaloneServletHandlerCreatesServletInstanceFromHeldClass() throws Exception {
+    public void standaloneServletHolderCreatesServletInstanceFromHeldClass() throws Exception {
         ServletHandler handler = new ServletHandler();
-        handler.setEnsureDefaultServlet(false);
         ServletHolder holder = handler.addServletWithMapping(CountingServlet.class, "/counting");
 
         try {
-            handler.start();
+            holder.start();
 
             Servlet servlet = holder.getServlet();
 
-            assertThat(handler.getServletContext()).isNotInstanceOf(ServletContextHandler.Context.class);
+            assertThat(handler.getServletContext()).isNull();
+            assertThat(handler.getServletMapping("/counting")).isNotNull();
             assertThat(servlet).isInstanceOf(CountingServlet.class);
             assertThat(((CountingServlet) servlet).getServletConfig()).isNotNull();
         } finally {
-            handler.stop();
+            holder.stop();
             handler.destroy();
         }
     }

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/java/org_eclipse_jetty/jetty_servlet/ServletHolderTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/java/org_eclipse_jetty/jetty_servlet/ServletHolderTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_servlet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.servlet.Servlet;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.junit.jupiter.api.Test;
+
+public class ServletHolderTest {
+    @Test
+    public void getNameOfJspClassUsesAvailableJasperUtility() {
+        ServletHolder holder = new ServletHolder();
+
+        String jspClassName = holder.getNameOfJspClass("/WEB-INF/pages/monthly-report.jsp");
+
+        assertThat(jspClassName).isEqualTo("javaIdentifier:monthly-report.jsp");
+    }
+
+    @Test
+    public void getPackageOfJspClassUsesAvailableJasperUtility() {
+        ServletHolder holder = new ServletHolder();
+
+        String jspPackage = holder.getPackageOfJspClass("/WEB-INF/pages/monthly-report.jsp");
+
+        assertThat(jspPackage).isEqualTo("javaPackage:/WEB-INF/pages");
+    }
+
+    @Test
+    public void getServletCreatesServletInstanceFromHeldClass() throws Exception {
+        Server server = new Server();
+        ServletContextHandler context = new ServletContextHandler(ServletContextHandler.NO_SESSIONS);
+        context.setContextPath("/");
+        ServletHolder holder = new ServletHolder("counting", CountingServlet.class);
+        context.addServlet(holder, "/counting");
+        server.setHandler(context);
+
+        try {
+            server.start();
+
+            Servlet servlet = holder.getServlet();
+
+            assertThat(servlet).isInstanceOf(CountingServlet.class);
+            assertThat(((CountingServlet) servlet).getServletConfig()).isNotNull();
+        } finally {
+            server.stop();
+            server.destroy();
+        }
+    }
+
+    @Test
+    public void standaloneServletHandlerCreatesServletInstanceFromHeldClass() throws Exception {
+        ServletHandler handler = new ServletHandler();
+        handler.setEnsureDefaultServlet(false);
+        ServletHolder holder = handler.addServletWithMapping(CountingServlet.class, "/counting");
+
+        try {
+            handler.start();
+
+            Servlet servlet = holder.getServlet();
+
+            assertThat(handler.getServletContext()).isNotInstanceOf(ServletContextHandler.Context.class);
+            assertThat(servlet).isInstanceOf(CountingServlet.class);
+            assertThat(((CountingServlet) servlet).getServletConfig()).isNotNull();
+        } finally {
+            handler.stop();
+            handler.destroy();
+        }
+    }
+
+    public static class CountingServlet extends HttpServlet {
+        private static final long serialVersionUID = 1L;
+
+        private ServletConfig servletConfig;
+
+        @Override
+        public void init(ServletConfig config) throws ServletException {
+            super.init(config);
+            servletConfig = config;
+        }
+
+        @Override
+        public ServletConfig getServletConfig() {
+            return servletConfig;
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,22 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.servlet.FilterHolder"
+      },
+      "type" : "org_eclipse_jetty.jetty_servlet.FilterHolderTest$RecordingFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.servlet.ServletHolder"
+      },
+      "type" : "org_eclipse_jetty.jetty_servlet.ServletHolderTest$CountingServlet"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.server.handler.ContextHandler$Context"
+      },
+      "type" : "org_eclipse_jetty.jetty_servlet.ServletHolderTest$CountingServlet"
+    }
+  ]
+}

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -17,6 +17,18 @@
         "typeReached" : "org.eclipse.jetty.server.handler.ContextHandler$Context"
       },
       "type" : "org_eclipse_jetty.jetty_servlet.ServletHolderTest$CountingServlet"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.servlet.DecoratingListener"
+      },
+      "type" : "org_eclipse_jetty.jetty_servlet.DecoratingListenerTest$MethodBasedDecorator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.jetty.servlet.ListenerHolder"
+      },
+      "type" : "org_eclipse_jetty.jetty_servlet.ListenerHolderTest$RecordingContextListener"
     }
   ]
 }

--- a/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/user-code-filter.json
+++ b/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/user-code-filter.json
@@ -1,0 +1,25 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.eclipse.jetty.servlet.**"
+    },
+    {
+      "includeClasses" : "org.eclipse.jetty.http.**"
+    },
+    {
+      "includeClasses" : "org.eclipse.jetty.server.handler.**"
+    },
+    {
+      "includeClasses" : "org.eclipse.jetty.util.**"
+    },
+    {
+      "includeClasses" : "org.apache.jasper.compiler.**"
+    },
+    {
+      "includeClasses" : "org_eclipse_jetty.jetty_servlet.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7547

This PR provides test fixes and new metadata for org.eclipse.jetty:jetty-servlet:9.4.20.v20190813, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 202590
- Cached input tokens: 2551296
- Output tokens: 22127
- Metadata entries: 26
- Test-only metadata entries: 5
- Iterations: 5
- Library coverage percentage: 24.07
- Previous library version metadata entries: 22
- Previous library version test-only metadata entries: 3
- Previous library version coverage percentage: 22.86

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `eb7753e730d8cba22457d18e07c3098946e15857`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.eclipse.jetty:jetty-servlet:9.4.8.v20171121: 10/10 covered calls (100.00%)
- org.eclipse.jetty:jetty-servlet:9.4.20.v20190813: 18/18 covered calls (100.00%)

**Reflection:**
- org.eclipse.jetty:jetty-servlet:9.4.8.v20171121: 9/9 covered calls (100.00%)
- org.eclipse.jetty:jetty-servlet:9.4.20.v20190813: 17/17 covered calls (100.00%)

**Resources:**
- org.eclipse.jetty:jetty-servlet:9.4.8.v20171121: 1/1 covered calls (100.00%)
- org.eclipse.jetty:jetty-servlet:9.4.20.v20190813: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.eclipse.jetty:jetty-servlet:9.4.8.v20171121: 2445/11937 (20.48%)
- org.eclipse.jetty:jetty-servlet:9.4.20.v20190813: 2632/12375 (21.27%)

**Line:**
- org.eclipse.jetty:jetty-servlet:9.4.8.v20171121: 628/2747 (22.86%)
- org.eclipse.jetty:jetty-servlet:9.4.20.v20190813: 691/2871 (24.07%)

**Method:**
- org.eclipse.jetty:jetty-servlet:9.4.8.v20171121: 131/447 (29.31%)
- org.eclipse.jetty:jetty-servlet:9.4.20.v20190813: 148/479 (30.90%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/java/org_eclipse_jetty/jetty_servlet/ContainerInitializerInnerServletContainerInitializerServletContextListenerTest.java 2/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/java/org_eclipse_jetty/jetty_servlet/ContainerInitializerInnerServletContainerInitializerServletContextListenerTest.java
new file mode 100644
index 0000000000..8127af08cf
--- /dev/null
+++ 2/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/java/org_eclipse_jetty/jetty_servlet/ContainerInitializerInnerServletContainerInitializerServletContextListenerTest.java
@@ -0,0 +1,49 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_servlet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.servlet.ServletContainerInitializer;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.listener.ContainerInitializer;
+import org.eclipse.jetty.servlet.listener.ContainerInitializer.ServletContainerInitializerServletContextListener;
+import org.junit.jupiter.api.Test;
+
+public class ContainerInitializerInnerServletContainerInitializerServletContextListenerTest {
+    @Test
+    public void contextInitializedLoadsConfiguredClassNamesWithThreadContextClassLoader() {
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.NO_SESSIONS);
+        ServletContext servletContext = contextHandler.getServletContext();
+        AtomicReference<Set<Class<?>>> startupClasses = new AtomicReference<>();
+        AtomicReference<ServletContext> startupContext = new AtomicReference<>();
+        AtomicBoolean afterStartupCalled = new AtomicBoolean();
+        ServletContainerInitializer initializer = (classes, context) -> {
+            startupClasses.set(classes);
+            startupContext.set(context);
+        };
+        ServletContainerInitializerServletContextListener listener = ContainerInitializer.asContextListener(initializer)
+                .addClasses(StartupTarget.class.getName())
+                .afterStartup(context -> afterStartupCalled.set(context == servletContext));
+
+        listener.contextInitialized(new ServletContextEvent(servletContext));
+
+        assertThat(startupClasses.get()).containsExactly(StartupTarget.class);
+        assertThat(startupContext.get()).isSameAs(servletContext);
+        assertThat(afterStartupCalled).isTrue();
+    }
+
+    public static class StartupTarget {
+    }
+}
diff --git 1/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/java/org_eclipse_jetty/jetty_servlet/DecoratingListenerTest.java 2/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/java/org_eclipse_jetty/jetty_servlet/DecoratingListenerTest.java
new file mode 100644
index 0000000000..8fa3cd3fea
--- /dev/null
+++ 2/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/java/org_eclipse_jetty/jetty_servlet/DecoratingListenerTest.java
@@ -0,0 +1,71 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_servlet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.jetty.servlet.DecoratingListener;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.junit.jupiter.api.Test;
+
+public class DecoratingListenerTest {
+    private static final String DECORATOR_ATTRIBUTE = "test.decorator";
+
+    @Test
+    public void constructorAdaptsExistingAttributeWithDecoratorMethods() {
+        ServletContextHandler context = new ServletContextHandler(ServletContextHandler.NO_SESSIONS);
+        MethodBasedDecorator decorator = new MethodBasedDecorator();
+        context.setAttribute(DECORATOR_ATTRIBUTE, decorator);
+
+        DecoratingListener listener = new DecoratingListener(context, DECORATOR_ATTRIBUTE);
+        Payload payload = new Payload();
+
+        Payload decorated = context.getObjectFactory().decorate(payload);
+        context.getObjectFactory().destroy(decorated);
+
+        assertThat(listener.getAttributeName()).isEqualTo(DECORATOR_ATTRIBUTE);
+        assertThat(decorated).isSameAs(payload);
+        assertThat(payload.isDecorated()).isTrue();
+        assertThat(payload.isDestroyed()).isTrue();
+    }
+
+    public static class MethodBasedDecorator {
+        public Object decorate(Object object) {
+            if (object instanceof Payload) {
+                ((Payload) object).markDecorated();
+            }
+            return object;
+        }
+
+        public void destroy(Object object) {
+            if (object instanceof Payload) {
+                ((Payload) object).markDestroyed();
+            }
+        }
+    }
+
+    public static class Payload {
+        private boolean decorated;
+        private boolean destroyed;
+
+        public void markDecorated() {
+            decorated = true;
+        }
+
+        public void markDestroyed() {
+            destroyed = true;
+        }
+
+        public boolean isDecorated() {
+            return decorated;
+        }
+
+        public boolean isDestroyed() {
+            return destroyed;
+        }
+    }
+}
diff --git 1/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/java/org_eclipse_jetty/jetty_servlet/ListenerHolderTest.java 2/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/java/org_eclipse_jetty/jetty_servlet/ListenerHolderTest.java
new file mode 100644
index 0000000000..9f5a3d9976
--- /dev/null
+++ 2/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/java/org_eclipse_jetty/jetty_servlet/ListenerHolderTest.java
@@ -0,0 +1,85 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_servlet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.servlet.ListenerHolder;
+import org.junit.jupiter.api.Test;
+
+public class ListenerHolderTest {
+    @Test
+    public void startCreatesListenerInstanceFromHeldClassInContextHandler() throws Exception {
+        ContextHandler contextHandler = new ContextHandler("/");
+        ListenerHolder holder = new ListenerHolder(RecordingContextListener.class);
+
+        try {
+            runInContext(contextHandler, holder::start);
+
+            assertThat(holder.getListener()).isInstanceOf(RecordingContextListener.class);
+            RecordingContextListener listener = (RecordingContextListener) holder.getListener();
+            assertThat(listener.isInitialized()).isFalse();
+            assertThat(listener.isDestroyed()).isFalse();
+            assertThat(contextHandler.getEventListeners()).contains(listener);
+        } finally {
+            holder.stop();
+            contextHandler.destroy();
+        }
+    }
+
+    private static void runInContext(ContextHandler contextHandler, ThrowingRunnable action) throws Exception {
+        Throwable[] failure = new Throwable[1];
+        contextHandler.handle(() -> {
+            try {
+                action.run();
+            } catch (Throwable throwable) {
+                failure[0] = throwable;
+            }
+        });
+
+        if (failure[0] instanceof Exception) {
+            throw (Exception) failure[0];
+        }
+        if (failure[0] instanceof Error) {
+            throw (Error) failure[0];
+        }
+        if (failure[0] != null) {
+            throw new Exception(failure[0]);
+        }
+    }
+
+    private interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+
+    public static class RecordingContextListener implements ServletContextListener {
+        private boolean initialized;
+        private boolean destroyed;
+
+        @Override
+        public void contextInitialized(ServletContextEvent event) {
+            initialized = true;
+        }
+
+        @Override
+        public void contextDestroyed(ServletContextEvent event) {
+            destroyed = true;
+        }
+
+        public boolean isInitialized() {
+            return initialized;
+        }
+
+        public boolean isDestroyed() {
+            return destroyed;
+        }
+    }
+}
diff --git 1/tests/src/org.eclipse.jetty/jetty-servlet/9.4.8.v20171121/src/test/java/org_eclipse_jetty/jetty_servlet/ServletHolderTest.java 2/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/java/org_eclipse_jetty/jetty_servlet/ServletHolderTest.java
index f83a073bf6..a3e823a510 100644
--- 1/tests/src/org.eclipse.jetty/jetty-servlet/9.4.8.v20171121/src/test/java/org_eclipse_jetty/jetty_servlet/ServletHolderTest.java
+++ 2/tests/src/org.eclipse.jetty/jetty-servlet/9.4.20.v20190813/src/test/java/org_eclipse_jetty/jetty_servlet/ServletHolderTest.java
@@ -61,21 +61,21 @@ public class ServletHolderTest {
     }
 
     @Test
-    public void standaloneServletHandlerCreatesServletInstanceFromHeldClass() throws Exception {
+    public void standaloneServletHolderCreatesServletInstanceFromHeldClass() throws Exception {
         ServletHandler handler = new ServletHandler();
-        handler.setEnsureDefaultServlet(false);
         ServletHolder holder = handler.addServletWithMapping(CountingServlet.class, "/counting");
 
         try {
-            handler.start();
+            holder.start();
 
             Servlet servlet = holder.getServlet();
 
-            assertThat(handler.getServletContext()).isNotInstanceOf(ServletContextHandler.Context.class);
+            assertThat(handler.getServletContext()).isNull();
+            assertThat(handler.getServletMapping("/counting")).isNotNull();
             assertThat(servlet).isInstanceOf(CountingServlet.class);
             assertThat(((CountingServlet) servlet).getServletConfig()).isNotNull();
         } finally {
-            handler.stop();
+            holder.stop();
             handler.destroy();
         }
     }

```

### Local CI Verification

- Status: `success`
- Commands run: 29
- Fixup attempts: 1
