### PR TITLE
[GenAI] Add support for com.google.protobuf:protobuf-javalite:3.25.3 using gpt-5.5

### DIFF
--- a/metadata/com.google.protobuf/protobuf-javalite/3.25.3/reachability-metadata.json
+++ b/metadata/com.google.protobuf/protobuf-javalite/3.25.3/reachability-metadata.json
@@ -2,6 +2,13 @@
   "reflection": [
     {
       "condition": {
+        "typeReached": "com.google.protobuf.GeneratedMessageLite$SerializedForm"
+      },
+      "type": "byte[]",
+      "serializable": true
+    },
+    {
+      "condition": {
         "typeReached": "com.google.protobuf.ManifestSchemaFactory"
       },
       "type": "com.google.protobuf.DescriptorMessageInfoFactory",
@@ -21,40 +28,38 @@
         {
           "name": "getEmptyRegistry",
           "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.protobuf.GeneratedMessageLite$SerializedForm"
-      },
-      "type": "byte[]",
-      "serializable": true
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.protobuf.GeneratedMessageLite$SerializedForm"
-      },
-      "type": "com.google.protobuf.GeneratedMessageLite$SerializedForm",
-      "serializable": true
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.protobuf.GeneratedMessageLite$SerializedForm"
-      },
-      "type": "java.lang.Object",
-      "methods": [
+        },
         {
-          "name": "<init>",
+          "name": "newInstance",
           "parameterTypes": []
         }
       ]
     },
     {
       "condition": {
+        "typeReached": "com.google.protobuf.ExtensionRegistryLite"
+      },
+      "type": "com.google.protobuf.ExtensionRegistry",
+      "methods": [
+        {
+          "name": "add",
+          "parameterTypes": [
+            "com.google.protobuf.Extension"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.StructuralMessageInfo$Builder"
+      },
+      "type": "com.google.protobuf.FieldInfo[]"
+    },
+    {
+      "condition": {
         "typeReached": "com.google.protobuf.GeneratedMessageLite$SerializedForm"
       },
-      "type": "java.lang.String",
+      "type": "com.google.protobuf.GeneratedMessageLite$SerializedForm",
       "serializable": true
     },
     {
@@ -89,6 +94,36 @@
     },
     {
       "condition": {
+        "typeReached": "com.google.protobuf.GeneratedMessageLite"
+      },
+      "type": "com.google.protobuf.StringValue",
+      "methods": [
+        {
+          "name": "getValue",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.Internal"
+      },
+      "type": "com.google.protobuf.StringValue",
+      "methods": [
+        {
+          "name": "getDefaultInstance",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.MessageSchema"
+      },
+      "type": "com.google.protobuf.StringValue"
+    },
+    {
+      "condition": {
         "typeReached": "com.google.protobuf.StringValue"
       },
       "type": "com.google.protobuf.StringValue",
@@ -97,6 +132,12 @@
           "name": "value_"
         }
       ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.MessageSchema"
+      },
+      "type": "com.google.protobuf.Struct"
     },
     {
       "condition": {
@@ -123,6 +164,12 @@
     },
     {
       "condition": {
+        "typeReached": "com.google.protobuf.MessageSchema"
+      },
+      "type": "com.google.protobuf.Value"
+    },
+    {
+      "condition": {
         "typeReached": "com.google.protobuf.Value"
       },
       "type": "com.google.protobuf.Value",
@@ -134,6 +181,84 @@
           "name": "kind_"
         }
       ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.GeneratedMessageLite$SerializedForm"
+      },
+      "type": "com_google_protobuf.protobuf_javalite.GeneratedMessageLiteInnerSerializedFormTest$DefaultInstanceMessage"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.GeneratedMessageLite$SerializedForm"
+      },
+      "type": "com_google_protobuf.protobuf_javalite.GeneratedMessageLiteInnerSerializedFormTest$LegacyDefaultInstanceMessage"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.DescriptorMessageInfoFactory"
+      },
+      "type": "com_google_protobuf.protobuf_javalite.SchemaUtilTest$GeneratedFullMessage"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.ByteBufferWriter"
+      },
+      "type": "java.io.FileOutputStream"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.UnsafeUtil$MemoryAccessor"
+      },
+      "type": "java.io.FileOutputStream",
+      "fields": [
+        {
+          "name": "channel"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.GeneratedMessageLite$SerializedForm"
+      },
+      "type": "java.lang.Object",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.ByteBufferWriter"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.GeneratedMessageLite$SerializedForm"
+      },
+      "type": "java.lang.String",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.ExtensionRegistryLite"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.UnsafeUtil$1"
+      },
+      "type": "java.lang.reflect.Field[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.UnsafeUtil"
+      },
+      "type": "java.lang.reflect.Method[]"
     },
     {
       "condition": {

--- a/metadata/com.google.protobuf/protobuf-javalite/3.25.3/reachability-metadata.json
+++ b/metadata/com.google.protobuf/protobuf-javalite/3.25.3/reachability-metadata.json
@@ -196,9 +196,27 @@
     },
     {
       "condition": {
+        "typeReached": "com.google.protobuf.MessageSchema"
+      },
+      "type": "com_google_protobuf.protobuf_javalite.MessageSchemaTest$InvalidFieldMessage"
+    },
+    {
+      "condition": {
         "typeReached": "com.google.protobuf.DescriptorMessageInfoFactory"
       },
       "type": "com_google_protobuf.protobuf_javalite.SchemaUtilTest$GeneratedFullMessage"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.DescriptorMessageInfoFactory"
+      },
+      "type": "com_google_protobuf.protobuf_javalite.UnsafeUtilInnerAndroid32MemoryAccessorTest$GeneratedFullMessage"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.DescriptorMessageInfoFactory"
+      },
+      "type": "com_google_protobuf.protobuf_javalite.UnsafeUtilInnerAndroid64MemoryAccessorTest$GeneratedFullMessage"
     },
     {
       "condition": {

--- a/metadata/com.google.protobuf/protobuf-javalite/3.25.3/reachability-metadata.json
+++ b/metadata/com.google.protobuf/protobuf-javalite/3.25.3/reachability-metadata.json
@@ -1,322 +1,286 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.GeneratedMessageLite$SerializedForm"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.GeneratedMessageLite$SerializedForm"
       },
-      "type": "byte[]",
-      "serializable": true
+      "type" : "byte[]",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.ManifestSchemaFactory"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.ManifestSchemaFactory"
       },
-      "type": "com.google.protobuf.DescriptorMessageInfoFactory",
-      "methods": [
+      "type" : "com.google.protobuf.DescriptorMessageInfoFactory",
+      "methods" : [
         {
-          "name": "getInstance",
-          "parameterTypes": []
+          "name" : "getInstance",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.ExtensionRegistryFactory"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.ExtensionRegistryFactory"
       },
-      "type": "com.google.protobuf.ExtensionRegistry",
-      "methods": [
+      "type" : "com.google.protobuf.ExtensionRegistry",
+      "methods" : [
         {
-          "name": "getEmptyRegistry",
-          "parameterTypes": []
+          "name" : "getEmptyRegistry",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "newInstance",
-          "parameterTypes": []
+          "name" : "newInstance",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.ExtensionRegistryLite"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.ExtensionRegistryLite"
       },
-      "type": "com.google.protobuf.ExtensionRegistry",
-      "methods": [
+      "type" : "com.google.protobuf.ExtensionRegistry",
+      "methods" : [
         {
-          "name": "add",
-          "parameterTypes": [
+          "name" : "add",
+          "parameterTypes" : [
             "com.google.protobuf.Extension"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.StructuralMessageInfo$Builder"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.StructuralMessageInfo$Builder"
       },
-      "type": "com.google.protobuf.FieldInfo[]"
+      "type" : "com.google.protobuf.FieldInfo[]"
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.GeneratedMessageLite$SerializedForm"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.GeneratedMessageLite$SerializedForm"
       },
-      "type": "com.google.protobuf.GeneratedMessageLite$SerializedForm",
-      "serializable": true
+      "type" : "com.google.protobuf.GeneratedMessageLite$SerializedForm",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.SchemaUtil"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.SchemaUtil"
       },
-      "type": "com.google.protobuf.GeneratedMessageV3"
+      "type" : "com.google.protobuf.GeneratedMessageV3"
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.MapFieldSchemas"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.MapFieldSchemas"
       },
-      "type": "com.google.protobuf.MapFieldSchemaFull",
-      "methods": [
+      "type" : "com.google.protobuf.MapFieldSchemaFull",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.NewInstanceSchemas"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.NewInstanceSchemas"
       },
-      "type": "com.google.protobuf.NewInstanceSchemaFull",
-      "methods": [
+      "type" : "com.google.protobuf.NewInstanceSchemaFull",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.GeneratedMessageLite"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.GeneratedMessageLite"
       },
-      "type": "com.google.protobuf.StringValue",
-      "methods": [
+      "type" : "com.google.protobuf.StringValue",
+      "methods" : [
         {
-          "name": "getValue",
-          "parameterTypes": []
+          "name" : "getValue",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.Internal"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.Internal"
       },
-      "type": "com.google.protobuf.StringValue",
-      "methods": [
+      "type" : "com.google.protobuf.StringValue",
+      "methods" : [
         {
-          "name": "getDefaultInstance",
-          "parameterTypes": []
+          "name" : "getDefaultInstance",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.MessageSchema"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.MessageSchema"
       },
-      "type": "com.google.protobuf.StringValue"
+      "type" : "com.google.protobuf.StringValue"
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.StringValue"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.StringValue"
       },
-      "type": "com.google.protobuf.StringValue",
-      "fields": [
+      "type" : "com.google.protobuf.StringValue",
+      "fields" : [
         {
-          "name": "value_"
+          "name" : "value_"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.MessageSchema"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.MessageSchema"
       },
-      "type": "com.google.protobuf.Struct"
+      "type" : "com.google.protobuf.Struct"
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.Struct"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.Struct"
       },
-      "type": "com.google.protobuf.Struct",
-      "fields": [
+      "type" : "com.google.protobuf.Struct",
+      "fields" : [
         {
-          "name": "fields_"
+          "name" : "fields_"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.SchemaUtil"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.SchemaUtil"
       },
-      "type": "com.google.protobuf.UnknownFieldSetSchema",
-      "methods": [
+      "type" : "com.google.protobuf.UnknownFieldSetSchema",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.MessageSchema"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.MessageSchema"
       },
-      "type": "com.google.protobuf.Value"
+      "type" : "com.google.protobuf.Value"
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.Value"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.Value"
       },
-      "type": "com.google.protobuf.Value",
-      "fields": [
+      "type" : "com.google.protobuf.Value",
+      "fields" : [
         {
-          "name": "kindCase_"
+          "name" : "kindCase_"
         },
         {
-          "name": "kind_"
+          "name" : "kind_"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.GeneratedMessageLite$SerializedForm"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.ByteBufferWriter"
       },
-      "type": "com_google_protobuf.protobuf_javalite.GeneratedMessageLiteInnerSerializedFormTest$DefaultInstanceMessage"
+      "type" : "java.io.FileOutputStream"
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.GeneratedMessageLite$SerializedForm"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.UnsafeUtil$MemoryAccessor"
       },
-      "type": "com_google_protobuf.protobuf_javalite.GeneratedMessageLiteInnerSerializedFormTest$LegacyDefaultInstanceMessage"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.protobuf.MessageSchema"
-      },
-      "type": "com_google_protobuf.protobuf_javalite.MessageSchemaTest$InvalidFieldMessage"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.protobuf.DescriptorMessageInfoFactory"
-      },
-      "type": "com_google_protobuf.protobuf_javalite.SchemaUtilTest$GeneratedFullMessage"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.protobuf.DescriptorMessageInfoFactory"
-      },
-      "type": "com_google_protobuf.protobuf_javalite.UnsafeUtilInnerAndroid32MemoryAccessorTest$GeneratedFullMessage"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.protobuf.DescriptorMessageInfoFactory"
-      },
-      "type": "com_google_protobuf.protobuf_javalite.UnsafeUtilInnerAndroid64MemoryAccessorTest$GeneratedFullMessage"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.protobuf.ByteBufferWriter"
-      },
-      "type": "java.io.FileOutputStream"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.protobuf.UnsafeUtil$MemoryAccessor"
-      },
-      "type": "java.io.FileOutputStream",
-      "fields": [
+      "type" : "java.io.FileOutputStream",
+      "fields" : [
         {
-          "name": "channel"
+          "name" : "channel"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.GeneratedMessageLite$SerializedForm"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.GeneratedMessageLite$SerializedForm"
       },
-      "type": "java.lang.Object",
-      "methods": [
+      "type" : "java.lang.Object",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.ByteBufferWriter"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.ByteBufferWriter"
       },
-      "type": "java.lang.StackTraceElement[]"
+      "type" : "java.lang.StackTraceElement[]"
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.GeneratedMessageLite$SerializedForm"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.GeneratedMessageLite$SerializedForm"
       },
-      "type": "java.lang.String",
-      "serializable": true
+      "type" : "java.lang.String",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.ExtensionRegistryLite"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.ExtensionRegistryLite"
       },
-      "type": "java.lang.String[]"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.UnsafeUtil$1"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.UnsafeUtil$1"
       },
-      "type": "java.lang.reflect.Field[]"
+      "type" : "java.lang.reflect.Field[]"
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.UnsafeUtil"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.UnsafeUtil"
       },
-      "type": "java.lang.reflect.Method[]"
+      "type" : "java.lang.reflect.Method[]"
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.UnsafeUtil"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.UnsafeUtil"
       },
-      "type": "java.nio.Buffer",
-      "fields": [
+      "type" : "java.nio.Buffer",
+      "fields" : [
         {
-          "name": "address"
+          "name" : "address"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.Android"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.Android"
       },
-      "type": "libcore.io.Memory"
+      "type" : "libcore.io.Memory"
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.UnsafeUtil"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.UnsafeUtil"
       },
-      "type": "libcore.io.Memory"
+      "type" : "libcore.io.Memory"
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.UnsafeUtil$1"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.UnsafeUtil$1"
       },
-      "type": "sun.misc.Unsafe",
-      "fields": [
+      "type" : "sun.misc.Unsafe",
+      "fields" : [
         {
-          "name": "theUnsafe"
+          "name" : "theUnsafe"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.UnsafeUtil$MemoryAccessor"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.UnsafeUtil$MemoryAccessor"
       },
-      "type": "sun.misc.Unsafe"
+      "type" : "sun.misc.Unsafe"
     }
   ]
 }

--- a/metadata/com.google.protobuf/protobuf-javalite/3.25.3/reachability-metadata.json
+++ b/metadata/com.google.protobuf/protobuf-javalite/3.25.3/reachability-metadata.json
@@ -1,0 +1,179 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.ManifestSchemaFactory"
+      },
+      "type": "com.google.protobuf.DescriptorMessageInfoFactory",
+      "methods": [
+        {
+          "name": "getInstance",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.ExtensionRegistryFactory"
+      },
+      "type": "com.google.protobuf.ExtensionRegistry",
+      "methods": [
+        {
+          "name": "getEmptyRegistry",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.GeneratedMessageLite$SerializedForm"
+      },
+      "type": "byte[]",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.GeneratedMessageLite$SerializedForm"
+      },
+      "type": "com.google.protobuf.GeneratedMessageLite$SerializedForm",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.GeneratedMessageLite$SerializedForm"
+      },
+      "type": "java.lang.Object",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.GeneratedMessageLite$SerializedForm"
+      },
+      "type": "java.lang.String",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.SchemaUtil"
+      },
+      "type": "com.google.protobuf.GeneratedMessageV3"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.MapFieldSchemas"
+      },
+      "type": "com.google.protobuf.MapFieldSchemaFull",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.NewInstanceSchemas"
+      },
+      "type": "com.google.protobuf.NewInstanceSchemaFull",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.StringValue"
+      },
+      "type": "com.google.protobuf.StringValue",
+      "fields": [
+        {
+          "name": "value_"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.Struct"
+      },
+      "type": "com.google.protobuf.Struct",
+      "fields": [
+        {
+          "name": "fields_"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.SchemaUtil"
+      },
+      "type": "com.google.protobuf.UnknownFieldSetSchema",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.Value"
+      },
+      "type": "com.google.protobuf.Value",
+      "fields": [
+        {
+          "name": "kindCase_"
+        },
+        {
+          "name": "kind_"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.UnsafeUtil"
+      },
+      "type": "java.nio.Buffer",
+      "fields": [
+        {
+          "name": "address"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.Android"
+      },
+      "type": "libcore.io.Memory"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.UnsafeUtil"
+      },
+      "type": "libcore.io.Memory"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.UnsafeUtil$1"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.UnsafeUtil$MemoryAccessor"
+      },
+      "type": "sun.misc.Unsafe"
+    }
+  ]
+}

--- a/metadata/com.google.protobuf/protobuf-javalite/index.json
+++ b/metadata/com.google.protobuf/protobuf-javalite/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.25.3",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-javalite/$version$/protobuf-javalite-$version$-sources.jar",
+    "repository-url" : "https://github.com/protocolbuffers/protobuf",
+    "test-code-url" : "https://github.com/protocolbuffers/protobuf/tree/v$version$/java/core/src/test/java/com/google/protobuf",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/google/protobuf/protobuf-javalite/$version$/protobuf-javalite-$version$-javadoc.jar",
+    "description" : "Protocol Buffers is a binary serialization format and runtime for encoding structured data efficiently across services and storage systems. protobuf-javalite provides the size-optimized Java Lite runtime for generated protobuf messages, trading some API/ABI stability for smaller deployments.",
+    "tested-versions" : [
+      "3.25.3"
+    ],
+    "allowed-packages" : [
+      "com.google.protobuf"
+    ]
+  }
+]

--- a/stats/com.google.protobuf/protobuf-javalite/3.25.3/execution-metrics.json
+++ b/stats/com.google.protobuf/protobuf-javalite/3.25.3/execution-metrics.json
@@ -1,0 +1,63 @@
+{
+  "add_new_library_support:2026-05-23": {
+    "timestamp": "2026-05-23T13:46:42.713895Z",
+    "library": "com.google.protobuf:protobuf-javalite:3.25.3",
+    "starting_commit": "2afec22cebe7768acf159f4bfc53434ccb5d03df",
+    "ending_commit": "f2a1d9aed2e5025aa397a8ccb87cf8ce951fe0f7",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.25.3",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.95122,
+            "coveredCalls": 39,
+            "totalCalls": 41
+          }
+        },
+        "coverageRatio": 0.95122,
+        "coveredCalls": 39,
+        "totalCalls": 41
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 7900,
+          "missed": 76289,
+          "ratio": 0.093836,
+          "total": 84189
+        },
+        "line": {
+          "covered": 1805,
+          "missed": 17789,
+          "ratio": 0.09212,
+          "total": 19594
+        },
+        "method": {
+          "covered": 467,
+          "missed": 3680,
+          "ratio": 0.112612,
+          "total": 4147
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 869382,
+      "cached_input_tokens_used": 15462912,
+      "output_tokens_used": 110001,
+      "iterations": 20,
+      "cost_usd": 11.0315,
+      "generated_loc": 997,
+      "tested_library_loc": 1805,
+      "metadata_entries": 51,
+      "test_only_metadata_entries": 26,
+      "code_coverage_percent": 9.21
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/java/com_google_protobuf/protobuf_javalite/GeneratedMessageLiteInnerSerializedFormTest.java",
+      "metadata_file": "metadata/com.google.protobuf/protobuf-javalite/3.25.3/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.google.protobuf/protobuf-javalite/3.25.3/stats.json
+++ b/stats/com.google.protobuf/protobuf-javalite/3.25.3/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "3.25.3",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.95122,
+          "coveredCalls" : 39,
+          "totalCalls" : 41
+        }
+      },
+      "coverageRatio" : 0.95122,
+      "coveredCalls" : 39,
+      "totalCalls" : 41
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 7900,
+        "missed" : 76289,
+        "ratio" : 0.093836,
+        "total" : 84189
+      },
+      "line" : {
+        "covered" : 1805,
+        "missed" : 17789,
+        "ratio" : 0.09212,
+        "total" : 19594
+      },
+      "method" : {
+        "covered" : 467,
+        "missed" : 3680,
+        "ratio" : 0.112612,
+        "total" : 4147
+      }
+    }
+  } ]
+}

--- a/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/.gitignore
+++ b/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/build.gradle
+++ b/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.google.protobuf:protobuf-javalite:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/build.gradle
+++ b/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     testImplementation "com.google.protobuf:protobuf-java:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 
-    androidAll 'org.robolectric:android-all:4.3_r2-robolectric-0'
+    androidAll 'org.robolectric:android-all:4.1.2_r1-robolectric-0'
     testRuntimeOnly files(androidLibcoreMemoryJar).builtBy(androidLibcoreMemoryJar)
 }
 

--- a/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/build.gradle
+++ b/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/build.gradle
@@ -29,6 +29,7 @@ TaskProvider<Jar> androidLibcoreMemoryJar = tasks.register("androidLibcoreMemory
 dependencies {
     testImplementation "com.google.protobuf:protobuf-javalite:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
+    testRuntimeOnly "com.google.protobuf:protobuf-java:$libraryVersion"
 
     androidAll 'org.robolectric:android-all:4.3_r2-robolectric-0'
     testRuntimeOnly files(androidLibcoreMemoryJar).builtBy(androidLibcoreMemoryJar)

--- a/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/build.gradle
+++ b/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/build.gradle
@@ -28,8 +28,8 @@ TaskProvider<Jar> androidLibcoreMemoryJar = tasks.register("androidLibcoreMemory
 
 dependencies {
     testImplementation "com.google.protobuf:protobuf-javalite:$libraryVersion"
+    testImplementation "com.google.protobuf:protobuf-java:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testRuntimeOnly "com.google.protobuf:protobuf-java:$libraryVersion"
 
     androidAll 'org.robolectric:android-all:4.3_r2-robolectric-0'
     testRuntimeOnly files(androidLibcoreMemoryJar).builtBy(androidLibcoreMemoryJar)

--- a/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/build.gradle
+++ b/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/build.gradle
@@ -4,15 +4,34 @@
  * You should have received a copy of the CC0 legalcode along with this
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
+import org.gradle.api.tasks.TaskProvider
+
 plugins {
     id "org.graalvm.internal.tck"
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
 
+configurations {
+    androidAll
+}
+
+// android-all also contains java.* classes, so only expose the libcore probe class to tests.
+TaskProvider<Jar> androidLibcoreMemoryJar = tasks.register("androidLibcoreMemoryJar", Jar) {
+    archiveFileName = "android-libcore-memory.jar"
+    from({
+        zipTree(configurations.androidAll.singleFile)
+    }) {
+        include "libcore/io/Memory.class"
+    }
+}
+
 dependencies {
     testImplementation "com.google.protobuf:protobuf-javalite:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
+
+    androidAll 'org.robolectric:android-all:4.3_r2-robolectric-0'
+    testRuntimeOnly files(androidLibcoreMemoryJar).builtBy(androidLibcoreMemoryJar)
 }
 
 graalvmNative {

--- a/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/build.gradle
+++ b/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     testImplementation "com.google.protobuf:protobuf-java:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 
-    androidAll 'org.robolectric:android-all:4.1.2_r1-robolectric-0'
+    androidAll 'org.robolectric:android-all:5.0.0_r2-robolectric-1'
     testRuntimeOnly files(androidLibcoreMemoryJar).builtBy(androidLibcoreMemoryJar)
 }
 

--- a/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/gradle.properties
+++ b/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.google.protobuf:protobuf-javalite:3.25.3
+library.version = 3.25.3
+metadata.dir = com.google.protobuf/protobuf-javalite/3.25.3/

--- a/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/settings.gradle
+++ b/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.google.protobuf.protobuf-javalite_tests'

--- a/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/java/com_google_protobuf/protobuf_javalite/ByteBufferWriterTest.java
+++ b/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/java/com_google_protobuf/protobuf_javalite/ByteBufferWriterTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_protobuf.protobuf_javalite;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.protobuf.ByteString;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.nio.ByteBuffer;
+import org.junit.jupiter.api.Test;
+
+public class ByteBufferWriterTest {
+    @Test
+    void writesDirectByteBufferToOutputStreamWithoutChangingPosition() throws Exception {
+        byte[] payload = new byte[] {0x10, 0x20, 0x30, 0x40};
+        ByteBuffer source = ByteBuffer.allocateDirect(payload.length + 2);
+        source.put((byte) 0x00);
+        source.put(payload);
+        source.put((byte) 0x7f);
+        source.flip();
+        source.position(1);
+        source.limit(1 + payload.length);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        writeDirectBuffer(source, output);
+
+        assertThat(output.toByteArray()).containsExactly(payload);
+        assertThat(source.position()).isEqualTo(1);
+    }
+
+    private static void writeDirectBuffer(ByteBuffer source, OutputStream output) throws Exception {
+        Class<?> writerType = Class.forName(
+                "com.google.protobuf.ByteBufferWriter",
+                true,
+                ByteString.class.getClassLoader());
+        MethodHandle write = MethodHandles.privateLookupIn(writerType, MethodHandles.lookup())
+                .findStatic(
+                        writerType,
+                        "write",
+                        MethodType.methodType(void.class, ByteBuffer.class, OutputStream.class));
+        try {
+            write.invoke(source, output);
+        } catch (Error | RuntimeException e) {
+            throw e;
+        } catch (Throwable e) {
+            throw new IllegalStateException("ByteBufferWriter.write failed", e);
+        }
+    }
+}

--- a/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/java/com_google_protobuf/protobuf_javalite/ExtensionRegistryLiteTest.java
+++ b/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/java/com_google_protobuf/protobuf_javalite/ExtensionRegistryLiteTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_protobuf.protobuf_javalite;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.protobuf.DescriptorProtos.DescriptorProto;
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.Descriptors.FileDescriptor;
+import com.google.protobuf.ExtensionRegistry;
+import com.google.protobuf.ExtensionRegistry.ExtensionInfo;
+import com.google.protobuf.ExtensionRegistryLite;
+import com.google.protobuf.GeneratedMessage;
+import com.google.protobuf.Message;
+import org.junit.jupiter.api.Test;
+
+public class ExtensionRegistryLiteTest {
+    @Test
+    void forwardsFullRuntimeExtensionToFullRegistry() throws Exception {
+        FileDescriptor fileDescriptor = FileDescriptor.buildFrom(
+                fileDescriptorProto(), new FileDescriptor[0]);
+        Descriptor hostDescriptor = fileDescriptor.findMessageTypeByName("Host");
+        FieldDescriptor extensionDescriptor = fileDescriptor
+                .findExtensionByName("sample_extension");
+        GeneratedMessage.GeneratedExtension<Message, Integer> extension =
+                GeneratedMessage.newFileScopedGeneratedExtension(Integer.class, null);
+        extension.internalInit(extensionDescriptor);
+
+        ExtensionRegistryLite registry = ExtensionRegistryLite.newInstance();
+
+        assertThat(registry).isInstanceOf(ExtensionRegistry.class);
+        registry.add(extension);
+        ExtensionInfo extensionInfo = ((ExtensionRegistry) registry)
+                .findImmutableExtensionByNumber(hostDescriptor, 100);
+        assertThat(extensionInfo).isNotNull();
+        assertThat(extensionInfo.descriptor.getFullName())
+                .isEqualTo("forge.protobuf.registry.sample_extension");
+    }
+
+    private static FileDescriptorProto fileDescriptorProto() {
+        DescriptorProto hostMessage = DescriptorProto.newBuilder()
+                .setName("Host")
+                .addExtensionRange(DescriptorProto.ExtensionRange.newBuilder()
+                        .setStart(100)
+                        .setEnd(101))
+                .build();
+        FieldDescriptorProto extension = FieldDescriptorProto.newBuilder()
+                .setName("sample_extension")
+                .setNumber(100)
+                .setLabel(FieldDescriptorProto.Label.LABEL_OPTIONAL)
+                .setType(FieldDescriptorProto.Type.TYPE_INT32)
+                .setExtendee(".forge.protobuf.registry.Host")
+                .build();
+        return FileDescriptorProto.newBuilder()
+                .setName("extension_registry_lite_test.proto")
+                .setPackage("forge.protobuf.registry")
+                .setSyntax("proto2")
+                .addMessageType(hostMessage)
+                .addExtension(extension)
+                .build();
+    }
+}

--- a/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/java/com_google_protobuf/protobuf_javalite/ExtensionSchemasTest.java
+++ b/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/java/com_google_protobuf/protobuf_javalite/ExtensionSchemasTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_protobuf.protobuf_javalite;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.protobuf.ExtensionRegistryLite;
+import com.google.protobuf.GeneratedMessageLite;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Parser;
+import org.junit.jupiter.api.Test;
+
+public class ExtensionSchemasTest {
+    @Test
+    void parsesExtendableProto2LiteMessageWithOptionalFullRuntimeSchema() throws Exception {
+        ExtendableProto2Message parsed = ExtendableProto2Message.parseFrom(
+                new byte[0], ExtensionRegistryLite.getEmptyRegistry());
+
+        assertThat(parsed).isEqualTo(ExtendableProto2Message.getDefaultInstance());
+    }
+
+    public static final class ExtendableProto2Message
+            extends GeneratedMessageLite.ExtendableMessage<
+                    ExtendableProto2Message, ExtendableProto2Message.Builder> {
+        private static final ExtendableProto2Message DEFAULT_INSTANCE;
+        private static volatile Parser<ExtendableProto2Message> parser;
+
+        static {
+            ExtendableProto2Message defaultInstance = new ExtendableProto2Message();
+            DEFAULT_INSTANCE = defaultInstance;
+            registerDefaultInstance(ExtendableProto2Message.class, defaultInstance);
+        }
+
+        private ExtendableProto2Message() {
+        }
+
+        public static ExtendableProto2Message parseFrom(
+                byte[] data,
+                ExtensionRegistryLite extensionRegistry) throws InvalidProtocolBufferException {
+            return parseFrom(DEFAULT_INSTANCE, data, extensionRegistry);
+        }
+
+        public static ExtendableProto2Message getDefaultInstance() {
+            return DEFAULT_INSTANCE;
+        }
+
+        @Override
+        @SuppressWarnings({"unchecked", "fallthrough"})
+        protected Object dynamicMethod(MethodToInvoke method, Object arg0, Object arg1) {
+            switch (method) {
+                case NEW_MUTABLE_INSTANCE:
+                    return new ExtendableProto2Message();
+                case NEW_BUILDER:
+                    return new Builder();
+                case BUILD_MESSAGE_INFO:
+                    return newMessageInfo(DEFAULT_INSTANCE, "\u0001\u0000", null);
+                case GET_DEFAULT_INSTANCE:
+                    return DEFAULT_INSTANCE;
+                case GET_PARSER:
+                    Parser<ExtendableProto2Message> localParser = parser;
+                    if (localParser == null) {
+                        synchronized (ExtendableProto2Message.class) {
+                            localParser = parser;
+                            if (localParser == null) {
+                                localParser = new DefaultInstanceBasedParser<>(DEFAULT_INSTANCE);
+                                parser = localParser;
+                            }
+                        }
+                    }
+                    return localParser;
+                case GET_MEMOIZED_IS_INITIALIZED:
+                    return (byte) 1;
+                case SET_MEMOIZED_IS_INITIALIZED:
+                    return null;
+                default:
+                    throw new UnsupportedOperationException();
+            }
+        }
+
+        public static final class Builder extends GeneratedMessageLite.ExtendableBuilder<
+                ExtendableProto2Message, Builder> {
+            private Builder() {
+                super(DEFAULT_INSTANCE);
+            }
+        }
+    }
+}

--- a/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/java/com_google_protobuf/protobuf_javalite/GeneratedMessageLiteInnerSerializedFormTest.java
+++ b/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/java/com_google_protobuf/protobuf_javalite/GeneratedMessageLiteInnerSerializedFormTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_protobuf.protobuf_javalite;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.protobuf.GeneratedMessageLite;
+import com.google.protobuf.GeneratedMessageLite.MethodToInvoke;
+import com.google.protobuf.MessageLite;
+import com.google.protobuf.Parser;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.jupiter.api.Test;
+
+public class GeneratedMessageLiteInnerSerializedFormTest {
+    @Test
+    void serializedFormRestoresMessageFromDefaultInstanceField() throws Exception {
+        DefaultInstanceMessage message = DefaultInstanceMessage.newBuilder().buildPartial();
+
+        Object restored = deserialize(serialize(serializedForm(message)));
+
+        assertThat(restored).isEqualTo(message);
+    }
+
+    @Test
+    void serializedFormRestoresMessageUsingLegacyClassNameField() throws Exception {
+        DefaultInstanceMessage message = DefaultInstanceMessage.newBuilder().buildPartial();
+
+        Object restored = deserialize(serializeWithNullMessageClass(
+                serializedForm(message), DefaultInstanceMessage.class));
+
+        assertThat(restored).isEqualTo(message);
+    }
+
+    @Test
+    void serializedFormRestoresMessageFromLegacyDefaultInstanceField() throws Exception {
+        LegacyDefaultInstanceMessage message = LegacyDefaultInstanceMessage
+                .newBuilder()
+                .buildPartial();
+
+        Object restored = deserialize(serialize(serializedForm(message)));
+
+        assertThat(restored).isEqualTo(message);
+    }
+
+    private static Object serializedForm(MessageLite message) {
+        return DefaultInstanceMessage.serializedForm(message);
+    }
+
+    private static byte[] serialize(Object object) throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+            output.writeObject(object);
+        }
+        return bytes.toByteArray();
+    }
+
+    private static byte[] serializeWithNullMessageClass(Object object, Class<?> messageClass)
+            throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (NullingMessageClassObjectOutputStream output =
+                new NullingMessageClassObjectOutputStream(bytes, messageClass)) {
+            output.writeObject(object);
+        }
+        return bytes.toByteArray();
+    }
+
+    private static Object deserialize(byte[] bytes) throws IOException, ClassNotFoundException {
+        try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+            return input.readObject();
+        }
+    }
+
+    private static final class NullingMessageClassObjectOutputStream extends ObjectOutputStream {
+        private final Class<?> messageClass;
+
+        private NullingMessageClassObjectOutputStream(
+                ByteArrayOutputStream output, Class<?> messageClass) throws IOException {
+            super(output);
+            this.messageClass = messageClass;
+            enableReplaceObject(true);
+        }
+
+        @Override
+        protected Object replaceObject(Object object) throws IOException {
+            if (object == messageClass) {
+                return null;
+            }
+            return super.replaceObject(object);
+        }
+    }
+
+    @SuppressWarnings("serial")
+    private static final class DefaultInstanceMessage extends GeneratedMessageLite<
+            DefaultInstanceMessage, DefaultInstanceMessage.Builder> {
+        private static final DefaultInstanceMessage DEFAULT_INSTANCE = new DefaultInstanceMessage();
+
+        static {
+            registerDefaultInstance(DefaultInstanceMessage.class, DEFAULT_INSTANCE);
+        }
+
+        private static volatile Parser<DefaultInstanceMessage> parser;
+
+        private DefaultInstanceMessage() {
+        }
+
+        private static Builder newBuilder() {
+            return DEFAULT_INSTANCE.createBuilder();
+        }
+
+        private static Object serializedForm(MessageLite message) {
+            return SerializedForm.of(message);
+        }
+
+        @Override
+        protected Object dynamicMethod(
+                MethodToInvoke method, Object firstArgument, Object secondArgument) {
+            switch (method) {
+                case NEW_MUTABLE_INSTANCE:
+                    return new DefaultInstanceMessage();
+                case NEW_BUILDER:
+                    return new Builder();
+                case BUILD_MESSAGE_INFO:
+                    return newMessageInfo(DEFAULT_INSTANCE, "\u0000\u0000", null);
+                case GET_DEFAULT_INSTANCE:
+                    return DEFAULT_INSTANCE;
+                case GET_PARSER:
+                    return parser();
+                case GET_MEMOIZED_IS_INITIALIZED:
+                    return (byte) 1;
+                case SET_MEMOIZED_IS_INITIALIZED:
+                    return null;
+                default:
+                    throw new UnsupportedOperationException("Unsupported method: " + method);
+            }
+        }
+
+        private static Parser<DefaultInstanceMessage> parser() {
+            Parser<DefaultInstanceMessage> result = parser;
+            if (result == null) {
+                synchronized (DefaultInstanceMessage.class) {
+                    result = parser;
+                    if (result == null) {
+                        result = new DefaultInstanceBasedParser<>(DEFAULT_INSTANCE);
+                        parser = result;
+                    }
+                }
+            }
+            return result;
+        }
+
+        private static final class Builder
+                extends GeneratedMessageLite.Builder<DefaultInstanceMessage, Builder> {
+            private Builder() {
+                super(DEFAULT_INSTANCE);
+            }
+        }
+    }
+
+    @SuppressWarnings("serial")
+    private static final class LegacyDefaultInstanceMessage extends GeneratedMessageLite<
+            LegacyDefaultInstanceMessage, LegacyDefaultInstanceMessage.Builder> {
+        @SuppressWarnings("checkstyle:ConstantName")
+        private static final LegacyDefaultInstanceMessage defaultInstance =
+                new LegacyDefaultInstanceMessage();
+
+        static {
+            registerDefaultInstance(LegacyDefaultInstanceMessage.class, defaultInstance);
+        }
+
+        private static volatile Parser<LegacyDefaultInstanceMessage> parser;
+
+        private LegacyDefaultInstanceMessage() {
+        }
+
+        private static Builder newBuilder() {
+            return defaultInstance.createBuilder();
+        }
+
+        @Override
+        protected Object dynamicMethod(
+                MethodToInvoke method, Object firstArgument, Object secondArgument) {
+            switch (method) {
+                case NEW_MUTABLE_INSTANCE:
+                    return new LegacyDefaultInstanceMessage();
+                case NEW_BUILDER:
+                    return new Builder();
+                case BUILD_MESSAGE_INFO:
+                    return newMessageInfo(defaultInstance, "\u0000\u0000", null);
+                case GET_DEFAULT_INSTANCE:
+                    return defaultInstance;
+                case GET_PARSER:
+                    return parser();
+                case GET_MEMOIZED_IS_INITIALIZED:
+                    return (byte) 1;
+                case SET_MEMOIZED_IS_INITIALIZED:
+                    return null;
+                default:
+                    throw new UnsupportedOperationException("Unsupported method: " + method);
+            }
+        }
+
+        private static Parser<LegacyDefaultInstanceMessage> parser() {
+            Parser<LegacyDefaultInstanceMessage> result = parser;
+            if (result == null) {
+                synchronized (LegacyDefaultInstanceMessage.class) {
+                    result = parser;
+                    if (result == null) {
+                        result = new DefaultInstanceBasedParser<>(defaultInstance);
+                        parser = result;
+                    }
+                }
+            }
+            return result;
+        }
+
+        private static final class Builder
+                extends GeneratedMessageLite.Builder<LegacyDefaultInstanceMessage, Builder> {
+            private Builder() {
+                super(defaultInstance);
+            }
+        }
+    }
+}

--- a/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/java/com_google_protobuf/protobuf_javalite/GeneratedMessageLiteTest.java
+++ b/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/java/com_google_protobuf/protobuf_javalite/GeneratedMessageLiteTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_protobuf.protobuf_javalite;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.protobuf.StringValue;
+import org.junit.jupiter.api.Test;
+
+public class GeneratedMessageLiteTest {
+    @Test
+    void toStringPrintsLiteMessageFieldsThroughGeneratedAccessors() {
+        StringValue message = StringValue.of("generated-message-lite");
+
+        String textFormat = message.toString();
+
+        assertThat(textFormat)
+                .startsWith("# com.google.protobuf.StringValue@")
+                .contains("value: \"generated-message-lite\"");
+    }
+}

--- a/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/java/com_google_protobuf/protobuf_javalite/InternalTest.java
+++ b/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/java/com_google_protobuf/protobuf_javalite/InternalTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_protobuf.protobuf_javalite;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.protobuf.Internal;
+import com.google.protobuf.MessageLite;
+import com.google.protobuf.StringValue;
+import org.junit.jupiter.api.Test;
+
+public class InternalTest {
+    @Test
+    void getDefaultInstanceReturnsGeneratedMessageDefaultInstance() {
+        StringValue defaultInstance = Internal.getDefaultInstance(StringValue.class);
+
+        assertThat(defaultInstance)
+                .isSameAs(StringValue.getDefaultInstance())
+                .isInstanceOf(MessageLite.class);
+    }
+}

--- a/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/java/com_google_protobuf/protobuf_javalite/MessageSchemaTest.java
+++ b/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/java/com_google_protobuf/protobuf_javalite/MessageSchemaTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_protobuf.protobuf_javalite;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.protobuf.GeneratedMessageLite;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Parser;
+import org.junit.jupiter.api.Test;
+
+public class MessageSchemaTest {
+    @Test
+    void reportsAvailableFieldsWhenRawMessageInfoNamesUnknownField() {
+        RuntimeException exception = InvalidFieldMessage.parseEmptyInput();
+
+        assertThat(exception)
+                .hasMessageContaining("unknown_")
+                .hasMessageContaining(InvalidFieldMessage.class.getName())
+                .hasMessageContaining("Known fields");
+    }
+
+    private static final class InvalidFieldMessage extends GeneratedMessageLite<
+            InvalidFieldMessage, InvalidFieldMessage.Builder> {
+        private static final InvalidFieldMessage DEFAULT_INSTANCE = new InvalidFieldMessage();
+        private static volatile Parser<InvalidFieldMessage> parser;
+
+        private int value_;
+
+        static {
+            registerDefaultInstance(InvalidFieldMessage.class, DEFAULT_INSTANCE);
+        }
+
+        private InvalidFieldMessage() {
+        }
+
+        private static RuntimeException parseEmptyInput() {
+            try {
+                parseFrom(DEFAULT_INSTANCE, new byte[0]);
+                throw new AssertionError("Expected schema creation to reject unknown field name");
+            } catch (RuntimeException e) {
+                return e;
+            } catch (InvalidProtocolBufferException e) {
+                throw new AssertionError("Schema creation should complete before input parsing", e);
+            }
+        }
+
+        @Override
+        protected Object dynamicMethod(
+                MethodToInvoke method, Object firstArgument, Object secondArgument) {
+            switch (method) {
+                case NEW_MUTABLE_INSTANCE:
+                    return new InvalidFieldMessage();
+                case NEW_BUILDER:
+                    return new Builder();
+                case BUILD_MESSAGE_INFO:
+                    return newMessageInfo(
+                            DEFAULT_INSTANCE, rawMessageInfo(), new Object[] {"unknown_"});
+                case GET_DEFAULT_INSTANCE:
+                    return DEFAULT_INSTANCE;
+                case GET_PARSER:
+                    return parser();
+                case GET_MEMOIZED_IS_INITIALIZED:
+                    return (byte) 1;
+                case SET_MEMOIZED_IS_INITIALIZED:
+                    return null;
+                default:
+                    throw new UnsupportedOperationException("Unsupported method: " + method);
+            }
+        }
+
+        private static Parser<InvalidFieldMessage> parser() {
+            Parser<InvalidFieldMessage> result = parser;
+            if (result == null) {
+                synchronized (InvalidFieldMessage.class) {
+                    result = parser;
+                    if (result == null) {
+                        result = new DefaultInstanceBasedParser<>(DEFAULT_INSTANCE);
+                        parser = result;
+                    }
+                }
+            }
+            return result;
+        }
+
+        private static String rawMessageInfo() {
+            return "\u0000\u0001\u0000\u0000\u0001\u0001\u0001\u0000\u0000\u0000\u0001\u0004";
+        }
+
+        private static final class Builder
+                extends GeneratedMessageLite.Builder<InvalidFieldMessage, Builder> {
+            private Builder() {
+                super(DEFAULT_INSTANCE);
+            }
+        }
+    }
+}

--- a/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/java/com_google_protobuf/protobuf_javalite/Protobuf_javaliteTest.java
+++ b/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/java/com_google_protobuf/protobuf_javalite/Protobuf_javaliteTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_protobuf.protobuf_javalite;
+
+import org.junit.jupiter.api.Test;
+
+class Protobuf_javaliteTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/java/com_google_protobuf/protobuf_javalite/Protobuf_javaliteTest.java
+++ b/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/java/com_google_protobuf/protobuf_javalite/Protobuf_javaliteTest.java
@@ -6,11 +6,17 @@
  */
 package com_google_protobuf.protobuf_javalite;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.protobuf.StringValue;
 import org.junit.jupiter.api.Test;
 
-class Protobuf_javaliteTest {
+public class Protobuf_javaliteTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void wrapsAndParsesStringValue() throws Exception {
+        StringValue value = StringValue.of("protobuf-lite");
+        StringValue parsed = StringValue.parseFrom(value.toByteArray());
+
+        assertThat(parsed.getValue()).isEqualTo("protobuf-lite");
     }
 }

--- a/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/java/com_google_protobuf/protobuf_javalite/SchemaUtilTest.java
+++ b/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/java/com_google_protobuf/protobuf_javalite/SchemaUtilTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_protobuf.protobuf_javalite;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import org.junit.jupiter.api.Test;
+
+public class SchemaUtilTest {
+    @Test
+    void serializesAndParsesLiteMapMessage() throws Exception {
+        Value value = Value.newBuilder().setStringValue("protobuf-javalite").build();
+        Struct message = Struct.newBuilder().putFields("library", value).build();
+
+        Struct parsed = Struct.parseFrom(message.toByteArray());
+
+        assertThat(parsed.getFieldsOrThrow("library").getStringValue())
+                .isEqualTo("protobuf-javalite");
+    }
+}

--- a/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/java/com_google_protobuf/protobuf_javalite/SchemaUtilTest.java
+++ b/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/java/com_google_protobuf/protobuf_javalite/SchemaUtilTest.java
@@ -8,8 +8,22 @@ package com_google_protobuf.protobuf_javalite;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.DescriptorProtos.DescriptorProto;
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
+import com.google.protobuf.DescriptorProtos.MessageOptions;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.DescriptorValidationException;
+import com.google.protobuf.Descriptors.FileDescriptor;
+import com.google.protobuf.ExtensionRegistryLite;
+import com.google.protobuf.GeneratedMessageV3;
+import com.google.protobuf.MapEntry;
+import com.google.protobuf.MapField;
+import com.google.protobuf.Message;
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
+import com.google.protobuf.WireFormat.FieldType;
 import org.junit.jupiter.api.Test;
 
 public class SchemaUtilTest {
@@ -22,5 +36,120 @@ public class SchemaUtilTest {
 
         assertThat(parsed.getFieldsOrThrow("library").getStringValue())
                 .isEqualTo("protobuf-javalite");
+    }
+
+    @Test
+    void createsGeneratedMessageV3SchemaForMapMessage() throws Exception {
+        GeneratedFullMessage message = new GeneratedFullMessage();
+
+        message.mergeEmptyPayloadThroughGeneratedMessageV3Schema();
+
+        assertThat(message.getDescriptorForType().getFullName())
+                .isEqualTo("forge.protobuf.GeneratedFullMessage");
+        assertThat(message.getDefaultInstanceForType())
+                .isSameAs(GeneratedFullMessage.getDefaultInstance());
+    }
+
+    @SuppressWarnings("checkstyle:MemberName")
+    public static final class GeneratedFullMessage extends GeneratedMessageV3 {
+        private static final Descriptor DESCRIPTOR;
+        private static final FieldAccessorTable FIELD_ACCESSOR_TABLE;
+        private static final GeneratedFullMessage DEFAULT_INSTANCE;
+
+        static {
+            try {
+                FileDescriptor fileDescriptor = FileDescriptor.buildFrom(
+                        fileDescriptorProto(), new FileDescriptor[0]);
+                DESCRIPTOR = fileDescriptor.findMessageTypeByName("GeneratedFullMessage");
+                FIELD_ACCESSOR_TABLE = new FieldAccessorTable(
+                        DESCRIPTOR, new String[] {"Metadata"});
+                DEFAULT_INSTANCE = new GeneratedFullMessage();
+            } catch (DescriptorValidationException e) {
+                throw new ExceptionInInitializerError(e);
+            }
+        }
+
+        private MapField<String, String> metadata_ =
+                MapField.emptyMapField(MetadataDefaultEntryHolder.defaultEntry);
+
+        private GeneratedFullMessage() {
+        }
+
+        public static GeneratedFullMessage getDefaultInstance() {
+            return DEFAULT_INSTANCE;
+        }
+
+        void mergeEmptyPayloadThroughGeneratedMessageV3Schema() throws Exception {
+            CodedInputStream input = CodedInputStream.newInstance(new byte[0]);
+            mergeFromAndMakeImmutableInternal(input, ExtensionRegistryLite.getEmptyRegistry());
+        }
+
+        @Override
+        protected FieldAccessorTable internalGetFieldAccessorTable() {
+            return FIELD_ACCESSOR_TABLE;
+        }
+
+        @Override
+        protected Message.Builder newBuilderForType(BuilderParent parent) {
+            throw new UnsupportedOperationException("Builder is not needed by this test fixture.");
+        }
+
+        @Override
+        public Message.Builder newBuilderForType() {
+            throw new UnsupportedOperationException("Builder is not needed by this test fixture.");
+        }
+
+        @Override
+        public Message.Builder toBuilder() {
+            throw new UnsupportedOperationException("Builder is not needed by this test fixture.");
+        }
+
+        @Override
+        public GeneratedFullMessage getDefaultInstanceForType() {
+            return DEFAULT_INSTANCE;
+        }
+
+        private static FileDescriptorProto fileDescriptorProto() {
+            DescriptorProto metadataEntry = DescriptorProto.newBuilder()
+                    .setName("MetadataEntry")
+                    .addField(FieldDescriptorProto.newBuilder()
+                            .setName("key")
+                            .setNumber(1)
+                            .setLabel(FieldDescriptorProto.Label.LABEL_OPTIONAL)
+                            .setType(FieldDescriptorProto.Type.TYPE_STRING))
+                    .addField(FieldDescriptorProto.newBuilder()
+                            .setName("value")
+                            .setNumber(2)
+                            .setLabel(FieldDescriptorProto.Label.LABEL_OPTIONAL)
+                            .setType(FieldDescriptorProto.Type.TYPE_STRING))
+                    .setOptions(MessageOptions.newBuilder().setMapEntry(true).build())
+                    .build();
+            DescriptorProto message = DescriptorProto.newBuilder()
+                    .setName("GeneratedFullMessage")
+                    .addField(FieldDescriptorProto.newBuilder()
+                            .setName("metadata")
+                            .setNumber(1)
+                            .setLabel(FieldDescriptorProto.Label.LABEL_REPEATED)
+                            .setType(FieldDescriptorProto.Type.TYPE_MESSAGE)
+                            .setTypeName(".forge.protobuf.GeneratedFullMessage.MetadataEntry"))
+                    .addNestedType(metadataEntry)
+                    .build();
+            return FileDescriptorProto.newBuilder()
+                    .setName("schema_util_test.proto")
+                    .setPackage("forge.protobuf")
+                    .setSyntax("proto3")
+                    .addMessageType(message)
+                    .build();
+        }
+
+        public static final class MetadataDefaultEntryHolder {
+            public static final MapEntry<String, String> defaultEntry = MapEntry
+                    .<String, String>newDefaultInstance(
+                            DESCRIPTOR.findNestedTypeByName("MetadataEntry"),
+                            FieldType.STRING,
+                            "",
+                            FieldType.STRING,
+                            "");
+        }
     }
 }

--- a/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/java/com_google_protobuf/protobuf_javalite/UnsafeUtilInnerAndroid32MemoryAccessorTest.java
+++ b/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/java/com_google_protobuf/protobuf_javalite/UnsafeUtilInnerAndroid32MemoryAccessorTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_protobuf.protobuf_javalite;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.DescriptorProtos.DescriptorProto;
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
+import com.google.protobuf.DescriptorProtos.MessageOptions;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.DescriptorValidationException;
+import com.google.protobuf.Descriptors.FileDescriptor;
+import com.google.protobuf.ExtensionRegistryLite;
+import com.google.protobuf.GeneratedMessageV3;
+import com.google.protobuf.MapEntry;
+import com.google.protobuf.MapField;
+import com.google.protobuf.Message;
+import com.google.protobuf.WireFormat.FieldType;
+import org.junit.jupiter.api.Test;
+
+public class UnsafeUtilInnerAndroid32MemoryAccessorTest {
+    @Test
+    void generatedMessageV3MapSchemaReadsDefaultEntryThroughAndroid32Accessor() throws Exception {
+        GeneratedFullMessage message = new GeneratedFullMessage();
+
+        message.mergeEmptyPayloadThroughGeneratedMessageV3Schema();
+
+        assertThat(message.getDescriptorForType().getFullName())
+                .isEqualTo("forge.protobuf.Android32AccessorMessage");
+        assertThat(message.getDefaultInstanceForType())
+                .isSameAs(GeneratedFullMessage.getDefaultInstance());
+    }
+
+    @SuppressWarnings("checkstyle:MemberName")
+    public static final class GeneratedFullMessage extends GeneratedMessageV3 {
+        private static final Descriptor DESCRIPTOR;
+        private static final FieldAccessorTable FIELD_ACCESSOR_TABLE;
+        private static final GeneratedFullMessage DEFAULT_INSTANCE;
+
+        static {
+            try {
+                FileDescriptor fileDescriptor = FileDescriptor.buildFrom(
+                        fileDescriptorProto(), new FileDescriptor[0]);
+                DESCRIPTOR = fileDescriptor.findMessageTypeByName("Android32AccessorMessage");
+                FIELD_ACCESSOR_TABLE = new FieldAccessorTable(
+                        DESCRIPTOR, new String[] {"Metadata"});
+                DEFAULT_INSTANCE = new GeneratedFullMessage();
+            } catch (DescriptorValidationException e) {
+                throw new ExceptionInInitializerError(e);
+            }
+        }
+
+        private MapField<String, String> metadata_ =
+                MapField.emptyMapField(MetadataDefaultEntryHolder.defaultEntry);
+
+        private GeneratedFullMessage() {
+        }
+
+        public static GeneratedFullMessage getDefaultInstance() {
+            return DEFAULT_INSTANCE;
+        }
+
+        void mergeEmptyPayloadThroughGeneratedMessageV3Schema() throws Exception {
+            CodedInputStream input = CodedInputStream.newInstance(new byte[0]);
+            mergeFromAndMakeImmutableInternal(input, ExtensionRegistryLite.getEmptyRegistry());
+        }
+
+        @Override
+        protected FieldAccessorTable internalGetFieldAccessorTable() {
+            return FIELD_ACCESSOR_TABLE;
+        }
+
+        @Override
+        protected Message.Builder newBuilderForType(BuilderParent parent) {
+            throw new UnsupportedOperationException("Builder is not needed by this test fixture.");
+        }
+
+        @Override
+        public Message.Builder newBuilderForType() {
+            throw new UnsupportedOperationException("Builder is not needed by this test fixture.");
+        }
+
+        @Override
+        public Message.Builder toBuilder() {
+            throw new UnsupportedOperationException("Builder is not needed by this test fixture.");
+        }
+
+        @Override
+        public GeneratedFullMessage getDefaultInstanceForType() {
+            return DEFAULT_INSTANCE;
+        }
+
+        private static FileDescriptorProto fileDescriptorProto() {
+            DescriptorProto metadataEntry = DescriptorProto.newBuilder()
+                    .setName("MetadataEntry")
+                    .addField(FieldDescriptorProto.newBuilder()
+                            .setName("key")
+                            .setNumber(1)
+                            .setLabel(FieldDescriptorProto.Label.LABEL_OPTIONAL)
+                            .setType(FieldDescriptorProto.Type.TYPE_STRING))
+                    .addField(FieldDescriptorProto.newBuilder()
+                            .setName("value")
+                            .setNumber(2)
+                            .setLabel(FieldDescriptorProto.Label.LABEL_OPTIONAL)
+                            .setType(FieldDescriptorProto.Type.TYPE_STRING))
+                    .setOptions(MessageOptions.newBuilder().setMapEntry(true).build())
+                    .build();
+            DescriptorProto message = DescriptorProto.newBuilder()
+                    .setName("Android32AccessorMessage")
+                    .addField(FieldDescriptorProto.newBuilder()
+                            .setName("metadata")
+                            .setNumber(1)
+                            .setLabel(FieldDescriptorProto.Label.LABEL_REPEATED)
+                            .setType(FieldDescriptorProto.Type.TYPE_MESSAGE)
+                            .setTypeName(".forge.protobuf.Android32AccessorMessage.MetadataEntry"))
+                    .addNestedType(metadataEntry)
+                    .build();
+            return FileDescriptorProto.newBuilder()
+                    .setName("unsafe_util_android32_memory_accessor_test.proto")
+                    .setPackage("forge.protobuf")
+                    .setSyntax("proto3")
+                    .addMessageType(message)
+                    .build();
+        }
+
+        public static final class MetadataDefaultEntryHolder {
+            public static final MapEntry<String, String> defaultEntry = MapEntry
+                    .<String, String>newDefaultInstance(
+                            DESCRIPTOR.findNestedTypeByName("MetadataEntry"),
+                            FieldType.STRING,
+                            "",
+                            FieldType.STRING,
+                            "");
+        }
+    }
+}

--- a/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/java/com_google_protobuf/protobuf_javalite/UnsafeUtilInnerAndroid64MemoryAccessorTest.java
+++ b/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/java/com_google_protobuf/protobuf_javalite/UnsafeUtilInnerAndroid64MemoryAccessorTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_protobuf.protobuf_javalite;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.DescriptorProtos.DescriptorProto;
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
+import com.google.protobuf.DescriptorProtos.MessageOptions;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.DescriptorValidationException;
+import com.google.protobuf.Descriptors.FileDescriptor;
+import com.google.protobuf.ExtensionRegistryLite;
+import com.google.protobuf.GeneratedMessageV3;
+import com.google.protobuf.MapEntry;
+import com.google.protobuf.MapField;
+import com.google.protobuf.Message;
+import com.google.protobuf.WireFormat.FieldType;
+import org.junit.jupiter.api.Test;
+
+public class UnsafeUtilInnerAndroid64MemoryAccessorTest {
+    @Test
+    void generatedMessageV3MapSchemaReadsDefaultEntryThroughAndroid64Accessor() throws Exception {
+        GeneratedFullMessage message = new GeneratedFullMessage();
+
+        message.mergeEmptyPayloadThroughGeneratedMessageV3Schema();
+
+        assertThat(message.getDescriptorForType().getFullName())
+                .isEqualTo("forge.protobuf.Android64AccessorMessage");
+        assertThat(message.getDefaultInstanceForType())
+                .isSameAs(GeneratedFullMessage.getDefaultInstance());
+    }
+
+    @SuppressWarnings("checkstyle:MemberName")
+    public static final class GeneratedFullMessage extends GeneratedMessageV3 {
+        private static final Descriptor DESCRIPTOR;
+        private static final FieldAccessorTable FIELD_ACCESSOR_TABLE;
+        private static final GeneratedFullMessage DEFAULT_INSTANCE;
+
+        static {
+            try {
+                FileDescriptor fileDescriptor = FileDescriptor.buildFrom(
+                        fileDescriptorProto(), new FileDescriptor[0]);
+                DESCRIPTOR = fileDescriptor.findMessageTypeByName("Android64AccessorMessage");
+                FIELD_ACCESSOR_TABLE = new FieldAccessorTable(
+                        DESCRIPTOR, new String[] {"Metadata"});
+                DEFAULT_INSTANCE = new GeneratedFullMessage();
+            } catch (DescriptorValidationException e) {
+                throw new ExceptionInInitializerError(e);
+            }
+        }
+
+        private MapField<String, String> metadata_ =
+                MapField.emptyMapField(MetadataDefaultEntryHolder.defaultEntry);
+
+        private GeneratedFullMessage() {
+        }
+
+        public static GeneratedFullMessage getDefaultInstance() {
+            return DEFAULT_INSTANCE;
+        }
+
+        void mergeEmptyPayloadThroughGeneratedMessageV3Schema() throws Exception {
+            CodedInputStream input = CodedInputStream.newInstance(new byte[0]);
+            mergeFromAndMakeImmutableInternal(input, ExtensionRegistryLite.getEmptyRegistry());
+        }
+
+        @Override
+        protected FieldAccessorTable internalGetFieldAccessorTable() {
+            return FIELD_ACCESSOR_TABLE;
+        }
+
+        @Override
+        protected Message.Builder newBuilderForType(BuilderParent parent) {
+            throw new UnsupportedOperationException("Builder is not needed by this test fixture.");
+        }
+
+        @Override
+        public Message.Builder newBuilderForType() {
+            throw new UnsupportedOperationException("Builder is not needed by this test fixture.");
+        }
+
+        @Override
+        public Message.Builder toBuilder() {
+            throw new UnsupportedOperationException("Builder is not needed by this test fixture.");
+        }
+
+        @Override
+        public GeneratedFullMessage getDefaultInstanceForType() {
+            return DEFAULT_INSTANCE;
+        }
+
+        private static FileDescriptorProto fileDescriptorProto() {
+            DescriptorProto metadataEntry = DescriptorProto.newBuilder()
+                    .setName("MetadataEntry")
+                    .addField(FieldDescriptorProto.newBuilder()
+                            .setName("key")
+                            .setNumber(1)
+                            .setLabel(FieldDescriptorProto.Label.LABEL_OPTIONAL)
+                            .setType(FieldDescriptorProto.Type.TYPE_STRING))
+                    .addField(FieldDescriptorProto.newBuilder()
+                            .setName("value")
+                            .setNumber(2)
+                            .setLabel(FieldDescriptorProto.Label.LABEL_OPTIONAL)
+                            .setType(FieldDescriptorProto.Type.TYPE_STRING))
+                    .setOptions(MessageOptions.newBuilder().setMapEntry(true).build())
+                    .build();
+            DescriptorProto message = DescriptorProto.newBuilder()
+                    .setName("Android64AccessorMessage")
+                    .addField(FieldDescriptorProto.newBuilder()
+                            .setName("metadata")
+                            .setNumber(1)
+                            .setLabel(FieldDescriptorProto.Label.LABEL_REPEATED)
+                            .setType(FieldDescriptorProto.Type.TYPE_MESSAGE)
+                            .setTypeName(".forge.protobuf.Android64AccessorMessage.MetadataEntry"))
+                    .addNestedType(metadataEntry)
+                    .build();
+            return FileDescriptorProto.newBuilder()
+                    .setName("unsafe_util_android64_memory_accessor_test.proto")
+                    .setPackage("forge.protobuf")
+                    .setSyntax("proto3")
+                    .addMessageType(message)
+                    .build();
+        }
+
+        public static final class MetadataDefaultEntryHolder {
+            public static final MapEntry<String, String> defaultEntry = MapEntry
+                    .<String, String>newDefaultInstance(
+                            DESCRIPTOR.findNestedTypeByName("MetadataEntry"),
+                            FieldType.STRING,
+                            "",
+                            FieldType.STRING,
+                            "");
+        }
+    }
+}

--- a/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/java/com_google_protobuf/protobuf_javalite/UnsafeUtilTest.java
+++ b/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/java/com_google_protobuf/protobuf_javalite/UnsafeUtilTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_protobuf.protobuf_javalite;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.GeneratedMessageLite;
+import com.google.protobuf.GeneratedMessageLite.MethodToInvoke;
+import com.google.protobuf.Parser;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import org.junit.jupiter.api.Test;
+
+public class UnsafeUtilTest {
+    @Test
+    void directBufferInputUsesProtobufUnsafeSupport() throws IOException {
+        ByteBuffer buffer = ByteBuffer.allocateDirect(Integer.BYTES);
+        buffer.put(new byte[] {0x78, 0x56, 0x34, 0x12});
+        buffer.flip();
+
+        CodedInputStream input = CodedInputStream.newInstance(buffer);
+
+        assertThat(input.readRawLittleEndian32()).isEqualTo(0x12345678);
+        assertThat(input.isAtEnd()).isTrue();
+    }
+
+    @Test
+    void unregisteredLiteMessageSchemaCreationUsesDefaultInstanceFallback() {
+        UnregisteredLiteMessage message = new UnregisteredLiteMessage();
+
+        assertThat(message.getSerializedSize()).isZero();
+        assertThat(message.isInitialized()).isTrue();
+    }
+
+    private static final class UnregisteredLiteMessage extends GeneratedMessageLite<
+            UnregisteredLiteMessage, UnregisteredLiteMessage.Builder> {
+        private static final UnregisteredLiteMessage DEFAULT_INSTANCE = new UnregisteredLiteMessage();
+        private static volatile Parser<UnregisteredLiteMessage> parser;
+
+        private UnregisteredLiteMessage() {
+        }
+
+        @Override
+        protected Object dynamicMethod(MethodToInvoke method, Object firstArgument, Object secondArgument) {
+            switch (method) {
+                case NEW_MUTABLE_INSTANCE:
+                    return new UnregisteredLiteMessage();
+                case NEW_BUILDER:
+                    return new Builder();
+                case BUILD_MESSAGE_INFO:
+                    return newMessageInfo(DEFAULT_INSTANCE, "\u0000\u0000", null);
+                case GET_DEFAULT_INSTANCE:
+                    return DEFAULT_INSTANCE;
+                case GET_PARSER:
+                    return parser();
+                case GET_MEMOIZED_IS_INITIALIZED:
+                    return (byte) 1;
+                case SET_MEMOIZED_IS_INITIALIZED:
+                    return null;
+                default:
+                    throw new UnsupportedOperationException("Unsupported method: " + method);
+            }
+        }
+
+        private static Parser<UnregisteredLiteMessage> parser() {
+            Parser<UnregisteredLiteMessage> result = parser;
+            if (result == null) {
+                synchronized (UnregisteredLiteMessage.class) {
+                    result = parser;
+                    if (result == null) {
+                        result = new DefaultInstanceBasedParser<>(DEFAULT_INSTANCE);
+                        parser = result;
+                    }
+                }
+            }
+            return result;
+        }
+
+        private static final class Builder extends GeneratedMessageLite.Builder<UnregisteredLiteMessage, Builder> {
+            private Builder() {
+                super(DEFAULT_INSTANCE);
+            }
+        }
+    }
+}

--- a/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,114 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com_google_protobuf.protobuf_javalite.GeneratedMessageLiteInnerSerializedFormTest"
+      },
+      "type": "com_google_protobuf.protobuf_javalite.GeneratedMessageLiteInnerSerializedFormTest$DefaultInstanceMessage",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.GeneratedMessageLite$SerializedForm"
+      },
+      "type": "com_google_protobuf.protobuf_javalite.GeneratedMessageLiteInnerSerializedFormTest$LegacyDefaultInstanceMessage",
+      "fields": [
+        {
+          "name": "defaultInstance"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_protobuf.protobuf_javalite.GeneratedMessageLiteInnerSerializedFormTest"
+      },
+      "type": "com_google_protobuf.protobuf_javalite.GeneratedMessageLiteInnerSerializedFormTest$LegacyDefaultInstanceMessage",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.DescriptorMessageInfoFactory"
+      },
+      "type": "com_google_protobuf.protobuf_javalite.SchemaUtilTest$GeneratedFullMessage",
+      "methods": [
+        {
+          "name": "getDefaultInstance",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.UnsafeUtil"
+      },
+      "type": "com_google_protobuf.protobuf_javalite.SchemaUtilTest$GeneratedFullMessage",
+      "fields": [
+        {
+          "name": "metadata_"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.SchemaUtil"
+      },
+      "type": "com_google_protobuf.protobuf_javalite.SchemaUtilTest$GeneratedFullMessage$MetadataDefaultEntryHolder"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.UnsafeUtil$Android64MemoryAccessor"
+      },
+      "type": "com_google_protobuf.protobuf_javalite.SchemaUtilTest$GeneratedFullMessage$MetadataDefaultEntryHolder",
+      "fields": [
+        {
+          "name": "defaultEntry"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.GeneratedMessageLite"
+      },
+      "type": "com_google_protobuf.protobuf_javalite.UnsafeUtilTest$UnregisteredLiteMessage"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.UnsafeUtil"
+      },
+      "type": "com_google_protobuf.protobuf_javalite.UnsafeUtilTest$UnregisteredLiteMessage",
+      "unsafeAllocated": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.Android"
+      },
+      "type": "org.robolectric.Robolectric"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_protobuf.protobuf_javalite.GeneratedMessageLiteInnerSerializedFormTest"
+      },
+      "type": "sun.security.provider.SHA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "com_google_protobuf.protobuf_javalite.GeneratedMessageLiteInnerSerializedFormTest"
+      },
+      "glob": "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_protobuf.protobuf_javalite.GeneratedMessageLiteInnerSerializedFormTest"
+      },
+      "glob": "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,114 +1,144 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "com_google_protobuf.protobuf_javalite.GeneratedMessageLiteInnerSerializedFormTest"
+      "condition" : {
+        "typeReached" : "com_google_protobuf.protobuf_javalite.GeneratedMessageLiteInnerSerializedFormTest"
       },
-      "type": "com_google_protobuf.protobuf_javalite.GeneratedMessageLiteInnerSerializedFormTest$DefaultInstanceMessage",
-      "serializable": true
+      "type" : "com_google_protobuf.protobuf_javalite.GeneratedMessageLiteInnerSerializedFormTest$DefaultInstanceMessage",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.GeneratedMessageLite$SerializedForm"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.GeneratedMessageLite$SerializedForm"
       },
-      "type": "com_google_protobuf.protobuf_javalite.GeneratedMessageLiteInnerSerializedFormTest$LegacyDefaultInstanceMessage",
-      "fields": [
+      "type" : "com_google_protobuf.protobuf_javalite.GeneratedMessageLiteInnerSerializedFormTest$LegacyDefaultInstanceMessage",
+      "fields" : [
         {
-          "name": "defaultInstance"
+          "name" : "defaultInstance"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com_google_protobuf.protobuf_javalite.GeneratedMessageLiteInnerSerializedFormTest"
+      "condition" : {
+        "typeReached" : "com_google_protobuf.protobuf_javalite.GeneratedMessageLiteInnerSerializedFormTest"
       },
-      "type": "com_google_protobuf.protobuf_javalite.GeneratedMessageLiteInnerSerializedFormTest$LegacyDefaultInstanceMessage",
-      "serializable": true
+      "type" : "com_google_protobuf.protobuf_javalite.GeneratedMessageLiteInnerSerializedFormTest$LegacyDefaultInstanceMessage",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.DescriptorMessageInfoFactory"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.DescriptorMessageInfoFactory"
       },
-      "type": "com_google_protobuf.protobuf_javalite.SchemaUtilTest$GeneratedFullMessage",
-      "methods": [
+      "type" : "com_google_protobuf.protobuf_javalite.SchemaUtilTest$GeneratedFullMessage",
+      "methods" : [
         {
-          "name": "getDefaultInstance",
-          "parameterTypes": []
+          "name" : "getDefaultInstance",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.UnsafeUtil"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.UnsafeUtil"
       },
-      "type": "com_google_protobuf.protobuf_javalite.SchemaUtilTest$GeneratedFullMessage",
-      "fields": [
+      "type" : "com_google_protobuf.protobuf_javalite.SchemaUtilTest$GeneratedFullMessage",
+      "fields" : [
         {
-          "name": "metadata_"
+          "name" : "metadata_"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.SchemaUtil"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.SchemaUtil"
       },
-      "type": "com_google_protobuf.protobuf_javalite.SchemaUtilTest$GeneratedFullMessage$MetadataDefaultEntryHolder"
+      "type" : "com_google_protobuf.protobuf_javalite.SchemaUtilTest$GeneratedFullMessage$MetadataDefaultEntryHolder"
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.UnsafeUtil$Android64MemoryAccessor"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.UnsafeUtil$Android64MemoryAccessor"
       },
-      "type": "com_google_protobuf.protobuf_javalite.SchemaUtilTest$GeneratedFullMessage$MetadataDefaultEntryHolder",
-      "fields": [
+      "type" : "com_google_protobuf.protobuf_javalite.SchemaUtilTest$GeneratedFullMessage$MetadataDefaultEntryHolder",
+      "fields" : [
         {
-          "name": "defaultEntry"
+          "name" : "defaultEntry"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.GeneratedMessageLite"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.GeneratedMessageLite"
       },
-      "type": "com_google_protobuf.protobuf_javalite.UnsafeUtilTest$UnregisteredLiteMessage"
+      "type" : "com_google_protobuf.protobuf_javalite.UnsafeUtilTest$UnregisteredLiteMessage"
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.UnsafeUtil"
+      "condition" : {
+        "typeReached" : "com.google.protobuf.UnsafeUtil"
       },
-      "type": "com_google_protobuf.protobuf_javalite.UnsafeUtilTest$UnregisteredLiteMessage",
-      "unsafeAllocated": true
+      "type" : "com_google_protobuf.protobuf_javalite.UnsafeUtilTest$UnregisteredLiteMessage",
+      "unsafeAllocated" : true
     },
     {
-      "condition": {
-        "typeReached": "com.google.protobuf.Android"
+      "condition" : {
+        "typeReached" : "com_google_protobuf.protobuf_javalite.GeneratedMessageLiteInnerSerializedFormTest"
       },
-      "type": "org.robolectric.Robolectric"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_protobuf.protobuf_javalite.GeneratedMessageLiteInnerSerializedFormTest"
-      },
-      "type": "sun.security.provider.SHA",
-      "methods": [
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.GeneratedMessageLite$SerializedForm"
+      },
+      "type" : "com_google_protobuf.protobuf_javalite.GeneratedMessageLiteInnerSerializedFormTest$DefaultInstanceMessage"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.GeneratedMessageLite$SerializedForm"
+      },
+      "type" : "com_google_protobuf.protobuf_javalite.GeneratedMessageLiteInnerSerializedFormTest$LegacyDefaultInstanceMessage"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.MessageSchema"
+      },
+      "type" : "com_google_protobuf.protobuf_javalite.MessageSchemaTest$InvalidFieldMessage"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.DescriptorMessageInfoFactory"
+      },
+      "type" : "com_google_protobuf.protobuf_javalite.SchemaUtilTest$GeneratedFullMessage"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.DescriptorMessageInfoFactory"
+      },
+      "type" : "com_google_protobuf.protobuf_javalite.UnsafeUtilInnerAndroid32MemoryAccessorTest$GeneratedFullMessage"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.DescriptorMessageInfoFactory"
+      },
+      "type" : "com_google_protobuf.protobuf_javalite.UnsafeUtilInnerAndroid64MemoryAccessorTest$GeneratedFullMessage"
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "com_google_protobuf.protobuf_javalite.GeneratedMessageLiteInnerSerializedFormTest"
+      "condition" : {
+        "typeReached" : "com_google_protobuf.protobuf_javalite.GeneratedMessageLiteInnerSerializedFormTest"
       },
-      "glob": "META-INF/services/org.assertj.core.configuration.Configuration"
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
     },
     {
-      "condition": {
-        "typeReached": "com_google_protobuf.protobuf_javalite.GeneratedMessageLiteInnerSerializedFormTest"
+      "condition" : {
+        "typeReached" : "com_google_protobuf.protobuf_javalite.GeneratedMessageLiteInnerSerializedFormTest"
       },
-      "glob": "META-INF/services/org.assertj.core.presentation.Representation"
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
     }
   ]
 }

--- a/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/user-code-filter.json
+++ b/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.google.protobuf.**"
+    }
+  ]
+}

--- a/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/user-code-filter.json
+++ b/tests/src/com.google.protobuf/protobuf-javalite/3.25.3/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.google.protobuf.**"
+      "includeClasses" : "com.google.protobuf.**"
+    },
+    {
+      "includeClasses" : "com_google_protobuf.protobuf_javalite.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #2711

This PR introduces tests and metadata for com.google.protobuf:protobuf-javalite:3.25.3, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 869382
- Cached input tokens: 15462912
- Output tokens: 110001
- Metadata entries: 51
- Test-only metadata entries: 26
- Iterations: 20
- Library coverage percentage: 9.21
- Generated lines of code: 997
- Tested library lines of code: 1805

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `c973a8aab682315d994dee041a10fca2ad74847e`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 39/41 covered calls (95.12%)
- Reflection: 39/41 covered calls (95.12%)

Library coverage:
- Instruction: 7900/84189 (9.38%)
- Line: 1805/19594 (9.21%)
- Method: 467/4147 (11.26%)

### Local CI Verification

- Status: `success`
- Commands run: 14
- Fixup attempts: 0
