### PR TITLE
Remove maintainer team from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,1 @@
-metadata/*       @oracle/graalvm-reachability-maintainer
-tests/src/*      @oracle/graalvm-reachability-maintainer
-tests/tck-build-logic/* @oracle/graalvm-reachability-maintainer
 metadata/library-and-framework-list.json @fniephaus
-.github/* @oracle/graalvm-reachability-maintainer
-docs/*    @oracle/graalvm-reachability-maintainer
-README.md @oracle/graalvm-reachability-maintainer
-gradle/*  @oracle/graalvm-reachability-maintainer
-/*        @oracle/graalvm-reachability-maintainer
-COVERAGE.md @oracle/graalvm-reachability-maintainer


### PR DESCRIPTION
## Summary

Remove the broad CODEOWNERS entries that assign ownership to `@oracle/graalvm-reachability-maintainer`.

The only remaining CODEOWNERS entry is the targeted `metadata/library-and-framework-list.json` ownership for `@fniephaus`.

## Rationale

We do not need maintainer-team CODEOWNERS auto-assignment because pull requests already need a maintainer approval before they can be merged. Keeping broad maintainer-team ownership mostly adds review-request noise without strengthening the merge gate.

This was probably set up so external contributions would automatically get maintainer reviewers assigned. Now that metadata is generated internally, that routing is no longer needed.

Fixes #7622