### PR TITLE
[GenAI] Test fix for io.opentelemetry:opentelemetry-exporter-common:1.28.0 using gpt-5.5

### DIFF
--- a/metadata/io.opentelemetry/opentelemetry-exporter-common/1.28.0/reachability-metadata.json
+++ b/metadata/io.opentelemetry/opentelemetry-exporter-common/1.28.0/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.exporter.internal.auth.Authenticator"
+      },
+      "type": "io_opentelemetry.opentelemetry_exporter_common.AuthenticatorTest$DelegatingBuilder"
+    }
+  ]
+}

--- a/metadata/io.opentelemetry/opentelemetry-exporter-common/1.28.0/reachability-metadata.json
+++ b/metadata/io.opentelemetry/opentelemetry-exporter-common/1.28.0/reachability-metadata.json
@@ -1,10 +1,1 @@
-{
-  "reflection": [
-    {
-      "condition": {
-        "typeReached": "io.opentelemetry.exporter.internal.auth.Authenticator"
-      },
-      "type": "io_opentelemetry.opentelemetry_exporter_common.AuthenticatorTest$DelegatingBuilder"
-    }
-  ]
-}
+{ }

--- a/metadata/io.opentelemetry/opentelemetry-exporter-common/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-exporter-common/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.28.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-exporter-common/$version$/opentelemetry-exporter-common-$version$-sources.jar",
+    "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",
+    "test-code-url" : "https://github.com/open-telemetry/opentelemetry-java/tree/v$version$/exporters/common/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-exporter-common/$version$/opentelemetry-exporter-common-$version$-javadoc.jar",
+    "description" : "OpenTelemetry Exporter Common provides shared Java helper code used by OpenTelemetry exporters. It contains common internal exporter utilities for building telemetry export integrations without forcing optional transport dependencies onto every consumer.",
     "tested-versions" : [
       "1.28.0"
     ],

--- a/metadata/io.opentelemetry/opentelemetry-exporter-common/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-exporter-common/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.28.0",
+    "tested-versions" : [
+      "1.28.0"
+    ],
+    "allowed-packages" : [
+      "io.opentelemetry.exporter.internal"
+    ]
+  },
+  {
     "metadata-version" : "1.19.0",
     "source-code-url" : "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-exporter-common/$version$/opentelemetry-exporter-common-$version$-sources.jar",
     "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",

--- a/stats/io.opentelemetry/opentelemetry-exporter-common/1.28.0/execution-metrics.json
+++ b/stats/io.opentelemetry/opentelemetry-exporter-common/1.28.0/execution-metrics.json
@@ -1,0 +1,101 @@
+{
+  "fix_javac_fail:2026-05-22": {
+    "timestamp": "2026-05-22T17:12:16.556810Z",
+    "library": "io.opentelemetry:opentelemetry-exporter-common:1.28.0",
+    "starting_commit": "90cf6d39e590be0c1aeb52e0f1d73b46dd228844",
+    "ending_commit": "f7f8031b87a62023c346e8e07c195882e4c97682",
+    "previous_library": "io.opentelemetry:opentelemetry-exporter-common:1.19.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.28.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 2,
+        "totalCalls": 2
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 143,
+          "missed": 5431,
+          "ratio": 0.025655,
+          "total": 5574
+        },
+        "line": {
+          "covered": 37,
+          "missed": 1306,
+          "ratio": 0.02755,
+          "total": 1343
+        },
+        "method": {
+          "covered": 8,
+          "missed": 312,
+          "ratio": 0.025,
+          "total": 320
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.19.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.5,
+            "coveredCalls": 2,
+            "totalCalls": 4
+          }
+        },
+        "coverageRatio": 0.5,
+        "coveredCalls": 2,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 161,
+          "missed": 5675,
+          "ratio": 0.027587,
+          "total": 5836
+        },
+        "line": {
+          "covered": 40,
+          "missed": 1368,
+          "ratio": 0.028409,
+          "total": 1408
+        },
+        "method": {
+          "covered": 12,
+          "missed": 329,
+          "ratio": 0.035191,
+          "total": 341
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 42791,
+      "cached_input_tokens_used": 357376,
+      "output_tokens_used": 7018,
+      "iterations": 2,
+      "cost_usd": 0.3892,
+      "tested_library_loc": 37,
+      "metadata_entries": 0,
+      "test_only_metadata_entries": 3,
+      "previous_library_metadata_entries": 0,
+      "previous_library_test_only_metadata_entries": 2,
+      "code_coverage_percent": 2.76,
+      "previous_library_coverage_percent": 2.84
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/src/test/java/io_opentelemetry/opentelemetry_exporter_common/RetryUtilTest.java",
+      "metadata_file": "metadata/io.opentelemetry/opentelemetry-exporter-common/1.28.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.opentelemetry/opentelemetry-exporter-common/1.28.0/stats.json
+++ b/stats/io.opentelemetry/opentelemetry-exporter-common/1.28.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "1.28.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 2,
+      "totalCalls" : 2
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 143,
+        "missed" : 5431,
+        "ratio" : 0.025655,
+        "total" : 5574
+      },
+      "line" : {
+        "covered" : 37,
+        "missed" : 1306,
+        "ratio" : 0.02755,
+        "total" : 1343
+      },
+      "method" : {
+        "covered" : 8,
+        "missed" : 312,
+        "ratio" : 0.025,
+        "total" : 320
+      }
+    }
+  } ]
+}

--- a/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/.gitignore
+++ b/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/build.gradle
+++ b/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.opentelemetry:opentelemetry-exporter-common:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/gradle.properties
+++ b/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.opentelemetry:opentelemetry-exporter-common:1.28.0
+library.version = 1.28.0
+metadata.dir = io.opentelemetry/opentelemetry-exporter-common/1.28.0/

--- a/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/settings.gradle
+++ b/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.opentelemetry.opentelemetry-exporter-common_tests'

--- a/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/src/test/java/io_opentelemetry/opentelemetry_exporter_common/AuthenticatorTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/src/test/java/io_opentelemetry/opentelemetry_exporter_common/AuthenticatorTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_opentelemetry.opentelemetry_exporter_common;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.opentelemetry.exporter.internal.auth.Authenticator;
+import io.opentelemetry.exporter.internal.http.HttpExporterBuilder;
+import io.opentelemetry.exporter.internal.marshal.Marshaler;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+public class AuthenticatorTest {
+    private final Authenticator authenticator = Collections::emptyMap;
+
+    @Test
+    void setsAuthenticatorOnHttpExporterDelegate() {
+        DelegatingBuilder builder =
+                new DelegatingBuilder(
+                        new HttpExporterBuilder<Marshaler>(
+                                "test-exporter", "telemetry", "http://localhost:4318/v1/test"));
+
+        assertThatCode(() -> Authenticator.setAuthenticatorOnDelegate(builder, authenticator))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void rejectsDelegateWithUnsupportedType() {
+        DelegatingBuilder builder = new DelegatingBuilder(new Object());
+
+        assertThatThrownBy(() -> Authenticator.setAuthenticatorOnDelegate(builder, authenticator))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Delegate field is not type");
+    }
+
+    private static final class DelegatingBuilder {
+        private final Object delegate;
+
+        private DelegatingBuilder(Object delegate) {
+            this.delegate = delegate;
+        }
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/src/test/java/io_opentelemetry/opentelemetry_exporter_common/RetryUtilTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/src/test/java/io_opentelemetry/opentelemetry_exporter_common/RetryUtilTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_opentelemetry.opentelemetry_exporter_common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.opentelemetry.exporter.internal.grpc.GrpcStatusUtil;
+import io.opentelemetry.exporter.internal.retry.RetryPolicy;
+import io.opentelemetry.exporter.internal.retry.RetryUtil;
+import org.junit.jupiter.api.Test;
+
+public class RetryUtilTest {
+    @Test
+    void exposesRetryableStatusCodes() {
+        assertThat(RetryUtil.retryableHttpResponseCodes())
+                .containsExactlyInAnyOrder(429, 502, 503, 504);
+        assertThat(RetryUtil.retryableGrpcStatusCodes())
+                .containsExactlyInAnyOrder(
+                        GrpcStatusUtil.GRPC_STATUS_CANCELLED,
+                        GrpcStatusUtil.GRPC_STATUS_DEADLINE_EXCEEDED,
+                        GrpcStatusUtil.GRPC_STATUS_RESOURCE_EXHAUSTED,
+                        GrpcStatusUtil.GRPC_STATUS_ABORTED,
+                        GrpcStatusUtil.GRPC_STATUS_OUT_OF_RANGE,
+                        GrpcStatusUtil.GRPC_STATUS_UNAVAILABLE,
+                        GrpcStatusUtil.GRPC_STATUS_DATA_LOSS);
+    }
+
+    @Test
+    void inspectsDelegateFieldWhenSettingRetryPolicy() {
+        DelegateHolder holder = new DelegateHolder(null);
+
+        assertThatThrownBy(
+                        () -> RetryUtil.setRetryPolicyOnDelegate(holder, RetryPolicy.getDefault()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("delegate field");
+    }
+
+    static final class DelegateHolder {
+        private final Object delegate;
+
+        private DelegateHolder(Object delegate) {
+            this.delegate = delegate;
+        }
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/src/test/java/io_opentelemetry/opentelemetry_exporter_common/RetryUtilTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/src/test/java/io_opentelemetry/opentelemetry_exporter_common/RetryUtilTest.java
@@ -7,10 +7,8 @@
 package io_opentelemetry.opentelemetry_exporter_common;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.exporter.internal.grpc.GrpcStatusUtil;
-import io.opentelemetry.exporter.internal.retry.RetryPolicy;
 import io.opentelemetry.exporter.internal.retry.RetryUtil;
 import org.junit.jupiter.api.Test;
 
@@ -31,20 +29,10 @@ public class RetryUtilTest {
     }
 
     @Test
-    void inspectsDelegateFieldWhenSettingRetryPolicy() {
-        DelegateHolder holder = new DelegateHolder(null);
-
-        assertThatThrownBy(
-                        () -> RetryUtil.setRetryPolicyOnDelegate(holder, RetryPolicy.getDefault()))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("delegate field");
-    }
-
-    static final class DelegateHolder {
-        private final Object delegate;
-
-        private DelegateHolder(Object delegate) {
-            this.delegate = delegate;
-        }
+    void excludesNonRetryableStatusCodes() {
+        assertThat(RetryUtil.retryableHttpResponseCodes())
+                .doesNotContain(200, 400, 500);
+        assertThat(RetryUtil.retryableGrpcStatusCodes())
+                .doesNotContain("0", "3", "5");
     }
 }

--- a/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,12 @@
+{
+  "reflection": [
+    {
+      "fields": [
+        {
+          "name": "delegate"
+        }
+      ],
+      "type": "io_opentelemetry.opentelemetry_exporter_common.RetryUtilTest$DelegateHolder"
+    }
+  ]
+}

--- a/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,12 +1,18 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "fields": [
+      "fields" : [
         {
-          "name": "delegate"
+          "name" : "delegate"
         }
       ],
-      "type": "io_opentelemetry.opentelemetry_exporter_common.RetryUtilTest$DelegateHolder"
+      "type" : "io_opentelemetry.opentelemetry_exporter_common.RetryUtilTest$DelegateHolder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.opentelemetry.exporter.internal.auth.Authenticator"
+      },
+      "type" : "io_opentelemetry.opentelemetry_exporter_common.AuthenticatorTest$DelegatingBuilder"
     }
   ]
 }

--- a/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/user-code-filter.json
+++ b/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "io.opentelemetry.exporter.internal.**"
+    }
+  ]
+}

--- a/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/user-code-filter.json
+++ b/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/user-code-filter.json
@@ -5,6 +5,9 @@
     },
     {
       "includeClasses" : "io.opentelemetry.exporter.internal.**"
+    },
+    {
+      "includeClasses" : "io_opentelemetry.opentelemetry_exporter_common.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #2565

This PR provides test fixes and new metadata for io.opentelemetry:opentelemetry-exporter-common:1.28.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 42791
- Cached input tokens: 357376
- Output tokens: 7018
- Metadata entries: 0
- Test-only metadata entries: 3
- Iterations: 2
- Library coverage percentage: 2.76
- Previous library version metadata entries: 0
- Previous library version test-only metadata entries: 2
- Previous library version coverage percentage: 2.84

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `c973a8aab682315d994dee041a10fca2ad74847e`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.opentelemetry:opentelemetry-exporter-common:1.19.0: 2/4 covered calls (50.00%)
- io.opentelemetry:opentelemetry-exporter-common:1.28.0: 2/2 covered calls (100.00%)

**Reflection:**
- io.opentelemetry:opentelemetry-exporter-common:1.19.0: 2/4 covered calls (50.00%)
- io.opentelemetry:opentelemetry-exporter-common:1.28.0: 2/2 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.opentelemetry:opentelemetry-exporter-common:1.19.0: 161/5836 (2.76%)
- io.opentelemetry:opentelemetry-exporter-common:1.28.0: 143/5574 (2.57%)

**Line:**
- io.opentelemetry:opentelemetry-exporter-common:1.19.0: 40/1408 (2.84%)
- io.opentelemetry:opentelemetry-exporter-common:1.28.0: 37/1343 (2.76%)

**Method:**
- io.opentelemetry:opentelemetry-exporter-common:1.19.0: 12/341 (3.52%)
- io.opentelemetry:opentelemetry-exporter-common:1.28.0: 8/320 (2.50%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/src/test/java/io_opentelemetry/opentelemetry_exporter_common/AuthenticatorTest.java 2/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/src/test/java/io_opentelemetry/opentelemetry_exporter_common/AuthenticatorTest.java
new file mode 100644
index 0000000000..579a8e8a0a
--- /dev/null
+++ 2/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/src/test/java/io_opentelemetry/opentelemetry_exporter_common/AuthenticatorTest.java
@@ -0,0 +1,48 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_opentelemetry.opentelemetry_exporter_common;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.opentelemetry.exporter.internal.auth.Authenticator;
+import io.opentelemetry.exporter.internal.http.HttpExporterBuilder;
+import io.opentelemetry.exporter.internal.marshal.Marshaler;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+public class AuthenticatorTest {
+    private final Authenticator authenticator = Collections::emptyMap;
+
+    @Test
+    void setsAuthenticatorOnHttpExporterDelegate() {
+        DelegatingBuilder builder =
+                new DelegatingBuilder(
+                        new HttpExporterBuilder<Marshaler>(
+                                "test-exporter", "telemetry", "http://localhost:4318/v1/test"));
+
+        assertThatCode(() -> Authenticator.setAuthenticatorOnDelegate(builder, authenticator))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void rejectsDelegateWithUnsupportedType() {
+        DelegatingBuilder builder = new DelegatingBuilder(new Object());
+
+        assertThatThrownBy(() -> Authenticator.setAuthenticatorOnDelegate(builder, authenticator))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Delegate field is not type");
+    }
+
+    private static final class DelegatingBuilder {
+        private final Object delegate;
+
+        private DelegatingBuilder(Object delegate) {
+            this.delegate = delegate;
+        }
+    }
+}
diff --git 1/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.19.0/src/test/java/io_opentelemetry/opentelemetry_exporter_common/RetryUtilTest.java 2/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/src/test/java/io_opentelemetry/opentelemetry_exporter_common/RetryUtilTest.java
index 836aaf4c3b..85e8ee80c3 100644
--- 1/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.19.0/src/test/java/io_opentelemetry/opentelemetry_exporter_common/RetryUtilTest.java
+++ 2/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/src/test/java/io_opentelemetry/opentelemetry_exporter_common/RetryUtilTest.java
@@ -7,10 +7,8 @@
 package io_opentelemetry.opentelemetry_exporter_common;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.exporter.internal.grpc.GrpcStatusUtil;
-import io.opentelemetry.exporter.internal.retry.RetryPolicy;
 import io.opentelemetry.exporter.internal.retry.RetryUtil;
 import org.junit.jupiter.api.Test;
 
@@ -31,20 +29,10 @@ public class RetryUtilTest {
     }
 
     @Test
-    void inspectsDelegateFieldWhenSettingRetryPolicy() {
-        DelegateHolder holder = new DelegateHolder(null);
-
-        assertThatThrownBy(
-                        () -> RetryUtil.setRetryPolicyOnDelegate(holder, RetryPolicy.getDefault()))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("delegate field");
-    }
-
-    static final class DelegateHolder {
-        private final Object delegate;
-
-        private DelegateHolder(Object delegate) {
-            this.delegate = delegate;
-        }
+    void excludesNonRetryableStatusCodes() {
+        assertThat(RetryUtil.retryableHttpResponseCodes())
+                .doesNotContain(200, 400, 500);
+        assertThat(RetryUtil.retryableGrpcStatusCodes())
+                .doesNotContain("0", "3", "5");
     }
 }
diff --git 1/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.19.0/user-code-filter.json 2/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/user-code-filter.json
index 72ed25fcfb..cc7fdb467c 100644
--- 1/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.19.0/user-code-filter.json
+++ 2/tests/src/io.opentelemetry/opentelemetry-exporter-common/1.28.0/user-code-filter.json
@@ -5,6 +5,9 @@
     },
     {
       "includeClasses" : "io.opentelemetry.exporter.internal.**"
+    },
+    {
+      "includeClasses" : "io_opentelemetry.opentelemetry_exporter_common.**"
     }
   ]
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 14
- Fixup attempts: 0
