### PR TITLE
[GenAI] Add support for org.apache.maven:maven-archiver:2.5 using gpt-5.5

### DIFF
--- a/metadata/org.apache.maven/maven-archiver/2.5/reachability-metadata.json
+++ b/metadata/org.apache.maven/maven-archiver/2.5/reachability-metadata.json
@@ -1,0 +1,18 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.archiver.MavenArchiver"
+      },
+      "type": "org.apache.maven.artifact.DefaultArtifact",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.archiver.MavenArchiver"
+      },
+      "type": "org.apache.maven.artifact.handler.DefaultArtifactHandler",
+      "allPublicMethods": true
+    }
+  ]
+}

--- a/metadata/org.apache.maven/maven-archiver/index.json
+++ b/metadata/org.apache.maven/maven-archiver/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.5",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/maven-archiver/$version$/maven-archiver-$version$-sources.jar",
+    "repository-url" : "https://svn.apache.org/repos/asf/maven/shared",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/maven-archiver/$version$/maven-archiver-$version$-source-release.zip",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/maven-archiver/$version$/maven-archiver-$version$-javadoc.jar",
+    "description" : "Maven Archiver provides utilities for Maven plugins and builds to create JARs and other archive files from a Maven project. It handles archive configuration such as manifests, Maven descriptors, and project metadata while delegating low-level archive creation to Plexus Archiver.",
+    "tested-versions" : [
+      "2.5"
+    ],
+    "allowed-packages" : [
+      "org.apache.maven.archiver"
+    ]
+  }
+]

--- a/stats/org.apache.maven/maven-archiver/2.5/execution-metrics.json
+++ b/stats/org.apache.maven/maven-archiver/2.5/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-23": {
+    "timestamp": "2026-05-23T03:26:34.249694Z",
+    "library": "org.apache.maven:maven-archiver:2.5",
+    "starting_commit": "5e7d523a2ce9587478c6643d497e276708ca44e1",
+    "ending_commit": "64f4c3c1ef7121e0b775141bdc80736d34b34ac3",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.5",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1215,
+          "missed": 203,
+          "ratio": 0.856841,
+          "total": 1418
+        },
+        "line": {
+          "covered": 284,
+          "missed": 45,
+          "ratio": 0.863222,
+          "total": 329
+        },
+        "method": {
+          "covered": 69,
+          "missed": 7,
+          "ratio": 0.907895,
+          "total": 76
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 269412,
+      "cached_input_tokens_used": 4088832,
+      "output_tokens_used": 26082,
+      "iterations": 4,
+      "cost_usd": 2.8269,
+      "generated_loc": 446,
+      "tested_library_loc": 284,
+      "metadata_entries": 4,
+      "code_coverage_percent": 86.32
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.maven/maven-archiver/2.5/src/test/java/org_apache_maven/maven_archiver/Maven_archiverTest.java",
+      "metadata_file": "metadata/org.apache.maven/maven-archiver/2.5/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.maven/maven-archiver/2.5/stats.json
+++ b/stats/org.apache.maven/maven-archiver/2.5/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.5",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1215,
+        "missed" : 203,
+        "ratio" : 0.856841,
+        "total" : 1418
+      },
+      "line" : {
+        "covered" : 284,
+        "missed" : 45,
+        "ratio" : 0.863222,
+        "total" : 329
+      },
+      "method" : {
+        "covered" : 69,
+        "missed" : 7,
+        "ratio" : 0.907895,
+        "total" : 76
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.maven/maven-archiver/2.5/.gitignore
+++ b/tests/src/org.apache.maven/maven-archiver/2.5/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.maven/maven-archiver/2.5/build.gradle
+++ b/tests/src/org.apache.maven/maven-archiver/2.5/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.maven:maven-archiver:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.maven/maven-archiver/2.5/build.gradle
+++ b/tests/src/org.apache.maven/maven-archiver/2.5/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.apache.maven:maven-archiver:$libraryVersion"
+    testImplementation 'org.apache.maven:maven-project:2.0.6'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.apache.maven/maven-archiver/2.5/gradle.properties
+++ b/tests/src/org.apache.maven/maven-archiver/2.5/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.maven:maven-archiver:2.5
+library.version = 2.5
+metadata.dir = org.apache.maven/maven-archiver/2.5/

--- a/tests/src/org.apache.maven/maven-archiver/2.5/settings.gradle
+++ b/tests/src/org.apache.maven/maven-archiver/2.5/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.maven.maven-archiver_tests'

--- a/tests/src/org.apache.maven/maven-archiver/2.5/src/test/java/org_apache_maven/maven_archiver/Maven_archiverTest.java
+++ b/tests/src/org.apache.maven/maven-archiver/2.5/src/test/java/org_apache_maven/maven_archiver/Maven_archiverTest.java
@@ -17,6 +17,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.LinkedHashSet;
 import java.util.Properties;
 import java.util.Set;
@@ -34,6 +35,7 @@ import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
 import org.apache.maven.artifact.repository.layout.ArtifactRepositoryLayout;
 import org.apache.maven.artifact.versioning.VersionRange;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Organization;
@@ -122,6 +124,19 @@ public class Maven_archiverTest {
         assertThat(manifestConfiguration.isAddDefaultSpecificationEntries()).isTrue();
         assertThat(manifestConfiguration.getMainClass()).isEqualTo("example.Main");
         assertThat(manifestConfiguration.getPackageName()).isEqualTo("example.package");
+    }
+
+    @Test
+    void manifestCreatedByIncludesMavenVersionFromSession() throws Exception {
+        MavenProject project = newProject("org.example", "session-app", "1.0.0");
+        Properties executionProperties = new Properties();
+        executionProperties.setProperty("maven.version", "test-session-version");
+        MavenSession session = new MavenSession(null, null, null, null, null, Collections.emptyList(),
+                tempDir.toString(), executionProperties, new Date(0L));
+
+        Manifest manifest = new MavenArchiver().getManifest(session, project, new ManifestConfiguration());
+
+        assertThat(mainAttribute(manifest, "Created-By")).isEqualTo("Apache Maven test-session-version");
     }
 
     @Test

--- a/tests/src/org.apache.maven/maven-archiver/2.5/src/test/java/org_apache_maven/maven_archiver/Maven_archiverTest.java
+++ b/tests/src/org.apache.maven/maven-archiver/2.5/src/test/java/org_apache_maven/maven_archiver/Maven_archiverTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven.maven_archiver;
+
+import org.junit.jupiter.api.Test;
+
+class Maven_archiverTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.apache.maven/maven-archiver/2.5/src/test/java/org_apache_maven/maven_archiver/Maven_archiverTest.java
+++ b/tests/src/org.apache.maven/maven-archiver/2.5/src/test/java/org_apache_maven/maven_archiver/Maven_archiverTest.java
@@ -375,7 +375,7 @@ public class Maven_archiverTest {
 
     private File createEmptyJar(String fileName) throws IOException {
         Path jarPath = tempDir.resolve(fileName);
-        Files.write(jarPath, new byte[] { 'P', 'K', 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 });
+        Files.write(jarPath, new byte[] {'P', 'K', 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 });
         return jarPath.toFile();
     }
 

--- a/tests/src/org.apache.maven/maven-archiver/2.5/src/test/java/org_apache_maven/maven_archiver/Maven_archiverTest.java
+++ b/tests/src/org.apache.maven/maven-archiver/2.5/src/test/java/org_apache_maven/maven_archiver/Maven_archiverTest.java
@@ -239,6 +239,48 @@ public class Maven_archiverTest {
     }
 
     @Test
+    void createArchiveMergesSuppliedManifestFileWithGeneratedEntries() throws Exception {
+        MavenProject project = newProject("org.example", "manifest-file-app", "1.0.0");
+        Path manifestFile = tempDir.resolve("MANIFEST.MF");
+        Files.writeString(manifestFile, """
+                Manifest-Version: 1.0
+                X-External: from-file
+
+                Name: docs/readme.txt
+                X-Section: section-value
+
+                """, StandardCharsets.UTF_8);
+
+        MavenArchiveConfiguration archiveConfiguration = new MavenArchiveConfiguration();
+        archiveConfiguration.setAddMavenDescriptor(false);
+        archiveConfiguration.setManifestFile(manifestFile.toFile());
+        archiveConfiguration.getManifest().setMainClass("org.example.ManifestFileMain");
+        archiveConfiguration.addManifestEntry("X-Configured", "from-configuration");
+
+        Path classesDirectory = tempDir.resolve("classes-manifest-file-app");
+        Files.createDirectories(classesDirectory);
+        Files.writeString(classesDirectory.resolve("content.txt"), "content", StandardCharsets.UTF_8);
+
+        MavenArchiver mavenArchiver = new MavenArchiver();
+        mavenArchiver.setArchiver(new JarArchiver());
+        mavenArchiver.getArchiver().addDirectory(classesDirectory.toFile());
+        Files.createDirectories(tempDir.resolve("target"));
+        File archiveFile = tempDir.resolve("target/manifest-file-app.jar").toFile();
+        mavenArchiver.setOutputFile(archiveFile);
+        mavenArchiver.createArchive(project, archiveConfiguration);
+
+        try (JarFile jarFile = new JarFile(archiveFile)) {
+            java.util.jar.Manifest jarManifest = jarFile.getManifest();
+            Attributes attributes = jarManifest.getMainAttributes();
+            assertThat(attributes.getValue("X-External")).isEqualTo("from-file");
+            assertThat(attributes.getValue("X-Configured")).isEqualTo("from-configuration");
+            assertThat(attributes.getValue("Main-Class")).isEqualTo("org.example.ManifestFileMain");
+            assertThat(jarManifest.getAttributes("docs/readme.txt").getValue("X-Section"))
+                    .isEqualTo("section-value");
+        }
+    }
+
+    @Test
     void createArchiveWritesManifestAndMavenDescriptors() throws Exception {
         MavenProject project = newProject("org.example", "archive-app", "2.0.0");
         Path pomFile = tempDir.resolve("pom.xml");

--- a/tests/src/org.apache.maven/maven-archiver/2.5/src/test/java/org_apache_maven/maven_archiver/Maven_archiverTest.java
+++ b/tests/src/org.apache.maven/maven-archiver/2.5/src/test/java/org_apache_maven/maven_archiver/Maven_archiverTest.java
@@ -6,11 +6,456 @@
  */
 package org_apache_maven.maven_archiver;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-class Maven_archiverTest {
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Properties;
+import java.util.Set;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+
+import org.apache.maven.archiver.ManifestConfiguration;
+import org.apache.maven.archiver.ManifestSection;
+import org.apache.maven.archiver.MavenArchiveConfiguration;
+import org.apache.maven.archiver.MavenArchiver;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
+import org.apache.maven.artifact.repository.layout.ArtifactRepositoryLayout;
+import org.apache.maven.artifact.versioning.VersionRange;
+import org.apache.maven.model.Build;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Organization;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.archiver.jar.JarArchiver;
+import org.codehaus.plexus.archiver.jar.Manifest;
+import org.codehaus.plexus.archiver.jar.ManifestException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class Maven_archiverTest {
+    @TempDir
+    Path tempDir;
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void configurationObjectsRetainValuesAndNormalizeClasspathPrefix() throws IOException {
+        MavenArchiveConfiguration archiveConfiguration = new MavenArchiveConfiguration();
+        assertThat(archiveConfiguration.isCompress()).isTrue();
+        assertThat(archiveConfiguration.isIndex()).isFalse();
+        assertThat(archiveConfiguration.isAddMavenDescriptor()).isTrue();
+        assertThat(archiveConfiguration.isForced()).isTrue();
+        assertThat(archiveConfiguration.isManifestEntriesEmpty()).isTrue();
+        assertThat(archiveConfiguration.isManifestSectionsEmpty()).isTrue();
+        assertThat(archiveConfiguration.getManifest()).isSameAs(archiveConfiguration.getManifest());
+
+        File manifestFile = tempDir.resolve("MANIFEST.MF").toFile();
+        File pomPropertiesFile = tempDir.resolve("custom-pom.properties").toFile();
+        archiveConfiguration.setCompress(false);
+        archiveConfiguration.setIndex(true);
+        archiveConfiguration.setAddMavenDescriptor(false);
+        archiveConfiguration.setForced(false);
+        archiveConfiguration.setManifestFile(manifestFile);
+        archiveConfiguration.setPomPropertiesFile(pomPropertiesFile);
+        archiveConfiguration.addManifestEntry("X-Entry", "one");
+        archiveConfiguration.addManifestEntries(Collections.singletonMap("X-Other", "two"));
+
+        ManifestSection section = new ManifestSection();
+        section.setName("dependencies/sample.jar");
+        section.addManifestEntry("SHA-256-Digest", "digest-value");
+        archiveConfiguration.addManifestSection(section);
+
+        assertThat(archiveConfiguration.isCompress()).isFalse();
+        assertThat(archiveConfiguration.isIndex()).isTrue();
+        assertThat(archiveConfiguration.isAddMavenDescriptor()).isFalse();
+        assertThat(archiveConfiguration.isForced()).isFalse();
+        assertThat(archiveConfiguration.getManifestFile()).isEqualTo(manifestFile);
+        assertThat(archiveConfiguration.getPomPropertiesFile()).isEqualTo(pomPropertiesFile);
+        assertThat(archiveConfiguration.getManifestEntries())
+                .containsEntry("X-Entry", "one")
+                .containsEntry("X-Other", "two");
+        assertThat(archiveConfiguration.getManifestSections()).containsExactly(section);
+        assertThat(section.getName()).isEqualTo("dependencies/sample.jar");
+        assertThat(section.isManifestEntriesEmpty()).isFalse();
+        assertThat(section.getManifestEntries()).containsEntry("SHA-256-Digest", "digest-value");
+
+        ManifestConfiguration manifestConfiguration = new ManifestConfiguration();
+        assertThat(manifestConfiguration.getClasspathPrefix()).isEmpty();
+        assertThat(manifestConfiguration.getClasspathLayoutType())
+                .isEqualTo(ManifestConfiguration.CLASSPATH_LAYOUT_TYPE_SIMPLE);
+        assertThat(manifestConfiguration.isUseUniqueVersions()).isTrue();
+
+        manifestConfiguration.setClasspathPrefix("lib\\nested");
+        manifestConfiguration.setClasspathMavenRepositoryLayout(true);
+        assertThat(manifestConfiguration.getClasspathPrefix()).isEqualTo("lib/nested/");
+        assertThat(manifestConfiguration.getClasspathLayoutType())
+                .isEqualTo(ManifestConfiguration.CLASSPATH_LAYOUT_TYPE_REPOSITORY);
+
+        manifestConfiguration.setClasspathLayoutType(ManifestConfiguration.CLASSPATH_LAYOUT_TYPE_CUSTOM);
+        manifestConfiguration.setCustomClasspathLayout(
+                "${artifact.groupId}/${artifact.artifactId}.${artifact.extension}");
+        manifestConfiguration.setUseUniqueVersions(false);
+        manifestConfiguration.setAddClasspath(true);
+        manifestConfiguration.setAddExtensions(true);
+        manifestConfiguration.setAddDefaultImplementationEntries(true);
+        manifestConfiguration.setAddDefaultSpecificationEntries(true);
+        manifestConfiguration.setMainClass("example.Main");
+        manifestConfiguration.setPackageName("example.package");
+        assertThat(manifestConfiguration.getClasspathLayoutType())
+                .isEqualTo(ManifestConfiguration.CLASSPATH_LAYOUT_TYPE_CUSTOM);
+        assertThat(manifestConfiguration.getCustomClasspathLayout())
+                .isEqualTo("${artifact.groupId}/${artifact.artifactId}.${artifact.extension}");
+        assertThat(manifestConfiguration.isUseUniqueVersions()).isFalse();
+        assertThat(manifestConfiguration.isAddClasspath()).isTrue();
+        assertThat(manifestConfiguration.isAddExtensions()).isTrue();
+        assertThat(manifestConfiguration.isAddDefaultImplementationEntries()).isTrue();
+        assertThat(manifestConfiguration.isAddDefaultSpecificationEntries()).isTrue();
+        assertThat(manifestConfiguration.getMainClass()).isEqualTo("example.Main");
+        assertThat(manifestConfiguration.getPackageName()).isEqualTo("example.package");
+    }
+
+    @Test
+    void manifestIncludesDefaultCustomAndSectionEntries() throws Exception {
+        MavenProject project = newProject("org.example", "demo-app", "1.2.3");
+        Organization organization = new Organization();
+        organization.setName("Example Foundation");
+        project.setOrganization(organization);
+
+        MavenArchiveConfiguration archiveConfiguration = new MavenArchiveConfiguration();
+        ManifestConfiguration manifestConfiguration = archiveConfiguration.getManifest();
+        manifestConfiguration.setMainClass("org.example.Main");
+        manifestConfiguration.setPackageName("org.example.package");
+        manifestConfiguration.setAddDefaultImplementationEntries(true);
+        manifestConfiguration.setAddDefaultSpecificationEntries(true);
+        archiveConfiguration.addManifestEntry("Created-By", "custom build tool");
+        archiveConfiguration.addManifestEntry("X-Custom", "custom-value");
+
+        ManifestSection section = new ManifestSection();
+        section.setName("plugins/sample-plugin.jar");
+        section.addManifestEntry("Plugin-Id", "sample-plugin");
+        archiveConfiguration.addManifestSection(section);
+
+        Manifest manifest = new MavenArchiver().getManifest(project, archiveConfiguration);
+
+        assertThat(mainAttribute(manifest, "Created-By")).isEqualTo("custom build tool");
+        assertThat(mainAttribute(manifest, "Built-By")).isNotNull();
+        assertThat(mainAttribute(manifest, "Build-Jdk")).isEqualTo(System.getProperty("java.version"));
+        assertThat(mainAttribute(manifest, "Package")).isEqualTo("org.example.package");
+        assertThat(mainAttribute(manifest, "Main-Class")).isEqualTo("org.example.Main");
+        assertThat(mainAttribute(manifest, "X-Custom")).isEqualTo("custom-value");
+        assertThat(mainAttribute(manifest, "Specification-Title")).isEqualTo("Demo App");
+        assertThat(mainAttribute(manifest, "Specification-Version")).isEqualTo("1.2.3");
+        assertThat(mainAttribute(manifest, "Specification-Vendor")).isEqualTo("Example Foundation");
+        assertThat(mainAttribute(manifest, "Implementation-Title")).isEqualTo("Demo App");
+        assertThat(mainAttribute(manifest, "Implementation-Version")).isEqualTo("1.2.3");
+        assertThat(mainAttribute(manifest, "Implementation-Vendor-Id")).isEqualTo("org.example");
+        assertThat(mainAttribute(manifest, "Implementation-Vendor")).isEqualTo("Example Foundation");
+        assertThat(manifest.getSection("plugins/sample-plugin.jar").getAttributeValue("Plugin-Id"))
+                .isEqualTo("sample-plugin");
+    }
+
+    @Test
+    void manifestBuildsClasspathWithSimpleRepositoryAndCustomLayouts() throws Exception {
+        File alphaJar = createEmptyJar("alpha-1.0.0.jar");
+        File betaJar = createEmptyJar("beta-2.0.0-tests.jar");
+        Artifact alpha = newArtifact("com.acme", "alpha", "1.0.0", null, "compile", alphaJar);
+        Artifact beta = newArtifact("org.sample", "beta", "2.0.0", "tests", "runtime", betaJar);
+        MavenProject project = newProject("org.example", "classpath-app", "1.0.0", alpha, beta);
+
+        assertThat(classPathFor(project, ManifestConfiguration.CLASSPATH_LAYOUT_TYPE_SIMPLE, "lib", null, true))
+                .isEqualTo("lib/alpha-1.0.0.jar lib/beta-2.0.0-tests.jar");
+        assertThat(classPathFor(project, ManifestConfiguration.CLASSPATH_LAYOUT_TYPE_REPOSITORY, "repo", null, true))
+                .isEqualTo("repo/com/acme/alpha/1.0.0/alpha-1.0.0.jar "
+                        + "repo/org/sample/beta/2.0.0/beta-2.0.0-tests.jar");
+        assertThat(classPathFor(project, ManifestConfiguration.CLASSPATH_LAYOUT_TYPE_CUSTOM, "", "modules/"
+                + "${artifact.groupIdPath}/${artifact.artifactId}${dashClassifier}.${artifact.extension}", true))
+                .isEqualTo("modules/com/acme/alpha.jar modules/org/sample/beta-tests.jar");
+    }
+
+    @Test
+    void manifestAddsExtensionEntriesForJarArtifactsOnly() throws Exception {
+        Artifact extension = newArtifact("com.acme", "feature.extension", "3.4.5", null, "runtime",
+                createEmptyJar("feature-extension.jar"));
+        extension.setRepository(new TestArtifactRepository("https://repo.example.invalid/releases"));
+        Artifact webModule = newArtifact("com.acme", "web-module", "1.0.0", null, "runtime",
+                createEmptyJar("web-module.war"), "war");
+        MavenProject project = newProject("org.example", "extension-app", "1.0.0", extension, webModule);
+
+        ManifestConfiguration manifestConfiguration = new ManifestConfiguration();
+        manifestConfiguration.setAddExtensions(true);
+        Manifest manifest = new MavenArchiver().getManifest(project, manifestConfiguration);
+
+        assertThat(mainAttribute(manifest, "Extension-List")).isEqualTo("feature.extension");
+        assertThat(mainAttribute(manifest, "feature_extension-Extension-Name")).isEqualTo("feature.extension");
+        assertThat(mainAttribute(manifest, "feature_extension-Implementation-Version")).isEqualTo("3.4.5");
+        assertThat(mainAttribute(manifest, "feature_extension-Implementation-URL"))
+                .isEqualTo("https://repo.example.invalid/releases/com.acme:feature.extension:jar:3.4.5:runtime");
+        assertThat(mainAttribute(manifest, "web-module-Extension-Name")).isNull();
+    }
+
+    @Test
+    void manifestReportsUnsupportedClasspathLayouts() throws Exception {
+        MavenProject project = newProject("org.example", "invalid-layout-app", "1.0.0",
+                newArtifact("com.acme", "alpha", "1.0.0", null, "compile", createEmptyJar("alpha.jar")));
+
+        ManifestConfiguration missingCustomLayout = new ManifestConfiguration();
+        missingCustomLayout.setAddClasspath(true);
+        missingCustomLayout.setClasspathLayoutType(ManifestConfiguration.CLASSPATH_LAYOUT_TYPE_CUSTOM);
+        assertThatExceptionOfType(ManifestException.class)
+                .isThrownBy(() -> new MavenArchiver().getManifest(project, missingCustomLayout))
+                .withMessageContaining("custom layout expression was not specified");
+
+        ManifestConfiguration unknownLayout = new ManifestConfiguration();
+        unknownLayout.setAddClasspath(true);
+        unknownLayout.setClasspathLayoutType("unsupported-layout");
+        assertThatExceptionOfType(ManifestException.class)
+                .isThrownBy(() -> new MavenArchiver().getManifest(project, unknownLayout))
+                .withMessageContaining("Unknown classpath layout type");
+    }
+
+    @Test
+    void createArchiveWritesManifestAndMavenDescriptors() throws Exception {
+        MavenProject project = newProject("org.example", "archive-app", "2.0.0");
+        Path pomFile = tempDir.resolve("pom.xml");
+        Files.writeString(pomFile, """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.example</groupId>
+                  <artifactId>archive-app</artifactId>
+                  <version>2.0.0</version>
+                </project>
+                """, StandardCharsets.UTF_8);
+        project.setFile(pomFile.toFile());
+
+        MavenArchiveConfiguration archiveConfiguration = new MavenArchiveConfiguration();
+        archiveConfiguration.setPomPropertiesFile(tempDir.resolve("generated/custom-pom.properties").toFile());
+        archiveConfiguration.getManifest().setMainClass("org.example.archive.Main");
+        archiveConfiguration.addManifestEntry("X-Archive", "created");
+
+        MavenArchiver mavenArchiver = new MavenArchiver();
+        mavenArchiver.setArchiver(new JarArchiver());
+        Files.createDirectories(tempDir.resolve("target"));
+        File archiveFile = tempDir.resolve("target/archive-app.jar").toFile();
+        mavenArchiver.setOutputFile(archiveFile);
+        mavenArchiver.createArchive(project, archiveConfiguration);
+
+        assertThat(archiveFile).isFile();
+        try (JarFile jarFile = new JarFile(archiveFile)) {
+            java.util.jar.Manifest jarManifest = jarFile.getManifest();
+            Attributes attributes = jarManifest.getMainAttributes();
+            assertThat(attributes.getValue("Main-Class")).isEqualTo("org.example.archive.Main");
+            assertThat(attributes.getValue("X-Archive")).isEqualTo("created");
+            assertThat(jarFile.getEntry("META-INF/maven/org.example/archive-app/pom.xml")).isNotNull();
+            assertThat(jarFile.getEntry("META-INF/maven/org.example/archive-app/pom.properties")).isNotNull();
+        }
+
+        Properties properties = new Properties();
+        File generatedProperties = tempDir.resolve("generated/custom-pom.properties").toFile();
+        try (FileInputStream inputStream = new FileInputStream(generatedProperties)) {
+            properties.load(inputStream);
+        }
+        assertThat(properties)
+                .containsEntry("groupId", "org.example")
+                .containsEntry("artifactId", "archive-app")
+                .containsEntry("version", "2.0.0");
+    }
+
+    private String classPathFor(MavenProject project, String layoutType, String prefix, String customLayout,
+            boolean uniqueVersions) throws Exception {
+        ManifestConfiguration manifestConfiguration = new ManifestConfiguration();
+        manifestConfiguration.setAddClasspath(true);
+        manifestConfiguration.setClasspathLayoutType(layoutType);
+        manifestConfiguration.setClasspathPrefix(prefix);
+        manifestConfiguration.setCustomClasspathLayout(customLayout);
+        manifestConfiguration.setUseUniqueVersions(uniqueVersions);
+        Manifest manifest = new MavenArchiver().getManifest(project, manifestConfiguration);
+        return mainAttribute(manifest, "Class-Path");
+    }
+
+    private MavenProject newProject(String groupId, String artifactId, String version, Artifact... artifacts)
+            throws IOException {
+        Model model = new Model();
+        model.setModelVersion("4.0.0");
+        model.setGroupId(groupId);
+        model.setArtifactId(artifactId);
+        model.setVersion(version);
+        model.setName(toDisplayName(artifactId));
+        model.setPackaging("jar");
+        Build build = new Build();
+        build.setDirectory(tempDir.resolve("target-" + artifactId).toString());
+        build.setOutputDirectory(tempDir.resolve("classes-" + artifactId).toString());
+        model.setBuild(build);
+
+        MavenProject project = new MavenProject(model);
+        project.setArtifact(newArtifact(groupId, artifactId, version, null, "compile", null));
+        Set<Artifact> artifactSet = new LinkedHashSet<>(Arrays.asList(artifacts));
+        project.setArtifacts(artifactSet);
+        return project;
+    }
+
+    private Artifact newArtifact(String groupId, String artifactId, String version, String classifier, String scope,
+            File file) {
+        return newArtifact(groupId, artifactId, version, classifier, scope, file, "jar");
+    }
+
+    private Artifact newArtifact(String groupId, String artifactId, String version, String classifier, String scope,
+            File file, String type) {
+        Artifact artifact = new DefaultArtifact(groupId, artifactId, VersionRange.createFromVersion(version), scope,
+                type, classifier, new ClasspathArtifactHandler(type));
+        artifact.setFile(file);
+        return artifact;
+    }
+
+    private File createEmptyJar(String fileName) throws IOException {
+        Path jarPath = tempDir.resolve(fileName);
+        Files.write(jarPath, new byte[] { 'P', 'K', 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 });
+        return jarPath.toFile();
+    }
+
+    private String mainAttribute(Manifest manifest, String name) {
+        return manifest.getMainSection().getAttributeValue(name);
+    }
+
+    private String toDisplayName(String artifactId) {
+        String[] words = artifactId.split("-");
+        StringBuilder builder = new StringBuilder();
+        for (String word : words) {
+            if (builder.length() > 0) {
+                builder.append(' ');
+            }
+            builder.append(Character.toUpperCase(word.charAt(0))).append(word.substring(1));
+        }
+        return builder.toString();
+    }
+
+    private static final class ClasspathArtifactHandler implements ArtifactHandler {
+        private final String type;
+
+        private ClasspathArtifactHandler(String type) {
+            this.type = type;
+        }
+
+        @Override
+        public String getExtension() {
+            return type;
+        }
+
+        @Override
+        public String getClassifier() {
+            return null;
+        }
+
+        @Override
+        public String getDirectory() {
+            return type + "s";
+        }
+
+        @Override
+        public String getPackaging() {
+            return type;
+        }
+
+        @Override
+        public boolean isIncludesDependencies() {
+            return false;
+        }
+
+        @Override
+        public String getLanguage() {
+            return "java";
+        }
+
+        @Override
+        public boolean isAddedToClasspath() {
+            return true;
+        }
+    }
+
+    private static final class TestArtifactRepository implements ArtifactRepository {
+        private final String url;
+
+        private TestArtifactRepository(String url) {
+            this.url = url;
+        }
+
+        @Override
+        public String pathOf(Artifact artifact) {
+            return artifact.toString();
+        }
+
+        @Override
+        public String pathOfRemoteRepositoryMetadata(org.apache.maven.artifact.metadata.ArtifactMetadata metadata) {
+            return metadata.toString();
+        }
+
+        @Override
+        public String pathOfLocalRepositoryMetadata(org.apache.maven.artifact.metadata.ArtifactMetadata metadata,
+                ArtifactRepository repository) {
+            return metadata.toString();
+        }
+
+        @Override
+        public String getUrl() {
+            return url;
+        }
+
+        @Override
+        public String getBasedir() {
+            return null;
+        }
+
+        @Override
+        public String getProtocol() {
+            return "https";
+        }
+
+        @Override
+        public String getId() {
+            return "test";
+        }
+
+        @Override
+        public ArtifactRepositoryPolicy getSnapshots() {
+            return null;
+        }
+
+        @Override
+        public ArtifactRepositoryPolicy getReleases() {
+            return null;
+        }
+
+        @Override
+        public ArtifactRepositoryLayout getLayout() {
+            return null;
+        }
+
+        @Override
+        public String getKey() {
+            return "test";
+        }
+
+        @Override
+        public boolean isUniqueVersion() {
+            return true;
+        }
+
+        @Override
+        public void setBlacklisted(boolean blacklisted) {
+        }
+
+        @Override
+        public boolean isBlacklisted() {
+            return false;
+        }
     }
 }

--- a/tests/src/org.apache.maven/maven-archiver/2.5/user-code-filter.json
+++ b/tests/src/org.apache.maven/maven-archiver/2.5/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.apache.maven.archiver.**"
+      "includeClasses" : "org.apache.maven.archiver.**"
+    },
+    {
+      "includeClasses" : "org_apache_maven.maven_archiver.**"
     }
   ]
 }

--- a/tests/src/org.apache.maven/maven-archiver/2.5/user-code-filter.json
+++ b/tests/src/org.apache.maven/maven-archiver/2.5/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.apache.maven.archiver.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #2359

This PR introduces tests and metadata for org.apache.maven:maven-archiver:2.5, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 269412
- Cached input tokens: 4088832
- Output tokens: 26082
- Metadata entries: 4
- Iterations: 4
- Library coverage percentage: 86.32
- Generated lines of code: 446
- Tested library lines of code: 284

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `c973a8aab682315d994dee041a10fca2ad74847e`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1215/1418 (85.68%)
- Line: 284/329 (86.32%)
- Method: 69/76 (90.79%)

### Local CI Verification

- Status: `success`
- Commands run: 14
- Fixup attempts: 0
