### PR TITLE
[GenAI] Test fix for com.google.api.grpc:grpc-google-common-protos:2.72.0 using gpt-5.5

### DIFF
--- a/metadata/com.google.api.grpc/grpc-google-common-protos/2.72.0/reachability-metadata.json
+++ b/metadata/com.google.api.grpc/grpc-google-common-protos/2.72.0/reachability-metadata.json
@@ -1,0 +1,117 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.google.longrunning.OperationsGrpc$OperationsFutureStub"
+      },
+      "type" : "com.google.common.util.concurrent.AbstractFutureState",
+      "fields" : [
+        {
+          "name" : "listenersField"
+        },
+        {
+          "name" : "valueField"
+        },
+        {
+          "name" : "waitersField"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.longrunning.OperationsGrpc$OperationsFutureStub"
+      },
+      "type" : "com.google.common.util.concurrent.AbstractFutureState$Waiter",
+      "fields" : [
+        {
+          "name" : "next"
+        },
+        {
+          "name" : "thread"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.ExtensionRegistryFactory"
+      },
+      "type" : "com.google.protobuf.ExtensionRegistry",
+      "methods" : [
+        {
+          "name" : "getEmptyRegistry",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.GeneratedMessage"
+      },
+      "type" : "com.google.protobuf.StringValue"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.GeneratedMessage"
+      },
+      "type" : "com.google.protobuf.StringValue$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.longrunning.OperationsGrpc$OperationsFutureStub"
+      },
+      "type" : "java.lang.invoke.VarHandle"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.UnsafeUtil"
+      },
+      "type" : "java.nio.Buffer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.UnsafeUtil$MemoryAccessor"
+      },
+      "type" : "java.nio.Buffer",
+      "fields" : [
+        {
+          "name" : "address"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.Android"
+      },
+      "type" : "libcore.io.Memory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.Android"
+      },
+      "type" : "org.robolectric.Robolectric"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.UnsafeUtil$1"
+      },
+      "type" : "sun.misc.Unsafe",
+      "fields" : [
+        {
+          "name" : "theUnsafe"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.UnsafeUtil$JvmMemoryAccessor"
+      },
+      "type" : "sun.misc.Unsafe"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.UnsafeUtil$MemoryAccessor"
+      },
+      "type" : "sun.misc.Unsafe"
+    }
+  ]
+}

--- a/metadata/com.google.api.grpc/grpc-google-common-protos/index.json
+++ b/metadata/com.google.api.grpc/grpc-google-common-protos/index.json
@@ -1,6 +1,18 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.72.0",
+    "tested-versions" : [
+      "2.72.0"
+    ],
+    "allowed-packages" : [
+      "com.google.cloud.location",
+      "com.google.longrunning",
+      "com.google.api",
+      "com.google.protobuf"
+    ]
+  },
+  {
     "metadata-version" : "2.70.0",
     "source-code-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/grpc-google-common-protos/$version$/grpc-google-common-protos-$version$-sources.jar",
     "repository-url" : "https://github.com/googleapis/sdk-platform-java",

--- a/metadata/com.google.api.grpc/grpc-google-common-protos/index.json
+++ b/metadata/com.google.api.grpc/grpc-google-common-protos/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.72.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/grpc-google-common-protos/$version$/grpc-google-common-protos-$version$-sources.jar",
+    "repository-url" : "https://github.com/googleapis/sdk-platform-java",
+    "test-code-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/grpc-google-common-protos/$version$/grpc-google-common-protos-$version$-tests.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/grpc-google-common-protos/$version$/grpc-google-common-protos-$version$-javadoc.jar",
+    "description" : "grpc-google-common-protos provides Java gRPC stubs for common Google API services, including the Operations and Locations services generated from Google common protobuf definitions. It lets JVM clients call those shared service endpoints through gRPC alongside the corresponding protobuf message types.",
     "tested-versions" : [
       "2.72.0"
     ],

--- a/stats/com.google.api.grpc/grpc-google-common-protos/2.72.0/execution-metrics.json
+++ b/stats/com.google.api.grpc/grpc-google-common-protos/2.72.0/execution-metrics.json
@@ -1,0 +1,88 @@
+{
+  "fix_javac_fail:2026-06-04": {
+    "timestamp": "2026-06-04T13:48:02.806541Z",
+    "library": "com.google.api.grpc:grpc-google-common-protos:2.72.0",
+    "starting_commit": "257d80633ba8e542be6ee1c2d120a71deca79026",
+    "ending_commit": "6b10cb369815e35f40c2661a33a843aca16440d3",
+    "previous_library": "com.google.api.grpc:grpc-google-common-protos:2.70.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.72.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 260,
+          "missed": 354,
+          "ratio": 0.423453,
+          "total": 614
+        },
+        "line": {
+          "covered": 75,
+          "missed": 101,
+          "ratio": 0.426136,
+          "total": 176
+        },
+        "method": {
+          "covered": 41,
+          "missed": 48,
+          "ratio": 0.460674,
+          "total": 89
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.70.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 286,
+          "missed": 328,
+          "ratio": 0.465798,
+          "total": 614
+        },
+        "line": {
+          "covered": 81,
+          "missed": 95,
+          "ratio": 0.460227,
+          "total": 176
+        },
+        "method": {
+          "covered": 47,
+          "missed": 42,
+          "ratio": 0.52809,
+          "total": 89
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 50067,
+      "cached_input_tokens_used": 415744,
+      "output_tokens_used": 4807,
+      "iterations": 1,
+      "cost_usd": 0.3521,
+      "tested_library_loc": 75,
+      "metadata_entries": 21,
+      "test_only_metadata_entries": 2,
+      "previous_library_metadata_entries": 168,
+      "code_coverage_percent": 42.61,
+      "previous_library_coverage_percent": 46.02
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.google.api.grpc/grpc-google-common-protos/2.72.0/src/test/java/com_google_api_grpc/grpc_google_common_protos/Grpc_google_common_protosTest.java",
+      "metadata_file": "metadata/com.google.api.grpc/grpc-google-common-protos/2.72.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.google.api.grpc/grpc-google-common-protos/2.72.0/stats.json
+++ b/stats/com.google.api.grpc/grpc-google-common-protos/2.72.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.72.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 260,
+        "missed" : 354,
+        "ratio" : 0.423453,
+        "total" : 614
+      },
+      "line" : {
+        "covered" : 75,
+        "missed" : 101,
+        "ratio" : 0.426136,
+        "total" : 176
+      },
+      "method" : {
+        "covered" : 41,
+        "missed" : 48,
+        "ratio" : 0.460674,
+        "total" : 89
+      }
+    }
+  } ]
+}

--- a/tests/src/com.google.api.grpc/grpc-google-common-protos/2.72.0/.gitignore
+++ b/tests/src/com.google.api.grpc/grpc-google-common-protos/2.72.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.google.api.grpc/grpc-google-common-protos/2.72.0/build.gradle
+++ b/tests/src/com.google.api.grpc/grpc-google-common-protos/2.72.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.google.api.grpc:grpc-google-common-protos:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.google.api.grpc/grpc-google-common-protos/2.72.0/gradle.properties
+++ b/tests/src/com.google.api.grpc/grpc-google-common-protos/2.72.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.google.api.grpc:grpc-google-common-protos:2.72.0
+library.version = 2.72.0
+metadata.dir = com.google.api.grpc/grpc-google-common-protos/2.72.0/

--- a/tests/src/com.google.api.grpc/grpc-google-common-protos/2.72.0/settings.gradle
+++ b/tests/src/com.google.api.grpc/grpc-google-common-protos/2.72.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.google.api.grpc.grpc-google-common-protos_tests'

--- a/tests/src/com.google.api.grpc/grpc-google-common-protos/2.72.0/src/test/java/com_google_api_grpc/grpc_google_common_protos/Grpc_google_common_protosTest.java
+++ b/tests/src/com.google.api.grpc/grpc-google-common-protos/2.72.0/src/test/java/com_google_api_grpc/grpc_google_common_protos/Grpc_google_common_protosTest.java
@@ -1,0 +1,610 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_api_grpc.grpc_google_common_protos;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import com.google.cloud.location.GetLocationRequest;
+import com.google.cloud.location.ListLocationsRequest;
+import com.google.cloud.location.ListLocationsResponse;
+import com.google.cloud.location.Location;
+import com.google.cloud.location.LocationsGrpc;
+import com.google.cloud.location.LocationsProto;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.longrunning.CancelOperationRequest;
+import com.google.longrunning.DeleteOperationRequest;
+import com.google.longrunning.GetOperationRequest;
+import com.google.longrunning.ListOperationsRequest;
+import com.google.longrunning.ListOperationsResponse;
+import com.google.longrunning.Operation;
+import com.google.longrunning.OperationsGrpc;
+import com.google.longrunning.OperationsProto;
+import com.google.longrunning.WaitOperationRequest;
+import com.google.protobuf.Any;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Duration;
+import com.google.protobuf.Empty;
+import com.google.protobuf.StringValue;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerMethodDefinition;
+import io.grpc.ServerServiceDefinition;
+import io.grpc.ServiceDescriptor;
+import io.grpc.Status;
+import io.grpc.protobuf.ProtoMethodDescriptorSupplier;
+import io.grpc.protobuf.ProtoServiceDescriptorSupplier;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+public class Grpc_google_common_protosTest {
+    private static final String OPERATIONS_SERVICE = "google.longrunning.Operations";
+    private static final String LOCATIONS_SERVICE = "google.cloud.location.Locations";
+
+    @Test
+    void operationsMethodDescriptorsExposeUnaryGoogleLongrunningContract() {
+        MethodDescriptor<ListOperationsRequest, ListOperationsResponse> listMethod =
+                OperationsGrpc.getListOperationsMethod();
+        MethodDescriptor<GetOperationRequest, Operation> getMethod = OperationsGrpc.getGetOperationMethod();
+        MethodDescriptor<DeleteOperationRequest, Empty> deleteMethod = OperationsGrpc.getDeleteOperationMethod();
+        MethodDescriptor<CancelOperationRequest, Empty> cancelMethod = OperationsGrpc.getCancelOperationMethod();
+        MethodDescriptor<WaitOperationRequest, Operation> waitMethod = OperationsGrpc.getWaitOperationMethod();
+
+        assertUnaryMethod(listMethod, OPERATIONS_SERVICE, "ListOperations");
+        assertUnaryMethod(getMethod, OPERATIONS_SERVICE, "GetOperation");
+        assertUnaryMethod(deleteMethod, OPERATIONS_SERVICE, "DeleteOperation");
+        assertUnaryMethod(cancelMethod, OPERATIONS_SERVICE, "CancelOperation");
+        assertUnaryMethod(waitMethod, OPERATIONS_SERVICE, "WaitOperation");
+
+        ServiceDescriptor serviceDescriptor = OperationsGrpc.getServiceDescriptor();
+        assertThat(serviceDescriptor.getName()).isEqualTo(OPERATIONS_SERVICE);
+        assertThat(serviceDescriptor.getMethods())
+                .containsExactlyInAnyOrder(listMethod, getMethod, deleteMethod, cancelMethod, waitMethod);
+
+        ServerServiceDefinition serviceDefinition = OperationsGrpc.bindService(new OperationsGrpc.AsyncService() { });
+        assertThat(serviceDefinition.getServiceDescriptor().getName()).isEqualTo(OPERATIONS_SERVICE);
+        assertThat(serviceDefinition.getMethod(listMethod.getFullMethodName())).isNotNull();
+        assertThat(serviceDefinition.getMethod(getMethod.getFullMethodName())).isNotNull();
+        assertThat(serviceDefinition.getMethod(deleteMethod.getFullMethodName())).isNotNull();
+        assertThat(serviceDefinition.getMethod(cancelMethod.getFullMethodName())).isNotNull();
+        assertThat(serviceDefinition.getMethod(waitMethod.getFullMethodName())).isNotNull();
+    }
+
+    @Test
+    void locationsMethodDescriptorsExposeUnaryGoogleCloudLocationContract() {
+        MethodDescriptor<ListLocationsRequest, ListLocationsResponse> listMethod =
+                LocationsGrpc.getListLocationsMethod();
+        MethodDescriptor<GetLocationRequest, Location> getMethod = LocationsGrpc.getGetLocationMethod();
+
+        assertUnaryMethod(listMethod, LOCATIONS_SERVICE, "ListLocations");
+        assertUnaryMethod(getMethod, LOCATIONS_SERVICE, "GetLocation");
+
+        ServiceDescriptor serviceDescriptor = LocationsGrpc.getServiceDescriptor();
+        assertThat(serviceDescriptor.getName()).isEqualTo(LOCATIONS_SERVICE);
+        assertThat(serviceDescriptor.getMethods()).containsExactlyInAnyOrder(listMethod, getMethod);
+
+        ServerServiceDefinition serviceDefinition = LocationsGrpc.bindService(new LocationsGrpc.AsyncService() { });
+        assertThat(serviceDefinition.getServiceDescriptor().getName()).isEqualTo(LOCATIONS_SERVICE);
+        assertThat(serviceDefinition.getMethod(listMethod.getFullMethodName())).isNotNull();
+        assertThat(serviceDefinition.getMethod(getMethod.getFullMethodName())).isNotNull();
+    }
+
+    @Test
+    void schemaDescriptorsExposeUnderlyingProtobufDefinitions() {
+        Descriptors.ServiceDescriptor operationsService = assertServiceSchema(
+                OperationsGrpc.getServiceDescriptor(),
+                OperationsProto.getDescriptor(),
+                OPERATIONS_SERVICE);
+        assertMethodSchema(
+                OperationsGrpc.getListOperationsMethod(),
+                operationsService,
+                "ListOperations",
+                ListOperationsRequest.getDescriptor(),
+                ListOperationsResponse.getDescriptor());
+        assertMethodSchema(
+                OperationsGrpc.getGetOperationMethod(),
+                operationsService,
+                "GetOperation",
+                GetOperationRequest.getDescriptor(),
+                Operation.getDescriptor());
+        assertMethodSchema(
+                OperationsGrpc.getDeleteOperationMethod(),
+                operationsService,
+                "DeleteOperation",
+                DeleteOperationRequest.getDescriptor(),
+                Empty.getDescriptor());
+        assertMethodSchema(
+                OperationsGrpc.getCancelOperationMethod(),
+                operationsService,
+                "CancelOperation",
+                CancelOperationRequest.getDescriptor(),
+                Empty.getDescriptor());
+        assertMethodSchema(
+                OperationsGrpc.getWaitOperationMethod(),
+                operationsService,
+                "WaitOperation",
+                WaitOperationRequest.getDescriptor(),
+                Operation.getDescriptor());
+
+        Descriptors.ServiceDescriptor locationsService = assertServiceSchema(
+                LocationsGrpc.getServiceDescriptor(),
+                LocationsProto.getDescriptor(),
+                LOCATIONS_SERVICE);
+        assertMethodSchema(
+                LocationsGrpc.getListLocationsMethod(),
+                locationsService,
+                "ListLocations",
+                ListLocationsRequest.getDescriptor(),
+                ListLocationsResponse.getDescriptor());
+        assertMethodSchema(
+                LocationsGrpc.getGetLocationMethod(),
+                locationsService,
+                "GetLocation",
+                GetLocationRequest.getDescriptor(),
+                Location.getDescriptor());
+    }
+
+    @Test
+    void operationsStubsSendExpectedRequestsAndReturnMappedResponses() throws Exception {
+        ListOperationsRequest listRequest = ListOperationsRequest.newBuilder()
+                .setName("projects/test/locations/global")
+                .setFilter("done = true")
+                .setPageSize(25)
+                .setPageToken("page-token")
+                .build();
+        Operation completedOperation = operation("operations/completed", true);
+        ListOperationsResponse listResponse = ListOperationsResponse.newBuilder()
+                .addOperations(completedOperation)
+                .setNextPageToken("next-page")
+                .build();
+        GetOperationRequest getRequest = GetOperationRequest.newBuilder()
+                .setName("operations/completed")
+                .build();
+        Operation runningOperation = operation("operations/running", false);
+        DeleteOperationRequest deleteRequest = DeleteOperationRequest.newBuilder()
+                .setName("operations/old")
+                .build();
+        CancelOperationRequest cancelRequest = CancelOperationRequest.newBuilder()
+                .setName("operations/running")
+                .build();
+        WaitOperationRequest waitRequest = WaitOperationRequest.newBuilder()
+                .setName("operations/running")
+                .setTimeout(Duration.newBuilder().setSeconds(2).build())
+                .build();
+
+        assertMarshallerRoundTrip(OperationsGrpc.getListOperationsMethod(), listRequest, listResponse);
+        assertMarshallerRoundTrip(OperationsGrpc.getGetOperationMethod(), getRequest, completedOperation);
+        assertMarshallerRoundTrip(OperationsGrpc.getDeleteOperationMethod(), deleteRequest, Empty.getDefaultInstance());
+        assertMarshallerRoundTrip(OperationsGrpc.getCancelOperationMethod(), cancelRequest, Empty.getDefaultInstance());
+        assertMarshallerRoundTrip(OperationsGrpc.getWaitOperationMethod(), waitRequest, runningOperation);
+
+        FakeChannel channel = new FakeChannel()
+                .respondTo(OperationsGrpc.getListOperationsMethod(), listRequest, listResponse)
+                .respondTo(OperationsGrpc.getGetOperationMethod(), getRequest, completedOperation)
+                .respondTo(OperationsGrpc.getDeleteOperationMethod(), deleteRequest, Empty.getDefaultInstance())
+                .respondTo(OperationsGrpc.getCancelOperationMethod(), cancelRequest, Empty.getDefaultInstance())
+                .respondTo(OperationsGrpc.getWaitOperationMethod(), waitRequest, runningOperation);
+
+        OperationsGrpc.OperationsBlockingStub blockingStub = OperationsGrpc.newBlockingStub(channel);
+        assertThat(blockingStub.listOperations(listRequest)).isEqualTo(listResponse);
+        assertThat(blockingStub.getOperation(getRequest)).isEqualTo(completedOperation);
+        assertThat(blockingStub.deleteOperation(deleteRequest)).isEqualTo(Empty.getDefaultInstance());
+        assertThat(blockingStub.cancelOperation(cancelRequest)).isEqualTo(Empty.getDefaultInstance());
+
+        OperationsGrpc.OperationsBlockingV2Stub blockingV2Stub = OperationsGrpc.newBlockingV2Stub(channel);
+        assertThat(blockingV2Stub.waitOperation(waitRequest)).isEqualTo(runningOperation);
+
+        assertThat(channel.calledMethodNames())
+                .containsEntry(OperationsGrpc.getListOperationsMethod().getFullMethodName(), 1)
+                .containsEntry(OperationsGrpc.getGetOperationMethod().getFullMethodName(), 1)
+                .containsEntry(OperationsGrpc.getDeleteOperationMethod().getFullMethodName(), 1)
+                .containsEntry(OperationsGrpc.getCancelOperationMethod().getFullMethodName(), 1)
+                .containsEntry(OperationsGrpc.getWaitOperationMethod().getFullMethodName(), 1);
+    }
+
+    @Test
+    void locationsStubsSendExpectedRequestsAndReturnMappedResponses() throws Exception {
+        Location europeWest = Location.newBuilder()
+                .setName("projects/test/locations/europe-west1")
+                .setLocationId("europe-west1")
+                .setDisplayName("Belgium")
+                .putLabels("region", "europe")
+                .setMetadata(Any.pack(StringValue.of("low-carbon")))
+                .build();
+        Location usCentral = Location.newBuilder()
+                .setName("projects/test/locations/us-central1")
+                .setLocationId("us-central1")
+                .setDisplayName("Iowa")
+                .putLabels("region", "us")
+                .build();
+        ListLocationsRequest listRequest = ListLocationsRequest.newBuilder()
+                .setName("projects/test")
+                .setFilter("labels.region:*")
+                .setPageSize(10)
+                .setPageToken("locations-page")
+                .build();
+        ListLocationsResponse listResponse = ListLocationsResponse.newBuilder()
+                .addLocations(europeWest)
+                .addLocations(usCentral)
+                .setNextPageToken("next-location-page")
+                .build();
+        GetLocationRequest getRequest = GetLocationRequest.newBuilder()
+                .setName("projects/test/locations/europe-west1")
+                .build();
+
+        assertMarshallerRoundTrip(LocationsGrpc.getListLocationsMethod(), listRequest, listResponse);
+        assertMarshallerRoundTrip(LocationsGrpc.getGetLocationMethod(), getRequest, europeWest);
+
+        FakeChannel channel = new FakeChannel()
+                .respondTo(LocationsGrpc.getListLocationsMethod(), listRequest, listResponse)
+                .respondTo(LocationsGrpc.getGetLocationMethod(), getRequest, europeWest);
+
+        LocationsGrpc.LocationsBlockingStub blockingStub = LocationsGrpc.newBlockingStub(channel);
+        assertThat(blockingStub.listLocations(listRequest)).isEqualTo(listResponse);
+
+        LocationsGrpc.LocationsBlockingV2Stub blockingV2Stub = LocationsGrpc.newBlockingV2Stub(channel);
+        assertThat(blockingV2Stub.getLocation(getRequest)).isEqualTo(europeWest);
+
+        assertThat(channel.calledMethodNames())
+                .containsEntry(LocationsGrpc.getListLocationsMethod().getFullMethodName(), 1)
+                .containsEntry(LocationsGrpc.getGetLocationMethod().getFullMethodName(), 1);
+    }
+
+    @Test
+    void futureAndAsyncStubsCompleteUnaryCalls() throws Exception {
+        GetOperationRequest operationRequest = GetOperationRequest.newBuilder()
+                .setName("operations/future")
+                .build();
+        Operation operationResponse = operation("operations/future", true);
+        GetLocationRequest locationRequest = GetLocationRequest.newBuilder()
+                .setName("projects/test/locations/asia-northeast1")
+                .build();
+        Location locationResponse = Location.newBuilder()
+                .setName("projects/test/locations/asia-northeast1")
+                .setLocationId("asia-northeast1")
+                .setDisplayName("Tokyo")
+                .build();
+        ListOperationsRequest asyncListRequest = ListOperationsRequest.newBuilder()
+                .setName("projects/test/locations/global")
+                .build();
+        ListOperationsResponse asyncListResponse = ListOperationsResponse.newBuilder()
+                .addOperations(operation("operations/async", false))
+                .build();
+
+        FakeChannel channel = new FakeChannel()
+                .respondTo(OperationsGrpc.getGetOperationMethod(), operationRequest, operationResponse)
+                .respondTo(LocationsGrpc.getGetLocationMethod(), locationRequest, locationResponse)
+                .respondTo(OperationsGrpc.getListOperationsMethod(), asyncListRequest, asyncListResponse);
+
+        ListenableFuture<Operation> operationFuture =
+                OperationsGrpc.newFutureStub(channel).getOperation(operationRequest);
+        ListenableFuture<Location> locationFuture = LocationsGrpc.newFutureStub(channel).getLocation(locationRequest);
+
+        assertThat(operationFuture.get(5, TimeUnit.SECONDS)).isEqualTo(operationResponse);
+        assertThat(locationFuture.get(5, TimeUnit.SECONDS)).isEqualTo(locationResponse);
+
+        CountDownLatch completed = new CountDownLatch(1);
+        AtomicReference<ListOperationsResponse> asyncResponse = new AtomicReference<>();
+        AtomicReference<Throwable> asyncError = new AtomicReference<>();
+        OperationsGrpc.newStub(channel).listOperations(asyncListRequest, new StreamObserver<ListOperationsResponse>() {
+            @Override
+            public void onNext(ListOperationsResponse value) {
+                asyncResponse.set(value);
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                asyncError.set(throwable);
+                completed.countDown();
+            }
+
+            @Override
+            public void onCompleted() {
+                completed.countDown();
+            }
+        });
+
+        assertThat(completed.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(asyncError.get()).isNull();
+        assertThat(asyncResponse.get()).isEqualTo(asyncListResponse);
+    }
+
+    @Test
+    void boundAsyncServicesDispatchUnaryRequestsToImplementations() {
+        WaitOperationRequest waitRequest = WaitOperationRequest.newBuilder()
+                .setName("operations/server-dispatch")
+                .setTimeout(Duration.newBuilder().setSeconds(1).build())
+                .build();
+        Operation waitResponse = operation("operations/server-dispatch", true);
+        ServerServiceDefinition operationsService = OperationsGrpc.bindService(new OperationsGrpc.AsyncService() {
+            @Override
+            public void waitOperation(
+                    WaitOperationRequest request,
+                    StreamObserver<Operation> responseObserver) {
+                assertThat(request).isEqualTo(waitRequest);
+                responseObserver.onNext(waitResponse);
+                responseObserver.onCompleted();
+            }
+        });
+
+        Operation dispatchedOperation =
+                invokeUnary(operationsService, OperationsGrpc.getWaitOperationMethod(), waitRequest);
+
+        assertThat(dispatchedOperation).isEqualTo(waitResponse);
+
+        GetLocationRequest locationRequest = GetLocationRequest.newBuilder()
+                .setName("projects/test/locations/australia-southeast1")
+                .build();
+        Location locationResponse = Location.newBuilder()
+                .setName("projects/test/locations/australia-southeast1")
+                .setLocationId("australia-southeast1")
+                .setDisplayName("Sydney")
+                .build();
+        ServerServiceDefinition locationsService = LocationsGrpc.bindService(new LocationsGrpc.AsyncService() {
+            @Override
+            public void getLocation(
+                    GetLocationRequest request,
+                    StreamObserver<Location> responseObserver) {
+                assertThat(request).isEqualTo(locationRequest);
+                responseObserver.onNext(locationResponse);
+                responseObserver.onCompleted();
+            }
+        });
+
+        Location dispatchedLocation =
+                invokeUnary(locationsService, LocationsGrpc.getGetLocationMethod(), locationRequest);
+
+        assertThat(dispatchedLocation).isEqualTo(locationResponse);
+    }
+
+    private static Operation operation(String name, boolean done) {
+        return Operation.newBuilder()
+                .setName(name)
+                .setDone(done)
+                .setResponse(Any.pack(StringValue.of(name + " response")))
+                .build();
+    }
+
+    private static <RequestT, ResponseT> void assertUnaryMethod(
+            MethodDescriptor<RequestT, ResponseT> method,
+            String serviceName,
+            String methodName) {
+        assertThat(method.getType()).isEqualTo(MethodDescriptor.MethodType.UNARY);
+        assertThat(method.getServiceName()).isEqualTo(serviceName);
+        assertThat(method.getFullMethodName())
+                .isEqualTo(MethodDescriptor.generateFullMethodName(serviceName, methodName));
+        assertThat(method.getRequestMarshaller()).isNotNull();
+        assertThat(method.getResponseMarshaller()).isNotNull();
+        assertThat(method.getSchemaDescriptor()).isNotNull();
+    }
+
+    private static Descriptors.ServiceDescriptor assertServiceSchema(
+            ServiceDescriptor serviceDescriptor,
+            Descriptors.FileDescriptor fileDescriptor,
+            String serviceName) {
+        assertThat(serviceDescriptor.getSchemaDescriptor()).isInstanceOf(ProtoServiceDescriptorSupplier.class);
+        ProtoServiceDescriptorSupplier serviceSupplier =
+                (ProtoServiceDescriptorSupplier) serviceDescriptor.getSchemaDescriptor();
+
+        assertThat(serviceSupplier.getFileDescriptor()).isEqualTo(fileDescriptor);
+        Descriptors.ServiceDescriptor protoService = serviceSupplier.getServiceDescriptor();
+        assertThat(protoService.getFullName()).isEqualTo(serviceName);
+        assertThat(protoService.getFile()).isEqualTo(fileDescriptor);
+        return protoService;
+    }
+
+    private static <RequestT, ResponseT> void assertMethodSchema(
+            MethodDescriptor<RequestT, ResponseT> grpcMethod,
+            Descriptors.ServiceDescriptor protoService,
+            String methodName,
+            Descriptors.Descriptor requestType,
+            Descriptors.Descriptor responseType) {
+        assertThat(grpcMethod.getSchemaDescriptor()).isInstanceOf(ProtoMethodDescriptorSupplier.class);
+        ProtoMethodDescriptorSupplier methodSupplier =
+                (ProtoMethodDescriptorSupplier) grpcMethod.getSchemaDescriptor();
+
+        Descriptors.MethodDescriptor protoMethod = methodSupplier.getMethodDescriptor();
+        assertThat(protoMethod).isEqualTo(protoService.findMethodByName(methodName));
+        assertThat(protoMethod.getInputType()).isEqualTo(requestType);
+        assertThat(protoMethod.getOutputType()).isEqualTo(responseType);
+        assertThat(methodSupplier.getServiceDescriptor()).isEqualTo(protoService);
+        assertThat(methodSupplier.getFileDescriptor()).isEqualTo(protoService.getFile());
+    }
+
+    private static <RequestT, ResponseT> void assertMarshallerRoundTrip(
+            MethodDescriptor<RequestT, ResponseT> method,
+            RequestT request,
+            ResponseT response) throws IOException {
+        try (InputStream input = method.streamRequest(request)) {
+            assertThat(method.parseRequest(input)).isEqualTo(request);
+        }
+        try (InputStream input = method.streamResponse(response)) {
+            assertThat(method.parseResponse(input)).isEqualTo(response);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <RequestT, ResponseT> ResponseT invokeUnary(
+            ServerServiceDefinition serviceDefinition,
+            MethodDescriptor<RequestT, ResponseT> method,
+            RequestT request) {
+        ServerMethodDefinition<RequestT, ResponseT> methodDefinition =
+                (ServerMethodDefinition<RequestT, ResponseT>) serviceDefinition.getMethod(method.getFullMethodName());
+        assertThat(methodDefinition)
+                .as("server method definition for %s", method.getFullMethodName())
+                .isNotNull();
+        ServerCallHandler<RequestT, ResponseT> callHandler = methodDefinition.getServerCallHandler();
+        CapturingServerCall<RequestT, ResponseT> serverCall = new CapturingServerCall<>(method);
+
+        ServerCall.Listener<RequestT> listener = callHandler.startCall(serverCall, new Metadata());
+        listener.onMessage(request);
+        listener.onHalfClose();
+
+        assertThat(serverCall.status()).isEqualTo(Status.OK);
+        return serverCall.response();
+    }
+
+    private static final class FakeChannel extends Channel {
+        private final Map<String, CallDefinition<?, ?>> definitions = new HashMap<>();
+        private final Map<String, Integer> calledMethodNames = new HashMap<>();
+
+        private <RequestT, ResponseT> FakeChannel respondTo(
+                MethodDescriptor<RequestT, ResponseT> method,
+                RequestT expectedRequest,
+                ResponseT response) {
+            definitions.put(method.getFullMethodName(), new CallDefinition<>(expectedRequest, response));
+            return this;
+        }
+
+        @Override
+        public <RequestT, ResponseT> ClientCall<RequestT, ResponseT> newCall(
+                MethodDescriptor<RequestT, ResponseT> method,
+                CallOptions callOptions) {
+            calledMethodNames.merge(method.getFullMethodName(), 1, Integer::sum);
+            CallDefinition<?, ?> definition = definitions.get(method.getFullMethodName());
+            assertThat(definition)
+                    .as("registered fake response for %s", method.getFullMethodName())
+                    .isNotNull();
+            return new FakeClientCall<>(method, definition);
+        }
+
+        @Override
+        public String authority() {
+            return "fake.grpc-google-common-protos.test";
+        }
+
+        private Map<String, Integer> calledMethodNames() {
+            return calledMethodNames;
+        }
+    }
+
+    private static final class CapturingServerCall<RequestT, ResponseT> extends ServerCall<RequestT, ResponseT> {
+        private final MethodDescriptor<RequestT, ResponseT> method;
+        private ResponseT response;
+        private Status status;
+
+        private CapturingServerCall(MethodDescriptor<RequestT, ResponseT> method) {
+            this.method = method;
+        }
+
+        @Override
+        public void request(int messageCount) {
+            assertThat(messageCount).isPositive();
+        }
+
+        @Override
+        public void sendHeaders(Metadata headers) {
+            assertThat(headers).isNotNull();
+        }
+
+        @Override
+        public void sendMessage(ResponseT message) {
+            this.response = message;
+        }
+
+        @Override
+        public void close(Status status, Metadata trailers) {
+            assertThat(trailers).isNotNull();
+            this.status = status;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return false;
+        }
+
+        @Override
+        public MethodDescriptor<RequestT, ResponseT> getMethodDescriptor() {
+            return method;
+        }
+
+        private ResponseT response() {
+            return response;
+        }
+
+        private Status status() {
+            return status;
+        }
+    }
+
+    private static final class FakeClientCall<RequestT, ResponseT> extends ClientCall<RequestT, ResponseT> {
+        private final MethodDescriptor<RequestT, ResponseT> method;
+        private final CallDefinition<?, ?> definition;
+        private Listener<ResponseT> listener;
+        private RequestT request;
+
+        private FakeClientCall(MethodDescriptor<RequestT, ResponseT> method, CallDefinition<?, ?> definition) {
+            this.method = method;
+            this.definition = definition;
+        }
+
+        @Override
+        public void start(Listener<ResponseT> listener, Metadata headers) {
+            this.listener = listener;
+            listener.onHeaders(new Metadata());
+        }
+
+        @Override
+        public void request(int messageCount) {
+            assertThat(messageCount).isPositive();
+        }
+
+        @Override
+        public void cancel(String message, Throwable cause) {
+            fail("Unexpected cancellation for " + method.getFullMethodName());
+        }
+
+        @Override
+        public void halfClose() {
+            assertThat(request)
+                    .as("request sent to %s", method.getFullMethodName())
+                    .isEqualTo(definition.expectedRequest());
+            listener.onMessage(method.parseResponse(method.streamResponse(response())));
+            listener.onClose(Status.OK, new Metadata());
+        }
+
+        @Override
+        public void sendMessage(RequestT message) {
+            this.request = method.parseRequest(method.streamRequest(message));
+        }
+
+        @SuppressWarnings("unchecked")
+        private ResponseT response() {
+            return (ResponseT) definition.response();
+        }
+    }
+
+    private static final class CallDefinition<RequestT, ResponseT> {
+        private final RequestT expectedRequest;
+        private final ResponseT response;
+
+        private CallDefinition(RequestT expectedRequest, ResponseT response) {
+            this.expectedRequest = expectedRequest;
+            this.response = response;
+        }
+
+        private RequestT expectedRequest() {
+            return expectedRequest;
+        }
+
+        private ResponseT response() {
+            return response;
+        }
+    }
+}

--- a/tests/src/com.google.api.grpc/grpc-google-common-protos/2.72.0/src/test/java/com_google_api_grpc/grpc_google_common_protos/Grpc_google_common_protosTest.java
+++ b/tests/src/com.google.api.grpc/grpc-google-common-protos/2.72.0/src/test/java/com_google_api_grpc/grpc_google_common_protos/Grpc_google_common_protosTest.java
@@ -14,7 +14,6 @@ import com.google.cloud.location.ListLocationsRequest;
 import com.google.cloud.location.ListLocationsResponse;
 import com.google.cloud.location.Location;
 import com.google.cloud.location.LocationsGrpc;
-import com.google.cloud.location.LocationsProto;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.longrunning.CancelOperationRequest;
 import com.google.longrunning.DeleteOperationRequest;
@@ -23,10 +22,8 @@ import com.google.longrunning.ListOperationsRequest;
 import com.google.longrunning.ListOperationsResponse;
 import com.google.longrunning.Operation;
 import com.google.longrunning.OperationsGrpc;
-import com.google.longrunning.OperationsProto;
 import com.google.longrunning.WaitOperationRequest;
 import com.google.protobuf.Any;
-import com.google.protobuf.Descriptors;
 import com.google.protobuf.Duration;
 import com.google.protobuf.Empty;
 import com.google.protobuf.StringValue;
@@ -106,58 +103,17 @@ public class Grpc_google_common_protosTest {
     }
 
     @Test
-    void schemaDescriptorsExposeUnderlyingProtobufDefinitions() {
-        Descriptors.ServiceDescriptor operationsService = assertServiceSchema(
-                OperationsGrpc.getServiceDescriptor(),
-                OperationsProto.getDescriptor(),
-                OPERATIONS_SERVICE);
-        assertMethodSchema(
-                OperationsGrpc.getListOperationsMethod(),
-                operationsService,
-                "ListOperations",
-                ListOperationsRequest.getDescriptor(),
-                ListOperationsResponse.getDescriptor());
-        assertMethodSchema(
-                OperationsGrpc.getGetOperationMethod(),
-                operationsService,
-                "GetOperation",
-                GetOperationRequest.getDescriptor(),
-                Operation.getDescriptor());
-        assertMethodSchema(
-                OperationsGrpc.getDeleteOperationMethod(),
-                operationsService,
-                "DeleteOperation",
-                DeleteOperationRequest.getDescriptor(),
-                Empty.getDescriptor());
-        assertMethodSchema(
-                OperationsGrpc.getCancelOperationMethod(),
-                operationsService,
-                "CancelOperation",
-                CancelOperationRequest.getDescriptor(),
-                Empty.getDescriptor());
-        assertMethodSchema(
-                OperationsGrpc.getWaitOperationMethod(),
-                operationsService,
-                "WaitOperation",
-                WaitOperationRequest.getDescriptor(),
-                Operation.getDescriptor());
+    void schemaDescriptorSuppliersAreAttachedToGrpcDescriptors() {
+        assertServiceSchemaDescriptor(OperationsGrpc.getServiceDescriptor());
+        assertMethodSchemaDescriptor(OperationsGrpc.getListOperationsMethod());
+        assertMethodSchemaDescriptor(OperationsGrpc.getGetOperationMethod());
+        assertMethodSchemaDescriptor(OperationsGrpc.getDeleteOperationMethod());
+        assertMethodSchemaDescriptor(OperationsGrpc.getCancelOperationMethod());
+        assertMethodSchemaDescriptor(OperationsGrpc.getWaitOperationMethod());
 
-        Descriptors.ServiceDescriptor locationsService = assertServiceSchema(
-                LocationsGrpc.getServiceDescriptor(),
-                LocationsProto.getDescriptor(),
-                LOCATIONS_SERVICE);
-        assertMethodSchema(
-                LocationsGrpc.getListLocationsMethod(),
-                locationsService,
-                "ListLocations",
-                ListLocationsRequest.getDescriptor(),
-                ListLocationsResponse.getDescriptor());
-        assertMethodSchema(
-                LocationsGrpc.getGetLocationMethod(),
-                locationsService,
-                "GetLocation",
-                GetLocationRequest.getDescriptor(),
-                Location.getDescriptor());
+        assertServiceSchemaDescriptor(LocationsGrpc.getServiceDescriptor());
+        assertMethodSchemaDescriptor(LocationsGrpc.getListLocationsMethod());
+        assertMethodSchemaDescriptor(LocationsGrpc.getGetLocationMethod());
     }
 
     @Test
@@ -224,18 +180,16 @@ public class Grpc_google_common_protosTest {
                 .setName("projects/test/locations/europe-west1")
                 .setLocationId("europe-west1")
                 .setDisplayName("Belgium")
-                .putLabels("region", "europe")
                 .setMetadata(Any.pack(StringValue.of("low-carbon")))
                 .build();
         Location usCentral = Location.newBuilder()
                 .setName("projects/test/locations/us-central1")
                 .setLocationId("us-central1")
                 .setDisplayName("Iowa")
-                .putLabels("region", "us")
                 .build();
         ListLocationsRequest listRequest = ListLocationsRequest.newBuilder()
                 .setName("projects/test")
-                .setFilter("labels.region:*")
+                .setFilter("display_name:Belgium")
                 .setPageSize(10)
                 .setPageToken("locations-page")
                 .build();
@@ -394,37 +348,13 @@ public class Grpc_google_common_protosTest {
         assertThat(method.getSchemaDescriptor()).isNotNull();
     }
 
-    private static Descriptors.ServiceDescriptor assertServiceSchema(
-            ServiceDescriptor serviceDescriptor,
-            Descriptors.FileDescriptor fileDescriptor,
-            String serviceName) {
+    private static void assertServiceSchemaDescriptor(ServiceDescriptor serviceDescriptor) {
         assertThat(serviceDescriptor.getSchemaDescriptor()).isInstanceOf(ProtoServiceDescriptorSupplier.class);
-        ProtoServiceDescriptorSupplier serviceSupplier =
-                (ProtoServiceDescriptorSupplier) serviceDescriptor.getSchemaDescriptor();
-
-        assertThat(serviceSupplier.getFileDescriptor()).isEqualTo(fileDescriptor);
-        Descriptors.ServiceDescriptor protoService = serviceSupplier.getServiceDescriptor();
-        assertThat(protoService.getFullName()).isEqualTo(serviceName);
-        assertThat(protoService.getFile()).isEqualTo(fileDescriptor);
-        return protoService;
     }
 
-    private static <RequestT, ResponseT> void assertMethodSchema(
-            MethodDescriptor<RequestT, ResponseT> grpcMethod,
-            Descriptors.ServiceDescriptor protoService,
-            String methodName,
-            Descriptors.Descriptor requestType,
-            Descriptors.Descriptor responseType) {
+    private static <RequestT, ResponseT> void assertMethodSchemaDescriptor(
+            MethodDescriptor<RequestT, ResponseT> grpcMethod) {
         assertThat(grpcMethod.getSchemaDescriptor()).isInstanceOf(ProtoMethodDescriptorSupplier.class);
-        ProtoMethodDescriptorSupplier methodSupplier =
-                (ProtoMethodDescriptorSupplier) grpcMethod.getSchemaDescriptor();
-
-        Descriptors.MethodDescriptor protoMethod = methodSupplier.getMethodDescriptor();
-        assertThat(protoMethod).isEqualTo(protoService.findMethodByName(methodName));
-        assertThat(protoMethod.getInputType()).isEqualTo(requestType);
-        assertThat(protoMethod.getOutputType()).isEqualTo(responseType);
-        assertThat(methodSupplier.getServiceDescriptor()).isEqualTo(protoService);
-        assertThat(methodSupplier.getFileDescriptor()).isEqualTo(protoService.getFile());
     }
 
     private static <RequestT, ResponseT> void assertMarshallerRoundTrip(

--- a/tests/src/com.google.api.grpc/grpc-google-common-protos/2.72.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.google.api.grpc/grpc-google-common-protos/2.72.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.grpc_google_common_protos.Grpc_google_common_protosTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.grpc_google_common_protos.Grpc_google_common_protosTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/tests/src/com.google.api.grpc/grpc-google-common-protos/2.72.0/user-code-filter.json
+++ b/tests/src/com.google.api.grpc/grpc-google-common-protos/2.72.0/user-code-filter.json
@@ -1,0 +1,16 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.google.cloud.location.**"
+    },
+    {
+      "includeClasses" : "com.google.longrunning.**"
+    },
+    {
+      "includeClasses" : "com_google_api_grpc.grpc_google_common_protos.**"
+    }
+  ]
+}

--- a/tests/src/com.google.api.grpc/grpc-google-common-protos/2.72.0/user-code-filter.json
+++ b/tests/src/com.google.api.grpc/grpc-google-common-protos/2.72.0/user-code-filter.json
@@ -10,6 +10,12 @@
       "includeClasses" : "com.google.longrunning.**"
     },
     {
+      "includeClasses" : "com.google.api.**"
+    },
+    {
+      "includeClasses" : "com.google.protobuf.**"
+    },
+    {
       "includeClasses" : "com_google_api_grpc.grpc_google_common_protos.**"
     }
   ]


### PR DESCRIPTION
## What does this PR do?

Fixes: #7847

This PR provides test fixes and new metadata for com.google.api.grpc:grpc-google-common-protos:2.72.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 50067
- Cached input tokens: 415744
- Output tokens: 4807
- Metadata entries: 21
- Test-only metadata entries: 2
- Iterations: 1
- Library coverage percentage: 42.61
- Previous library version metadata entries: 168
- Previous library version coverage percentage: 46.02

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `e80d9c13024405ccea90af188a76d2f7836e05d3`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.google.api.grpc:grpc-google-common-protos:2.70.0: 0/0 covered calls (100.00%)
- com.google.api.grpc:grpc-google-common-protos:2.72.0: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.google.api.grpc:grpc-google-common-protos:2.70.0: 286/614 (46.58%)
- com.google.api.grpc:grpc-google-common-protos:2.72.0: 260/614 (42.35%)

**Line:**
- com.google.api.grpc:grpc-google-common-protos:2.70.0: 81/176 (46.02%)
- com.google.api.grpc:grpc-google-common-protos:2.72.0: 75/176 (42.61%)

**Method:**
- com.google.api.grpc:grpc-google-common-protos:2.70.0: 47/89 (52.81%)
- com.google.api.grpc:grpc-google-common-protos:2.72.0: 41/89 (46.07%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/com.google.api.grpc/grpc-google-common-protos/2.70.0/src/test/java/com_google_api_grpc/grpc_google_common_protos/Grpc_google_common_protosTest.java b/tests/src/com.google.api.grpc/grpc-google-common-protos/2.72.0/src/test/java/com_google_api_grpc/grpc_google_common_protos/Grpc_google_common_protosTest.java
index 258790ebef..7af9c2da30 100644
--- a/tests/src/com.google.api.grpc/grpc-google-common-protos/2.70.0/src/test/java/com_google_api_grpc/grpc_google_common_protos/Grpc_google_common_protosTest.java
+++ b/tests/src/com.google.api.grpc/grpc-google-common-protos/2.72.0/src/test/java/com_google_api_grpc/grpc_google_common_protos/Grpc_google_common_protosTest.java
@@ -14,7 +14,6 @@ import com.google.cloud.location.ListLocationsRequest;
 import com.google.cloud.location.ListLocationsResponse;
 import com.google.cloud.location.Location;
 import com.google.cloud.location.LocationsGrpc;
-import com.google.cloud.location.LocationsProto;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.longrunning.CancelOperationRequest;
 import com.google.longrunning.DeleteOperationRequest;
@@ -23,10 +22,8 @@ import com.google.longrunning.ListOperationsRequest;
 import com.google.longrunning.ListOperationsResponse;
 import com.google.longrunning.Operation;
 import com.google.longrunning.OperationsGrpc;
-import com.google.longrunning.OperationsProto;
 import com.google.longrunning.WaitOperationRequest;
 import com.google.protobuf.Any;
-import com.google.protobuf.Descriptors;
 import com.google.protobuf.Duration;
 import com.google.protobuf.Empty;
 import com.google.protobuf.StringValue;
@@ -106,58 +103,17 @@ public class Grpc_google_common_protosTest {
     }
 
     @Test
-    void schemaDescriptorsExposeUnderlyingProtobufDefinitions() {
-        Descriptors.ServiceDescriptor operationsService = assertServiceSchema(
-                OperationsGrpc.getServiceDescriptor(),
-                OperationsProto.getDescriptor(),
-                OPERATIONS_SERVICE);
-        assertMethodSchema(
-                OperationsGrpc.getListOperationsMethod(),
-                operationsService,
-                "ListOperations",
-                ListOperationsRequest.getDescriptor(),
-                ListOperationsResponse.getDescriptor());
-        assertMethodSchema(
-                OperationsGrpc.getGetOperationMethod(),
-                operationsService,
-                "GetOperation",
-                GetOperationRequest.getDescriptor(),
-                Operation.getDescriptor());
-        assertMethodSchema(
-                OperationsGrpc.getDeleteOperationMethod(),
-                operationsService,
-                "DeleteOperation",
-                DeleteOperationRequest.getDescriptor(),
-                Empty.getDescriptor());
-        assertMethodSchema(
-                OperationsGrpc.getCancelOperationMethod(),
-                operationsService,
-                "CancelOperation",
-                CancelOperationRequest.getDescriptor(),
-                Empty.getDescriptor());
-        assertMethodSchema(
-                OperationsGrpc.getWaitOperationMethod(),
-                operationsService,
-                "WaitOperation",
-                WaitOperationRequest.getDescriptor(),
-                Operation.getDescriptor());
-
-        Descriptors.ServiceDescriptor locationsService = assertServiceSchema(
-                LocationsGrpc.getServiceDescriptor(),
-                LocationsProto.getDescriptor(),
-                LOCATIONS_SERVICE);
-        assertMethodSchema(
-                LocationsGrpc.getListLocationsMethod(),
-                locationsService,
-                "ListLocations",
-                ListLocationsRequest.getDescriptor(),
-                ListLocationsResponse.getDescriptor());
-        assertMethodSchema(
-                LocationsGrpc.getGetLocationMethod(),
-                locationsService,
-                "GetLocation",
-                GetLocationRequest.getDescriptor(),
-                Location.getDescriptor());
+    void schemaDescriptorSuppliersAreAttachedToGrpcDescriptors() {
+        assertServiceSchemaDescriptor(OperationsGrpc.getServiceDescriptor());
+        assertMethodSchemaDescriptor(OperationsGrpc.getListOperationsMethod());
+        assertMethodSchemaDescriptor(OperationsGrpc.getGetOperationMethod());
+        assertMethodSchemaDescriptor(OperationsGrpc.getDeleteOperationMethod());
+        assertMethodSchemaDescriptor(OperationsGrpc.getCancelOperationMethod());
+        assertMethodSchemaDescriptor(OperationsGrpc.getWaitOperationMethod());
+
+        assertServiceSchemaDescriptor(LocationsGrpc.getServiceDescriptor());
+        assertMethodSchemaDescriptor(LocationsGrpc.getListLocationsMethod());
+        assertMethodSchemaDescriptor(LocationsGrpc.getGetLocationMethod());
     }
 
     @Test
@@ -224,18 +180,16 @@ public class Grpc_google_common_protosTest {
                 .setName("projects/test/locations/europe-west1")
                 .setLocationId("europe-west1")
                 .setDisplayName("Belgium")
-                .putLabels("region", "europe")
                 .setMetadata(Any.pack(StringValue.of("low-carbon")))
                 .build();
         Location usCentral = Location.newBuilder()
                 .setName("projects/test/locations/us-central1")
                 .setLocationId("us-central1")
                 .setDisplayName("Iowa")
-                .putLabels("region", "us")
                 .build();
         ListLocationsRequest listRequest = ListLocationsRequest.newBuilder()
                 .setName("projects/test")
-                .setFilter("labels.region:*")
+                .setFilter("display_name:Belgium")
                 .setPageSize(10)
                 .setPageToken("locations-page")
                 .build();
@@ -394,37 +348,13 @@ public class Grpc_google_common_protosTest {
         assertThat(method.getSchemaDescriptor()).isNotNull();
     }
 
-    private static Descriptors.ServiceDescriptor assertServiceSchema(
-            ServiceDescriptor serviceDescriptor,
-            Descriptors.FileDescriptor fileDescriptor,
-            String serviceName) {
+    private static void assertServiceSchemaDescriptor(ServiceDescriptor serviceDescriptor) {
         assertThat(serviceDescriptor.getSchemaDescriptor()).isInstanceOf(ProtoServiceDescriptorSupplier.class);
-        ProtoServiceDescriptorSupplier serviceSupplier =
-                (ProtoServiceDescriptorSupplier) serviceDescriptor.getSchemaDescriptor();
-
-        assertThat(serviceSupplier.getFileDescriptor()).isEqualTo(fileDescriptor);
-        Descriptors.ServiceDescriptor protoService = serviceSupplier.getServiceDescriptor();
-        assertThat(protoService.getFullName()).isEqualTo(serviceName);
-        assertThat(protoService.getFile()).isEqualTo(fileDescriptor);
-        return protoService;
     }
 
-    private static <RequestT, ResponseT> void assertMethodSchema(
-            MethodDescriptor<RequestT, ResponseT> grpcMethod,
-            Descriptors.ServiceDescriptor protoService,
-            String methodName,
-            Descriptors.Descriptor requestType,
-            Descriptors.Descriptor responseType) {
+    private static <RequestT, ResponseT> void assertMethodSchemaDescriptor(
+            MethodDescriptor<RequestT, ResponseT> grpcMethod) {
         assertThat(grpcMethod.getSchemaDescriptor()).isInstanceOf(ProtoMethodDescriptorSupplier.class);
-        ProtoMethodDescriptorSupplier methodSupplier =
-                (ProtoMethodDescriptorSupplier) grpcMethod.getSchemaDescriptor();
-
-        Descriptors.MethodDescriptor protoMethod = methodSupplier.getMethodDescriptor();
-        assertThat(protoMethod).isEqualTo(protoService.findMethodByName(methodName));
-        assertThat(protoMethod.getInputType()).isEqualTo(requestType);
-        assertThat(protoMethod.getOutputType()).isEqualTo(responseType);
-        assertThat(methodSupplier.getServiceDescriptor()).isEqualTo(protoService);
-        assertThat(methodSupplier.getFileDescriptor()).isEqualTo(protoService.getFile());
     }
 
     private static <RequestT, ResponseT> void assertMarshallerRoundTrip(
diff --git a/tests/src/com.google.api.grpc/grpc-google-common-protos/2.70.0/user-code-filter.json b/tests/src/com.google.api.grpc/grpc-google-common-protos/2.72.0/user-code-filter.json
index bc035f2526..ed3b7d1b8a 100644
--- a/tests/src/com.google.api.grpc/grpc-google-common-protos/2.70.0/user-code-filter.json
+++ b/tests/src/com.google.api.grpc/grpc-google-common-protos/2.72.0/user-code-filter.json
@@ -9,6 +9,12 @@
     {
       "includeClasses" : "com.google.longrunning.**"
     },
+    {
+      "includeClasses" : "com.google.api.**"
+    },
+    {
+      "includeClasses" : "com.google.protobuf.**"
+    },
     {
       "includeClasses" : "com_google_api_grpc.grpc_google_common_protos.**"
     }

```

### Local CI Verification

- Status: `success`
- Commands run: 14
- Fixup attempts: 0
