### PR TITLE
[GenAI] Test fix for org.apache.maven.wagon:wagon-ssh:2.12 using gpt-5.5

### DIFF
--- a/metadata/org.apache.maven.wagon/wagon-ssh/2.12/reachability-metadata.json
+++ b/metadata/org.apache.maven.wagon/wagon-ssh/2.12/reachability-metadata.json
@@ -1,0 +1,34 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.wagon.providers.ssh.jsch.AbstractJschWagon"
+      },
+      "type": "byte[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.wagon.providers.ssh.jsch.AbstractJschWagon"
+      },
+      "type": "com.jcraft.jsch.jce.Random",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.wagon.providers.ssh.jsch.AbstractJschWagon"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.wagon.providers.ssh.jsch.AbstractJschWagon"
+      },
+      "type": "sun.security.provider.NativePRNG"
+    }
+  ]
+}

--- a/metadata/org.apache.maven.wagon/wagon-ssh/index.json
+++ b/metadata/org.apache.maven.wagon/wagon-ssh/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.12",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-ssh/$version$/wagon-ssh-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/maven-wagon",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon/$version$/wagon-$version$-source-release.zip",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-ssh/$version$/wagon-ssh-$version$-javadoc.jar",
+    "description" : "Apache Maven Wagon SSH Provider adds SSH transport support to Maven Wagon using JSch. It lets Maven and other Wagon clients transfer artifacts to and from repositories over SSH-based protocols such as SCP and SFTP.",
     "tested-versions" : [
       "2.12"
     ],

--- a/metadata/org.apache.maven.wagon/wagon-ssh/index.json
+++ b/metadata/org.apache.maven.wagon/wagon-ssh/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.12",
+    "tested-versions" : [
+      "2.12"
+    ],
+    "allowed-packages" : [
+      "org.apache.maven.wagon.providers.ssh.jsch"
+    ]
+  },
+  {
     "metadata-version" : "1.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-ssh/$version$/wagon-ssh-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/maven-wagon",

--- a/stats/org.apache.maven.wagon/wagon-ssh/2.12/execution-metrics.json
+++ b/stats/org.apache.maven.wagon/wagon-ssh/2.12/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_java_run_fail:2026-05-23": {
+    "timestamp": "2026-05-23T00:24:03.919411Z",
+    "library": "org.apache.maven.wagon:wagon-ssh:2.12",
+    "starting_commit": "5ba6a19e776e76be333d756e363b124208a1117d",
+    "ending_commit": "1b916fd5e228dae0cb0613356d7392f43917ddac",
+    "previous_library": "org.apache.maven.wagon:wagon-ssh:1.0",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.12",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 411,
+          "missed": 2258,
+          "ratio": 0.15399,
+          "total": 2669
+        },
+        "line": {
+          "covered": 100,
+          "missed": 464,
+          "ratio": 0.177305,
+          "total": 564
+        },
+        "method": {
+          "covered": 24,
+          "missed": 52,
+          "ratio": 0.315789,
+          "total": 76
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 383,
+          "missed": 2130,
+          "ratio": 0.152407,
+          "total": 2513
+        },
+        "line": {
+          "covered": 94,
+          "missed": 443,
+          "ratio": 0.175047,
+          "total": 537
+        },
+        "method": {
+          "covered": 22,
+          "missed": 47,
+          "ratio": 0.318841,
+          "total": 69
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 55321,
+      "cached_input_tokens_used": 266240,
+      "output_tokens_used": 2281,
+      "iterations": 1,
+      "cost_usd": 0.2015,
+      "tested_library_loc": 100,
+      "metadata_entries": 5,
+      "previous_library_metadata_entries": 76,
+      "code_coverage_percent": 17.73,
+      "previous_library_coverage_percent": 17.5
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.maven.wagon/wagon-ssh/2.12/src/test/java/org_apache_maven_wagon/wagon_ssh/Wagon_sshTest.java",
+      "metadata_file": "metadata/org.apache.maven.wagon/wagon-ssh/2.12/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.maven.wagon/wagon-ssh/2.12/stats.json
+++ b/stats/org.apache.maven.wagon/wagon-ssh/2.12/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.12",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 411,
+        "missed" : 2258,
+        "ratio" : 0.15399,
+        "total" : 2669
+      },
+      "line" : {
+        "covered" : 100,
+        "missed" : 464,
+        "ratio" : 0.177305,
+        "total" : 564
+      },
+      "method" : {
+        "covered" : 24,
+        "missed" : 52,
+        "ratio" : 0.315789,
+        "total" : 76
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.maven.wagon/wagon-ssh/2.12/.gitignore
+++ b/tests/src/org.apache.maven.wagon/wagon-ssh/2.12/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.maven.wagon/wagon-ssh/2.12/build.gradle
+++ b/tests/src/org.apache.maven.wagon/wagon-ssh/2.12/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.maven.wagon:wagon-ssh:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.maven.wagon/wagon-ssh/2.12/gradle.properties
+++ b/tests/src/org.apache.maven.wagon/wagon-ssh/2.12/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.maven.wagon:wagon-ssh:2.12
+library.version = 2.12
+metadata.dir = org.apache.maven.wagon/wagon-ssh/2.12/

--- a/tests/src/org.apache.maven.wagon/wagon-ssh/2.12/settings.gradle
+++ b/tests/src/org.apache.maven.wagon/wagon-ssh/2.12/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.maven.wagon.wagon-ssh_tests'

--- a/tests/src/org.apache.maven.wagon/wagon-ssh/2.12/src/test/java/org_apache_maven_wagon/wagon_ssh/Wagon_sshTest.java
+++ b/tests/src/org.apache.maven.wagon/wagon-ssh/2.12/src/test/java/org_apache_maven_wagon/wagon_ssh/Wagon_sshTest.java
@@ -57,6 +57,9 @@ import org.junit.jupiter.api.io.TempDir;
 
 @Timeout(value = 20, unit = TimeUnit.SECONDS)
 public class Wagon_sshTest {
+    private static final String DEFAULT_PREFERRED_AUTHENTICATIONS =
+            "gssapi-with-mic,publickey,password,keyboard-interactive";
+
     @TempDir
     Path temporaryDirectory;
 
@@ -69,9 +72,11 @@ public class Wagon_sshTest {
             NullInteractiveUserInfo interactiveUserInfo = new NullInteractiveUserInfo(true);
             wagon.setKnownHostsProvider(knownHostsProvider);
             wagon.setInteractiveUserInfo(interactiveUserInfo);
+            wagon.setPreferredAuthentications(DEFAULT_PREFERRED_AUTHENTICATIONS);
             wagon.setInteractive(false);
 
             assertThat(wagon.supportsDirectoryCopy()).isTrue();
+            assertThat(wagon.getPreferredAuthentications()).isEqualTo(DEFAULT_PREFERRED_AUTHENTICATIONS);
             assertThat(wagon.getKnownHostsProvider()).isSameAs(knownHostsProvider);
             assertThat(wagon.getInteractiveUserInfo()).isSameAs(interactiveUserInfo);
             wagon.setKnownHostsProvider(null);
@@ -108,6 +113,7 @@ public class Wagon_sshTest {
 
             try {
                 wagon.setKnownHostsProvider(new NullKnownHostProvider());
+                wagon.setPreferredAuthentications(DEFAULT_PREFERRED_AUTHENTICATIONS);
                 wagon.setInteractive(false);
 
                 Repository proxiedRepository = new Repository("proxied", "scp://repository.example.test/repository");

--- a/tests/src/org.apache.maven.wagon/wagon-ssh/2.12/src/test/java/org_apache_maven_wagon/wagon_ssh/Wagon_sshTest.java
+++ b/tests/src/org.apache.maven.wagon/wagon-ssh/2.12/src/test/java/org_apache_maven_wagon/wagon_ssh/Wagon_sshTest.java
@@ -1,0 +1,440 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_wagon.wagon_ssh;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.jcraft.jsch.UIKeyboardInteractive;
+import com.jcraft.jsch.UserInfo;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.StringReader;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.apache.maven.wagon.Streams;
+import org.apache.maven.wagon.authentication.AuthenticationException;
+import org.apache.maven.wagon.authentication.AuthenticationInfo;
+import org.apache.maven.wagon.providers.ssh.CommandExecutorStreamProcessor;
+import org.apache.maven.wagon.providers.ssh.LSParser;
+import org.apache.maven.wagon.providers.ssh.interactive.ConsoleInteractiveUserInfo;
+import org.apache.maven.wagon.providers.ssh.interactive.NullInteractiveUserInfo;
+import org.apache.maven.wagon.providers.ssh.jsch.AbstractJschWagon;
+import org.apache.maven.wagon.providers.ssh.jsch.ScpWagon;
+import org.apache.maven.wagon.providers.ssh.jsch.SftpWagon;
+import org.apache.maven.wagon.providers.ssh.jsch.interactive.PrompterUIKeyboardInteractive;
+import org.apache.maven.wagon.providers.ssh.jsch.interactive.UserInfoUIKeyboardInteractiveProxy;
+import org.apache.maven.wagon.providers.ssh.knownhost.FileKnownHostsProvider;
+import org.apache.maven.wagon.providers.ssh.knownhost.KnownHostsProvider;
+import org.apache.maven.wagon.providers.ssh.knownhost.NullKnownHostProvider;
+import org.apache.maven.wagon.providers.ssh.knownhost.SingleKnownHostProvider;
+import org.apache.maven.wagon.providers.ssh.knownhost.StreamKnownHostsProvider;
+import org.apache.maven.wagon.proxy.ProxyInfo;
+import org.apache.maven.wagon.repository.Repository;
+import org.codehaus.plexus.components.interactivity.Prompter;
+import org.codehaus.plexus.components.interactivity.PrompterException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+@Timeout(value = 20, unit = TimeUnit.SECONDS)
+public class Wagon_sshTest {
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void scpAndSftpWagonsApplyConfigurationBeforeConnectionFailure() throws Exception {
+        int port = findUnusedLocalPort();
+
+        for (AbstractJschWagon wagon : List.of(new ScpWagon(), new SftpWagon())) {
+            NullKnownHostProvider knownHostsProvider = new NullKnownHostProvider();
+            NullInteractiveUserInfo interactiveUserInfo = new NullInteractiveUserInfo(true);
+            wagon.setKnownHostsProvider(knownHostsProvider);
+            wagon.setInteractiveUserInfo(interactiveUserInfo);
+            wagon.setInteractive(false);
+
+            assertThat(wagon.supportsDirectoryCopy()).isTrue();
+            assertThat(wagon.getKnownHostsProvider()).isSameAs(knownHostsProvider);
+            assertThat(wagon.getInteractiveUserInfo()).isSameAs(interactiveUserInfo);
+            wagon.setKnownHostsProvider(null);
+            assertThat(wagon.getKnownHostsProvider()).isNull();
+            wagon.setKnownHostsProvider(knownHostsProvider);
+            wagon.setInteractiveUserInfo(null);
+            assertThat(wagon.getInteractiveUserInfo()).isNull();
+            wagon.setInteractiveUserInfo(interactiveUserInfo);
+
+            assertThatThrownBy(() -> wagon.connect(repository(port), authenticationInfo()))
+                    .isInstanceOf(AuthenticationException.class)
+                    .hasMessageContaining("Cannot connect");
+            assertThat(wagon.getRepository().getPort()).isEqualTo(port);
+            assertThat(wagon.getAuthenticationInfo().getUserName()).isEqualTo("wagon-user");
+            assertThat(wagon.getInteractiveUserInfo()).isInstanceOf(NullInteractiveUserInfo.class);
+
+            wagon.disconnect();
+        }
+    }
+
+    @Test
+    void httpProxyConfigurationIsUsedWhenConnecting() throws Exception {
+        try (ServerSocket proxyServer = new ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"))) {
+            proxyServer.setSoTimeout(5_000);
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            Future<List<String>> proxyRequest = executor.submit(() -> readHttpProxyRequest(proxyServer));
+            ScpWagon wagon = new ScpWagon();
+            ProxyInfo proxyInfo = new ProxyInfo();
+            proxyInfo.setType(ProxyInfo.PROXY_HTTP);
+            proxyInfo.setHost("127.0.0.1");
+            proxyInfo.setPort(proxyServer.getLocalPort());
+            proxyInfo.setUserName("proxy-user");
+            proxyInfo.setPassword("proxy-password");
+
+            try {
+                wagon.setKnownHostsProvider(new NullKnownHostProvider());
+                wagon.setInteractive(false);
+
+                Repository proxiedRepository = new Repository("proxied", "scp://repository.example.test/repository");
+                proxiedRepository.setPort(2222);
+
+                assertThatThrownBy(() -> wagon.connect(proxiedRepository, authenticationInfo(), proxyInfo))
+                        .isInstanceOf(AuthenticationException.class)
+                        .hasMessageContaining("Cannot connect");
+
+                List<String> requestLines = proxyRequest.get(5, TimeUnit.SECONDS);
+                String authorizationHeader = "Proxy-Authorization: Basic " + Base64.getEncoder()
+                        .encodeToString("proxy-user:proxy-password".getBytes(StandardCharsets.ISO_8859_1));
+                assertThat(requestLines.get(0)).isEqualTo("CONNECT repository.example.test:2222 HTTP/1.0");
+                assertThat(requestLines).contains(authorizationHeader);
+            } finally {
+                wagon.disconnect();
+                executor.shutdownNow();
+            }
+        }
+    }
+
+    @Test
+    void knownHostsProvidersExposeAndPersistContents() throws Exception {
+        KnownHostsProvider singleProvider = new SingleKnownHostProvider(
+                "example.test", "AAAAB3NzaC1yc2EAAAADAQABAAABAQC");
+        assertThat(singleProvider.getContents())
+                .isEqualTo("example.test ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC\n");
+        assertThat(singleProvider.getHostKeyChecking()).isEqualTo("ask");
+        singleProvider.setHostKeyChecking("no");
+        assertThat(singleProvider.getHostKeyChecking()).isEqualTo("no");
+
+        String knownHosts = "server.test ssh-rsa AAAA\nother.test ssh-dss BBBB\n";
+        StreamKnownHostsProvider streamProvider = new StreamKnownHostsProvider(
+                new ByteArrayInputStream(knownHosts.getBytes(StandardCharsets.UTF_8)));
+        assertThat(streamProvider.getContents()).isEqualTo(knownHosts);
+
+        File knownHostsFile = temporaryDirectory.resolve("ssh/known_hosts").toFile();
+        FileKnownHostsProvider emptyFileProvider = new FileKnownHostsProvider(knownHostsFile);
+        assertThat(emptyFileProvider.getFile()).isEqualTo(knownHostsFile);
+        assertThat(emptyFileProvider.getContents()).isEmpty();
+
+        emptyFileProvider.storeKnownHosts(knownHosts);
+        assertThat(Files.readString(knownHostsFile.toPath())).isEqualTo(knownHosts);
+        FileKnownHostsProvider populatedFileProvider = new FileKnownHostsProvider(knownHostsFile);
+        assertThat(populatedFileProvider.getContents()).isEqualTo(knownHosts);
+
+        NullKnownHostProvider nullProvider = new NullKnownHostProvider();
+        assertThat(nullProvider.getContents()).isNull();
+        nullProvider.storeKnownHosts("ignored");
+        assertThat(nullProvider.getContents()).isNull();
+    }
+
+    @Test
+    void prompterKeyboardInteractiveUsesEchoFlagsAndHandlesFailures() throws Exception {
+        RecordingPrompter prompter = new RecordingPrompter();
+        PrompterUIKeyboardInteractive interactive = new PrompterUIKeyboardInteractive(prompter);
+
+        String[] answers = interactive.promptKeyboardInteractive(
+                "destination", "name", "instruction", new String[] {"login", "secret"}, new boolean[] {true, false});
+
+        assertThat(answers).containsExactly("answer:login", "password:secret");
+        assertThat(prompter.prompts).containsExactly("login");
+        assertThat(prompter.passwordPrompts).containsExactly("secret");
+        assertThatThrownBy(() -> interactive.promptKeyboardInteractive(
+                "destination", "name", "instruction", new String[] {"one"}, new boolean[0]))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("different");
+
+        prompter.failOnPrompt = true;
+        assertThat(interactive.promptKeyboardInteractive(
+                "destination", "name", "instruction", new String[] {"login"}, new boolean[] {true}))
+                .isNull();
+    }
+
+    @Test
+    void consoleInteractiveUserInfoRoutesPromptsThroughPrompter() {
+        ConsolePrompter prompter = new ConsolePrompter();
+        ConsoleInteractiveUserInfo interactiveUserInfo = new ConsoleInteractiveUserInfo(prompter);
+
+        prompter.promptReply = "yes";
+        assertThat(interactiveUserInfo.promptYesNo("Trust host?"))
+                .isTrue();
+        prompter.promptReply = "NO";
+        assertThat(interactiveUserInfo.promptYesNo("Trust second host?"))
+                .isFalse();
+        assertThat(prompter.prompts)
+                .containsExactly("Trust host?", "Trust second host?");
+        assertThat(prompter.possibleValues)
+                .containsExactly(List.of("yes", "no"), List.of("yes", "no"));
+
+        prompter.passwordReply = "secret";
+        assertThat(interactiveUserInfo.promptPassword("Password:"))
+                .isEqualTo("secret");
+        prompter.passwordReply = "phrase";
+        assertThat(interactiveUserInfo.promptPassphrase("Passphrase:"))
+                .isEqualTo("phrase");
+        assertThat(prompter.passwordPrompts)
+                .containsExactly("Password:", "Passphrase:");
+
+        interactiveUserInfo.showMessage("notice");
+        assertThat(prompter.messages)
+                .containsExactly("notice");
+
+        prompter.failOnPrompt = true;
+        assertThat(interactiveUserInfo.promptYesNo("Unavailable?"))
+                .isFalse();
+        prompter.failOnPasswordPrompt = true;
+        assertThat(interactiveUserInfo.promptPassword("Unavailable password:"))
+                .isNull();
+        assertThat(interactiveUserInfo.promptPassphrase("Unavailable passphrase:"))
+                .isNull();
+        prompter.failOnShowMessage = true;
+        interactiveUserInfo.showMessage("ignored");
+    }
+
+    @Test
+    void userInfoKeyboardInteractiveProxyDelegatesBothInterfaces() {
+        RecordingUserInfo userInfo = new RecordingUserInfo();
+        UIKeyboardInteractive keyboardInteractive = (destination, name, instruction, prompt, echo) -> new String[] {
+                destination, name, instruction, prompt[0], Boolean.toString(echo[0])
+        };
+        UserInfoUIKeyboardInteractiveProxy proxy = new UserInfoUIKeyboardInteractiveProxy(
+                userInfo, keyboardInteractive);
+
+        assertThat(proxy.getPassphrase()).isEqualTo("delegate-passphrase");
+        assertThat(proxy.getPassword()).isEqualTo("delegate-password");
+        assertThat(proxy.promptPassword("password?")).isTrue();
+        assertThat(proxy.promptPassphrase("passphrase?")).isFalse();
+        assertThat(proxy.promptYesNo("continue?")).isTrue();
+        proxy.showMessage("hello");
+        assertThat(userInfo.messages).containsExactly("hello");
+        assertThat(proxy.promptKeyboardInteractive(
+                "dest", "name", "instruction", new String[] {"prompt"}, new boolean[] {true}))
+                .containsExactly(
+                        "dest",
+                        "name",
+                        "instruction",
+                        "Keyboard interactive required, supplied password is ignored\nprompt",
+                        "true");
+    }
+
+    @Test
+    void sshUtilityParsersCollectExpectedOutput() throws Exception {
+        Streams streams = CommandExecutorStreamProcessor.processStreams(
+                reader("Could not chdir to home directory /missing\nttyname: Operation not supported\nreal error\n"),
+                reader("first line\nsecond line\n"));
+        assertThat(streams.getErr()).isEqualTo("real error\n");
+        assertThat(streams.getOut()).isEqualTo("first line\nsecond line\n");
+
+        assertThat(new LSParser().parseFiles("total 8\n-rw-r--r-- 1 user group 12 Jan 01 12:34 artifact.jar\n"
+                + "drwxr-xr-x 2 user group 96 Feb 02 2024 directory\ninvalid\n"))
+                .containsExactly("artifact.jar", "directory");
+    }
+
+    private static BufferedReader reader(String content) {
+        return new BufferedReader(new StringReader(content));
+    }
+
+    private static List<String> readHttpProxyRequest(ServerSocket serverSocket) throws IOException {
+        try (Socket socket = serverSocket.accept()) {
+            socket.setSoTimeout(5_000);
+            BufferedReader requestReader = new BufferedReader(
+                    new InputStreamReader(socket.getInputStream(), StandardCharsets.ISO_8859_1));
+            List<String> requestLines = new ArrayList<>();
+            String line;
+            while ((line = requestReader.readLine()) != null && !line.isEmpty()) {
+                requestLines.add(line);
+            }
+            byte[] response = "HTTP/1.0 403 Forbidden\r\nContent-Length: 0\r\n\r\n"
+                    .getBytes(StandardCharsets.ISO_8859_1);
+            socket.getOutputStream().write(response);
+            socket.getOutputStream().flush();
+            return requestLines;
+        }
+    }
+
+    private static Repository repository(int port) {
+        Repository repository = new Repository("test", "scp://127.0.0.1/repository");
+        repository.setPort(port);
+        return repository;
+    }
+
+    private static AuthenticationInfo authenticationInfo() {
+        AuthenticationInfo authenticationInfo = new AuthenticationInfo();
+        authenticationInfo.setUserName("wagon-user");
+        authenticationInfo.setPassword("secret-password");
+        return authenticationInfo;
+    }
+
+    private static int findUnusedLocalPort() throws IOException {
+        try (ServerSocket serverSocket = new ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"))) {
+            return serverSocket.getLocalPort();
+        }
+    }
+
+    private static final class ConsolePrompter implements Prompter {
+        private final List<String> prompts = new ArrayList<>();
+        private final List<List<String>> possibleValues = new ArrayList<>();
+        private final List<String> passwordPrompts = new ArrayList<>();
+        private final List<String> messages = new ArrayList<>();
+        private String promptReply = "yes";
+        private String passwordReply = "secret";
+        private boolean failOnPrompt;
+        private boolean failOnPasswordPrompt;
+        private boolean failOnShowMessage;
+
+        @Override
+        public String prompt(String message) throws PrompterException {
+            if (failOnPrompt) {
+                throw new PrompterException("failed");
+            }
+            prompts.add(message);
+            return promptReply;
+        }
+
+        @Override
+        public String prompt(String message, String defaultReply) throws PrompterException {
+            return prompt(message);
+        }
+
+        @Override
+        public String prompt(String message, List possibleValues) throws PrompterException {
+            List<String> values = new ArrayList<>();
+            for (Object possibleValue : possibleValues) {
+                values.add(String.valueOf(possibleValue));
+            }
+            this.possibleValues.add(values);
+            return prompt(message);
+        }
+
+        @Override
+        public String prompt(String message, List possibleValues, String defaultReply) throws PrompterException {
+            return prompt(message, possibleValues);
+        }
+
+        @Override
+        public String promptForPassword(String message) throws PrompterException {
+            if (failOnPasswordPrompt) {
+                throw new PrompterException("failed");
+            }
+            passwordPrompts.add(message);
+            return passwordReply;
+        }
+
+        @Override
+        public void showMessage(String message) throws PrompterException {
+            if (failOnShowMessage) {
+                throw new PrompterException("failed");
+            }
+            messages.add(message);
+        }
+    }
+
+    private static final class RecordingPrompter implements Prompter {
+        private final List<String> prompts = new ArrayList<>();
+        private final List<String> passwordPrompts = new ArrayList<>();
+        private boolean failOnPrompt;
+
+        @Override
+        public String prompt(String message) throws PrompterException {
+            if (failOnPrompt) {
+                throw new PrompterException("failed");
+            }
+            prompts.add(message);
+            return "answer:" + message;
+        }
+
+        @Override
+        public String prompt(String message, String defaultReply) throws PrompterException {
+            return prompt(message);
+        }
+
+        @Override
+        public String prompt(String message, List possibleValues) throws PrompterException {
+            return prompt(message);
+        }
+
+        @Override
+        public String prompt(String message, List possibleValues, String defaultReply) throws PrompterException {
+            return prompt(message);
+        }
+
+        @Override
+        public String promptForPassword(String message) throws PrompterException {
+            if (failOnPrompt) {
+                throw new PrompterException("failed");
+            }
+            passwordPrompts.add(message);
+            return "password:" + message;
+        }
+
+        @Override
+        public void showMessage(String message) {
+        }
+    }
+
+    private static final class RecordingUserInfo implements UserInfo {
+        private final List<String> messages = new ArrayList<>();
+
+        @Override
+        public String getPassphrase() {
+            return "delegate-passphrase";
+        }
+
+        @Override
+        public String getPassword() {
+            return "delegate-password";
+        }
+
+        @Override
+        public boolean promptPassword(String message) {
+            return true;
+        }
+
+        @Override
+        public boolean promptPassphrase(String message) {
+            return false;
+        }
+
+        @Override
+        public boolean promptYesNo(String message) {
+            return true;
+        }
+
+        @Override
+        public void showMessage(String message) {
+            messages.add(message);
+        }
+    }
+}

--- a/tests/src/org.apache.maven.wagon/wagon-ssh/2.12/user-code-filter.json
+++ b/tests/src/org.apache.maven.wagon/wagon-ssh/2.12/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.maven.wagon.providers.ssh.jsch.**"
+    },
+    {
+      "includeClasses" : "org_apache_maven_wagon.wagon_ssh.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7567

This PR provides test fixes and new metadata for org.apache.maven.wagon:wagon-ssh:2.12, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 55321
- Cached input tokens: 266240
- Output tokens: 2281
- Metadata entries: 5
- Iterations: 1
- Library coverage percentage: 17.73
- Previous library version metadata entries: 76
- Previous library version coverage percentage: 17.5

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `c973a8aab682315d994dee041a10fca2ad74847e`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.maven.wagon:wagon-ssh:1.0: 0/0 covered calls (100.00%)
- org.apache.maven.wagon:wagon-ssh:2.12: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.maven.wagon:wagon-ssh:1.0: 383/2513 (15.24%)
- org.apache.maven.wagon:wagon-ssh:2.12: 411/2669 (15.40%)

**Line:**
- org.apache.maven.wagon:wagon-ssh:1.0: 94/537 (17.50%)
- org.apache.maven.wagon:wagon-ssh:2.12: 100/564 (17.73%)

**Method:**
- org.apache.maven.wagon:wagon-ssh:1.0: 22/69 (31.88%)
- org.apache.maven.wagon:wagon-ssh:2.12: 24/76 (31.58%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.maven.wagon/wagon-ssh/1.0/src/test/java/org_apache_maven_wagon/wagon_ssh/Wagon_sshTest.java 2/tests/src/org.apache.maven.wagon/wagon-ssh/2.12/src/test/java/org_apache_maven_wagon/wagon_ssh/Wagon_sshTest.java
index 70534b7cfa..24d13037e7 100644
--- 1/tests/src/org.apache.maven.wagon/wagon-ssh/1.0/src/test/java/org_apache_maven_wagon/wagon_ssh/Wagon_sshTest.java
+++ 2/tests/src/org.apache.maven.wagon/wagon-ssh/2.12/src/test/java/org_apache_maven_wagon/wagon_ssh/Wagon_sshTest.java
@@ -57,6 +57,9 @@ import org.junit.jupiter.api.io.TempDir;
 
 @Timeout(value = 20, unit = TimeUnit.SECONDS)
 public class Wagon_sshTest {
+    private static final String DEFAULT_PREFERRED_AUTHENTICATIONS =
+            "gssapi-with-mic,publickey,password,keyboard-interactive";
+
     @TempDir
     Path temporaryDirectory;
 
@@ -69,9 +72,11 @@ public class Wagon_sshTest {
             NullInteractiveUserInfo interactiveUserInfo = new NullInteractiveUserInfo(true);
             wagon.setKnownHostsProvider(knownHostsProvider);
             wagon.setInteractiveUserInfo(interactiveUserInfo);
+            wagon.setPreferredAuthentications(DEFAULT_PREFERRED_AUTHENTICATIONS);
             wagon.setInteractive(false);
 
             assertThat(wagon.supportsDirectoryCopy()).isTrue();
+            assertThat(wagon.getPreferredAuthentications()).isEqualTo(DEFAULT_PREFERRED_AUTHENTICATIONS);
             assertThat(wagon.getKnownHostsProvider()).isSameAs(knownHostsProvider);
             assertThat(wagon.getInteractiveUserInfo()).isSameAs(interactiveUserInfo);
             wagon.setKnownHostsProvider(null);
@@ -108,6 +113,7 @@ public class Wagon_sshTest {
 
             try {
                 wagon.setKnownHostsProvider(new NullKnownHostProvider());
+                wagon.setPreferredAuthentications(DEFAULT_PREFERRED_AUTHENTICATIONS);
                 wagon.setInteractive(false);
 
                 Repository proxiedRepository = new Repository("proxied", "scp://repository.example.test/repository");

```

### Local CI Verification

- Status: `success`
- Commands run: 14
- Fixup attempts: 0
