### PR TITLE
Audit and de-duplicate Forge workflow code across entry points

### DIFF
--- a/forge/ai_workflows/core/workflow_strategy.py
+++ b/forge/ai_workflows/core/workflow_strategy.py
@@ -455,6 +455,19 @@ class WorkflowStrategy(ABC):
         print(f"ERROR: checkMetadataFiles still fails after updating allowed-packages for {library}.", file=sys.stderr)
         return False
 
+    def finalize_run(self, base_commit: str | None, workflow_status: str = RUN_STATUS_SUCCESS) -> str:
+        """Finalize a PR-eligible run and merge the finalization status.
+
+        The single driver-facing finalization path (§WF-forge-workflow-drivers.3):
+        a chunk-ready run stays chunk-ready when finalization succeeds, otherwise
+        the finalization status becomes the run status.
+        """
+        finalize_status, _ = self._finalize_successful_iteration(base_commit=base_commit)
+        finalize_succeeded = finalize_status in {RUN_STATUS_SUCCESS, SUCCESS_WITH_INTERVENTION_STATUS}
+        if finalize_succeeded and workflow_status == RUN_STATUS_CHUNK_READY:
+            return RUN_STATUS_CHUNK_READY
+        return finalize_status
+
     def _finalize_successful_iteration(self, base_commit: str | None = None) -> tuple[str, str | None]:
         """Generate metadata, run follow-up Gradle tasks, and commit the iteration."""
         log_stage("generate-metadata", f"Running generateMetadata for {self.library}")

--- a/forge/ai_workflows/drivers/add_new_library_support.py
+++ b/forge/ai_workflows/drivers/add_new_library_support.py
@@ -49,8 +49,8 @@ from utility_scripts.library_preparation_preflight import (
 )
 from utility_scripts.metadata_index import is_not_for_native_image, write_not_for_native_image_marker
 from utility_scripts.native_image_artifact import evaluate_native_image_eligibility
-from utility_scripts.repo_path_resolver import require_complete_reachability_repo, resolve_repo_roots
-from utility_scripts.schema_validator import validate_run_metrics, validate_benchmark_run_metrics
+from utility_scripts.repo_path_resolver import require_complete_reachability_repo
+from utility_scripts.schema_validator import validate_benchmark_run_metrics
 from utility_scripts.source_context import (
     discover_artifact_metadata,
     normalize_source_context_types,
@@ -67,9 +67,15 @@ from utility_scripts.test_quality_checks import (
 )
 from utility_scripts.metrics_writer import create_failure_run_metrics_output
 from utility_scripts.strategy_loader import require_strategy_by_name
-from utility_scripts.workflow_setup import resolve_graalvm_java_home, validate_repo_paths
+from utility_scripts.workflow_setup import (
+    list_all_files,
+    resolve_graalvm_java_home,
+    resolve_workflow_repo_paths,
+    validate_repo_paths,
+)
 
 DEFAULT_MODEL_NAME = "oca/gpt-5.4"
+METRICS_TASK_TYPE = "add_new_library_support"
 
 
 class ScaffoldError(RuntimeError):
@@ -78,18 +84,6 @@ class ScaffoldError(RuntimeError):
 
 def get_repo_root():
     return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
-
-def list_all_files(directory_path):
-    """Recursively list all file paths in the given directory."""
-    files = []
-    if not directory_path or not os.path.isdir(directory_path):
-        return files
-
-    for root_dir, _, file_names in os.walk(directory_path):
-        for file_name in file_names:
-            files.append(os.path.join(root_dir, file_name))
-    return files
 
 
 def build_parser():
@@ -234,24 +228,6 @@ def parse_flags(argv_list):
     )
 
 
-def resolve_repo_paths(
-        explicit_repo_path: str | None,
-        explicit_metrics_repo_path: str | None,
-        benchmark_mode: bool,
-):
-    """Resolve paths for reachability-metadata and metrics-metadata-forge repositories."""
-
-    res_reachability_repo, res_metrics_repo = resolve_repo_roots(
-        explicit_repo_path,
-        explicit_metrics_repo_path,
-    )
-
-    subdir_name = "benchmark_run_metrics" if benchmark_mode else "script_run_metrics"
-    resolved_metrics_repo = os.path.join(res_metrics_repo, subdir_name)
-    os.makedirs(resolved_metrics_repo, exist_ok=True)
-    return res_reachability_repo, resolved_metrics_repo, res_metrics_repo
-
-
 def resolve_add_new_library_support_metrics_json(
         run_metrics: dict,
         metrics_repo_dir: str,
@@ -260,13 +236,13 @@ def resolve_add_new_library_support_metrics_json(
 ) -> str:
     """Resolve the metrics JSON path for the current execution mode."""
     if is_benchmark_mode:
-        return os.path.join(metrics_repo_dir, "add_new_library_support.json")
-
-    in_repo_root = metrics_writer.in_metadata_repo_metrics_root(metrics_repo_root)
-    if in_repo_root:
-        return metrics_writer.execution_metrics_path(in_repo_root, run_metrics)
-
-    return os.path.join(metrics_repo_dir, "add_new_library_support.json")
+        return os.path.join(metrics_repo_dir, f"{METRICS_TASK_TYPE}.json")
+    return metrics_writer.resolve_workflow_metrics_json(
+        run_metrics,
+        metrics_repo_dir,
+        metrics_repo_root,
+        METRICS_TASK_TYPE,
+    )
 
 
 def create_feature_branch_for_library(group, artifact, library_version):
@@ -356,59 +332,49 @@ def _build_benchmark_metrics_entry(run_metrics: dict) -> dict:
     return benchmark_entry
 
 
-def write_add_new_library_support_metrics(run_metrics, metrics_json, is_benchmark_mode, package, artifact,
+def write_add_new_library_support_metrics(run_metrics, metrics_repo_dir, is_benchmark_mode, package, artifact,
                                           library_version, metrics_repo_root=None):
-    """Write or update add_new_library_support metrics depending on the execution mode."""
+    """Write or update add_new_library_support metrics depending on the execution mode.
 
-    # When running in benchmark mode, update the last benchmark record instead of appending to script_run_metrics.
-    if is_benchmark_mode:
-        if not os.path.isfile(metrics_json):
-            print(f"ERROR: Benchmark metrics file not found: {metrics_json}")
-            sys.exit(1)
+    Non-benchmark runs publish through the shared workflow metrics writer
+    (§WF-forge-workflow-drivers.3); benchmark mode updates the last benchmark
+    record instead of appending a run entry.
+    """
+    if not is_benchmark_mode:
+        log_stage("schema-validation", "Validating schema")
+        metrics_writer.write_workflow_run_metrics(run_metrics, metrics_repo_dir, metrics_repo_root, METRICS_TASK_TYPE)
+        log_stage("schema-validation", "Schema validated")
+        return
 
-        with open(metrics_json, "r", encoding="utf-8") as f:
-            data = json.load(f)
+    metrics_json = os.path.join(metrics_repo_dir, f"{METRICS_TASK_TYPE}.json")
+    if not os.path.isfile(metrics_json):
+        print(f"ERROR: Benchmark metrics file not found: {metrics_json}")
+        sys.exit(1)
 
-        benchmark_obj = data[-1]
-        metrics_array = benchmark_obj.get("metrics")
-        library_id = f"{package}:{artifact}:{library_version}"
+    with open(metrics_json, "r", encoding="utf-8") as f:
+        data = json.load(f)
 
-        updated = False
-        for index, item in enumerate(metrics_array):
-            if item.get("library") == library_id:
-                metrics_array[index] = _build_benchmark_metrics_entry(run_metrics)
-                updated = True
-                break
+    benchmark_obj = data[-1]
+    metrics_array = benchmark_obj.get("metrics")
+    library_id = f"{package}:{artifact}:{library_version}"
 
-        if not updated:
-            print(f"ERROR: No benchmark metrics entry found for library {library_id}.")
-            sys.exit(1)
+    updated = False
+    for index, item in enumerate(metrics_array):
+        if item.get("library") == library_id:
+            metrics_array[index] = _build_benchmark_metrics_entry(run_metrics)
+            updated = True
+            break
 
-        with open(metrics_json, "w", encoding="utf-8") as f:
-            json.dump(data, f, indent=2, ensure_ascii=False)
-            f.write("\n")
-    else:
-        in_repo_root = metrics_writer.in_metadata_repo_metrics_root(metrics_repo_root)
-        if in_repo_root:
-            written_metrics_json = metrics_writer.append_execution_metrics(
-                in_repo_root,
-                run_metrics,
-                "add_new_library_support",
-            )
-            if written_metrics_json != metrics_json:
-                raise ValueError(
-                    f"ERROR: Resolved metrics path {metrics_json} does not match written path {written_metrics_json}"
-                )
-        else:
-            metrics_writer.append_run_metrics(run_metrics, metrics_json)
-        if metrics_repo_root:
-            metrics_writer.write_pending_metrics(metrics_repo_root, run_metrics)
+    if not updated:
+        print(f"ERROR: No benchmark metrics entry found for library {library_id}.")
+        sys.exit(1)
+
+    with open(metrics_json, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+        f.write("\n")
 
     log_stage("schema-validation", "Validating schema")
-    if not is_benchmark_mode:
-        validate_run_metrics(metrics_json)
-    elif is_benchmark_mode:
-        validate_benchmark_run_metrics(metrics_json)
+    validate_benchmark_run_metrics(metrics_json)
     log_stage("schema-validation", "Schema validated")
 
 
@@ -458,10 +424,10 @@ def main(argv=None):
     strategy = require_strategy_by_name(strategy_name)
 
     # Resolve repository locations (possibly cloning)
-    reachability_repo_path, metrics_repo_dir, metrics_repo_root = resolve_repo_paths(
+    reachability_repo_path, metrics_repo_dir, metrics_repo_root = resolve_workflow_repo_paths(
         explicit_repo_path,
         explicit_metrics_repo_path,
-        is_benchmark_mode,
+        "benchmark_run_metrics" if is_benchmark_mode else "script_run_metrics",
     )
     # Apply deterministic preflight setup into the resolved worktree before
     # generation; only advisory guidance reaches the prompt context.
@@ -654,11 +620,7 @@ def main(argv=None):
             elif not strategy_obj._commit_library_iteration():
                 workflow_status = RUN_STATUS_FAILURE
         else:
-            finalize_status, _ = strategy_obj._finalize_successful_iteration(base_commit=checkpoint_commit_hash)
-            if finalize_status in {RUN_STATUS_SUCCESS, SUCCESS_WITH_INTERVENTION_STATUS} and workflow_status == RUN_STATUS_CHUNK_READY:
-                workflow_status = RUN_STATUS_CHUNK_READY
-            else:
-                workflow_status = finalize_status
+            workflow_status = strategy_obj.finalize_run(checkpoint_commit_hash, workflow_status)
 
     ending_commit_hash = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
     if workflow_status == RUN_STATUS_SUCCESS:
@@ -708,15 +670,9 @@ def main(argv=None):
             library_preparation_preflight=library_preparation_preflight,
         )
 
-    metrics_json = resolve_add_new_library_support_metrics_json(
-        run_metrics=run_metrics,
-        metrics_repo_dir=metrics_repo_dir,
-        metrics_repo_root=metrics_repo_root,
-        is_benchmark_mode=is_benchmark_mode,
-    )
     write_add_new_library_support_metrics(
         run_metrics=run_metrics,
-        metrics_json=metrics_json,
+        metrics_repo_dir=metrics_repo_dir,
         is_benchmark_mode=is_benchmark_mode,
         package=package,
         artifact=artifact,

--- a/forge/ai_workflows/drivers/fix_javac_fail.py
+++ b/forge/ai_workflows/drivers/fix_javac_fail.py
@@ -25,12 +25,6 @@ if __package__ in (None, ""):
 
 from ai_workflows.drivers.java_fail_workflow import JAVAC_CONFIG, run_java_fail_workflow
 
-# Re-export symbols used by forge_metadata.py and other callers
-from ai_workflows.drivers.java_fail_workflow import (  # noqa: F401
-    list_all_files,
-    init_agent,
-)
-
 
 def main(argv=None):
     """Execute the end-to-end javac-fix driver for a version bump.

--- a/forge/ai_workflows/drivers/fix_ni_run.py
+++ b/forge/ai_workflows/drivers/fix_ni_run.py
@@ -30,8 +30,7 @@ from utility_scripts.library_preparation_preflight import (
 )
 from utility_scripts.metadata_index import resolve_metadata_version, resolve_test_version
 from utility_scripts.metrics_writer import create_failure_run_metrics_output
-from utility_scripts.repo_path_resolver import require_complete_reachability_repo, resolve_repo_roots
-from utility_scripts.schema_validator import validate_run_metrics
+from utility_scripts.repo_path_resolver import require_complete_reachability_repo
 from utility_scripts.source_context import (
     normalize_source_context_types,
     populate_artifact_urls,
@@ -40,7 +39,12 @@ from utility_scripts.source_context import (
 )
 from utility_scripts.stage_logger import log_stage
 from utility_scripts.strategy_loader import require_strategy_by_name
-from utility_scripts.workflow_setup import resolve_graalvm_java_home, validate_repo_paths
+from utility_scripts.workflow_setup import (
+    list_all_files,
+    resolve_graalvm_java_home,
+    resolve_workflow_repo_paths,
+    validate_repo_paths,
+)
 
 DEFAULT_MODEL_NAME = "oca/gpt-5.5"
 DEFAULT_STRATEGY_NAME = "library_update_pi_gpt-5.5"
@@ -96,28 +100,6 @@ def build_parser():
         help="Path to the dispatcher-created library preparation preflight JSON record.",
     )
     return parser
-
-
-def list_all_files(directory_path: str) -> list[str]:
-    """Recursively list all file paths in the given directory."""
-    files: list[str] = []
-    if not directory_path or not os.path.isdir(directory_path):
-        return files
-    for root_dir, _, file_names in os.walk(directory_path):
-        for file_name in file_names:
-            files.append(os.path.join(root_dir, file_name))
-    return files
-
-
-def resolve_repo_paths(explicit_repo_path, explicit_metrics_repo_path):
-    """Resolve repository paths for code and metrics outputs."""
-    resolved_reachability_repo, resolved_metrics_repo = resolve_repo_roots(
-        explicit_repo_path,
-        explicit_metrics_repo_path,
-    )
-    resolved_metrics_dir = os.path.join(resolved_metrics_repo, "script_run_metrics")
-    os.makedirs(resolved_metrics_dir, exist_ok=True)
-    return resolved_reachability_repo, resolved_metrics_dir, resolved_metrics_repo
 
 
 def run_fix_test_native_image_run(
@@ -271,7 +253,7 @@ def build_strategy_and_agent(
     """Construct the dynamic-access strategy object and its agent for the new coordinate.
 
     Source contexts are downloaded only when exploring: the skip-exploration path
-    finalizes the seed through `_finalize_successful_iteration`, which sends no
+    finalizes the seed through `finalize_run`, which sends no
     agent prompts and needs neither downloaded sources nor a live agent session.
     """
     strategy = require_strategy_by_name(strategy_name)
@@ -342,34 +324,18 @@ def build_strategy_and_agent(
     return strategy_obj, agent, model_name, test_source_layout.source_root
 
 
-def write_metrics(run_metrics: dict, metrics_repo_dir: str, metrics_repo_root: str | None) -> None:
-    """Append run metrics to execution-metrics.json (or local fallback) and write pending metrics."""
-    in_repo_root = metrics_writer.in_metadata_repo_metrics_root(metrics_repo_root)
-    if in_repo_root:
-        metrics_json = metrics_writer.execution_metrics_path(in_repo_root, run_metrics)
-        written = metrics_writer.append_execution_metrics(in_repo_root, run_metrics, METRICS_TASK_TYPE)
-        if written != metrics_json:
-            raise ValueError(f"ERROR: Resolved metrics path {metrics_json} does not match written path {written}")
-    else:
-        metrics_json = os.path.join(metrics_repo_dir, f"{METRICS_TASK_TYPE}.json")
-        metrics_writer.append_run_metrics(run_metrics, metrics_json)
-    if metrics_repo_root:
-        metrics_writer.write_pending_metrics(metrics_repo_root, run_metrics)
-    validate_run_metrics(metrics_json)
-
-
 def main(argv=None) -> int:
     """Run the Native Image fix driver.
 
     The single-run driver (§WF-forge-workflow-drivers) for
     §WF-native-image-run-fix-workflow. `fixTestNativeImageRun` produces the seed;
     dynamic-access exploration runs only when the new version has uncovered
-    calls; the shared `_finalize_successful_iteration` path (three native-test
+    calls; the shared `finalize_run` path (three native-test
     lanes + dual-coordinate finalization) always gates PR eligibility.
     """
     args = build_parser().parse_args(sys.argv[1:] if argv is None else argv)
 
-    reachability_metadata_path, metrics_repo_dir, metrics_repo_root = resolve_repo_paths(
+    reachability_metadata_path, metrics_repo_dir, metrics_repo_root = resolve_workflow_repo_paths(
         args.reachability_metadata_path,
         args.metrics_repo_path,
     )
@@ -484,7 +450,7 @@ def main(argv=None) -> int:
                 explore=False,
             )
 
-    finalize_status, _ = strategy_obj._finalize_successful_iteration(base_commit=checkpoint)
+    finalize_status = strategy_obj.finalize_run(checkpoint)
     succeeded = finalize_status in {RUN_STATUS_SUCCESS, SUCCESS_WITH_INTERVENTION_STATUS}
 
     if succeeded:
@@ -526,7 +492,7 @@ def main(argv=None) -> int:
             library_preparation_preflight=library_preparation_preflight,
         )
 
-    write_metrics(run_metrics, metrics_repo_dir, metrics_repo_root)
+    metrics_writer.write_workflow_run_metrics(run_metrics, metrics_repo_dir, metrics_repo_root, METRICS_TASK_TYPE)
 
     if not succeeded:
         return 1

--- a/forge/ai_workflows/drivers/improve_library_coverage.py
+++ b/forge/ai_workflows/drivers/improve_library_coverage.py
@@ -26,7 +26,6 @@ import re
 import shutil
 import subprocess
 import sys
-import tempfile
 from typing import Any, Callable
 
 if __package__ in (None, ""):
@@ -36,7 +35,6 @@ import ai_workflows.agents  # noqa: F401 - triggers agent registration
 import ai_workflows.core  # noqa: F401 - triggers strategy registration
 from ai_workflows.agents import Agent
 from ai_workflows.core.workflow_strategy import (
-    RUN_STATUS_FAILURE,
     RUN_STATUS_CHUNK_READY,
     RUN_STATUS_SUCCESS,
     SUCCESS_WITH_INTERVENTION_STATUS,
@@ -61,8 +59,6 @@ from utility_scripts.metadata_index import (
     resolve_library_update_target,
 )
 from utility_scripts.metrics_writer import count_metadata_entries, count_test_only_metadata_entries, create_failure_run_metrics_output
-from utility_scripts.repo_path_resolver import resolve_repo_roots
-from utility_scripts.schema_validator import validate_run_metrics
 from utility_scripts.source_context import (
     normalize_source_context_types,
     populate_artifact_urls,
@@ -71,24 +67,19 @@ from utility_scripts.source_context import (
 )
 from utility_scripts.stage_logger import log_stage
 from utility_scripts.strategy_loader import require_strategy_by_name
-from utility_scripts.workflow_setup import resolve_graalvm_java_home, validate_repo_paths
+from utility_scripts.workflow_setup import (
+    list_all_files,
+    resolve_graalvm_java_home,
+    resolve_workflow_repo_paths,
+    validate_repo_paths,
+)
+from utility_scripts.worktree_reset import reset_worktree_preserving_paths
 
 DEFAULT_MODEL_NAME = "oca/gpt-5.5"
 DEFAULT_STRATEGY_NAME = "library_update_pi_gpt-5.5"
 METRICS_TASK_TYPE = "improve_library_coverage"
 BASELINE_STATS_FILENAME = ".baseline-stats.json"
 LIBRARY_UPDATE_TARGET_FILENAME = ".library_update_target.json"
-
-
-def list_all_files(directory_path: str) -> list[str]:
-    """Recursively list all file paths in the given directory."""
-    files: list[str] = []
-    if not directory_path or not os.path.isdir(directory_path):
-        return files
-    for root_dir, _, file_names in os.walk(directory_path):
-        for file_name in file_names:
-            files.append(os.path.join(root_dir, file_name))
-    return files
 
 
 def format_resolved_edit_scope_context(
@@ -217,43 +208,6 @@ def parse_flags(argv_list: list[str]):
         flags.issue_requested_metadata_context,
         flags.library_preparation_preflight_path,
     )
-
-
-def resolve_repo_paths(
-        explicit_repo_path: str | None,
-        explicit_metrics_repo_path: str | None,
-) -> tuple[str, str, str]:
-    """Resolve repository paths for code and metrics outputs."""
-    resolved_reachability_repo, resolved_metrics_repo = resolve_repo_roots(
-        explicit_repo_path,
-        explicit_metrics_repo_path,
-    )
-    resolved_metrics_dir = os.path.join(resolved_metrics_repo, "script_run_metrics")
-    os.makedirs(resolved_metrics_dir, exist_ok=True)
-    return resolved_reachability_repo, resolved_metrics_dir, resolved_metrics_repo
-
-
-def resolve_metrics_json(run_metrics: dict, metrics_repo_dir: str, metrics_repo_root: str | None) -> str:
-    """Resolve the metrics JSON path for the current execution."""
-    in_repo_root = metrics_writer.in_metadata_repo_metrics_root(metrics_repo_root)
-    if in_repo_root:
-        return metrics_writer.execution_metrics_path(in_repo_root, run_metrics)
-    return os.path.join(metrics_repo_dir, f"{METRICS_TASK_TYPE}.json")
-
-
-def write_metrics(run_metrics: dict, metrics_repo_dir: str, metrics_repo_root: str | None) -> None:
-    """Append metrics to JSON, write pending metrics, and validate schema."""
-    metrics_json = resolve_metrics_json(run_metrics, metrics_repo_dir, metrics_repo_root)
-    in_repo_root = metrics_writer.in_metadata_repo_metrics_root(metrics_repo_root)
-    if in_repo_root:
-        written = metrics_writer.append_execution_metrics(in_repo_root, run_metrics, METRICS_TASK_TYPE)
-        if written != metrics_json:
-            raise ValueError(f"ERROR: Resolved metrics path {metrics_json} does not match written path {written}")
-    else:
-        metrics_writer.append_run_metrics(run_metrics, metrics_json)
-    if metrics_repo_root:
-        metrics_writer.write_pending_metrics(metrics_repo_root, run_metrics)
-    validate_run_metrics(metrics_json)
 
 
 def _version_numbers(version: str) -> tuple[int, ...]:
@@ -712,43 +666,6 @@ def write_library_update_target_sidecar(metrics_repo_root: str | None, target: L
         sidecar_file.write("\n")
 
 
-def _snapshot_existing_paths(paths: list[str]) -> str | None:
-    snapshot_root = tempfile.mkdtemp(prefix="forge-update-failure-")
-    copied = False
-    for index, path in enumerate(paths):
-        if not os.path.exists(path):
-            continue
-        destination = os.path.join(snapshot_root, str(index))
-        if os.path.isdir(path):
-            shutil.copytree(path, destination)
-        else:
-            shutil.copy2(path, destination)
-        copied = True
-    if copied:
-        return snapshot_root
-    shutil.rmtree(snapshot_root, ignore_errors=True)
-    return None
-
-
-def _restore_snapshot_paths(snapshot_root: str | None, paths: list[str]) -> None:
-    if snapshot_root is None:
-        return
-    for index, path in enumerate(paths):
-        source = os.path.join(snapshot_root, str(index))
-        if not os.path.exists(source):
-            continue
-        if os.path.exists(path):
-            if os.path.isdir(path):
-                shutil.rmtree(path)
-            else:
-                os.remove(path)
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        if os.path.isdir(source):
-            shutil.copytree(source, path)
-        else:
-            shutil.copy2(source, path)
-
-
 def reset_failed_library_update_worktree(
         repo_path: str,
         checkpoint_commit: str,
@@ -762,14 +679,7 @@ def reset_failed_library_update_worktree(
         target.metadata_dir,
         stats_artifact_dir(repo_path, group, artifact),
     ]
-    snapshot_root = _snapshot_existing_paths(paths)
-    try:
-        subprocess.run(["git", "reset", "--hard", checkpoint_commit], cwd=repo_path, check=True)
-        _restore_snapshot_paths(snapshot_root, paths)
-    finally:
-        if snapshot_root is not None:
-            shutil.rmtree(snapshot_root, ignore_errors=True)
-    return subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo_path, text=True).strip()
+    return reset_worktree_preserving_paths(repo_path, checkpoint_commit, paths)
 
 
 def format_issue_requested_metadata_context(context: str) -> str:
@@ -819,7 +729,7 @@ def main(argv=None) -> int:
 
     library = f"{group}:{artifact}:{version}"
     strategy = require_strategy_by_name(strategy_name)
-    reachability_repo_path, metrics_repo_dir, metrics_repo_root = resolve_repo_paths(
+    reachability_repo_path, metrics_repo_dir, metrics_repo_root = resolve_workflow_repo_paths(
         explicit_repo_path,
         explicit_metrics_repo_path,
     )
@@ -1001,11 +911,7 @@ def main(argv=None) -> int:
     workflow_status, iterations = run_result[0], run_result[1]
 
     if workflow_status in {RUN_STATUS_SUCCESS, RUN_STATUS_CHUNK_READY}:
-        finalize_status, _ = strategy_obj._finalize_successful_iteration(base_commit=checkpoint_commit)
-        if finalize_status in {RUN_STATUS_SUCCESS, SUCCESS_WITH_INTERVENTION_STATUS} and workflow_status == RUN_STATUS_CHUNK_READY:
-            workflow_status = RUN_STATUS_CHUNK_READY
-        else:
-            workflow_status = finalize_status
+        workflow_status = strategy_obj.finalize_run(checkpoint_commit, workflow_status)
 
     ending_commit = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
 
@@ -1051,7 +957,7 @@ def main(argv=None) -> int:
         )
 
     write_library_update_target_sidecar(metrics_repo_root, update_target)
-    write_metrics(run_metrics, metrics_repo_dir, metrics_repo_root)
+    metrics_writer.write_workflow_run_metrics(run_metrics, metrics_repo_dir, metrics_repo_root, METRICS_TASK_TYPE)
     return 0 if workflow_status in {RUN_STATUS_SUCCESS, SUCCESS_WITH_INTERVENTION_STATUS, RUN_STATUS_CHUNK_READY} else 1
 
 

--- a/forge/ai_workflows/drivers/java_fail_workflow.py
+++ b/forge/ai_workflows/drivers/java_fail_workflow.py
@@ -18,10 +18,11 @@ import ai_workflows.agents  # noqa: F401 - triggers agent registration
 import ai_workflows.core  # noqa: F401 - triggers strategy registration
 from ai_workflows.agents import Agent
 from ai_workflows.core.workflow_strategy import (
+    RUN_STATUS_FAILURE,
     RUN_STATUS_SUCCESS,
     SUCCESS_WITH_INTERVENTION_STATUS,
+    WorkflowStrategy,
 )
-from ai_workflows.core.workflow_strategy import WorkflowStrategy
 from git_scripts.common_git import build_ai_branch_name, delete_remote_branch_if_exists, ensure_gh_authenticated
 from utility_scripts import metrics_writer
 from utility_scripts.gradle_environment import gradle_command_environment
@@ -30,8 +31,7 @@ from utility_scripts.library_preparation_preflight import (
 )
 from utility_scripts.metadata_index import is_newer_than_latest_metadata_version
 from utility_scripts.metrics_writer import create_failure_run_metrics_output
-from utility_scripts.repo_path_resolver import require_complete_reachability_repo, resolve_repo_roots
-from utility_scripts.schema_validator import validate_run_metrics
+from utility_scripts.repo_path_resolver import require_complete_reachability_repo
 from utility_scripts.source_context import (
     normalize_source_context_types,
     populate_artifact_urls,
@@ -39,7 +39,13 @@ from utility_scripts.source_context import (
     resolve_test_source_layout,
 )
 from utility_scripts.strategy_loader import require_strategy_by_name
-from utility_scripts.workflow_setup import resolve_graalvm_java_home, validate_repo_paths
+from utility_scripts.workflow_setup import (
+    list_all_files,
+    resolve_graalvm_java_home,
+    resolve_workflow_repo_paths,
+    validate_repo_paths,
+)
+from utility_scripts.worktree_reset import reset_worktree_to_commit
 
 DEFAULT_MODEL_NAME = "oca/gpt5"
 ADD_LIBRARY_METADATA_INDEX_TASK = "addLibraryMetadataIndexJson"
@@ -60,13 +66,13 @@ class JavaFailWorkflowConfig:
         default_strategy_name: str,
         task_type: str,
         branch_prefix: str,
-        metrics_filename: str,
+        metrics_task_type: str,
     ):
         self.mode = mode
         self.default_strategy_name = default_strategy_name
         self.task_type = task_type
         self.branch_prefix = branch_prefix
-        self.metrics_filename = metrics_filename
+        self.metrics_task_type = metrics_task_type
 
 
 JAVAC_CONFIG = JavaFailWorkflowConfig(
@@ -74,7 +80,7 @@ JAVAC_CONFIG = JavaFailWorkflowConfig(
     default_strategy_name=DEFAULT_JAVAC_STRATEGY,
     task_type="fix-javac-fail",
     branch_prefix="fix-javac",
-    metrics_filename="fix_javac_fail.json",
+    metrics_task_type="fix_javac_fail",
 )
 
 JAVA_RUN_CONFIG = JavaFailWorkflowConfig(
@@ -82,20 +88,8 @@ JAVA_RUN_CONFIG = JavaFailWorkflowConfig(
     default_strategy_name=DEFAULT_JAVA_RUN_STRATEGY,
     task_type="fix-java-run-fail",
     branch_prefix="fix-java-run",
-    metrics_filename="fix_java_run_fail.json",
+    metrics_task_type="fix_java_run_fail",
 )
-
-
-def list_all_files(directory_path):
-    """Recursively list all files under the provided directory path."""
-    files = []
-    if not directory_path or not os.path.exists(directory_path):
-        return files
-
-    for root_dir, _, file_names in os.walk(directory_path):
-        for file_name in file_names:
-            files.append(os.path.join(root_dir, file_name))
-    return files
 
 
 def build_parser(config: JavaFailWorkflowConfig):
@@ -179,18 +173,6 @@ def parse_flags(config: JavaFailWorkflowConfig, argv_list):
     )
 
 
-def resolve_repo_paths(explicit_repo_path, explicit_metrics_repo_path):
-    """Resolve repository paths for code and metrics outputs."""
-    resolved_reachability_repo, resolved_metrics_repo = resolve_repo_roots(
-        explicit_repo_path,
-        explicit_metrics_repo_path,
-    )
-
-    resolved_metrics_dir = os.path.join(resolved_metrics_repo, "script_run_metrics")
-    os.makedirs(resolved_metrics_dir, exist_ok=True)
-    return resolved_reachability_repo, resolved_metrics_dir, resolved_metrics_repo
-
-
 def resolve_fix_metrics_json(
         config: JavaFailWorkflowConfig,
         run_metrics: dict,
@@ -198,11 +180,12 @@ def resolve_fix_metrics_json(
         metrics_repo_root: str | None = None,
 ) -> str:
     """Resolve the metrics JSON path for the current execution mode."""
-    in_repo_root = metrics_writer.in_metadata_repo_metrics_root(metrics_repo_root)
-    if in_repo_root:
-        return metrics_writer.execution_metrics_path(in_repo_root, run_metrics)
-
-    return os.path.join(metrics_repo_dir, config.metrics_filename)
+    return metrics_writer.resolve_workflow_metrics_json(
+        run_metrics,
+        metrics_repo_dir,
+        metrics_repo_root,
+        config.metrics_task_type,
+    )
 
 
 def _same_filesystem_path(first_path: str, second_path: str) -> bool:
@@ -373,17 +356,13 @@ def reset_failed_java_fix_worktree(
     reset_target = last_passing_candidate_commit or commit_checkpoint
     if last_passing_candidate_commit is not None:
         print(f"[Test fixing failed; preserving last passing candidate at {last_passing_candidate_commit}.]")
-    subprocess.run(["git", "reset", "--hard", reset_target], cwd=reachability_repo_path, check=True)
+    head_commit = reset_worktree_to_commit(reachability_repo_path, reset_target)
     if last_passing_candidate_commit is None:
         if not tests_dir_preexisted:
             shutil.rmtree(tests_dir, ignore_errors=True)
         if not metadata_dir_preexisted:
             shutil.rmtree(metadata_dir, ignore_errors=True)
-    return subprocess.check_output(
-        ["git", "rev-parse", "HEAD"],
-        cwd=reachability_repo_path,
-        text=True,
-    ).strip()
+    return head_commit
 
 
 def init_agent(
@@ -427,25 +406,12 @@ def init_agent(
 
 def write_fix_metrics(config: JavaFailWorkflowConfig, run_metrics, metrics_repo_dir, metrics_repo_root=None):
     """Append fix metrics to JSON, write pending metrics, and validate schema."""
-    metrics_json = resolve_fix_metrics_json(
-        config=config,
-        run_metrics=run_metrics,
-        metrics_repo_dir=metrics_repo_dir,
-        metrics_repo_root=metrics_repo_root,
+    metrics_writer.write_workflow_run_metrics(
+        run_metrics,
+        metrics_repo_dir,
+        metrics_repo_root,
+        config.metrics_task_type,
     )
-    in_repo_root = metrics_writer.in_metadata_repo_metrics_root(metrics_repo_root)
-    if in_repo_root:
-        task_type = os.path.splitext(config.metrics_filename)[0]
-        written_metrics_json = metrics_writer.append_execution_metrics(in_repo_root, run_metrics, task_type)
-        if written_metrics_json != metrics_json:
-            raise ValueError(
-                f"ERROR: Resolved metrics path {metrics_json} does not match written path {written_metrics_json}"
-            )
-    else:
-        metrics_writer.append_run_metrics(run_metrics, metrics_json)
-    if metrics_repo_root:
-        metrics_writer.write_pending_metrics(metrics_repo_root, run_metrics)
-    validate_run_metrics(metrics_json)
 
 
 def run_java_fail_workflow(config: JavaFailWorkflowConfig, argv=None):
@@ -469,7 +435,7 @@ def run_java_fail_workflow(config: JavaFailWorkflowConfig, argv=None):
     ) = parse_flags(config, argv if argv is not None else sys.argv[1:])
 
     strategy = require_strategy_by_name(strategy_name)
-    reachability_repo_path, metrics_repo_dir, metrics_repo_root = resolve_repo_paths(
+    reachability_repo_path, metrics_repo_dir, metrics_repo_root = resolve_workflow_repo_paths(
         explicit_repo_path,
         explicit_metrics_repo_path,
     )
@@ -581,8 +547,7 @@ def run_java_fail_workflow(config: JavaFailWorkflowConfig, argv=None):
         if last_passing_candidate_commit is None:
             workflow_status = RUN_STATUS_FAILURE
         else:
-            finalize_status, _ = strategy_obj._finalize_successful_iteration(base_commit=commit_checkpoint)
-            workflow_status = finalize_status
+            workflow_status = strategy_obj.finalize_run(commit_checkpoint, workflow_status)
 
     if workflow_status not in {RUN_STATUS_SUCCESS, SUCCESS_WITH_INTERVENTION_STATUS}:
         print("[Test fixing failed.]")

--- a/forge/docs/git-scripts.md
+++ b/forge/docs/git-scripts.md
@@ -2,8 +2,9 @@
 
 Git scripts are Forge's publication component for issue resolution
 (§FS-forge-issue-resolution-goal). The `git_scripts/` directory holds
-workflow-specific `make_pr_*.py` publishers plus shared GitHub and git helpers
-in `common_git.py`. Orchestration (§ORCH-forge-orchestration-spec) chooses when
+workflow-specific `make_pr_*.py` publishers, the shared branch-publication
+pipeline in `pr_publication.py` (§GIT-shared-publication-pipeline), and shared
+GitHub and git helpers in `common_git.py`. Orchestration (§ORCH-forge-orchestration-spec) chooses when
 publication is allowed and invokes the matching publisher after a workflow
 returns a PR-eligible status (§GIT-pr-eligibility); git scripts own how the
 verified diff becomes a labeled, linked pull request. A publisher reads the
@@ -25,6 +26,23 @@ classified as PR-eligible: `RUN_STATUS_SUCCESS`,
 turn a failed workflow into a PR, and they must preserve the verification,
 intervention, metrics, and diagnostics context produced by
 §FS-local-ci-equivalent-verification in the commit or PR body.
+
+## GIT-shared-publication-pipeline: Shared branch publication pipeline
+
+Every `make_pr_*.py` publisher must route branch publication through the shared
+pipeline in `git_scripts/pr_publication.py`: feature-branch creation in the AI
+branch namespace, stale remote-branch deletion, workflow-specific staging,
+fork-aware base fetch and rebase, local CI-equivalent verification
+(§FS-local-ci-equivalent-verification), and the final push. Publishers
+contribute only their workflow-specific parts — the staging policy
+(§GIT-expected-paths), optional pre-rebase and post-verification assertions,
+and the PR title/body/label construction (§GIT-pr-body, §GIT-issue-linking) —
+so there is exactly one code path for how a verified diff becomes a pushed
+branch. Publication bookkeeping needed by several publishers (PR-number
+parsing, large-library progress updates after publishing, the old-vs-new test
+diff embedded in PR bodies) lives in the same module instead of per-script
+copies. The target repository, base branch, and configured reviewer list are
+declared once there and shared by every publisher.
 
 ## GIT-expected-paths: Expected path staging
 

--- a/forge/docs/workflows/dynamic-access.md
+++ b/forge/docs/workflows/dynamic-access.md
@@ -161,7 +161,7 @@ work and is absent for direct CLI invocations.
   `Anonymous<digit>` and `$<name>` with `Inner<name>` to avoid `$` in filenames.
 - Iterative runs produce one git commit per resolved or partially resolved
   class. Bulk runs produce one commit per accepted broad-pass iteration.
-- A final **metadata commit** produced by the standard `_finalize_successful_iteration`
+- A final **metadata commit** produced by the standard `finalize_run` finalization
   / `generateMetadata` step (in benchmark mode, only `generateMetadata` runs).
 - A per-run metrics record persisted to
   `stats/<group>/<artifact>/<version>/execution-metrics.json`; in-flight metrics
@@ -468,14 +468,14 @@ flowchart TD
     Final --> EntryFinalize[add_new_library_support.main]
     EntryFinalize --> Mode{benchmark mode?}
     Mode -- yes --> GenMeta[gradle generateMetadata,<br/>commit library iteration]
-    Mode -- no --> StdFinalize[strategy._finalize_successful_iteration<br/>see 6.6]
+    Mode -- no --> StdFinalize[strategy.finalize_run<br/>see 6.6]
     GenMeta --> Metrics[Write run metrics, validate schema]
     StdFinalize --> Metrics
 ```
 
 ### 6.6 Finalization order
 
-`_finalize_successful_iteration` runs in this order:
+The underlying finalization (driven through `finalize_run`) runs in this order:
 
 ```mermaid
 flowchart LR
@@ -603,8 +603,8 @@ support iff **all** requirements for its selected engine hold at exit:
    returned success before any dynamic-access coverage phase started. If the
    primary failed, the composite result is that primary failure and no
    dynamic-access coverage phase is required.
-5. `_finalize_successful_iteration` (or, in benchmark mode, `generateMetadata`
-   followed by a commit) returns success. In `_finalize_successful_iteration`,
+5. `finalize_run` (or, in benchmark mode, `generateMetadata`
+   followed by a commit) returns success. In the shared finalization,
    a failing post-generation `./gradlew test` is repaired by Codex metadata
    fixup and, if needed, Pi before finalization commits (§6.6).
 6. After each configured batch of per-class iterations that committed a

--- a/forge/docs/workflows/native-image-run-fix.md
+++ b/forge/docs/workflows/native-image-run-fix.md
@@ -67,7 +67,7 @@ flowchart TD
     Explore -- yes --> DynamicAccess[dynamic-access explore phase<br/>merge discovered metadata]
     DynamicAccess --> Finalize
     Explore -- no --> Finalize
-    Finalize[_finalize_successful_iteration:<br/>3 native-test lanes + dual-coordinate finalization] --> FinalOK{finalization passed?}
+    Finalize[finalize_run:<br/>3 native-test lanes + dual-coordinate finalization] --> FinalOK{finalization passed?}
     FinalOK -- yes --> Metrics[Write run metrics + return success]
     FinalOK -- no --> Fail
 ```
@@ -109,7 +109,7 @@ Required behavior:
    Exploration is best-effort: a partial or failed explore does not abort the
    workflow, because a reset returns to the valid seed checkpoint and
    finalization is the gate.
-8. **Mandatory finalization.** Run the shared `_finalize_successful_iteration` path
+8. **Mandatory finalization.** Run the shared `finalize_run` path
    (§WF-dynamic-access-iterative-strategy): `generateMetadata
    --agentAllowedPackages=fromJar` (the merge step that preserves seed/agent
    metadata), the three native-test lanes (current-defaults latest GraalVM,

--- a/forge/docs/workflows/workflow-drivers.md
+++ b/forge/docs/workflows/workflow-drivers.md
@@ -222,3 +222,28 @@ Preparation:
 - Populate artifact URLs after the new version is prepared.
 - Run library finalization for the generated test and metadata before returning
   success.
+
+## 3. Shared run finalization and metrics publication
+
+After the workflow engine returns, a PR-eligible run must be finalized through
+the engine's public `finalize_run(...)` API on `WorkflowStrategy`. That API
+runs the shared finalization path (metadata generation, the native-test lanes,
+per-coordinate library finalization, and the iteration commit) and owns the
+status merge: a chunk-ready run stays `RUN_STATUS_CHUNK_READY` when
+finalization succeeds, otherwise the finalization status becomes the run
+status. Drivers must not call the private finalization internals and must not
+re-implement the status merge at their call sites.
+
+Run metrics flow through the shared writer
+(`metrics_writer.write_workflow_run_metrics`): it appends the run entry to the
+execution-metrics store (or to the local fallback file named by the driver's
+task type), writes the pending metrics consumed by publication, and
+schema-validates the written file. Drivers contribute only their task type and
+the per-workflow metrics payload; benchmark-mode metrics, which update an
+existing benchmark record instead of appending a run entry, remain
+driver-owned.
+
+Failed runs roll the worktree back through the shared checkpoint-reset helpers
+in `utility_scripts/worktree_reset.py`; drivers contribute only the policy —
+which paths survive the reset for follow-up branches, or which directories are
+removed when they did not pre-exist.

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -155,7 +155,7 @@ from utility_scripts.task_logs import (
     resolve_logs_root,
     sanitize_library_log_segment,
 )
-from utility_scripts.workflow_setup import require_graalvm_home_env
+from utility_scripts.workflow_setup import list_all_files, require_graalvm_home_env
 
 try:
     import fcntl

--- a/forge/git_scripts/make_pr_improve_coverage.py
+++ b/forge/git_scripts/make_pr_improve_coverage.py
@@ -6,7 +6,6 @@
 import argparse
 import json
 import os
-import re
 import shutil
 import subprocess
 import sys
@@ -23,10 +22,14 @@ from git_scripts.common_git import (
     load_library_stats,
     format_stats_before_after,
     format_forge_revision_section,
-    build_ai_branch_name,
-    delete_remote_branch_if_exists,
-    get_configured_reviewers,
-    run_git_transport,
+)
+from git_scripts.pr_publication import (
+    BASE_BRANCH,
+    REPO,
+    REVIEWERS,
+    parse_pr_number,
+    publish_branch,
+    update_large_library_state_after_publish,
 )
 from utility_scripts.library_stats import stats_artifact_dir
 from utility_scripts.metadata_index import resolve_metadata_version, resolve_test_version
@@ -35,19 +38,15 @@ from utility_scripts.metrics_writer import (
     count_test_only_metadata_entries,
     read_pending_metrics,
 )
-from utility_scripts.large_library_progress import LABEL_LARGE_LIBRARY_PART, LargeLibraryProgressState
+from utility_scripts.large_library_progress import LABEL_LARGE_LIBRARY_PART
 from utility_scripts.repo_path_resolver import resolve_repo_roots
 from utility_scripts.local_ci_verification import (
     HUMAN_INTERVENTION_LABEL,
     LOCAL_CI_VERIFICATION_KEY,
     format_local_ci_verification_pr_section,
     local_ci_requires_human_intervention,
-    run_local_ci_verification,
 )
 
-REPO = "oracle/graalvm-reachability-metadata"
-BASE_BRANCH = "master"
-REVIEWERS = get_configured_reviewers()
 BASELINE_STATS_FILENAME = ".baseline-stats.json"
 LIBRARY_UPDATE_TARGET_FILENAME = ".library_update_target.json"
 IGNORED_FINALIZATION_DIRTY_PATHS = {
@@ -310,24 +309,6 @@ def stage_and_commit(
     return candidate_paths
 
 
-def _fetch_pr_base(repo_path: str) -> str:
-    """Fetch the upstream PR base and return the ref to rebase onto."""
-    upstream_url = f"https://github.com/{REPO}.git"
-    upstream_remote_url = subprocess.run(
-        ["git", "remote", "get-url", "upstream"],
-        cwd=repo_path,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-        text=True,
-        check=False,
-    )
-    if upstream_remote_url.returncode == 0 and REPO in upstream_remote_url.stdout.strip():
-        run_git_transport(["fetch", "upstream", BASE_BRANCH], cwd=repo_path)
-        return f"upstream/{BASE_BRANCH}"
-    run_git_transport(["fetch", upstream_url, BASE_BRANCH], cwd=repo_path)
-    return "FETCH_HEAD"
-
-
 def create_pull_request(
         branch: str, coordinates: str, metrics_repo_root: str, repo_path: str,
         group: str, artifact: str, version: str,
@@ -381,7 +362,7 @@ def create_pull_request(
         for r in REVIEWERS:
             cmd.extend(["--reviewer", r])
     result = gh(*cmd[1:])
-    return _parse_pr_number(result.stdout)
+    return parse_pr_number(result.stdout)
 
 
 def build_pull_request_preview(
@@ -503,48 +484,20 @@ def push_current_branch_to_origin(
     branch_suffix = f"improve-coverage-{group}-{artifact}-{library_version}"
     if large_library_part is not None:
         branch_suffix = f"{branch_suffix}-part-{large_library_part:04d}"
-    new_branch = build_ai_branch_name(branch_suffix, cwd=repo_path)
-    delete_remote_branch_if_exists(new_branch, cwd=repo_path)
-    subprocess.run(["git", "switch", "-C", new_branch], check=True, cwd=repo_path)
 
-    expected_paths = stage_and_commit(group, artifact, library_version, coordinates, repo_path)
-    assert_no_out_of_scope_changes(repo_path, expected_paths)
+    def stage() -> None:
+        expected_paths = stage_and_commit(group, artifact, library_version, coordinates, repo_path)
+        assert_no_out_of_scope_changes(repo_path, expected_paths)
 
-    base_ref = _fetch_pr_base(repo_path)
-    subprocess.run(["git", "rebase", base_ref], check=True, cwd=repo_path)
-    run_local_ci_verification(
+    new_branch, _ = publish_branch(
         repo_path=repo_path,
+        branch_suffix=branch_suffix,
         coordinates=coordinates,
-        base_commit=base_ref,
+        stage=stage,
         metrics_repo_path=metrics_repo_path,
     )
-    run_git_transport(["push", "origin", new_branch], cwd=repo_path)
 
     return new_branch
-
-
-def _parse_pr_number(output: str) -> int | None:
-    """Extract a PR number from gh pr create output."""
-    match = re.search(r"/pull/(\d+)", output)
-    return int(match.group(1)) if match else None
-
-
-def update_large_library_state_after_publish(
-        state_path: str | None,
-        branch: str,
-        repo_path: str,
-        pr_number: int | None,
-        final_part: bool,
-) -> None:
-    """Record the published branch/commit in the large-library progress artifact."""
-    if not state_path:
-        return
-    state = LargeLibraryProgressState.load(state_path)
-    commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo_path, text=True).strip()
-    state.record_published_pr(branch, commit, pr_number)
-    if not final_part:
-        state.advance_to_next_part()
-    state.save(state_path)
 
 
 def main(argv=None) -> None:

--- a/forge/git_scripts/make_pr_java_run_fix.py
+++ b/forge/git_scripts/make_pr_java_run_fix.py
@@ -4,8 +4,7 @@
 # work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 import argparse
-import os
-import subprocess
+import shutil
 import sys
 
 from git_scripts.common_git import (
@@ -13,66 +12,29 @@ from git_scripts.common_git import (
     gh,
     parse_coordinate_parts,
     get_origin_owner,
-    stage_and_commit as stage_and_commit_common,
     find_issue_for_coordinates as find_issue_common,
     get_model_display_name,
     get_agent_name,
     format_stats_diff,
     format_forge_revision_section,
     assert_no_dynamic_access_category_regressions,
-    build_ai_branch_name,
-    delete_remote_branch_if_exists,
-    run_git_transport,
 )
-from git_scripts.make_pr_javac_fix import generate_diff_text
-from utility_scripts.library_stats import stats_artifact_dir
+from git_scripts.pr_publication import (
+    BASE_BRANCH,
+    REPO,
+    REVIEWERS,
+    generate_diff_text,
+    publish_branch,
+    stage_library_version_paths,
+)
 from utility_scripts.local_ci_verification import (
     HUMAN_INTERVENTION_LABEL,
     LOCAL_CI_VERIFICATION_KEY,
-    fetch_pr_base_ref,
     format_local_ci_verification_pr_section,
     local_ci_requires_human_intervention,
-    run_local_ci_verification,
 )
 from utility_scripts.metrics_writer import read_pending_metrics
 from utility_scripts.repo_path_resolver import resolve_repo_roots
-import shutil
-
-REPO = 'oracle/graalvm-reachability-metadata'
-BASE_BRANCH = 'master'
-REVIEWERS = ["vjovanov", "jormundur00", "kimeta"]
-def resolve_repo_paths(
-        explicit_repo_path: str | None,
-        explicit_metrics_repo_path: str | None,
-):
-    """Resolve repo and metrics paths using provided values or local defaults."""
-    return resolve_repo_roots(
-        explicit_repo_path,
-        explicit_metrics_repo_path,
-    )
-
-
-def stage_and_commit(
-        group: str,
-        artifact: str,
-        library_version: str,
-        coordinates: str,
-        repo_path: str,
-        metrics_repo_path: str | None = None,
-        include_in_repo_metrics: bool = False,
-):
-    """Stage the expected files/directories and commit with the required message."""
-    candidate_paths = [
-        str(os.path.join("tests", "src", group, artifact, library_version)),
-        str(os.path.join("metadata", group, artifact, "index.json")),
-        str(os.path.join("metadata", group, artifact, library_version)),
-        str(os.path.relpath(stats_artifact_dir(repo_path, group, artifact), repo_path)),
-    ]
-    del metrics_repo_path, include_in_repo_metrics
-    candidate_paths = [path for path in candidate_paths if os.path.exists(os.path.join(repo_path, path))]
-
-    commit_message = f"Fixed test for {coordinates}"
-    stage_and_commit_common(candidate_paths, commit_message, cwd=repo_path)
 
 
 def create_pull_request(
@@ -247,9 +209,9 @@ def parse_flags(argv_list):
     """Parse CLI flags and resolve repository paths."""
     parser = build_parser()
     flags = parser.parse_args(argv_list)
-    repo_path, metrics_repo_path = resolve_repo_paths(
-        explicit_repo_path=flags.reachability_metadata_path,
-        explicit_metrics_repo_path=flags.metrics_repo_path,
+    repo_path, metrics_repo_path = resolve_repo_roots(
+        flags.reachability_metadata_path,
+        flags.metrics_repo_path,
     )
     return flags.coordinates, flags.new_version, repo_path, metrics_repo_path, flags.issue_number
 
@@ -259,42 +221,23 @@ def push_current_branch_to_origin(
         new_version: str,
         repo_path: str,
         metrics_repo_path: str | None = None,
-        include_in_repo_metrics: bool = False,
 ):
     """Create a feature branch, stage and commit changes, and push to the remote."""
     group, artifact, old_version = parse_coordinate_parts(old_coordinates)
     new_coordinates = f"{group}:{artifact}:{new_version}"
 
-    branch = build_ai_branch_name(
-        f"fix-java-run-{group}-{artifact}-{new_version}",
-        cwd=repo_path,
-    )
-    delete_remote_branch_if_exists(branch, cwd=repo_path)
-    subprocess.run(
-        ["git", "switch", "-C", branch],
-        check=True,
-        cwd=repo_path,
-    )
-    stage_and_commit(
-        group,
-        artifact,
-        new_version,
-        new_coordinates,
-        repo_path,
-        metrics_repo_path=metrics_repo_path,
-        include_in_repo_metrics=include_in_repo_metrics,
-    )
-    base_ref = fetch_pr_base_ref(repo_path, REPO, BASE_BRANCH)
-    subprocess.run(["git", "rebase", base_ref], check=True, cwd=repo_path)
-    run_local_ci_verification(
+    branch, _ = publish_branch(
         repo_path=repo_path,
+        branch_suffix=f"fix-java-run-{group}-{artifact}-{new_version}",
         coordinates=new_coordinates,
-        base_commit=base_ref,
+        stage=lambda: stage_library_version_paths(
+            group, artifact, new_version, repo_path, f"Fixed test for {new_coordinates}",
+        ),
         metrics_repo_path=metrics_repo_path,
+        after_verification=lambda: assert_no_dynamic_access_category_regressions(
+            repo_path, old_coordinates, new_coordinates,
+        ),
     )
-    assert_no_dynamic_access_category_regressions(repo_path, old_coordinates, new_coordinates)
-
-    run_git_transport(["push", "origin", branch], cwd=repo_path)
 
     return branch, group, artifact, old_version, new_coordinates
 

--- a/forge/git_scripts/make_pr_javac_fix.py
+++ b/forge/git_scripts/make_pr_javac_fix.py
@@ -4,136 +4,37 @@
 # work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 import argparse
-import os
 import shutil
-import subprocess
 import sys
-import tempfile
 
 from git_scripts.common_git import (
     ensure_gh_authenticated,
     gh,
     parse_coordinate_parts,
     get_origin_owner,
-    git_files_under,
-    is_java_fix_test_module_file,
-    stage_and_commit as stage_and_commit_common,
     find_issue_for_coordinates as find_issue_common,
     get_model_display_name,
     get_agent_name,
     format_stats_diff,
     format_forge_revision_section,
     assert_no_dynamic_access_category_regressions,
-    build_ai_branch_name,
-    delete_remote_branch_if_exists,
-    get_configured_reviewers,
-    run_git_transport,
 )
-from utility_scripts.library_stats import stats_artifact_dir
+from git_scripts.pr_publication import (
+    BASE_BRANCH,
+    REPO,
+    REVIEWERS,
+    generate_diff_text,
+    publish_branch,
+    stage_library_version_paths,
+)
 from utility_scripts.local_ci_verification import (
     HUMAN_INTERVENTION_LABEL,
     LOCAL_CI_VERIFICATION_KEY,
-    fetch_pr_base_ref,
     format_local_ci_verification_pr_section,
     local_ci_requires_human_intervention,
-    run_local_ci_verification,
 )
 from utility_scripts.metrics_writer import read_pending_metrics
 from utility_scripts.repo_path_resolver import resolve_repo_roots
-
-REPO = "oracle/graalvm-reachability-metadata"
-BASE_BRANCH = 'master'
-REVIEWERS = get_configured_reviewers()
-def resolve_repo_paths(
-        explicit_repo_path: str | None,
-        explicit_metrics_repo_path: str | None,
-):
-    """Resolve repo and metrics paths using provided values or local defaults."""
-    return resolve_repo_roots(
-        explicit_repo_path,
-        explicit_metrics_repo_path,
-    )
-
-
-def stage_and_commit(
-        group: str,
-        artifact: str,
-        library_version: str,
-        coordinates: str,
-        repo_path: str,
-        metrics_repo_path: str | None = None,
-        include_in_repo_metrics: bool = False,
-):
-    """Stage the expected files/directories and commit with the required message."""
-    candidate_paths = [
-        str(os.path.join("tests", "src", group, artifact, library_version)),
-        str(os.path.join("metadata", group, artifact, "index.json")),
-        str(os.path.join("metadata", group, artifact, library_version)),
-        str(os.path.relpath(stats_artifact_dir(repo_path, group, artifact), repo_path)),
-    ]
-    del metrics_repo_path, include_in_repo_metrics
-    candidate_paths = [path for path in candidate_paths if os.path.exists(os.path.join(repo_path, path))]
-
-    commit_message = f"Fixed test for {coordinates}"
-    stage_and_commit_common(candidate_paths, commit_message, cwd=repo_path)
-
-
-def _copy_git_files_under(repo_path: str, source_dir: str, destination_dir: str) -> None:
-    os.makedirs(destination_dir, exist_ok=True)
-    for git_path in git_files_under(repo_path, source_dir):
-        source_file = os.path.join(repo_path, git_path)
-        relative_file = os.path.relpath(source_file, source_dir)
-        if relative_file.startswith(os.pardir + os.sep) or relative_file == os.pardir:
-            continue
-        if not is_java_fix_test_module_file(relative_file):
-            continue
-        destination_file = os.path.join(destination_dir, relative_file)
-        os.makedirs(os.path.dirname(destination_file), exist_ok=True)
-        shutil.copy2(source_file, destination_file)
-
-
-def generate_diff_text(group: str, artifact: str, current_version: str, new_version: str, repo_path: str):
-    """Build a diff text between the current and new test directories for a library version."""
-    old_dir = os.path.join(repo_path, "tests", "src", group, artifact, current_version)
-    new_dir = os.path.join(repo_path, "tests", "src", group, artifact, new_version)
-    old_display_dir = os.path.relpath(old_dir, repo_path).replace(os.sep, "/")
-    new_display_dir = os.path.relpath(new_dir, repo_path).replace(os.sep, "/")
-    old_diff_display_dir = f"/{old_display_dir}"
-    new_diff_display_dir = f"/{new_display_dir}"
-
-    # Prepare temp copies from Git's file list with a narrow allow-list for the PR body diff.
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tmp_old = os.path.join(tmpdir, "old")
-        tmp_new = os.path.join(tmpdir, "new")
-
-        _copy_git_files_under(repo_path, old_dir, tmp_old)
-        _copy_git_files_under(repo_path, new_dir, tmp_new)
-
-        # Compute diff text using: git diff --no-index --find-renames tmp_old tmp_new
-        res = subprocess.run(
-            ["git", "diff", "--no-index", "--find-renames", tmp_old, tmp_new],
-            capture_output=True,
-            text=True,
-        )
-        if res.returncode in (0, 1):
-            diff_text = res.stdout
-
-            diff_text = diff_text.replace(tmp_old.replace(os.sep, "/"), old_diff_display_dir)
-            diff_text = diff_text.replace(tmp_new.replace(os.sep, "/"), new_diff_display_dir)
-            diff_text = diff_text.replace(tmp_old, old_diff_display_dir)
-            diff_text = diff_text.replace(tmp_new, new_diff_display_dir)
-            return diff_text
-        else:
-            error_message = (
-                f"Subprocess failed with return code: {res.returncode}. "
-                f"Error output:\n{res.stderr.strip()}"
-            )
-            raise RuntimeError(error_message)
-
-
-def load_fix_javac_metrics(metrics_repo_root: str, old_coordinates: str, new_coordinates: str):
-    """Load the pending metrics entry for a javac-fix run."""
-    return read_pending_metrics(metrics_repo_root)
 
 
 def create_pull_request(
@@ -220,11 +121,7 @@ def build_pull_request_preview(
 ) -> tuple[str, str, dict]:
     """Build the PR title/body without creating a GitHub pull request."""
     issue_no = issue_number if issue_number is not None else find_issue_common(new_coordinates, REPO)
-    metrics_entry = load_fix_javac_metrics(
-        metrics_repo_root=metrics_repo_root,
-        old_coordinates=old_coordinates,
-        new_coordinates=new_coordinates,
-    )
+    metrics_entry = read_pending_metrics(metrics_repo_root)
     metrics = metrics_entry.get("metrics", {})
     strategy_name = metrics_entry.get("strategy_name", "")
     model_display_name = get_model_display_name(strategy_name)
@@ -334,9 +231,9 @@ def parse_flags(argv_list):
     """Parse CLI flags and resolve repository paths."""
     parser = build_parser()
     flags = parser.parse_args(argv_list)
-    repo_path, metrics_repo_path = resolve_repo_paths(
-        explicit_repo_path=flags.reachability_metadata_path,
-        explicit_metrics_repo_path=flags.metrics_repo_path,
+    repo_path, metrics_repo_path = resolve_repo_roots(
+        flags.reachability_metadata_path,
+        flags.metrics_repo_path,
     )
     return flags.coordinates, flags.new_version, repo_path, metrics_repo_path, flags.issue_number
 
@@ -346,42 +243,23 @@ def push_current_branch_to_origin(
         new_version: str,
         repo_path: str,
         metrics_repo_path: str | None = None,
-        include_in_repo_metrics: bool = False,
 ):
     """Create a feature branch, stage and commit changes, and push to the remote."""
     group, artifact, old_version = parse_coordinate_parts(old_coordinates)
     new_coordinates = f"{group}:{artifact}:{new_version}"
 
-    branch = build_ai_branch_name(
-        f"fix-javac-{group}-{artifact}-{new_version}",
-        cwd=repo_path,
-    )
-    delete_remote_branch_if_exists(branch, cwd=repo_path)
-    subprocess.run(
-        ["git", "switch", "-C", branch],
-        check=True,
-        cwd=repo_path,
-    )
-    stage_and_commit(
-        group,
-        artifact,
-        new_version,
-        new_coordinates,
-        repo_path,
-        metrics_repo_path=metrics_repo_path,
-        include_in_repo_metrics=include_in_repo_metrics,
-    )
-    base_ref = fetch_pr_base_ref(repo_path, REPO, BASE_BRANCH)
-    subprocess.run(["git", "rebase", base_ref], check=True, cwd=repo_path)
-    run_local_ci_verification(
+    branch, _ = publish_branch(
         repo_path=repo_path,
+        branch_suffix=f"fix-javac-{group}-{artifact}-{new_version}",
         coordinates=new_coordinates,
-        base_commit=base_ref,
+        stage=lambda: stage_library_version_paths(
+            group, artifact, new_version, repo_path, f"Fixed test for {new_coordinates}",
+        ),
         metrics_repo_path=metrics_repo_path,
+        after_verification=lambda: assert_no_dynamic_access_category_regressions(
+            repo_path, old_coordinates, new_coordinates,
+        ),
     )
-    assert_no_dynamic_access_category_regressions(repo_path, old_coordinates, new_coordinates)
-
-    run_git_transport(["push", "origin", branch], cwd=repo_path)
 
     return branch, group, artifact, old_version, new_coordinates
 

--- a/forge/git_scripts/make_pr_new_library_support.py
+++ b/forge/git_scripts/make_pr_new_library_support.py
@@ -6,9 +6,7 @@
 import argparse
 import json
 import os
-import re
 import shutil
-import subprocess
 import sys
 from dataclasses import dataclass
 
@@ -17,31 +15,33 @@ from git_scripts.common_git import (
     gh,
     get_origin_owner,
     parse_coordinate_parts,
-    stage_and_commit as stage_and_commit_common,
     find_issue_for_coordinates as find_issue_common,
     get_model_display_name,
     get_agent_name,
     load_library_stats,
     format_stats_section,
     format_forge_revision_section,
-    build_ai_branch_name,
-    delete_remote_branch_if_exists,
-    get_configured_reviewers,
-    run_git_transport,
+)
+from git_scripts.pr_publication import (
+    BASE_BRANCH,
+    REPO,
+    REVIEWERS,
+    parse_pr_number,
+    publish_branch,
+    stage_library_version_paths,
+    update_large_library_state_after_publish,
 )
 from utility_scripts.metrics_writer import (
     collect_new_library_support_quality_issues,
     read_pending_metrics,
 )
-from utility_scripts.large_library_progress import LABEL_LARGE_LIBRARY_PART, LargeLibraryProgressState
-from utility_scripts.library_stats import stats_artifact_dir
+from utility_scripts.large_library_progress import LABEL_LARGE_LIBRARY_PART
 from utility_scripts.dynamic_access_report import DynamicAccessCallSite, load_dynamic_access_coverage_report
 from utility_scripts.local_ci_verification import (
     HUMAN_INTERVENTION_LABEL,
     LOCAL_CI_VERIFICATION_KEY,
     format_local_ci_verification_pr_section,
     local_ci_requires_human_intervention,
-    run_local_ci_verification,
 )
 from utility_scripts.repo_path_resolver import resolve_repo_roots
 from utility_scripts.test_quality_checks import (
@@ -51,9 +51,6 @@ from utility_scripts.test_quality_checks import (
     format_placeholder_occurrence,
 )
 
-REPO = "oracle/graalvm-reachability-metadata"
-BASE_BRANCH = 'master'
-REVIEWERS = get_configured_reviewers()
 DYNAMIC_ACCESS_METADATA_ENTRY_NOTE_RATIO = 1.75
 DYNAMIC_ACCESS_METADATA_ENTRY_NOTE_MAX_ITEMS = 8
 
@@ -343,53 +340,6 @@ Summary:
     return body
 
 
-def stage_and_commit(
-        group,
-        artifact,
-        library_version,
-        coordinates,
-        repo_path,
-        metrics_repo_path: str | None = None,
-        include_in_repo_metrics: bool = False,
-):
-    """Stage the expected new-library paths and commit with the required message.
-
-    Publication scripts stage the workflow-specific expected paths instead of a
-    generic repository-wide add, keeping the path boundary explicit
-    (§GIT-expected-paths).
-    """
-    candidate_paths = [
-        str(os.path.join("tests", "src", group, artifact, library_version)),
-        str(os.path.join("metadata", group, artifact, "index.json")),
-        str(os.path.join("metadata", group, artifact, library_version)),
-        str(os.path.relpath(stats_artifact_dir(repo_path, group, artifact), repo_path)),
-    ]
-    del metrics_repo_path, include_in_repo_metrics
-    candidate_paths = [path for path in candidate_paths if os.path.exists(os.path.join(repo_path, path))]
-
-    commit_message = f"Add support for {coordinates}"
-    stage_and_commit_common(candidate_paths, commit_message, cwd=repo_path)
-
-
-def _fetch_pr_base(repo_path: str) -> str:
-    """Fetch the upstream PR base and return the ref to rebase onto."""
-    upstream_url = f"https://github.com/{REPO}.git"
-    upstream_remote_url = subprocess.run(
-        ["git", "remote", "get-url", "upstream"],
-        cwd=repo_path,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-        text=True,
-        check=False,
-    )
-    if upstream_remote_url.returncode == 0 and REPO in upstream_remote_url.stdout.strip():
-        run_git_transport(["fetch", "upstream", BASE_BRANCH], cwd=repo_path)
-        return f"upstream/{BASE_BRANCH}"
-
-    run_git_transport(["fetch", upstream_url, BASE_BRANCH], cwd=repo_path)
-    return "FETCH_HEAD"
-
-
 def create_pull_request(
         branch,
         coordinates,
@@ -446,7 +396,7 @@ def create_pull_request(
         for r in REVIEWERS:
             cmd.extend(["--reviewer", r])
     result = gh(*cmd[1:])
-    return _parse_pr_number(result.stdout)
+    return parse_pr_number(result.stdout)
 
 
 def build_pull_request_preview(
@@ -539,29 +489,13 @@ def build_parser():
     return parser
 
 
-def resolve_repo_paths(
-        explicit_repo_path: str | None,
-        explicit_metrics_repo_path: str | None,
-):
-    """Resolve repo and metrics paths similar to add_new_library_support.
-
-    If explicit paths are provided via CLI, use them as-is. Otherwise, use
-    local clones under 'local_repositories'.
-    """
-
-    return resolve_repo_roots(
-        explicit_repo_path,
-        explicit_metrics_repo_path,
-    )
-
-
 def parse_flags(argv_list):
     """Parse CLI flags and return coordinates, repo_path, metrics_repo_path."""
     parser = build_parser()
     flags = parser.parse_args(argv_list)
 
     coordinates = flags.coordinates
-    resolved_repo_path, resolved_metrics_repo_path = resolve_repo_paths(
+    resolved_repo_path, resolved_metrics_repo_path = resolve_repo_roots(
         flags.reachability_metadata_path,
         flags.metrics_repo_path,
     )
@@ -582,7 +516,6 @@ def push_current_branch_to_origin(
         coordinates,
         repo_path,
         metrics_repo_path=None,
-        include_in_repo_metrics=False,
         large_library_part=None,
 ):
     """Create, locally verify, and push a feature branch for PR publication.
@@ -596,59 +529,18 @@ def push_current_branch_to_origin(
     branch_suffix = f"add-lib-support-{group}-{artifact}-{library_version}"
     if large_library_part is not None:
         branch_suffix = f"{branch_suffix}-part-{large_library_part:04d}"
-    new_branch = build_ai_branch_name(branch_suffix, cwd=repo_path)
-    delete_remote_branch_if_exists(new_branch, cwd=repo_path)
-    subprocess.run(["git", "switch", "-C", new_branch], check=True, cwd=repo_path)
 
-    stage_and_commit(
-        group,
-        artifact,
-        library_version,
-        coordinates,
-        repo_path,
-        metrics_repo_path=metrics_repo_path,
-        include_in_repo_metrics=include_in_repo_metrics,
-    )
-
-    base_ref = _fetch_pr_base(repo_path)
-    subprocess.run(["git", "rebase", base_ref], check=True, cwd=repo_path)
-    run_local_ci_verification(
+    new_branch, _ = publish_branch(
         repo_path=repo_path,
+        branch_suffix=branch_suffix,
         coordinates=coordinates,
-        base_commit=base_ref,
+        stage=lambda: stage_library_version_paths(
+            group, artifact, library_version, repo_path, f"Add support for {coordinates}",
+        ),
         metrics_repo_path=metrics_repo_path,
     )
-    run_git_transport(["push", "origin", new_branch], cwd=repo_path)
 
     return new_branch
-
-
-def _parse_pr_number(output: str) -> int | None:
-    """Extract a PR number from gh pr create output."""
-    match = re.search(r"/pull/(\d+)", output)
-    return int(match.group(1)) if match else None
-
-
-def update_large_library_state_after_publish(
-        state_path: str | None,
-        branch: str,
-        repo_path: str,
-        pr_number: int | None,
-        final_part: bool,
-) -> None:
-    """Record the published branch/commit in the large-library progress artifact.
-
-    The next chunk resumes only after this published state is present on the
-    base branch (§WF-dynamic-access-exhaust-report).
-    """
-    if not state_path:
-        return
-    state = LargeLibraryProgressState.load(state_path)
-    commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo_path, text=True).strip()
-    state.record_published_pr(branch, commit, pr_number)
-    if not final_part:
-        state.advance_to_next_part()
-    state.save(state_path)
 
 
 def validate_run_quality(coordinates: str, metrics_repo_path: str, repo_path: str) -> None:

--- a/forge/git_scripts/make_pr_ni_run_fix.py
+++ b/forge/git_scripts/make_pr_ni_run_fix.py
@@ -20,12 +20,14 @@ from git_scripts.common_git import (
     format_forge_revision_section,
     get_model_display_name,
     get_agent_name,
-    build_ai_branch_name,
-    delete_remote_branch_if_exists,
-    get_configured_reviewers,
-    run_git_transport,
 )
-from git_scripts.make_pr_javac_fix import generate_diff_text
+from git_scripts.pr_publication import (
+    BASE_BRANCH,
+    REPO,
+    REVIEWERS,
+    generate_diff_text,
+    publish_branch,
+)
 from utility_scripts.metadata_index import resolve_test_version
 from utility_scripts.metrics_writer import (
     count_metadata_entries,
@@ -37,15 +39,10 @@ from utility_scripts.library_stats import stats_artifact_dir
 from utility_scripts.local_ci_verification import (
     HUMAN_INTERVENTION_LABEL,
     LocalCIVerificationResult,
-    fetch_pr_base_ref,
     format_local_ci_verification_pr_section,
-    run_local_ci_verification,
 )
 from utility_scripts.repo_path_resolver import resolve_repo_roots
 
-REPO = "oracle/graalvm-reachability-metadata"
-BASE_BRANCH = 'master'
-REVIEWERS = get_configured_reviewers()
 SEVERE_METADATA_DROP_RATIO = 0.25
 TEST_SOURCE_DIR_NAMES: tuple[str, ...] = ("java", "kotlin", "groovy", "scala")
 
@@ -363,39 +360,28 @@ def push_current_branch_to_origin(
     group, artifact, old_version = parse_coordinate_parts(old_coordinates)
     new_coordinates = f"{group}:{artifact}:{new_version}"
 
-    branch = build_ai_branch_name(
-        f"fix-native-image-run-{group}-{artifact}-{new_version}",
-        cwd=repo_path,
-    )
-    delete_remote_branch_if_exists(branch, cwd=repo_path)
-    subprocess.run(
-        ["git", "switch", "-C", branch],
-        cwd=repo_path,
-        check=True,
-    )
-    # Exploration splits the seed's shared entry into a version-specific one, so
-    # the resolved test version is the new version; otherwise tests stay shared
-    # under the old version (metadata-first seed).
-    resolved_test_version = resolve_test_version(repo_path, group, artifact, new_version)
-    stage_and_commit(
-        group=group,
-        artifact=artifact,
-        test_version=resolved_test_version,
-        metadata_version=new_version,
-        coordinates=new_coordinates,
-        repo_path=repo_path,
-    )
-    assert_no_tracked_worktree_changes(repo_path)
-    base_ref = fetch_pr_base_ref(repo_path, REPO, BASE_BRANCH)
-    subprocess.run(["git", "rebase", base_ref], cwd=repo_path, check=True)
-    local_ci_verification = run_local_ci_verification(
-        repo_path=repo_path,
-        coordinates=new_coordinates,
-        base_commit=base_ref,
-        metrics_repo_path=metrics_repo_path,
-    )
+    def stage() -> None:
+        # Exploration splits the seed's shared entry into a version-specific one, so
+        # the resolved test version is the new version; otherwise tests stay shared
+        # under the old version (metadata-first seed).
+        resolved_test_version = resolve_test_version(repo_path, group, artifact, new_version)
+        stage_and_commit(
+            group=group,
+            artifact=artifact,
+            test_version=resolved_test_version,
+            metadata_version=new_version,
+            coordinates=new_coordinates,
+            repo_path=repo_path,
+        )
 
-    run_git_transport(["push", "origin", branch], cwd=repo_path)
+    branch, local_ci_verification = publish_branch(
+        repo_path=repo_path,
+        branch_suffix=f"fix-native-image-run-{group}-{artifact}-{new_version}",
+        coordinates=new_coordinates,
+        stage=stage,
+        metrics_repo_path=metrics_repo_path,
+        before_rebase=lambda: assert_no_tracked_worktree_changes(repo_path),
+    )
 
     return branch, group, artifact, new_coordinates, local_ci_verification
 

--- a/forge/git_scripts/make_pr_not_for_native_image.py
+++ b/forge/git_scripts/make_pr_not_for_native_image.py
@@ -8,36 +8,30 @@
 import argparse
 import os
 import shutil
-import subprocess
 
 from git_scripts.common_git import (
-    build_ai_branch_name,
-    delete_remote_branch_if_exists,
     ensure_gh_authenticated,
     find_issue_for_coordinates,
     format_forge_revision_section,
-    get_configured_reviewers,
     get_origin_owner,
     gh,
     parse_coordinate_parts,
-    run_git_transport,
     stage_and_commit,
+)
+from git_scripts.pr_publication import (
+    BASE_BRANCH,
+    REPO,
+    REVIEWERS,
+    publish_branch,
 )
 from utility_scripts.metadata_index import get_not_for_native_image_marker
 from utility_scripts.local_ci_verification import (
     HUMAN_INTERVENTION_LABEL,
     LocalCIVerificationResult,
-    fetch_pr_base_ref,
     format_local_ci_verification_pr_section,
     local_ci_requires_human_intervention,
-    run_local_ci_verification,
 )
 from utility_scripts.repo_path_resolver import resolve_repo_roots
-
-
-REPO = "oracle/graalvm-reachability-metadata"
-BASE_BRANCH = "master"
-REVIEWERS = get_configured_reviewers()
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -57,11 +51,6 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def fetch_pr_base(repo_path: str) -> str:
-    """Fetch the upstream PR base and return the ref to rebase onto."""
-    return fetch_pr_base_ref(repo_path, REPO, BASE_BRANCH)
-
-
 def push_marker_branch(
         coordinates: str,
         repo_path: str,
@@ -69,24 +58,17 @@ def push_marker_branch(
 ) -> tuple[str, LocalCIVerificationResult]:
     """Create, commit, rebase, and push the marker branch."""
     group, artifact, _version = parse_coordinate_parts(coordinates)
-    branch = build_ai_branch_name(f"not-for-native-image-{group}-{artifact}", cwd=repo_path)
-    delete_remote_branch_if_exists(branch, cwd=repo_path)
-    subprocess.run(["git", "switch", "-C", branch], check=True, cwd=repo_path)
-    stage_and_commit(
-        [os.path.join("metadata", group, artifact, "index.json")],
-        f"Mark {group}:{artifact} as not for Native Image",
-        cwd=repo_path,
-    )
-    base_ref = fetch_pr_base(repo_path)
-    subprocess.run(["git", "rebase", base_ref], check=True, cwd=repo_path)
-    local_ci_verification = run_local_ci_verification(
+    return publish_branch(
         repo_path=repo_path,
+        branch_suffix=f"not-for-native-image-{group}-{artifact}",
         coordinates=coordinates,
-        base_commit=base_ref,
+        stage=lambda: stage_and_commit(
+            [os.path.join("metadata", group, artifact, "index.json")],
+            f"Mark {group}:{artifact} as not for Native Image",
+            cwd=repo_path,
+        ),
         metrics_repo_path=metrics_repo_path,
     )
-    run_git_transport(["push", "origin", branch], cwd=repo_path)
-    return branch, local_ci_verification
 
 
 def create_pull_request(

--- a/forge/git_scripts/pr_publication.py
+++ b/forge/git_scripts/pr_publication.py
@@ -1,0 +1,175 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+"""Shared branch-publication pipeline for the make_pr_* publishers (§GIT-shared-publication-pipeline)."""
+
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Callable
+
+from git_scripts.common_git import (
+    build_ai_branch_name,
+    delete_remote_branch_if_exists,
+    get_configured_reviewers,
+    git_files_under,
+    is_java_fix_test_module_file,
+    run_git_transport,
+    stage_and_commit as stage_and_commit_common,
+)
+from utility_scripts.large_library_progress import LargeLibraryProgressState
+from utility_scripts.library_stats import stats_artifact_dir
+from utility_scripts.local_ci_verification import (
+    LocalCIVerificationResult,
+    fetch_pr_base_ref,
+    run_local_ci_verification,
+)
+
+REPO: str = "oracle/graalvm-reachability-metadata"
+BASE_BRANCH: str = "master"
+REVIEWERS: list[str] = get_configured_reviewers()
+
+
+def publish_branch(
+        repo_path: str,
+        branch_suffix: str,
+        coordinates: str,
+        stage: Callable[[], None],
+        metrics_repo_path: str | None = None,
+        before_rebase: Callable[[], None] | None = None,
+        after_verification: Callable[[], None] | None = None,
+) -> tuple[str, LocalCIVerificationResult]:
+    """Create, stage, rebase, verify, and push the publication branch.
+
+    The one shared path from a verified worktree to a pushed PR branch
+    (§GIT-shared-publication-pipeline): publishers supply only their staging
+    policy (§GIT-expected-paths) and optional pre-rebase / post-verification
+    assertions. Local CI-equivalent verification always runs before the push
+    that makes the branch PR-eligible (§GIT-pr-eligibility).
+    """
+    branch = build_ai_branch_name(branch_suffix, cwd=repo_path)
+    delete_remote_branch_if_exists(branch, cwd=repo_path)
+    subprocess.run(["git", "switch", "-C", branch], check=True, cwd=repo_path)
+    stage()
+    if before_rebase is not None:
+        before_rebase()
+    base_ref = fetch_pr_base_ref(repo_path, REPO, BASE_BRANCH)
+    subprocess.run(["git", "rebase", base_ref], check=True, cwd=repo_path)
+    local_ci_verification = run_local_ci_verification(
+        repo_path=repo_path,
+        coordinates=coordinates,
+        base_commit=base_ref,
+        metrics_repo_path=metrics_repo_path,
+    )
+    if after_verification is not None:
+        after_verification()
+    run_git_transport(["push", "origin", branch], cwd=repo_path)
+    return branch, local_ci_verification
+
+
+def stage_library_version_paths(
+        group: str,
+        artifact: str,
+        library_version: str,
+        repo_path: str,
+        commit_message: str,
+) -> None:
+    """Stage the standard per-version tests/metadata/stats paths and commit.
+
+    Publication scripts stage the workflow-specific expected paths instead of a
+    generic repository-wide add, keeping the path boundary explicit
+    (§GIT-expected-paths).
+    """
+    candidate_paths: list[str] = [
+        str(os.path.join("tests", "src", group, artifact, library_version)),
+        str(os.path.join("metadata", group, artifact, "index.json")),
+        str(os.path.join("metadata", group, artifact, library_version)),
+        str(os.path.relpath(stats_artifact_dir(repo_path, group, artifact), repo_path)),
+    ]
+    candidate_paths = [path for path in candidate_paths if os.path.exists(os.path.join(repo_path, path))]
+    stage_and_commit_common(candidate_paths, commit_message, cwd=repo_path)
+
+
+def parse_pr_number(output: str) -> int | None:
+    """Extract a PR number from gh pr create output."""
+    match = re.search(r"/pull/(\d+)", output)
+    return int(match.group(1)) if match else None
+
+
+def update_large_library_state_after_publish(
+        state_path: str | None,
+        branch: str,
+        repo_path: str,
+        pr_number: int | None,
+        final_part: bool,
+) -> None:
+    """Record the published branch/commit in the large-library progress artifact.
+
+    The next chunk resumes only after this published state is present on the
+    base branch (§WF-dynamic-access-exhaust-report).
+    """
+    if not state_path:
+        return
+    state = LargeLibraryProgressState.load(state_path)
+    commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo_path, text=True).strip()
+    state.record_published_pr(branch, commit, pr_number)
+    if not final_part:
+        state.advance_to_next_part()
+    state.save(state_path)
+
+
+def _copy_git_files_under(repo_path: str, source_dir: str, destination_dir: str) -> None:
+    os.makedirs(destination_dir, exist_ok=True)
+    for git_path in git_files_under(repo_path, source_dir):
+        source_file = os.path.join(repo_path, git_path)
+        relative_file = os.path.relpath(source_file, source_dir)
+        if relative_file.startswith(os.pardir + os.sep) or relative_file == os.pardir:
+            continue
+        if not is_java_fix_test_module_file(relative_file):
+            continue
+        destination_file = os.path.join(destination_dir, relative_file)
+        os.makedirs(os.path.dirname(destination_file), exist_ok=True)
+        shutil.copy2(source_file, destination_file)
+
+
+def generate_diff_text(group: str, artifact: str, current_version: str, new_version: str, repo_path: str) -> str:
+    """Build a diff text between the current and new test directories for a library version."""
+    old_dir = os.path.join(repo_path, "tests", "src", group, artifact, current_version)
+    new_dir = os.path.join(repo_path, "tests", "src", group, artifact, new_version)
+    old_display_dir = os.path.relpath(old_dir, repo_path).replace(os.sep, "/")
+    new_display_dir = os.path.relpath(new_dir, repo_path).replace(os.sep, "/")
+    old_diff_display_dir = f"/{old_display_dir}"
+    new_diff_display_dir = f"/{new_display_dir}"
+
+    # Prepare temp copies from Git's file list with a narrow allow-list for the PR body diff.
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_old = os.path.join(tmpdir, "old")
+        tmp_new = os.path.join(tmpdir, "new")
+
+        _copy_git_files_under(repo_path, old_dir, tmp_old)
+        _copy_git_files_under(repo_path, new_dir, tmp_new)
+
+        # Compute diff text using: git diff --no-index --find-renames tmp_old tmp_new
+        res = subprocess.run(
+            ["git", "diff", "--no-index", "--find-renames", tmp_old, tmp_new],
+            capture_output=True,
+            text=True,
+        )
+        if res.returncode in (0, 1):
+            diff_text = res.stdout
+
+            diff_text = diff_text.replace(tmp_old.replace(os.sep, "/"), old_diff_display_dir)
+            diff_text = diff_text.replace(tmp_new.replace(os.sep, "/"), new_diff_display_dir)
+            diff_text = diff_text.replace(tmp_old, old_diff_display_dir)
+            diff_text = diff_text.replace(tmp_new, new_diff_display_dir)
+            return diff_text
+
+        error_message = (
+            f"Subprocess failed with return code: {res.returncode}. "
+            f"Error output:\n{res.stderr.strip()}"
+        )
+        raise RuntimeError(error_message)

--- a/forge/tests/test_large_library_progress.py
+++ b/forge/tests/test_large_library_progress.py
@@ -7,8 +7,7 @@ import os
 import tempfile
 import unittest
 
-from git_scripts.make_pr_improve_coverage import _parse_pr_number as parse_improve_pr_number
-from git_scripts.make_pr_new_library_support import _parse_pr_number as parse_new_lib_pr_number
+from git_scripts.pr_publication import parse_pr_number
 from utility_scripts.large_library_progress import (
     LargeLibraryProgressState,
     copy_progress_artifacts,
@@ -20,17 +19,15 @@ from utility_scripts.large_library_progress import (
 class ParsePrNumberTests(unittest.TestCase):
     def test_pr_number_extracted_from_url(self) -> None:
         output = "https://github.com/oracle/graalvm-reachability-metadata/pull/4242\n"
-        self.assertEqual(parse_new_lib_pr_number(output), 4242)
-        self.assertEqual(parse_improve_pr_number(output), 4242)
+        self.assertEqual(parse_pr_number(output), 4242)
 
     def test_pr_number_ignores_org_or_repo_with_digits(self) -> None:
         output = "https://github.com/owner123/repo456/pull/77\n"
-        self.assertEqual(parse_new_lib_pr_number(output), 77)
-        self.assertEqual(parse_improve_pr_number(output), 77)
+        self.assertEqual(parse_pr_number(output), 77)
 
     def test_pr_number_returns_none_when_url_absent(self) -> None:
-        self.assertIsNone(parse_new_lib_pr_number(""))
-        self.assertIsNone(parse_improve_pr_number("Pull request already exists for branch foo.\n"))
+        self.assertIsNone(parse_pr_number(""))
+        self.assertIsNone(parse_pr_number("Pull request already exists for branch foo.\n"))
 
 
 class LargeLibraryProgressStateTests(unittest.TestCase):

--- a/forge/tests/test_make_pr_not_for_native_image.py
+++ b/forge/tests/test_make_pr_not_for_native_image.py
@@ -7,7 +7,7 @@ import subprocess
 import unittest
 from unittest.mock import patch
 
-from git_scripts import make_pr_not_for_native_image
+from git_scripts import make_pr_not_for_native_image, pr_publication
 from utility_scripts.local_ci_verification import LocalCIVerificationResult
 
 
@@ -20,9 +20,13 @@ class MakePrNotForNativeImageTests(unittest.TestCase):
             del check, cwd
             if command[:2] == ["git", "rebase"]:
                 events.append("rebase")
-            if command[:2] == ["git", "push"]:
-                events.append("push")
             return subprocess.CompletedProcess(command, 0)
+
+        def fake_run_git_transport(args: list[str], cwd: str | None = None):
+            del cwd
+            if args[:1] == ["push"]:
+                events.append("push")
+            return subprocess.CompletedProcess(["git", *args], 0)
 
         def fake_run_local_ci_verification(**kwargs):
             events.append("local-ci")
@@ -30,16 +34,17 @@ class MakePrNotForNativeImageTests(unittest.TestCase):
             self.assertEqual(kwargs["base_commit"], "FETCH_HEAD")
             return result
 
-        with patch.object(make_pr_not_for_native_image, "build_ai_branch_name", return_value="not-native-branch"), \
-                patch.object(make_pr_not_for_native_image, "delete_remote_branch_if_exists"), \
+        with patch.object(pr_publication, "build_ai_branch_name", return_value="not-native-branch"), \
+                patch.object(pr_publication, "delete_remote_branch_if_exists"), \
                 patch.object(make_pr_not_for_native_image, "stage_and_commit"), \
-                patch.object(make_pr_not_for_native_image, "fetch_pr_base", return_value="FETCH_HEAD"), \
+                patch.object(pr_publication, "fetch_pr_base_ref", return_value="FETCH_HEAD"), \
                 patch.object(
-                    make_pr_not_for_native_image,
+                    pr_publication,
                     "run_local_ci_verification",
                     side_effect=fake_run_local_ci_verification,
                 ), \
-                patch.object(make_pr_not_for_native_image.subprocess, "run", side_effect=fake_subprocess_run):
+                patch.object(pr_publication, "run_git_transport", side_effect=fake_run_git_transport), \
+                patch.object(pr_publication.subprocess, "run", side_effect=fake_subprocess_run):
             branch, local_ci_verification = make_pr_not_for_native_image.push_marker_branch(
                 "org.example:demo:1.0.0",
                 "/repo",

--- a/forge/tests/test_metrics_paths.py
+++ b/forge/tests/test_metrics_paths.py
@@ -606,7 +606,7 @@ class MetricsPathTests(unittest.TestCase):
 
             write_add_new_library_support_metrics(
                 run_metrics=run_metrics,
-                metrics_json=metrics_json,
+                metrics_repo_dir=metrics_repo_dir,
                 is_benchmark_mode=False,
                 package="org.example",
                 artifact="demo",

--- a/forge/tests/test_workflow_strategy.py
+++ b/forge/tests/test_workflow_strategy.py
@@ -10,7 +10,13 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-from ai_workflows.core.workflow_strategy import RUN_STATUS_SUCCESS, WorkflowStrategy
+from ai_workflows.core.workflow_strategy import (
+    RUN_STATUS_CHUNK_READY,
+    RUN_STATUS_FAILURE,
+    RUN_STATUS_SUCCESS,
+    SUCCESS_WITH_INTERVENTION_STATUS,
+    WorkflowStrategy,
+)
 
 
 class _TestWorkflowStrategy(WorkflowStrategy):
@@ -151,6 +157,31 @@ class WorkflowStrategyTests(unittest.TestCase):
         self.assertEqual(checkpoint, "checkpoint")
         self.assertEqual(tested_libraries, expected_libraries)
         self.assertEqual(finalized_libraries, expected_libraries)
+
+    def test_finalize_run_merges_finalization_status_for_all_driver_cases(self) -> None:
+        strategy = _TestWorkflowStrategy(
+            {"model": "test-model"},
+            reachability_repo_path="/tmp/reachability",
+            library="org.example:demo:1.0.0",
+        )
+        # (finalization status, incoming workflow status) -> merged run status.
+        cases = [
+            (RUN_STATUS_SUCCESS, RUN_STATUS_SUCCESS, RUN_STATUS_SUCCESS),
+            (SUCCESS_WITH_INTERVENTION_STATUS, RUN_STATUS_SUCCESS, SUCCESS_WITH_INTERVENTION_STATUS),
+            (RUN_STATUS_FAILURE, RUN_STATUS_SUCCESS, RUN_STATUS_FAILURE),
+            (RUN_STATUS_SUCCESS, RUN_STATUS_CHUNK_READY, RUN_STATUS_CHUNK_READY),
+            (SUCCESS_WITH_INTERVENTION_STATUS, RUN_STATUS_CHUNK_READY, RUN_STATUS_CHUNK_READY),
+            (RUN_STATUS_FAILURE, RUN_STATUS_CHUNK_READY, RUN_STATUS_FAILURE),
+        ]
+        for finalize_status, workflow_status, expected_status in cases:
+            with self.subTest(finalize_status=finalize_status, workflow_status=workflow_status), \
+                    patch.object(
+                        strategy,
+                        "_finalize_successful_iteration",
+                        return_value=(finalize_status, "checkpoint"),
+                    ) as finalize:
+                self.assertEqual(strategy.finalize_run("base", workflow_status), expected_status)
+                finalize.assert_called_once_with(base_commit="base")
 
 
 if __name__ == "__main__":

--- a/forge/utility_scripts/metrics_writer.py
+++ b/forge/utility_scripts/metrics_writer.py
@@ -19,6 +19,7 @@ import utility_scripts.count_reachability_entries as reachability_metadata_count
 import utility_scripts.count_native_image_config_entries as legacy_metadata_count
 from utility_scripts.library_stats import load_library_stats_entry
 from utility_scripts.metadata_index import resolve_metadata_version, resolve_test_version
+from utility_scripts.schema_validator import validate_run_metrics
 from utility_scripts.native_image_config_policy import (
     find_changed_legacy_test_native_image_config_files_for_coordinate,
     format_legacy_test_native_image_config_error,
@@ -906,6 +907,47 @@ def read_pending_metrics(metrics_repo_root: str) -> dict:
     path = os.path.join(metrics_repo_root, PENDING_METRICS_FILENAME)
     with open(path, "r", encoding="utf-8") as f:
         return json.load(f)
+
+
+def resolve_workflow_metrics_json(
+        run_metrics: dict,
+        metrics_repo_dir: str,
+        metrics_repo_root: str | None,
+        task_type: str,
+) -> str:
+    """Resolve the run-metrics JSON path for a workflow driver execution."""
+    in_repo_root = in_metadata_repo_metrics_root(metrics_repo_root)
+    if in_repo_root:
+        return execution_metrics_path(in_repo_root, run_metrics)
+    return os.path.join(metrics_repo_dir, f"{task_type}.json")
+
+
+def write_workflow_run_metrics(
+        run_metrics: dict,
+        metrics_repo_dir: str,
+        metrics_repo_root: str | None,
+        task_type: str,
+) -> str:
+    """Append run metrics, write pending metrics, and validate the written file.
+
+    The shared metrics-publication path for all workflow drivers
+    (§WF-forge-workflow-drivers.3); drivers contribute only their task type and
+    the per-workflow metrics payload.
+    """
+    metrics_json = resolve_workflow_metrics_json(run_metrics, metrics_repo_dir, metrics_repo_root, task_type)
+    in_repo_root = in_metadata_repo_metrics_root(metrics_repo_root)
+    if in_repo_root:
+        written_metrics_json = append_execution_metrics(in_repo_root, run_metrics, task_type)
+        if written_metrics_json != metrics_json:
+            raise ValueError(
+                f"ERROR: Resolved metrics path {metrics_json} does not match written path {written_metrics_json}"
+            )
+    else:
+        append_run_metrics(run_metrics, metrics_json)
+    if metrics_repo_root:
+        write_pending_metrics(metrics_repo_root, run_metrics)
+    validate_run_metrics(metrics_json)
+    return metrics_json
 
 
 def _resolve_primary_worktree_root(repo_root: str) -> str:

--- a/forge/utility_scripts/workflow_setup.py
+++ b/forge/utility_scripts/workflow_setup.py
@@ -10,8 +10,34 @@ import sys
 from ai_workflows.core.fix_metadata_codex import run_codex_metadata_fix
 from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.library_finalization import run_library_finalization
-from utility_scripts.repo_path_resolver import require_complete_reachability_repo
+from utility_scripts.repo_path_resolver import require_complete_reachability_repo, resolve_repo_roots
 from utility_scripts.stage_logger import log_stage
+
+
+def list_all_files(directory_path: str) -> list[str]:
+    """Recursively list all file paths under the provided directory."""
+    files: list[str] = []
+    if not directory_path or not os.path.exists(directory_path):
+        return files
+    for root_dir, _, file_names in os.walk(directory_path):
+        for file_name in file_names:
+            files.append(os.path.join(root_dir, file_name))
+    return files
+
+
+def resolve_workflow_repo_paths(
+        explicit_repo_path: str | None,
+        explicit_metrics_repo_path: str | None,
+        metrics_subdir: str = "script_run_metrics",
+) -> tuple[str, str, str]:
+    """Resolve the reachability repo, metrics output dir, and metrics root for a driver run."""
+    resolved_reachability_repo, resolved_metrics_repo = resolve_repo_roots(
+        explicit_repo_path,
+        explicit_metrics_repo_path,
+    )
+    resolved_metrics_dir = os.path.join(resolved_metrics_repo, metrics_subdir)
+    os.makedirs(resolved_metrics_dir, exist_ok=True)
+    return resolved_reachability_repo, resolved_metrics_dir, resolved_metrics_repo
 
 
 def resolve_graalvm_java_home():

--- a/forge/utility_scripts/worktree_reset.py
+++ b/forge/utility_scripts/worktree_reset.py
@@ -1,0 +1,68 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+"""Shared checkpoint-reset helpers for failed workflow runs (§WF-forge-workflow-drivers.3)."""
+
+import os
+import shutil
+import subprocess
+import tempfile
+
+
+def reset_worktree_to_commit(repo_path: str, commit: str) -> str:
+    """Hard-reset the worktree to a commit and return the resulting HEAD hash."""
+    subprocess.run(["git", "reset", "--hard", commit], cwd=repo_path, check=True)
+    return subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo_path, text=True).strip()
+
+
+def snapshot_existing_paths(paths: list[str]) -> str | None:
+    """Copy the existing paths into a temporary snapshot root, or return None when nothing exists."""
+    snapshot_root = tempfile.mkdtemp(prefix="forge-update-failure-")
+    copied = False
+    for index, path in enumerate(paths):
+        if not os.path.exists(path):
+            continue
+        destination = os.path.join(snapshot_root, str(index))
+        if os.path.isdir(path):
+            shutil.copytree(path, destination)
+        else:
+            shutil.copy2(path, destination)
+        copied = True
+    if copied:
+        return snapshot_root
+    shutil.rmtree(snapshot_root, ignore_errors=True)
+    return None
+
+
+def restore_snapshot_paths(snapshot_root: str | None, paths: list[str]) -> None:
+    """Restore previously snapshotted paths over the current worktree content."""
+    if snapshot_root is None:
+        return
+    for index, path in enumerate(paths):
+        source = os.path.join(snapshot_root, str(index))
+        if not os.path.exists(source):
+            continue
+        if os.path.exists(path):
+            if os.path.isdir(path):
+                shutil.rmtree(path)
+            else:
+                os.remove(path)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        if os.path.isdir(source):
+            shutil.copytree(source, path)
+        else:
+            shutil.copy2(source, path)
+
+
+def reset_worktree_preserving_paths(repo_path: str, commit: str, paths: list[str]) -> str:
+    """Reset to a commit while preserving the current content of the given paths."""
+    snapshot_root = snapshot_existing_paths(paths)
+    try:
+        subprocess.run(["git", "reset", "--hard", commit], cwd=repo_path, check=True)
+        restore_snapshot_paths(snapshot_root, paths)
+    finally:
+        if snapshot_root is not None:
+            shutil.rmtree(snapshot_root, ignore_errors=True)
+    return subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo_path, text=True).strip()


### PR DESCRIPTION
Closes #7850.

## Why

Forge had the same workflow step, finalization flow, and helper reimplemented across modules and wired up through several hand-rolled call sites from different entry points (`add_new_library_support`, `java_fail_workflow`, `improve_library_coverage`, `fix_ni_run`, the `make_pr_*` scripts). Duplicated code paths are a problem for agentic coding: an agent — or a human — editing one path has no way to know the other copies exist, so the copies drift and a fix lands in only one of them. This consolidates each duplicated thing into a single shared home so there is one obvious code path per step.

## What changed

- **PR publication** — the six `make_pr_*` scripts each re-implemented branch creation, staging, fork-aware base fetch/rebase, local CI-equivalent verification, push, PR-number parsing, the old-vs-new test diff, and large-library state updates. They now route through a shared `git_scripts/pr_publication.py` pipeline (`§GIT-shared-publication-pipeline`); parsers and PR title/body builders stay per-script. This subsumes the original base-fetch consolidation that opened this PR.
- **Finalization** — all four drivers reached into the private `_finalize_successful_iteration` and re-implemented the status merge, with one driver subtly diverging. A public `WorkflowStrategy.finalize_run` now owns both the finalization call and the merge (`§WF-forge-workflow-drivers.3`).
- **Metrics, repo-path resolution, file listing** — four near-identical metrics writers and copied helpers collapsed into `metrics_writer.write_workflow_run_metrics` and `workflow_setup`.
- **Failed-run rollback** — two implementations merged into `utility_scripts/worktree_reset.py`.

Drift removed in passing: `make_pr_java_run_fix`'s hardcoded reviewer list, and a `stage_and_commit` copy that had lost parameters its siblings kept. Two latent `NameError`s present on master were also fixed: `RUN_STATUS_FAILURE` used but not imported in `java_fail_workflow`, and `list_all_files` used but never defined in `forge_metadata`.
