### PR TITLE
Raise optimistic dynamic-access test retries

### DIFF
--- a/forge/strategies/predefined_strategies.json
+++ b/forge/strategies/predefined_strategies.json
@@ -444,7 +444,7 @@
     "parameters": {
       "max-iterations": 2,
       "max-optimistic-iterations": 3,
-      "max-test-iterations": 3,
+      "max-test-iterations": 5,
       "max-class-test-iterations": 2,
       "source-context-types": [
         "main"
@@ -538,7 +538,7 @@
       "optimistic-dynamic-access-iteration": "prompt_templates/dynamic_access/optimistic-dynamic-access-iteration.md"
     },
     "parameters": {
-      "max-test-iterations": 3,
+      "max-test-iterations": 5,
       "source-context-types": [
         "main"
       ],
@@ -557,7 +557,7 @@
       "optimistic-dynamic-access-iteration": "prompt_templates/dynamic_access/optimistic-dynamic-access-iteration.md"
     },
     "parameters": {
-      "max-test-iterations": 3,
+      "max-test-iterations": 5,
       "source-context-types": [
         "main"
       ],
@@ -576,7 +576,7 @@
       "optimistic-dynamic-access-iteration": "prompt_templates/dynamic_access/optimistic-dynamic-access-iteration.md"
     },
     "parameters": {
-      "max-test-iterations": 3,
+      "max-test-iterations": 5,
       "graphify-context": true,
       "source-context-types": [
         "main"
@@ -596,7 +596,7 @@
       "optimistic-dynamic-access-iteration": "prompt_templates/dynamic_access/optimistic-dynamic-access-iteration.md"
     },
     "parameters": {
-      "max-test-iterations": 3,
+      "max-test-iterations": 5,
       "graphify-context": true,
       "source-context-types": [
         "main"
@@ -619,7 +619,7 @@
     },
     "parameters": {
       "max-iterations": 2,
-      "max-test-iterations": 3,
+      "max-test-iterations": 5,
       "max-class-test-iterations": 2,
       "source-context-types": [
         "main"
@@ -642,7 +642,7 @@
     },
     "parameters": {
       "max-iterations": 2,
-      "max-test-iterations": 3,
+      "max-test-iterations": 5,
       "max-class-test-iterations": 2,
       "source-context-types": [
         "main"
@@ -665,7 +665,7 @@
     },
     "parameters": {
       "max-iterations": 2,
-      "max-test-iterations": 3,
+      "max-test-iterations": 5,
       "max-class-test-iterations": 2,
       "source-context-types": [
         "main"
@@ -688,7 +688,7 @@
     },
     "parameters": {
       "max-iterations": 2,
-      "max-test-iterations": 3,
+      "max-test-iterations": 5,
       "max-class-test-iterations": 2,
       "source-context-types": [
         "main"
@@ -785,7 +785,7 @@
     },
     "parameters": {
       "max-optimistic-iterations": 3,
-      "max-test-iterations": 3,
+      "max-test-iterations": 5,
       "max-native-test-verification-iterations": 40,
       "source-context-types": [
         "main"
@@ -807,7 +807,7 @@
     },
     "parameters": {
       "max-optimistic-iterations": 3,
-      "max-test-iterations": 3,
+      "max-test-iterations": 5,
       "max-iterations": 3,
       "max-class-test-iterations": 2,
       "source-context-types": [


### PR DESCRIPTION
## Summary
- increase `max-test-iterations` from 3 to 5 for strategies using optimistic bulk dynamic-access
- keep per-class refinement iteration limits unchanged

## Rationale
Large bulk dynamic-access generations can add more tests in one pass, so they can surface more fixable errors during the internal test-fix loop. The larger retry budget gives those generations more room to converge.

## Testing
- `jq empty forge/strategies/predefined_strategies.json`
- `git diff --check`

Fixes #7558