### PR TITLE
[GenAI] Test fix for com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-json-provider:2.22.0 using gpt-5.5

### DIFF
--- a/metadata/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.22.0/reachability-metadata.json
+++ b/metadata/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.22.0/reachability-metadata.json
@@ -1,0 +1,34 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.fasterxml.jackson.jakarta.rs.json.JsonMapperConfigurator"
+      },
+      "type": "com.fasterxml.jackson.databind.ext.Java7SupportImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "com.fasterxml.jackson.jakarta.rs.json.JsonMapperConfigurator"
+      },
+      "type": "com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntrospector",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.fasterxml.jackson.jakarta.rs.json.JsonMapperConfigurator"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.fasterxml.jackson.jakarta.rs.json.JsonMapperConfigurator"
+      },
+      "type": "sun.util.resources.cldr.CalendarData"
+    }
+  ]
+}

--- a/metadata/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/index.json
+++ b/metadata/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.22.0",
+    "tested-versions" : [
+      "2.22.0"
+    ],
+    "allowed-packages" : [
+      "com.fasterxml.jackson.jakarta.rs.json"
+    ]
+  },
+  {
     "metadata-version" : "2.18.5",
     "source-code-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/jakarta/rs/jackson-jakarta-rs-json-provider/$version$/jackson-jakarta-rs-json-provider-$version$-sources.jar",
     "repository-url" : "https://github.com/FasterXML/jackson-jakarta-rs-providers",

--- a/metadata/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/index.json
+++ b/metadata/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.22.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/jakarta/rs/jackson-jakarta-rs-json-provider/$version$/jackson-jakarta-rs-json-provider-$version$-sources.jar",
+    "repository-url" : "https://github.com/FasterXML/jackson-jakarta-rs-providers",
+    "test-code-url" : "https://github.com/FasterXML/jackson-jakarta-rs-providers/tree/jackson-jakarta-rs-providers-$version$/json/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/jakarta/rs/jackson-jakarta-rs-json-provider/$version$/jackson-jakarta-rs-json-provider-$version$-javadoc.jar",
+    "description" : "Jackson Jakarta-RS JSON Provider integrates Jackson data binding with Jakarta RESTful Web Services implementations to read and write JSON request and response bodies. It supplies JSON MessageBodyReader and MessageBodyWriter providers, automatic provider registration, and Jackson-specific configuration support for REST endpoints.",
     "tested-versions" : [
       "2.22.0"
     ],

--- a/stats/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.22.0/execution-metrics.json
+++ b/stats/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.22.0/execution-metrics.json
@@ -1,0 +1,99 @@
+{
+  "fix_javac_fail:2026-06-05": {
+    "timestamp": "2026-06-05T19:06:32.336807Z",
+    "library": "com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-json-provider:2.22.0",
+    "starting_commit": "9d15d0854cecfec7b970f60554fa95734f175ab7",
+    "ending_commit": "9934aa693326e15bd929476bc5bfaed5bef93a4e",
+    "previous_library": "com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-json-provider:2.18.5",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.22.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 2,
+        "totalCalls": 2
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 109,
+          "missed": 333,
+          "ratio": 0.246606,
+          "total": 442
+        },
+        "line": {
+          "covered": 24,
+          "missed": 84,
+          "ratio": 0.222222,
+          "total": 108
+        },
+        "method": {
+          "covered": 4,
+          "missed": 29,
+          "ratio": 0.121212,
+          "total": 33
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.18.5",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 2,
+        "totalCalls": 2
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 105,
+          "missed": 343,
+          "ratio": 0.234375,
+          "total": 448
+        },
+        "line": {
+          "covered": 23,
+          "missed": 88,
+          "ratio": 0.207207,
+          "total": 111
+        },
+        "method": {
+          "covered": 4,
+          "missed": 29,
+          "ratio": 0.121212,
+          "total": 33
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 94513,
+      "cached_input_tokens_used": 734720,
+      "output_tokens_used": 8959,
+      "iterations": 2,
+      "cost_usd": 0.6362,
+      "tested_library_loc": 24,
+      "metadata_entries": 5,
+      "previous_library_metadata_entries": 10,
+      "code_coverage_percent": 22.22,
+      "previous_library_coverage_percent": 20.72
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.22.0/src/test/java/com_fasterxml_jackson_jakarta_rs/jackson_jakarta_rs_json_provider/JsonMapperConfiguratorTest.java",
+      "metadata_file": "metadata/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.22.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.22.0/stats.json
+++ b/stats/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.22.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "2.22.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 2,
+      "totalCalls" : 2
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 109,
+        "missed" : 333,
+        "ratio" : 0.246606,
+        "total" : 442
+      },
+      "line" : {
+        "covered" : 24,
+        "missed" : 84,
+        "ratio" : 0.222222,
+        "total" : 108
+      },
+      "method" : {
+        "covered" : 4,
+        "missed" : 29,
+        "ratio" : 0.121212,
+        "total" : 33
+      }
+    }
+  } ]
+}

--- a/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.22.0/.gitignore
+++ b/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.22.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.22.0/build.gradle
+++ b/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.22.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-json-provider:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.22.0/gradle.properties
+++ b/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.22.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-json-provider:2.22.0
+library.version = 2.22.0
+metadata.dir = com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.22.0/

--- a/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.22.0/settings.gradle
+++ b/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.22.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.fasterxml.jackson.jakarta.rs.jackson-jakarta-rs-json-provider_tests'

--- a/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.22.0/src/test/java/com_fasterxml_jackson_jakarta_rs/jackson_jakarta_rs_json_provider/JsonMapperConfiguratorTest.java
+++ b/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.22.0/src/test/java/com_fasterxml_jackson_jakarta_rs/jackson_jakarta_rs_json_provider/JsonMapperConfiguratorTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jakarta_rs.jackson_jakarta_rs_json_provider;
+
+import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.jakarta.rs.cfg.Annotations;
+import com.fasterxml.jackson.jakarta.rs.json.JsonMapperConfigurator;
+import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntrospector;
+import jakarta.xml.bind.annotation.XmlElement;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JsonMapperConfiguratorTest {
+    @Test
+    void configuresDefaultMapperWithJakartaXmlBindAnnotations() throws Exception {
+        JsonMapperConfigurator configurator = new JsonMapperConfigurator(null,
+                new Annotations[] {Annotations.JAKARTA_XML_BIND});
+
+        ObjectMapper mapper = configurator.getDefaultMapper();
+
+        assertThat(mapper.getSerializationConfig().getAnnotationIntrospector().allIntrospectors())
+                .extracting(AnnotationIntrospector::getClass)
+                .contains(JakartaXmlBindAnnotationIntrospector.class);
+        assertThat(mapper.writeValueAsString(new XmlElementBean("configured")))
+                .isEqualTo("{\"xml_name\":\"configured\"}");
+    }
+
+    public static final class XmlElementBean {
+        @XmlElement(name = "xml_name")
+        public final String name;
+
+        public XmlElementBean(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.22.0/src/test/java/com_fasterxml_jackson_jakarta_rs/jackson_jakarta_rs_json_provider/JsonMapperConfiguratorTest.java
+++ b/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.22.0/src/test/java/com_fasterxml_jackson_jakarta_rs/jackson_jakarta_rs_json_provider/JsonMapperConfiguratorTest.java
@@ -6,8 +6,10 @@
  */
 package com_fasterxml_jackson_jakarta_rs.jackson_jakarta_rs_json_provider;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import com.fasterxml.jackson.jakarta.rs.cfg.Annotations;
 import com.fasterxml.jackson.jakarta.rs.json.JsonMapperConfigurator;
 import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntrospector;
@@ -17,6 +19,20 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class JsonMapperConfiguratorTest {
+    @Test
+    void configuresDefaultMapperWithJacksonAnnotations() throws Exception {
+        JsonMapperConfigurator configurator = new JsonMapperConfigurator(null,
+                new Annotations[] {Annotations.JACKSON});
+
+        ObjectMapper mapper = configurator.getDefaultMapper();
+
+        assertThat(mapper.getSerializationConfig().getAnnotationIntrospector().allIntrospectors())
+                .extracting(AnnotationIntrospector::getClass)
+                .contains(JacksonAnnotationIntrospector.class);
+        assertThat(mapper.writeValueAsString(new JsonPropertyBean("configured")))
+                .isEqualTo("{\"json_name\":\"configured\"}");
+    }
+
     @Test
     void configuresDefaultMapperWithJakartaXmlBindAnnotations() throws Exception {
         JsonMapperConfigurator configurator = new JsonMapperConfigurator(null,
@@ -29,6 +45,15 @@ public class JsonMapperConfiguratorTest {
                 .contains(JakartaXmlBindAnnotationIntrospector.class);
         assertThat(mapper.writeValueAsString(new XmlElementBean("configured")))
                 .isEqualTo("{\"xml_name\":\"configured\"}");
+    }
+
+    public static final class JsonPropertyBean {
+        @JsonProperty("json_name")
+        public final String name;
+
+        public JsonPropertyBean(String name) {
+            this.name = name;
+        }
     }
 
     public static final class XmlElementBean {

--- a/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.22.0/user-code-filter.json
+++ b/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.22.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.fasterxml.jackson.jakarta.rs.json.**"
+    },
+    {
+      "includeClasses" : "com_fasterxml_jackson_jakarta_rs.jackson_jakarta_rs_json_provider.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7727

This PR provides test fixes and new metadata for com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-json-provider:2.22.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 94513
- Cached input tokens: 734720
- Output tokens: 8959
- Metadata entries: 5
- Iterations: 2
- Library coverage percentage: 22.22
- Previous library version metadata entries: 10
- Previous library version coverage percentage: 20.72

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `6f47d297244aefe22667588f47136d7b7443abb3`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-json-provider:2.18.5: 2/2 covered calls (100.00%)
- com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-json-provider:2.22.0: 2/2 covered calls (100.00%)

**Reflection:**
- com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-json-provider:2.18.5: 2/2 covered calls (100.00%)
- com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-json-provider:2.22.0: 2/2 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-json-provider:2.18.5: 105/448 (23.44%)
- com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-json-provider:2.22.0: 109/442 (24.66%)

**Line:**
- com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-json-provider:2.18.5: 23/111 (20.72%)
- com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-json-provider:2.22.0: 24/108 (22.22%)

**Method:**
- com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-json-provider:2.18.5: 4/33 (12.12%)
- com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-json-provider:2.22.0: 4/33 (12.12%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.18.5/src/test/java/com_fasterxml_jackson_jakarta_rs/jackson_jakarta_rs_json_provider/JsonMapperConfiguratorTest.java 2/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.22.0/src/test/java/com_fasterxml_jackson_jakarta_rs/jackson_jakarta_rs_json_provider/JsonMapperConfiguratorTest.java
index 6c7a2c56a3..f5368a13b4 100644
--- 1/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.18.5/src/test/java/com_fasterxml_jackson_jakarta_rs/jackson_jakarta_rs_json_provider/JsonMapperConfiguratorTest.java
+++ 2/tests/src/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.22.0/src/test/java/com_fasterxml_jackson_jakarta_rs/jackson_jakarta_rs_json_provider/JsonMapperConfiguratorTest.java
@@ -6,8 +6,10 @@
  */
 package com_fasterxml_jackson_jakarta_rs.jackson_jakarta_rs_json_provider;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import com.fasterxml.jackson.jakarta.rs.cfg.Annotations;
 import com.fasterxml.jackson.jakarta.rs.json.JsonMapperConfigurator;
 import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntrospector;
@@ -17,6 +19,20 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class JsonMapperConfiguratorTest {
+    @Test
+    void configuresDefaultMapperWithJacksonAnnotations() throws Exception {
+        JsonMapperConfigurator configurator = new JsonMapperConfigurator(null,
+                new Annotations[] {Annotations.JACKSON});
+
+        ObjectMapper mapper = configurator.getDefaultMapper();
+
+        assertThat(mapper.getSerializationConfig().getAnnotationIntrospector().allIntrospectors())
+                .extracting(AnnotationIntrospector::getClass)
+                .contains(JacksonAnnotationIntrospector.class);
+        assertThat(mapper.writeValueAsString(new JsonPropertyBean("configured")))
+                .isEqualTo("{\"json_name\":\"configured\"}");
+    }
+
     @Test
     void configuresDefaultMapperWithJakartaXmlBindAnnotations() throws Exception {
         JsonMapperConfigurator configurator = new JsonMapperConfigurator(null,
@@ -31,6 +47,15 @@ public class JsonMapperConfiguratorTest {
                 .isEqualTo("{\"xml_name\":\"configured\"}");
     }
 
+    public static final class JsonPropertyBean {
+        @JsonProperty("json_name")
+        public final String name;
+
+        public JsonPropertyBean(String name) {
+            this.name = name;
+        }
+    }
+
     public static final class XmlElementBean {
         @XmlElement(name = "xml_name")
         public final String name;

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
