### PR TITLE
[Automation] Generated metadata for com.github.luben:zstd-jni:1.5.7-10

### DIFF
--- a/metadata/com.github.luben/zstd-jni/1.5.7-10/reachability-metadata.json
+++ b/metadata/com.github.luben/zstd-jni/1.5.7-10/reachability-metadata.json
@@ -1,0 +1,140 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.AutoCloseBase"
+      },
+      "type": "com.github.luben.zstd.AutoCloseBase"
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.ZstdDirectBufferDecompressingStreamNoFinalizer"
+      },
+      "type": "com.github.luben.zstd.BaseZstdBufferDecompressingStreamNoFinalizer",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "consumed"
+        },
+        {
+          "name": "produced"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.ZstdDictCompress"
+      },
+      "type": "com.github.luben.zstd.ZstdDictCompress",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "nativePtr"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.ZstdDictDecompress"
+      },
+      "type": "com.github.luben.zstd.ZstdDictDecompress",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "nativePtr"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.ZstdDirectBufferCompressingStreamNoFinalizer"
+      },
+      "type": "com.github.luben.zstd.ZstdDirectBufferCompressingStream$1"
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.ZstdDirectBufferCompressingStreamNoFinalizer"
+      },
+      "type": "com.github.luben.zstd.ZstdDirectBufferCompressingStreamNoFinalizer",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "consumed"
+        },
+        {
+          "name": "produced"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.ZstdDirectBufferDecompressingStreamNoFinalizer"
+      },
+      "type": "com.github.luben.zstd.ZstdDirectBufferDecompressingStream$1"
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.ZstdInputStreamNoFinalizer"
+      },
+      "type": "com.github.luben.zstd.ZstdInputStreamNoFinalizer",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "dstPos"
+        },
+        {
+          "name": "srcPos"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.ZstdOutputStreamNoFinalizer"
+      },
+      "type": "com.github.luben.zstd.ZstdOutputStreamNoFinalizer",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "dstPos"
+        },
+        {
+          "name": "srcPos"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.util.Native"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.util.Native"
+      },
+      "type": "sun.security.provider.SHA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.util.Native"
+      },
+      "glob": "linux/amd64/libzstd-jni-1.5.7-10.so"
+    }
+  ]
+}

--- a/metadata/com.github.luben/zstd-jni/index.json
+++ b/metadata/com.github.luben/zstd-jni/index.json
@@ -1,5 +1,21 @@
 [
   {
+    "latest" : true,
+    "metadata-version" : "1.5.7-10",
+    "test-version" : "1.5.2-5",
+    "tested-versions" : [
+      "1.5.7-10"
+    ],
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/github/luben/zstd-jni/$version$/zstd-jni-$version$-sources.jar",
+    "repository-url" : "https://github.com/luben/zstd-jni",
+    "test-code-url" : "https://github.com/luben/zstd-jni/tree/7f1ffbed8778d505026fa4fe83cd9710ff10f9aa/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/github/luben/zstd-jni/$version$/zstd-jni-$version$-javadoc.jar",
+    "description" : "zstd-jni provides JNI bindings for the Zstandard native compression library to Java and other JVM languages. It exposes byte-array, direct-buffer, stream, and dictionary APIs for compressing and decompressing data with bundled native binaries.",
+    "allowed-packages" : [
+      "com.github.luben"
+    ]
+  },
+  {
     "metadata-version" : "1.5.2-5",
     "source-code-url" : "https://repo1.maven.org/maven2/com/github/luben/zstd-jni/$version$/zstd-jni-$version$-sources.jar",
     "repository-url" : "https://github.com/luben/zstd-jni/tree/c1.5.2-5",
@@ -57,7 +73,6 @@
     ]
   },
   {
-    "latest" : true,
     "metadata-version" : "1.5.7-2",
     "test-version" : "1.5.2-5",
     "tested-versions" : [

--- a/stats/com.github.luben/zstd-jni/1.5.7-10/stats.json
+++ b/stats/com.github.luben/zstd-jni/1.5.7-10/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "1.5.7-10",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 1,
+      "totalCalls" : 1
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1724,
+        "missed" : 4902,
+        "ratio" : 0.260187,
+        "total" : 6626
+      },
+      "line" : {
+        "covered" : 471,
+        "missed" : 1170,
+        "ratio" : 0.28702,
+        "total" : 1641
+      },
+      "method" : {
+        "covered" : 102,
+        "missed" : 274,
+        "ratio" : 0.271277,
+        "total" : 376
+      }
+    }
+  } ]
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7746

This PR provides new metadata needed for the com.github.luben:zstd-jni:1.5.7-10, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `com.github.luben:zstd-jni:1.5.2-5`): 41
- Metadata entries (new `com.github.luben:zstd-jni:1.5.7-10`): 30
- Library coverage (previous): 36.76%
- Library coverage (new): 28.70%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `62c414cb3fad52c858f91791bd2b5cdec96d4f51`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.github.luben:zstd-jni:1.5.2-5: 1/1 covered calls (100.00%)
- com.github.luben:zstd-jni:1.5.7-10: 1/1 covered calls (100.00%)

**Resources:**
- com.github.luben:zstd-jni:1.5.2-5: 1/1 covered calls (100.00%)
- com.github.luben:zstd-jni:1.5.7-10: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.github.luben:zstd-jni:1.5.2-5: 1549/4679 (33.11%)
- com.github.luben:zstd-jni:1.5.7-10: 1724/6626 (26.02%)

**Line:**
- com.github.luben:zstd-jni:1.5.2-5: 426/1159 (36.76%)
- com.github.luben:zstd-jni:1.5.7-10: 471/1641 (28.70%)

**Method:**
- com.github.luben:zstd-jni:1.5.2-5: 90/260 (34.62%)
- com.github.luben:zstd-jni:1.5.7-10: 102/376 (27.13%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
