### PR TITLE
[GenAI] Test fix for jakarta.servlet:jakarta.servlet-api:6.2.0-M1 using gpt-5.5

### DIFF
--- a/metadata/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/reachability-metadata.json
+++ b/metadata/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/reachability-metadata.json
@@ -1,0 +1,30 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "jakarta.servlet.http.Cookie"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.servlet.http.HttpServlet"
+      },
+      "type": "java.lang.reflect.Method[]"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "jakarta.servlet.GenericFilter"
+      },
+      "bundle": "jakarta.servlet.LocalStrings"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.servlet.http.Cookie"
+      },
+      "bundle": "jakarta.servlet.http.LocalStrings"
+    }
+  ]
+}

--- a/metadata/jakarta.servlet/jakarta.servlet-api/index.json
+++ b/metadata/jakarta.servlet/jakarta.servlet-api/index.json
@@ -1,5 +1,15 @@
 [
   {
+    "latest" : true,
+    "metadata-version" : "6.2.0-M1",
+    "tested-versions" : [
+      "6.2.0-M1"
+    ],
+    "allowed-packages" : [
+      "jakarta.servlet"
+    ]
+  },
+  {
     "metadata-version" : "4.0.4",
     "source-code-url" : "https://repo1.maven.org/maven2/jakarta/servlet/jakarta.servlet-api/$version$/jakarta.servlet-api-$version$-sources.jar",
     "repository-url" : "https://github.com/jakartaee/servlet",
@@ -14,7 +24,6 @@
     ]
   },
   {
-    "latest" : true,
     "metadata-version" : "5.0.0",
     "source-code-url" : "https://repo1.maven.org/maven2/jakarta/servlet/jakarta.servlet-api/$version$/jakarta.servlet-api-$version$-sources.jar",
     "repository-url" : "https://github.com/jakartaee/servlet",

--- a/metadata/jakarta.servlet/jakarta.servlet-api/index.json
+++ b/metadata/jakarta.servlet/jakarta.servlet-api/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "6.2.0-M1",
+    "source-code-url" : "https://repo1.maven.org/maven2/jakarta/servlet/jakarta.servlet-api/$version$/jakarta.servlet-api-$version$-sources.jar",
+    "repository-url" : "https://github.com/jakartaee/servlet",
+    "test-code-url" : "https://github.com/jakartaee/servlet/tree/$version$-RELEASE-tck/tck",
+    "documentation-url" : "https://repo1.maven.org/maven2/jakarta/servlet/jakarta.servlet-api/$version$/jakarta.servlet-api-$version$-javadoc.jar",
+    "description" : "Jakarta Servlet defines the standard server-side API that Java web applications use to process HTTP requests and produce HTTP responses in Jakarta EE servlet containers. It provides the servlet, filter, listener, session, and HTTP support contracts implemented by containers and used by web frameworks.",
     "tested-versions" : [
       "6.2.0-M1"
     ],

--- a/stats/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/execution-metrics.json
+++ b/stats/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/execution-metrics.json
@@ -1,0 +1,109 @@
+{
+  "fix_javac_fail:2026-05-26": {
+    "timestamp": "2026-05-26T14:27:30.272595Z",
+    "library": "jakarta.servlet:jakarta.servlet-api:6.2.0-M1",
+    "starting_commit": "735d77a887f02a797837dbca04e2b65e06a2cc8d",
+    "ending_commit": "81f05a32d8ec57f0d25c2b98cd2e29e16c0b0c46",
+    "previous_library": "jakarta.servlet:jakarta.servlet-api:5.0.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "6.2.0-M1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 7,
+            "totalCalls": 7
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 8,
+        "totalCalls": 8
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 658,
+          "missed": 2582,
+          "ratio": 0.203086,
+          "total": 3240
+        },
+        "line": {
+          "covered": 189,
+          "missed": 727,
+          "ratio": 0.206332,
+          "total": 916
+        },
+        "method": {
+          "covered": 56,
+          "missed": 301,
+          "ratio": 0.156863,
+          "total": 357
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "5.0.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.0,
+            "coveredCalls": 0,
+            "totalCalls": 1
+          },
+          "resources": {
+            "coverageRatio": 0.25,
+            "coveredCalls": 2,
+            "totalCalls": 8
+          }
+        },
+        "coverageRatio": 0.222222,
+        "coveredCalls": 2,
+        "totalCalls": 9
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 14,
+          "missed": 3185,
+          "ratio": 0.004376,
+          "total": 3199
+        },
+        "line": {
+          "covered": 6,
+          "missed": 872,
+          "ratio": 0.006834,
+          "total": 878
+        },
+        "method": {
+          "covered": 4,
+          "missed": 328,
+          "ratio": 0.012048,
+          "total": 332
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 138556,
+      "cached_input_tokens_used": 1349120,
+      "output_tokens_used": 16405,
+      "iterations": 6,
+      "cost_usd": 1.1667,
+      "tested_library_loc": 189,
+      "metadata_entries": 4,
+      "previous_library_metadata_entries": 2,
+      "code_coverage_percent": 20.63,
+      "previous_library_coverage_percent": 0.68
+    },
+    "artifacts": {
+      "test_file": "tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/NoBodyOutputStreamTest.java",
+      "metadata_file": "metadata/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/stats.json
+++ b/stats/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "6.2.0-M1",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 7,
+          "totalCalls" : 7
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 8,
+      "totalCalls" : 8
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 658,
+        "missed" : 2582,
+        "ratio" : 0.203086,
+        "total" : 3240
+      },
+      "line" : {
+        "covered" : 189,
+        "missed" : 727,
+        "ratio" : 0.206332,
+        "total" : 916
+      },
+      "method" : {
+        "covered" : 56,
+        "missed" : 301,
+        "ratio" : 0.156863,
+        "total" : 357
+      }
+    }
+  } ]
+}

--- a/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/.gitignore
+++ b/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/build.gradle
+++ b/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/build.gradle
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "jakarta.servlet:jakarta.servlet-api:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}

--- a/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/build.gradle
+++ b/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/build.gradle
@@ -10,7 +10,22 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 
+repositories {
+    exclusiveContent {
+        forRepository {
+            mavenCentral {
+                metadataSources {
+                    artifact()
+                }
+            }
+        }
+        filter {
+            includeGroup "jakarta.servlet"
+        }
+    }
+}
+
 dependencies {
-    testImplementation "jakarta.servlet:jakarta.servlet-api:$libraryVersion"
+    testImplementation "jakarta.servlet:jakarta.servlet-api:$libraryVersion@jar"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }

--- a/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/gradle.properties
+++ b/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 6.2.0-M1
+metadata.dir = jakarta.servlet/jakarta.servlet-api/6.2.0-M1/

--- a/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/settings.gradle
+++ b/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'jakarta.servlet.jakarta.servlet-api_tests'

--- a/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/CookieTest.java
+++ b/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/CookieTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_servlet.jakarta_servlet_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import jakarta.servlet.http.Cookie;
+
+import org.junit.jupiter.api.Test;
+
+public class CookieTest {
+    @Test
+    void constructorInitializesCookieAndLoadsLocalizedMessages() {
+        Cookie cookie = new Cookie("sessionId", "initial");
+
+        assertThat(cookie.getName()).isEqualTo("sessionId");
+        assertThat(cookie.getValue()).isEqualTo("initial");
+        assertThat(cookie.getAttributes()).isEmpty();
+    }
+
+    @Test
+    void constructorRejectsInvalidNameWithBundleBackedMessage() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new Cookie("bad name", "value"))
+                .withMessageContaining("Cookie name \"bad name\"")
+                .withMessageContaining("invalid character");
+    }
+
+    @Test
+    void configuredAttributesAreCaseInsensitiveAndCopiedByClone() {
+        Cookie cookie = new Cookie("preferences", "compact");
+        cookie.setDomain("Example.COM");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(60);
+        cookie.setPath("/catalog");
+        cookie.setSecure(true);
+        cookie.setAttribute("SameSite", "Strict");
+        cookie.setAttribute("Partitioned", "");
+        cookie.setValue("expanded");
+
+        Cookie clonedCookie = (Cookie) cookie.clone();
+
+        assertThat(clonedCookie).isNotSameAs(cookie);
+        assertThat(clonedCookie).isEqualTo(cookie);
+        assertThat(clonedCookie.getName()).isEqualTo("preferences");
+        assertThat(clonedCookie.getValue()).isEqualTo("expanded");
+        assertThat(clonedCookie.getDomain()).isEqualTo("example.com");
+        assertThat(clonedCookie.isHttpOnly()).isTrue();
+        assertThat(clonedCookie.getMaxAge()).isEqualTo(60);
+        assertThat(clonedCookie.getPath()).isEqualTo("/catalog");
+        assertThat(clonedCookie.getSecure()).isTrue();
+        assertThat(clonedCookie.getAttribute("samesite")).isEqualTo("Strict");
+        assertThat(clonedCookie.getAttribute("partitioned")).isEmpty();
+        assertThat(clonedCookie.getAttributes())
+                .containsEntry("Domain", "example.com")
+                .containsEntry("HttpOnly", "")
+                .containsEntry("Max-Age", "60")
+                .containsEntry("Path", "/catalog")
+                .containsEntry("Secure", "")
+                .containsEntry("SameSite", "Strict")
+                .containsEntry("Partitioned", "");
+    }
+}

--- a/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/GenericFilterTests.java
+++ b/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/GenericFilterTests.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_servlet.jakarta_servlet_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.GenericFilter;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+
+import org.junit.jupiter.api.Test;
+
+public class GenericFilterTests {
+    @Test
+    void getFilterNameBeforeInitializationUsesBundleBackedMessage() {
+        TestGenericFilter filter = new TestGenericFilter();
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, filter::getFilterName);
+
+        assertThat(exception).hasMessage("ServletConfig has not been initialized");
+    }
+
+    private static final class TestGenericFilter extends GenericFilter {
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+                throws IOException, ServletException {
+        }
+    }
+}

--- a/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/HttpServletTests.java
+++ b/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/HttpServletTests.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_servlet.jakarta_servlet_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.Test;
+
+public class HttpServletTests {
+    @Test
+    void doOptionsIncludesSubclassHttpMethodsInAllowHeader() throws ServletException, IOException {
+        ExposedHttpServlet servlet = new ExposedHttpServlet();
+        RecordedResponse response = new RecordedResponse();
+
+        servlet.invokeDoOptions(requestWithProtocol("HTTP/1.1"), response.asHttpServletResponse());
+
+        assertThat(response.headerName()).isEqualTo("Allow");
+        assertThat(response.headerValue()).isEqualTo("POST, TRACE, OPTIONS");
+    }
+
+    private static HttpServletRequest requestWithProtocol(String protocol) {
+        return (HttpServletRequest) Proxy.newProxyInstance(
+                HttpServletTests.class.getClassLoader(),
+                new Class<?>[]{HttpServletRequest.class},
+                new RequestInvocationHandler(protocol));
+    }
+
+    private static final class ExposedHttpServlet extends HttpServlet {
+        void invokeDoOptions(HttpServletRequest request, HttpServletResponse response)
+                throws ServletException, IOException {
+            super.doOptions(request, response);
+        }
+
+        @Override
+        protected void doPost(HttpServletRequest request, HttpServletResponse response) {
+        }
+    }
+
+    private static final class RecordedResponse {
+        private String headerName;
+        private String headerValue;
+
+        HttpServletResponse asHttpServletResponse() {
+            return (HttpServletResponse) Proxy.newProxyInstance(
+                    HttpServletTests.class.getClassLoader(),
+                    new Class<?>[]{HttpServletResponse.class},
+                    this::handleInvocation);
+        }
+
+        String headerName() {
+            return headerName;
+        }
+
+        String headerValue() {
+            return headerValue;
+        }
+
+        private Object handleInvocation(Object proxy, Method method, Object[] arguments) {
+            if (isObjectMethod(method)) {
+                return handleObjectMethod(proxy, method, arguments);
+            }
+            if (method.getName().equals("setHeader") && arguments.length == 2) {
+                headerName = (String) arguments[0];
+                headerValue = (String) arguments[1];
+                return null;
+            }
+            throw new UnsupportedOperationException(method.toGenericString());
+        }
+    }
+
+    private static final class RequestInvocationHandler implements InvocationHandler {
+        private final String protocol;
+
+        private RequestInvocationHandler(String protocol) {
+            this.protocol = protocol;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] arguments) {
+            if (isObjectMethod(method)) {
+                return handleObjectMethod(proxy, method, arguments);
+            }
+            if (method.getName().equals("getProtocol")) {
+                return protocol;
+            }
+            throw new UnsupportedOperationException(method.toGenericString());
+        }
+    }
+
+    private static boolean isObjectMethod(Method method) {
+        return method.getDeclaringClass().equals(Object.class);
+    }
+
+    private static Object handleObjectMethod(Object proxy, Method method, Object[] arguments) {
+        return switch (method.getName()) {
+            case "equals" -> proxy == arguments[0];
+            case "hashCode" -> System.identityHashCode(proxy);
+            case "toString" -> proxy.getClass().getName();
+            default -> throw new UnsupportedOperationException(method.toGenericString());
+        };
+    }
+}

--- a/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/JakartaServletTests.java
+++ b/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/JakartaServletTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_servlet.jakarta_servlet_api;
+
+import java.io.IOException;
+
+import jakarta.servlet.GenericServlet;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServlet;
+import org.junit.jupiter.api.Test;
+
+
+class JakartaServletTests {
+    @Test
+    void instantiateServlet() {
+        new CustomServlet();
+    }
+
+  @Test
+  void instantiateHttpServlet() {
+    new CustomHttpServlet();
+  }
+
+  static class CustomServlet extends GenericServlet {
+    @Override
+    public void service(ServletRequest req, ServletResponse res) throws ServletException, IOException {
+
+    }
+  }
+
+  static class CustomHttpServlet extends HttpServlet {
+
+  }
+}

--- a/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/JakartaServletTests.java
+++ b/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/JakartaServletTests.java
@@ -12,7 +12,7 @@ import jakarta.servlet.GenericServlet;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
-import jakarta.servlet.http.HttpServlet;
+
 import org.junit.jupiter.api.Test;
 
 
@@ -22,19 +22,10 @@ public class JakartaServletTests {
         new CustomServlet();
     }
 
-    @Test
-    void instantiateHttpServlet() {
-        new CustomHttpServlet();
-    }
-
     static class CustomServlet extends GenericServlet {
         @Override
         public void service(ServletRequest req, ServletResponse res) throws ServletException, IOException {
 
         }
-    }
-
-    static class CustomHttpServlet extends HttpServlet {
-
     }
 }

--- a/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/JakartaServletTests.java
+++ b/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/JakartaServletTests.java
@@ -16,25 +16,25 @@ import jakarta.servlet.http.HttpServlet;
 import org.junit.jupiter.api.Test;
 
 
-class JakartaServletTests {
+public class JakartaServletTests {
     @Test
     void instantiateServlet() {
         new CustomServlet();
     }
 
-  @Test
-  void instantiateHttpServlet() {
-    new CustomHttpServlet();
-  }
+    @Test
+    void instantiateHttpServlet() {
+        new CustomHttpServlet();
+    }
 
-  static class CustomServlet extends GenericServlet {
-    @Override
-    public void service(ServletRequest req, ServletResponse res) throws ServletException, IOException {
+    static class CustomServlet extends GenericServlet {
+        @Override
+        public void service(ServletRequest req, ServletResponse res) throws ServletException, IOException {
+
+        }
+    }
+
+    static class CustomHttpServlet extends HttpServlet {
 
     }
-  }
-
-  static class CustomHttpServlet extends HttpServlet {
-
-  }
 }

--- a/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/NoBodyOutputStreamTest.java
+++ b/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/NoBodyOutputStreamTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_servlet.jakarta_servlet_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.nio.charset.StandardCharsets;
+
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.Test;
+
+public class NoBodyOutputStreamTest {
+    @Test
+    void legacyHeadHandlingCountsWrittenBodyWithoutSendingIt() throws ServletException, IOException {
+        BodyWritingServlet servlet = new BodyWritingServlet("hello");
+        RecordedContentLengthResponse response = new RecordedContentLengthResponse();
+
+        servlet.init(configWithLegacyHeadHandlingEnabled());
+        servlet.invokeDoHead(request(), response.asHttpServletResponse());
+
+        assertThat(response.contentLength()).isEqualTo(5);
+    }
+
+    private static ServletConfig configWithLegacyHeadHandlingEnabled() {
+        return (ServletConfig) Proxy.newProxyInstance(
+                NoBodyOutputStreamTest.class.getClassLoader(),
+                new Class<?>[]{ServletConfig.class},
+                new ServletConfigInvocationHandler());
+    }
+
+    private static HttpServletRequest request() {
+        return (HttpServletRequest) Proxy.newProxyInstance(
+                NoBodyOutputStreamTest.class.getClassLoader(),
+                new Class<?>[]{HttpServletRequest.class},
+                NoBodyOutputStreamTest::handleUnsupportedInvocation);
+    }
+
+    private static final class BodyWritingServlet extends HttpServlet {
+        private final byte[] body;
+
+        private BodyWritingServlet(String body) {
+            this.body = body.getBytes(StandardCharsets.UTF_8);
+        }
+
+        private void invokeDoHead(HttpServletRequest request, HttpServletResponse response)
+                throws ServletException, IOException {
+            super.doHead(request, response);
+        }
+
+        @Override
+        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+            response.getOutputStream().write(body);
+        }
+    }
+
+    private static final class ServletConfigInvocationHandler implements InvocationHandler {
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] arguments) {
+            if (isObjectMethod(method)) {
+                return handleObjectMethod(proxy, method, arguments);
+            }
+            if (method.getName().equals("getInitParameter")) {
+                return HttpServlet.LEGACY_DO_HEAD.equals(arguments[0]) ? "true" : null;
+            }
+            throw new UnsupportedOperationException(method.toGenericString());
+        }
+    }
+
+    private static final class RecordedContentLengthResponse {
+        private int contentLength = -1;
+
+        private HttpServletResponse asHttpServletResponse() {
+            return (HttpServletResponse) Proxy.newProxyInstance(
+                    NoBodyOutputStreamTest.class.getClassLoader(),
+                    new Class<?>[]{HttpServletResponse.class},
+                    this::handleInvocation);
+        }
+
+        private int contentLength() {
+            return contentLength;
+        }
+
+        private Object handleInvocation(Object proxy, Method method, Object[] arguments) {
+            if (isObjectMethod(method)) {
+                return handleObjectMethod(proxy, method, arguments);
+            }
+            if (method.getName().equals("setContentLength") && arguments.length == 1) {
+                contentLength = (Integer) arguments[0];
+                return null;
+            }
+            throw new UnsupportedOperationException(method.toGenericString());
+        }
+    }
+
+    private static Object handleUnsupportedInvocation(Object proxy, Method method, Object[] arguments) {
+        if (isObjectMethod(method)) {
+            return handleObjectMethod(proxy, method, arguments);
+        }
+        throw new UnsupportedOperationException(method.toGenericString());
+    }
+
+    private static boolean isObjectMethod(Method method) {
+        return method.getDeclaringClass().equals(Object.class);
+    }
+
+    private static Object handleObjectMethod(Object proxy, Method method, Object[] arguments) {
+        return switch (method.getName()) {
+            case "equals" -> proxy == arguments[0];
+            case "hashCode" -> System.identityHashCode(proxy);
+            case "toString" -> proxy.getClass().getName();
+            default -> throw new UnsupportedOperationException(method.toGenericString());
+        };
+    }
+}

--- a/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/ServletOutputStreamTest.java
+++ b/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/ServletOutputStreamTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_servlet.jakarta_servlet_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
+
+import org.junit.jupiter.api.Test;
+
+public class ServletOutputStreamTest {
+    @Test
+    void printBooleanUsesServletResourceBundleDuringOutputStreamInitialization() throws IOException {
+        RecordingServletOutputStream outputStream = new RecordingServletOutputStream();
+
+        outputStream.print(true);
+        outputStream.println(false);
+
+        assertThat(outputStream.toIso88591String()).isEqualTo("truefalse\r\n");
+    }
+
+    private static final class RecordingServletOutputStream extends ServletOutputStream {
+        private final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+
+        @Override
+        public void write(int b) {
+            bytes.write(b);
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setWriteListener(WriteListener writeListener) {
+            throw new UnsupportedOperationException("Non-blocking writes are not used by this test");
+        }
+
+        private String toIso88591String() {
+            return bytes.toString(StandardCharsets.ISO_8859_1);
+        }
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7611

This PR provides test fixes and new metadata for jakarta.servlet:jakarta.servlet-api:6.2.0-M1, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 138556
- Cached input tokens: 1349120
- Output tokens: 16405
- Metadata entries: 4
- Iterations: 6
- Library coverage percentage: 20.63
- Previous library version metadata entries: 2
- Previous library version coverage percentage: 0.68

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `e259a6951388e8a542eb4f29166a9d28c0bdc8bd`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- jakarta.servlet:jakarta.servlet-api:5.0.0: 2/9 covered calls (22.22%)
- jakarta.servlet:jakarta.servlet-api:6.2.0-M1: 8/8 covered calls (100.00%)

**Reflection:**
- jakarta.servlet:jakarta.servlet-api:5.0.0: 0/1 covered calls (0.00%)
- jakarta.servlet:jakarta.servlet-api:6.2.0-M1: 1/1 covered calls (100.00%)

**Resources:**
- jakarta.servlet:jakarta.servlet-api:5.0.0: 2/8 covered calls (25.00%)
- jakarta.servlet:jakarta.servlet-api:6.2.0-M1: 7/7 covered calls (100.00%)

#### Library coverage

**Instruction:**
- jakarta.servlet:jakarta.servlet-api:5.0.0: 14/3199 (0.44%)
- jakarta.servlet:jakarta.servlet-api:6.2.0-M1: 658/3240 (20.31%)

**Line:**
- jakarta.servlet:jakarta.servlet-api:5.0.0: 6/878 (0.68%)
- jakarta.servlet:jakarta.servlet-api:6.2.0-M1: 189/916 (20.63%)

**Method:**
- jakarta.servlet:jakarta.servlet-api:5.0.0: 4/332 (1.20%)
- jakarta.servlet:jakarta.servlet-api:6.2.0-M1: 56/357 (15.69%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/jakarta.servlet/jakarta.servlet-api/5.0.0/build.gradle 2/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/build.gradle
index b3a9beb77a..5484aac989 100644
--- 1/tests/src/jakarta.servlet/jakarta.servlet-api/5.0.0/build.gradle
+++ 2/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/build.gradle
@@ -10,7 +10,22 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 
+repositories {
+    exclusiveContent {
+        forRepository {
+            mavenCentral {
+                metadataSources {
+                    artifact()
+                }
+            }
+        }
+        filter {
+            includeGroup "jakarta.servlet"
+        }
+    }
+}
+
 dependencies {
-    testImplementation "jakarta.servlet:jakarta.servlet-api:$libraryVersion"
+    testImplementation "jakarta.servlet:jakarta.servlet-api:$libraryVersion@jar"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
diff --git 1/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/CookieTest.java 2/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/CookieTest.java
new file mode 100644
index 0000000000..fad1befc14
--- /dev/null
+++ 2/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/CookieTest.java
@@ -0,0 +1,68 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_servlet.jakarta_servlet_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import jakarta.servlet.http.Cookie;
+
+import org.junit.jupiter.api.Test;
+
+public class CookieTest {
+    @Test
+    void constructorInitializesCookieAndLoadsLocalizedMessages() {
+        Cookie cookie = new Cookie("sessionId", "initial");
+
+        assertThat(cookie.getName()).isEqualTo("sessionId");
+        assertThat(cookie.getValue()).isEqualTo("initial");
+        assertThat(cookie.getAttributes()).isEmpty();
+    }
+
+    @Test
+    void constructorRejectsInvalidNameWithBundleBackedMessage() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new Cookie("bad name", "value"))
+                .withMessageContaining("Cookie name \"bad name\"")
+                .withMessageContaining("invalid character");
+    }
+
+    @Test
+    void configuredAttributesAreCaseInsensitiveAndCopiedByClone() {
+        Cookie cookie = new Cookie("preferences", "compact");
+        cookie.setDomain("Example.COM");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(60);
+        cookie.setPath("/catalog");
+        cookie.setSecure(true);
+        cookie.setAttribute("SameSite", "Strict");
+        cookie.setAttribute("Partitioned", "");
+        cookie.setValue("expanded");
+
+        Cookie clonedCookie = (Cookie) cookie.clone();
+
+        assertThat(clonedCookie).isNotSameAs(cookie);
+        assertThat(clonedCookie).isEqualTo(cookie);
+        assertThat(clonedCookie.getName()).isEqualTo("preferences");
+        assertThat(clonedCookie.getValue()).isEqualTo("expanded");
+        assertThat(clonedCookie.getDomain()).isEqualTo("example.com");
+        assertThat(clonedCookie.isHttpOnly()).isTrue();
+        assertThat(clonedCookie.getMaxAge()).isEqualTo(60);
+        assertThat(clonedCookie.getPath()).isEqualTo("/catalog");
+        assertThat(clonedCookie.getSecure()).isTrue();
+        assertThat(clonedCookie.getAttribute("samesite")).isEqualTo("Strict");
+        assertThat(clonedCookie.getAttribute("partitioned")).isEmpty();
+        assertThat(clonedCookie.getAttributes())
+                .containsEntry("Domain", "example.com")
+                .containsEntry("HttpOnly", "")
+                .containsEntry("Max-Age", "60")
+                .containsEntry("Path", "/catalog")
+                .containsEntry("Secure", "")
+                .containsEntry("SameSite", "Strict")
+                .containsEntry("Partitioned", "");
+    }
+}
diff --git 1/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/GenericFilterTests.java 2/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/GenericFilterTests.java
new file mode 100644
index 0000000000..53b4ccd332
--- /dev/null
+++ 2/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/GenericFilterTests.java
@@ -0,0 +1,38 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_servlet.jakarta_servlet_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.GenericFilter;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+
+import org.junit.jupiter.api.Test;
+
+public class GenericFilterTests {
+    @Test
+    void getFilterNameBeforeInitializationUsesBundleBackedMessage() {
+        TestGenericFilter filter = new TestGenericFilter();
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, filter::getFilterName);
+
+        assertThat(exception).hasMessage("ServletConfig has not been initialized");
+    }
+
+    private static final class TestGenericFilter extends GenericFilter {
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+                throws IOException, ServletException {
+        }
+    }
+}
diff --git 1/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/HttpServletTests.java 2/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/HttpServletTests.java
new file mode 100644
index 0000000000..764cc84f65
--- /dev/null
+++ 2/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/HttpServletTests.java
@@ -0,0 +1,116 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_servlet.jakarta_servlet_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.Test;
+
+public class HttpServletTests {
+    @Test
+    void doOptionsIncludesSubclassHttpMethodsInAllowHeader() throws ServletException, IOException {
+        ExposedHttpServlet servlet = new ExposedHttpServlet();
+        RecordedResponse response = new RecordedResponse();
+
+        servlet.invokeDoOptions(requestWithProtocol("HTTP/1.1"), response.asHttpServletResponse());
+
+        assertThat(response.headerName()).isEqualTo("Allow");
+        assertThat(response.headerValue()).isEqualTo("POST, TRACE, OPTIONS");
+    }
+
+    private static HttpServletRequest requestWithProtocol(String protocol) {
+        return (HttpServletRequest) Proxy.newProxyInstance(
+                HttpServletTests.class.getClassLoader(),
+                new Class<?>[]{HttpServletRequest.class},
+                new RequestInvocationHandler(protocol));
+    }
+
+    private static final class ExposedHttpServlet extends HttpServlet {
+        void invokeDoOptions(HttpServletRequest request, HttpServletResponse response)
+                throws ServletException, IOException {
+            super.doOptions(request, response);
+        }
+
+        @Override
+        protected void doPost(HttpServletRequest request, HttpServletResponse response) {
+        }
+    }
+
+    private static final class RecordedResponse {
+        private String headerName;
+        private String headerValue;
+
+        HttpServletResponse asHttpServletResponse() {
+            return (HttpServletResponse) Proxy.newProxyInstance(
+                    HttpServletTests.class.getClassLoader(),
+                    new Class<?>[]{HttpServletResponse.class},
+                    this::handleInvocation);
+        }
+
+        String headerName() {
+            return headerName;
+        }
+
+        String headerValue() {
+            return headerValue;
+        }
+
+        private Object handleInvocation(Object proxy, Method method, Object[] arguments) {
+            if (isObjectMethod(method)) {
+                return handleObjectMethod(proxy, method, arguments);
+            }
+            if (method.getName().equals("setHeader") && arguments.length == 2) {
+                headerName = (String) arguments[0];
+                headerValue = (String) arguments[1];
+                return null;
+            }
+            throw new UnsupportedOperationException(method.toGenericString());
+        }
+    }
+
+    private static final class RequestInvocationHandler implements InvocationHandler {
+        private final String protocol;
+
+        private RequestInvocationHandler(String protocol) {
+            this.protocol = protocol;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] arguments) {
+            if (isObjectMethod(method)) {
+                return handleObjectMethod(proxy, method, arguments);
+            }
+            if (method.getName().equals("getProtocol")) {
+                return protocol;
+            }
+            throw new UnsupportedOperationException(method.toGenericString());
+        }
+    }
+
+    private static boolean isObjectMethod(Method method) {
+        return method.getDeclaringClass().equals(Object.class);
+    }
+
+    private static Object handleObjectMethod(Object proxy, Method method, Object[] arguments) {
+        return switch (method.getName()) {
+            case "equals" -> proxy == arguments[0];
+            case "hashCode" -> System.identityHashCode(proxy);
+            case "toString" -> proxy.getClass().getName();
+            default -> throw new UnsupportedOperationException(method.toGenericString());
+        };
+    }
+}
diff --git 1/tests/src/jakarta.servlet/jakarta.servlet-api/5.0.0/src/test/java/jakarta_servlet/jakarta_servlet_api/JakartaServletTests.java 2/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/JakartaServletTests.java
index 46b06a0e47..99c2da1eee 100644
--- 1/tests/src/jakarta.servlet/jakarta.servlet-api/5.0.0/src/test/java/jakarta_servlet/jakarta_servlet_api/JakartaServletTests.java
+++ 2/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/JakartaServletTests.java
@@ -12,29 +12,20 @@ import jakarta.servlet.GenericServlet;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
-import jakarta.servlet.http.HttpServlet;
+
 import org.junit.jupiter.api.Test;
 
 
-class JakartaServletTests {
+public class JakartaServletTests {
     @Test
     void instantiateServlet() {
         new CustomServlet();
     }
 
-  @Test
-  void instantiateHttpServlet() {
-    new CustomHttpServlet();
-  }
-
-  static class CustomServlet extends GenericServlet {
-    @Override
-    public void service(ServletRequest req, ServletResponse res) throws ServletException, IOException {
+    static class CustomServlet extends GenericServlet {
+        @Override
+        public void service(ServletRequest req, ServletResponse res) throws ServletException, IOException {
 
+        }
     }
-  }
-
-  static class CustomHttpServlet extends HttpServlet {
-
-  }
 }
diff --git 1/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/NoBodyOutputStreamTest.java 2/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/NoBodyOutputStreamTest.java
new file mode 100644
index 0000000000..615ab8947a
--- /dev/null
+++ 2/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/NoBodyOutputStreamTest.java
@@ -0,0 +1,127 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_servlet.jakarta_servlet_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.nio.charset.StandardCharsets;
+
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.Test;
+
+public class NoBodyOutputStreamTest {
+    @Test
+    void legacyHeadHandlingCountsWrittenBodyWithoutSendingIt() throws ServletException, IOException {
+        BodyWritingServlet servlet = new BodyWritingServlet("hello");
+        RecordedContentLengthResponse response = new RecordedContentLengthResponse();
+
+        servlet.init(configWithLegacyHeadHandlingEnabled());
+        servlet.invokeDoHead(request(), response.asHttpServletResponse());
+
+        assertThat(response.contentLength()).isEqualTo(5);
+    }
+
+    private static ServletConfig configWithLegacyHeadHandlingEnabled() {
+        return (ServletConfig) Proxy.newProxyInstance(
+                NoBodyOutputStreamTest.class.getClassLoader(),
+                new Class<?>[]{ServletConfig.class},
+                new ServletConfigInvocationHandler());
+    }
+
+    private static HttpServletRequest request() {
+        return (HttpServletRequest) Proxy.newProxyInstance(
+                NoBodyOutputStreamTest.class.getClassLoader(),
+                new Class<?>[]{HttpServletRequest.class},
+                NoBodyOutputStreamTest::handleUnsupportedInvocation);
+    }
+
+    private static final class BodyWritingServlet extends HttpServlet {
+        private final byte[] body;
+
+        private BodyWritingServlet(String body) {
+            this.body = body.getBytes(StandardCharsets.UTF_8);
+        }
+
+        private void invokeDoHead(HttpServletRequest request, HttpServletResponse response)
+                throws ServletException, IOException {
+            super.doHead(request, response);
+        }
+
+        @Override
+        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+            response.getOutputStream().write(body);
+        }
+    }
+
+    private static final class ServletConfigInvocationHandler implements InvocationHandler {
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] arguments) {
+            if (isObjectMethod(method)) {
+                return handleObjectMethod(proxy, method, arguments);
+            }
+            if (method.getName().equals("getInitParameter")) {
+                return HttpServlet.LEGACY_DO_HEAD.equals(arguments[0]) ? "true" : null;
+            }
+            throw new UnsupportedOperationException(method.toGenericString());
+        }
+    }
+
+    private static final class RecordedContentLengthResponse {
+        private int contentLength = -1;
+
+        private HttpServletResponse asHttpServletResponse() {
+            return (HttpServletResponse) Proxy.newProxyInstance(
+                    NoBodyOutputStreamTest.class.getClassLoader(),
+                    new Class<?>[]{HttpServletResponse.class},
+                    this::handleInvocation);
+        }
+
+        private int contentLength() {
+            return contentLength;
+        }
+
+        private Object handleInvocation(Object proxy, Method method, Object[] arguments) {
+            if (isObjectMethod(method)) {
+                return handleObjectMethod(proxy, method, arguments);
+            }
+            if (method.getName().equals("setContentLength") && arguments.length == 1) {
+                contentLength = (Integer) arguments[0];
+                return null;
+            }
+            throw new UnsupportedOperationException(method.toGenericString());
+        }
+    }
+
+    private static Object handleUnsupportedInvocation(Object proxy, Method method, Object[] arguments) {
+        if (isObjectMethod(method)) {
+            return handleObjectMethod(proxy, method, arguments);
+        }
+        throw new UnsupportedOperationException(method.toGenericString());
+    }
+
+    private static boolean isObjectMethod(Method method) {
+        return method.getDeclaringClass().equals(Object.class);
+    }
+
+    private static Object handleObjectMethod(Object proxy, Method method, Object[] arguments) {
+        return switch (method.getName()) {
+            case "equals" -> proxy == arguments[0];
+            case "hashCode" -> System.identityHashCode(proxy);
+            case "toString" -> proxy.getClass().getName();
+            default -> throw new UnsupportedOperationException(method.toGenericString());
+        };
+    }
+}
diff --git 1/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/ServletOutputStreamTest.java 2/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/ServletOutputStreamTest.java
new file mode 100644
index 0000000000..529f191a74
--- /dev/null
+++ 2/tests/src/jakarta.servlet/jakarta.servlet-api/6.2.0-M1/src/test/java/jakarta_servlet/jakarta_servlet_api/ServletOutputStreamTest.java
@@ -0,0 +1,53 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_servlet.jakarta_servlet_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
+
+import org.junit.jupiter.api.Test;
+
+public class ServletOutputStreamTest {
+    @Test
+    void printBooleanUsesServletResourceBundleDuringOutputStreamInitialization() throws IOException {
+        RecordingServletOutputStream outputStream = new RecordingServletOutputStream();
+
+        outputStream.print(true);
+        outputStream.println(false);
+
+        assertThat(outputStream.toIso88591String()).isEqualTo("truefalse\r\n");
+    }
+
+    private static final class RecordingServletOutputStream extends ServletOutputStream {
+        private final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+
+        @Override
+        public void write(int b) {
+            bytes.write(b);
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setWriteListener(WriteListener writeListener) {
+            throw new UnsupportedOperationException("Non-blocking writes are not used by this test");
+        }
+
+        private String toIso88591String() {
+            return bytes.toString(StandardCharsets.ISO_8859_1);
+        }
+    }
+}

```

### Local CI Verification

- Status: `success`
- Commands run: 14
- Fixup attempts: 0
