### PR TITLE
[Automation] Generated metadata for com.google.cloud:grpc-gcp:1.11.0

### DIFF
--- a/metadata/com.google.cloud/grpc-gcp/1.11.0/reachability-metadata.json
+++ b/metadata/com.google.cloud/grpc-gcp/1.11.0/reachability-metadata.json
@@ -1,0 +1,1149 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "android.app.Application"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpManagedChannel"
+      },
+      "type": "com.google.cloud.grpc.proto.AffinityConfig",
+      "methods": [
+        {
+          "name": "getAffinityKey",
+          "parameterTypes": []
+        },
+        {
+          "name": "getCommandValue",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpManagedChannelBuilder"
+      },
+      "type": "com.google.cloud.grpc.proto.AffinityConfig",
+      "methods": [
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.proto.AffinityConfig"
+      },
+      "type": "com.google.cloud.grpc.proto.AffinityConfig",
+      "methods": [
+        {
+          "name": "getAffinityKey",
+          "parameterTypes": []
+        },
+        {
+          "name": "getCommandValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.proto.MethodConfig"
+      },
+      "type": "com.google.cloud.grpc.proto.AffinityConfig"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpManagedChannelBuilder"
+      },
+      "type": "com.google.cloud.grpc.proto.AffinityConfig$Builder",
+      "methods": [
+        {
+          "name": "getAffinityKey",
+          "parameterTypes": []
+        },
+        {
+          "name": "getCommandValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "setAffinityKey",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "setCommandValue",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.proto.AffinityConfig"
+      },
+      "type": "com.google.cloud.grpc.proto.AffinityConfig$Builder",
+      "methods": [
+        {
+          "name": "getAffinityKey",
+          "parameterTypes": []
+        },
+        {
+          "name": "getCommandValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "setAffinityKey",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "setCommandValue",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.proto.AffinityConfig"
+      },
+      "type": "com.google.cloud.grpc.proto.AffinityConfig$Command"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpManagedChannel"
+      },
+      "type": "com.google.cloud.grpc.proto.ApiConfig",
+      "methods": [
+        {
+          "name": "getChannelPool",
+          "parameterTypes": []
+        },
+        {
+          "name": "getMethodList",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasChannelPool",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.proto.ApiConfig"
+      },
+      "type": "com.google.cloud.grpc.proto.ApiConfig",
+      "methods": [
+        {
+          "name": "getChannelPool",
+          "parameterTypes": []
+        },
+        {
+          "name": "getMethodList",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasChannelPool",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpManagedChannelBuilder"
+      },
+      "type": "com.google.cloud.grpc.proto.ApiConfig$Builder",
+      "methods": [
+        {
+          "name": "addMethod",
+          "parameterTypes": [
+            "com.google.cloud.grpc.proto.MethodConfig"
+          ]
+        },
+        {
+          "name": "getMethodCount",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasChannelPool",
+          "parameterTypes": []
+        },
+        {
+          "name": "setChannelPool",
+          "parameterTypes": [
+            "com.google.cloud.grpc.proto.ChannelPoolConfig"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.proto.ApiConfig"
+      },
+      "type": "com.google.cloud.grpc.proto.ApiConfig$Builder",
+      "methods": [
+        {
+          "name": "addMethod",
+          "parameterTypes": [
+            "com.google.cloud.grpc.proto.MethodConfig"
+          ]
+        },
+        {
+          "name": "getMethodCount",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasChannelPool",
+          "parameterTypes": []
+        },
+        {
+          "name": "setChannelPool",
+          "parameterTypes": [
+            "com.google.cloud.grpc.proto.ChannelPoolConfig"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpManagedChannel"
+      },
+      "type": "com.google.cloud.grpc.proto.ChannelPoolConfig",
+      "methods": [
+        {
+          "name": "getIdleTimeout",
+          "parameterTypes": []
+        },
+        {
+          "name": "getMaxConcurrentStreamsLowWatermark",
+          "parameterTypes": []
+        },
+        {
+          "name": "getMaxSize",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpManagedChannelBuilder"
+      },
+      "type": "com.google.cloud.grpc.proto.ChannelPoolConfig",
+      "methods": [
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.proto.ApiConfig"
+      },
+      "type": "com.google.cloud.grpc.proto.ChannelPoolConfig"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.proto.ChannelPoolConfig"
+      },
+      "type": "com.google.cloud.grpc.proto.ChannelPoolConfig",
+      "methods": [
+        {
+          "name": "getIdleTimeout",
+          "parameterTypes": []
+        },
+        {
+          "name": "getMaxConcurrentStreamsLowWatermark",
+          "parameterTypes": []
+        },
+        {
+          "name": "getMaxSize",
+          "parameterTypes": []
+        },
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpManagedChannelBuilder"
+      },
+      "type": "com.google.cloud.grpc.proto.ChannelPoolConfig$Builder",
+      "methods": [
+        {
+          "name": "getMaxConcurrentStreamsLowWatermark",
+          "parameterTypes": []
+        },
+        {
+          "name": "getMaxSize",
+          "parameterTypes": []
+        },
+        {
+          "name": "setMaxConcurrentStreamsLowWatermark",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "setMaxSize",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.proto.ChannelPoolConfig"
+      },
+      "type": "com.google.cloud.grpc.proto.ChannelPoolConfig$Builder",
+      "methods": [
+        {
+          "name": "getIdleTimeout",
+          "parameterTypes": []
+        },
+        {
+          "name": "getMaxConcurrentStreamsLowWatermark",
+          "parameterTypes": []
+        },
+        {
+          "name": "getMaxSize",
+          "parameterTypes": []
+        },
+        {
+          "name": "setIdleTimeout",
+          "parameterTypes": [
+            "long"
+          ]
+        },
+        {
+          "name": "setMaxConcurrentStreamsLowWatermark",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "setMaxSize",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpManagedChannel"
+      },
+      "type": "com.google.cloud.grpc.proto.MethodConfig",
+      "methods": [
+        {
+          "name": "getAffinity",
+          "parameterTypes": []
+        },
+        {
+          "name": "getNameList",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasAffinity",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpManagedChannelBuilder"
+      },
+      "type": "com.google.cloud.grpc.proto.MethodConfig",
+      "methods": [
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.proto.ApiConfig"
+      },
+      "type": "com.google.cloud.grpc.proto.MethodConfig"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.proto.MethodConfig"
+      },
+      "type": "com.google.cloud.grpc.proto.MethodConfig",
+      "methods": [
+        {
+          "name": "getAffinity",
+          "parameterTypes": []
+        },
+        {
+          "name": "getNameList",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasAffinity",
+          "parameterTypes": []
+        },
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpManagedChannelBuilder"
+      },
+      "type": "com.google.cloud.grpc.proto.MethodConfig$Builder",
+      "methods": [
+        {
+          "name": "addName",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "getNameCount",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasAffinity",
+          "parameterTypes": []
+        },
+        {
+          "name": "setAffinity",
+          "parameterTypes": [
+            "com.google.cloud.grpc.proto.AffinityConfig"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.proto.MethodConfig"
+      },
+      "type": "com.google.cloud.grpc.proto.MethodConfig$Builder",
+      "methods": [
+        {
+          "name": "addName",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "getNameCount",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasAffinity",
+          "parameterTypes": []
+        },
+        {
+          "name": "setAffinity",
+          "parameterTypes": [
+            "com.google.cloud.grpc.proto.AffinityConfig"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpManagedChannel"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpManagedChannel"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions",
+      "methods": [
+        {
+          "name": "getDeprecated",
+          "parameterTypes": []
+        },
+        {
+          "name": "getEditionDefaultsList",
+          "parameterTypes": []
+        },
+        {
+          "name": "getTargetsCount",
+          "parameterTypes": []
+        },
+        {
+          "name": "getUninterpretedOptionList",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasCtype",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasDebugRedact",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasDeprecated",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasFeatureSupport",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasFeatures",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasJstype",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasLazy",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasPacked",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasRetention",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasUnverifiedLazy",
+          "parameterTypes": []
+        },
+        {
+          "name": "hasWeak",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpManagedChannel"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpManagedChannel"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$CType"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpManagedChannel"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$EditionDefault"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpManagedChannel"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$FeatureSupport"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpManagedChannel"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$JSType"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpManagedChannel"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$OptionRetention"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpManagedChannel"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$OptionTargetType"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpManagedChannel"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.proto.ApiConfig"
+      },
+      "type": "com.google.protobuf.ExtensionRegistry",
+      "methods": [
+        {
+          "name": "getEmptyRegistry",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "io.grpc.census.InternalCensusStatsAccessor"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "io.grpc.internal.DnsNameResolverProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "io.grpc.netty.shaded.io.grpc.netty.NettyChannelProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "io.grpc.netty.shaded.io.grpc.netty.UdsNameResolverProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "io.grpc.netty.shaded.io.grpc.netty.UdsNettyChannelProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "io.grpc.netty.shaded.io.netty.channel.ChannelException",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "io.grpc.netty.shaded.io.netty.channel.DefaultFileRegion",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "file"
+        },
+        {
+          "name": "transferred"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "io.grpc.netty.shaded.io.netty.channel.epoll.Epoll",
+      "methods": [
+        {
+          "name": "isAvailable",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "io.grpc.netty.shaded.io.netty.channel.epoll.EpollDomainSocketChannel"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "io.grpc.netty.shaded.io.netty.channel.epoll.EpollEventLoopGroup"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "io.grpc.netty.shaded.io.netty.channel.epoll.EpollServerSocketChannel"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "io.grpc.netty.shaded.io.netty.channel.epoll.EpollSocketChannel"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "io.grpc.netty.shaded.io.netty.channel.epoll.LinuxSocket",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "io.grpc.netty.shaded.io.netty.channel.epoll.Native",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "io.grpc.netty.shaded.io.netty.channel.epoll.NativeDatagramPacketArray$NativeDatagramPacket",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "count"
+        },
+        {
+          "name": "memoryAddress"
+        },
+        {
+          "name": "recipientAddr"
+        },
+        {
+          "name": "recipientAddrLen"
+        },
+        {
+          "name": "recipientPort"
+        },
+        {
+          "name": "recipientScopeId"
+        },
+        {
+          "name": "segmentSize"
+        },
+        {
+          "name": "senderAddr"
+        },
+        {
+          "name": "senderAddrLen"
+        },
+        {
+          "name": "senderPort"
+        },
+        {
+          "name": "senderScopeId"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "io.grpc.netty.shaded.io.netty.channel.epoll.NativeStaticallyReferencedJniMethods",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "io.grpc.netty.shaded.io.netty.channel.unix.Buffer",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "io.grpc.netty.shaded.io.netty.channel.unix.DatagramSocketAddress",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "byte[]",
+            "int",
+            "int",
+            "int",
+            "io.grpc.netty.shaded.io.netty.channel.unix.DatagramSocketAddress"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "io.grpc.netty.shaded.io.netty.channel.unix.DomainDatagramSocketAddress",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "byte[]",
+            "int",
+            "io.grpc.netty.shaded.io.netty.channel.unix.DomainDatagramSocketAddress"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "io.grpc.netty.shaded.io.netty.channel.unix.ErrorsStaticallyReferencedJniMethods",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "io.grpc.netty.shaded.io.netty.channel.unix.FileDescriptor",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "io.grpc.netty.shaded.io.netty.channel.unix.LimitsStaticallyReferencedJniMethods",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "io.grpc.netty.shaded.io.netty.channel.unix.PeerCredentials",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "int",
+            "int",
+            "int[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "io.grpc.netty.shaded.io.netty.channel.unix.Socket",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "io.grpc.netty.shaded.io.netty.util.AbstractReferenceCounted",
+      "fields": [
+        {
+          "name": "refCnt"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "io.grpc.netty.shaded.io.netty.util.DefaultAttributeMap"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "io.grpc.netty.shaded.io.netty.util.internal.NativeLibraryUtil",
+      "methods": [
+        {
+          "name": "loadLibrary",
+          "parameterTypes": [
+            "java.lang.String",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "io.grpc.override.ContextStorageOverride"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "java.io.FileDescriptor",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "fd"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "java.io.IOException",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "java.lang.BaseVirtualThread"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "java.lang.OutOfMemoryError",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "java.lang.RuntimeException",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "java.lang.Thread",
+      "methods": [
+        {
+          "name": "isVirtual",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "java.net.InetSocketAddress",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "java.net.PortUnreachableException",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "java.nio.Bits",
+      "fields": [
+        {
+          "name": "UNALIGNED"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "java.nio.Buffer",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "address"
+        },
+        {
+          "name": "limit"
+        },
+        {
+          "name": "position"
+        }
+      ],
+      "methods": [
+        {
+          "name": "limit",
+          "parameterTypes": []
+        },
+        {
+          "name": "position",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.proto.ApiConfig"
+      },
+      "type": "java.nio.Buffer",
+      "fields": [
+        {
+          "name": "address"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "java.nio.ByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "java.nio.DirectByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "java.nio.channels.ClosedChannelException",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "java.nio.channels.FileChannel"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "java.time.Instant"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "jdk.internal.misc.Unsafe",
+      "methods": [
+        {
+          "name": "getUnsafe",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.proto.ApiConfig"
+      },
+      "type": "libcore.io.Memory"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.proto.ApiConfig"
+      },
+      "type": "org.robolectric.Robolectric"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ],
+      "methods": [
+        {
+          "name": "invokeCleaner",
+          "parameterTypes": [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.proto.ApiConfig"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "type": "sun.nio.ch.FileChannelImpl",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "fd"
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "glob": "META-INF/native/libio_grpc_netty_shaded_netty_transport_native_epoll_x86_64.so"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "glob": "META-INF/services/io.grpc.ManagedChannelProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpMultiEndpointChannel"
+      },
+      "glob": "META-INF/services/io.grpc.NameResolverProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpManagedChannel"
+      },
+      "glob": "META-INF/services/java.time.zone.ZoneRulesProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpManagedChannel"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GcpManagedChannel"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en_US.properties"
+    },
+    {
+      "bundle": "sun.util.logging.resources.logging"
+    }
+  ]
+}

--- a/metadata/com.google.cloud/grpc-gcp/index.json
+++ b/metadata/com.google.cloud/grpc-gcp/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.11.0",
+    "test-version" : "1.10.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/google/cloud/grpc-gcp/$version$/grpc-gcp-$version$-sources.jar",
+    "repository-url" : "https://github.com/googleapis/google-cloud-java",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/com/google/cloud/grpc-gcp/$version$/grpc-gcp-$version$-tests.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/google/cloud/grpc-gcp/$version$/grpc-gcp-$version$-javadoc.jar",
+    "description" : "grpc-gcp provides Java extensions for using gRPC clients with Google Cloud Platform services. It adds a managed-channel layer with channel pooling, affinity configuration, multi-endpoint support, fallback handling, and metrics integration for Cloud API calls.",
+    "tested-versions" : [
+      "1.11.0"
+    ],
+    "allowed-packages" : [
+      "com.google.cloud.grpc"
+    ]
+  },
+  {
     "metadata-version" : "1.10.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/com/google/cloud/grpc-gcp/$version$/grpc-gcp-$version$-sources.jar",
     "repository-url" : "https://github.com/GoogleCloudPlatform/grpc-gcp-java",

--- a/stats/com.google.cloud/grpc-gcp/1.11.0/stats.json
+++ b/stats/com.google.cloud/grpc-gcp/1.11.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.11.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 6591,
+        "missed" : 9435,
+        "ratio" : 0.411269,
+        "total" : 16026
+      },
+      "line" : {
+        "covered" : 1760,
+        "missed" : 2201,
+        "ratio" : 0.444332,
+        "total" : 3961
+      },
+      "method" : {
+        "covered" : 409,
+        "missed" : 376,
+        "ratio" : 0.521019,
+        "total" : 785
+      }
+    }
+  } ]
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7848

This PR provides new metadata needed for the com.google.cloud:grpc-gcp:1.11.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `com.google.cloud:grpc-gcp:1.10.0`): 18
- Metadata entries (new `com.google.cloud:grpc-gcp:1.11.0`): 230
- Library coverage (previous): 44.52%
- Library coverage (new): 44.43%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `e80d9c13024405ccea90af188a76d2f7836e05d3`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.google.cloud:grpc-gcp:1.10.0: 0/0 covered calls (100.00%)
- com.google.cloud:grpc-gcp:1.11.0: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.google.cloud:grpc-gcp:1.10.0: 6554/15943 (41.11%)
- com.google.cloud:grpc-gcp:1.11.0: 6591/16026 (41.13%)

**Line:**
- com.google.cloud:grpc-gcp:1.10.0: 1750/3931 (44.52%)
- com.google.cloud:grpc-gcp:1.11.0: 1760/3961 (44.43%)

**Method:**
- com.google.cloud:grpc-gcp:1.10.0: 414/810 (51.11%)
- com.google.cloud:grpc-gcp:1.11.0: 409/785 (52.10%)

### Local CI Verification

- Status: `success`
- Commands run: 14
- Fixup attempts: 0
