### PR TITLE
[GenAI] Mark org.eclipse.platform:org.eclipse.swt as not for Native Image

### DIFF
--- a/metadata/org.eclipse.platform/org.eclipse.swt/index.json
+++ b/metadata/org.eclipse.platform/org.eclipse.swt/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published org.eclipse.swt 3.133.0 JAR contains only bundle metadata, p2.inf, legal resources, and no JVM .class files; runtime SWT classes are provided by platform-specific dependencies selected by the POM.",
+    "replacement": "Use the platform-specific SWT artifact selected by the POM, such as org.eclipse.platform:org.eclipse.swt.gtk.linux.x86_64:3.133.0, org.eclipse.platform:org.eclipse.swt.cocoa.macosx.aarch64:3.133.0, or org.eclipse.platform:org.eclipse.swt.win32.win32.x86_64:3.133.0."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #7708

This PR records `org.eclipse.platform:org.eclipse.swt` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published org.eclipse.swt 3.133.0 JAR contains only bundle metadata, p2.inf, legal resources, and no JVM .class files; runtime SWT classes are provided by platform-specific dependencies selected by the POM.

Replacement guidance:
- Use the platform-specific SWT artifact selected by the POM, such as org.eclipse.platform:org.eclipse.swt.gtk.linux.x86_64:3.133.0, org.eclipse.platform:org.eclipse.swt.cocoa.macosx.aarch64:3.133.0, or org.eclipse.platform:org.eclipse.swt.win32.win32.x86_64:3.133.0.

### Forge

- Forge monitored branch: `rhei/fixture-backed-e2e-7627`
- Forge branch: `rhei/fixture-backed-e2e-7627`
- Forge commit hash: `6fcd31ad32981ff29ad11f31ebf3c90964994b4c`

### Local CI Verification

- Status: `success`
- Commands run: 6
- Fixup attempts: 0
