### PR TITLE
[Automation] Generated metadata for net.java.dev.jna:jna:5.19.0

### DIFF
--- a/metadata/net.java.dev.jna/jna/5.19.0/reachability-metadata.json
+++ b/metadata/net.java.dev.jna/jna/5.19.0/reachability-metadata.json
@@ -1,0 +1,894 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "com.sun.jna.Callback",
+      "jniAccessible" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.CallbackReference"
+      },
+      "type" : "com.sun.jna.CallbackProxy"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "com.sun.jna.CallbackReference",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "getCallback",
+          "parameterTypes" : [
+            "java.lang.Class",
+            "com.sun.jna.Pointer",
+            "boolean"
+          ]
+        },
+        {
+          "name" : "getFunctionPointer",
+          "parameterTypes" : [
+            "com.sun.jna.Callback",
+            "boolean"
+          ]
+        },
+        {
+          "name" : "getNativeString",
+          "parameterTypes" : [
+            "java.lang.Object",
+            "boolean"
+          ]
+        },
+        {
+          "name" : "initializeThread",
+          "parameterTypes" : [
+            "com.sun.jna.Callback",
+            "com.sun.jna.CallbackReference$AttachOptions"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "com.sun.jna.CallbackReference$AttachOptions",
+      "jniAccessible" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "com.sun.jna.FromNativeConverter",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "nativeType",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "com.sun.jna.IntegerType",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "value"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "com.sun.jna.JNIEnv",
+      "jniAccessible" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "com.sun.jna.Native",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "dispose",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "fromNative",
+          "parameterTypes" : [
+            "com.sun.jna.FromNativeConverter",
+            "java.lang.Object",
+            "java.lang.reflect.Method"
+          ]
+        },
+        {
+          "name" : "fromNative",
+          "parameterTypes" : [
+            "java.lang.Class",
+            "java.lang.Object"
+          ]
+        },
+        {
+          "name" : "fromNative",
+          "parameterTypes" : [
+            "java.lang.reflect.Method",
+            "java.lang.Object"
+          ]
+        },
+        {
+          "name" : "nativeType",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name" : "toNative",
+          "parameterTypes" : [
+            "com.sun.jna.ToNativeConverter",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "com.sun.jna.Native$ffi_callback",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "invoke",
+          "parameterTypes" : [
+            "long",
+            "long",
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "com.sun.jna.NativeMapped",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "toNative",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "com.sun.jna.Pointer",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "peer"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "com.sun.jna.PointerType",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "pointer"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "com.sun.jna.SecurityManagerExposer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getClassContext",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "com.sun.jna.Structure",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "memory"
+        },
+        {
+          "name" : "typeInfo"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "autoRead",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "autoWrite",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getTypeInfo",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "newInstance",
+          "parameterTypes" : [
+            "java.lang.Class",
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "com.sun.jna.Structure$ByValue",
+      "jniAccessible" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "com.sun.jna.Structure$FFIType$FFITypes",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "ffi_type_double"
+        },
+        {
+          "name" : "ffi_type_float"
+        },
+        {
+          "name" : "ffi_type_longdouble"
+        },
+        {
+          "name" : "ffi_type_pointer"
+        },
+        {
+          "name" : "ffi_type_sint16"
+        },
+        {
+          "name" : "ffi_type_sint32"
+        },
+        {
+          "name" : "ffi_type_sint64"
+        },
+        {
+          "name" : "ffi_type_sint8"
+        },
+        {
+          "name" : "ffi_type_uint16"
+        },
+        {
+          "name" : "ffi_type_uint32"
+        },
+        {
+          "name" : "ffi_type_uint64"
+        },
+        {
+          "name" : "ffi_type_uint8"
+        },
+        {
+          "name" : "ffi_type_void"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "com.sun.jna.WString",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.lang.Boolean",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "TYPE"
+        },
+        {
+          "name" : "value"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.lang.Byte",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "TYPE"
+        },
+        {
+          "name" : "value"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "byte"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.lang.Character",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "TYPE"
+        },
+        {
+          "name" : "value"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "char"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.lang.Class",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "getComponentType",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.lang.Double",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "TYPE"
+        },
+        {
+          "name" : "value"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "double"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.lang.Float",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "TYPE"
+        },
+        {
+          "name" : "value"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "float"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.lang.Integer",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "TYPE"
+        },
+        {
+          "name" : "value"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.lang.Long",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "TYPE"
+        },
+        {
+          "name" : "value"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Library$Handler"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.lang.Object",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "toString",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.lang.Short",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "TYPE"
+        },
+        {
+          "name" : "value"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "short"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.lang.StackWalker",
+      "methods" : [
+        {
+          "name" : "getInstance",
+          "parameterTypes" : [
+            "java.lang.StackWalker$Option"
+          ]
+        },
+        {
+          "name" : "walk",
+          "parameterTypes" : [
+            "java.util.function.Function"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.lang.StackWalker$Option"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.lang.StackWalker$StackFrame",
+      "methods" : [
+        {
+          "name" : "getDeclaringClass",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.lang.String",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "byte[]"
+          ]
+        },
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "byte[]",
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "getBytes",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getBytes",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "toCharArray",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.lang.System",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "getProperty",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.NativeLibrary"
+      },
+      "type" : "java.lang.Throwable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.lang.Void",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "TYPE"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.internal.ReflectionUtils"
+      },
+      "type" : "java.lang.invoke.MethodHandle"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.internal.ReflectionUtils"
+      },
+      "type" : "java.lang.invoke.MethodHandles"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.internal.ReflectionUtils"
+      },
+      "type" : "java.lang.invoke.MethodHandles$Lookup"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.internal.ReflectionUtils"
+      },
+      "type" : "java.lang.invoke.MethodType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.lang.reflect.Method",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "getParameterTypes",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getReturnType",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.VarArgsChecker"
+      },
+      "type" : "java.lang.reflect.Method"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.internal.ReflectionUtils"
+      },
+      "type" : "java.lang.reflect.Method",
+      "methods" : [
+        {
+          "name" : "isDefault",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.nio.Buffer",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "position",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Platform"
+      },
+      "type" : "java.nio.Buffer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.nio.ByteBuffer",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "array",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "arrayOffset",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.nio.CharBuffer",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "array",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "arrayOffset",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.nio.DoubleBuffer",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "array",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "arrayOffset",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.nio.FloatBuffer",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "array",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "arrayOffset",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.nio.IntBuffer",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "array",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "arrayOffset",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.nio.LongBuffer",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "array",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "arrayOffset",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.nio.ShortBuffer",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "array",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "arrayOffset",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.security.AccessController",
+      "methods" : [
+        {
+          "name" : "doPrivileged",
+          "parameterTypes" : [
+            "java.security.PrivilegedAction"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "glob" : "com/sun/jna/linux-x86-64/libjnidispatch.so"
+    }
+  ]
+}

--- a/metadata/net.java.dev.jna/jna/index.json
+++ b/metadata/net.java.dev.jna/jna/index.json
@@ -1,16 +1,28 @@
 [
   {
-    "latest": true,
-    "allowed-packages": [
-      "com.sun.jna"
+    "latest" : true,
+    "metadata-version" : "5.19.0",
+    "test-version" : "5.8.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/net/java/dev/jna/jna/$version$/jna-$version$-sources.jar",
+    "repository-url" : "https://github.com/java-native-access/jna",
+    "test-code-url" : "https://github.com/java-native-access/jna/tree/$version$/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/net/java/dev/jna/jna/$version$/jna-$version$-javadoc.jar",
+    "description" : "JNA provides Java programs with easy access to native shared libraries without requiring JNI code. It lets Java code call native functions and map native data structures through Java interfaces and classes.",
+    "tested-versions" : [
+      "5.19.0"
     ],
-    "metadata-version": "5.8.0",
-    "source-code-url": "https://repo1.maven.org/maven2/net/java/dev/jna/jna/$version$/jna-$version$-sources.jar",
-    "repository-url": "https://github.com/java-native-access/jna",
-    "test-code-url": "https://github.com/java-native-access/jna/tree/$version$/test",
-    "documentation-url": "https://repo1.maven.org/maven2/net/java/dev/jna/jna/$version$/jna-$version$-javadoc.jar",
-    "description": "JNA provides Java programs with easy access to native shared libraries without requiring JNI code. It lets Java code call native functions and map native data structures through Java interfaces and classes.",
-    "tested-versions": [
+    "allowed-packages" : [
+      "com.sun.jna"
+    ]
+  },
+  {
+    "metadata-version" : "5.8.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/net/java/dev/jna/jna/$version$/jna-$version$-sources.jar",
+    "repository-url" : "https://github.com/java-native-access/jna",
+    "test-code-url" : "https://github.com/java-native-access/jna/tree/$version$/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/net/java/dev/jna/jna/$version$/jna-$version$-javadoc.jar",
+    "description" : "JNA provides Java programs with easy access to native shared libraries without requiring JNI code. It lets Java code call native functions and map native data structures through Java interfaces and classes.",
+    "tested-versions" : [
       "5.8.0",
       "5.9.0",
       "5.10.0",
@@ -24,6 +36,9 @@
       "5.17.0",
       "5.18.0",
       "5.18.1"
+    ],
+    "allowed-packages" : [
+      "com.sun.jna"
     ]
   }
 ]

--- a/stats/net.java.dev.jna/jna/5.19.0/stats.json
+++ b/stats/net.java.dev.jna/jna/5.19.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "5.19.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.093023,
+          "coveredCalls" : 4,
+          "totalCalls" : 43
+        },
+        "resources" : {
+          "coverageRatio" : 0.2,
+          "coveredCalls" : 1,
+          "totalCalls" : 5
+        }
+      },
+      "coverageRatio" : 0.104167,
+      "coveredCalls" : 5,
+      "totalCalls" : 48
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2783,
+        "missed" : 19739,
+        "ratio" : 0.123568,
+        "total" : 22522
+      },
+      "line" : {
+        "covered" : 659,
+        "missed" : 4227,
+        "ratio" : 0.134875,
+        "total" : 4886
+      },
+      "method" : {
+        "covered" : 118,
+        "missed" : 751,
+        "ratio" : 0.135788,
+        "total" : 869
+      }
+    }
+  } ]
+}

--- a/tests/src/net.java.dev.jna/jna/5.8.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/net.java.dev.jna/jna/5.8.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,8 +1,18 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
+          "net_java_dev_jna.jna.CLibrary"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : {
+        "proxy" : [
           "net_java_dev_jna.jna.CLibrary"
         ]
       }


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7741

This PR provides new metadata needed for the net.java.dev.jna:jna:5.19.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `net.java.dev.jna:jna:5.8.0`): 196
- Test-only metadata entries (previous `net.java.dev.jna:jna:5.8.0`): 2
- Metadata entries (new `net.java.dev.jna:jna:5.19.0`): 188
- Test-only metadata entries (new `net.java.dev.jna:jna:5.19.0`): 2
- Library coverage (previous): 12.51%
- Library coverage (new): 13.49%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `c2a0c671c17747958a5fafcd468bfdb69d00df0a`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- net.java.dev.jna:jna:5.8.0: 5/48 covered calls (10.42%)
- net.java.dev.jna:jna:5.19.0: 5/48 covered calls (10.42%)

**Reflection:**
- net.java.dev.jna:jna:5.8.0: 4/43 covered calls (9.30%)
- net.java.dev.jna:jna:5.19.0: 4/43 covered calls (9.30%)

**Resources:**
- net.java.dev.jna:jna:5.8.0: 1/5 covered calls (20.00%)
- net.java.dev.jna:jna:5.19.0: 1/5 covered calls (20.00%)

#### Library coverage

**Instruction:**
- net.java.dev.jna:jna:5.8.0: 2528/21910 (11.54%)
- net.java.dev.jna:jna:5.19.0: 2783/22522 (12.36%)

**Line:**
- net.java.dev.jna:jna:5.8.0: 586/4684 (12.51%)
- net.java.dev.jna:jna:5.19.0: 659/4886 (13.49%)

**Method:**
- net.java.dev.jna:jna:5.8.0: 105/835 (12.57%)
- net.java.dev.jna:jna:5.19.0: 118/869 (13.58%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
