### PR TITLE
Split Forge local verification into generation and pre-publication tiers

### DIFF
--- a/forge/ai_workflows/core/workflow_strategy.py
+++ b/forge/ai_workflows/core/workflow_strategy.py
@@ -19,7 +19,7 @@ from ai_workflows.core.fix_post_generation_pi import (
     run_pi_post_generation_fix,
 )
 from utility_scripts.library_finalization import run_library_finalization
-from utility_scripts.workflow_setup import build_graalvm_environment
+from utility_scripts.workflow_setup import build_graalvm_environment, require_graalvm_home_env
 from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.gradle_test_runner import run_gradle_test_command
 from utility_scripts.library_stats import stats_artifact_dir
@@ -282,9 +282,8 @@ class WorkflowStrategy(ABC):
         # generation lanes with the same metadata/Pi fixers, because the
         # pre-publication gate (§FS-local-ci-equivalent-verification.2) no longer
         # reproduces the native test matrix.
-        # GRAALVM_HOME_25_0 presence is already preflighted at startup
-        # (forge_metadata POST_GENERATION_GRAALVM_ENV_VAR), so read it directly.
-        current_defaults_25_env = build_graalvm_environment(os.environ["GRAALVM_HOME_25_0"])
+        graalvm_home_25 = require_graalvm_home_env("GRAALVM_HOME_25_0")
+        current_defaults_25_env = build_graalvm_environment(graalvm_home_25)
         current_defaults_25_env.pop("GVM_TCK_NATIVE_IMAGE_MODE", None)
         current_defaults_25_status = run_lane(
             "current-defaults GraalVM 25 test",

--- a/forge/ai_workflows/core/workflow_strategy.py
+++ b/forge/ai_workflows/core/workflow_strategy.py
@@ -19,6 +19,7 @@ from ai_workflows.core.fix_post_generation_pi import (
     run_pi_post_generation_fix,
 )
 from utility_scripts.library_finalization import run_library_finalization
+from utility_scripts.workflow_setup import build_graalvm_environment
 from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.gradle_test_runner import run_gradle_test_command
 from utility_scripts.library_stats import stats_artifact_dir
@@ -276,8 +277,29 @@ class WorkflowStrategy(ABC):
         if future_defaults_status == SUCCESS_WITH_INTERVENTION_STATUS:
             final_status = SUCCESS_WITH_INTERVENTION_STATUS
 
-        # Full CI-matrix GraalVM coverage, including GRAALVM_HOME_25_0, runs in
-        # local CI verification after generation.
+        # Generation/finalization tier (§FS-local-ci-equivalent-verification.1):
+        # current-defaults coverage on the GraalVM 25 toolchain runs here, in the
+        # generation lanes with the same metadata/Pi fixers, because the
+        # pre-publication gate (§FS-local-ci-equivalent-verification.2) no longer
+        # reproduces the native test matrix.
+        graalvm_25_home = os.environ.get("GRAALVM_HOME_25_0")
+        if not graalvm_25_home:
+            raise RuntimeError(
+                "Missing required environment variable GRAALVM_HOME_25_0 for the GraalVM 25 current-defaults test lane."
+            )
+        current_defaults_25_env = build_graalvm_environment(graalvm_25_home)
+        current_defaults_25_env.pop("GVM_TCK_NATIVE_IMAGE_MODE", None)
+        current_defaults_25_status = run_lane(
+            "current-defaults GraalVM 25 test",
+            lambda: self._run_command_with_env(test_cmd, current_defaults_25_env),
+            f'GRAALVM_HOME="$GRAALVM_HOME_25_0" JAVA_HOME="$GRAALVM_HOME_25_0" {test_cmd}',
+            current_defaults_25_env,
+        )
+        if current_defaults_25_status == RUN_STATUS_FAILURE:
+            return RUN_STATUS_FAILURE
+        if current_defaults_25_status == SUCCESS_WITH_INTERVENTION_STATUS:
+            final_status = SUCCESS_WITH_INTERVENTION_STATUS
+
         return final_status
 
     def _finalization_libraries(self) -> list[str]:

--- a/forge/ai_workflows/core/workflow_strategy.py
+++ b/forge/ai_workflows/core/workflow_strategy.py
@@ -19,7 +19,7 @@ from ai_workflows.core.fix_post_generation_pi import (
     run_pi_post_generation_fix,
 )
 from utility_scripts.library_finalization import run_library_finalization
-from utility_scripts.workflow_setup import build_graalvm_environment, require_graalvm_home_env
+from utility_scripts.workflow_setup import build_graalvm_environment
 from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.gradle_test_runner import run_gradle_test_command
 from utility_scripts.library_stats import stats_artifact_dir
@@ -282,8 +282,8 @@ class WorkflowStrategy(ABC):
         # generation lanes with the same metadata/Pi fixers, because the
         # pre-publication gate (§FS-local-ci-equivalent-verification.2) no longer
         # reproduces the native test matrix.
-        graalvm_home_25 = require_graalvm_home_env("GRAALVM_HOME_25_0")
-        current_defaults_25_env = build_graalvm_environment(graalvm_home_25)
+        # GRAALVM_HOME_25_0 is preflighted by workflow_setup.resolve_graalvm_java_home().
+        current_defaults_25_env = build_graalvm_environment(os.environ["GRAALVM_HOME_25_0"])
         current_defaults_25_env.pop("GVM_TCK_NATIVE_IMAGE_MODE", None)
         current_defaults_25_status = run_lane(
             "current-defaults GraalVM 25 test",

--- a/forge/ai_workflows/core/workflow_strategy.py
+++ b/forge/ai_workflows/core/workflow_strategy.py
@@ -282,12 +282,9 @@ class WorkflowStrategy(ABC):
         # generation lanes with the same metadata/Pi fixers, because the
         # pre-publication gate (§FS-local-ci-equivalent-verification.2) no longer
         # reproduces the native test matrix.
-        graalvm_25_home = os.environ.get("GRAALVM_HOME_25_0")
-        if not graalvm_25_home:
-            raise RuntimeError(
-                "Missing required environment variable GRAALVM_HOME_25_0 for the GraalVM 25 current-defaults test lane."
-            )
-        current_defaults_25_env = build_graalvm_environment(graalvm_25_home)
+        # GRAALVM_HOME_25_0 presence is already preflighted at startup
+        # (forge_metadata POST_GENERATION_GRAALVM_ENV_VAR), so read it directly.
+        current_defaults_25_env = build_graalvm_environment(os.environ["GRAALVM_HOME_25_0"])
         current_defaults_25_env.pop("GVM_TCK_NATIVE_IMAGE_MODE", None)
         current_defaults_25_status = run_lane(
             "current-defaults GraalVM 25 test",

--- a/forge/docs/functional-spec.md
+++ b/forge/docs/functional-spec.md
@@ -240,22 +240,25 @@ keeping the loop short as called for by §GOAL-shorten-issue-to-shipped-metadata
 
 ### FS-local-ci-equivalent-verification: Local CI-equivalent verification
 
-Every Forge task must be fully tested locally in the same way it will be
-tested by CI before it is allowed to produce a PR-eligible result. This is a
-hard requirement, not an optimization or best-effort check.
+Every Forge task must pass local verification before it is allowed to produce a
+PR-eligible result. The default local verification mode is a smoke gate for fast
+publication: it validates the generated coordinate's metadata with
+`checkMetadataFiles`, rejects legacy test-only Native Image configuration, and
+runs the cheap repository gates that apply to the PR diff, including
+infrastructure validation, index validation, style checks, stats validation,
+documentation links, and Docker-image vulnerability scanning when allowed-image
+files change.
 
-For the task's affected coordinate set, Forge must run the same validation
-surface that the corresponding CI workflow will run, including metadata
-validation, style checks, compilation, JVM tests, native-image build/run
-tests, Docker image pre-pull requirements, vulnerability checks when Docker
-images change, stats validation, and any workflow-specific gates. The local
-commands, coordinates filter, native-image mode, JDK/GraalVM selection, and
-Docker/image setup must be derived from the same repo configuration that CI
-uses, including `ci.json` and the Gradle task contracts. Where CI exercises more
-than one native-image mode, local verification must too: Forge runs the
-generated tests under both the current GraalVM defaults and the
-`future-defaults-all` native-image mode (selected by `GVM_TCK_NATIVE_IMAGE_MODE`),
-so a regression that only appears under future defaults is caught before a PR.
+Forge must also expose a full local verification mode for operators and
+programmatic callers that need local reproduction of the expensive per-PR CI
+surface. Full mode derives its commands, coordinates filter, native-image mode,
+JDK/GraalVM selection, and Docker/image setup from the same repo configuration
+that CI uses, including `ci.json` and the Gradle task contracts. In full mode
+Forge expands the changed-metadata test matrix, pre-pulls Docker images for
+coordinates that declare them, runs the generated tests under the CI native-image
+mode matrix, and runs Spring AOT smoke verification when metadata changes affect
+Spring AOT projects. The default smoke mode intentionally leaves those expensive
+native and Spring AOT checks to repository CI.
 
 Local verification runs must be non-privileged. Forge must not invoke `sudo`,
 must not run scripts that invoke `sudo`, and must not prompt for an
@@ -275,16 +278,16 @@ configuration files appear under the generated test sources, the run fails
 rather than publishing them, because that config form is no longer accepted and
 the reachability metadata belongs in the coordinate's `metadata/` directory.
 
-Forge must record the exact local verification commands and their outcomes in
-the run metrics and PR description. A task must not open a PR, mark a project
-item `Done`, return `RUN_STATUS_SUCCESS`, return
-`SUCCESS_WITH_INTERVENTION_STATUS`, or return `RUN_STATUS_CHUNK_READY` until
-that local CI-equivalent verification has passed. If Forge cannot reproduce
-the CI-equivalent validation locally, the workflow must return
+Forge must record the selected local verification mode, exact local verification
+commands, and command outcomes in the run metrics and PR description. A task
+must not open a PR, mark a project item `Done`, return `RUN_STATUS_SUCCESS`,
+return `SUCCESS_WITH_INTERVENTION_STATUS`, or return `RUN_STATUS_CHUNK_READY`
+until the selected local verification mode has passed. If Forge cannot complete
+the selected local verification mode, the workflow must return
 `RUN_STATUS_FAILURE` and preserve enough diagnostics for human follow-up.
 
-If local CI-equivalent verification fails, Forge may run a bounded fixup step
-before retrying the full verification. The fixup may repair generated
+If local verification fails, Forge may run a bounded fixup step
+before retrying the selected verification mode. The fixup may repair generated
 library-scoped files or shared repository files when the failure is caused by
 the repository itself. After verification passes, Forge must algorithmically
 compare the final PR diff with the expected library-scoped paths. If any

--- a/forge/docs/functional-spec.md
+++ b/forge/docs/functional-spec.md
@@ -283,15 +283,29 @@ no longer accepted and the reachability metadata belongs in the coordinate's
 #### 2. Pre-publication gate
 
 Before a task may produce a PR-eligible result, Forge must also pass a
-pre-publication gate that runs only the cross-cutting checks a single-library
-generation cannot settle: index-file validation (an aggregate that depends on
-the rebased `master` state), Docker-image vulnerability scanning when
-allowed-image files change, and the human-intervention classification that
-detects changes outside the coordinate's library scope. The gate intentionally
-does not re-run the library-scoped checks that finalization
-(§FS-local-ci-equivalent-verification.1) already established, does not re-run the
-native test matrix owned by the generation lanes, and leaves the expensive
-Spring AOT smoke verification to repository CI.
+pre-publication gate. This tier exists because the generated branch is rebased
+onto the current `master` before publication, and some checks can then fail for
+reasons no single-library generation could have settled: they depend on
+repository state that only exists once the branch sits on top of the latest
+`master`. An index-file bucket that another merged PR has since changed, a newly
+flagged Docker image, or a stray edit outside the coordinate's library scope can
+break the whole PR even though the generated metadata and tests are themselves
+valid. The gate therefore runs exactly the post-rebase, cross-cutting checks:
+index-file validation (`validateIndexFiles`, an aggregate over the rebased
+`master` state), Docker-image vulnerability scanning when allowed-image files
+change, and the human-intervention classification that detects changes outside
+the coordinate's library scope.
+
+The gate intentionally does not re-run the library-scoped checks that
+finalization (§FS-local-ci-equivalent-verification.1) already established, and by
+default it does not re-run the native test matrix or the Spring AOT smoke tests,
+which the generation lanes and repository CI cover. Forge must, however, expose
+an opt-in full-reproduction option (`reproduce_full_ci`) for operators and
+programmatic callers that need to reproduce the expensive per-PR CI surface
+locally: when enabled, the gate additionally expands the changed-metadata native
+test matrix, pre-pulls Docker images for coordinates that declare them, runs the
+generated tests under the CI native-image mode matrix, and runs Spring AOT smoke
+verification when metadata changes affect Spring AOT projects.
 
 If the gate fails, Forge may run a bounded fixup step before retrying it. The
 fixup may repair generated library-scoped files or shared repository files when

--- a/forge/docs/functional-spec.md
+++ b/forge/docs/functional-spec.md
@@ -103,7 +103,7 @@ metadata-relevant coverage from broader behavior coverage.
 | **Workflow driver** | Deterministic script in the `drivers/` subdirectory of [ai_workflows/](../ai_workflows/) that prepares the working environment, directories, branch/context, strategy bundle, workflow engine, agent, and metrics for one claimed unit of work. The driver runs Forge plumbing; Codex or another LLM agent should not decide that setup during a generated run. Specified by §WF-forge-workflow-drivers. |
 | **Workflow engine** | A registered state-machine-like workflow implementation among the core workflow objects in [ai_workflows/core/](../ai_workflows/core/), such as `basic_iterative` or `dynamic_access_iterative`. The engine owns prompts, command execution, retries, transitions, and terminal status selection for one run. |
 | **Predefined strategy** | Named configuration bundle in [strategies/predefined_strategies.json](../strategies/predefined_strategies.json). It selects the workflow engine, agent backend, model, prompts, workflow parameters, optional MCPs, and optional persistent instructions. Selected via `--strategy-name`. |
-| **Post-generation intervention** | The built-in recovery sequence the workflow base class runs when the post-iteration `./gradlew test` still fails during finalization. It is a fixed Codex-then-Pi lane, not a pluggable registry and not selected per strategy: a Codex metadata fix runs first (using the `fix-missing-reachability-metadata` skill, pinned to the run's GraalVM); only if that does not recover does Pi remove the offending failing tests as a last resort. When recovery makes the post-generation test pass, the run reports `SUCCESS_WITH_INTERVENTION_STATUS` and the intervention record (stage, intervention file, analysis) is saved for the run metrics and PR body. The base class runs this lane once per GraalVM test mode (current defaults and `future-defaults-all`). |
+| **Post-generation intervention** | The built-in recovery sequence the workflow base class runs when the post-iteration `./gradlew test` still fails during finalization. It is a fixed Codex-then-Pi lane, not a pluggable registry and not selected per strategy: a Codex metadata fix runs first (using the `fix-missing-reachability-metadata` skill, pinned to the run's GraalVM); only if that does not recover does Pi remove the offending failing tests as a last resort. When recovery makes the post-generation test pass, the run reports `SUCCESS_WITH_INTERVENTION_STATUS` and the intervention record (stage, intervention file, analysis) is saved for the run metrics and PR body. The base class runs this lane once per GraalVM test lane (current defaults and `future-defaults-all` on the latest GraalVM, plus current defaults on the GraalVM 25 toolchain). |
 | **Human intervention** | A maintainer follow-up signal applied through the `human-intervention` issue or PR label when Forge has evidence that generated work, repository automation, or library execution semantics require human judgment. It is distinct from post-generation intervention, which is an automated recovery step. The policy is defined in §FS-human-intervention-policy. |
 | **Dynamic access** | Reflection, JNI, resource access, serialization, or proxy use that GraalVM `native-image` cannot determine statically. |
 | **Dynamic-access report** | JSON written by Gradle task `generateDynamicAccessCoverageReport` to `tests/src/<group>/<artifact>/<version>/build/reports/dynamic-access/dynamic-access-coverage.json`, listing classes and per-class call sites that require dynamic-access metadata, marked covered/uncovered. |
@@ -236,64 +236,71 @@ If a run fails or times out, the saved logs are part of the diagnostic artifact
 set that allows maintainers or a later Forge run to continue from evidence,
 keeping the loop short as called for by §GOAL-shorten-issue-to-shipped-metadata.
 
-## 6. Local CI-Equivalent Verification
+## 6. Local Pre-Publication Verification
 
-### FS-local-ci-equivalent-verification: Local CI-equivalent verification
+### FS-local-ci-equivalent-verification: Local pre-publication verification
 
 Every Forge task must pass local verification before it is allowed to produce a
-PR-eligible result. The default local verification mode is a smoke gate for fast
-publication: it validates the generated coordinate's metadata with
-`checkMetadataFiles`, rejects legacy test-only Native Image configuration, and
-runs the cheap repository gates that apply to the PR diff, including
-infrastructure validation, index validation, style checks, stats validation,
-documentation links, and Docker-image vulnerability scanning when allowed-image
-files change.
+PR-eligible result. Verification is split into two tiers along the boundary
+between what a single-library generation can settle on its own and what it
+cannot: a library-scoped tier that runs during generation and finalization
+(§FS-local-ci-equivalent-verification.1), and a cross-cutting gate that runs
+before publication (§FS-local-ci-equivalent-verification.2).
 
-Forge must also expose a full local verification mode for operators and
-programmatic callers that need local reproduction of the expensive per-PR CI
-surface. Full mode derives its commands, coordinates filter, native-image mode,
-JDK/GraalVM selection, and Docker/image setup from the same repo configuration
-that CI uses, including `ci.json` and the Gradle task contracts. In full mode
-Forge expands the changed-metadata test matrix, pre-pulls Docker images for
-coordinates that declare them, runs the generated tests under the CI native-image
-mode matrix, and runs Spring AOT smoke verification when metadata changes affect
-Spring AOT projects. The default smoke mode intentionally leaves those expensive
-native and Spring AOT checks to repository CI.
-
-Local verification runs must be non-privileged. Forge must not invoke `sudo`,
-must not run scripts that invoke `sudo`, and must not prompt for an
-administrator password during local automation. CI-only host mutation steps
+Local verification runs must be non-privileged in both tiers. Forge must not
+invoke `sudo`, must not run scripts that invoke `sudo`, and must not prompt for
+an administrator password during local automation. CI-only host mutation steps
 that require elevated privileges, such as changing system Docker networking,
-must be replaced by no-sudo local gates or omitted from local execution while
-preserving the rest of the CI-equivalent validation surface. A command that
-would require `sudo` is a local verification failure, not an interactive
-prompt. For Docker-backed tests, local verification must fail if tests create
-Docker images after the `pullAllowedDockerImages` gate, because that indicates
-the local run may have passed by pulling images that CI's disabled-network
-phase would reject.
+must be replaced by no-sudo local gates or omitted from local execution. A
+command that would require `sudo` is a local verification failure, not an
+interactive prompt.
 
-Local verification must also reject legacy test-only Native Image configuration
-for the coordinate: if uncommitted or changed `META-INF/native-image` test
-configuration files appear under the generated test sources, the run fails
-rather than publishing them, because that config form is no longer accepted and
-the reachability metadata belongs in the coordinate's `metadata/` directory.
+Forge must record the local verification commands and their outcomes in the run
+metrics and PR description. A task must not open a PR, mark a project item
+`Done`, return `RUN_STATUS_SUCCESS`, return `SUCCESS_WITH_INTERVENTION_STATUS`,
+or return `RUN_STATUS_CHUNK_READY` until both tiers have passed. If Forge cannot
+complete either tier, the workflow must return `RUN_STATUS_FAILURE` and preserve
+enough diagnostics for human follow-up.
 
-Forge must record the selected local verification mode, exact local verification
-commands, and command outcomes in the run metrics and PR description. A task
-must not open a PR, mark a project item `Done`, return `RUN_STATUS_SUCCESS`,
-return `SUCCESS_WITH_INTERVENTION_STATUS`, or return `RUN_STATUS_CHUNK_READY`
-until the selected local verification mode has passed. If Forge cannot complete
-the selected local verification mode, the workflow must return
-`RUN_STATUS_FAILURE` and preserve enough diagnostics for human follow-up.
+#### 1. Generation and finalization
 
-If local verification fails, Forge may run a bounded fixup step
-before retrying the selected verification mode. The fixup may repair generated
-library-scoped files or shared repository files when the failure is caused by
-the repository itself. After verification passes, Forge must algorithmically
-compare the final PR diff with the expected library-scoped paths. If any
-shared repository file changed, the PR must be labeled `human-intervention`
-and the verification metrics and PR description must list the repository-level
-paths that require maintainer review, following §FS-human-intervention-policy.
+Library-scoped correctness is established during generation and finalization,
+because a single-library generation owns and can fully settle these checks.
+Forge runs the generated tests for the coordinate under the CI native-image
+surface: current GraalVM defaults and the `future-defaults-all` mode on the
+latest GraalVM, plus current defaults on the GraalVM 25 toolchain (selected by
+`GRAALVM_HOME_25_0`). Each native lane may run a bounded metadata/intervention
+fixup and retry, so a regression that only appears under future defaults or on
+GraalVM 25 is caught before publication. Finalization then validates the
+coordinate's metadata with `checkMetadataFiles`, derives missing
+`allowed-packages`, applies and checks style, regenerates library stats, and
+rejects legacy test-only Native Image configuration: if uncommitted or changed
+`META-INF/native-image` test configuration files appear under the generated test
+sources, the run fails rather than publishing them, because that config form is
+no longer accepted and the reachability metadata belongs in the coordinate's
+`metadata/` directory.
+
+#### 2. Pre-publication gate
+
+Before a task may produce a PR-eligible result, Forge must also pass a
+pre-publication gate that runs only the cross-cutting checks a single-library
+generation cannot settle: index-file validation (an aggregate that depends on
+the rebased `master` state), Docker-image vulnerability scanning when
+allowed-image files change, and the human-intervention classification that
+detects changes outside the coordinate's library scope. The gate intentionally
+does not re-run the library-scoped checks that finalization
+(§FS-local-ci-equivalent-verification.1) already established, does not re-run the
+native test matrix owned by the generation lanes, and leaves the expensive
+Spring AOT smoke verification to repository CI.
+
+If the gate fails, Forge may run a bounded fixup step before retrying it. The
+fixup may repair generated library-scoped files or shared repository files when
+the failure is caused by the repository itself. After the gate passes, Forge
+must algorithmically compare the final PR diff with the expected library-scoped
+paths. If any shared repository file changed, the PR must be labeled
+`human-intervention` and the verification metrics and PR description must list
+the repository-level paths that require maintainer review, following
+§FS-human-intervention-policy.
 
 ### FS-human-intervention-policy: Human intervention policy
 

--- a/forge/tests/test_local_ci_verification.py
+++ b/forge/tests/test_local_ci_verification.py
@@ -207,6 +207,40 @@ class LocalCIVerificationTests(unittest.TestCase):
         # are owned by generation/finalization, so only the shared Docker scan runs here.
         self.assertEqual(recorded_gates, ["docker-image-scan"])
 
+    def test_reproduce_full_ci_runs_native_matrix_and_spring_aot(self) -> None:
+        result = LocalCIVerificationResult(status="running", base_commit="base")
+        gradle_tasks: list[str] = []
+
+        def fake_gradle_json_output(repo_path, task_name, base_commit, result_arg, gate, extra_args=None):
+            del repo_path, base_commit, result_arg, gate, extra_args
+            gradle_tasks.append(task_name)
+            return {"include": []}
+
+        changed_files = ["metadata/org.example/demo/1.0.0/reachability-metadata.json"]
+        with patch("utility_scripts.local_ci_verification.changed_files_for_ci", return_value=changed_files), \
+                patch("utility_scripts.local_ci_verification._run_index_validation", return_value=None), \
+                patch("utility_scripts.local_ci_verification._gradle_json_output", side_effect=fake_gradle_json_output), \
+                patch("utility_scripts.local_ci_verification._run_test_matrix_entries", return_value=None) as matrix, \
+                patch("utility_scripts.local_ci_verification._run_spring_aot_verification", return_value=None) as spring:
+            failed = _run_verification_once("/repo", "base", result, reproduce_full_ci=True)
+
+        self.assertIsNone(failed)
+        self.assertIn("generateChangedMetadataTestMatrix", gradle_tasks)
+        matrix.assert_called_once()
+        spring.assert_called_once()
+
+    def test_default_gate_does_not_run_native_matrix(self) -> None:
+        result = LocalCIVerificationResult(status="running", base_commit="base")
+        with patch(
+                "utility_scripts.local_ci_verification.changed_files_for_ci",
+                return_value=["metadata/org.example/demo/1.0.0/reachability-metadata.json"],
+        ), patch("utility_scripts.local_ci_verification._run_index_validation", return_value=None), \
+                patch("utility_scripts.local_ci_verification._run_test_matrix_entries", return_value=None) as matrix:
+            failed = _run_verification_once("/repo", "base", result)
+
+        self.assertIsNone(failed)
+        matrix.assert_not_called()
+
     def test_verification_once_skips_docker_scan_without_allowed_image_changes(self) -> None:
         result = LocalCIVerificationResult(status="running", base_commit="base")
         with patch(

--- a/forge/tests/test_local_ci_verification.py
+++ b/forge/tests/test_local_ci_verification.py
@@ -20,15 +20,8 @@ from utility_scripts.local_ci_verification import (
     local_ci_requires_human_intervention,
     run_local_ci_verification,
     _github_repo_slug_from_url,
-    _graalvm_home_for_java_version,
-    _run_legacy_test_native_image_config_validation,
-    _run_infrastructure_matrix_entries,
     _run_recorded_command,
-    _run_recorded_command_without_new_docker_images,
-    _run_spring_aot_matrix_entries,
-    _run_test_matrix_entries,
     _run_verification_once,
-    _should_run_spring_aot_tests,
 )
 from utility_scripts.metrics_writer import PENDING_METRICS_FILENAME
 
@@ -189,6 +182,43 @@ class LocalCIVerificationTests(unittest.TestCase):
         self.assertIn("Local CI Verification", section)
         self.assertIn("build.gradle", section)
 
+    def test_verification_once_runs_only_index_and_docker_gates(self) -> None:
+        result = LocalCIVerificationResult(status="running", base_commit="base")
+        recorded_gates: list[str] = []
+
+        def fake_recorded(repo_path, gate, command, result_arg, env=None, failure_output_pattern=None):
+            del repo_path, command, result_arg, env, failure_output_pattern
+            recorded_gates.append(gate)
+            return None
+
+        changed_files = [
+            "metadata/org.example/demo/1.0.0/reachability-metadata.json",
+            "metadata/org.example/demo/index.json",
+            "tests/tck-build-logic/src/main/resources/allowed-docker-images/demo.json",
+        ]
+        with patch("utility_scripts.local_ci_verification.changed_files_for_ci", return_value=changed_files), \
+                patch("utility_scripts.local_ci_verification._run_index_validation", return_value=None) as index_gate, \
+                patch("utility_scripts.local_ci_verification._run_recorded_command", side_effect=fake_recorded):
+            failed = _run_verification_once("/repo", "base", result)
+
+        self.assertIsNone(failed)
+        index_gate.assert_called_once()
+        # The library-scoped gates (checkMetadataFiles, spotless, stats, doc-links)
+        # are owned by generation/finalization, so only the shared Docker scan runs here.
+        self.assertEqual(recorded_gates, ["docker-image-scan"])
+
+    def test_verification_once_skips_docker_scan_without_allowed_image_changes(self) -> None:
+        result = LocalCIVerificationResult(status="running", base_commit="base")
+        with patch(
+                "utility_scripts.local_ci_verification.changed_files_for_ci",
+                return_value=["metadata/org.example/demo/1.0.0/reachability-metadata.json"],
+        ), patch("utility_scripts.local_ci_verification._run_index_validation", return_value=None), \
+                patch("utility_scripts.local_ci_verification._run_recorded_command") as recorded:
+            failed = _run_verification_once("/repo", "base", result)
+
+        self.assertIsNone(failed)
+        recorded.assert_not_called()
+
     def test_run_recorded_command_fails_on_ci_failure_output_pattern(self) -> None:
         with tempfile.TemporaryDirectory() as repo_path, tempfile.TemporaryDirectory() as log_path:
             result = LocalCIVerificationResult(status="running", base_commit="base")
@@ -252,190 +282,6 @@ class LocalCIVerificationTests(unittest.TestCase):
         self.assertEqual(captured_env["GRADLE_OPTS"], "-Xmx2g -Dfile.encoding=UTF-8")
         self.assertNotIn("JAVA_OPTS", captured_env)
 
-    def test_test_matrix_skips_docker_networking_for_non_docker_coordinate(self) -> None:
-        result = LocalCIVerificationResult(status="running", base_commit="base")
-        failed_record = CommandRecord(gate="run-consecutive-tests", command=["bash"], returncode=1)
-        gates: list[str] = []
-
-        def fake_run_recorded_command(
-                repo_path: str,
-                gate: str,
-                command: list[str],
-                local_result: LocalCIVerificationResult,
-                env: dict[str, str] | None = None,
-                failure_output_pattern: str | None = None,
-        ) -> CommandRecord | None:
-            gates.append(gate)
-            if gate == "run-consecutive-tests":
-                self.assertEqual(failure_output_pattern, r"^FAILED")
-                return failed_record
-            return None
-
-        with patch("utility_scripts.local_ci_verification._run_recorded_command", side_effect=fake_run_recorded_command), \
-                patch(
-                    "utility_scripts.local_ci_verification._run_recorded_command_without_new_docker_images",
-                    side_effect=fake_run_recorded_command,
-                ):
-            failed = _run_test_matrix_entries(
-                "/repo",
-                [{"coordinates": "org.example:demo:1.0.0", "versions": ["1.0.0"]}],
-                result,
-            )
-
-        self.assertIs(failed, failed_record)
-        self.assertEqual(gates, ["check-metadata-files", "run-consecutive-tests"])
-        self.assertNotIn("disable-docker-networking", gates)
-        self.assertNotIn("restore-docker-networking", gates)
-
-    def test_legacy_test_native_image_config_validation_fails_changed_legacy_file(self) -> None:
-        with tempfile.TemporaryDirectory() as repo_path, tempfile.TemporaryDirectory() as log_path:
-            _git(repo_path, "init")
-            with open(os.path.join(repo_path, "README.md"), "w", encoding="utf-8") as file:
-                file.write("base\n")
-            base = _commit_all(repo_path, "base")
-            legacy_dir = os.path.join(
-                repo_path,
-                "tests",
-                "src",
-                "org.example",
-                "demo",
-                "1.0.0",
-                "src",
-                "test",
-                "resources",
-                "META-INF",
-                "native-image",
-            )
-            os.makedirs(legacy_dir)
-            with open(os.path.join(legacy_dir, "reflect-config.json"), "w", encoding="utf-8") as file:
-                file.write("[]\n")
-
-            result = LocalCIVerificationResult(status="running", base_commit=base)
-            with patch(
-                    "utility_scripts.local_ci_verification.build_timestamped_task_log_path",
-                    return_value=os.path.join(log_path, "policy.log"),
-            ):
-                failed = _run_legacy_test_native_image_config_validation(
-                    repo_path,
-                    base,
-                    result,
-                    [
-                        "tests/src/org.example/demo/1.0.0/src/test/resources/"
-                        "META-INF/native-image/reflect-config.json",
-                    ],
-                )
-
-        self.assertIsNotNone(failed)
-        self.assertEqual(failed.gate, "legacy-test-native-image-config")
-        self.assertIn("reflect-config.json", result.commands[0].output_excerpt)
-        self.assertIn("reachability-metadata.json", result.commands[0].output_excerpt)
-
-    def test_test_matrix_prepulls_docker_images_without_privileged_network_scripts(self) -> None:
-        with tempfile.TemporaryDirectory() as repo_path:
-            docker_test_dir = os.path.join(repo_path, "tests", "src", "org.example", "docker-demo", "1.0.0")
-            os.makedirs(docker_test_dir)
-            with open(os.path.join(docker_test_dir, "required-docker-images.txt"), "w", encoding="utf-8") as file:
-                file.write("nginx:1-alpine-slim\n")
-
-            result = LocalCIVerificationResult(status="running", base_commit="base")
-            calls: list[tuple[str, list[str]]] = []
-
-            def fake_run_recorded_command(
-                    repo_path_arg: str,
-                    gate: str,
-                    command: list[str],
-                    local_result: LocalCIVerificationResult,
-                    env: dict[str, str] | None = None,
-                    failure_output_pattern: str | None = None,
-            ) -> CommandRecord | None:
-                del repo_path_arg, local_result, env, failure_output_pattern
-                calls.append((gate, command))
-                return None
-
-            with patch("utility_scripts.local_ci_verification._run_recorded_command", side_effect=fake_run_recorded_command), \
-                    patch(
-                        "utility_scripts.local_ci_verification._run_recorded_command_without_new_docker_images",
-                        side_effect=fake_run_recorded_command,
-                    ):
-                failed = _run_test_matrix_entries(
-                    repo_path,
-                    [
-                        {"coordinates": "org.example:plain-demo:1.0.0", "versions": ["1.0.0"]},
-                        {"coordinates": "org.example:docker-demo:1.0.0", "versions": ["1.0.0"]},
-                    ],
-                    result,
-                )
-
-            self.assertIsNone(failed)
-            self.assertEqual(
-                [call for call in calls if call[0] == "pull-allowed-docker-images"],
-                [
-                    (
-                        "pull-allowed-docker-images",
-                        ["./gradlew", "pullAllowedDockerImages", "-Pcoordinates=org.example:docker-demo:1.0.0"],
-                    ),
-                ],
-            )
-            self.assertNotIn("disable-docker-networking", [call[0] for call in calls])
-            self.assertNotIn("restore-docker-networking", [call[0] for call in calls])
-            self.assertEqual([call[0] for call in calls].count("run-consecutive-tests"), 2)
-
-    def test_test_matrix_resolves_docker_declaration_from_index_test_version(self) -> None:
-        with tempfile.TemporaryDirectory() as repo_path:
-            metadata_dir = os.path.join(repo_path, "metadata", "org.example", "demo")
-            docker_test_dir = os.path.join(repo_path, "tests", "src", "org.example", "demo", "1.0.0")
-            os.makedirs(metadata_dir)
-            os.makedirs(docker_test_dir)
-            with open(os.path.join(metadata_dir, "index.json"), "w", encoding="utf-8") as file:
-                json.dump([
-                    {
-                        "metadata-version": "2.0.0",
-                        "test-version": "1.0.0",
-                        "tested-versions": ["2.0.1"],
-                    },
-                ], file)
-            with open(os.path.join(docker_test_dir, "required-docker-images.txt"), "w", encoding="utf-8") as file:
-                file.write("# comment\n\nnginx:1-alpine-slim\n")
-
-            result = LocalCIVerificationResult(status="running", base_commit="base")
-            calls: list[tuple[str, list[str]]] = []
-
-            def fake_run_recorded_command(
-                    repo_path_arg: str,
-                    gate: str,
-                    command: list[str],
-                    local_result: LocalCIVerificationResult,
-                    env: dict[str, str] | None = None,
-                    failure_output_pattern: str | None = None,
-            ) -> CommandRecord | None:
-                del repo_path_arg, local_result, env, failure_output_pattern
-                calls.append((gate, command))
-                return None
-
-            with patch("utility_scripts.local_ci_verification._run_recorded_command", side_effect=fake_run_recorded_command), \
-                    patch(
-                        "utility_scripts.local_ci_verification._run_recorded_command_without_new_docker_images",
-                        side_effect=fake_run_recorded_command,
-                    ):
-                failed = _run_test_matrix_entries(
-                    repo_path,
-                    [{"coordinates": "org.example:demo:2.0.1", "versions": ["2.0.1"]}],
-                    result,
-                )
-
-            self.assertIsNone(failed)
-            self.assertEqual(
-                [call for call in calls if call[0] == "pull-allowed-docker-images"],
-                [
-                    (
-                        "pull-allowed-docker-images",
-                        ["./gradlew", "pullAllowedDockerImages", "-Pcoordinates=org.example:demo:2.0.1"],
-                    ),
-                ],
-            )
-            self.assertNotIn("disable-docker-networking", [call[0] for call in calls])
-            self.assertNotIn("restore-docker-networking", [call[0] for call in calls])
-
     def test_run_recorded_command_rejects_sudo_command_without_running_it(self) -> None:
         with tempfile.TemporaryDirectory() as repo_path, tempfile.TemporaryDirectory() as log_path:
             result = LocalCIVerificationResult(status="running", base_commit="base")
@@ -498,220 +344,6 @@ class LocalCIVerificationTests(unittest.TestCase):
             run.assert_not_called()
             self.assertEqual(result.commands[0].returncode, 1)
             self.assertIn("gradlew", result.commands[0].output_excerpt)
-
-    def test_run_recorded_command_without_new_docker_images_fails_when_test_pulls_image(self) -> None:
-        with tempfile.TemporaryDirectory() as repo_path, tempfile.TemporaryDirectory() as log_path:
-            result = LocalCIVerificationResult(status="running", base_commit="base")
-            docker_outputs = [
-                "postgres:16 image-a\n",
-                "postgres:16 image-a\nredis:7 image-b\n",
-            ]
-
-            def fake_run(
-                    command: list[str],
-                    cwd: str | None = None,
-                    env: dict[str, str] | None = None,
-                    stdin=None,
-                    stdout=None,
-                    stderr=None,
-                    text: bool | None = None,
-                    check: bool | None = None,
-            ) -> subprocess.CompletedProcess[str]:
-                del cwd, env, stdin, stderr, text, check
-                if command[:3] == ["docker", "image", "ls"]:
-                    return subprocess.CompletedProcess(command, 0, stdout=docker_outputs.pop(0))
-                if command == ["bash", "run-tests"]:
-                    stdout.write("tests passed\n")
-                    return subprocess.CompletedProcess(command, 0, stdout="tests passed\n")
-                raise AssertionError(f"unexpected command: {command}")
-
-            log_paths = [
-                os.path.join(log_path, "run.log"),
-                os.path.join(log_path, "docker.log"),
-            ]
-            with patch(
-                    "utility_scripts.local_ci_verification.build_timestamped_task_log_path",
-                    side_effect=log_paths,
-            ), patch("utility_scripts.local_ci_verification.subprocess.run", side_effect=fake_run):
-                failed = _run_recorded_command_without_new_docker_images(
-                    repo_path,
-                    "run-consecutive-tests",
-                    ["bash", "run-tests"],
-                    result,
-                )
-
-            self.assertIsNotNone(failed)
-            self.assertEqual(failed.gate, "unexpected-docker-image-pull")
-            self.assertEqual(result.commands[-1].returncode, 1)
-            self.assertIn("redis:7 image-b", result.commands[-1].output_excerpt)
-
-    def test_infrastructure_matrix_runs_test_infra_for_each_entry(self) -> None:
-        result = LocalCIVerificationResult(status="running", base_commit="base")
-        calls: list[tuple[str, list[str], dict[str, str] | None]] = []
-
-        def fake_run_recorded_command(
-                repo_path: str,
-                gate: str,
-                command: list[str],
-                local_result: LocalCIVerificationResult,
-                env: dict[str, str] | None = None,
-                failure_output_pattern: str | None = None,
-        ) -> CommandRecord | None:
-            del repo_path, local_result, failure_output_pattern
-            calls.append((gate, command, env))
-            return None
-
-        with patch.dict(os.environ, {"GRAALVM_HOME_25_0": "/graalvm25"}, clear=True), \
-                patch("utility_scripts.local_ci_verification._run_recorded_command", side_effect=fake_run_recorded_command):
-            failed = _run_infrastructure_matrix_entries(
-                "/repo",
-                [{"coordinates": "org.example:demo:1.0.0", "version": "25", "nativeImageMode": "future-defaults-all"}],
-                result,
-            )
-
-        self.assertIsNone(failed)
-        self.assertEqual(
-            [call[0] for call in calls],
-            [
-                "infrastructure-check-metadata-files",
-                "test-infra",
-            ],
-        )
-        self.assertEqual(
-            calls[-1][1],
-            ["./gradlew", "testInfra", "-Pcoordinates=org.example:demo:1.0.0", "-Pparallelism=1", "--stacktrace"],
-        )
-        self.assertEqual(calls[-1][2]["GRAALVM_HOME"], "/graalvm25")
-        self.assertEqual(calls[-1][2]["GVM_TCK_NATIVE_IMAGE_MODE"], "future-defaults-all")
-
-    def test_infrastructure_matrix_pulls_docker_images_when_coordinate_declares_them(self) -> None:
-        with tempfile.TemporaryDirectory() as repo_path:
-            docker_test_dir = os.path.join(repo_path, "tests", "src", "org.example", "demo", "1.0.0")
-            os.makedirs(docker_test_dir)
-            with open(os.path.join(docker_test_dir, "required-docker-images.txt"), "w", encoding="utf-8") as file:
-                file.write("nginx:1-alpine-slim\n")
-
-            result = LocalCIVerificationResult(status="running", base_commit="base")
-            gates: list[str] = []
-
-            def fake_run_recorded_command(
-                    repo_path_arg: str,
-                    gate: str,
-                    command: list[str],
-                    local_result: LocalCIVerificationResult,
-                    env: dict[str, str] | None = None,
-                    failure_output_pattern: str | None = None,
-            ) -> CommandRecord | None:
-                del repo_path_arg, command, local_result, env, failure_output_pattern
-                gates.append(gate)
-                return None
-
-            with patch("utility_scripts.local_ci_verification._run_recorded_command", side_effect=fake_run_recorded_command):
-                failed = _run_infrastructure_matrix_entries(
-                    repo_path,
-                    [{"coordinates": "org.example:demo:1.0.0"}],
-                    result,
-                )
-
-            self.assertIsNone(failed)
-            self.assertEqual(
-                gates,
-                [
-                    "infrastructure-pull-allowed-docker-images",
-                    "infrastructure-check-metadata-files",
-                    "test-infra",
-                ],
-            )
-
-    def test_spring_aot_matrix_runs_triaged_smoke_test(self) -> None:
-        result = LocalCIVerificationResult(status="running", base_commit="base")
-        calls: list[tuple[str, list[str], dict[str, str] | None]] = []
-
-        def fake_run_recorded_command(
-                repo_path: str,
-                gate: str,
-                command: list[str],
-                local_result: LocalCIVerificationResult,
-                env: dict[str, str] | None = None,
-                failure_output_pattern: str | None = None,
-        ) -> CommandRecord | None:
-            del repo_path, local_result, failure_output_pattern
-            calls.append((gate, command, env))
-            return None
-
-        with patch.dict(os.environ, {"GRAALVM_HOME_25_0": "/graalvm25"}, clear=True), \
-                patch("utility_scripts.local_ci_verification._run_recorded_command", side_effect=fake_run_recorded_command):
-            failed = _run_spring_aot_matrix_entries(
-                "/repo",
-                "/tmp/spring-aot-smoke-tests",
-                [{"project": ":data:data-mongodb", "java": "25"}],
-                result,
-            )
-
-        self.assertIsNone(failed)
-        self.assertEqual(calls[0][0], "spring-aot-smoke-test")
-        self.assertEqual(
-            calls[0][1],
-            [
-                "bash",
-                ".github/workflows/scripts/run-spring-aot-triaged-test.sh",
-                "/tmp/spring-aot-smoke-tests",
-                ":data:data-mongodb",
-                "4.1.x",
-            ],
-        )
-        self.assertEqual(calls[0][2]["JAVA_HOME"], "/graalvm25")
-
-    def test_verification_once_runs_infrastructure_but_skips_spring_lane(self) -> None:
-        result = LocalCIVerificationResult(status="running", base_commit="base")
-        gradle_tasks: list[str] = []
-
-        def fake_gradle_json_output(
-                repo_path: str,
-                task_name: str,
-                base_commit: str,
-                local_result: LocalCIVerificationResult,
-                gate: str,
-                extra_args: list[str] | None = None,
-        ) -> dict:
-            del repo_path, base_commit, local_result, gate, extra_args
-            gradle_tasks.append(task_name)
-            if task_name == "generateInfrastructureChangedCoordinatesMatrix":
-                return {"include": [{"coordinates": "org.example:demo:1.0.0"}]}
-            return {"include": []}
-
-        changed_files = [
-            "build.gradle",
-            "metadata/org.springframework/spring-jcl/6.0.0/reachability-metadata.json",
-        ]
-        with patch("utility_scripts.local_ci_verification.changed_files_for_ci", return_value=changed_files), \
-                patch("utility_scripts.local_ci_verification._gradle_json_output", side_effect=fake_gradle_json_output), \
-                patch("utility_scripts.local_ci_verification._run_test_matrix_entries", return_value=None), \
-                patch("utility_scripts.local_ci_verification._run_infrastructure_matrix_entries", return_value=None) as infra, \
-                patch("utility_scripts.local_ci_verification._run_spring_aot_verification", return_value=None) as spring, \
-                patch("utility_scripts.local_ci_verification._run_index_validation", return_value=None), \
-                patch("utility_scripts.local_ci_verification._run_style_validation", return_value=None), \
-                patch("utility_scripts.local_ci_verification._run_recorded_command", return_value=None):
-            failed = _run_verification_once("/repo", "base", result)
-
-        self.assertIsNone(failed)
-        self.assertIn("generateInfrastructureChangedCoordinatesMatrix", gradle_tasks)
-        infra.assert_called_once()
-        spring.assert_not_called()
-
-    def test_spring_aot_tests_are_left_to_ci(self) -> None:
-        self.assertFalse(_should_run_spring_aot_tests([
-            "metadata/org.springframework/spring-jcl/6.0.0/reachability-metadata.json",
-            ".github/workflows/scripts/run-spring-aot-triaged-test.sh",
-        ]))
-
-    def test_latest_ea_requires_latest_ea_graalvm_home(self) -> None:
-        with patch.dict(os.environ, {"GRAALVM_HOME": "/stable"}, clear=True):
-            with self.assertRaisesRegex(RuntimeError, "GRAALVM_HOME_LATEST_EA"):
-                _graalvm_home_for_java_version("latest-ea")
-
-        with patch.dict(os.environ, {"GRAALVM_HOME_LATEST_EA": "/ea"}, clear=True):
-            self.assertEqual(_graalvm_home_for_java_version("latest-ea"), "/ea")
 
     def test_github_repo_slug_from_url_accepts_https_and_ssh_forms(self) -> None:
         expected = "oracle/graalvm-reachability-metadata"

--- a/forge/tests/test_workflow_strategy.py
+++ b/forge/tests/test_workflow_strategy.py
@@ -19,7 +19,7 @@ class _TestWorkflowStrategy(WorkflowStrategy):
 
 
 class WorkflowStrategyTests(unittest.TestCase):
-    def test_post_generation_tests_defer_ci_matrix_graalvm_versions_to_final_verification(self) -> None:
+    def test_post_generation_tests_run_latest_and_graalvm_25_current_defaults_lanes(self) -> None:
         strategy = _TestWorkflowStrategy(
             {"model": "test-model"},
             reachability_repo_path="/tmp/reachability",
@@ -32,15 +32,29 @@ class WorkflowStrategyTests(unittest.TestCase):
             return "BUILD SUCCESSFUL"
 
         with patch.object(strategy, "_run_command_with_env", side_effect=run_command), \
-                patch.dict(os.environ, {"GRAALVM_HOME": "/dev/graalvm", "JAVA_HOME": "/dev/graalvm"}, clear=True):
+                patch.dict(
+                    os.environ,
+                    {
+                        "GRAALVM_HOME": "/dev/graalvm",
+                        "JAVA_HOME": "/dev/graalvm",
+                        "GRAALVM_HOME_25_0": "/dev/graalvm-25",
+                    },
+                    clear=True,
+                ):
             status = strategy._run_test_with_retry("org.example:demo:1.0.0")
 
         self.assertEqual(status, RUN_STATUS_SUCCESS)
-        self.assertEqual(len(commands), 2)
+        self.assertEqual(len(commands), 3)
+        # Lane 1: current defaults on the latest GraalVM (ambient environment).
         self.assertIsNone(commands[0][1])
+        # Lane 2: future-defaults on the latest GraalVM.
         self.assertEqual(commands[1][1]["GRAALVM_HOME"], "/dev/graalvm")
         self.assertEqual(commands[1][1]["JAVA_HOME"], "/dev/graalvm")
         self.assertEqual(commands[1][1]["GVM_TCK_NATIVE_IMAGE_MODE"], "future-defaults-all")
+        # Lane 3: current defaults on the GraalVM 25 toolchain.
+        self.assertEqual(commands[2][1]["GRAALVM_HOME"], "/dev/graalvm-25")
+        self.assertEqual(commands[2][1]["JAVA_HOME"], "/dev/graalvm-25")
+        self.assertNotIn("GVM_TCK_NATIVE_IMAGE_MODE", commands[2][1])
 
     def test_commit_library_iteration_stages_resolved_test_version(self) -> None:
         with tempfile.TemporaryDirectory() as repo:

--- a/forge/utility_scripts/local_ci_verification.py
+++ b/forge/utility_scripts/local_ci_verification.py
@@ -3,7 +3,7 @@
 # You should have received a copy of the CC0 legalcode along with this
 # work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
-"""Local reproduction of the CI gates that run on generated Forge PRs."""
+"""Local verification gates that run before generated Forge PRs are published."""
 
 from __future__ import annotations
 
@@ -15,6 +15,7 @@ import subprocess
 import tempfile
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
+from typing import Literal
 
 from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.metadata_index import resolve_test_version
@@ -24,10 +25,13 @@ from utility_scripts.native_image_config_policy import (
     format_legacy_test_native_image_config_error,
     is_legacy_test_native_image_config_path,
 )
+from utility_scripts.stage_logger import log_stage
 from utility_scripts.task_logs import build_timestamped_task_log_path, display_log_path
 
 LOCAL_CI_VERIFICATION_KEY = "local_ci_verification"
 HUMAN_INTERVENTION_LABEL = "human-intervention"
+LocalCIVerificationMode = Literal["smoke", "full"]
+DEFAULT_LOCAL_CI_VERIFICATION_MODE: LocalCIVerificationMode = "smoke"
 MAX_OUTPUT_CHARS = 12000
 MAX_FIXUP_ATTEMPTS = 2
 CODEX_MODEL_NAME = "oca/gpt-5.4"
@@ -71,6 +75,7 @@ class LocalCIVerificationResult:
 
     status: str
     base_commit: str
+    verification_mode: str = DEFAULT_LOCAL_CI_VERIFICATION_MODE
     final_commit: str | None = None
     commands: list[CommandRecord] = field(default_factory=list)
     fixups: list[FixupRecord] = field(default_factory=list)
@@ -85,7 +90,7 @@ class LocalCIVerificationResult:
 
 
 class LocalCIVerificationError(RuntimeError):
-    """Raised when local CI-equivalent verification cannot be satisfied."""
+    """Raised when local CI verification cannot be satisfied."""
 
     def __init__(self, result: LocalCIVerificationResult):
         self.result = result
@@ -109,6 +114,15 @@ def parse_coordinate_parts(coordinates: str) -> tuple[str, str, str]:
     return parts[0], parts[1], parts[2]
 
 
+def _validate_verification_mode(verification_mode: str) -> None:
+    if verification_mode not in ("smoke", "full"):
+        raise ValueError(f"Expected local CI verification mode 'smoke' or 'full', got {verification_mode!r}")
+
+
+def _log_local_ci(message: str, indent_level: int = 0) -> None:
+    log_stage("local-ci", message, indent_level=indent_level)
+
+
 def run_local_ci_verification(
         *,
         repo_path: str,
@@ -116,27 +130,44 @@ def run_local_ci_verification(
         base_commit: str,
         metrics_repo_path: str | None = None,
         max_fixup_attempts: int = MAX_FIXUP_ATTEMPTS,
+        verification_mode: LocalCIVerificationMode = DEFAULT_LOCAL_CI_VERIFICATION_MODE,
 ) -> LocalCIVerificationResult:
-    """Run CI-equivalent local verification, fixing and retrying when possible."""
-    result = LocalCIVerificationResult(status="running", base_commit=base_commit)
+    """Run local verification, fixing and retrying when possible."""
+    _validate_verification_mode(verification_mode)
+    result = LocalCIVerificationResult(
+        status="running",
+        base_commit=base_commit,
+        verification_mode=verification_mode,
+    )
+    _log_local_ci(f"Starting local CI verification for {coordinates} in {verification_mode} mode")
     for attempt in range(max_fixup_attempts + 1):
-        failed_command = _run_verification_once(repo_path, base_commit, result)
+        _log_local_ci(f"Verification attempt {attempt + 1}/{max_fixup_attempts + 1}", indent_level=1)
+        failed_command = _run_verification_once(
+            repo_path,
+            base_commit,
+            result,
+            coordinates=coordinates,
+            verification_mode=verification_mode,
+        )
         if failed_command is None:
             result.status = "success"
             result.final_commit = _git_stdout(repo_path, ["rev-parse", "HEAD"])
             result.repo_fix_paths = classify_repo_fix_paths(repo_path, base_commit, coordinates)
             result.human_intervention_required = bool(result.repo_fix_paths)
+            _log_local_ci(f"Verification passed for {coordinates}", indent_level=1)
             _write_verification_metrics(metrics_repo_path, result)
             return result
 
         result.failure_gate = failed_command.gate
         result.failure_command = failed_command.command
+        _log_local_ci(f"Verification failed at gate {failed_command.gate}", indent_level=1)
         if attempt >= max_fixup_attempts:
             result.status = "failure"
             result.final_commit = _git_stdout(repo_path, ["rev-parse", "HEAD"])
             _write_verification_metrics(metrics_repo_path, result)
             raise LocalCIVerificationError(result)
 
+        _log_local_ci(f"Running fixup after {failed_command.gate}", indent_level=1)
         fixup = _run_fixup(repo_path, coordinates, failed_command)
         result.fixups.append(fixup)
         if fixup.commit is None:
@@ -190,6 +221,7 @@ def format_local_ci_verification_pr_section(local_ci_verification: dict | None) 
     if not isinstance(local_ci_verification, dict):
         return ""
     status = local_ci_verification.get("status", "unknown")
+    verification_mode = local_ci_verification.get("verification_mode", "unknown")
     commands = local_ci_verification.get("commands")
     command_count = len(commands) if isinstance(commands, list) else 0
     fixups = local_ci_verification.get("fixups")
@@ -199,6 +231,7 @@ def format_local_ci_verification_pr_section(local_ci_verification: dict | None) 
     body = (
         "\n### Local CI Verification\n\n"
         f"- Status: `{status}`\n"
+        f"- Mode: `{verification_mode}`\n"
         f"- Commands run: {command_count}\n"
         f"- Fixup attempts: {fixup_count}\n"
     )
@@ -240,20 +273,26 @@ def _run_verification_once(
         repo_path: str,
         base_commit: str,
         result: LocalCIVerificationResult,
+        coordinates: str | None = None,
+        verification_mode: LocalCIVerificationMode = DEFAULT_LOCAL_CI_VERIFICATION_MODE,
 ) -> CommandRecord | None:
+    _validate_verification_mode(verification_mode)
     changed_files = changed_files_for_ci(repo_path, base_commit)
+    _log_local_ci(f"Changed files detected: {len(changed_files)}", indent_level=1)
     failed = _run_legacy_test_native_image_config_validation(repo_path, base_commit, result, changed_files)
     if failed is not None:
         return failed
 
     try:
-        changed_metadata_matrix = _gradle_json_output(
-            repo_path,
-            "generateChangedMetadataTestMatrix",
-            base_commit,
-            result,
-            "changed-metadata-matrix",
-        )
+        changed_metadata_matrix = {}
+        if verification_mode == "full":
+            changed_metadata_matrix = _gradle_json_output(
+                repo_path,
+                "generateChangedMetadataTestMatrix",
+                base_commit,
+                result,
+                "changed-metadata-matrix",
+            )
         changed_infrastructure_matrix = {}
         if _should_run_infrastructure_tests(changed_files):
             changed_infrastructure_matrix = _gradle_json_output(
@@ -266,19 +305,39 @@ def _run_verification_once(
     except _GradleOutputFailure as exc:
         return exc.record
 
-    test_entries = _matrix_entries(changed_metadata_matrix)
-    failed = _run_test_matrix_entries(repo_path, test_entries, result)
-    if failed is not None:
-        return failed
-
-    failed = _run_infrastructure_matrix_entries(repo_path, _matrix_entries(changed_infrastructure_matrix), result)
-    if failed is not None:
-        return failed
-
-    if _should_run_spring_aot_tests(changed_files):
-        failed = _run_spring_aot_verification(repo_path, base_commit, changed_files, result)
+    if verification_mode == "full":
+        test_entries = _matrix_entries(changed_metadata_matrix)
+        _log_local_ci(f"Full metadata test matrix entries: {len(test_entries)}", indent_level=1)
+        failed = _run_test_matrix_entries(repo_path, test_entries, result)
         if failed is not None:
             return failed
+    elif coordinates is not None:
+        _log_local_ci(f"Smoke mode: checking metadata files for {coordinates}", indent_level=1)
+        failed = _run_recorded_command(
+            repo_path,
+            "check-metadata-files",
+            ["./gradlew", "checkMetadataFiles", f"-Pcoordinates={coordinates}"],
+            result,
+        )
+        if failed is not None:
+            return failed
+        _log_local_ci("Smoke mode: skipped changed metadata native test matrix", indent_level=1)
+    else:
+        _log_local_ci("Smoke mode: no coordinate supplied; skipped target checkMetadataFiles", indent_level=1)
+
+    infrastructure_entries = _matrix_entries(changed_infrastructure_matrix)
+    if infrastructure_entries:
+        _log_local_ci(f"Infrastructure matrix entries: {len(infrastructure_entries)}", indent_level=1)
+    failed = _run_infrastructure_matrix_entries(repo_path, infrastructure_entries, result)
+    if failed is not None:
+        return failed
+
+    if _should_run_spring_aot_tests(changed_files, verification_mode):
+        failed = _run_spring_aot_verification(repo_path, base_commit, changed_files, result, verification_mode)
+        if failed is not None:
+            return failed
+    elif verification_mode == "smoke":
+        _log_local_ci("Smoke mode: skipped Spring AOT verification", indent_level=1)
 
     failed = _run_index_validation(repo_path, base_commit, changed_files, result)
     if failed is not None:
@@ -336,6 +395,7 @@ def _run_legacy_test_native_image_config_validation(
         output_excerpt=output[:MAX_OUTPUT_CHARS],
     )
     result.commands.append(record)
+    _log_local_ci(f"Gate legacy-test-native-image-config failed; log: {record.log_path}", indent_level=1)
     return record
 
 
@@ -345,6 +405,7 @@ def _run_test_matrix_entries(
         result: LocalCIVerificationResult,
 ) -> CommandRecord | None:
     if not entries:
+        _log_local_ci("Full metadata test matrix is empty", indent_level=1)
         return None
 
     pulled_coordinates: set[str] = set()
@@ -354,6 +415,7 @@ def _run_test_matrix_entries(
             continue
         if not _coordinate_uses_docker(repo_path, coordinates):
             continue
+        _log_local_ci(f"Pre-pulling Docker images for {coordinates}", indent_level=1)
         failed = _run_recorded_command(
             repo_path,
             "pull-allowed-docker-images",
@@ -369,6 +431,8 @@ def _run_test_matrix_entries(
         versions = entry.get("versions")
         if not coordinates or not isinstance(versions, list):
             continue
+        version_text = ", ".join(str(version) for version in versions)
+        _log_local_ci(f"Running full metadata test matrix entry for {coordinates}: {version_text}", indent_level=1)
         env = _matrix_env(entry)
         failed = _run_recorded_command(
             repo_path,
@@ -402,10 +466,13 @@ def _run_infrastructure_matrix_entries(
         entries: list[dict],
         result: LocalCIVerificationResult,
 ) -> CommandRecord | None:
+    if not entries:
+        return None
     for entry in entries:
         coordinates = str(entry.get("coordinates") or "").strip()
         if not coordinates:
             continue
+        _log_local_ci(f"Running infrastructure matrix entry for {coordinates}", indent_level=1)
         env = _matrix_env(entry)
         if _coordinate_uses_docker(repo_path, coordinates):
             failed = _run_recorded_command(
@@ -443,10 +510,12 @@ def _run_spring_aot_verification(
         base_commit: str,
         changed_files: list[str],
         result: LocalCIVerificationResult,
+        verification_mode: LocalCIVerificationMode = DEFAULT_LOCAL_CI_VERIFICATION_MODE,
 ) -> CommandRecord | None:
-    if not _should_run_spring_aot_tests(changed_files):
+    if not _should_run_spring_aot_tests(changed_files, verification_mode):
         return None
 
+    _log_local_ci("Running full Spring AOT verification", indent_level=1)
     with tempfile.TemporaryDirectory(prefix="forge-spring-aot-") as spring_parent:
         os.symlink(os.path.join(repo_path, "metadata"), os.path.join(spring_parent, "metadata"))
         spring_path = os.path.join(spring_parent, "spring-aot-smoke-tests")
@@ -483,10 +552,12 @@ def _run_spring_aot_matrix_entries(
         entries: list[dict],
         result: LocalCIVerificationResult,
 ) -> CommandRecord | None:
+    _log_local_ci(f"Spring AOT matrix entries: {len(entries)}", indent_level=1)
     for entry in entries:
         project = str(entry.get("project") or "").strip()
         if not project:
             continue
+        _log_local_ci(f"Running Spring AOT smoke test for {project}", indent_level=1)
         env = _spring_aot_env(entry)
         failed = _run_recorded_command(
             repo_path,
@@ -732,6 +803,8 @@ def _run_recorded_command(
     _remove_gradle_java_home_overrides(command_env)
     command_env = gradle_command_environment(repo_path, command_env)
     log_path = build_timestamped_task_log_path("local-ci", gate, Path(command[0]).name)
+    _log_local_ci(f"Running gate {gate}: {shlex.join(command)}", indent_level=1)
+    _log_local_ci(f"Log: {display_log_path(log_path)}", indent_level=2)
     sudo_reason = _sudo_usage_reason(repo_path, command)
     if sudo_reason:
         output = f"{NO_SUDO_FAILURE_MESSAGE} {sudo_reason}\n"
@@ -746,6 +819,7 @@ def _run_recorded_command(
             output_excerpt=output,
         )
         result.commands.append(record)
+        _log_local_ci(f"Gate {gate} failed before execution: sudo is not allowed", indent_level=1)
         return record
 
     with open(log_path, "w+", encoding="utf-8") as log_file:
@@ -778,7 +852,9 @@ def _run_recorded_command(
     )
     result.commands.append(record)
     if returncode != 0:
+        _log_local_ci(f"Gate {gate} failed with exit code {returncode}; log: {record.log_path}", indent_level=1)
         return record
+    _log_local_ci(f"Gate {gate} passed; log: {record.log_path}", indent_level=1)
     return None
 
 
@@ -888,6 +964,7 @@ def _record_synthetic_failure(
         output_excerpt=_tail(output),
     )
     result.commands.append(record)
+    _log_local_ci(f"Gate {gate} failed; log: {record.log_path}", indent_level=1)
     return record
 
 
@@ -1144,9 +1221,11 @@ def _should_run_infrastructure_tests(changed_files: list[str]) -> bool:
     )
 
 
-def _should_run_spring_aot_tests(changed_files: list[str]) -> bool:
-    del changed_files
-    return False
+def _should_run_spring_aot_tests(
+        changed_files: list[str],
+        verification_mode: LocalCIVerificationMode = DEFAULT_LOCAL_CI_VERIFICATION_MODE,
+) -> bool:
+    return verification_mode == "full" and any(path.startswith("metadata/") for path in changed_files)
 
 
 def _should_run_docker_scan(changed_files: list[str]) -> bool:

--- a/forge/utility_scripts/local_ci_verification.py
+++ b/forge/utility_scripts/local_ci_verification.py
@@ -3,11 +3,17 @@
 # You should have received a copy of the CC0 legalcode along with this
 # work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
-"""Local verification gates that run before generated Forge PRs are published."""
+"""Pre-publication verification gate for generated Forge PRs.
+
+Implements the second verification tier of §FS-local-ci-equivalent-verification.2:
+the cross-cutting checks a single-library generation cannot settle on its own.
+Library-scoped verification (metadata, style, stats, and the native test lanes)
+is owned by the generation/finalization tier
+(§FS-local-ci-equivalent-verification.1) and is intentionally not repeated here.
+"""
 
 from __future__ import annotations
 
-import json
 import os
 import re
 import shlex
@@ -15,35 +21,20 @@ import subprocess
 import tempfile
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Literal
 
 from utility_scripts.gradle_environment import gradle_command_environment
-from utility_scripts.metadata_index import resolve_test_version
 from utility_scripts.metrics_writer import PENDING_METRICS_FILENAME, read_pending_metrics, write_pending_metrics
-from utility_scripts.native_image_config_policy import (
-    find_changed_legacy_test_native_image_config_files,
-    format_legacy_test_native_image_config_error,
-    is_legacy_test_native_image_config_path,
-)
 from utility_scripts.stage_logger import log_stage
 from utility_scripts.task_logs import build_timestamped_task_log_path, display_log_path
 
 LOCAL_CI_VERIFICATION_KEY = "local_ci_verification"
 HUMAN_INTERVENTION_LABEL = "human-intervention"
-LocalCIVerificationMode = Literal["smoke", "full"]
-DEFAULT_LOCAL_CI_VERIFICATION_MODE: LocalCIVerificationMode = "smoke"
 MAX_OUTPUT_CHARS = 12000
 MAX_FIXUP_ATTEMPTS = 2
 CODEX_MODEL_NAME = "oca/gpt-5.4"
 CODEX_TIMEOUT_SECONDS = 1800
 DEFAULT_BASE_BRANCH = "master"
-SPRING_AOT_BRANCH = "main"
-SPRING_AOT_REPO_URL = "https://github.com/spring-projects/spring-aot-smoke-tests.git"
 NO_SUDO_FAILURE_MESSAGE = "ERROR: Local CI verification runs must not invoke sudo."
-UNEXPECTED_DOCKER_IMAGE_FAILURE_MESSAGE = (
-    "ERROR: Local CI verification detected Docker images created during the no-network-equivalent test gate."
-)
-DOCKER_IMAGE_LIST_COMMAND = ["docker", "image", "ls", "--format", "{{.Repository}}:{{.Tag}} {{.ID}}"]
 
 
 @dataclass
@@ -75,7 +66,6 @@ class LocalCIVerificationResult:
 
     status: str
     base_commit: str
-    verification_mode: str = DEFAULT_LOCAL_CI_VERIFICATION_MODE
     final_commit: str | None = None
     commands: list[CommandRecord] = field(default_factory=list)
     fixups: list[FixupRecord] = field(default_factory=list)
@@ -114,11 +104,6 @@ def parse_coordinate_parts(coordinates: str) -> tuple[str, str, str]:
     return parts[0], parts[1], parts[2]
 
 
-def _validate_verification_mode(verification_mode: str) -> None:
-    if verification_mode not in ("smoke", "full"):
-        raise ValueError(f"Expected local CI verification mode 'smoke' or 'full', got {verification_mode!r}")
-
-
 def _log_local_ci(message: str, indent_level: int = 0) -> None:
     log_stage("local-ci", message, indent_level=indent_level)
 
@@ -130,25 +115,13 @@ def run_local_ci_verification(
         base_commit: str,
         metrics_repo_path: str | None = None,
         max_fixup_attempts: int = MAX_FIXUP_ATTEMPTS,
-        verification_mode: LocalCIVerificationMode = DEFAULT_LOCAL_CI_VERIFICATION_MODE,
 ) -> LocalCIVerificationResult:
     """Run local verification, fixing and retrying when possible."""
-    _validate_verification_mode(verification_mode)
-    result = LocalCIVerificationResult(
-        status="running",
-        base_commit=base_commit,
-        verification_mode=verification_mode,
-    )
-    _log_local_ci(f"Starting local CI verification for {coordinates} in {verification_mode} mode")
+    result = LocalCIVerificationResult(status="running", base_commit=base_commit)
+    _log_local_ci(f"Starting local CI verification for {coordinates}")
     for attempt in range(max_fixup_attempts + 1):
         _log_local_ci(f"Verification attempt {attempt + 1}/{max_fixup_attempts + 1}", indent_level=1)
-        failed_command = _run_verification_once(
-            repo_path,
-            base_commit,
-            result,
-            coordinates=coordinates,
-            verification_mode=verification_mode,
-        )
+        failed_command = _run_verification_once(repo_path, base_commit, result)
         if failed_command is None:
             result.status = "success"
             result.final_commit = _git_stdout(repo_path, ["rev-parse", "HEAD"])
@@ -221,7 +194,6 @@ def format_local_ci_verification_pr_section(local_ci_verification: dict | None) 
     if not isinstance(local_ci_verification, dict):
         return ""
     status = local_ci_verification.get("status", "unknown")
-    verification_mode = local_ci_verification.get("verification_mode", "unknown")
     commands = local_ci_verification.get("commands")
     command_count = len(commands) if isinstance(commands, list) else 0
     fixups = local_ci_verification.get("fixups")
@@ -231,7 +203,6 @@ def format_local_ci_verification_pr_section(local_ci_verification: dict | None) 
     body = (
         "\n### Local CI Verification\n\n"
         f"- Status: `{status}`\n"
-        f"- Mode: `{verification_mode}`\n"
         f"- Commands run: {command_count}\n"
         f"- Fixup attempts: {fixup_count}\n"
     )
@@ -273,86 +244,18 @@ def _run_verification_once(
         repo_path: str,
         base_commit: str,
         result: LocalCIVerificationResult,
-        coordinates: str | None = None,
-        verification_mode: LocalCIVerificationMode = DEFAULT_LOCAL_CI_VERIFICATION_MODE,
 ) -> CommandRecord | None:
-    _validate_verification_mode(verification_mode)
+    # Pre-publication gate (§FS-local-ci-equivalent-verification.2): run only the
+    # cross-cutting checks a single-library generation cannot settle on its own —
+    # index-file validation (an aggregate that depends on the rebased master
+    # state), the shared Docker-image vulnerability scan, and the
+    # human-intervention classification performed by the caller. Library-scoped
+    # verification (metadata, style, stats, native tests) belongs to the
+    # generation/finalization tier (§FS-local-ci-equivalent-verification.1).
     changed_files = changed_files_for_ci(repo_path, base_commit)
     _log_local_ci(f"Changed files detected: {len(changed_files)}", indent_level=1)
-    failed = _run_legacy_test_native_image_config_validation(repo_path, base_commit, result, changed_files)
-    if failed is not None:
-        return failed
-
-    try:
-        changed_metadata_matrix = {}
-        if verification_mode == "full":
-            changed_metadata_matrix = _gradle_json_output(
-                repo_path,
-                "generateChangedMetadataTestMatrix",
-                base_commit,
-                result,
-                "changed-metadata-matrix",
-            )
-        changed_infrastructure_matrix = {}
-        if _should_run_infrastructure_tests(changed_files):
-            changed_infrastructure_matrix = _gradle_json_output(
-                repo_path,
-                "generateInfrastructureChangedCoordinatesMatrix",
-                base_commit,
-                result,
-                "changed-infrastructure-matrix",
-            )
-    except _GradleOutputFailure as exc:
-        return exc.record
-
-    if verification_mode == "full":
-        test_entries = _matrix_entries(changed_metadata_matrix)
-        _log_local_ci(f"Full metadata test matrix entries: {len(test_entries)}", indent_level=1)
-        failed = _run_test_matrix_entries(repo_path, test_entries, result)
-        if failed is not None:
-            return failed
-    elif coordinates is not None:
-        _log_local_ci(f"Smoke mode: checking metadata files for {coordinates}", indent_level=1)
-        failed = _run_recorded_command(
-            repo_path,
-            "check-metadata-files",
-            ["./gradlew", "checkMetadataFiles", f"-Pcoordinates={coordinates}"],
-            result,
-        )
-        if failed is not None:
-            return failed
-        _log_local_ci("Smoke mode: skipped changed metadata native test matrix", indent_level=1)
-    else:
-        _log_local_ci("Smoke mode: no coordinate supplied; skipped target checkMetadataFiles", indent_level=1)
-
-    infrastructure_entries = _matrix_entries(changed_infrastructure_matrix)
-    if infrastructure_entries:
-        _log_local_ci(f"Infrastructure matrix entries: {len(infrastructure_entries)}", indent_level=1)
-    failed = _run_infrastructure_matrix_entries(repo_path, infrastructure_entries, result)
-    if failed is not None:
-        return failed
-
-    if _should_run_spring_aot_tests(changed_files, verification_mode):
-        failed = _run_spring_aot_verification(repo_path, base_commit, changed_files, result, verification_mode)
-        if failed is not None:
-            return failed
-    elif verification_mode == "smoke":
-        _log_local_ci("Smoke mode: skipped Spring AOT verification", indent_level=1)
 
     failed = _run_index_validation(repo_path, base_commit, changed_files, result)
-    if failed is not None:
-        return failed
-
-    failed = _run_style_validation(repo_path, base_commit, changed_files, result)
-    if failed is not None:
-        return failed
-
-    if _should_run_library_stats_validation(changed_files):
-        failed = _run_recorded_command(repo_path, "library-stats-validation", ["./gradlew", "validateLibraryStats"], result)
-        if failed is not None:
-            return failed
-
-    failed = _run_recorded_command(repo_path, "doc-links", ["./gradlew", "checkDocLinks", "--console=plain"], result)
     if failed is not None:
         return failed
 
@@ -366,214 +269,6 @@ def _run_verification_once(
         if failed is not None:
             return failed
 
-    return None
-
-
-def _run_legacy_test_native_image_config_validation(
-        repo_path: str,
-        base_commit: str,
-        result: LocalCIVerificationResult,
-        changed_files: list[str] | None = None,
-) -> CommandRecord | None:
-    legacy_paths = (
-        sorted(path for path in changed_files if is_legacy_test_native_image_config_path(path))
-        if changed_files is not None
-        else find_changed_legacy_test_native_image_config_files(repo_path, base_commit)
-    )
-    if not legacy_paths:
-        return None
-
-    output = format_legacy_test_native_image_config_error(legacy_paths) + "\n"
-    log_path = build_timestamped_task_log_path("local-ci", "legacy-test-native-image-config", "policy")
-    with open(log_path, "w", encoding="utf-8") as log_file:
-        log_file.write(output)
-    record = CommandRecord(
-        gate="legacy-test-native-image-config",
-        command=["legacy-test-native-image-config-policy"],
-        returncode=1,
-        log_path=display_log_path(log_path),
-        output_excerpt=output[:MAX_OUTPUT_CHARS],
-    )
-    result.commands.append(record)
-    _log_local_ci(f"Gate legacy-test-native-image-config failed; log: {record.log_path}", indent_level=1)
-    return record
-
-
-def _run_test_matrix_entries(
-        repo_path: str,
-        entries: list[dict],
-        result: LocalCIVerificationResult,
-) -> CommandRecord | None:
-    if not entries:
-        _log_local_ci("Full metadata test matrix is empty", indent_level=1)
-        return None
-
-    pulled_coordinates: set[str] = set()
-    for entry in entries:
-        coordinates = str(entry.get("coordinates") or "").strip()
-        if not coordinates or coordinates in pulled_coordinates:
-            continue
-        if not _coordinate_uses_docker(repo_path, coordinates):
-            continue
-        _log_local_ci(f"Pre-pulling Docker images for {coordinates}", indent_level=1)
-        failed = _run_recorded_command(
-            repo_path,
-            "pull-allowed-docker-images",
-            ["./gradlew", "pullAllowedDockerImages", f"-Pcoordinates={coordinates}"],
-            result,
-        )
-        if failed is not None:
-            return failed
-        pulled_coordinates.add(coordinates)
-
-    for entry in entries:
-        coordinates = str(entry.get("coordinates") or "").strip()
-        versions = entry.get("versions")
-        if not coordinates or not isinstance(versions, list):
-            continue
-        version_text = ", ".join(str(version) for version in versions)
-        _log_local_ci(f"Running full metadata test matrix entry for {coordinates}: {version_text}", indent_level=1)
-        env = _matrix_env(entry)
-        failed = _run_recorded_command(
-            repo_path,
-            "check-metadata-files",
-            ["./gradlew", "checkMetadataFiles", f"-Pcoordinates={coordinates}"],
-            result,
-            env=env,
-        )
-        if failed is not None:
-            return failed
-        failed = _run_recorded_command_without_new_docker_images(
-            repo_path,
-            "run-consecutive-tests",
-            [
-                "bash",
-                "./.github/workflows/scripts/run-consecutive-tests.sh",
-                coordinates,
-                json.dumps([str(version) for version in versions]),
-            ],
-            result,
-            env=env,
-            failure_output_pattern=r"^FAILED",
-        )
-        if failed is not None:
-            return failed
-    return None
-
-
-def _run_infrastructure_matrix_entries(
-        repo_path: str,
-        entries: list[dict],
-        result: LocalCIVerificationResult,
-) -> CommandRecord | None:
-    if not entries:
-        return None
-    for entry in entries:
-        coordinates = str(entry.get("coordinates") or "").strip()
-        if not coordinates:
-            continue
-        _log_local_ci(f"Running infrastructure matrix entry for {coordinates}", indent_level=1)
-        env = _matrix_env(entry)
-        if _coordinate_uses_docker(repo_path, coordinates):
-            failed = _run_recorded_command(
-                repo_path,
-                "infrastructure-pull-allowed-docker-images",
-                ["./gradlew", "pullAllowedDockerImages", f"-Pcoordinates={coordinates}"],
-                result,
-                env=env,
-            )
-            if failed is not None:
-                return failed
-        failed = _run_recorded_command(
-            repo_path,
-            "infrastructure-check-metadata-files",
-            ["./gradlew", "checkMetadataFiles", f"-Pcoordinates={coordinates}"],
-            result,
-            env=env,
-        )
-        if failed is not None:
-            return failed
-        failed = _run_recorded_command(
-            repo_path,
-            "test-infra",
-            ["./gradlew", "testInfra", f"-Pcoordinates={coordinates}", "-Pparallelism=1", "--stacktrace"],
-            result,
-            env=env,
-        )
-        if failed is not None:
-            return failed
-    return None
-
-
-def _run_spring_aot_verification(
-        repo_path: str,
-        base_commit: str,
-        changed_files: list[str],
-        result: LocalCIVerificationResult,
-        verification_mode: LocalCIVerificationMode = DEFAULT_LOCAL_CI_VERIFICATION_MODE,
-) -> CommandRecord | None:
-    if not _should_run_spring_aot_tests(changed_files, verification_mode):
-        return None
-
-    _log_local_ci("Running full Spring AOT verification", indent_level=1)
-    with tempfile.TemporaryDirectory(prefix="forge-spring-aot-") as spring_parent:
-        os.symlink(os.path.join(repo_path, "metadata"), os.path.join(spring_parent, "metadata"))
-        spring_path = os.path.join(spring_parent, "spring-aot-smoke-tests")
-        failed = _run_recorded_command(
-            repo_path,
-            "checkout-spring-aot-smoke-tests",
-            ["git", "clone", "--depth", "1", "--branch", SPRING_AOT_BRANCH, SPRING_AOT_REPO_URL, spring_path],
-            result,
-        )
-        if failed is not None:
-            return failed
-
-        try:
-            spring_matrix = _gradle_json_output(
-                repo_path,
-                "generateAffectedSpringTestMatrix",
-                base_commit,
-                result,
-                "affected-spring-aot-matrix",
-                extra_args=[
-                    f"-PspringAotBranch={SPRING_AOT_BRANCH}",
-                    f"-PspringAotPath={spring_path}",
-                ],
-            )
-        except _GradleOutputFailure as exc:
-            return exc.record
-
-        return _run_spring_aot_matrix_entries(repo_path, spring_path, _matrix_entries(spring_matrix), result)
-
-
-def _run_spring_aot_matrix_entries(
-        repo_path: str,
-        spring_path: str,
-        entries: list[dict],
-        result: LocalCIVerificationResult,
-) -> CommandRecord | None:
-    _log_local_ci(f"Spring AOT matrix entries: {len(entries)}", indent_level=1)
-    for entry in entries:
-        project = str(entry.get("project") or "").strip()
-        if not project:
-            continue
-        _log_local_ci(f"Running Spring AOT smoke test for {project}", indent_level=1)
-        env = _spring_aot_env(entry)
-        failed = _run_recorded_command(
-            repo_path,
-            "spring-aot-smoke-test",
-            [
-                "bash",
-                ".github/workflows/scripts/run-spring-aot-triaged-test.sh",
-                spring_path,
-                project,
-                "4.1.x",
-            ],
-            result,
-            env=env,
-        )
-        if failed is not None:
-            return failed
     return None
 
 
@@ -604,61 +299,6 @@ def _run_index_validation(
         ["./gradlew", "validateIndexFiles", f"-Pcoordinates={changed_coordinates}"],
         result,
     )
-
-
-def _run_style_validation(
-        repo_path: str,
-        base_commit: str,
-        changed_files: list[str],
-        result: LocalCIVerificationResult,
-) -> CommandRecord | None:
-    if not _should_run_style_validation(changed_files):
-        return None
-    failed = _run_recorded_command(repo_path, "spotless", ["./gradlew", "spotlessCheck", "--console=plain"], result)
-    if failed is not None:
-        return failed
-    try:
-        matrix = _gradle_json_output(
-            repo_path,
-            "generateChangedCoordinatesOnlyMatrix",
-            base_commit,
-            result,
-            "changed-coordinates-only-matrix",
-        )
-    except _GradleOutputFailure as exc:
-        return exc.record
-    coordinates = matrix.get("coordinates")
-    if not isinstance(coordinates, list):
-        return None
-    for coordinate in coordinates:
-        failed = _run_recorded_command(
-            repo_path,
-            "checkstyle",
-            ["./gradlew", "checkstyle", f"-Pcoordinates={coordinate}", "--console=plain"],
-            result,
-        )
-        if failed is not None:
-            return failed
-    return None
-
-
-def _gradle_json_output(
-        repo_path: str,
-        task_name: str,
-        base_commit: str,
-        result: LocalCIVerificationResult,
-        gate: str,
-        extra_args: list[str] | None = None,
-) -> dict:
-    output = _gradle_output(repo_path, task_name, base_commit, result, gate, extra_args=extra_args)
-    raw_matrix = output.get("matrix")
-    if raw_matrix is None:
-        return {}
-    try:
-        parsed = json.loads(raw_matrix)
-    except json.JSONDecodeError as exc:
-        raise RuntimeError(f"Failed to parse matrix output from {task_name}: {exc}") from exc
-    return parsed if isinstance(parsed, dict) else {}
 
 
 def _gradle_output(
@@ -699,94 +339,6 @@ def _parse_github_output_file(path: str) -> dict[str, str]:
             key, value = stripped.split("=", 1)
             output[key] = value
     return output
-
-
-def _matrix_entries(matrix: dict) -> list[dict]:
-    include = matrix.get("include")
-    if isinstance(include, list):
-        return [entry for entry in include if isinstance(entry, dict)]
-    return []
-
-
-def _matrix_env(entry: dict) -> dict[str, str]:
-    env: dict[str, str] = {}
-    native_image_mode = str(entry.get("nativeImageMode") or "").strip()
-    if native_image_mode:
-        env["GVM_TCK_NATIVE_IMAGE_MODE"] = native_image_mode
-    java_version = str(entry.get("version") or "").strip()
-    graalvm_home = _graalvm_home_for_java_version(java_version)
-    if graalvm_home:
-        env["GRAALVM_HOME"] = graalvm_home
-        env["JAVA_HOME"] = graalvm_home
-    return env
-
-
-def _coordinate_uses_docker(repo_path: str, coordinates: str) -> bool:
-    """Return whether the coordinate declares Docker images for its tests."""
-    required_images_path = _required_docker_images_path(repo_path, coordinates)
-    if required_images_path is None:
-        return False
-    with open(required_images_path, "r", encoding="utf-8") as required_images_file:
-        return any(_is_required_docker_image_line(line) for line in required_images_file)
-
-
-def _required_docker_images_path(repo_path: str, coordinates: str) -> str | None:
-    """Return the Docker declaration path for the coordinate's resolved test version."""
-    group, artifact, _version = parse_coordinate_parts(coordinates)
-    test_version = _resolve_coordinate_test_version(repo_path, coordinates)
-    if test_version is None:
-        return None
-    required_images_path = os.path.join(
-        repo_path,
-        "tests",
-        "src",
-        group,
-        artifact,
-        test_version,
-        "required-docker-images.txt",
-    )
-    if not os.path.isfile(required_images_path):
-        return None
-    return required_images_path
-
-
-def _resolve_coordinate_test_version(repo_path: str, coordinates: str) -> str | None:
-    """Resolve the test-version used by pullAllowedDockerImages for a coordinate."""
-    group, artifact, version = parse_coordinate_parts(coordinates)
-    return resolve_test_version(repo_path, group, artifact, version)
-
-
-def _is_required_docker_image_line(line: str) -> bool:
-    stripped = line.strip()
-    return bool(stripped and not stripped.startswith("#"))
-
-
-def _spring_aot_env(entry: dict) -> dict[str, str]:
-    env: dict[str, str] = {}
-    java_version = str(entry.get("java") or "").strip()
-    graalvm_home = _graalvm_home_for_java_version(java_version)
-    if graalvm_home:
-        env["GRAALVM_HOME"] = graalvm_home
-        env["JAVA_HOME"] = graalvm_home
-    return env
-
-
-def _graalvm_home_for_java_version(java_version: str) -> str | None:
-    if not java_version:
-        return None
-    if java_version == "25":
-        return _required_env("GRAALVM_HOME_25_0")
-    if java_version == "latest-ea":
-        return _required_env("GRAALVM_HOME_LATEST_EA")
-    env_name = "GRAALVM_HOME_" + re.sub(r"[^A-Za-z0-9]", "_", java_version).upper()
-    return _required_env(env_name)
-
-
-def _required_env(name: str) -> str:
-    value = os.environ.get(name)
-    if not value:
-        raise RuntimeError(f"Missing required environment variable {name} for local CI verification.")
-    return value
 
 
 def _run_recorded_command(
@@ -873,99 +425,6 @@ def _remove_gradle_java_home_overrides(command_env: dict[str, str]) -> None:
             command_env[env_name] = shlex.join(filtered_tokens)
         else:
             command_env.pop(env_name, None)
-
-
-def _run_recorded_command_without_new_docker_images(
-        repo_path: str,
-        gate: str,
-        command: list[str],
-        result: LocalCIVerificationResult,
-        env: dict[str, str] | None = None,
-        failure_output_pattern: str | None = None,
-) -> CommandRecord | None:
-    try:
-        before_images = _docker_image_ids(repo_path)
-    except RuntimeError as exc:
-        output = f"ERROR: Cannot run local CI no-network-equivalent Docker validation. {exc}\n"
-        return _record_synthetic_failure(repo_path, "docker-image-baseline", command, result, env, output)
-
-    failed = _run_recorded_command(
-        repo_path,
-        gate,
-        command,
-        result,
-        env=env,
-        failure_output_pattern=failure_output_pattern,
-    )
-    if failed is not None:
-        return failed
-
-    try:
-        after_images = _docker_image_ids(repo_path)
-    except RuntimeError as exc:
-        output = f"ERROR: Cannot complete local CI no-network-equivalent Docker validation. {exc}\n"
-        return _record_synthetic_failure(repo_path, "docker-image-after-test", command, result, env, output)
-
-    new_images = sorted(after_images - before_images)
-    if not new_images:
-        return None
-
-    output = "\n".join([
-        UNEXPECTED_DOCKER_IMAGE_FAILURE_MESSAGE,
-        "CI disables Docker networking after `pullAllowedDockerImages`; local verification must not pass by pulling images on demand.",
-        "New Docker images:",
-        *[f"- {image}" for image in new_images],
-        "",
-    ])
-    return _record_synthetic_failure(repo_path, "unexpected-docker-image-pull", command, result, env, output)
-
-
-def _docker_image_ids(repo_path: str) -> set[str]:
-    try:
-        completed = subprocess.run(
-            DOCKER_IMAGE_LIST_COMMAND,
-            cwd=repo_path,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            check=False,
-        )
-    except OSError as exc:
-        raise RuntimeError(str(exc)) from exc
-    if completed.returncode != 0:
-        output = (completed.stdout or "").strip()
-        details = f" Output: {output}" if output else ""
-        raise RuntimeError(f"Cannot list Docker images for local CI no-network-equivalent verification.{details}")
-    images: set[str] = set()
-    for line in completed.stdout.splitlines():
-        stripped = line.strip()
-        if stripped and not stripped.startswith("<none>:<none>"):
-            images.add(stripped)
-    return images
-
-
-def _record_synthetic_failure(
-        repo_path: str,
-        gate: str,
-        command: list[str],
-        result: LocalCIVerificationResult,
-        env: dict[str, str] | None,
-        output: str,
-) -> CommandRecord:
-    log_path = build_timestamped_task_log_path("local-ci", gate, Path(command[0]).name)
-    with open(log_path, "w", encoding="utf-8") as log_file:
-        log_file.write(output)
-    record = CommandRecord(
-        gate=gate,
-        command=command,
-        returncode=1,
-        env=dict(env or {}),
-        log_path=display_log_path(log_path),
-        output_excerpt=_tail(output),
-    )
-    result.commands.append(record)
-    _log_local_ci(f"Gate {gate} failed; log: {record.log_path}", indent_level=1)
-    return record
 
 
 def _sudo_usage_reason(repo_path: str, command: list[str]) -> str | None:
@@ -1185,47 +644,6 @@ def _tail(output: str) -> str:
 def _is_metadata_index_file(path: str) -> bool:
     parts = path.split("/")
     return len(parts) == 4 and parts[0] == "metadata" and parts[3] == "index.json"
-
-
-def _should_run_style_validation(changed_files: list[str]) -> bool:
-    for path in changed_files:
-        if path.startswith("docs/"):
-            continue
-        if path.endswith(".md"):
-            continue
-        if os.path.basename(path).startswith("library-and-framework-list") and path.endswith(".json"):
-            continue
-        return True
-    return False
-
-
-def _should_run_library_stats_validation(changed_files: list[str]) -> bool:
-    for path in changed_files:
-        if re.match(r"^stats/[^/]+/[^/]+/[^/]+/stats\.json$", path):
-            return True
-        if path.startswith("stats/schemas/") and os.path.basename(path).startswith("library-stats-schema"):
-            return True
-        if re.match(r"^metadata/[^/]+/[^/]+/[^/]+/", path):
-            return True
-    return False
-
-
-def _should_run_infrastructure_tests(changed_files: list[str]) -> bool:
-    return any(
-        path == "build.gradle"
-        or path == "settings.gradle"
-        or path == "gradle.properties"
-        or path.startswith("gradle/")
-        or path.startswith("tests/tck-build-logic/")
-        for path in changed_files
-    )
-
-
-def _should_run_spring_aot_tests(
-        changed_files: list[str],
-        verification_mode: LocalCIVerificationMode = DEFAULT_LOCAL_CI_VERIFICATION_MODE,
-) -> bool:
-    return verification_mode == "full" and any(path.startswith("metadata/") for path in changed_files)
 
 
 def _should_run_docker_scan(changed_files: list[str]) -> bool:

--- a/forge/utility_scripts/local_ci_verification.py
+++ b/forge/utility_scripts/local_ci_verification.py
@@ -669,7 +669,6 @@ def _build_fixup_prompt(coordinates: str, failed_command: CommandRecord) -> str:
         reproduction = " ".join(env_lines + [reproduction])
     return "\n".join([
         "Fix the repository so the local CI-equivalent verification gate passes.",
-        "The fix may update generated library files or shared repository files when the root cause is in the repository.",
         "Keep the change minimal and targeted to the failing gate.",
         "",
         f"Library: {coordinates}",

--- a/forge/utility_scripts/local_ci_verification.py
+++ b/forge/utility_scripts/local_ci_verification.py
@@ -6,14 +6,18 @@
 """Pre-publication verification gate for generated Forge PRs.
 
 Implements the second verification tier of §FS-local-ci-equivalent-verification.2:
-the cross-cutting checks a single-library generation cannot settle on its own.
-Library-scoped verification (metadata, style, stats, and the native test lanes)
-is owned by the generation/finalization tier
-(§FS-local-ci-equivalent-verification.1) and is intentionally not repeated here.
+the post-rebase, cross-cutting checks a single-library generation cannot settle
+on its own. Library-scoped verification (metadata, style, stats, and the native
+test lanes) is owned by the generation/finalization tier
+(§FS-local-ci-equivalent-verification.1) and is not repeated here by default. The
+opt-in `reproduce_full_ci` flag additionally reproduces the expensive per-PR CI
+surface locally — the whole changed-metadata native test matrix and the Spring
+AOT smoke tests.
 """
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import shlex
@@ -23,6 +27,7 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
 from utility_scripts.gradle_environment import gradle_command_environment
+from utility_scripts.metadata_index import resolve_test_version
 from utility_scripts.metrics_writer import PENDING_METRICS_FILENAME, read_pending_metrics, write_pending_metrics
 from utility_scripts.stage_logger import log_stage
 from utility_scripts.task_logs import build_timestamped_task_log_path, display_log_path
@@ -34,7 +39,13 @@ MAX_FIXUP_ATTEMPTS = 2
 CODEX_MODEL_NAME = "oca/gpt-5.4"
 CODEX_TIMEOUT_SECONDS = 1800
 DEFAULT_BASE_BRANCH = "master"
+SPRING_AOT_BRANCH = "main"
+SPRING_AOT_REPO_URL = "https://github.com/spring-projects/spring-aot-smoke-tests.git"
 NO_SUDO_FAILURE_MESSAGE = "ERROR: Local CI verification runs must not invoke sudo."
+UNEXPECTED_DOCKER_IMAGE_FAILURE_MESSAGE = (
+    "ERROR: Local CI verification detected Docker images created during the no-network-equivalent test gate."
+)
+DOCKER_IMAGE_LIST_COMMAND = ["docker", "image", "ls", "--format", "{{.Repository}}:{{.Tag}} {{.ID}}"]
 
 
 @dataclass
@@ -115,13 +126,20 @@ def run_local_ci_verification(
         base_commit: str,
         metrics_repo_path: str | None = None,
         max_fixup_attempts: int = MAX_FIXUP_ATTEMPTS,
+        reproduce_full_ci: bool = False,
 ) -> LocalCIVerificationResult:
-    """Run local verification, fixing and retrying when possible."""
+    """Run local verification, fixing and retrying when possible.
+
+    When `reproduce_full_ci` is set, the pre-publication gate additionally
+    reproduces the per-PR CI surface locally — the whole changed-metadata native
+    test matrix and the Spring AOT smoke tests — instead of leaving those to
+    repository CI (§FS-local-ci-equivalent-verification.2).
+    """
     result = LocalCIVerificationResult(status="running", base_commit=base_commit)
     _log_local_ci(f"Starting local CI verification for {coordinates}")
     for attempt in range(max_fixup_attempts + 1):
         _log_local_ci(f"Verification attempt {attempt + 1}/{max_fixup_attempts + 1}", indent_level=1)
-        failed_command = _run_verification_once(repo_path, base_commit, result)
+        failed_command = _run_verification_once(repo_path, base_commit, result, reproduce_full_ci=reproduce_full_ci)
         if failed_command is None:
             result.status = "success"
             result.final_commit = _git_stdout(repo_path, ["rev-parse", "HEAD"])
@@ -244,6 +262,7 @@ def _run_verification_once(
         repo_path: str,
         base_commit: str,
         result: LocalCIVerificationResult,
+        reproduce_full_ci: bool = False,
 ) -> CommandRecord | None:
     # Pre-publication gate (§FS-local-ci-equivalent-verification.2): run only the
     # cross-cutting checks a single-library generation cannot settle on its own —
@@ -269,7 +288,92 @@ def _run_verification_once(
         if failed is not None:
             return failed
 
+    # Opt-in full local reproduction of the per-PR CI surface the gate otherwise
+    # leaves to repository CI (§FS-local-ci-equivalent-verification.2): the whole
+    # changed-metadata native test matrix and the Spring AOT smoke tests.
+    if reproduce_full_ci:
+        failed = _run_full_ci_reproduction(repo_path, base_commit, changed_files, result)
+        if failed is not None:
+            return failed
+
     return None
+
+
+def _run_full_ci_reproduction(
+        repo_path: str,
+        base_commit: str,
+        changed_files: list[str],
+        result: LocalCIVerificationResult,
+) -> CommandRecord | None:
+    """Reproduce the expensive per-PR CI surface locally: native matrix + Spring AOT."""
+    _log_local_ci("Full CI reproduction: changed-metadata native test matrix and Spring AOT", indent_level=1)
+    try:
+        changed_metadata_matrix = _gradle_json_output(
+            repo_path,
+            "generateChangedMetadataTestMatrix",
+            base_commit,
+            result,
+            "changed-metadata-matrix",
+        )
+    except _GradleOutputFailure as exc:
+        return exc.record
+
+    test_entries = _matrix_entries(changed_metadata_matrix)
+    _log_local_ci(f"Changed-metadata test matrix entries: {len(test_entries)}", indent_level=1)
+    failed = _run_test_matrix_entries(repo_path, test_entries, result)
+    if failed is not None:
+        return failed
+
+    if _should_run_spring_aot_tests(changed_files):
+        failed = _run_spring_aot_verification(repo_path, base_commit, changed_files, result)
+        if failed is not None:
+            return failed
+
+    return None
+
+
+def _run_spring_aot_verification(
+        repo_path: str,
+        base_commit: str,
+        changed_files: list[str],
+        result: LocalCIVerificationResult,
+) -> CommandRecord | None:
+    if not _should_run_spring_aot_tests(changed_files):
+        return None
+
+    _log_local_ci("Running full Spring AOT verification", indent_level=1)
+    with tempfile.TemporaryDirectory(prefix="forge-spring-aot-") as spring_parent:
+        os.symlink(os.path.join(repo_path, "metadata"), os.path.join(spring_parent, "metadata"))
+        spring_path = os.path.join(spring_parent, "spring-aot-smoke-tests")
+        failed = _run_recorded_command(
+            repo_path,
+            "checkout-spring-aot-smoke-tests",
+            ["git", "clone", "--depth", "1", "--branch", SPRING_AOT_BRANCH, SPRING_AOT_REPO_URL, spring_path],
+            result,
+        )
+        if failed is not None:
+            return failed
+
+        try:
+            spring_matrix = _gradle_json_output(
+                repo_path,
+                "generateAffectedSpringTestMatrix",
+                base_commit,
+                result,
+                "affected-spring-aot-matrix",
+                extra_args=[
+                    f"-PspringAotBranch={SPRING_AOT_BRANCH}",
+                    f"-PspringAotPath={spring_path}",
+                ],
+            )
+        except _GradleOutputFailure as exc:
+            return exc.record
+
+        return _run_spring_aot_matrix_entries(repo_path, spring_path, _matrix_entries(spring_matrix), result)
+
+
+def _should_run_spring_aot_tests(changed_files: list[str]) -> bool:
+    return any(path.startswith("metadata/") for path in changed_files)
 
 
 def _run_index_validation(
@@ -648,3 +752,296 @@ def _is_metadata_index_file(path: str) -> bool:
 
 def _should_run_docker_scan(changed_files: list[str]) -> bool:
     return any(path.startswith("tests/tck-build-logic/src/main/resources/allowed-docker-images/") for path in changed_files)
+
+
+def _run_test_matrix_entries(
+        repo_path: str,
+        entries: list[dict],
+        result: LocalCIVerificationResult,
+) -> CommandRecord | None:
+    if not entries:
+        _log_local_ci("Full metadata test matrix is empty", indent_level=1)
+        return None
+
+    pulled_coordinates: set[str] = set()
+    for entry in entries:
+        coordinates = str(entry.get("coordinates") or "").strip()
+        if not coordinates or coordinates in pulled_coordinates:
+            continue
+        if not _coordinate_uses_docker(repo_path, coordinates):
+            continue
+        _log_local_ci(f"Pre-pulling Docker images for {coordinates}", indent_level=1)
+        failed = _run_recorded_command(
+            repo_path,
+            "pull-allowed-docker-images",
+            ["./gradlew", "pullAllowedDockerImages", f"-Pcoordinates={coordinates}"],
+            result,
+        )
+        if failed is not None:
+            return failed
+        pulled_coordinates.add(coordinates)
+
+    for entry in entries:
+        coordinates = str(entry.get("coordinates") or "").strip()
+        versions = entry.get("versions")
+        if not coordinates or not isinstance(versions, list):
+            continue
+        version_text = ", ".join(str(version) for version in versions)
+        _log_local_ci(f"Running full metadata test matrix entry for {coordinates}: {version_text}", indent_level=1)
+        env = _matrix_env(entry)
+        failed = _run_recorded_command(
+            repo_path,
+            "check-metadata-files",
+            ["./gradlew", "checkMetadataFiles", f"-Pcoordinates={coordinates}"],
+            result,
+            env=env,
+        )
+        if failed is not None:
+            return failed
+        failed = _run_recorded_command_without_new_docker_images(
+            repo_path,
+            "run-consecutive-tests",
+            [
+                "bash",
+                "./.github/workflows/scripts/run-consecutive-tests.sh",
+                coordinates,
+                json.dumps([str(version) for version in versions]),
+            ],
+            result,
+            env=env,
+            failure_output_pattern=r"^FAILED",
+        )
+        if failed is not None:
+            return failed
+    return None
+
+
+def _run_spring_aot_matrix_entries(
+        repo_path: str,
+        spring_path: str,
+        entries: list[dict],
+        result: LocalCIVerificationResult,
+) -> CommandRecord | None:
+    _log_local_ci(f"Spring AOT matrix entries: {len(entries)}", indent_level=1)
+    for entry in entries:
+        project = str(entry.get("project") or "").strip()
+        if not project:
+            continue
+        _log_local_ci(f"Running Spring AOT smoke test for {project}", indent_level=1)
+        env = _spring_aot_env(entry)
+        failed = _run_recorded_command(
+            repo_path,
+            "spring-aot-smoke-test",
+            [
+                "bash",
+                ".github/workflows/scripts/run-spring-aot-triaged-test.sh",
+                spring_path,
+                project,
+                "4.1.x",
+            ],
+            result,
+            env=env,
+        )
+        if failed is not None:
+            return failed
+    return None
+
+
+def _gradle_json_output(
+        repo_path: str,
+        task_name: str,
+        base_commit: str,
+        result: LocalCIVerificationResult,
+        gate: str,
+        extra_args: list[str] | None = None,
+) -> dict:
+    output = _gradle_output(repo_path, task_name, base_commit, result, gate, extra_args=extra_args)
+    raw_matrix = output.get("matrix")
+    if raw_matrix is None:
+        return {}
+    try:
+        parsed = json.loads(raw_matrix)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Failed to parse matrix output from {task_name}: {exc}") from exc
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _matrix_entries(matrix: dict) -> list[dict]:
+    include = matrix.get("include")
+    if isinstance(include, list):
+        return [entry for entry in include if isinstance(entry, dict)]
+    return []
+
+
+def _matrix_env(entry: dict) -> dict[str, str]:
+    env: dict[str, str] = {}
+    native_image_mode = str(entry.get("nativeImageMode") or "").strip()
+    if native_image_mode:
+        env["GVM_TCK_NATIVE_IMAGE_MODE"] = native_image_mode
+    java_version = str(entry.get("version") or "").strip()
+    graalvm_home = _graalvm_home_for_java_version(java_version)
+    if graalvm_home:
+        env["GRAALVM_HOME"] = graalvm_home
+        env["JAVA_HOME"] = graalvm_home
+    return env
+
+
+def _coordinate_uses_docker(repo_path: str, coordinates: str) -> bool:
+    """Return whether the coordinate declares Docker images for its tests."""
+    required_images_path = _required_docker_images_path(repo_path, coordinates)
+    if required_images_path is None:
+        return False
+    with open(required_images_path, "r", encoding="utf-8") as required_images_file:
+        return any(_is_required_docker_image_line(line) for line in required_images_file)
+
+
+def _required_docker_images_path(repo_path: str, coordinates: str) -> str | None:
+    """Return the Docker declaration path for the coordinate's resolved test version."""
+    group, artifact, _version = parse_coordinate_parts(coordinates)
+    test_version = _resolve_coordinate_test_version(repo_path, coordinates)
+    if test_version is None:
+        return None
+    required_images_path = os.path.join(
+        repo_path,
+        "tests",
+        "src",
+        group,
+        artifact,
+        test_version,
+        "required-docker-images.txt",
+    )
+    if not os.path.isfile(required_images_path):
+        return None
+    return required_images_path
+
+
+def _resolve_coordinate_test_version(repo_path: str, coordinates: str) -> str | None:
+    """Resolve the test-version used by pullAllowedDockerImages for a coordinate."""
+    group, artifact, version = parse_coordinate_parts(coordinates)
+    return resolve_test_version(repo_path, group, artifact, version)
+
+
+def _is_required_docker_image_line(line: str) -> bool:
+    stripped = line.strip()
+    return bool(stripped and not stripped.startswith("#"))
+
+
+def _spring_aot_env(entry: dict) -> dict[str, str]:
+    env: dict[str, str] = {}
+    java_version = str(entry.get("java") or "").strip()
+    graalvm_home = _graalvm_home_for_java_version(java_version)
+    if graalvm_home:
+        env["GRAALVM_HOME"] = graalvm_home
+        env["JAVA_HOME"] = graalvm_home
+    return env
+
+
+def _graalvm_home_for_java_version(java_version: str) -> str | None:
+    if not java_version:
+        return None
+    if java_version == "25":
+        return _required_env("GRAALVM_HOME_25_0")
+    if java_version == "latest-ea":
+        return _required_env("GRAALVM_HOME_LATEST_EA")
+    env_name = "GRAALVM_HOME_" + re.sub(r"[^A-Za-z0-9]", "_", java_version).upper()
+    return _required_env(env_name)
+
+
+def _required_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f"Missing required environment variable {name} for local CI verification.")
+    return value
+
+
+def _run_recorded_command_without_new_docker_images(
+        repo_path: str,
+        gate: str,
+        command: list[str],
+        result: LocalCIVerificationResult,
+        env: dict[str, str] | None = None,
+        failure_output_pattern: str | None = None,
+) -> CommandRecord | None:
+    try:
+        before_images = _docker_image_ids(repo_path)
+    except RuntimeError as exc:
+        output = f"ERROR: Cannot run local CI no-network-equivalent Docker validation. {exc}\n"
+        return _record_synthetic_failure(repo_path, "docker-image-baseline", command, result, env, output)
+
+    failed = _run_recorded_command(
+        repo_path,
+        gate,
+        command,
+        result,
+        env=env,
+        failure_output_pattern=failure_output_pattern,
+    )
+    if failed is not None:
+        return failed
+
+    try:
+        after_images = _docker_image_ids(repo_path)
+    except RuntimeError as exc:
+        output = f"ERROR: Cannot complete local CI no-network-equivalent Docker validation. {exc}\n"
+        return _record_synthetic_failure(repo_path, "docker-image-after-test", command, result, env, output)
+
+    new_images = sorted(after_images - before_images)
+    if not new_images:
+        return None
+
+    output = "\n".join([
+        UNEXPECTED_DOCKER_IMAGE_FAILURE_MESSAGE,
+        "CI disables Docker networking after `pullAllowedDockerImages`; local verification must not pass by pulling images on demand.",
+        "New Docker images:",
+        *[f"- {image}" for image in new_images],
+        "",
+    ])
+    return _record_synthetic_failure(repo_path, "unexpected-docker-image-pull", command, result, env, output)
+
+
+def _docker_image_ids(repo_path: str) -> set[str]:
+    try:
+        completed = subprocess.run(
+            DOCKER_IMAGE_LIST_COMMAND,
+            cwd=repo_path,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            check=False,
+        )
+    except OSError as exc:
+        raise RuntimeError(str(exc)) from exc
+    if completed.returncode != 0:
+        output = (completed.stdout or "").strip()
+        details = f" Output: {output}" if output else ""
+        raise RuntimeError(f"Cannot list Docker images for local CI no-network-equivalent verification.{details}")
+    images: set[str] = set()
+    for line in completed.stdout.splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("<none>:<none>"):
+            images.add(stripped)
+    return images
+
+
+def _record_synthetic_failure(
+        repo_path: str,
+        gate: str,
+        command: list[str],
+        result: LocalCIVerificationResult,
+        env: dict[str, str] | None,
+        output: str,
+) -> CommandRecord:
+    log_path = build_timestamped_task_log_path("local-ci", gate, Path(command[0]).name)
+    with open(log_path, "w", encoding="utf-8") as log_file:
+        log_file.write(output)
+    record = CommandRecord(
+        gate=gate,
+        command=command,
+        returncode=1,
+        env=dict(env or {}),
+        log_path=display_log_path(log_path),
+        output_excerpt=_tail(output),
+    )
+    result.commands.append(record)
+    _log_local_ci(f"Gate {gate} failed; log: {record.log_path}", indent_level=1)
+    return record

--- a/forge/utility_scripts/workflow_setup.py
+++ b/forge/utility_scripts/workflow_setup.py
@@ -20,6 +20,7 @@ def resolve_graalvm_java_home():
     Logic:
     - If GRAALVM_HOME is set and contains bin/native-image, use it for both GRAALVM_HOME and JAVA_HOME.
     - Else, if JAVA_HOME is set and contains bin/native-image, use it for both GRAALVM_HOME and JAVA_HOME.
+    - Require GRAALVM_HOME_25_0 for the post-generation GraalVM 25 validation lane.
     - Otherwise, print an error and exit(1).
     """
 
@@ -31,12 +32,14 @@ def resolve_graalvm_java_home():
     if graalvm_home_env and has_native_image(graalvm_home_env):
         os.environ["GRAALVM_HOME"] = graalvm_home_env
         os.environ["JAVA_HOME"] = graalvm_home_env
+        require_graalvm_home_env("GRAALVM_HOME_25_0")
         return graalvm_home_env
 
     java_home_env = os.environ.get("JAVA_HOME")
     if java_home_env and has_native_image(java_home_env):
         os.environ["GRAALVM_HOME"] = java_home_env
         os.environ["JAVA_HOME"] = java_home_env
+        require_graalvm_home_env("GRAALVM_HOME_25_0")
         return java_home_env
 
     print(


### PR DESCRIPTION
Fixes #7743.

Forge generated PRs previously reproduced the full native test matrix and Spring AOT lanes during pre-publication verification, and re-ran metadata/style/legacy checks that finalization had already established. This restructures local verification into two tiers, split along the boundary between what a single-library generation can settle on its own and what it cannot.

### Generation/finalization tier (FS-local-ci-equivalent-verification.1)
Owns library-scoped correctness. Runs the generated tests under current defaults and `future-defaults-all` on the latest GraalVM, **plus a new current-defaults lane on the GraalVM 25 toolchain** (`GRAALVM_HOME_25_0`), each wrapped by the existing Codex/Pi fixers. Finalization continues to validate metadata (`checkMetadataFiles`), derive `allowed-packages`, apply/check style, regenerate stats, and reject legacy test-only Native Image config.
