### PR TITLE
[GenAI] Test fix for org.flywaydb:flyway-sqlserver:11.8.1 using gpt-5.5

### DIFF
--- a/metadata/org.flywaydb/flyway-sqlserver/11.8.1/reachability-metadata.json
+++ b/metadata/org.flywaydb/flyway-sqlserver/11.8.1/reachability-metadata.json
@@ -1,0 +1,1264 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "com.fasterxml.jackson.databind.ext.Java7SupportImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "com.sun.crypto.provider.AESCipher$General",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "com.sun.crypto.provider.ARCFOURCipher",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Poly1305",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "com.sun.crypto.provider.DESCipher",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "com.sun.crypto.provider.DESedeCipher",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "com.sun.crypto.provider.DHParameters",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "com.sun.crypto.provider.GaloisCounterMode$AESGCM",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      },
+      "type": "com.sun.crypto.provider.GaloisCounterMode$AESGCM",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "com.sun.crypto.provider.TlsKeyMaterialGenerator",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      },
+      "type": "com.sun.crypto.provider.TlsKeyMaterialGenerator",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "com.sun.crypto.provider.TlsMasterSecretGenerator",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      },
+      "type": "com.sun.crypto.provider.TlsMasterSecretGenerator",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "com.sun.crypto.provider.TlsPrfGenerator$V12",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      },
+      "type": "com.sun.crypto.provider.TlsPrfGenerator$V12",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "java.lang.Comparable"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "java.net.Socket",
+      "methods": [
+        {
+          "name": "setOption",
+          "parameterTypes": [
+            "java.net.SocketOption",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      },
+      "type": "java.net.Socket",
+      "methods": [
+        {
+          "name": "setOption",
+          "parameterTypes": [
+            "java.net.SocketOption",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "java.security.AlgorithmParametersSpi"
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "java.security.MessageDigestSpi"
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "java.security.interfaces.RSAPrivateKey"
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "java.security.interfaces.RSAPublicKey"
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "java.sql.SQLException"
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "jdk.net.ExtendedSocketOptions",
+      "fields": [
+        {
+          "name": "TCP_KEEPIDLE"
+        },
+        {
+          "name": "TCP_KEEPINTERVAL"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.util.FeatureDetector"
+      },
+      "type": "org.apache.commons.logging.Log"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.util.FeatureDetector"
+      },
+      "type": "org.apache.logging.log4j.Logger"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.clean.CleanModeCommandExtension"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.clean.database.SQLServerCleanModePlugin"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.api.migration.baseline.BaselineAppliedMigration"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.api.configuration.ClassicConfiguration"
+      },
+      "type": "org.flywaydb.core.api.migration.baseline.BaselineMigrationConfigurationExtension"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "org.flywaydb.core.api.migration.baseline.BaselineMigrationConfigurationExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "getBaselineMigrationPrefix",
+          "parameterTypes": []
+        },
+        {
+          "name": "setBaselineMigrationPrefix",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.api.migration.baseline.BaselineMigrationConfigurationExtension"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.api.migration.baseline.BaselineMigrationResolver"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.api.migration.baseline.BaselineResourceTypeProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "org.flywaydb.core.extensibility.ConfigurationExtension"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "org.flywaydb.core.extensibility.Plugin"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.NullFlywayTelemetryManager"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "org.flywaydb.core.internal.command.clean.CleanModeConfigurationExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "getClean",
+          "parameterTypes": []
+        },
+        {
+          "name": "setClean",
+          "parameterTypes": [
+            "org.flywaydb.core.internal.command.clean.CleanModel"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.command.clean.CleanModeConfigurationExtension"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "org.flywaydb.core.internal.command.clean.CleanModel"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "org.flywaydb.core.internal.command.clean.SchemaModel"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "org.flywaydb.core.internal.configuration.extensions.DeployScriptFilenameConfigurationExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "getScriptFilename",
+          "parameterTypes": []
+        },
+        {
+          "name": "setScriptFilename",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.configuration.extensions.DeployScriptFilenameConfigurationExtension"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "org.flywaydb.core.internal.configuration.extensions.PrepareScriptFilenameConfigurationExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "getScriptFilename",
+          "parameterTypes": []
+        },
+        {
+          "name": "setScriptFilename",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.configuration.extensions.PrepareScriptFilenameConfigurationExtension"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.configuration.resolvers.EnvironmentProvisionerNone"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.configuration.resolvers.EnvironmentVariableResolver"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.configuration.resolvers.PlaceholderPropertyResolver"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.database.base.TestContainersDatabaseType"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.database.h2.H2DatabaseType"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.database.sqlite.SQLiteDatabaseType"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.proprietaryStubs.AuthCommandExtensionStub"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.proprietaryStubs.CommandExtensionStub"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.proprietaryStubs.DeployCommandExtensionStub"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.proprietaryStubs.DiffCommandExtensionStub"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.proprietaryStubs.DiffTextCommandExtensionStub"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.proprietaryStubs.GenerateCommandExtensionStub"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.api.configuration.ClassicConfiguration"
+      },
+      "type": "org.flywaydb.core.internal.proprietaryStubs.LicensingConfigurationExtensionStub"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.proprietaryStubs.LicensingConfigurationExtensionStub"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.proprietaryStubs.ModelCommandExtensionStub"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.api.configuration.ClassicConfiguration"
+      },
+      "type": "org.flywaydb.core.internal.proprietaryStubs.PATTokenConfigurationExtensionStub"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.proprietaryStubs.PATTokenConfigurationExtensionStub"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.proprietaryStubs.PrepareCommandExtensionStub"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.api.configuration.ClassicConfiguration"
+      },
+      "type": "org.flywaydb.core.internal.publishing.PublishingConfigurationExtension"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "org.flywaydb.core.internal.publishing.PublishingConfigurationExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "isCheckDriftOnMigrate",
+          "parameterTypes": []
+        },
+        {
+          "name": "isPublishResult",
+          "parameterTypes": []
+        },
+        {
+          "name": "setCheckDriftOnMigrate",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "setPublishResult",
+          "parameterTypes": [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.publishing.PublishingConfigurationExtension"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.resource.CoreResourceTypeProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.core.internal.schemahistory.BaseAppliedMigration"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "org.flywaydb.database.sqlserver.KerberosModel",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "getLogin",
+          "parameterTypes": []
+        },
+        {
+          "name": "setLogin",
+          "parameterTypes": [
+            "org.flywaydb.database.sqlserver.LoginModel"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "org.flywaydb.database.sqlserver.LoginModel",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "getFile",
+          "parameterTypes": []
+        },
+        {
+          "name": "setFile",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type": "org.flywaydb.database.sqlserver.SQLServerConfigurationExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "getClean",
+          "parameterTypes": []
+        },
+        {
+          "name": "getKerberos",
+          "parameterTypes": []
+        },
+        {
+          "name": "setClean",
+          "parameterTypes": [
+            "org.flywaydb.core.internal.command.clean.CleanModel"
+          ]
+        },
+        {
+          "name": "setKerberos",
+          "parameterTypes": [
+            "org.flywaydb.database.sqlserver.KerberosModel"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.database.sqlserver.SQLServerConfigurationExtension"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.database.sqlserver.SQLServerDatabaseType"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type": "org.flywaydb.database.sqlserver.synapse.SynapseDatabaseType"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.util.FeatureDetector"
+      },
+      "type": "org.slf4j.Logger"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.util.ClassUtils"
+      },
+      "type": "org.slf4j.spi.SLF4JServiceProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "sun.security.provider.DSA$SHA224withDSA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "sun.security.provider.DSA$SHA256withDSA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "sun.security.provider.SHA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "sun.security.provider.SHA2$SHA224",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcTemplate"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.schemahistory.JdbcTableSchemaHistory"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.database.sqlserver.SQLServerConnection"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.database.sqlserver.synapse.SynapseDatabaseType"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "sun.security.provider.SHA5$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "sun.security.provider.SHA5$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "sun.security.provider.X509Factory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      },
+      "type": "sun.security.provider.X509Factory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "sun.security.rsa.PSSParameters",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "sun.security.rsa.RSAKeyFactory$Legacy",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "sun.security.rsa.RSAPSSSignature",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      },
+      "type": "sun.security.rsa.RSAPSSSignature",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "sun.security.rsa.RSASignature$SHA224withRSA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "sun.security.rsa.RSASignature$SHA256withRSA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "sun.security.ssl.SSLContextImpl$TLSContext",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      },
+      "type": "sun.security.ssl.SSLContextImpl$TLSContext",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "sun.security.x509.AuthorityInfoAccessExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "sun.security.x509.AuthorityKeyIdentifierExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "sun.security.x509.BasicConstraintsExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "sun.security.x509.CRLDistributionPointsExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "sun.security.x509.CertificatePoliciesExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "sun.security.x509.ExtendedKeyUsageExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "sun.security.x509.KeyUsageExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "sun.security.x509.SubjectAlternativeNameExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type": "sun.security.x509.SubjectKeyIdentifierExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "glob": "META-INF/services/java.net.spi.URLStreamHandlerProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "glob": "META-INF/services/java.time.zone.ZoneRulesProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "glob": "META-INF/services/java.util.spi.ResourceBundleControlProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "glob": "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "glob": "META-INF/services/org.assertj.core.presentation.Representation"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "glob": "META-INF/services/org.flywaydb.core.extensibility.Plugin"
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "glob": "com/microsoft/sqlserver/jdbc/SQLServerResource_en.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "glob": "com/microsoft/sqlserver/jdbc/SQLServerResource_en_US.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.scanner.ClasspathClassScanner"
+      },
+      "glob": "db/callback"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.scanner.Scanner"
+      },
+      "glob": "db/migration"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.resource.classpath.ClassPathResource"
+      },
+      "glob": "db/migration/V1__create_table.sql"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.resource.classpath.ClassPathResource"
+      },
+      "glob": "db/migration/V2__alter_table.sql"
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.license.VersionPrinter"
+      },
+      "glob": "org/flywaydb/core/internal/version.txt"
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "module": "java.base",
+      "glob": "jdk/internal/icu/impl/data/icudt76b/nfkc.nrm"
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en_US.properties"
+    },
+    {
+      "bundle": "com.microsoft.sqlserver.jdbc.SQLServerResource"
+    },
+    {
+      "bundle": "sun.util.logging.resources.logging"
+    }
+  ]
+}

--- a/metadata/org.flywaydb/flyway-sqlserver/11.8.1/reachability-metadata.json
+++ b/metadata/org.flywaydb/flyway-sqlserver/11.8.1/reachability-metadata.json
@@ -1,206 +1,86 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
       },
-      "type": "com.fasterxml.jackson.databind.ext.Java7SupportImpl",
-      "methods": [
+      "type" : "com.fasterxml.jackson.databind.ext.Java7SupportImpl",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.jdbc.JdbcUtils"
       },
-      "type": "com.sun.crypto.provider.AESCipher$General",
-      "methods": [
+      "type" : "com.sun.crypto.provider.GaloisCounterMode$AESGCM",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.jdbc.JdbcUtils"
       },
-      "type": "com.sun.crypto.provider.ARCFOURCipher",
-      "methods": [
+      "type" : "com.sun.crypto.provider.TlsKeyMaterialGenerator",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.jdbc.JdbcUtils"
       },
-      "type": "com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Poly1305",
-      "methods": [
+      "type" : "com.sun.crypto.provider.TlsMasterSecretGenerator",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.jdbc.JdbcUtils"
       },
-      "type": "com.sun.crypto.provider.DESCipher",
-      "methods": [
+      "type" : "com.sun.crypto.provider.TlsPrfGenerator$V12",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
       },
-      "type": "com.sun.crypto.provider.DESedeCipher",
-      "methods": [
+      "type" : "java.lang.Comparable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      },
+      "type" : "java.net.Socket",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "type": "com.sun.crypto.provider.DHParameters",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "type": "com.sun.crypto.provider.GaloisCounterMode$AESGCM",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
-      },
-      "type": "com.sun.crypto.provider.GaloisCounterMode$AESGCM",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "type": "com.sun.crypto.provider.TlsKeyMaterialGenerator",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
-      },
-      "type": "com.sun.crypto.provider.TlsKeyMaterialGenerator",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "type": "com.sun.crypto.provider.TlsMasterSecretGenerator",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
-      },
-      "type": "com.sun.crypto.provider.TlsMasterSecretGenerator",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "type": "com.sun.crypto.provider.TlsPrfGenerator$V12",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
-      },
-      "type": "com.sun.crypto.provider.TlsPrfGenerator$V12",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
-      },
-      "type": "java.lang.Comparable"
-    },
-    {
-      "condition": {
-        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
-      },
-      "type": "java.lang.String[]"
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "type": "java.net.Socket",
-      "methods": [
-        {
-          "name": "setOption",
-          "parameterTypes": [
+          "name" : "setOption",
+          "parameterTypes" : [
             "java.net.SocketOption",
             "java.lang.Object"
           ]
@@ -208,1057 +88,606 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.util.FeatureDetector"
       },
-      "type": "java.net.Socket",
-      "methods": [
+      "type" : "org.apache.commons.logging.Log"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.util.FeatureDetector"
+      },
+      "type" : "org.apache.logging.log4j.Logger"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.clean.CleanModeCommandExtension"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.clean.database.SQLServerCleanModePlugin"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.api.migration.baseline.BaselineAppliedMigration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.api.configuration.ClassicConfiguration"
+      },
+      "type" : "org.flywaydb.core.api.migration.baseline.BaselineMigrationConfigurationExtension"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type" : "org.flywaydb.core.api.migration.baseline.BaselineMigrationConfigurationExtension",
+      "methods" : [
         {
-          "name": "setOption",
-          "parameterTypes": [
-            "java.net.SocketOption",
-            "java.lang.Object"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "type": "java.security.AlgorithmParametersSpi"
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "type": "java.security.MessageDigestSpi"
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "type": "java.security.interfaces.RSAPrivateKey"
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "type": "java.security.interfaces.RSAPublicKey"
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "type": "java.sql.SQLException"
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "type": "jdk.net.ExtendedSocketOptions",
-      "fields": [
-        {
-          "name": "TCP_KEEPIDLE"
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "TCP_KEEPINTERVAL"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.util.FeatureDetector"
-      },
-      "type": "org.apache.commons.logging.Log"
-    },
-    {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.util.FeatureDetector"
-      },
-      "type": "org.apache.logging.log4j.Logger"
-    },
-    {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
-      },
-      "type": "org.flywaydb.clean.CleanModeCommandExtension"
-    },
-    {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
-      },
-      "type": "org.flywaydb.clean.database.SQLServerCleanModePlugin"
-    },
-    {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
-      },
-      "type": "org.flywaydb.core.api.migration.baseline.BaselineAppliedMigration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.flywaydb.core.api.configuration.ClassicConfiguration"
-      },
-      "type": "org.flywaydb.core.api.migration.baseline.BaselineMigrationConfigurationExtension"
-    },
-    {
-      "condition": {
-        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
-      },
-      "type": "org.flywaydb.core.api.migration.baseline.BaselineMigrationConfigurationExtension",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "getBaselineMigrationPrefix",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "getBaselineMigrationPrefix",
-          "parameterTypes": []
-        },
-        {
-          "name": "setBaselineMigrationPrefix",
-          "parameterTypes": [
+          "name" : "setBaselineMigrationPrefix",
+          "parameterTypes" : [
             "java.lang.String"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.api.migration.baseline.BaselineMigrationConfigurationExtension"
+      "type" : "org.flywaydb.core.api.migration.baseline.BaselineMigrationConfigurationExtension"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.api.migration.baseline.BaselineMigrationResolver"
+      "type" : "org.flywaydb.core.api.migration.baseline.BaselineMigrationResolver"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.api.migration.baseline.BaselineResourceTypeProvider"
+      "type" : "org.flywaydb.core.api.migration.baseline.BaselineResourceTypeProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
       },
-      "type": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      "type" : "org.flywaydb.core.extensibility.ConfigurationExtension"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
       },
-      "type": "org.flywaydb.core.extensibility.Plugin"
+      "type" : "org.flywaydb.core.extensibility.Plugin"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.NullFlywayTelemetryManager"
+      "type" : "org.flywaydb.core.internal.NullFlywayTelemetryManager"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
       },
-      "type": "org.flywaydb.core.internal.command.clean.CleanModeConfigurationExtension",
-      "methods": [
+      "type" : "org.flywaydb.core.internal.command.clean.CleanModeConfigurationExtension",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "getClean",
-          "parameterTypes": []
+          "name" : "getClean",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "setClean",
-          "parameterTypes": [
+          "name" : "setClean",
+          "parameterTypes" : [
             "org.flywaydb.core.internal.command.clean.CleanModel"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.command.clean.CleanModeConfigurationExtension"
+      "type" : "org.flywaydb.core.internal.command.clean.CleanModeConfigurationExtension"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
       },
-      "type": "org.flywaydb.core.internal.command.clean.CleanModel"
+      "type" : "org.flywaydb.core.internal.command.clean.CleanModel"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
       },
-      "type": "org.flywaydb.core.internal.command.clean.SchemaModel"
+      "type" : "org.flywaydb.core.internal.command.clean.SchemaModel"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
       },
-      "type": "org.flywaydb.core.internal.configuration.extensions.DeployScriptFilenameConfigurationExtension",
-      "methods": [
+      "type" : "org.flywaydb.core.internal.configuration.extensions.DeployScriptFilenameConfigurationExtension",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "getScriptFilename",
-          "parameterTypes": []
+          "name" : "getScriptFilename",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "setScriptFilename",
-          "parameterTypes": [
+          "name" : "setScriptFilename",
+          "parameterTypes" : [
             "java.lang.String"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.configuration.extensions.DeployScriptFilenameConfigurationExtension"
+      "type" : "org.flywaydb.core.internal.configuration.extensions.DeployScriptFilenameConfigurationExtension"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
       },
-      "type": "org.flywaydb.core.internal.configuration.extensions.PrepareScriptFilenameConfigurationExtension",
-      "methods": [
+      "type" : "org.flywaydb.core.internal.configuration.extensions.PrepareScriptFilenameConfigurationExtension",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "getScriptFilename",
-          "parameterTypes": []
+          "name" : "getScriptFilename",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "setScriptFilename",
-          "parameterTypes": [
+          "name" : "setScriptFilename",
+          "parameterTypes" : [
             "java.lang.String"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.configuration.extensions.PrepareScriptFilenameConfigurationExtension"
+      "type" : "org.flywaydb.core.internal.configuration.extensions.PrepareScriptFilenameConfigurationExtension"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.configuration.resolvers.EnvironmentProvisionerNone"
+      "type" : "org.flywaydb.core.internal.configuration.resolvers.EnvironmentProvisionerNone"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.configuration.resolvers.EnvironmentVariableResolver"
+      "type" : "org.flywaydb.core.internal.configuration.resolvers.EnvironmentVariableResolver"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.configuration.resolvers.PlaceholderPropertyResolver"
+      "type" : "org.flywaydb.core.internal.configuration.resolvers.PlaceholderPropertyResolver"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.database.base.TestContainersDatabaseType"
+      "type" : "org.flywaydb.core.internal.database.base.TestContainersDatabaseType"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.database.h2.H2DatabaseType"
+      "type" : "org.flywaydb.core.internal.database.h2.H2DatabaseType"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.database.sqlite.SQLiteDatabaseType"
+      "type" : "org.flywaydb.core.internal.database.sqlite.SQLiteDatabaseType"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.proprietaryStubs.AuthCommandExtensionStub"
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.AuthCommandExtensionStub"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.proprietaryStubs.CommandExtensionStub"
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.CommandExtensionStub"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.proprietaryStubs.DeployCommandExtensionStub"
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.DeployCommandExtensionStub"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.proprietaryStubs.DiffCommandExtensionStub"
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.DiffCommandExtensionStub"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.proprietaryStubs.DiffTextCommandExtensionStub"
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.DiffTextCommandExtensionStub"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.proprietaryStubs.GenerateCommandExtensionStub"
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.GenerateCommandExtensionStub"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.api.configuration.ClassicConfiguration"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.api.configuration.ClassicConfiguration"
       },
-      "type": "org.flywaydb.core.internal.proprietaryStubs.LicensingConfigurationExtensionStub"
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.LicensingConfigurationExtensionStub"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.proprietaryStubs.LicensingConfigurationExtensionStub"
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.LicensingConfigurationExtensionStub"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.proprietaryStubs.ModelCommandExtensionStub"
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.ModelCommandExtensionStub"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.api.configuration.ClassicConfiguration"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.api.configuration.ClassicConfiguration"
       },
-      "type": "org.flywaydb.core.internal.proprietaryStubs.PATTokenConfigurationExtensionStub"
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.PATTokenConfigurationExtensionStub"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.proprietaryStubs.PATTokenConfigurationExtensionStub"
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.PATTokenConfigurationExtensionStub"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.proprietaryStubs.PrepareCommandExtensionStub"
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.PrepareCommandExtensionStub"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.api.configuration.ClassicConfiguration"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.api.configuration.ClassicConfiguration"
       },
-      "type": "org.flywaydb.core.internal.publishing.PublishingConfigurationExtension"
+      "type" : "org.flywaydb.core.internal.publishing.PublishingConfigurationExtension"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
       },
-      "type": "org.flywaydb.core.internal.publishing.PublishingConfigurationExtension",
-      "methods": [
+      "type" : "org.flywaydb.core.internal.publishing.PublishingConfigurationExtension",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "isCheckDriftOnMigrate",
-          "parameterTypes": []
+          "name" : "isCheckDriftOnMigrate",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "isPublishResult",
-          "parameterTypes": []
+          "name" : "isPublishResult",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "setCheckDriftOnMigrate",
-          "parameterTypes": [
+          "name" : "setCheckDriftOnMigrate",
+          "parameterTypes" : [
             "boolean"
           ]
         },
         {
-          "name": "setPublishResult",
-          "parameterTypes": [
+          "name" : "setPublishResult",
+          "parameterTypes" : [
             "boolean"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.publishing.PublishingConfigurationExtension"
+      "type" : "org.flywaydb.core.internal.publishing.PublishingConfigurationExtension"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.resource.CoreResourceTypeProvider"
+      "type" : "org.flywaydb.core.internal.resource.CoreResourceTypeProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.schemahistory.BaseAppliedMigration"
+      "type" : "org.flywaydb.core.internal.schemahistory.BaseAppliedMigration"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
       },
-      "type": "org.flywaydb.database.sqlserver.KerberosModel",
-      "methods": [
+      "type" : "org.flywaydb.database.sqlserver.KerberosModel",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "getLogin",
-          "parameterTypes": []
+          "name" : "getLogin",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "setLogin",
-          "parameterTypes": [
+          "name" : "setLogin",
+          "parameterTypes" : [
             "org.flywaydb.database.sqlserver.LoginModel"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
       },
-      "type": "org.flywaydb.database.sqlserver.LoginModel",
-      "methods": [
+      "type" : "org.flywaydb.database.sqlserver.LoginModel",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "getFile",
-          "parameterTypes": []
+          "name" : "getFile",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "setFile",
-          "parameterTypes": [
+          "name" : "setFile",
+          "parameterTypes" : [
             "java.lang.String"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
       },
-      "type": "org.flywaydb.database.sqlserver.SQLServerConfigurationExtension",
-      "methods": [
+      "type" : "org.flywaydb.database.sqlserver.SQLServerConfigurationExtension",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "getClean",
-          "parameterTypes": []
+          "name" : "getClean",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "getKerberos",
-          "parameterTypes": []
+          "name" : "getKerberos",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "setClean",
-          "parameterTypes": [
+          "name" : "setClean",
+          "parameterTypes" : [
             "org.flywaydb.core.internal.command.clean.CleanModel"
           ]
         },
         {
-          "name": "setKerberos",
-          "parameterTypes": [
+          "name" : "setKerberos",
+          "parameterTypes" : [
             "org.flywaydb.database.sqlserver.KerberosModel"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.database.sqlserver.SQLServerConfigurationExtension"
+      "type" : "org.flywaydb.database.sqlserver.SQLServerConfigurationExtension"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.database.sqlserver.SQLServerDatabaseType"
+      "type" : "org.flywaydb.database.sqlserver.SQLServerDatabaseType"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.database.sqlserver.synapse.SynapseDatabaseType"
+      "type" : "org.flywaydb.database.sqlserver.synapse.SynapseDatabaseType"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.util.FeatureDetector"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.util.FeatureDetector"
       },
-      "type": "org.slf4j.Logger"
+      "type" : "org.slf4j.Logger"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.util.ClassUtils"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.util.ClassUtils"
       },
-      "type": "org.slf4j.spi.SLF4JServiceProvider"
+      "type" : "org.slf4j.spi.SLF4JServiceProvider"
     },
     {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.jdbc.JdbcUtils"
       },
-      "type": "sun.security.provider.DSA$SHA224withDSA",
-      "methods": [
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "type": "sun.security.provider.DSA$SHA256withDSA",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "type": "sun.security.provider.NativePRNG",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.security.SecureRandomParameters"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.jdbc.JdbcTemplate"
       },
-      "type": "sun.security.provider.NativePRNG",
-      "methods": [
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.security.SecureRandomParameters"
-          ]
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.jdbc.JdbcUtils"
       },
-      "type": "sun.security.provider.SHA",
-      "methods": [
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.schemahistory.JdbcTableSchemaHistory"
       },
-      "type": "sun.security.provider.SHA2$SHA224",
-      "methods": [
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      "condition" : {
+        "typeReached" : "org.flywaydb.database.sqlserver.SQLServerConnection"
       },
-      "type": "sun.security.provider.SHA2$SHA256",
-      "methods": [
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcTemplate"
+      "condition" : {
+        "typeReached" : "org.flywaydb.database.sqlserver.synapse.SynapseDatabaseType"
       },
-      "type": "sun.security.provider.SHA2$SHA256",
-      "methods": [
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.jdbc.JdbcUtils"
       },
-      "type": "sun.security.provider.SHA2$SHA256",
-      "methods": [
+      "type" : "sun.security.provider.X509Factory",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.schemahistory.JdbcTableSchemaHistory"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.jdbc.JdbcUtils"
       },
-      "type": "sun.security.provider.SHA2$SHA256",
-      "methods": [
+      "type" : "sun.security.rsa.RSAPSSSignature",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.database.sqlserver.SQLServerConnection"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.jdbc.JdbcUtils"
       },
-      "type": "sun.security.provider.SHA2$SHA256",
-      "methods": [
+      "type" : "sun.security.ssl.SSLContextImpl$TLSContext",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.flywaydb.database.sqlserver.synapse.SynapseDatabaseType"
-      },
-      "type": "sun.security.provider.SHA2$SHA256",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "type": "sun.security.provider.SHA5$SHA384",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "type": "sun.security.provider.SHA5$SHA512",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "type": "sun.security.provider.X509Factory",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
-      },
-      "type": "sun.security.provider.X509Factory",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "type": "sun.security.rsa.PSSParameters",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "type": "sun.security.rsa.RSAKeyFactory$Legacy",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "type": "sun.security.rsa.RSAPSSSignature",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
-      },
-      "type": "sun.security.rsa.RSAPSSSignature",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "type": "sun.security.rsa.RSASignature$SHA224withRSA",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "type": "sun.security.rsa.RSASignature$SHA256withRSA",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "type": "sun.security.ssl.SSLContextImpl$TLSContext",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
-      },
-      "type": "sun.security.ssl.SSLContextImpl$TLSContext",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "type": "sun.security.x509.AuthorityInfoAccessExtension",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.Boolean",
-            "java.lang.Object"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "type": "sun.security.x509.AuthorityKeyIdentifierExtension",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.Boolean",
-            "java.lang.Object"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "type": "sun.security.x509.BasicConstraintsExtension",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.Boolean",
-            "java.lang.Object"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "type": "sun.security.x509.CRLDistributionPointsExtension",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.Boolean",
-            "java.lang.Object"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "type": "sun.security.x509.CertificatePoliciesExtension",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.Boolean",
-            "java.lang.Object"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "type": "sun.security.x509.ExtendedKeyUsageExtension",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.Boolean",
-            "java.lang.Object"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "type": "sun.security.x509.KeyUsageExtension",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.Boolean",
-            "java.lang.Object"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "type": "sun.security.x509.SubjectAlternativeNameExtension",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.Boolean",
-            "java.lang.Object"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "type": "sun.security.x509.SubjectKeyIdentifierExtension",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.Boolean",
-            "java.lang.Object"
-          ]
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "glob": "META-INF/services/java.net.spi.URLStreamHandlerProvider"
+      "glob" : "META-INF/services/org.flywaydb.core.extensibility.Plugin"
     },
     {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.scanner.ClasspathClassScanner"
       },
-      "glob": "META-INF/services/java.time.zone.ZoneRulesProvider"
+      "glob" : "db/callback"
     },
     {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.scanner.Scanner"
       },
-      "glob": "META-INF/services/java.util.spi.ResourceBundleControlProvider"
+      "glob" : "db/migration"
     },
     {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.license.VersionPrinter"
       },
-      "glob": "META-INF/services/org.assertj.core.configuration.Configuration"
+      "glob" : "org/flywaydb/core/internal/version.txt"
     },
     {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "glob": "META-INF/services/org.assertj.core.presentation.Representation"
+      "bundle" : "com.microsoft.sqlserver.jdbc.SQLServerResource"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
-      },
-      "glob": "META-INF/services/org.flywaydb.core.extensibility.Plugin"
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "glob": "com/microsoft/sqlserver/jdbc/SQLServerResource_en.properties"
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "glob": "com/microsoft/sqlserver/jdbc/SQLServerResource_en_US.properties"
-    },
-    {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.scanner.ClasspathClassScanner"
-      },
-      "glob": "db/callback"
-    },
-    {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.scanner.Scanner"
-      },
-      "glob": "db/migration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.resource.classpath.ClassPathResource"
-      },
-      "glob": "db/migration/V1__create_table.sql"
-    },
-    {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.resource.classpath.ClassPathResource"
-      },
-      "glob": "db/migration/V2__alter_table.sql"
-    },
-    {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.license.VersionPrinter"
-      },
-      "glob": "org/flywaydb/core/internal/version.txt"
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "module": "java.base",
-      "glob": "jdk/internal/icu/impl/data/icudt76b/nfkc.nrm"
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "module": "java.logging",
-      "glob": "sun/util/logging/resources/logging_en.properties"
-    },
-    {
-      "condition": {
-        "typeReached": "flyway.sqlserver.FlywaySqlServerTests"
-      },
-      "module": "java.logging",
-      "glob": "sun/util/logging/resources/logging_en_US.properties"
-    },
-    {
-      "bundle": "com.microsoft.sqlserver.jdbc.SQLServerResource"
-    },
-    {
-      "bundle": "sun.util.logging.resources.logging"
+      "bundle" : "sun.util.logging.resources.logging"
     }
   ]
 }

--- a/metadata/org.flywaydb/flyway-sqlserver/index.json
+++ b/metadata/org.flywaydb/flyway-sqlserver/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "11.8.1",
+    "tested-versions" : [
+      "11.8.1"
+    ],
+    "allowed-packages" : [
+      "org.flywaydb"
+    ]
+  },
+  {
     "metadata-version" : "10.19.0",
     "test-version" : "10.10.0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/flywaydb/flyway-sqlserver/$version$/flyway-sqlserver-$version$-sources.jar",

--- a/metadata/org.flywaydb/flyway-sqlserver/index.json
+++ b/metadata/org.flywaydb/flyway-sqlserver/index.json
@@ -2,11 +2,18 @@
   {
     "latest" : true,
     "metadata-version" : "11.8.1",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/flywaydb/flyway-sqlserver/$version$/flyway-sqlserver-$version$-sources.jar",
+    "repository-url" : "https://github.com/flyway/flyway",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://github.com/flyway/flyway/blob/flyway-$version$/documentation/Reference/Database%20Driver%20Reference/SQL%20Server%20Database.md",
+    "description" : "Flyway SQL Server support module adds Microsoft SQL Server and Azure Synapse database-specific support to Flyway. It provides the SQL Server database type, parser, schema handling, and clean-mode integrations used to run Flyway migrations against those platforms.",
     "tested-versions" : [
       "11.8.1"
     ],
     "allowed-packages" : [
-      "org.flywaydb"
+      "org.flywaydb",
+      "org.flywaydb.clean",
+      "org.flywaydb.database.sqlserver"
     ]
   },
   {

--- a/stats/org.flywaydb/flyway-sqlserver/11.8.1/execution-metrics.json
+++ b/stats/org.flywaydb/flyway-sqlserver/11.8.1/execution-metrics.json
@@ -1,0 +1,89 @@
+{
+  "fix_java_run_fail:2026-06-04": {
+    "timestamp": "2026-06-04T23:48:20.873513Z",
+    "library": "org.flywaydb:flyway-sqlserver:11.8.1",
+    "starting_commit": "787d32ecc8694590987c9e041c4ed2b2e434b058",
+    "ending_commit": "94d4a0e70cb134e2e16c9826c7e2c3eb2e54b246",
+    "previous_library": "org.flywaydb:flyway-sqlserver:10.10.0",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "11.8.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1154,
+          "missed": 3167,
+          "ratio": 0.267068,
+          "total": 4321
+        },
+        "line": {
+          "covered": 197,
+          "missed": 514,
+          "ratio": 0.277075,
+          "total": 711
+        },
+        "method": {
+          "covered": 79,
+          "missed": 148,
+          "ratio": 0.348018,
+          "total": 227
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "10.10.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1128,
+          "missed": 3125,
+          "ratio": 0.265225,
+          "total": 4253
+        },
+        "line": {
+          "covered": 192,
+          "missed": 503,
+          "ratio": 0.276259,
+          "total": 695
+        },
+        "method": {
+          "covered": 76,
+          "missed": 147,
+          "ratio": 0.340807,
+          "total": 223
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 32037,
+      "cached_input_tokens_used": 293376,
+      "output_tokens_used": 2768,
+      "iterations": 1,
+      "cost_usd": 0.2297,
+      "tested_library_loc": 197,
+      "metadata_entries": 118,
+      "test_only_metadata_entries": 95,
+      "previous_library_metadata_entries": 12,
+      "previous_library_test_only_metadata_entries": 2,
+      "code_coverage_percent": 27.71,
+      "previous_library_coverage_percent": 27.63
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.flywaydb/flyway-sqlserver/11.8.1/src/test/java/flyway/sqlserver/FixedResourceProvider.java",
+      "metadata_file": "metadata/org.flywaydb/flyway-sqlserver/11.8.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.flywaydb/flyway-sqlserver/11.8.1/stats.json
+++ b/stats/org.flywaydb/flyway-sqlserver/11.8.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "11.8.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1154,
+        "missed" : 3167,
+        "ratio" : 0.267068,
+        "total" : 4321
+      },
+      "line" : {
+        "covered" : 197,
+        "missed" : 514,
+        "ratio" : 0.277075,
+        "total" : 711
+      },
+      "method" : {
+        "covered" : 79,
+        "missed" : 148,
+        "ratio" : 0.348018,
+        "total" : 227
+      }
+    }
+  } ]
+}

--- a/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/.gitignore
+++ b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/.gitignore
@@ -1,0 +1,6 @@
+gradlew.bat
+gradlew
+gradle/
+build/
+mssql-stderr.txt
+mssql-stdout.txt

--- a/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/build.gradle
+++ b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/build.gradle
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.assertj:assertj-core:3.22.0"
+    testImplementation "org.awaitility:awaitility:4.2.0"
+    testImplementation "org.flywaydb:flyway-sqlserver:$libraryVersion"
+    testImplementation "com.microsoft.sqlserver:mssql-jdbc:12.2.0.jre11"
+}
+
+graalvmNative {
+    binaries {
+        all {
+            buildArgs.add("-H:+AddAllCharsets")
+        }
+    }
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/build.gradle
+++ b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     testImplementation "org.assertj:assertj-core:3.22.0"
     testImplementation "org.awaitility:awaitility:4.2.0"
     testImplementation "org.flywaydb:flyway-sqlserver:$libraryVersion"
+    testImplementation "com.fasterxml.jackson.core:jackson-databind:2.15.2"
     testImplementation "com.microsoft.sqlserver:mssql-jdbc:12.2.0.jre11"
 }
 

--- a/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/gradle.properties
+++ b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 11.8.1
+metadata.dir = org.flywaydb/flyway-sqlserver/11.8.1/

--- a/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/required-docker-images.txt
+++ b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/required-docker-images.txt
@@ -1,0 +1,1 @@
+mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04

--- a/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/settings.gradle
+++ b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.flywaydb.flyway-sqlserver_tests'

--- a/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/src/test/java/flyway/sqlserver/FixedResourceProvider.java
+++ b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/src/test/java/flyway/sqlserver/FixedResourceProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package flyway.sqlserver;
+
+import org.flywaydb.core.api.ResourceProvider;
+import org.flywaydb.core.api.resource.LoadableResource;
+import org.flywaydb.core.internal.resource.classpath.ClassPathResource;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * This is needed as GraalVM doesn't support enumerating resources. It uses a hardcoded list of migrations.
+ */
+class FixedResourceProvider implements ResourceProvider {
+    private static final Set<String> MIGRATIONS;
+
+    static {
+        Set<String> migrations = new HashSet<>();
+        migrations.add("db/migration/V1__create_table.sql");
+        migrations.add("db/migration/V2__alter_table.sql");
+        MIGRATIONS = Collections.unmodifiableSet(migrations);
+    }
+
+    @Override
+    public LoadableResource getResource(String name) {
+        if (!MIGRATIONS.contains(name)) {
+            return null;
+        }
+        return new ClassPathResource(null, name, getClass().getClassLoader(), StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public Collection<LoadableResource> getResources(String prefix, String[] suffixes) {
+        return MIGRATIONS.stream()
+                .map(file -> new ClassPathResource(null, file, getClass().getClassLoader(), StandardCharsets.UTF_8))
+                .collect(Collectors.toList());
+    }
+}

--- a/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/src/test/java/flyway/sqlserver/FlywaySqlServerTests.java
+++ b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/src/test/java/flyway/sqlserver/FlywaySqlServerTests.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package flyway.sqlserver;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import javax.sql.DataSource;
+
+import com.microsoft.sqlserver.jdbc.SQLServerDataSource;
+import org.awaitility.Awaitility;
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.api.configuration.FluentConfiguration;
+import org.flywaydb.core.api.output.MigrateResult;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FlywaySqlServerTests {
+
+    private static final String USERNAME = "sa";
+
+    private static final String PASSWORD = "Secret12";
+
+    private static final String JDBC_URL = "jdbc:sqlserver://localhost:1433;encrypt=false";
+
+    private static Process process;
+
+    @BeforeAll
+    static void beforeAll() throws IOException {
+        System.out.println("Starting MSSQL ...");
+        process = new ProcessBuilder(
+                "docker", "run", "--rm", "-p", "1433:1433", "-e", "ACCEPT_EULA=Y",
+                "-e", "MSSQL_SA_PASSWORD=" + PASSWORD,
+                "mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04")
+                .redirectOutput(new File("mssql-stdout.txt"))
+                .redirectError(new File("mssql-stderr.txt"))
+                .start();
+
+        // Wait until connection can be established
+        Awaitility.await().atMost(Duration.ofMinutes(1)).ignoreExceptions().until(() -> {
+            getDataSource().getConnection().close();
+            return true;
+        });
+        System.out.println("MSSQL started");
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (process != null && process.isAlive()) {
+            System.out.println("Shutting down MSSQL");
+            process.destroy();
+        }
+    }
+
+    @Test
+    void migrate() {
+        DataSource dataSource = getDataSource();
+
+        Configuration configuration = new FluentConfiguration()
+                .dataSource(dataSource)
+                .encoding(StandardCharsets.UTF_8)
+                .resourceProvider(new FixedResourceProvider());
+
+        Flyway flyway = new Flyway(configuration);
+        MigrateResult migration = flyway.migrate();
+
+        assertThat(migration.success).isTrue();
+        assertThat(migration.migrationsExecuted).isEqualTo(2);
+    }
+
+    private static DataSource getDataSource() {
+        SQLServerDataSource dataSource = new SQLServerDataSource();
+        dataSource.setURL(JDBC_URL);
+        dataSource.setUser(USERNAME);
+        dataSource.setPassword(PASSWORD);
+        return dataSource;
+    }
+
+}

--- a/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,10 +1,583 @@
 {
-  "resources": [
+  "resources" : [
     {
-      "glob": "db/migration/V1__create_table.sql"
+      "glob" : "db/migration/V1__create_table.sql"
     },
     {
-      "glob": "db/migration/V2__alter_table.sql"
+      "glob" : "db/migration/V2__alter_table.sql"
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "glob" : "META-INF/services/java.net.spi.URLStreamHandlerProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "glob" : "META-INF/services/java.time.zone.ZoneRulesProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "glob" : "META-INF/services/java.util.spi.ResourceBundleControlProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "glob" : "com/microsoft/sqlserver/jdbc/SQLServerResource_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "glob" : "com/microsoft/sqlserver/jdbc/SQLServerResource_en_US.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.resource.classpath.ClassPathResource"
+      },
+      "glob" : "db/migration/V1__create_table.sql"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.resource.classpath.ClassPathResource"
+      },
+      "glob" : "db/migration/V2__alter_table.sql"
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "module" : "java.base",
+      "glob" : "jdk/internal/icu/impl/data/icudt76b/nfkc.nrm"
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "module" : "java.logging",
+      "glob" : "sun/util/logging/resources/logging_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "module" : "java.logging",
+      "glob" : "sun/util/logging/resources/logging_en_US.properties"
+    }
+  ],
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "com.sun.crypto.provider.AESCipher$General",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "com.sun.crypto.provider.ARCFOURCipher",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Poly1305",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "com.sun.crypto.provider.DESCipher",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "com.sun.crypto.provider.DESedeCipher",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "com.sun.crypto.provider.DHParameters",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "com.sun.crypto.provider.GaloisCounterMode$AESGCM",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "com.sun.crypto.provider.TlsKeyMaterialGenerator",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "com.sun.crypto.provider.TlsMasterSecretGenerator",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "com.sun.crypto.provider.TlsPrfGenerator$V12",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "java.net.Socket",
+      "methods" : [
+        {
+          "name" : "setOption",
+          "parameterTypes" : [
+            "java.net.SocketOption",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "java.security.AlgorithmParametersSpi"
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "java.security.MessageDigestSpi"
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "java.security.interfaces.RSAPrivateKey"
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "java.security.interfaces.RSAPublicKey"
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "java.sql.SQLException"
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "jdk.net.ExtendedSocketOptions",
+      "fields" : [
+        {
+          "name" : "TCP_KEEPIDLE"
+        },
+        {
+          "name" : "TCP_KEEPINTERVAL"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "sun.security.provider.DSA$SHA224withDSA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "sun.security.provider.DSA$SHA256withDSA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "sun.security.provider.SHA2$SHA224",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "sun.security.provider.SHA5$SHA384",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "sun.security.provider.SHA5$SHA512",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "sun.security.provider.X509Factory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "sun.security.rsa.PSSParameters",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "sun.security.rsa.RSAKeyFactory$Legacy",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "sun.security.rsa.RSAPSSSignature",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "sun.security.rsa.RSASignature$SHA224withRSA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "sun.security.rsa.RSASignature$SHA256withRSA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "sun.security.ssl.SSLContextImpl$TLSContext",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "sun.security.x509.AuthorityInfoAccessExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "sun.security.x509.AuthorityKeyIdentifierExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "sun.security.x509.BasicConstraintsExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "sun.security.x509.CRLDistributionPointsExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "sun.security.x509.CertificatePoliciesExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "sun.security.x509.ExtendedKeyUsageExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "sun.security.x509.KeyUsageExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "sun.security.x509.SubjectAlternativeNameExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "flyway.sqlserver.FlywaySqlServerTests"
+      },
+      "type" : "sun.security.x509.SubjectKeyIdentifierExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources": [
+    {
+      "glob": "db/migration/V1__create_table.sql"
+    },
+    {
+      "glob": "db/migration/V2__alter_table.sql"
+    }
+  ]
+}

--- a/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/src/test/resources/db/migration/V1__create_table.sql
+++ b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/src/test/resources/db/migration/V1__create_table.sql
@@ -1,0 +1,5 @@
+CREATE TABLE test
+(
+    id    INT PRIMARY KEY,
+    title VARCHAR NOT NULL
+);

--- a/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/src/test/resources/db/migration/V2__alter_table.sql
+++ b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/src/test/resources/db/migration/V2__alter_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE test
+    ADD name INT NOT NULL DEFAULT 1;

--- a/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/user-code-filter.json
+++ b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.flywaydb.**"
+    }
+  ]
+}

--- a/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/user-code-filter.json
+++ b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/user-code-filter.json
@@ -5,6 +5,15 @@
     },
     {
       "includeClasses" : "org.flywaydb.**"
+    },
+    {
+      "includeClasses" : "org.flywaydb.clean.**"
+    },
+    {
+      "includeClasses" : "org.flywaydb.database.sqlserver.**"
+    },
+    {
+      "includeClasses" : "flyway.sqlserver.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #1657

This PR provides test fixes and new metadata for org.flywaydb:flyway-sqlserver:11.8.1, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 32037
- Cached input tokens: 293376
- Output tokens: 2768
- Metadata entries: 118
- Test-only metadata entries: 95
- Iterations: 1
- Library coverage percentage: 27.71
- Previous library version metadata entries: 12
- Previous library version test-only metadata entries: 2
- Previous library version coverage percentage: 27.63

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `62c414cb3fad52c858f91791bd2b5cdec96d4f51`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.flywaydb:flyway-sqlserver:10.10.0: 0/0 covered calls (100.00%)
- org.flywaydb:flyway-sqlserver:11.8.1: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.flywaydb:flyway-sqlserver:10.10.0: 1128/4253 (26.52%)
- org.flywaydb:flyway-sqlserver:11.8.1: 1154/4321 (26.71%)

**Line:**
- org.flywaydb:flyway-sqlserver:10.10.0: 192/695 (27.63%)
- org.flywaydb:flyway-sqlserver:11.8.1: 197/711 (27.71%)

**Method:**
- org.flywaydb:flyway-sqlserver:10.10.0: 76/223 (34.08%)
- org.flywaydb:flyway-sqlserver:11.8.1: 79/227 (34.80%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/org.flywaydb/flyway-sqlserver/10.10.0/build.gradle b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/build.gradle
index d412c25335..f6633e6d0e 100644
--- a/tests/src/org.flywaydb/flyway-sqlserver/10.10.0/build.gradle
+++ b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     testImplementation "org.assertj:assertj-core:3.22.0"
     testImplementation "org.awaitility:awaitility:4.2.0"
     testImplementation "org.flywaydb:flyway-sqlserver:$libraryVersion"
+    testImplementation "com.fasterxml.jackson.core:jackson-databind:2.15.2"
     testImplementation "com.microsoft.sqlserver:mssql-jdbc:12.2.0.jre11"
 }
 
diff --git a/tests/src/org.flywaydb/flyway-sqlserver/10.10.0/user-code-filter.json b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/user-code-filter.json
index 46bbe981bf..a55ab603c2 100644
--- a/tests/src/org.flywaydb/flyway-sqlserver/10.10.0/user-code-filter.json
+++ b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/user-code-filter.json
@@ -5,6 +5,15 @@
     },
     {
       "includeClasses" : "org.flywaydb.**"
+    },
+    {
+      "includeClasses" : "org.flywaydb.clean.**"
+    },
+    {
+      "includeClasses" : "org.flywaydb.database.sqlserver.**"
+    },
+    {
+      "includeClasses" : "flyway.sqlserver.**"
     }
   ]
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
