### PR TITLE
Fix final index validation before auto-merge

### DIFF
--- a/forge/docs/functional-spec.md
+++ b/forge/docs/functional-spec.md
@@ -199,6 +199,40 @@ shared repository file changed, the PR must be labeled `human-intervention`
 and the verification metrics and PR description must list the repository-level
 paths that require maintainer review.
 
+### 6.1 PR review and merge safeguards
+
+Forge review queues may merge approved pull requests only after GitHub reports
+that the pull request is mergeable and all status gates are green. For any pull
+request that changes a library index file matching
+`metadata/<group>/<artifact>/index.json`, Forge must run a final local index
+validation against the tree that would be merged into the current
+`master` branch.
+
+The final validation must use a fresh `origin/master`, apply the reviewed pull
+request head without committing it, verify that the fetched head still matches
+the reviewed head SHA, and run:
+
+```bash
+./gradlew validateIndexFiles -Pcoordinates=all --stacktrace
+```
+
+PR review automation must instruct the reviewer to run this final validation
+for index-changing pull requests before approving. If validation fails because
+tested versions are in the wrong metadata-version bucket or duplicated across
+buckets, the reviewer must use the `fix-index-file-inconsistencies` skill to
+repair only the affected `index.json` files, commit the repair, push it to the
+same pull request branch, and rerun full index validation before submitting the
+review. Forge must not add `human-intervention` for these fixable index bucket
+inconsistencies.
+
+Forge also runs the final index validation immediately before merging an
+approved index-changing pull request as a safety net. If the reviewer did not
+repair the pull request and this merge-time validation still fails, Forge must
+not merge the pull request and the review pass may fail. Infrastructure
+failures while preparing the validation candidate, such as fetch failures,
+merge conflicts, or a changed pull request head SHA, remain hard automation
+failures.
+
 ## 7. Failure Semantics
 
 Every workflow records one of these statuses:

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -174,6 +174,7 @@ LABEL_NOT_FOR_NATIVE_IMAGE = "not-for-native-image"
 
 SCRATCH_WORKTREE_DIRNAME = "forge_worktrees"
 SCRATCH_REVIEW_WORKTREE_DIRNAME = "forge_review_worktrees"
+SCRATCH_FINAL_INDEX_VALIDATION_WORKTREE_DIRNAME = "forge_final_index_validation_worktrees"
 SCRATCH_METRICS_DIRNAME = "forge_run_metrics"
 ISSUE_CLAIM_LOCK_DIRNAME = "metadata-forge-issue-claim-locks"
 ISSUE_CLAIM_CACHE_REASON_ASSIGNED = "assigned"
@@ -1865,7 +1866,150 @@ def resolve_pull_request_merge_flag(pr: dict) -> str:
     return "--squash"
 
 
-def merge_pull_request(pr: dict) -> None:
+def is_metadata_index_file_path(path: str) -> bool:
+    """Return True when a repository path is a library index file."""
+    parts = path.split("/")
+    return len(parts) == 4 and parts[0] == "metadata" and parts[3] == "index.json"
+
+
+def get_pull_request_changed_files(pr_number: int) -> list[str]:
+    """Return changed file paths for a pull request."""
+    result = gh(
+        "pr",
+        "diff",
+        str(pr_number),
+        "--repo",
+        REPO,
+        "--name-only",
+        quiet=True,
+    )
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def get_pull_request_changed_index_files(pr_number: int) -> list[str]:
+    """Return changed library index files for a pull request."""
+    return [
+        path for path in get_pull_request_changed_files(pr_number)
+        if is_metadata_index_file_path(path)
+    ]
+
+
+def output_tail(output: str | None, max_lines: int = 80) -> str:
+    """Return the final lines from command output."""
+    if not output:
+        return ""
+    return "\n".join(output.strip().splitlines()[-max_lines:])
+
+
+def run_checked_command(
+        command: list[str],
+        cwd: str,
+        error_message: str,
+) -> subprocess.CompletedProcess:
+    """Run a command and report its captured output on failure."""
+    try:
+        return subprocess.run(
+            command,
+            cwd=cwd,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        tail = output_tail(exc.stdout)
+        print(f"ERROR: {error_message}" + (f":\n{tail}" if tail else ""), file=sys.stderr)
+        raise
+
+
+def validate_index_files_on_current_master_candidate(
+        pr_number: int,
+        head_ref_oid: str,
+        reachability_metadata_path: str,
+) -> None:
+    """Validate index files after applying the pull request head to current master."""
+    repo_root = get_repo_root()
+    validation_worktrees_root = os.path.join(
+        repo_root,
+        "local_repositories",
+        SCRATCH_FINAL_INDEX_VALIDATION_WORKTREE_DIRNAME,
+    )
+    os.makedirs(validation_worktrees_root, exist_ok=True)
+
+    validation_run_id = f"index-pr-{pr_number}-{uuid.uuid4().hex[:8]}"
+    validation_worktree_path = os.path.join(validation_worktrees_root, validation_run_id)
+
+    fetch_review_base_ref(reachability_metadata_path)
+    create_detached_worktree(
+        reachability_metadata_path,
+        validation_worktree_path,
+        f"origin/{DEFAULT_WORKTREE_BASE_REF}",
+        f"Failed to create final index validation worktree for PR #{pr_number}",
+    )
+    try:
+        run_checked_command(
+            ["git", "fetch", "--quiet", "origin", f"refs/pull/{pr_number}/head"],
+            validation_worktree_path,
+            f"Failed to fetch PR #{pr_number} head for final index validation",
+        )
+        fetched_head = run_checked_command(
+            ["git", "rev-parse", "FETCH_HEAD"],
+            validation_worktree_path,
+            f"Failed to resolve fetched PR #{pr_number} head for final index validation",
+        ).stdout.strip()
+        if fetched_head != head_ref_oid:
+            print(
+                (
+                    f"ERROR: PR #{pr_number} head changed before final index validation: "
+                    f"expected {head_ref_oid}, fetched {fetched_head}."
+                ),
+                file=sys.stderr,
+            )
+            raise RuntimeError(f"Pull request #{pr_number} head changed before final index validation")
+
+        run_checked_command(
+            ["git", "merge", "--no-commit", "--no-ff", "FETCH_HEAD"],
+            validation_worktree_path,
+            (
+                f"Failed to merge PR #{pr_number} into current "
+                f"{DEFAULT_WORKTREE_BASE_REF} for final index validation"
+            ),
+        )
+        print(
+            f"[Validating all index files on current {DEFAULT_WORKTREE_BASE_REF} "
+            f"plus PR #{pr_number}.]"
+        )
+        run_checked_command(
+            ["./gradlew", "validateIndexFiles", "-Pcoordinates=all", "--stacktrace"],
+            validation_worktree_path,
+            f"Final index validation failed for PR #{pr_number}",
+        )
+    finally:
+        remove_worktree(reachability_metadata_path, validation_worktree_path)
+
+
+def validate_pull_request_indexes_before_merge(
+        pr_number: int,
+        head_ref_oid: str,
+        reachability_metadata_path: str,
+) -> None:
+    """Run final-tree index validation for pull requests that change index files."""
+    changed_index_files = get_pull_request_changed_index_files(pr_number)
+    if not changed_index_files:
+        return
+
+    print(
+        f"[PR #{pr_number} changes {len(changed_index_files)} index file(s); "
+        f"running final index validation before merge.]"
+    )
+    validate_index_files_on_current_master_candidate(
+        pr_number,
+        head_ref_oid,
+        reachability_metadata_path,
+    )
+
+
+def merge_pull_request(pr: dict, reachability_metadata_path: str | None = None) -> None:
     """Merge a pull request using the repository's configured merge method."""
     pr_number = pr.get("number")
     head_ref_oid = pr.get("headRefOid")
@@ -1873,6 +2017,10 @@ def merge_pull_request(pr: dict) -> None:
     if not isinstance(pr_number, int) or not isinstance(head_ref_oid, str) or not head_ref_oid:
         print(f"ERROR: Missing merge metadata for pull request #{pr_number}.", file=sys.stderr)
         raise RuntimeError(f"Missing merge metadata for pull request #{pr_number}")
+    if reachability_metadata_path is None:
+        reachability_metadata_path = get_repo_root()
+
+    validate_pull_request_indexes_before_merge(pr_number, head_ref_oid, reachability_metadata_path)
 
     merge_args = [
         "pr",
@@ -1892,7 +2040,10 @@ def merge_pull_request(pr: dict) -> None:
     gh(*merge_args)
 
 
-def reconcile_reviewed_pull_request(pr_number: int) -> bool:
+def reconcile_reviewed_pull_request(
+        pr_number: int,
+        reachability_metadata_path: str | None = None,
+) -> bool:
     """Apply post-review PR follow-up actions based on the latest review state."""
     try:
         pr = get_pull_request_state(pr_number)
@@ -1938,7 +2089,7 @@ def reconcile_reviewed_pull_request(pr_number: int) -> bool:
             print(f"[Skipping merge for PR #{pr_number}: merge gates are not fully passing yet.]")
             return True
 
-        merge_pull_request(pr)
+        merge_pull_request(pr, reachability_metadata_path)
         return True
     except Exception as exc:
         print(
@@ -2206,8 +2357,12 @@ def build_review_prompt(pr_number: int) -> str:
         "source for the pull request's changed files and patch content. "
         "A fresh `origin/master` ref was fetched before checkout, so local `git diff origin/master...HEAD` "
         "may be used for convenience, but if local git output disagrees with `gh pr diff`, trust `gh pr diff`. "
-        "Do not run `gh pr checkout`, `git checkout`, or `git switch`. "
-        "Do not write any files. "
+        "During normal review, do not run `gh pr checkout`, `git checkout`, or `git switch`, and do not write files. "
+        "Exception: if the PR changes `metadata/<group>/<artifact>/index.json` files, run final index validation "
+        "against current `origin/master` before approving. If that validation fails because tested versions are in "
+        "the wrong metadata bucket or duplicated across buckets, use the `fix-index-file-inconsistencies` skill. "
+        "In that exception path, you may check out the PR branch, fix only the required `index.json` files, commit "
+        "the repair, and push it to this PR branch before submitting the GitHub review. "
         "If you find blocking issues, submit a review that requests changes with a concise summary. "
         "If there are no blocking issues, submit an approval review summarizing the check and stating that you found no blocking issues."
     )
@@ -2280,7 +2435,7 @@ def process_pull_requests_with_label(
                 f"Approved after manual follow-up marked this PR as '{LABEL_HUMAN_INTERVENTION_FIXED}'.",
             )
             pr = get_pull_request_state(pr_number)
-            merge_pull_request(pr)
+            merge_pull_request(pr, reachability_metadata_path)
         except Exception as exc:
             print(
                 f"ERROR: Failed to merge human-intervention-fixed PR #{pr_number}: {exc!r}",
@@ -2364,7 +2519,7 @@ def process_pull_requests_with_label(
         ):
             failed_reviews.append(pr_number)
             continue
-        if not reconcile_reviewed_pull_request(pr_number):
+        if not reconcile_reviewed_pull_request(pr_number, reachability_metadata_path):
             failed_reviews.append(pr_number)
 
     if failed_reviews:

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -1568,7 +1568,7 @@ class PullRequestReviewSelectionTests(unittest.TestCase):
             "https://github.com/oracle/graalvm-reachability-metadata/pull/100",
             None,
         )
-        reconcile_reviewed_pull_request.assert_called_once_with(100)
+        reconcile_reviewed_pull_request.assert_called_once_with(100, "/tmp/reachability")
 
 
 class IssueClaimCacheTests(unittest.TestCase):
@@ -2365,6 +2365,92 @@ class InterruptHandlingTests(unittest.TestCase):
 
 
 class PullRequestReviewTests(unittest.TestCase):
+    def test_merge_pull_request_validates_index_candidate_before_merge(self) -> None:
+        pr = {
+            "number": 3513,
+            "url": "https://github.com/oracle/graalvm-reachability-metadata/pull/3513",
+            "headRefOid": "abc123",
+        }
+
+        with patch.object(
+                forge_metadata,
+                "get_pull_request_changed_index_files",
+                return_value=["metadata/org.example/demo/index.json"],
+        ), patch.object(
+                forge_metadata,
+                "validate_index_files_on_current_master_candidate",
+        ) as validate_candidate, patch.object(forge_metadata, "gh") as gh:
+            forge_metadata.merge_pull_request(pr, "/repo")
+
+        validate_candidate.assert_called_once_with(3513, "abc123", "/repo")
+        gh.assert_called_once_with(
+            "pr",
+            "merge",
+            "3513",
+            "--repo",
+            forge_metadata.REPO,
+            "--match-head-commit",
+            "abc123",
+            "--squash",
+        )
+
+    def test_merge_pull_request_skips_index_validation_when_index_unchanged(self) -> None:
+        pr = {
+            "number": 3513,
+            "url": "https://github.com/oracle/graalvm-reachability-metadata/pull/3513",
+            "headRefOid": "abc123",
+        }
+
+        with patch.object(
+                forge_metadata,
+                "get_pull_request_changed_index_files",
+                return_value=[],
+        ), patch.object(
+                forge_metadata,
+                "validate_index_files_on_current_master_candidate",
+        ) as validate_candidate, patch.object(forge_metadata, "gh") as gh:
+            forge_metadata.merge_pull_request(pr, "/repo")
+
+        validate_candidate.assert_not_called()
+        gh.assert_called_once()
+
+    def test_merge_pull_request_stops_when_final_index_validation_fails(self) -> None:
+        pr = {
+            "number": 3513,
+            "url": "https://github.com/oracle/graalvm-reachability-metadata/pull/3513",
+            "headRefOid": "abc123",
+        }
+
+        with patch.object(
+                forge_metadata,
+                "get_pull_request_changed_index_files",
+                return_value=["metadata/org.example/demo/index.json"],
+        ), patch.object(
+                forge_metadata,
+                "validate_index_files_on_current_master_candidate",
+                side_effect=RuntimeError("invalid index"),
+        ), patch.object(forge_metadata, "gh") as gh:
+            with self.assertRaises(RuntimeError):
+                forge_metadata.merge_pull_request(pr, "/repo")
+
+        gh.assert_not_called()
+
+    def test_get_pull_request_changed_index_files_filters_library_indexes(self) -> None:
+        with patch.object(
+                forge_metadata,
+                "get_pull_request_changed_files",
+                return_value=[
+                    "metadata/org.example/demo/index.json",
+                    "metadata/schemas/metadata-library-index-schema-v2.1.0.json",
+                    "tests/src/org.example/demo/1.0.0/build.gradle",
+                    "metadata/org.example/demo/1.0.0/reachability-metadata.json",
+                ],
+        ):
+            self.assertEqual(
+                forge_metadata.get_pull_request_changed_index_files(3513),
+                ["metadata/org.example/demo/index.json"],
+            )
+
     def test_reconcile_approved_pr_with_failed_ci_reruns_failed_jobs_without_merging(self) -> None:
         pr = {
             "number": 3513,
@@ -2473,6 +2559,9 @@ class PullRequestReviewTests(unittest.TestCase):
         self.assertIn("authoritative", prompt)
         self.assertIn("if local git output disagrees with `gh pr diff`, trust `gh pr diff`", prompt)
         self.assertIn("A fresh `origin/master` ref was fetched before checkout", prompt)
+        self.assertIn("fix-index-file-inconsistencies", prompt)
+        self.assertIn("you may check out the PR branch", prompt)
+        self.assertIn("commit the repair, and push it to this PR branch", prompt)
 
 
 if __name__ == "__main__":

--- a/metadata/org.apache.camel/camel-xml-jaxp-util/index.json
+++ b/metadata/org.apache.camel/camel-xml-jaxp-util/index.json
@@ -7,8 +7,7 @@
     "documentation-url" : "https://repo1.maven.org/maven2/org/apache/camel/camel-xml-jaxp-util/$version$/camel-xml-jaxp-util-$version$-javadoc.jar",
     "description" : "Camel XML JAXP Util provides Apache Camel's JAXP-based XML utility classes, including a secure SAX-driven pretty printer for XML text. It is used by Camel code that needs lightweight XML formatting and colorization support without pulling in a full XML component.",
     "tested-versions" : [
-      "4.19.0",
-      "4.20.0"
+      "4.19.0"
     ],
     "allowed-packages" : [
       "org.apache.camel.util.xml.pretty"

--- a/skills/README.md
+++ b/skills/README.md
@@ -11,6 +11,14 @@ Skills are loaded by symlinking the desired skill directory into the matching re
 Fixes missing GraalVM reachability metadata for a library specified by coordinates. 
 It runs the target tests, identifies missing metadata entries from the error output, and adds them to the correct section of `reachability-metadata.json`. This process repeats until all required metadata is available and the tests pass.
 
+### `fix-index-file-inconsistencies`
+
+Fixes PR review failures where final `validateIndexFiles` against current
+`master` fails because `index.json` tested versions are in the wrong
+metadata-version bucket, duplicated across buckets, or stale after another
+index-changing PR landed first. The reviewer repairs the PR branch, validates,
+commits, and pushes the corrected index files.
+
 ### `review-library-bulk-update`
 
 Reviews automated pull requests with the `library-bulk-update` label.

--- a/skills/fix-index-file-inconsistencies/SKILL.md
+++ b/skills/fix-index-file-inconsistencies/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: fix-index-file-inconsistencies
+description: Fix graalvm-reachability-metadata PRs where final validateIndexFiles against current master fails because metadata index.json tested versions are in the wrong metadata-version bucket, duplicated across buckets, or stale after another index-changing PR landed. Use during PR review when an index-changing PR must be repaired and pushed instead of labeled human-intervention.
+---
+
+# Fix Index File Inconsistencies
+
+Use this skill while reviewing a PR that changes
+`metadata/<group>/<artifact>/index.json` and fails final index validation on
+current `master`.
+
+The goal is to repair the PR branch, commit the fix, push it to the same PR,
+and then continue the review. Do not label the PR `human-intervention` for
+fixable index bucket inconsistencies.
+
+## What To Fix
+
+`validateIndexFiles` enforces that each non-`latest` metadata entry owns only
+tested versions that belong before the next metadata entry. Common failures:
+
+- A PR was valid when an older entry was `latest`, but another PR added a newer
+  metadata entry first. The older entry is now non-`latest`, so the PR's added
+  tested versions must move to a later bucket.
+- A tested version appears in an older entry even though the same version has
+  its own metadata entry.
+- A tested version was appended to the closest textual entry instead of the
+  compatible metadata-version range.
+
+Fix only the affected `index.json` files unless the branch must first be
+rebased onto `origin/master` so the correct target bucket exists locally.
+
+## Reproduce The Final Candidate
+
+From the PR review worktree:
+
+```bash
+PR_NUMBER=<pr>
+git fetch --quiet origin +master:refs/remotes/origin/master
+PR_HEAD="$(git rev-parse HEAD)"
+TMP="$(mktemp -d)"
+git worktree add --detach "$TMP" origin/master
+git -C "$TMP" fetch --quiet origin "refs/pull/${PR_NUMBER}/head"
+test "$(git -C "$TMP" rev-parse FETCH_HEAD)" = "$PR_HEAD"
+git -C "$TMP" merge --no-commit --no-ff FETCH_HEAD
+(cd "$TMP" && ./gradlew validateIndexFiles -Pcoordinates=all --stacktrace)
+git worktree remove --force "$TMP"
+```
+
+Read the validation errors. They usually name the library coordinate and the
+specific tested versions that exceed the next metadata-version boundary.
+
+## Repair The PR Branch
+
+The review worktree starts in detached HEAD. To push a fix, check out the PR
+branch only after you have confirmed this is a fixable index inconsistency:
+
+```bash
+PR_NUMBER=<pr>
+gh pr view "$PR_NUMBER" --json headRefName,headRepositoryOwner,isCrossRepository
+gh pr checkout "$PR_NUMBER"
+git fetch --quiet origin +master:refs/remotes/origin/master
+git rebase origin/master
+```
+
+If the PR is from a fork and you cannot push to it, request changes with the
+validation error and the exact index repair needed. Do not add
+`human-intervention`.
+
+Edit the affected `index.json` files:
+
+- Move tested versions from the older metadata entry into the correct later
+  entry when the validator says they are greater than or equal to the next
+  metadata-version boundary.
+- Remove a tested version from an older entry when that version already has its
+  own metadata entry.
+- Preserve URL fields, `allowed-packages`, `requires`, `latest`, and
+  `metadata-version` unless the validator error directly proves one is wrong.
+- Preserve the file's existing JSON formatting and version ordering style.
+
+Validate the repair:
+
+```bash
+./gradlew validateIndexFiles -Pcoordinates=all --stacktrace
+```
+
+Then commit and push:
+
+```bash
+git diff
+git add metadata/<group>/<artifact>/index.json
+git commit -m "Fix index version buckets"
+git push --force-with-lease
+```
+
+After pushing, submit the GitHub review. If the fix is complete and no other
+blocking issues remain, approve with a short note that the index bucket repair
+was pushed and full index validation now passes.
+
+## Examples
+
+### Stale latest bucket
+
+An older Jetty entry was once `latest`, so a PR appended `9.4.1` through
+`9.4.7` there. After another PR added a Jetty `9.4.8` entry, the old entry was
+no longer `latest`, and the validator rejected the `9.4.x` tested versions
+under the `9.3.x` metadata bucket.
+
+Fix: move `9.4.1` through `9.4.7` from the `9.3.19.v20170502` entry into the
+`9.4.0.v20180619` entry, leaving the `9.3.x` tested versions in the older
+entry.
+
+### Duplicate tested version
+
+A Camel entry for `4.19.0` contained:
+
+```json
+"tested-versions" : [
+  "4.19.0",
+  "4.20.0"
+]
+```
+
+but `4.20.0` already had its own metadata entry.
+
+Fix: remove `4.20.0` from the `4.19.0` entry. Do not delete the `4.20.0`
+metadata entry.
+
+## Review Decision
+
+- If the index repair validates and the rest of the PR is clean, approve.
+- If the index repair exposes unrelated contamination, request changes for the
+  unrelated issue.
+- If the branch cannot be pushed, request changes with the exact repair
+  instructions.


### PR DESCRIPTION
### Summary

This fixes stale-base index validation failures that can occur when multiple generated index-changing PRs are reviewed while `master` keeps moving. A PR can pass `validateIndexFiles` against its original base, but become invalid after another index-changing PR lands first and changes the effective metadata version buckets.

This PR also fixes the existing Camel `index.json` duplicate on `master` by removing `4.20.0` from the older `4.19.0` entry because `4.20.0` already has its own metadata entry.

### Reviewer-driven index repair

Forge now instructs PR reviewers to perform final index validation for PRs that change library index files matching `metadata/<group>/<artifact>/index.json` before approving.

If validation fails because tested versions are in the wrong metadata-version bucket, duplicated across buckets, or stale after another index-changing PR landed, the reviewer uses the new `fix-index-file-inconsistencies` skill. That skill tells the reviewer to:

1. Reproduce the final candidate by applying the reviewed PR head to fresh `origin/master`.
2. Run `./gradlew validateIndexFiles -Pcoordinates=all --stacktrace`.
3. Identify whether the failure is a fixable index bucket inconsistency.
4. Check out the PR branch only for that repair path.
5. Edit only the affected `index.json` files.
6. Re-run full index validation.
7. Commit the repair with `Fix index version buckets`.
8. Push the fix back to the same PR branch.
9. Submit the GitHub review after the repaired PR validates.

This replaces the earlier approach of marking these PRs with `human-intervention`. Forge must not add `human-intervention` for fixable index bucket inconsistencies; the reviewer should repair and push the branch instead.

### Auto-merge safety net

Forge still performs a final candidate validation immediately before auto-merging any approved PR that changes a library `index.json`.

Before calling `gh pr merge`, Forge:

1. Detects whether the PR changes a library `index.json`.
2. Fetches fresh `origin/master`.
3. Creates a temporary detached worktree from current `master`.
4. Fetches the PR head through `refs/pull/<number>/head`.
5. Verifies that the fetched head still matches the reviewed `headRefOid`.
6. Merges the PR head into the temporary worktree without committing.
7. Runs `./gradlew validateIndexFiles -Pcoordinates=all --stacktrace`.
8. Removes the temporary worktree.

If validation passes, Forge merges the PR as before. If validation fails at this late safety-net stage, Forge does not merge and the review pass may fail. That should be rare because the reviewer prompt now directs the review agent to repair fixable index bucket problems before approval.

Candidate setup problems, such as fetch failures, merge conflicts, or the PR head changing between review and merge, still fail the automation pass because those are infrastructure or race conditions rather than index repairs the reviewer can safely infer.

### Documentation and skill

- `forge/docs/functional-spec.md` documents the PR review and merge safeguard contract.
- `skills/fix-index-file-inconsistencies/SKILL.md` documents the repair workflow with Jetty and Camel examples.
- `skills/README.md` lists the new skill.

### Validation

Passed:

- `PYTHONPATH=forge /tmp/grm-forge-test-venv/bin/python -m unittest forge.tests.test_forge_metadata.PullRequestReviewTests forge.tests.test_forge_metadata.PullRequestReviewSelectionTests -v`
- `PYTHONPATH=forge /tmp/grm-forge-test-venv/bin/python -m py_compile forge/forge_metadata.py forge/tests/test_forge_metadata.py`
- `git diff --check`
- `./gradlew validateIndexFiles -Pcoordinates=org.apache.camel:camel-xml-jaxp-util:4.20.0 --stacktrace`

Checked against current `origin/master` after fetching:

- `./gradlew validateIndexFiles -Pcoordinates=org.eclipse.jetty:jetty-servlet:9.4.20.v20190813 --stacktrace` passes on current `origin/master`.
- `./gradlew validateIndexFiles -Pcoordinates=org.apache.camel:camel-xml-jaxp-util:4.20.0 --stacktrace` fails on current `origin/master`; this PR fixes that duplicate.

Fixes #7589