### PR TITLE
[GenAI] Test fix for com.google.api.grpc:grpc-google-cloud-spanner-v1:6.118.0 using gpt-5.5

### DIFF
--- a/metadata/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/reachability-metadata.json
+++ b/metadata/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/reachability-metadata.json
@@ -1,399 +1,198 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
+      "condition" : {
+        "typeReached" : "com.google.spanner.v1.CommitResponseProto"
       },
-      "type": "android.app.Application"
+      "type" : "com.google.api.FieldBehavior"
     },
     {
-      "condition": {
-        "typeReached": "com.google.spanner.v1.CommitResponseProto"
+      "condition" : {
+        "typeReached" : "com.google.spanner.v1.TypeProto"
       },
-      "type": "com.google.api.FieldBehavior"
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet"
     },
     {
-      "condition": {
-        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test"
+      "condition" : {
+        "typeReached" : "com.google.spanner.v1.TypeProto"
       },
-      "type": "com.google.common.util.concurrent.AbstractFutureState",
-      "fields": [
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.spanner.v1.TypeProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$EnforceNamingStyle"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.spanner.v1.TypeProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$EnumType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.spanner.v1.TypeProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$FieldPresence"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.spanner.v1.TypeProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$JsonFormat"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.spanner.v1.TypeProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$MessageEncoding"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.spanner.v1.TypeProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$RepeatedFieldEncoding"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.spanner.v1.TypeProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$Utf8Validation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.spanner.v1.TypeProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$VisibilityFeature$DefaultSymbolVisibility"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.spanner.v1.CreateSessionRequest"
+      },
+      "type" : "com.google.protobuf.ExtensionRegistry",
+      "methods" : [
         {
-          "name": "listenersField"
-        },
-        {
-          "name": "valueField"
-        },
-        {
-          "name": "waitersField"
+          "name" : "getEmptyRegistry",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test"
+      "condition" : {
+        "typeReached" : "com.google.spanner.v1.CommitResponseProto"
       },
-      "type": "com.google.common.util.concurrent.AbstractFutureState$Waiter",
-      "fields": [
+      "type" : "java.nio.Buffer",
+      "fields" : [
         {
-          "name": "next"
-        },
-        {
-          "name": "thread"
+          "name" : "address"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.google.spanner.v1.TypeProto"
+      "condition" : {
+        "typeReached" : "com.google.spanner.v1.SpannerGrpc$AsyncService"
       },
-      "type": "com.google.protobuf.DescriptorProtos$FeatureSet"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.spanner.v1.TypeProto"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$Builder"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.spanner.v1.TypeProto"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$EnforceNamingStyle"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.spanner.v1.TypeProto"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$EnumType"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.spanner.v1.TypeProto"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$FieldPresence"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.spanner.v1.TypeProto"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$JsonFormat"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.spanner.v1.TypeProto"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$MessageEncoding"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.spanner.v1.TypeProto"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$RepeatedFieldEncoding"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.spanner.v1.TypeProto"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$Utf8Validation"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.spanner.v1.TypeProto"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$VisibilityFeature$DefaultSymbolVisibility"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.spanner.v1.CreateSessionRequest"
-      },
-      "type": "com.google.protobuf.ExtensionRegistry",
-      "methods": [
+      "type" : "java.util.concurrent.atomic.LongAdder",
+      "methods" : [
         {
-          "name": "getEmptyRegistry",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
-      },
-      "type": "io.grpc.census.InternalCensusStatsAccessor"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
-      },
-      "type": "io.grpc.census.InternalCensusTracingAccessor"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
-      },
-      "type": "io.grpc.internal.DnsNameResolverProvider"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
-      },
-      "type": "io.grpc.internal.PickFirstLoadBalancerProvider"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test"
-      },
-      "type": "io.grpc.internal.SerializingExecutor"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test"
-      },
-      "type": "io.grpc.override.ContextStorageOverride"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test"
-      },
-      "type": "io.perfmark.impl.SecretPerfMarkImpl$PerfMarkImpl"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test"
-      },
-      "type": "java.lang.invoke.VarHandle"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.spanner.v1.CommitResponseProto"
-      },
-      "type": "java.nio.Buffer",
-      "fields": [
-        {
-          "name": "address"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
-      },
-      "type": "java.time.Instant"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
-      },
-      "type": "java.util.concurrent.ScheduledThreadPoolExecutor",
-      "methods": [
-        {
-          "name": "setRemoveOnCancelPolicy",
-          "parameterTypes": [
-            "boolean"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.spanner.v1.SpannerGrpc$AsyncService"
-      },
-      "type": "java.util.concurrent.atomic.LongAdder",
-      "methods": [
-        {
-          "name": "add",
-          "parameterTypes": [
+          "name" : "add",
+          "parameterTypes" : [
             "long"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.google.spanner.v1.SpannerGrpc$SpannerBlockingStub"
+      "condition" : {
+        "typeReached" : "com.google.spanner.v1.SpannerGrpc$SpannerBlockingStub"
       },
-      "type": "java.util.concurrent.atomic.LongAdder",
-      "methods": [
+      "type" : "java.util.concurrent.atomic.LongAdder",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "add",
-          "parameterTypes": [
+          "name" : "add",
+          "parameterTypes" : [
             "long"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.google.spanner.v1.SpannerGrpc$SpannerBlockingV2Stub"
+      "condition" : {
+        "typeReached" : "com.google.spanner.v1.SpannerGrpc$SpannerBlockingV2Stub"
       },
-      "type": "java.util.concurrent.atomic.LongAdder",
-      "methods": [
+      "type" : "java.util.concurrent.atomic.LongAdder",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "add",
-          "parameterTypes": [
+          "name" : "add",
+          "parameterTypes" : [
             "long"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.google.spanner.v1.SpannerGrpc$SpannerFutureStub"
+      "condition" : {
+        "typeReached" : "com.google.spanner.v1.SpannerGrpc$SpannerFutureStub"
       },
-      "type": "java.util.concurrent.atomic.LongAdder",
-      "methods": [
+      "type" : "java.util.concurrent.atomic.LongAdder",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "add",
-          "parameterTypes": [
+          "name" : "add",
+          "parameterTypes" : [
             "long"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.google.spanner.v1.SpannerGrpc$SpannerStub"
+      "condition" : {
+        "typeReached" : "com.google.spanner.v1.SpannerGrpc$SpannerStub"
       },
-      "type": "java.util.concurrent.atomic.LongAdder",
-      "methods": [
+      "type" : "java.util.concurrent.atomic.LongAdder",
+      "methods" : [
         {
-          "name": "add",
-          "parameterTypes": [
+          "name" : "add",
+          "parameterTypes" : [
             "long"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test"
+      "condition" : {
+        "typeReached" : "com.google.spanner.v1.CreateSessionRequest"
       },
-      "type": "java.util.concurrent.atomic.LongAdder",
-      "methods": [
+      "type" : "libcore.io.Memory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.spanner.v1.CreateSessionRequest"
+      },
+      "type" : "org.robolectric.Robolectric"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.spanner.v1.CommitResponseProto"
+      },
+      "type" : "sun.misc.Unsafe",
+      "fields" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "add",
-          "parameterTypes": [
-            "long"
-          ]
+          "name" : "theUnsafe"
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$FakeSpannerService"
-      },
-      "type": "java.util.concurrent.atomic.LongAdder",
-      "methods": [
-        {
-          "name": "add",
-          "parameterTypes": [
-            "long"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
-      },
-      "type": "java.util.concurrent.atomic.LongAdder",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.spanner.v1.CreateSessionRequest"
-      },
-      "type": "libcore.io.Memory"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.spanner.v1.CreateSessionRequest"
-      },
-      "type": "org.robolectric.Robolectric"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.spanner.v1.CommitResponseProto"
-      },
-      "type": "sun.misc.Unsafe",
-      "fields": [
-        {
-          "name": "theUnsafe"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
-      },
-      "type": "sun.security.provider.NativePRNG",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.security.SecureRandomParameters"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
-      },
-      "type": "sun.security.provider.SHA",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    }
-  ],
-  "resources": [
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
-      },
-      "glob": "META-INF/services/io.grpc.LoadBalancerProvider"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
-      },
-      "glob": "META-INF/services/io.grpc.NameResolverProvider"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test"
-      },
-      "glob": "META-INF/services/org.assertj.core.configuration.Configuration"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test"
-      },
-      "glob": "META-INF/services/org.assertj.core.presentation.Representation"
     }
   ]
 }

--- a/metadata/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/reachability-metadata.json
+++ b/metadata/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/reachability-metadata.json
@@ -1,0 +1,399 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
+      },
+      "type": "android.app.Application"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.v1.CommitResponseProto"
+      },
+      "type": "com.google.api.FieldBehavior"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test"
+      },
+      "type": "com.google.common.util.concurrent.AbstractFutureState",
+      "fields": [
+        {
+          "name": "listenersField"
+        },
+        {
+          "name": "valueField"
+        },
+        {
+          "name": "waitersField"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test"
+      },
+      "type": "com.google.common.util.concurrent.AbstractFutureState$Waiter",
+      "fields": [
+        {
+          "name": "next"
+        },
+        {
+          "name": "thread"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.v1.TypeProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.v1.TypeProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.v1.TypeProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$EnforceNamingStyle"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.v1.TypeProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$EnumType"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.v1.TypeProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$FieldPresence"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.v1.TypeProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$JsonFormat"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.v1.TypeProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$MessageEncoding"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.v1.TypeProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$RepeatedFieldEncoding"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.v1.TypeProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$Utf8Validation"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.v1.TypeProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$VisibilityFeature$DefaultSymbolVisibility"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.v1.CreateSessionRequest"
+      },
+      "type": "com.google.protobuf.ExtensionRegistry",
+      "methods": [
+        {
+          "name": "getEmptyRegistry",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
+      },
+      "type": "io.grpc.census.InternalCensusStatsAccessor"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
+      },
+      "type": "io.grpc.census.InternalCensusTracingAccessor"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
+      },
+      "type": "io.grpc.internal.DnsNameResolverProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
+      },
+      "type": "io.grpc.internal.PickFirstLoadBalancerProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test"
+      },
+      "type": "io.grpc.internal.SerializingExecutor"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test"
+      },
+      "type": "io.grpc.override.ContextStorageOverride"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test"
+      },
+      "type": "io.perfmark.impl.SecretPerfMarkImpl$PerfMarkImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test"
+      },
+      "type": "java.lang.invoke.VarHandle"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.v1.CommitResponseProto"
+      },
+      "type": "java.nio.Buffer",
+      "fields": [
+        {
+          "name": "address"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
+      },
+      "type": "java.time.Instant"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
+      },
+      "type": "java.util.concurrent.ScheduledThreadPoolExecutor",
+      "methods": [
+        {
+          "name": "setRemoveOnCancelPolicy",
+          "parameterTypes": [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.v1.SpannerGrpc$AsyncService"
+      },
+      "type": "java.util.concurrent.atomic.LongAdder",
+      "methods": [
+        {
+          "name": "add",
+          "parameterTypes": [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.v1.SpannerGrpc$SpannerBlockingStub"
+      },
+      "type": "java.util.concurrent.atomic.LongAdder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "add",
+          "parameterTypes": [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.v1.SpannerGrpc$SpannerBlockingV2Stub"
+      },
+      "type": "java.util.concurrent.atomic.LongAdder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "add",
+          "parameterTypes": [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.v1.SpannerGrpc$SpannerFutureStub"
+      },
+      "type": "java.util.concurrent.atomic.LongAdder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "add",
+          "parameterTypes": [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.v1.SpannerGrpc$SpannerStub"
+      },
+      "type": "java.util.concurrent.atomic.LongAdder",
+      "methods": [
+        {
+          "name": "add",
+          "parameterTypes": [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test"
+      },
+      "type": "java.util.concurrent.atomic.LongAdder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "add",
+          "parameterTypes": [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$FakeSpannerService"
+      },
+      "type": "java.util.concurrent.atomic.LongAdder",
+      "methods": [
+        {
+          "name": "add",
+          "parameterTypes": [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
+      },
+      "type": "java.util.concurrent.atomic.LongAdder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.v1.CreateSessionRequest"
+      },
+      "type": "libcore.io.Memory"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.v1.CreateSessionRequest"
+      },
+      "type": "org.robolectric.Robolectric"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.v1.CommitResponseProto"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
+      },
+      "type": "sun.security.provider.SHA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
+      },
+      "glob": "META-INF/services/io.grpc.LoadBalancerProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
+      },
+      "glob": "META-INF/services/io.grpc.NameResolverProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test"
+      },
+      "glob": "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test"
+      },
+      "glob": "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/metadata/com.google.api.grpc/grpc-google-cloud-spanner-v1/index.json
+++ b/metadata/com.google.api.grpc/grpc-google-cloud-spanner-v1/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "6.118.0",
+    "tested-versions" : [
+      "6.118.0"
+    ],
+    "allowed-packages" : [
+      "com.google.spanner.v1"
+    ]
+  },
+  {
     "metadata-version" : "6.116.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/com/google/api/grpc/grpc-google-cloud-spanner-v1/$version$/grpc-google-cloud-spanner-v1-$version$-sources.jar",
     "repository-url" : "https://github.com/googleapis/google-cloud-java",

--- a/metadata/com.google.api.grpc/grpc-google-cloud-spanner-v1/index.json
+++ b/metadata/com.google.api.grpc/grpc-google-cloud-spanner-v1/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "6.118.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/google/api/grpc/grpc-google-cloud-spanner-v1/$version$/grpc-google-cloud-spanner-v1-$version$-sources.jar",
+    "repository-url" : "https://github.com/googleapis/google-cloud-java",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/com/google/api/grpc/grpc-google-cloud-spanner-v1/$version$/grpc-google-cloud-spanner-v1-$version$-tests.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/google/api/grpc/grpc-google-cloud-spanner-v1/$version$/grpc-google-cloud-spanner-v1-$version$-javadoc.jar",
+    "description" : "This artifact provides generated Java gRPC stubs for the Google Cloud Spanner v1 API. It lets JVM applications call Spanner service RPCs directly using gRPC and the generated protobuf service bindings.",
     "tested-versions" : [
       "6.118.0"
     ],

--- a/stats/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/execution-metrics.json
+++ b/stats/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/execution-metrics.json
@@ -1,0 +1,88 @@
+{
+  "fix_java_run_fail:2026-06-04": {
+    "timestamp": "2026-06-04T14:06:12.619483Z",
+    "library": "com.google.api.grpc:grpc-google-cloud-spanner-v1:6.118.0",
+    "starting_commit": "ef1d6b8dea826f186e6cf8b934e6fe0843e6863f",
+    "ending_commit": "3ea59e64acf024e3e1f1b6822d2def8b131e123e",
+    "previous_library": "com.google.api.grpc:grpc-google-cloud-spanner-v1:6.116.1",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "6.118.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 439,
+          "missed": 472,
+          "ratio": 0.481888,
+          "total": 911
+        },
+        "line": {
+          "covered": 118,
+          "missed": 145,
+          "ratio": 0.448669,
+          "total": 263
+        },
+        "method": {
+          "covered": 46,
+          "missed": 62,
+          "ratio": 0.425926,
+          "total": 108
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "6.116.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 406,
+          "missed": 468,
+          "ratio": 0.464531,
+          "total": 874
+        },
+        "line": {
+          "covered": 109,
+          "missed": 142,
+          "ratio": 0.434263,
+          "total": 251
+        },
+        "method": {
+          "covered": 43,
+          "missed": 61,
+          "ratio": 0.413462,
+          "total": 104
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 52748,
+      "cached_input_tokens_used": 379392,
+      "output_tokens_used": 4194,
+      "iterations": 1,
+      "cost_usd": 0.3155,
+      "tested_library_loc": 118,
+      "metadata_entries": 32,
+      "test_only_metadata_entries": 34,
+      "previous_library_metadata_entries": 44,
+      "code_coverage_percent": 44.87,
+      "previous_library_coverage_percent": 43.43
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/src/test/java/com_google_api_grpc/grpc_google_cloud_spanner_v1/Grpc_google_cloud_spanner_v1Test.java",
+      "metadata_file": "metadata/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/stats.json
+++ b/stats/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "6.118.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 439,
+        "missed" : 472,
+        "ratio" : 0.481888,
+        "total" : 911
+      },
+      "line" : {
+        "covered" : 118,
+        "missed" : 145,
+        "ratio" : 0.448669,
+        "total" : 263
+      },
+      "method" : {
+        "covered" : 46,
+        "missed" : 62,
+        "ratio" : 0.425926,
+        "total" : 108
+      }
+    }
+  } ]
+}

--- a/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/.gitignore
+++ b/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/build.gradle
+++ b/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/build.gradle
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.google.api.grpc:grpc-google-cloud-spanner-v1:$libraryVersion"
+    testImplementation 'io.grpc:grpc-inprocess:1.80.0'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/gradle.properties
+++ b/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.google.api.grpc:grpc-google-cloud-spanner-v1:6.118.0
+library.version = 6.118.0
+metadata.dir = com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/

--- a/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/settings.gradle
+++ b/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.google.api.grpc.grpc-google-cloud-spanner-v1_tests'

--- a/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/src/test/java/com_google_api_grpc/grpc_google_cloud_spanner_v1/Grpc_google_cloud_spanner_v1Test.java
+++ b/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/src/test/java/com_google_api_grpc/grpc_google_cloud_spanner_v1/Grpc_google_cloud_spanner_v1Test.java
@@ -1,0 +1,499 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_api_grpc.grpc_google_cloud_spanner_v1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Empty;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.MessageLite;
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.Value;
+import com.google.rpc.Status;
+import com.google.spanner.v1.BatchCreateSessionsRequest;
+import com.google.spanner.v1.BatchCreateSessionsResponse;
+import com.google.spanner.v1.BatchWriteRequest;
+import com.google.spanner.v1.BatchWriteResponse;
+import com.google.spanner.v1.BeginTransactionRequest;
+import com.google.spanner.v1.CommitRequest;
+import com.google.spanner.v1.CommitResponse;
+import com.google.spanner.v1.CreateSessionRequest;
+import com.google.spanner.v1.DeleteSessionRequest;
+import com.google.spanner.v1.ExecuteBatchDmlRequest;
+import com.google.spanner.v1.ExecuteBatchDmlResponse;
+import com.google.spanner.v1.ExecuteSqlRequest;
+import com.google.spanner.v1.GetSessionRequest;
+import com.google.spanner.v1.ListSessionsRequest;
+import com.google.spanner.v1.ListSessionsResponse;
+import com.google.spanner.v1.PartialResultSet;
+import com.google.spanner.v1.PartitionQueryRequest;
+import com.google.spanner.v1.PartitionReadRequest;
+import com.google.spanner.v1.PartitionResponse;
+import com.google.spanner.v1.ReadRequest;
+import com.google.spanner.v1.ResultSet;
+import com.google.spanner.v1.RollbackRequest;
+import com.google.spanner.v1.Session;
+import com.google.spanner.v1.SpannerGrpc;
+import com.google.spanner.v1.Transaction;
+import io.grpc.ManagedChannel;
+import io.grpc.MethodDescriptor;
+import io.grpc.Server;
+import io.grpc.ServerServiceDefinition;
+import io.grpc.ServiceDescriptor;
+import io.grpc.Status.Code;
+import io.grpc.StatusRuntimeException;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.BlockingClientCall;
+import io.grpc.stub.StreamObserver;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+public class Grpc_google_cloud_spanner_v1Test {
+    private static final String DATABASE = "projects/test/instances/test/databases/test";
+    private static final String SESSION = DATABASE + "/sessions/session-1";
+
+    @Test
+    void serviceDescriptorExposesAllPublicSpannerMethods() {
+        ServiceDescriptor descriptor = SpannerGrpc.getServiceDescriptor();
+        ServerServiceDefinition boundService = SpannerGrpc.bindService(new FakeSpannerService());
+
+        assertThat(descriptor.getName()).isEqualTo(SpannerGrpc.SERVICE_NAME);
+        assertThat(boundService.getServiceDescriptor().getName()).isEqualTo(SpannerGrpc.SERVICE_NAME);
+        assertThat(descriptor.getSchemaDescriptor()).isNotNull();
+        assertThat(boundService.getMethods()).hasSize(16);
+        assertThat(descriptor.getMethods())
+                .extracting(MethodDescriptor::getFullMethodName)
+                .containsExactlyInAnyOrderElementsOf(expectedFullMethodNames());
+
+        assertUnaryMethod(SpannerGrpc.getCreateSessionMethod(), "CreateSession");
+        assertUnaryMethod(SpannerGrpc.getBatchCreateSessionsMethod(), "BatchCreateSessions");
+        assertUnaryMethod(SpannerGrpc.getGetSessionMethod(), "GetSession");
+        assertUnaryMethod(SpannerGrpc.getListSessionsMethod(), "ListSessions");
+        assertUnaryMethod(SpannerGrpc.getDeleteSessionMethod(), "DeleteSession");
+        assertUnaryMethod(SpannerGrpc.getExecuteSqlMethod(), "ExecuteSql");
+        assertServerStreamingMethod(SpannerGrpc.getExecuteStreamingSqlMethod(), "ExecuteStreamingSql");
+        assertUnaryMethod(SpannerGrpc.getExecuteBatchDmlMethod(), "ExecuteBatchDml");
+        assertUnaryMethod(SpannerGrpc.getReadMethod(), "Read");
+        assertServerStreamingMethod(SpannerGrpc.getStreamingReadMethod(), "StreamingRead");
+        assertUnaryMethod(SpannerGrpc.getBeginTransactionMethod(), "BeginTransaction");
+        assertUnaryMethod(SpannerGrpc.getCommitMethod(), "Commit");
+        assertUnaryMethod(SpannerGrpc.getRollbackMethod(), "Rollback");
+        assertUnaryMethod(SpannerGrpc.getPartitionQueryMethod(), "PartitionQuery");
+        assertUnaryMethod(SpannerGrpc.getPartitionReadMethod(), "PartitionRead");
+        assertServerStreamingMethod(SpannerGrpc.getBatchWriteMethod(), "BatchWrite");
+    }
+
+    @Test
+    void methodDescriptorMarshallersRoundTripTypedMessages() throws Exception {
+        CreateSessionRequest request = CreateSessionRequest.newBuilder().setDatabase(DATABASE).build();
+        Session response = session("marshaller-session");
+
+        assertThat(roundTrip(SpannerGrpc.getCreateSessionMethod().getRequestMarshaller(), request)).isEqualTo(request);
+        assertThat(roundTrip(SpannerGrpc.getCreateSessionMethod().getResponseMarshaller(), response))
+                .isEqualTo(response);
+        assertThat(SpannerGrpc.getCreateSessionMethod()).isSameAs(SpannerGrpc.getCreateSessionMethod());
+    }
+
+    @Test
+    void blockingStubInvokesEveryUnaryAndStreamingRpcAgainstInProcessService() throws Exception {
+        try (GrpcFixture fixture = GrpcFixture.start()) {
+            SpannerGrpc.SpannerBlockingStub stub = SpannerGrpc.newBlockingStub(fixture.channel);
+
+            assertThat(stub.createSession(CreateSessionRequest.newBuilder().setDatabase(DATABASE).build()).getName())
+                    .isEqualTo(DATABASE + "/sessions/created");
+            assertThat(stub.batchCreateSessions(batchCreateSessionsRequest()).getSession(0).getCreatorRole())
+                    .isEqualTo("batch:2");
+            assertThat(stub.getSession(GetSessionRequest.newBuilder().setName(SESSION).build()).getName())
+                    .isEqualTo(SESSION);
+            assertThat(stub.listSessions(ListSessionsRequest.newBuilder().setDatabase(DATABASE).setPageSize(10).build())
+                            .getSessionsList())
+                    .extracting(Session::getName)
+                    .containsExactly(DATABASE + "/sessions/listed");
+            assertThat(stub.deleteSession(DeleteSessionRequest.newBuilder().setName(SESSION).build()))
+                    .isEqualTo(Empty.getDefaultInstance());
+            assertThat(stub.executeSql(sqlRequest("select 1")).getRows(0).getValues(0).getStringValue())
+                    .isEqualTo("select 1");
+            assertThat(toList(stub.executeStreamingSql(sqlRequest("stream sql"))))
+                    .extracting(PartialResultSet::getResumeToken)
+                    .containsExactly(ByteString.copyFromUtf8("sql-1"), ByteString.copyFromUtf8("sql-2"));
+            assertThat(stub.executeBatchDml(batchDmlRequest()).getStatus().getMessage()).isEqualTo("dml:1");
+            assertThat(stub.read(readRequest("Albums")).getRows(0).getValues(0).getStringValue()).isEqualTo("Albums");
+            assertThat(toList(stub.streamingRead(readRequest("Singers"))))
+                    .extracting(PartialResultSet::getResumeToken)
+                    .containsExactly(ByteString.copyFromUtf8("read-1"), ByteString.copyFromUtf8("read-2"));
+            assertThat(stub.beginTransaction(BeginTransactionRequest.newBuilder().setSession(SESSION).build()).getId())
+                    .isEqualTo(ByteString.copyFromUtf8(SESSION));
+            assertThat(stub.commit(CommitRequest.newBuilder()
+                            .setSession(SESSION)
+                            .setTransactionId(ByteString.copyFromUtf8("tx-1"))
+                            .build())
+                    .getCommitTimestamp()
+                    .getSeconds())
+                    .isEqualTo(123L);
+            assertThat(stub.rollback(RollbackRequest.newBuilder()
+                            .setSession(SESSION)
+                            .setTransactionId(ByteString.copyFromUtf8("tx-1"))
+                            .build()))
+                    .isEqualTo(Empty.getDefaultInstance());
+            assertThat(stub.partitionQuery(PartitionQueryRequest.newBuilder()
+                                    .setSession(SESSION)
+                                    .setSql("select *")
+                                    .build())
+                            .getTransaction()
+                            .getId())
+                    .isEqualTo(ByteString.copyFromUtf8("partition-query"));
+            assertThat(stub.partitionRead(PartitionReadRequest.newBuilder()
+                                    .setSession(SESSION)
+                                    .setTable("Albums")
+                                    .build())
+                            .getTransaction()
+                            .getId())
+                    .isEqualTo(ByteString.copyFromUtf8("partition-read"));
+            assertThat(toList(stub.batchWrite(BatchWriteRequest.newBuilder().setSession(SESSION).build())))
+                    .extracting(BatchWriteResponse::getIndexesList)
+                    .containsExactly(List.of(0), List.of(1));
+        }
+    }
+
+    @Test
+    void futureAndAsyncStubsDeliverUnaryAndStreamingResponses() throws Exception {
+        try (GrpcFixture fixture = GrpcFixture.start()) {
+            CreateSessionRequest request = CreateSessionRequest.newBuilder().setDatabase(DATABASE).build();
+            ListenableFuture<Session> future = SpannerGrpc.newFutureStub(fixture.channel).createSession(request);
+
+            assertThat(future.get(5, TimeUnit.SECONDS).getName()).isEqualTo(DATABASE + "/sessions/created");
+            assertThat(SpannerGrpc.newBlockingV2Stub(fixture.channel).createSession(request).getName())
+                    .isEqualTo(DATABASE + "/sessions/created");
+
+            RecordingObserver<PartialResultSet> observer = new RecordingObserver<>();
+            SpannerGrpc.newStub(fixture.channel).executeStreamingSql(sqlRequest("async stream"), observer);
+
+            assertThat(observer.awaitValues()).extracting(PartialResultSet::getResumeToken)
+                    .containsExactly(ByteString.copyFromUtf8("sql-1"), ByteString.copyFromUtf8("sql-2"));
+            assertThat(observer.error).isNull();
+        }
+    }
+
+    @Test
+    void blockingV2StubReadsServerStreamingResponsesThroughBlockingClientCall() throws Exception {
+        try (GrpcFixture fixture = GrpcFixture.start()) {
+            SpannerGrpc.SpannerBlockingV2Stub stub = SpannerGrpc.newBlockingV2Stub(fixture.channel);
+
+            BlockingClientCall<?, PartialResultSet> sqlCall = stub.executeStreamingSql(sqlRequest("v2 stream sql"));
+            assertThat(readNext(sqlCall).getResumeToken()).isEqualTo(ByteString.copyFromUtf8("sql-1"));
+            assertThat(readNext(sqlCall).getResumeToken()).isEqualTo(ByteString.copyFromUtf8("sql-2"));
+            assertThat(readNext(sqlCall)).isNull();
+
+            BlockingClientCall<?, PartialResultSet> readCall = stub.streamingRead(readRequest("Singers"));
+            assertThat(readNext(readCall).getResumeToken()).isEqualTo(ByteString.copyFromUtf8("read-1"));
+            assertThat(readNext(readCall).getResumeToken()).isEqualTo(ByteString.copyFromUtf8("read-2"));
+            assertThat(readNext(readCall)).isNull();
+
+            BlockingClientCall<?, BatchWriteResponse> batchWriteCall =
+                    stub.batchWrite(BatchWriteRequest.newBuilder().setSession(SESSION).build());
+            assertThat(readNext(batchWriteCall).getIndexesList()).containsExactly(0);
+            assertThat(readNext(batchWriteCall).getIndexesList()).containsExactly(1);
+            assertThat(readNext(batchWriteCall)).isNull();
+        }
+    }
+
+    @Test
+    void directAsyncServiceReportsUnimplementedForDefaultRpcHandlers() throws Exception {
+        try (GrpcFixture fixture = GrpcFixture.start(new DefaultAsyncSpannerService())) {
+            SpannerGrpc.SpannerBlockingStub stub =
+                    SpannerGrpc.newBlockingStub(fixture.channel).withDeadlineAfter(5, TimeUnit.SECONDS);
+
+            assertThatThrownBy(() -> stub.getSession(GetSessionRequest.newBuilder().setName(SESSION).build()))
+                    .isInstanceOfSatisfying(StatusRuntimeException.class,
+                            exception -> assertThat(exception.getStatus().getCode()).isEqualTo(Code.UNIMPLEMENTED));
+        }
+    }
+
+    private static List<String> expectedFullMethodNames() {
+        return List.of(
+                fullMethodName("CreateSession"),
+                fullMethodName("BatchCreateSessions"),
+                fullMethodName("GetSession"),
+                fullMethodName("ListSessions"),
+                fullMethodName("DeleteSession"),
+                fullMethodName("ExecuteSql"),
+                fullMethodName("ExecuteStreamingSql"),
+                fullMethodName("ExecuteBatchDml"),
+                fullMethodName("Read"),
+                fullMethodName("StreamingRead"),
+                fullMethodName("BeginTransaction"),
+                fullMethodName("Commit"),
+                fullMethodName("Rollback"),
+                fullMethodName("PartitionQuery"),
+                fullMethodName("PartitionRead"),
+                fullMethodName("BatchWrite"));
+    }
+
+    private static void assertUnaryMethod(MethodDescriptor<?, ?> method, String name) {
+        assertThat(method.getType()).isEqualTo(MethodDescriptor.MethodType.UNARY);
+        assertThat(method.getFullMethodName()).isEqualTo(fullMethodName(name));
+        assertThat(method.isSampledToLocalTracing()).isTrue();
+    }
+
+    private static void assertServerStreamingMethod(MethodDescriptor<?, ?> method, String name) {
+        assertThat(method.getType()).isEqualTo(MethodDescriptor.MethodType.SERVER_STREAMING);
+        assertThat(method.getFullMethodName()).isEqualTo(fullMethodName(name));
+        assertThat(method.isSampledToLocalTracing()).isTrue();
+    }
+
+    private static String fullMethodName(String method) {
+        return MethodDescriptor.generateFullMethodName(SpannerGrpc.SERVICE_NAME, method);
+    }
+
+    private static <T extends MessageLite> T roundTrip(MethodDescriptor.Marshaller<T> marshaller, T message)
+            throws Exception {
+        try (InputStream input = marshaller.stream(message)) {
+            return marshaller.parse(input);
+        }
+    }
+
+    private static BatchCreateSessionsRequest batchCreateSessionsRequest() {
+        return BatchCreateSessionsRequest.newBuilder()
+                .setDatabase(DATABASE)
+                .setSessionTemplate(Session.newBuilder().putLabels("purpose", "test"))
+                .setSessionCount(2)
+                .build();
+    }
+
+    private static ExecuteSqlRequest sqlRequest(String sql) {
+        return ExecuteSqlRequest.newBuilder().setSession(SESSION).setSql(sql).build();
+    }
+
+    private static ExecuteBatchDmlRequest batchDmlRequest() {
+        return ExecuteBatchDmlRequest.newBuilder()
+                .setSession(SESSION)
+                .addStatements(ExecuteBatchDmlRequest.Statement.newBuilder().setSql("update Albums set Title='A'"))
+                .build();
+    }
+
+    private static ReadRequest readRequest(String table) {
+        return ReadRequest.newBuilder().setSession(SESSION).setTable(table).addColumns("Id").build();
+    }
+
+    private static Session session(String name) {
+        return Session.newBuilder().setName(name).build();
+    }
+
+    private static ResultSet singleStringRow(String value) {
+        return ResultSet.newBuilder()
+                .addRows(ListValue.newBuilder().addValues(Value.newBuilder().setStringValue(value)))
+                .build();
+    }
+
+    private static PartialResultSet partial(String token) {
+        return PartialResultSet.newBuilder().setResumeToken(ByteString.copyFromUtf8(token)).build();
+    }
+
+    private static <T> List<T> toList(Iterator<T> iterator) {
+        List<T> values = new ArrayList<>();
+        iterator.forEachRemaining(values::add);
+        return values;
+    }
+
+    private static <T> T readNext(BlockingClientCall<?, T> call) throws Exception {
+        return call.read(5, TimeUnit.SECONDS);
+    }
+
+    private static final class GrpcFixture implements AutoCloseable {
+        private final Server server;
+        private final ManagedChannel channel;
+
+        private GrpcFixture(Server server, ManagedChannel channel) {
+            this.server = server;
+            this.channel = channel;
+        }
+
+        static GrpcFixture start() throws Exception {
+            String serverName = InProcessServerBuilder.generateName();
+            Server server = InProcessServerBuilder.forName(serverName)
+                    .directExecutor()
+                    .addService(new FakeSpannerService())
+                    .build()
+                    .start();
+            ManagedChannel channel = InProcessChannelBuilder.forName(serverName).directExecutor().build();
+            return new GrpcFixture(server, channel);
+        }
+
+        static GrpcFixture start(SpannerGrpc.AsyncService service) throws Exception {
+            String serverName = InProcessServerBuilder.generateName();
+            Server server = InProcessServerBuilder.forName(serverName)
+                    .directExecutor()
+                    .addService(SpannerGrpc.bindService(service))
+                    .build()
+                    .start();
+            ManagedChannel channel = InProcessChannelBuilder.forName(serverName).directExecutor().build();
+            return new GrpcFixture(server, channel);
+        }
+
+        @Override
+        public void close() throws Exception {
+            channel.shutdownNow();
+            assertThat(channel.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+            server.shutdownNow();
+            assertThat(server.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+        }
+    }
+
+    private static final class DefaultAsyncSpannerService implements SpannerGrpc.AsyncService {
+    }
+
+    private static final class FakeSpannerService extends SpannerGrpc.SpannerImplBase {
+        @Override
+        public void createSession(CreateSessionRequest request, StreamObserver<Session> responseObserver) {
+            complete(responseObserver, session(request.getDatabase() + "/sessions/created"));
+        }
+
+        @Override
+        public void batchCreateSessions(
+                BatchCreateSessionsRequest request, StreamObserver<BatchCreateSessionsResponse> responseObserver) {
+            Session created = Session.newBuilder().setName(request.getDatabase() + "/sessions/batch").setCreatorRole(
+                    "batch:" + request.getSessionCount()).build();
+            complete(responseObserver, BatchCreateSessionsResponse.newBuilder().addSession(created).build());
+        }
+
+        @Override
+        public void getSession(GetSessionRequest request, StreamObserver<Session> responseObserver) {
+            complete(responseObserver, session(request.getName()));
+        }
+
+        @Override
+        public void listSessions(ListSessionsRequest request, StreamObserver<ListSessionsResponse> responseObserver) {
+            complete(responseObserver,
+                    ListSessionsResponse.newBuilder()
+                            .addSessions(session(request.getDatabase() + "/sessions/listed"))
+                            .build());
+        }
+
+        @Override
+        public void deleteSession(DeleteSessionRequest request, StreamObserver<Empty> responseObserver) {
+            complete(responseObserver, Empty.getDefaultInstance());
+        }
+
+        @Override
+        public void executeSql(ExecuteSqlRequest request, StreamObserver<ResultSet> responseObserver) {
+            complete(responseObserver, singleStringRow(request.getSql()));
+        }
+
+        @Override
+        public void executeStreamingSql(
+                ExecuteSqlRequest request, StreamObserver<PartialResultSet> responseObserver) {
+            stream(responseObserver, partial("sql-1"), partial("sql-2"));
+        }
+
+        @Override
+        public void executeBatchDml(
+                ExecuteBatchDmlRequest request, StreamObserver<ExecuteBatchDmlResponse> responseObserver) {
+            Status status = Status.newBuilder().setCode(0).setMessage("dml:" + request.getStatementsCount()).build();
+            complete(responseObserver, ExecuteBatchDmlResponse.newBuilder().setStatus(status).build());
+        }
+
+        @Override
+        public void read(ReadRequest request, StreamObserver<ResultSet> responseObserver) {
+            complete(responseObserver, singleStringRow(request.getTable()));
+        }
+
+        @Override
+        public void streamingRead(ReadRequest request, StreamObserver<PartialResultSet> responseObserver) {
+            stream(responseObserver, partial("read-1"), partial("read-2"));
+        }
+
+        @Override
+        public void beginTransaction(BeginTransactionRequest request, StreamObserver<Transaction> responseObserver) {
+            complete(responseObserver,
+                    Transaction.newBuilder().setId(ByteString.copyFromUtf8(request.getSession())).build());
+        }
+
+        @Override
+        public void commit(CommitRequest request, StreamObserver<CommitResponse> responseObserver) {
+            complete(responseObserver,
+                    CommitResponse.newBuilder().setCommitTimestamp(Timestamp.newBuilder().setSeconds(123L)).build());
+        }
+
+        @Override
+        public void rollback(RollbackRequest request, StreamObserver<Empty> responseObserver) {
+            complete(responseObserver, Empty.getDefaultInstance());
+        }
+
+        @Override
+        public void partitionQuery(
+                PartitionQueryRequest request, StreamObserver<PartitionResponse> responseObserver) {
+            complete(responseObserver, partitionResponse("partition-query"));
+        }
+
+        @Override
+        public void partitionRead(PartitionReadRequest request, StreamObserver<PartitionResponse> responseObserver) {
+            complete(responseObserver, partitionResponse("partition-read"));
+        }
+
+        @Override
+        public void batchWrite(BatchWriteRequest request, StreamObserver<BatchWriteResponse> responseObserver) {
+            stream(responseObserver,
+                    BatchWriteResponse.newBuilder().addIndexes(0).build(),
+                    BatchWriteResponse.newBuilder().addIndexes(1).build());
+        }
+
+        private static PartitionResponse partitionResponse(String transactionId) {
+            return PartitionResponse.newBuilder()
+                    .setTransaction(Transaction.newBuilder().setId(ByteString.copyFromUtf8(transactionId)))
+                    .build();
+        }
+
+        private static <T> void complete(StreamObserver<T> responseObserver, T value) {
+            responseObserver.onNext(value);
+            responseObserver.onCompleted();
+        }
+
+        @SafeVarargs
+        private static <T> void stream(StreamObserver<T> responseObserver, T... values) {
+            for (T value : values) {
+                responseObserver.onNext(value);
+            }
+            responseObserver.onCompleted();
+        }
+    }
+
+    private static final class RecordingObserver<T> implements StreamObserver<T> {
+        private final CountDownLatch completed = new CountDownLatch(1);
+        private final List<T> values = new ArrayList<>();
+        private Throwable error;
+
+        @Override
+        public void onNext(T value) {
+            values.add(value);
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            error = throwable;
+            completed.countDown();
+        }
+
+        @Override
+        public void onCompleted() {
+            completed.countDown();
+        }
+
+        List<T> awaitValues() throws InterruptedException {
+            assertThat(completed.await(5, TimeUnit.SECONDS)).isTrue();
+            return values;
+        }
+    }
+}

--- a/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/src/test/java/com_google_api_grpc/grpc_google_cloud_spanner_v1/Grpc_google_cloud_spanner_v1Test.java
+++ b/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/src/test/java/com_google_api_grpc/grpc_google_cloud_spanner_v1/Grpc_google_cloud_spanner_v1Test.java
@@ -22,6 +22,7 @@ import com.google.spanner.v1.BatchCreateSessionsResponse;
 import com.google.spanner.v1.BatchWriteRequest;
 import com.google.spanner.v1.BatchWriteResponse;
 import com.google.spanner.v1.BeginTransactionRequest;
+import com.google.spanner.v1.CacheUpdate;
 import com.google.spanner.v1.CommitRequest;
 import com.google.spanner.v1.CommitResponse;
 import com.google.spanner.v1.CreateSessionRequest;
@@ -29,6 +30,7 @@ import com.google.spanner.v1.DeleteSessionRequest;
 import com.google.spanner.v1.ExecuteBatchDmlRequest;
 import com.google.spanner.v1.ExecuteBatchDmlResponse;
 import com.google.spanner.v1.ExecuteSqlRequest;
+import com.google.spanner.v1.FetchCacheUpdateRequest;
 import com.google.spanner.v1.GetSessionRequest;
 import com.google.spanner.v1.ListSessionsRequest;
 import com.google.spanner.v1.ListSessionsResponse;
@@ -73,7 +75,7 @@ public class Grpc_google_cloud_spanner_v1Test {
         assertThat(descriptor.getName()).isEqualTo(SpannerGrpc.SERVICE_NAME);
         assertThat(boundService.getServiceDescriptor().getName()).isEqualTo(SpannerGrpc.SERVICE_NAME);
         assertThat(descriptor.getSchemaDescriptor()).isNotNull();
-        assertThat(boundService.getMethods()).hasSize(16);
+        assertThat(boundService.getMethods()).hasSize(17);
         assertThat(descriptor.getMethods())
                 .extracting(MethodDescriptor::getFullMethodName)
                 .containsExactlyInAnyOrderElementsOf(expectedFullMethodNames());
@@ -94,6 +96,7 @@ public class Grpc_google_cloud_spanner_v1Test {
         assertUnaryMethod(SpannerGrpc.getPartitionQueryMethod(), "PartitionQuery");
         assertUnaryMethod(SpannerGrpc.getPartitionReadMethod(), "PartitionRead");
         assertServerStreamingMethod(SpannerGrpc.getBatchWriteMethod(), "BatchWrite");
+        assertServerStreamingMethod(SpannerGrpc.getFetchCacheUpdateMethod(), "FetchCacheUpdate");
     }
 
     @Test
@@ -165,6 +168,9 @@ public class Grpc_google_cloud_spanner_v1Test {
             assertThat(toList(stub.batchWrite(BatchWriteRequest.newBuilder().setSession(SESSION).build())))
                     .extracting(BatchWriteResponse::getIndexesList)
                     .containsExactly(List.of(0), List.of(1));
+            assertThat(toList(stub.fetchCacheUpdate(fetchCacheUpdateRequest())))
+                    .extracting(CacheUpdate::getDatabaseId)
+                    .containsExactly(101L, 202L);
         }
     }
 
@@ -178,12 +184,20 @@ public class Grpc_google_cloud_spanner_v1Test {
             assertThat(SpannerGrpc.newBlockingV2Stub(fixture.channel).createSession(request).getName())
                     .isEqualTo(DATABASE + "/sessions/created");
 
+            SpannerGrpc.SpannerStub asyncStub = SpannerGrpc.newStub(fixture.channel);
             RecordingObserver<PartialResultSet> observer = new RecordingObserver<>();
-            SpannerGrpc.newStub(fixture.channel).executeStreamingSql(sqlRequest("async stream"), observer);
+            asyncStub.executeStreamingSql(sqlRequest("async stream"), observer);
 
             assertThat(observer.awaitValues()).extracting(PartialResultSet::getResumeToken)
                     .containsExactly(ByteString.copyFromUtf8("sql-1"), ByteString.copyFromUtf8("sql-2"));
             assertThat(observer.error).isNull();
+
+            RecordingObserver<CacheUpdate> cacheUpdateObserver = new RecordingObserver<>();
+            asyncStub.fetchCacheUpdate(fetchCacheUpdateRequest(), cacheUpdateObserver);
+
+            assertThat(cacheUpdateObserver.awaitValues()).extracting(CacheUpdate::getDatabaseId)
+                    .containsExactly(101L, 202L);
+            assertThat(cacheUpdateObserver.error).isNull();
         }
     }
 
@@ -207,6 +221,11 @@ public class Grpc_google_cloud_spanner_v1Test {
             assertThat(readNext(batchWriteCall).getIndexesList()).containsExactly(0);
             assertThat(readNext(batchWriteCall).getIndexesList()).containsExactly(1);
             assertThat(readNext(batchWriteCall)).isNull();
+
+            BlockingClientCall<?, CacheUpdate> cacheUpdateCall = stub.fetchCacheUpdate(fetchCacheUpdateRequest());
+            assertThat(readNext(cacheUpdateCall).getDatabaseId()).isEqualTo(101L);
+            assertThat(readNext(cacheUpdateCall).getDatabaseId()).isEqualTo(202L);
+            assertThat(readNext(cacheUpdateCall)).isNull();
         }
     }
 
@@ -239,7 +258,8 @@ public class Grpc_google_cloud_spanner_v1Test {
                 fullMethodName("Rollback"),
                 fullMethodName("PartitionQuery"),
                 fullMethodName("PartitionRead"),
-                fullMethodName("BatchWrite"));
+                fullMethodName("BatchWrite"),
+                fullMethodName("FetchCacheUpdate"));
     }
 
     private static void assertUnaryMethod(MethodDescriptor<?, ?> method, String name) {
@@ -286,6 +306,14 @@ public class Grpc_google_cloud_spanner_v1Test {
 
     private static ReadRequest readRequest(String table) {
         return ReadRequest.newBuilder().setSession(SESSION).setTable(table).addColumns("Id").build();
+    }
+
+    private static FetchCacheUpdateRequest fetchCacheUpdateRequest() {
+        return FetchCacheUpdateRequest.newBuilder()
+                .setDatabase(DATABASE)
+                .setMaxRecipeCount(2)
+                .setMaxRangeCount(2)
+                .build();
     }
 
     private static Session session(String name) {
@@ -448,6 +476,14 @@ public class Grpc_google_cloud_spanner_v1Test {
             stream(responseObserver,
                     BatchWriteResponse.newBuilder().addIndexes(0).build(),
                     BatchWriteResponse.newBuilder().addIndexes(1).build());
+        }
+
+        @Override
+        public void fetchCacheUpdate(
+                FetchCacheUpdateRequest request, StreamObserver<CacheUpdate> responseObserver) {
+            stream(responseObserver,
+                    CacheUpdate.newBuilder().setDatabaseId(101L).build(),
+                    CacheUpdate.newBuilder().setDatabaseId(202L).build());
         }
 
         private static PartitionResponse partitionResponse(String transactionId) {

--- a/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,205 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
+      },
+      "type" : "android.app.Application"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test"
+      },
+      "type" : "com.google.common.util.concurrent.AbstractFutureState",
+      "fields" : [
+        {
+          "name" : "listenersField"
+        },
+        {
+          "name" : "valueField"
+        },
+        {
+          "name" : "waitersField"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test"
+      },
+      "type" : "com.google.common.util.concurrent.AbstractFutureState$Waiter",
+      "fields" : [
+        {
+          "name" : "next"
+        },
+        {
+          "name" : "thread"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
+      },
+      "type" : "io.grpc.census.InternalCensusStatsAccessor"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
+      },
+      "type" : "io.grpc.census.InternalCensusTracingAccessor"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
+      },
+      "type" : "io.grpc.internal.DnsNameResolverProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
+      },
+      "type" : "io.grpc.internal.PickFirstLoadBalancerProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test"
+      },
+      "type" : "io.grpc.internal.SerializingExecutor"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test"
+      },
+      "type" : "io.grpc.override.ContextStorageOverride"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test"
+      },
+      "type" : "io.perfmark.impl.SecretPerfMarkImpl$PerfMarkImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test"
+      },
+      "type" : "java.lang.invoke.VarHandle"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
+      },
+      "type" : "java.time.Instant"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
+      },
+      "type" : "java.util.concurrent.ScheduledThreadPoolExecutor",
+      "methods" : [
+        {
+          "name" : "setRemoveOnCancelPolicy",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test"
+      },
+      "type" : "java.util.concurrent.atomic.LongAdder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "add",
+          "parameterTypes" : [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$FakeSpannerService"
+      },
+      "type" : "java.util.concurrent.atomic.LongAdder",
+      "methods" : [
+        {
+          "name" : "add",
+          "parameterTypes" : [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
+      },
+      "type" : "java.util.concurrent.atomic.LongAdder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
+      },
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
+      },
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
+      },
+      "glob" : "META-INF/services/io.grpc.LoadBalancerProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test$GrpcFixture"
+      },
+      "glob" : "META-INF/services/io.grpc.NameResolverProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.grpc_google_cloud_spanner_v1.Grpc_google_cloud_spanner_v1Test"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/user-code-filter.json
+++ b/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.google.spanner.v1.**"
+    }
+  ]
+}

--- a/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/user-code-filter.json
+++ b/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.google.spanner.v1.**"
+      "includeClasses" : "com.google.spanner.v1.**"
+    },
+    {
+      "includeClasses" : "com_google_api_grpc.grpc_google_cloud_spanner_v1.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #7846

This PR provides test fixes and new metadata for com.google.api.grpc:grpc-google-cloud-spanner-v1:6.118.0, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 52748
- Cached input tokens: 379392
- Output tokens: 4194
- Metadata entries: 32
- Test-only metadata entries: 34
- Iterations: 1
- Library coverage percentage: 44.87
- Previous library version metadata entries: 44
- Previous library version coverage percentage: 43.43

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `e80d9c13024405ccea90af188a76d2f7836e05d3`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.google.api.grpc:grpc-google-cloud-spanner-v1:6.116.1: 0/0 covered calls (100.00%)
- com.google.api.grpc:grpc-google-cloud-spanner-v1:6.118.0: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.google.api.grpc:grpc-google-cloud-spanner-v1:6.116.1: 406/874 (46.45%)
- com.google.api.grpc:grpc-google-cloud-spanner-v1:6.118.0: 439/911 (48.19%)

**Line:**
- com.google.api.grpc:grpc-google-cloud-spanner-v1:6.116.1: 109/251 (43.43%)
- com.google.api.grpc:grpc-google-cloud-spanner-v1:6.118.0: 118/263 (44.87%)

**Method:**
- com.google.api.grpc:grpc-google-cloud-spanner-v1:6.116.1: 43/104 (41.35%)
- com.google.api.grpc:grpc-google-cloud-spanner-v1:6.118.0: 46/108 (42.59%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.116.1/src/test/java/com_google_api_grpc/grpc_google_cloud_spanner_v1/Grpc_google_cloud_spanner_v1Test.java b/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/src/test/java/com_google_api_grpc/grpc_google_cloud_spanner_v1/Grpc_google_cloud_spanner_v1Test.java
index f0d7ea4167..c72df78934 100644
--- a/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.116.1/src/test/java/com_google_api_grpc/grpc_google_cloud_spanner_v1/Grpc_google_cloud_spanner_v1Test.java
+++ b/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/src/test/java/com_google_api_grpc/grpc_google_cloud_spanner_v1/Grpc_google_cloud_spanner_v1Test.java
@@ -22,6 +22,7 @@ import com.google.spanner.v1.BatchCreateSessionsResponse;
 import com.google.spanner.v1.BatchWriteRequest;
 import com.google.spanner.v1.BatchWriteResponse;
 import com.google.spanner.v1.BeginTransactionRequest;
+import com.google.spanner.v1.CacheUpdate;
 import com.google.spanner.v1.CommitRequest;
 import com.google.spanner.v1.CommitResponse;
 import com.google.spanner.v1.CreateSessionRequest;
@@ -29,6 +30,7 @@ import com.google.spanner.v1.DeleteSessionRequest;
 import com.google.spanner.v1.ExecuteBatchDmlRequest;
 import com.google.spanner.v1.ExecuteBatchDmlResponse;
 import com.google.spanner.v1.ExecuteSqlRequest;
+import com.google.spanner.v1.FetchCacheUpdateRequest;
 import com.google.spanner.v1.GetSessionRequest;
 import com.google.spanner.v1.ListSessionsRequest;
 import com.google.spanner.v1.ListSessionsResponse;
@@ -73,7 +75,7 @@ public class Grpc_google_cloud_spanner_v1Test {
         assertThat(descriptor.getName()).isEqualTo(SpannerGrpc.SERVICE_NAME);
         assertThat(boundService.getServiceDescriptor().getName()).isEqualTo(SpannerGrpc.SERVICE_NAME);
         assertThat(descriptor.getSchemaDescriptor()).isNotNull();
-        assertThat(boundService.getMethods()).hasSize(16);
+        assertThat(boundService.getMethods()).hasSize(17);
         assertThat(descriptor.getMethods())
                 .extracting(MethodDescriptor::getFullMethodName)
                 .containsExactlyInAnyOrderElementsOf(expectedFullMethodNames());
@@ -94,6 +96,7 @@ public class Grpc_google_cloud_spanner_v1Test {
         assertUnaryMethod(SpannerGrpc.getPartitionQueryMethod(), "PartitionQuery");
         assertUnaryMethod(SpannerGrpc.getPartitionReadMethod(), "PartitionRead");
         assertServerStreamingMethod(SpannerGrpc.getBatchWriteMethod(), "BatchWrite");
+        assertServerStreamingMethod(SpannerGrpc.getFetchCacheUpdateMethod(), "FetchCacheUpdate");
     }
 
     @Test
@@ -165,6 +168,9 @@ public class Grpc_google_cloud_spanner_v1Test {
             assertThat(toList(stub.batchWrite(BatchWriteRequest.newBuilder().setSession(SESSION).build())))
                     .extracting(BatchWriteResponse::getIndexesList)
                     .containsExactly(List.of(0), List.of(1));
+            assertThat(toList(stub.fetchCacheUpdate(fetchCacheUpdateRequest())))
+                    .extracting(CacheUpdate::getDatabaseId)
+                    .containsExactly(101L, 202L);
         }
     }
 
@@ -178,12 +184,20 @@ public class Grpc_google_cloud_spanner_v1Test {
             assertThat(SpannerGrpc.newBlockingV2Stub(fixture.channel).createSession(request).getName())
                     .isEqualTo(DATABASE + "/sessions/created");
 
+            SpannerGrpc.SpannerStub asyncStub = SpannerGrpc.newStub(fixture.channel);
             RecordingObserver<PartialResultSet> observer = new RecordingObserver<>();
-            SpannerGrpc.newStub(fixture.channel).executeStreamingSql(sqlRequest("async stream"), observer);
+            asyncStub.executeStreamingSql(sqlRequest("async stream"), observer);
 
             assertThat(observer.awaitValues()).extracting(PartialResultSet::getResumeToken)
                     .containsExactly(ByteString.copyFromUtf8("sql-1"), ByteString.copyFromUtf8("sql-2"));
             assertThat(observer.error).isNull();
+
+            RecordingObserver<CacheUpdate> cacheUpdateObserver = new RecordingObserver<>();
+            asyncStub.fetchCacheUpdate(fetchCacheUpdateRequest(), cacheUpdateObserver);
+
+            assertThat(cacheUpdateObserver.awaitValues()).extracting(CacheUpdate::getDatabaseId)
+                    .containsExactly(101L, 202L);
+            assertThat(cacheUpdateObserver.error).isNull();
         }
     }
 
@@ -207,6 +221,11 @@ public class Grpc_google_cloud_spanner_v1Test {
             assertThat(readNext(batchWriteCall).getIndexesList()).containsExactly(0);
             assertThat(readNext(batchWriteCall).getIndexesList()).containsExactly(1);
             assertThat(readNext(batchWriteCall)).isNull();
+
+            BlockingClientCall<?, CacheUpdate> cacheUpdateCall = stub.fetchCacheUpdate(fetchCacheUpdateRequest());
+            assertThat(readNext(cacheUpdateCall).getDatabaseId()).isEqualTo(101L);
+            assertThat(readNext(cacheUpdateCall).getDatabaseId()).isEqualTo(202L);
+            assertThat(readNext(cacheUpdateCall)).isNull();
         }
     }
 
@@ -239,7 +258,8 @@ public class Grpc_google_cloud_spanner_v1Test {
                 fullMethodName("Rollback"),
                 fullMethodName("PartitionQuery"),
                 fullMethodName("PartitionRead"),
-                fullMethodName("BatchWrite"));
+                fullMethodName("BatchWrite"),
+                fullMethodName("FetchCacheUpdate"));
     }
 
     private static void assertUnaryMethod(MethodDescriptor<?, ?> method, String name) {
@@ -288,6 +308,14 @@ public class Grpc_google_cloud_spanner_v1Test {
         return ReadRequest.newBuilder().setSession(SESSION).setTable(table).addColumns("Id").build();
     }
 
+    private static FetchCacheUpdateRequest fetchCacheUpdateRequest() {
+        return FetchCacheUpdateRequest.newBuilder()
+                .setDatabase(DATABASE)
+                .setMaxRecipeCount(2)
+                .setMaxRangeCount(2)
+                .build();
+    }
+
     private static Session session(String name) {
         return Session.newBuilder().setName(name).build();
     }
@@ -450,6 +478,14 @@ public class Grpc_google_cloud_spanner_v1Test {
                     BatchWriteResponse.newBuilder().addIndexes(1).build());
         }
 
+        @Override
+        public void fetchCacheUpdate(
+                FetchCacheUpdateRequest request, StreamObserver<CacheUpdate> responseObserver) {
+            stream(responseObserver,
+                    CacheUpdate.newBuilder().setDatabaseId(101L).build(),
+                    CacheUpdate.newBuilder().setDatabaseId(202L).build());
+        }
+
         private static PartitionResponse partitionResponse(String transactionId) {
             return PartitionResponse.newBuilder()
                     .setTransaction(Transaction.newBuilder().setId(ByteString.copyFromUtf8(transactionId)))
diff --git a/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.116.1/user-code-filter.json b/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/user-code-filter.json
index 397d5c562e..32c8514e8e 100644
--- a/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.116.1/user-code-filter.json
+++ b/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-v1/6.118.0/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.google.spanner.v1.**"
+      "includeClasses" : "com.google.spanner.v1.**"
+    },
+    {
+      "includeClasses" : "com_google_api_grpc.grpc_google_cloud_spanner_v1.**"
     }
   ]
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 14
- Fixup attempts: 0
