### PR TITLE
[GenAI] Test fix for com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.22.0 using gpt-5.5

### DIFF
--- a/metadata/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.22.0/reachability-metadata.json
+++ b/metadata/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.22.0/reachability-metadata.json
@@ -1,0 +1,119 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest"
+      },
+      "type": "com.fasterxml.jackson.databind.ext.Java7SupportImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.fasterxml.jackson.jaxrs.json.JsonMapperConfigurator"
+      },
+      "type": "com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.fasterxml.jackson.jaxrs.json.JsonMapperConfigurator"
+      },
+      "type": "com.fasterxml.jackson.module.jaxb.deser.DataHandlerJsonDeserializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.fasterxml.jackson.jaxrs.json.JsonMapperConfigurator"
+      },
+      "type": "com.fasterxml.jackson.module.jaxb.ser.DataHandlerJsonSerializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest"
+      },
+      "type": "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest$JaxbPayload",
+      "fields": [
+        {
+          "name": "message"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest"
+      },
+      "type": "java.io.Serializable"
+    },
+    {
+      "condition": {
+        "typeReached": "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest"
+      },
+      "type": "java.lang.Class",
+      "methods": [
+        {
+          "name": "isRecord",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest"
+      },
+      "type": "java.util.AbstractMap"
+    },
+    {
+      "condition": {
+        "typeReached": "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest"
+      },
+      "type": "java.util.ImmutableCollections$AbstractImmutableMap"
+    },
+    {
+      "condition": {
+        "typeReached": "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest"
+      },
+      "type": "java.util.ImmutableCollections$Map1"
+    },
+    {
+      "condition": {
+        "typeReached": "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest"
+      },
+      "type": "java.util.Map"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest"
+      },
+      "glob": "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition": {
+        "typeReached": "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest"
+      },
+      "glob": "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/metadata/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.22.0/reachability-metadata.json
+++ b/metadata/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.22.0/reachability-metadata.json
@@ -1,119 +1,40 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest"
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jaxrs.json.JsonMapperConfigurator"
       },
-      "type": "com.fasterxml.jackson.databind.ext.Java7SupportImpl",
-      "methods": [
+      "type" : "com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.fasterxml.jackson.jaxrs.json.JsonMapperConfigurator"
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jaxrs.json.JsonMapperConfigurator"
       },
-      "type": "com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector",
-      "methods": [
+      "type" : "com.fasterxml.jackson.module.jaxb.deser.DataHandlerJsonDeserializer",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.fasterxml.jackson.jaxrs.json.JsonMapperConfigurator"
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jaxrs.json.JsonMapperConfigurator"
       },
-      "type": "com.fasterxml.jackson.module.jaxb.deser.DataHandlerJsonDeserializer",
-      "methods": [
+      "type" : "com.fasterxml.jackson.module.jaxb.ser.DataHandlerJsonSerializer",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "com.fasterxml.jackson.jaxrs.json.JsonMapperConfigurator"
-      },
-      "type": "com.fasterxml.jackson.module.jaxb.ser.DataHandlerJsonSerializer",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest"
-      },
-      "type": "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest$JaxbPayload",
-      "fields": [
-        {
-          "name": "message"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest"
-      },
-      "type": "java.io.Serializable"
-    },
-    {
-      "condition": {
-        "typeReached": "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest"
-      },
-      "type": "java.lang.Class",
-      "methods": [
-        {
-          "name": "isRecord",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest"
-      },
-      "type": "java.util.AbstractMap"
-    },
-    {
-      "condition": {
-        "typeReached": "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest"
-      },
-      "type": "java.util.ImmutableCollections$AbstractImmutableMap"
-    },
-    {
-      "condition": {
-        "typeReached": "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest"
-      },
-      "type": "java.util.ImmutableCollections$Map1"
-    },
-    {
-      "condition": {
-        "typeReached": "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest"
-      },
-      "type": "java.util.Map"
-    }
-  ],
-  "resources": [
-    {
-      "condition": {
-        "typeReached": "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest"
-      },
-      "glob": "META-INF/services/org.assertj.core.configuration.Configuration"
-    },
-    {
-      "condition": {
-        "typeReached": "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest"
-      },
-      "glob": "META-INF/services/org.assertj.core.presentation.Representation"
     }
   ]
 }

--- a/metadata/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/index.json
+++ b/metadata/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.22.0",
+    "tested-versions" : [
+      "2.22.0"
+    ],
+    "allowed-packages" : [
+      "com.fasterxml.jackson.jaxrs.json"
+    ]
+  },
+  {
     "metadata-version" : "2.9.8",
     "source-code-url" : "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jaxrs/jackson-jaxrs-json-provider/$version$/jackson-jaxrs-json-provider-$version$-sources.jar",
     "repository-url" : "https://github.com/FasterXML/jackson-jaxrs-providers",

--- a/metadata/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/index.json
+++ b/metadata/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.22.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jaxrs/jackson-jaxrs-json-provider/$version$/jackson-jaxrs-json-provider-$version$-sources.jar",
+    "repository-url" : "https://github.com/FasterXML/jackson-jaxrs-providers",
+    "test-code-url" : "https://github.com/FasterXML/jackson-jaxrs-providers/tree/jackson-jaxrs-providers-$version$/json/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jaxrs/jackson-jaxrs-json-provider/$version$/jackson-jaxrs-json-provider-$version$-javadoc.jar",
+    "description" : "Jackson JAX-RS JSON Provider integrates Jackson databinding with JAX-RS implementations such as Jersey and RESTEasy to read and write JSON request and response bodies. It supplies MessageBodyReader and MessageBodyWriter providers plus related JSON/JAXB configuration support for REST endpoints.",
     "tested-versions" : [
       "2.22.0"
     ],

--- a/stats/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.22.0/execution-metrics.json
+++ b/stats/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.22.0/execution-metrics.json
@@ -1,0 +1,100 @@
+{
+  "fix_javac_fail:2026-06-05": {
+    "timestamp": "2026-06-05T06:08:15.784913Z",
+    "library": "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.22.0",
+    "starting_commit": "8f714a9b0a0734f73a610dc9e1adc72e43991bdb",
+    "ending_commit": "6f453e01c3eabfbc6b6a36e2c3b03ae097d625a2",
+    "previous_library": "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.9.8",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.22.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 104,
+          "missed": 333,
+          "ratio": 0.237986,
+          "total": 437
+        },
+        "line": {
+          "covered": 24,
+          "missed": 84,
+          "ratio": 0.222222,
+          "total": 108
+        },
+        "method": {
+          "covered": 4,
+          "missed": 29,
+          "ratio": 0.121212,
+          "total": 33
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.9.8",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 86,
+          "missed": 372,
+          "ratio": 0.187773,
+          "total": 458
+        },
+        "line": {
+          "covered": 19,
+          "missed": 94,
+          "ratio": 0.168142,
+          "total": 113
+        },
+        "method": {
+          "covered": 4,
+          "missed": 30,
+          "ratio": 0.117647,
+          "total": 34
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 85163,
+      "cached_input_tokens_used": 839168,
+      "output_tokens_used": 7974,
+      "iterations": 2,
+      "cost_usd": 0.6588,
+      "tested_library_loc": 24,
+      "metadata_entries": 6,
+      "test_only_metadata_entries": 13,
+      "previous_library_metadata_entries": 10,
+      "code_coverage_percent": 22.22,
+      "previous_library_coverage_percent": 16.81
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.22.0/src/test/java/com_fasterxml_jackson_jaxrs/jackson_jaxrs_json_provider/JsonMapperConfiguratorTest.java",
+      "metadata_file": "metadata/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.22.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.22.0/stats.json
+++ b/stats/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.22.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "2.22.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 1,
+      "totalCalls" : 1
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 104,
+        "missed" : 333,
+        "ratio" : 0.237986,
+        "total" : 437
+      },
+      "line" : {
+        "covered" : 24,
+        "missed" : 84,
+        "ratio" : 0.222222,
+        "total" : 108
+      },
+      "method" : {
+        "covered" : 4,
+        "missed" : 29,
+        "ratio" : 0.121212,
+        "total" : 33
+      }
+    }
+  } ]
+}

--- a/tests/src/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.22.0/.gitignore
+++ b/tests/src/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.22.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.22.0/build.gradle
+++ b/tests/src/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.22.0/build.gradle
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:$libraryVersion"
+    testImplementation 'javax.xml.bind:jaxb-api:2.3.1'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.22.0/gradle.properties
+++ b/tests/src/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.22.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.22.0
+library.version = 2.22.0
+metadata.dir = com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.22.0/

--- a/tests/src/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.22.0/settings.gradle
+++ b/tests/src/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.22.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider_tests'

--- a/tests/src/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.22.0/src/test/java/com_fasterxml_jackson_jaxrs/jackson_jaxrs_json_provider/JsonMapperConfiguratorTest.java
+++ b/tests/src/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.22.0/src/test/java/com_fasterxml_jackson_jaxrs/jackson_jaxrs_json_provider/JsonMapperConfiguratorTest.java
@@ -8,16 +8,36 @@ package com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider;
 
 import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import com.fasterxml.jackson.jaxrs.cfg.Annotations;
 import com.fasterxml.jackson.jaxrs.json.JsonMapperConfigurator;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
+
+import javax.xml.bind.annotation.XmlElement;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class JsonMapperConfiguratorTest {
     @Test
-    public void getDefaultMapperInstantiatesJaxbAnnotationIntrospector() {
+    public void getDefaultMapperConfiguresJacksonAnnotationIntrospector() throws Exception {
+        JsonMapperConfigurator configurator = new JsonMapperConfigurator(
+                null,
+                new Annotations[] {Annotations.JACKSON});
+
+        ObjectMapper mapper = configurator.getDefaultMapper();
+
+        AnnotationIntrospector introspector = mapper.getSerializationConfig()
+                .getAnnotationIntrospector();
+        assertThat(introspector).isInstanceOf(JacksonAnnotationIntrospector.class);
+        assertThat(mapper.writeValueAsString(Map.of("message", "hello"))).isEqualTo("{\"message\":\"hello\"}");
+        assertThat(configurator.getDefaultMapper()).isSameAs(mapper);
+    }
+
+    @Test
+    public void getDefaultMapperConfiguresJaxbAnnotationIntrospector() throws Exception {
         JsonMapperConfigurator configurator = new JsonMapperConfigurator(
                 null,
                 new Annotations[] {Annotations.JAXB});
@@ -27,6 +47,17 @@ public class JsonMapperConfiguratorTest {
         AnnotationIntrospector introspector = mapper.getSerializationConfig()
                 .getAnnotationIntrospector();
         assertThat(introspector).isInstanceOf(JaxbAnnotationIntrospector.class);
+        assertThat(mapper.writeValueAsString(new JaxbPayload("hello")))
+                .isEqualTo("{\"jaxbMessage\":\"hello\"}");
         assertThat(configurator.getDefaultMapper()).isSameAs(mapper);
+    }
+
+    public static class JaxbPayload {
+        @XmlElement(name = "jaxbMessage")
+        public String message;
+
+        public JaxbPayload(String message) {
+            this.message = message;
+        }
     }
 }

--- a/tests/src/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.22.0/src/test/java/com_fasterxml_jackson_jaxrs/jackson_jaxrs_json_provider/JsonMapperConfiguratorTest.java
+++ b/tests/src/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.22.0/src/test/java/com_fasterxml_jackson_jaxrs/jackson_jaxrs_json_provider/JsonMapperConfiguratorTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider;
+
+import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.jaxrs.cfg.Annotations;
+import com.fasterxml.jackson.jaxrs.json.JsonMapperConfigurator;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JsonMapperConfiguratorTest {
+    @Test
+    public void getDefaultMapperInstantiatesJaxbAnnotationIntrospector() {
+        JsonMapperConfigurator configurator = new JsonMapperConfigurator(
+                null,
+                new Annotations[] {Annotations.JAXB});
+
+        ObjectMapper mapper = configurator.getDefaultMapper();
+
+        AnnotationIntrospector introspector = mapper.getSerializationConfig()
+                .getAnnotationIntrospector();
+        assertThat(introspector).isInstanceOf(JaxbAnnotationIntrospector.class);
+        assertThat(configurator.getDefaultMapper()).isSameAs(mapper);
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.22.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.22.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,83 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest"
+      },
+      "type" : "com.fasterxml.jackson.databind.ext.Java7SupportImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest"
+      },
+      "type" : "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest$JaxbPayload",
+      "fields" : [
+        {
+          "name" : "message"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest"
+      },
+      "type" : "java.io.Serializable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest"
+      },
+      "type" : "java.lang.Class",
+      "methods" : [
+        {
+          "name" : "isRecord",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest"
+      },
+      "type" : "java.util.AbstractMap"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest"
+      },
+      "type" : "java.util.ImmutableCollections$AbstractImmutableMap"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest"
+      },
+      "type" : "java.util.ImmutableCollections$Map1"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest"
+      },
+      "type" : "java.util.Map"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.JsonMapperConfiguratorTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/tests/src/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.22.0/user-code-filter.json
+++ b/tests/src/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.22.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.fasterxml.jackson.jaxrs.json.**"
+    },
+    {
+      "includeClasses" : "com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7729

This PR provides test fixes and new metadata for com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.22.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 85163
- Cached input tokens: 839168
- Output tokens: 7974
- Metadata entries: 6
- Test-only metadata entries: 13
- Iterations: 2
- Library coverage percentage: 22.22
- Previous library version metadata entries: 10
- Previous library version coverage percentage: 16.81

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `0027434fa250f671d462d514e04c1cd389a258d0`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.9.8: 1/1 covered calls (100.00%)
- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.22.0: 1/1 covered calls (100.00%)

**Reflection:**
- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.9.8: 1/1 covered calls (100.00%)
- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.22.0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.9.8: 86/458 (18.78%)
- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.22.0: 104/437 (23.80%)

**Line:**
- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.9.8: 19/113 (16.81%)
- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.22.0: 24/108 (22.22%)

**Method:**
- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.9.8: 4/34 (11.76%)
- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.22.0: 4/33 (12.12%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.9.8/src/test/java/com_fasterxml_jackson_jaxrs/jackson_jaxrs_json_provider/JsonMapperConfiguratorTest.java b/tests/src/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.22.0/src/test/java/com_fasterxml_jackson_jaxrs/jackson_jaxrs_json_provider/JsonMapperConfiguratorTest.java
index 632b59a7b6..98d4ccbfb9 100644
--- a/tests/src/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.9.8/src/test/java/com_fasterxml_jackson_jaxrs/jackson_jaxrs_json_provider/JsonMapperConfiguratorTest.java
+++ b/tests/src/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.22.0/src/test/java/com_fasterxml_jackson_jaxrs/jackson_jaxrs_json_provider/JsonMapperConfiguratorTest.java
@@ -8,16 +8,36 @@ package com_fasterxml_jackson_jaxrs.jackson_jaxrs_json_provider;
 
 import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import com.fasterxml.jackson.jaxrs.cfg.Annotations;
 import com.fasterxml.jackson.jaxrs.json.JsonMapperConfigurator;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
+
+import javax.xml.bind.annotation.XmlElement;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class JsonMapperConfiguratorTest {
     @Test
-    public void getDefaultMapperInstantiatesJaxbAnnotationIntrospector() {
+    public void getDefaultMapperConfiguresJacksonAnnotationIntrospector() throws Exception {
+        JsonMapperConfigurator configurator = new JsonMapperConfigurator(
+                null,
+                new Annotations[] {Annotations.JACKSON});
+
+        ObjectMapper mapper = configurator.getDefaultMapper();
+
+        AnnotationIntrospector introspector = mapper.getSerializationConfig()
+                .getAnnotationIntrospector();
+        assertThat(introspector).isInstanceOf(JacksonAnnotationIntrospector.class);
+        assertThat(mapper.writeValueAsString(Map.of("message", "hello"))).isEqualTo("{\"message\":\"hello\"}");
+        assertThat(configurator.getDefaultMapper()).isSameAs(mapper);
+    }
+
+    @Test
+    public void getDefaultMapperConfiguresJaxbAnnotationIntrospector() throws Exception {
         JsonMapperConfigurator configurator = new JsonMapperConfigurator(
                 null,
                 new Annotations[] {Annotations.JAXB});
@@ -27,6 +47,17 @@ public class JsonMapperConfiguratorTest {
         AnnotationIntrospector introspector = mapper.getSerializationConfig()
                 .getAnnotationIntrospector();
         assertThat(introspector).isInstanceOf(JaxbAnnotationIntrospector.class);
+        assertThat(mapper.writeValueAsString(new JaxbPayload("hello")))
+                .isEqualTo("{\"jaxbMessage\":\"hello\"}");
         assertThat(configurator.getDefaultMapper()).isSameAs(mapper);
     }
+
+    public static class JaxbPayload {
+        @XmlElement(name = "jaxbMessage")
+        public String message;
+
+        public JaxbPayload(String message) {
+            this.message = message;
+        }
+    }
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
