### PR TITLE
[GenAI] Test fix for com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-yaml-provider:2.22.0 using gpt-5.5

### DIFF
--- a/metadata/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/2.22.0/reachability-metadata.json
+++ b/metadata/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/2.22.0/reachability-metadata.json
@@ -1,108 +1,58 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "com.fasterxml.jackson.jakarta.rs.yaml.YAMLMapperConfigurator"
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jakarta.rs.yaml.YAMLMapperConfigurator"
       },
-      "type": "com.fasterxml.jackson.databind.ext.Java7SupportImpl",
-      "methods": [
+      "type" : "com.fasterxml.jackson.databind.ext.Java7SupportImpl",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.fasterxml.jackson.jakarta.rs.yaml.YAMLMapperConfigurator"
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jakarta.rs.yaml.YAMLMapperConfigurator"
       },
-      "type": "com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntrospector",
-      "methods": [
+      "type" : "com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntrospector",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.fasterxml.jackson.jakarta.rs.yaml.YAMLMapperConfigurator"
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jakarta.rs.yaml.YAMLMapperConfigurator"
       },
-      "type": "com.fasterxml.jackson.module.jakarta.xmlbind.deser.DataHandlerDeserializer",
-      "methods": [
+      "type" : "com.fasterxml.jackson.module.jakarta.xmlbind.deser.DataHandlerDeserializer",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.fasterxml.jackson.jakarta.rs.yaml.YAMLMapperConfigurator"
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jakarta.rs.yaml.YAMLMapperConfigurator"
       },
-      "type": "com.fasterxml.jackson.module.jakarta.xmlbind.ser.DataHandlerSerializer",
-      "methods": [
+      "type" : "com.fasterxml.jackson.module.jakarta.xmlbind.ser.DataHandlerSerializer",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com_fasterxml_jackson_jakarta_rs.jackson_jakarta_rs_yaml_provider.YAMLMapperConfiguratorTest"
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jakarta.rs.yaml.YAMLMapperConfigurator"
       },
-      "type": "com_fasterxml_jackson_jakarta_rs.jackson_jakarta_rs_yaml_provider.YAMLMapperConfiguratorTest$JakartaXmlBindBean",
-      "methods": [
-        {
-          "name": "getValue",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "com.fasterxml.jackson.jakarta.rs.yaml.YAMLMapperConfigurator"
-      },
-      "type": "java.lang.Class"
-    },
-    {
-      "condition": {
-        "typeReached": "com_fasterxml_jackson_jakarta_rs.jackson_jakarta_rs_yaml_provider.YAMLMapperConfiguratorTest"
-      },
-      "type": "java.lang.Class",
-      "methods": [
-        {
-          "name": "isRecord",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "com_fasterxml_jackson_jakarta_rs.jackson_jakarta_rs_yaml_provider.YAMLMapperConfiguratorTest"
-      },
-      "type": "java.sql.Date"
-    },
-    {
-      "condition": {
-        "typeReached": "com_fasterxml_jackson_jakarta_rs.jackson_jakarta_rs_yaml_provider.YAMLMapperConfiguratorTest"
-      },
-      "type": "java.sql.Timestamp"
-    }
-  ],
-  "resources": [
-    {
-      "condition": {
-        "typeReached": "com_fasterxml_jackson_jakarta_rs.jackson_jakarta_rs_yaml_provider.YAMLMapperConfiguratorTest"
-      },
-      "glob": "META-INF/services/org.assertj.core.configuration.Configuration"
-    },
-    {
-      "condition": {
-        "typeReached": "com_fasterxml_jackson_jakarta_rs.jackson_jakarta_rs_yaml_provider.YAMLMapperConfiguratorTest"
-      },
-      "glob": "META-INF/services/org.assertj.core.presentation.Representation"
+      "type" : "java.lang.Class"
     }
   ]
 }

--- a/metadata/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/2.22.0/reachability-metadata.json
+++ b/metadata/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/2.22.0/reachability-metadata.json
@@ -1,0 +1,108 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.fasterxml.jackson.jakarta.rs.yaml.YAMLMapperConfigurator"
+      },
+      "type": "com.fasterxml.jackson.databind.ext.Java7SupportImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.fasterxml.jackson.jakarta.rs.yaml.YAMLMapperConfigurator"
+      },
+      "type": "com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntrospector",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.fasterxml.jackson.jakarta.rs.yaml.YAMLMapperConfigurator"
+      },
+      "type": "com.fasterxml.jackson.module.jakarta.xmlbind.deser.DataHandlerDeserializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.fasterxml.jackson.jakarta.rs.yaml.YAMLMapperConfigurator"
+      },
+      "type": "com.fasterxml.jackson.module.jakarta.xmlbind.ser.DataHandlerSerializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_fasterxml_jackson_jakarta_rs.jackson_jakarta_rs_yaml_provider.YAMLMapperConfiguratorTest"
+      },
+      "type": "com_fasterxml_jackson_jakarta_rs.jackson_jakarta_rs_yaml_provider.YAMLMapperConfiguratorTest$JakartaXmlBindBean",
+      "methods": [
+        {
+          "name": "getValue",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.fasterxml.jackson.jakarta.rs.yaml.YAMLMapperConfigurator"
+      },
+      "type": "java.lang.Class"
+    },
+    {
+      "condition": {
+        "typeReached": "com_fasterxml_jackson_jakarta_rs.jackson_jakarta_rs_yaml_provider.YAMLMapperConfiguratorTest"
+      },
+      "type": "java.lang.Class",
+      "methods": [
+        {
+          "name": "isRecord",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_fasterxml_jackson_jakarta_rs.jackson_jakarta_rs_yaml_provider.YAMLMapperConfiguratorTest"
+      },
+      "type": "java.sql.Date"
+    },
+    {
+      "condition": {
+        "typeReached": "com_fasterxml_jackson_jakarta_rs.jackson_jakarta_rs_yaml_provider.YAMLMapperConfiguratorTest"
+      },
+      "type": "java.sql.Timestamp"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "com_fasterxml_jackson_jakarta_rs.jackson_jakarta_rs_yaml_provider.YAMLMapperConfiguratorTest"
+      },
+      "glob": "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition": {
+        "typeReached": "com_fasterxml_jackson_jakarta_rs.jackson_jakarta_rs_yaml_provider.YAMLMapperConfiguratorTest"
+      },
+      "glob": "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/metadata/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/index.json
+++ b/metadata/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.22.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jakarta/rs/jackson-jakarta-rs-yaml-provider/$version$/jackson-jakarta-rs-yaml-provider-$version$-sources.jar",
+    "repository-url" : "https://github.com/FasterXML/jackson-jakarta-rs-providers",
+    "test-code-url" : "https://github.com/FasterXML/jackson-jakarta-rs-providers/tree/jackson-jakarta-rs-providers-$version$/yaml/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jakarta/rs/jackson-jakarta-rs-yaml-provider/$version$/jackson-jakarta-rs-yaml-provider-$version$-javadoc.jar",
+    "description" : "Jackson Jakarta-RS YAML Provider integrates Jackson data binding with Jakarta RESTful Web Services implementations to read and write YAML request and response bodies. It supplies YAML MessageBodyReader and MessageBodyWriter providers, including JAXB-annotation-aware support, for frameworks such as Jersey and RESTEasy.",
     "tested-versions" : [
       "2.22.0"
     ],

--- a/metadata/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/index.json
+++ b/metadata/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.22.0",
+    "tested-versions" : [
+      "2.22.0"
+    ],
+    "allowed-packages" : [
+      "com.fasterxml.jackson.jakarta.rs.yaml"
+    ]
+  },
+  {
     "metadata-version" : "2.21.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jakarta/rs/jackson-jakarta-rs-yaml-provider/$version$/jackson-jakarta-rs-yaml-provider-$version$-sources.jar",
     "repository-url" : "https://github.com/FasterXML/jackson-jakarta-rs-providers",

--- a/stats/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/2.22.0/execution-metrics.json
+++ b/stats/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/2.22.0/execution-metrics.json
@@ -1,0 +1,100 @@
+{
+  "fix_javac_fail:2026-06-05": {
+    "timestamp": "2026-06-05T14:07:18.671234Z",
+    "library": "com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-yaml-provider:2.22.0",
+    "starting_commit": "628ba691ad7ac077e2d84e2287185b14fe557dfa",
+    "ending_commit": "dcf79486f41618e89b2136d5bf6c88a7a9895180",
+    "previous_library": "com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-yaml-provider:2.21.2",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.22.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 2,
+        "totalCalls": 2
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 106,
+          "missed": 251,
+          "ratio": 0.296919,
+          "total": 357
+        },
+        "line": {
+          "covered": 23,
+          "missed": 64,
+          "ratio": 0.264368,
+          "total": 87
+        },
+        "method": {
+          "covered": 4,
+          "missed": 26,
+          "ratio": 0.133333,
+          "total": 30
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.21.2",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 2,
+        "totalCalls": 2
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 106,
+          "missed": 251,
+          "ratio": 0.296919,
+          "total": 357
+        },
+        "line": {
+          "covered": 23,
+          "missed": 64,
+          "ratio": 0.264368,
+          "total": 87
+        },
+        "method": {
+          "covered": 4,
+          "missed": 26,
+          "ratio": 0.133333,
+          "total": 30
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 136664,
+      "cached_input_tokens_used": 1076224,
+      "output_tokens_used": 15583,
+      "iterations": 3,
+      "cost_usd": 1.0056,
+      "tested_library_loc": 23,
+      "metadata_entries": 9,
+      "test_only_metadata_entries": 8,
+      "previous_library_metadata_entries": 6,
+      "code_coverage_percent": 26.44,
+      "previous_library_coverage_percent": 26.44
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/2.22.0/src/test/java/com_fasterxml_jackson_jakarta_rs/jackson_jakarta_rs_yaml_provider/YAMLMapperConfiguratorTest.java",
+      "metadata_file": "metadata/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/2.22.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/2.22.0/stats.json
+++ b/stats/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/2.22.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "2.22.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 2,
+      "totalCalls" : 2
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 106,
+        "missed" : 251,
+        "ratio" : 0.296919,
+        "total" : 357
+      },
+      "line" : {
+        "covered" : 23,
+        "missed" : 64,
+        "ratio" : 0.264368,
+        "total" : 87
+      },
+      "method" : {
+        "covered" : 4,
+        "missed" : 26,
+        "ratio" : 0.133333,
+        "total" : 30
+      }
+    }
+  } ]
+}

--- a/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/2.22.0/.gitignore
+++ b/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/2.22.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/2.22.0/build.gradle
+++ b/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/2.22.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-yaml-provider:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/2.22.0/gradle.properties
+++ b/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/2.22.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-yaml-provider:2.22.0
+library.version = 2.22.0
+metadata.dir = com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/2.22.0/

--- a/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/2.22.0/settings.gradle
+++ b/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/2.22.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.fasterxml.jackson.jakarta.rs.jackson-jakarta-rs-yaml-provider_tests'

--- a/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/2.22.0/src/test/java/com_fasterxml_jackson_jakarta_rs/jackson_jakarta_rs_yaml_provider/YAMLMapperConfiguratorTest.java
+++ b/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/2.22.0/src/test/java/com_fasterxml_jackson_jakarta_rs/jackson_jakarta_rs_yaml_provider/YAMLMapperConfiguratorTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jakarta_rs.jackson_jakarta_rs_yaml_provider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import com.fasterxml.jackson.jakarta.rs.cfg.Annotations;
+import com.fasterxml.jackson.jakarta.rs.yaml.YAMLMapperConfigurator;
+import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntrospector;
+import jakarta.xml.bind.annotation.XmlElement;
+import org.junit.jupiter.api.Test;
+
+public class YAMLMapperConfiguratorTest {
+    @Test
+    void defaultMapperResolvesJakartaXmlBindAnnotationIntrospector() throws Exception {
+        YAMLMapperConfigurator configurator = new YAMLMapperConfigurator(
+                null,
+                new Annotations[] {Annotations.JAKARTA_XML_BIND });
+
+        YAMLMapper mapper = configurator.getDefaultMapper();
+
+        AnnotationIntrospector introspector = mapper.getSerializationConfig().getAnnotationIntrospector();
+        assertThat(introspector).isInstanceOf(JakartaXmlBindAnnotationIntrospector.class);
+
+        String yaml = mapper.writeValueAsString(new JakartaXmlBindBean("configured"));
+        assertThat(yaml).contains("xmlName:", "configured");
+    }
+
+    public static final class JakartaXmlBindBean {
+        private final String value;
+
+        public JakartaXmlBindBean(String value) {
+            this.value = value;
+        }
+
+        @XmlElement(name = "xmlName")
+        public String getValue() {
+            return value;
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/2.22.0/src/test/java/com_fasterxml_jackson_jakarta_rs/jackson_jakarta_rs_yaml_provider/YAMLMapperConfiguratorTest.java
+++ b/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/2.22.0/src/test/java/com_fasterxml_jackson_jakarta_rs/jackson_jakarta_rs_yaml_provider/YAMLMapperConfiguratorTest.java
@@ -25,7 +25,8 @@ public class YAMLMapperConfiguratorTest {
 
         YAMLMapper mapper = configurator.getDefaultMapper();
 
-        AnnotationIntrospector introspector = mapper.getSerializationConfig().getAnnotationIntrospector();
+        AnnotationIntrospector introspector = mapper.getSerializationConfig()
+                .getAnnotationIntrospector();
         assertThat(introspector).isInstanceOf(JakartaXmlBindAnnotationIntrospector.class);
 
         String yaml = mapper.writeValueAsString(new JakartaXmlBindBean("configured"));

--- a/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/2.22.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/2.22.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,54 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jakarta_rs.jackson_jakarta_rs_yaml_provider.YAMLMapperConfiguratorTest"
+      },
+      "type" : "com_fasterxml_jackson_jakarta_rs.jackson_jakarta_rs_yaml_provider.YAMLMapperConfiguratorTest$JakartaXmlBindBean",
+      "methods" : [
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jakarta_rs.jackson_jakarta_rs_yaml_provider.YAMLMapperConfiguratorTest"
+      },
+      "type" : "java.lang.Class",
+      "methods" : [
+        {
+          "name" : "isRecord",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jakarta_rs.jackson_jakarta_rs_yaml_provider.YAMLMapperConfiguratorTest"
+      },
+      "type" : "java.sql.Date"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jakarta_rs.jackson_jakarta_rs_yaml_provider.YAMLMapperConfiguratorTest"
+      },
+      "type" : "java.sql.Timestamp"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jakarta_rs.jackson_jakarta_rs_yaml_provider.YAMLMapperConfiguratorTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jakarta_rs.jackson_jakarta_rs_yaml_provider.YAMLMapperConfiguratorTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/2.22.0/user-code-filter.json
+++ b/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/2.22.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.fasterxml.jackson.jakarta.rs.yaml.**"
+    },
+    {
+      "includeClasses" : "com_fasterxml_jackson_jakarta_rs.jackson_jakarta_rs_yaml_provider.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7728

This PR provides test fixes and new metadata for com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-yaml-provider:2.22.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 136664
- Cached input tokens: 1076224
- Output tokens: 15583
- Metadata entries: 9
- Test-only metadata entries: 8
- Iterations: 3
- Library coverage percentage: 26.44
- Previous library version metadata entries: 6
- Previous library version coverage percentage: 26.44

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `c2a0c671c17747958a5fafcd468bfdb69d00df0a`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-yaml-provider:2.21.2: 2/2 covered calls (100.00%)
- com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-yaml-provider:2.22.0: 2/2 covered calls (100.00%)

**Reflection:**
- com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-yaml-provider:2.21.2: 2/2 covered calls (100.00%)
- com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-yaml-provider:2.22.0: 2/2 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-yaml-provider:2.21.2: 106/357 (29.69%)
- com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-yaml-provider:2.22.0: 106/357 (29.69%)

**Line:**
- com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-yaml-provider:2.21.2: 23/87 (26.44%)
- com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-yaml-provider:2.22.0: 23/87 (26.44%)

**Method:**
- com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-yaml-provider:2.21.2: 4/30 (13.33%)
- com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-yaml-provider:2.22.0: 4/30 (13.33%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/2.21.2/src/test/java/com_fasterxml_jackson_jakarta_rs/jackson_jakarta_rs_yaml_provider/YAMLMapperConfiguratorTest.java b/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/2.22.0/src/test/java/com_fasterxml_jackson_jakarta_rs/jackson_jakarta_rs_yaml_provider/YAMLMapperConfiguratorTest.java
index 5e4103a321..3a88db858f 100644
--- a/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/2.21.2/src/test/java/com_fasterxml_jackson_jakarta_rs/jackson_jakarta_rs_yaml_provider/YAMLMapperConfiguratorTest.java
+++ b/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-yaml-provider/2.22.0/src/test/java/com_fasterxml_jackson_jakarta_rs/jackson_jakarta_rs_yaml_provider/YAMLMapperConfiguratorTest.java
@@ -25,7 +25,8 @@ public class YAMLMapperConfiguratorTest {
 
         YAMLMapper mapper = configurator.getDefaultMapper();
 
-        AnnotationIntrospector introspector = mapper.getSerializationConfig().getAnnotationIntrospector();
+        AnnotationIntrospector introspector = mapper.getSerializationConfig()
+                .getAnnotationIntrospector();
         assertThat(introspector).isInstanceOf(JakartaXmlBindAnnotationIntrospector.class);
 
         String yaml = mapper.writeValueAsString(new JakartaXmlBindBean("configured"));

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
