### PR TITLE
[GenAI] Test fix for dev.langchain4j:langchain4j:1.16.0 using gpt-5.5

### DIFF
--- a/metadata/dev.langchain4j/langchain4j/1.16.0/reachability-metadata.json
+++ b/metadata/dev.langchain4j/langchain4j/1.16.0/reachability-metadata.json
@@ -1,406 +1,320 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.internal.JacksonJsonCodec"
       },
-      "type": "com.fasterxml.jackson.databind.deser.Deserializers[]"
+      "type" : "com.fasterxml.jackson.databind.deser.Deserializers[]"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.internal.JacksonJsonCodec"
       },
-      "type": "com.fasterxml.jackson.databind.ext.Java7SupportImpl"
+      "type" : "com.fasterxml.jackson.databind.ext.Java7SupportImpl"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.internal.JacksonJsonCodec"
       },
-      "type": "com.fasterxml.jackson.databind.ser.Serializers[]"
+      "type" : "com.fasterxml.jackson.databind.ser.Serializers[]"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.classinstance.ClassInstanceLoader"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.internal.JacksonJsonCodec"
       },
-      "type": "dev.langchain4j.service.guardrail.DefaultGuardrailServiceTest$RecordingInputGuardrail"
+      "type" : "java.lang.Iterable"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.service.output.EnumOutputParser"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.internal.JacksonJsonCodec"
       },
-      "type": "dev.langchain4j.service.output.ServiceOutputParserTest$AssistantResponse"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.service.AiServiceValidation"
       },
-      "type": "java.lang.Iterable"
+      "type" : "java.lang.annotation.Annotation[]"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.service.guardrail.GuardrailService"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.service.AiServiceValidation"
       },
-      "type": "java.lang.StackTraceElement[]"
+      "type" : "java.lang.annotation.Annotation[][]"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.classloading.ReflectionBasedClassMetadataProviderFactory"
       },
-      "type": "java.lang.String[]"
+      "type" : "java.lang.reflect.Method[]"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.service.AiServiceValidation"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.internal.JacksonJsonCodec"
       },
-      "type": "java.lang.annotation.Annotation[]"
+      "type" : "java.util.AbstractCollection"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.service.AiServiceValidation"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.internal.JacksonJsonCodec"
       },
-      "type": "java.lang.annotation.Annotation[][]"
+      "type" : "java.util.AbstractList"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.service.output.PojoOutputParser"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.internal.JacksonJsonCodec"
       },
-      "type": "java.lang.reflect.Field[]"
+      "type" : "java.util.AbstractMap"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.classloading.ReflectionBasedClassMetadataProviderFactory"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.internal.JacksonJsonCodec"
       },
-      "type": "java.lang.reflect.Method[]"
+      "type" : "java.util.Collection"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.internal.JacksonJsonCodec"
       },
-      "type": "java.util.AbstractCollection"
+      "type" : "java.util.HashMap"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.internal.JacksonJsonCodec"
       },
-      "type": "java.util.AbstractList"
+      "type" : "java.util.Map"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.internal.JacksonJsonCodec"
       },
-      "type": "java.util.AbstractMap"
+      "type" : "java.util.RandomAccess"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.internal.JacksonJsonCodec"
       },
-      "type": "java.util.Collection"
+      "type" : "java.util.SequencedCollection"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.internal.JacksonJsonCodec"
       },
-      "type": "java.util.HashMap"
+      "type" : "java.util.SequencedMap"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.data.document.splitter.DocumentBySentenceSplitter"
       },
-      "type": "java.util.Map"
-    },
-    {
-      "condition": {
-        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
-      },
-      "type": "java.util.RandomAccess"
-    },
-    {
-      "condition": {
-        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
-      },
-      "type": "java.util.SequencedCollection"
-    },
-    {
-      "condition": {
-        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
-      },
-      "type": "java.util.SequencedMap"
-    },
-    {
-      "condition": {
-        "typeReached": "dev.langchain4j.data.document.splitter.DocumentBySentenceSplitter"
-      },
-      "type": "opennlp.tools.sentdetect.SentenceDetectorFactory",
-      "methods": [
+      "type" : "opennlp.tools.sentdetect.SentenceDetectorFactory",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.service.DefaultAiServices$1"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.service.DefaultAiServices$1"
       },
-      "type": "sun.security.provider.NativePRNG"
+      "type" : "sun.security.provider.NativePRNG"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.service.DefaultAiServices$1"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.service.DefaultAiServices$1"
       },
-      "type": "sun.security.provider.SHA"
+      "type" : "sun.security.provider.SHA"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.internal.JacksonJsonCodec"
       },
-      "type": "sun.util.resources.cldr.CalendarData"
+      "type" : "sun.util.resources.cldr.CalendarData"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.internal.JacksonJsonCodec"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "com.fasterxml.jackson.databind.annotation.JacksonStdImpl"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.internal.Utils"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.internal.Utils"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "dev.langchain4j.agent.tool.Tool"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.service.output.EnumOutputParser"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.service.AiServiceValidation"
       },
-      "type": {
-        "proxy": [
-          "dev.langchain4j.model.output.structured.Description"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "dev.langchain4j.service.output.PojoOutputParser"
-      },
-      "type": {
-        "proxy": [
-          "dev.langchain4j.model.output.structured.Description"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "dev.langchain4j.service.AiServiceValidation"
-      },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "dev.langchain4j.service.SystemMessage"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.service.DefaultAiServices"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.service.DefaultAiServices"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "dev.langchain4j.service.SystemMessage"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.classloading.ReflectionBasedClassMetadataProviderFactory"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.classloading.ReflectionBasedClassMetadataProviderFactory"
       },
-      "type": {
-        "proxy": [
-          "dev.langchain4j.service.guardrail.InputGuardrails"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "dev.langchain4j.service.DefaultAiServices"
-      },
-      "type": {
-        "proxy": [
-          "dev_langchain4j.langchain4j.Langchain4jTest$Assistant"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "dev.langchain4j.classloading.ReflectionBasedClassMetadataProviderFactory"
-      },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Retention"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.internal.JacksonJsonCodec"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Retention"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.internal.Utils"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.internal.Utils"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Retention"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.service.AiServiceValidation"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.service.AiServiceValidation"
       },
-      "type": {
-        "proxy": [
-          "java.lang.annotation.Retention"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "dev.langchain4j.service.output.PojoOutputParser"
-      },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Retention"
         ]
       }
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.internal.JacksonJsonCodec"
       },
-      "glob": "META-INF/services/com.fasterxml.jackson.databind.Module"
+      "glob" : "META-INF/services/com.fasterxml.jackson.databind.Module"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.service.ParameterNameResolver$Holder"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.service.ParameterNameResolver$Holder"
       },
-      "glob": "META-INF/services/dev.langchain4j.service.ParameterNameResolver"
+      "glob" : "META-INF/services/dev.langchain4j.service.ParameterNameResolver"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.service.guardrail.GuardrailService"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.classinstance.ClassInstanceLoader"
       },
-      "glob": "META-INF/services/dev.langchain4j.service.guardrail.spi.GuardrailServiceBuilderFactory"
+      "glob" : "META-INF/services/dev.langchain4j.spi.classloading.ClassInstanceFactory"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.classinstance.ClassInstanceLoader"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.classloading.ClassMetadataProvider"
       },
-      "glob": "META-INF/services/dev.langchain4j.spi.classloading.ClassInstanceFactory"
+      "glob" : "META-INF/services/dev.langchain4j.spi.classloading.ClassMetadataProviderFactory"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.classloading.ClassMetadataProvider"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.guardrail.InputGuardrailExecutor"
       },
-      "glob": "META-INF/services/dev.langchain4j.spi.classloading.ClassMetadataProviderFactory"
+      "glob" : "META-INF/services/dev.langchain4j.spi.guardrail.InputGuardrailExecutorBuilderFactory"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.guardrail.InputGuardrailExecutor"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.guardrail.OutputGuardrailExecutor"
       },
-      "glob": "META-INF/services/dev.langchain4j.spi.guardrail.InputGuardrailExecutorBuilderFactory"
+      "glob" : "META-INF/services/dev.langchain4j.spi.guardrail.OutputGuardrailExecutorBuilderFactory"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.guardrail.OutputGuardrailExecutor"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.guardrail.config.InputGuardrailsConfig"
       },
-      "glob": "META-INF/services/dev.langchain4j.spi.guardrail.OutputGuardrailExecutorBuilderFactory"
+      "glob" : "META-INF/services/dev.langchain4j.spi.guardrail.config.InputGuardrailsConfigBuilderFactory"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.guardrail.config.InputGuardrailsConfig"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.guardrail.config.OutputGuardrailsConfig"
       },
-      "glob": "META-INF/services/dev.langchain4j.spi.guardrail.config.InputGuardrailsConfigBuilderFactory"
+      "glob" : "META-INF/services/dev.langchain4j.spi.guardrail.config.OutputGuardrailsConfigBuilderFactory"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.guardrail.config.OutputGuardrailsConfig"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.spi.ServiceHelper"
       },
-      "glob": "META-INF/services/dev.langchain4j.spi.guardrail.config.OutputGuardrailsConfigBuilderFactory"
+      "glob" : "META-INF/services/dev.langchain4j.spi.json.JsonCodecFactory"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.spi.ServiceHelper"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.observability.api.AiServiceListenerRegistrar"
       },
-      "glob": "META-INF/services/dev.langchain4j.spi.json.JsonCodecFactory"
+      "glob" : "META-INF/services/dev.langchain4j.spi.observability.AiServiceListenerRegistrarFactory"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.observability.api.AiServiceListenerRegistrar"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.spi.ServiceHelper"
       },
-      "glob": "META-INF/services/dev.langchain4j.spi.observability.AiServiceListenerRegistrarFactory"
+      "glob" : "META-INF/services/dev.langchain4j.spi.prompt.PromptTemplateFactory"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.spi.ServiceHelper"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.spi.ServiceHelper"
       },
-      "glob": "META-INF/services/dev.langchain4j.spi.prompt.PromptTemplateFactory"
+      "glob" : "META-INF/services/dev.langchain4j.spi.services.AiServiceContextFactory"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.spi.ServiceHelper"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.spi.ServiceHelper"
       },
-      "glob": "META-INF/services/dev.langchain4j.spi.services.AiServiceContextFactory"
+      "glob" : "META-INF/services/dev.langchain4j.spi.services.AiServicesFactory"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.spi.ServiceHelper"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.spi.ServiceHelper"
       },
-      "glob": "META-INF/services/dev.langchain4j.spi.services.AiServicesFactory"
+      "glob" : "META-INF/services/dev.langchain4j.spi.services.TokenStreamAdapter"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.spi.ServiceHelper"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.observability.api.DefaultAiServiceListenerRegistrar"
       },
-      "glob": "META-INF/services/dev.langchain4j.spi.services.TokenStreamAdapter"
+      "glob" : "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.observability.api.DefaultAiServiceListenerRegistrar"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.service.DefaultAiServices"
       },
-      "glob": "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
+      "glob" : "dev_langchain4j/langchain4j/langchain4j-system-message.txt"
     },
     {
-      "condition": {
-        "typeReached": "dev.langchain4j.service.DefaultAiServices"
+      "condition" : {
+        "typeReached" : "dev.langchain4j.data.document.splitter.DocumentBySentenceSplitter"
       },
-      "glob": "dev_langchain4j/langchain4j/langchain4j-system-message.txt"
-    },
-    {
-      "condition": {
-        "typeReached": "dev.langchain4j.service.DefaultAiServices"
-      },
-      "glob": "langchain4j-system-message.txt"
-    },
-    {
-      "condition": {
-        "typeReached": "dev.langchain4j.data.document.splitter.DocumentBySentenceSplitter"
-      },
-      "glob": "opennlp/opennlp-en-ud-ewt-sentence-1.2-2.5.0.bin"
+      "glob" : "opennlp/opennlp-en-ud-ewt-sentence-1.2-2.5.0.bin"
     }
   ]
 }

--- a/metadata/dev.langchain4j/langchain4j/1.16.0/reachability-metadata.json
+++ b/metadata/dev.langchain4j/langchain4j/1.16.0/reachability-metadata.json
@@ -1,0 +1,406 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      },
+      "type": "com.fasterxml.jackson.databind.deser.Deserializers[]"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      },
+      "type": "com.fasterxml.jackson.databind.ext.Java7SupportImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      },
+      "type": "com.fasterxml.jackson.databind.ser.Serializers[]"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.classinstance.ClassInstanceLoader"
+      },
+      "type": "dev.langchain4j.service.guardrail.DefaultGuardrailServiceTest$RecordingInputGuardrail"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.service.output.EnumOutputParser"
+      },
+      "type": "dev.langchain4j.service.output.ServiceOutputParserTest$AssistantResponse"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      },
+      "type": "java.lang.Iterable"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.service.guardrail.GuardrailService"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.service.AiServiceValidation"
+      },
+      "type": "java.lang.annotation.Annotation[]"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.service.AiServiceValidation"
+      },
+      "type": "java.lang.annotation.Annotation[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.service.output.PojoOutputParser"
+      },
+      "type": "java.lang.reflect.Field[]"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.classloading.ReflectionBasedClassMetadataProviderFactory"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      },
+      "type": "java.util.AbstractCollection"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      },
+      "type": "java.util.AbstractList"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      },
+      "type": "java.util.AbstractMap"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      },
+      "type": "java.util.Collection"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      },
+      "type": "java.util.HashMap"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      },
+      "type": "java.util.Map"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      },
+      "type": "java.util.RandomAccess"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      },
+      "type": "java.util.SequencedCollection"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      },
+      "type": "java.util.SequencedMap"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.data.document.splitter.DocumentBySentenceSplitter"
+      },
+      "type": "opennlp.tools.sentdetect.SentenceDetectorFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.service.DefaultAiServices$1"
+      },
+      "type": "sun.security.provider.NativePRNG"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.service.DefaultAiServices$1"
+      },
+      "type": "sun.security.provider.SHA"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      },
+      "type": "sun.util.resources.cldr.CalendarData"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      },
+      "type": {
+        "proxy": [
+          "com.fasterxml.jackson.databind.annotation.JacksonStdImpl"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.internal.Utils"
+      },
+      "type": {
+        "proxy": [
+          "dev.langchain4j.agent.tool.Tool"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.service.output.EnumOutputParser"
+      },
+      "type": {
+        "proxy": [
+          "dev.langchain4j.model.output.structured.Description"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.service.output.PojoOutputParser"
+      },
+      "type": {
+        "proxy": [
+          "dev.langchain4j.model.output.structured.Description"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.service.AiServiceValidation"
+      },
+      "type": {
+        "proxy": [
+          "dev.langchain4j.service.SystemMessage"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.service.DefaultAiServices"
+      },
+      "type": {
+        "proxy": [
+          "dev.langchain4j.service.SystemMessage"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.classloading.ReflectionBasedClassMetadataProviderFactory"
+      },
+      "type": {
+        "proxy": [
+          "dev.langchain4j.service.guardrail.InputGuardrails"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.service.DefaultAiServices"
+      },
+      "type": {
+        "proxy": [
+          "dev_langchain4j.langchain4j.Langchain4jTest$Assistant"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.classloading.ReflectionBasedClassMetadataProviderFactory"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.internal.Utils"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.service.AiServiceValidation"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.service.output.PojoOutputParser"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.internal.JacksonJsonCodec"
+      },
+      "glob": "META-INF/services/com.fasterxml.jackson.databind.Module"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.service.ParameterNameResolver$Holder"
+      },
+      "glob": "META-INF/services/dev.langchain4j.service.ParameterNameResolver"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.service.guardrail.GuardrailService"
+      },
+      "glob": "META-INF/services/dev.langchain4j.service.guardrail.spi.GuardrailServiceBuilderFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.classinstance.ClassInstanceLoader"
+      },
+      "glob": "META-INF/services/dev.langchain4j.spi.classloading.ClassInstanceFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.classloading.ClassMetadataProvider"
+      },
+      "glob": "META-INF/services/dev.langchain4j.spi.classloading.ClassMetadataProviderFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.guardrail.InputGuardrailExecutor"
+      },
+      "glob": "META-INF/services/dev.langchain4j.spi.guardrail.InputGuardrailExecutorBuilderFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.guardrail.OutputGuardrailExecutor"
+      },
+      "glob": "META-INF/services/dev.langchain4j.spi.guardrail.OutputGuardrailExecutorBuilderFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.guardrail.config.InputGuardrailsConfig"
+      },
+      "glob": "META-INF/services/dev.langchain4j.spi.guardrail.config.InputGuardrailsConfigBuilderFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.guardrail.config.OutputGuardrailsConfig"
+      },
+      "glob": "META-INF/services/dev.langchain4j.spi.guardrail.config.OutputGuardrailsConfigBuilderFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.spi.ServiceHelper"
+      },
+      "glob": "META-INF/services/dev.langchain4j.spi.json.JsonCodecFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.observability.api.AiServiceListenerRegistrar"
+      },
+      "glob": "META-INF/services/dev.langchain4j.spi.observability.AiServiceListenerRegistrarFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.spi.ServiceHelper"
+      },
+      "glob": "META-INF/services/dev.langchain4j.spi.prompt.PromptTemplateFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.spi.ServiceHelper"
+      },
+      "glob": "META-INF/services/dev.langchain4j.spi.services.AiServiceContextFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.spi.ServiceHelper"
+      },
+      "glob": "META-INF/services/dev.langchain4j.spi.services.AiServicesFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.spi.ServiceHelper"
+      },
+      "glob": "META-INF/services/dev.langchain4j.spi.services.TokenStreamAdapter"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.observability.api.DefaultAiServiceListenerRegistrar"
+      },
+      "glob": "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.service.DefaultAiServices"
+      },
+      "glob": "dev_langchain4j/langchain4j/langchain4j-system-message.txt"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.service.DefaultAiServices"
+      },
+      "glob": "langchain4j-system-message.txt"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.langchain4j.data.document.splitter.DocumentBySentenceSplitter"
+      },
+      "glob": "opennlp/opennlp-en-ud-ewt-sentence-1.2-2.5.0.bin"
+    }
+  ]
+}

--- a/metadata/dev.langchain4j/langchain4j/index.json
+++ b/metadata/dev.langchain4j/langchain4j/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.16.0",
+    "tested-versions" : [
+      "1.16.0"
+    ],
+    "allowed-packages" : [
+      "dev.langchain4j"
+    ]
+  },
+  {
     "metadata-version" : "1.9.0",
     "source-code-url" : "https://repo1.maven.org/maven2/dev/langchain4j/langchain4j/$version$/langchain4j-$version$-sources.jar",
     "repository-url" : "https://github.com/langchain4j/langchain4j",

--- a/metadata/dev.langchain4j/langchain4j/index.json
+++ b/metadata/dev.langchain4j/langchain4j/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.16.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/dev/langchain4j/langchain4j/$version$/langchain4j-$version$-sources.jar",
+    "repository-url" : "https://github.com/langchain4j/langchain4j",
+    "test-code-url" : "https://repo1.maven.org/maven2/dev/langchain4j/langchain4j/$version$/langchain4j-$version$-test-sources.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/dev/langchain4j/langchain4j/$version$/langchain4j-$version$-javadoc.jar",
+    "description" : "LangChain4j is an open-source Java library that simplifies integrating large language models into Java applications through a unified API. It provides abstractions and integrations for building AI features such as chat, retrieval-augmented generation, tool calling, and agents.",
     "tested-versions" : [
       "1.16.0"
     ],

--- a/stats/dev.langchain4j/langchain4j/1.16.0/execution-metrics.json
+++ b/stats/dev.langchain4j/langchain4j/1.16.0/execution-metrics.json
@@ -1,0 +1,110 @@
+{
+  "fix_java_run_fail:2026-06-05": {
+    "timestamp": "2026-06-05T19:18:57.130523Z",
+    "library": "dev.langchain4j:langchain4j:1.16.0",
+    "starting_commit": "0eb9cc5cf0049c620248e8a58d511d46643a30e6",
+    "ending_commit": "b94d095ecfe91de3ca5081e185916859c0b2d227",
+    "previous_library": "dev.langchain4j:langchain4j:1.9.0",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.16.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 7,
+            "totalCalls": 7
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 11,
+        "totalCalls": 11
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3905,
+          "missed": 14139,
+          "ratio": 0.216415,
+          "total": 18044
+        },
+        "line": {
+          "covered": 968,
+          "missed": 3220,
+          "ratio": 0.231137,
+          "total": 4188
+        },
+        "method": {
+          "covered": 272,
+          "missed": 889,
+          "ratio": 0.234281,
+          "total": 1161
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.9.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 9,
+            "totalCalls": 9
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 13,
+        "totalCalls": 13
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3192,
+          "missed": 9929,
+          "ratio": 0.243274,
+          "total": 13121
+        },
+        "line": {
+          "covered": 768,
+          "missed": 2310,
+          "ratio": 0.249513,
+          "total": 3078
+        },
+        "method": {
+          "covered": 219,
+          "missed": 669,
+          "ratio": 0.246622,
+          "total": 888
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 26111,
+      "cached_input_tokens_used": 246784,
+      "output_tokens_used": 1547,
+      "iterations": 1,
+      "cost_usd": 0.1698,
+      "tested_library_loc": 968,
+      "metadata_entries": 47,
+      "test_only_metadata_entries": 11,
+      "previous_library_metadata_entries": 50,
+      "code_coverage_percent": 23.11,
+      "previous_library_coverage_percent": 24.95
+    },
+    "artifacts": {
+      "test_file": "tests/src/dev.langchain4j/langchain4j/1.16.0/src/test/java/dev_langchain4j/langchain4j/Langchain4jTest.java",
+      "metadata_file": "metadata/dev.langchain4j/langchain4j/1.16.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/dev.langchain4j/langchain4j/1.16.0/stats.json
+++ b/stats/dev.langchain4j/langchain4j/1.16.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "1.16.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 7,
+          "totalCalls" : 7
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 4,
+          "totalCalls" : 4
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 11,
+      "totalCalls" : 11
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3905,
+        "missed" : 14139,
+        "ratio" : 0.216415,
+        "total" : 18044
+      },
+      "line" : {
+        "covered" : 968,
+        "missed" : 3220,
+        "ratio" : 0.231137,
+        "total" : 4188
+      },
+      "method" : {
+        "covered" : 272,
+        "missed" : 889,
+        "ratio" : 0.234281,
+        "total" : 1161
+      }
+    }
+  } ]
+}

--- a/tests/src/dev.langchain4j/langchain4j/1.16.0/.gitignore
+++ b/tests/src/dev.langchain4j/langchain4j/1.16.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/dev.langchain4j/langchain4j/1.16.0/build.gradle
+++ b/tests/src/dev.langchain4j/langchain4j/1.16.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "dev.langchain4j:langchain4j:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/dev.langchain4j/langchain4j/1.16.0/gradle.properties
+++ b/tests/src/dev.langchain4j/langchain4j/1.16.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = dev.langchain4j:langchain4j:1.16.0
+library.version = 1.16.0
+metadata.dir = dev.langchain4j/langchain4j/1.16.0/

--- a/tests/src/dev.langchain4j/langchain4j/1.16.0/settings.gradle
+++ b/tests/src/dev.langchain4j/langchain4j/1.16.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'dev.langchain4j.langchain4j_tests'

--- a/tests/src/dev.langchain4j/langchain4j/1.16.0/src/test/java/dev/langchain4j/service/guardrail/DefaultGuardrailServiceTest.java
+++ b/tests/src/dev.langchain4j/langchain4j/1.16.0/src/test/java/dev/langchain4j/service/guardrail/DefaultGuardrailServiceTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package dev.langchain4j.service.guardrail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.guardrail.InputGuardrail;
+import org.junit.jupiter.api.Test;
+
+class DefaultGuardrailServiceTest {
+
+    @Test
+    void resolvesAnnotatedGuardrailsByMethodName() {
+        DefaultGuardrailService guardrailService =
+                (DefaultGuardrailService) GuardrailService.builder(GuardedAssistant.class).build();
+
+        assertThat(guardrailService.getInputGuardrails("answer"))
+                .singleElement()
+                .isInstanceOf(RecordingInputGuardrail.class);
+    }
+
+    interface GuardedAssistant {
+
+        @InputGuardrails(RecordingInputGuardrail.class)
+        String answer(String prompt);
+    }
+
+    public static final class RecordingInputGuardrail implements InputGuardrail {}
+}

--- a/tests/src/dev.langchain4j/langchain4j/1.16.0/src/test/java/dev/langchain4j/service/output/ServiceOutputParserTest.java
+++ b/tests/src/dev.langchain4j/langchain4j/1.16.0/src/test/java/dev/langchain4j/service/output/ServiceOutputParserTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package dev.langchain4j.service.output;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.model.output.structured.Description;
+import org.junit.jupiter.api.Test;
+
+class ServiceOutputParserTest {
+
+    @Test
+    void includesAnnotatedEnumDescriptionsInFormatInstructions() {
+        ServiceOutputParser serviceOutputParser = new ServiceOutputParser();
+
+        String formatInstructions = serviceOutputParser.outputFormatInstructions(AssistantResponse.class);
+
+        assertThat(formatInstructions)
+                .contains("\nAPPROVED - safe to return to the user")
+                .contains("\nREJECTED - requires escalation")
+                .contains("\nUNKNOWN");
+    }
+
+    @Test
+    void includesPojoFieldsInFormatInstructions() {
+        ServiceOutputParser serviceOutputParser = new ServiceOutputParser();
+
+        String formatInstructions = serviceOutputParser.outputFormatInstructions(StructuredAssistantResponse.class);
+
+        assertThat(formatInstructions)
+                .contains("\"message\": (assistant reply; type: string)")
+                .contains("\"confidence\": (type: float)")
+                .doesNotContain("IGNORED_STATIC_FIELD");
+    }
+
+    private enum AssistantResponse {
+
+        @Description("safe to return to the user")
+        APPROVED,
+
+        @Description({"requires", "escalation"})
+        REJECTED,
+
+        UNKNOWN
+    }
+
+    private static final class StructuredAssistantResponse {
+
+        static final String IGNORED_STATIC_FIELD = "ignored";
+
+        @Description("assistant reply")
+        String message;
+
+        float confidence;
+    }
+}

--- a/tests/src/dev.langchain4j/langchain4j/1.16.0/src/test/java/dev_langchain4j/langchain4j/Langchain4jTest.java
+++ b/tests/src/dev.langchain4j/langchain4j/1.16.0/src/test/java/dev_langchain4j/langchain4j/Langchain4jTest.java
@@ -83,7 +83,7 @@ class Langchain4jTest {
     }
 
     @Test
-    void registersOnlyDeclaredToolMethodsFromToolObjects() {
+    void registersAnnotatedToolMethodsFromToolObjects() {
         ToolCallingChatModel chatModel = new ToolCallingChatModel();
         Assistant assistant = AiServices.builder(Assistant.class)
                 .chatModel(chatModel)
@@ -162,7 +162,7 @@ class Langchain4jTest {
             if (invocationCount == 1) {
                 assertThat(chatRequest.toolSpecifications())
                         .extracting(ToolSpecification::name)
-                        .containsExactly("declaredTool");
+                        .containsExactly("declaredTool", "inheritedTool");
                 return ChatResponse.builder()
                         .aiMessage(AiMessage.from(ToolExecutionRequest.builder()
                                 .id("tool-call-2")

--- a/tests/src/dev.langchain4j/langchain4j/1.16.0/src/test/java/dev_langchain4j/langchain4j/Langchain4jTest.java
+++ b/tests/src/dev.langchain4j/langchain4j/1.16.0/src/test/java/dev_langchain4j/langchain4j/Langchain4jTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package dev_langchain4j.langchain4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.document.source.ClassPathSource;
+import dev.langchain4j.data.document.splitter.DocumentBySentenceSplitter;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.AiServices;
+import dev.langchain4j.service.SystemMessage;
+import dev.langchain4j.service.tool.DefaultToolExecutor;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class Langchain4jTest {
+
+    private static final String SYSTEM_MESSAGE_RESOURCE = "langchain4j-system-message.txt";
+
+    @Test
+    void buildsProxyAndLoadsSystemMessageTemplateFromRootClasspathResource() {
+        RecordingChatModel chatModel = new RecordingChatModel();
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(chatModel)
+                .build();
+
+        String response = assistant.answer("Summarize the prompt");
+        ChatMessage systemMessage = chatModel.messages().get(0);
+        ChatMessage userMessage = chatModel.messages().get(1);
+
+        assertThat(response).isEqualTo("stubbed answer");
+        assertThat(chatModel.messages()).hasSize(2);
+        assertThat(systemMessage).isInstanceOfSatisfying(
+                dev.langchain4j.data.message.SystemMessage.class,
+                message -> assertThat(message.text().stripTrailing())
+                        .isEqualTo("You must answer from the root classpath resource."));
+        assertThat(userMessage)
+                .isInstanceOfSatisfying(UserMessage.class, message -> assertThat(message.singleText())
+                        .isEqualTo("Summarize the prompt"));
+    }
+
+    @Test
+    void loadsClassPathSourceFromClasspathResource() throws IOException {
+        ClassLoader classLoader = Langchain4jTest.class.getClassLoader();
+        ClassPathSource source = ClassPathSource.from(SYSTEM_MESSAGE_RESOURCE, classLoader);
+
+        assertThat(source.classLoader()).isSameAs(classLoader);
+        assertThat(source.url()).isNotNull();
+        try (InputStream inputStream = source.inputStream()) {
+            String content = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+            assertThat(content).contains("root classpath resource");
+        }
+    }
+
+    @Test
+    void executesToolRequestByResolvingMethodNameFromTheRequest() {
+        ToolExecutionRequest toolExecutionRequest = ToolExecutionRequest.builder()
+                .id("tool-call-1")
+                .name("toolResponse")
+                .arguments("{}")
+                .build();
+        DefaultToolExecutor toolExecutor = new DefaultToolExecutor(new RequestNamedTool(), toolExecutionRequest);
+
+        String result = toolExecutor.execute(toolExecutionRequest, "memory-1");
+
+        assertThat(result).isEqualTo("tool response");
+    }
+
+    @Test
+    void registersOnlyDeclaredToolMethodsFromToolObjects() {
+        ToolCallingChatModel chatModel = new ToolCallingChatModel();
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(chatModel)
+                .tools(new DeclaredToolContainer())
+                .build();
+
+        String response = assistant.answer("Check tools");
+
+        assertThat(response).isEqualTo("tool-backed answer");
+        assertThat(chatModel.invocationCount()).isEqualTo(2);
+    }
+
+    @Test
+    void splitsTextIntoSentencesUsingTheBundledSentenceModel() {
+        DocumentBySentenceSplitter splitter = new DocumentBySentenceSplitter(100, 0);
+
+        String[] sentences = splitter.split("First sentence. Second sentence? Third sentence!");
+
+        assertThat(sentences)
+                .containsExactly("First sentence.", "Second sentence?", "Third sentence!");
+    }
+
+    interface Assistant {
+
+        @SystemMessage(fromResource = "langchain4j-system-message.txt")
+        String answer(String prompt);
+    }
+
+    private static final class RequestNamedTool {
+
+        public String toolResponse() {
+            return "tool response";
+        }
+    }
+
+    private static class InheritedToolContainer {
+
+        @Tool
+        public String inheritedTool() {
+            return "inherited response";
+        }
+    }
+
+    private static final class DeclaredToolContainer extends InheritedToolContainer {
+
+        @Tool
+        public String declaredTool() {
+            return "declared response";
+        }
+    }
+
+    private static final class RecordingChatModel implements ChatModel {
+
+        private List<ChatMessage> messages;
+
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            this.messages = chatRequest.messages();
+            return ChatResponse.builder()
+                    .aiMessage(AiMessage.from("stubbed answer"))
+                    .build();
+        }
+
+        List<ChatMessage> messages() {
+            return messages;
+        }
+    }
+
+    private static final class ToolCallingChatModel implements ChatModel {
+
+        private int invocationCount;
+
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            invocationCount++;
+            if (invocationCount == 1) {
+                assertThat(chatRequest.toolSpecifications())
+                        .extracting(ToolSpecification::name)
+                        .containsExactly("declaredTool");
+                return ChatResponse.builder()
+                        .aiMessage(AiMessage.from(ToolExecutionRequest.builder()
+                                .id("tool-call-2")
+                                .name("declaredTool")
+                                .arguments("{}")
+                                .build()))
+                        .build();
+            }
+
+            ChatMessage lastMessage = chatRequest.messages().get(chatRequest.messages().size() - 1);
+            assertThat(lastMessage).isInstanceOfSatisfying(ToolExecutionResultMessage.class, message -> {
+                assertThat(message.toolName()).isEqualTo("declaredTool");
+                assertThat(message.text()).isEqualTo("declared response");
+            });
+            return ChatResponse.builder()
+                    .aiMessage(AiMessage.from("tool-backed answer"))
+                    .build();
+        }
+
+        int invocationCount() {
+            return invocationCount;
+        }
+    }
+}

--- a/tests/src/dev.langchain4j/langchain4j/1.16.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/dev.langchain4j/langchain4j/1.16.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,92 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "dev.langchain4j.classinstance.ClassInstanceLoader"
+      },
+      "type" : "dev.langchain4j.service.guardrail.DefaultGuardrailServiceTest$RecordingInputGuardrail"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.langchain4j.service.output.EnumOutputParser"
+      },
+      "type" : "dev.langchain4j.service.output.ServiceOutputParserTest$AssistantResponse"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.langchain4j.service.guardrail.GuardrailService"
+      },
+      "type" : "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.langchain4j.service.output.PojoOutputParser"
+      },
+      "type" : "java.lang.reflect.Field[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.langchain4j.service.output.EnumOutputParser"
+      },
+      "type" : {
+        "proxy" : [
+          "dev.langchain4j.model.output.structured.Description"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.langchain4j.service.output.PojoOutputParser"
+      },
+      "type" : {
+        "proxy" : [
+          "dev.langchain4j.model.output.structured.Description"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.langchain4j.classloading.ReflectionBasedClassMetadataProviderFactory"
+      },
+      "type" : {
+        "proxy" : [
+          "dev.langchain4j.service.guardrail.InputGuardrails"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.langchain4j.service.DefaultAiServices"
+      },
+      "type" : {
+        "proxy" : [
+          "dev_langchain4j.langchain4j.Langchain4jTest$Assistant"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.langchain4j.service.output.PojoOutputParser"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "dev.langchain4j.service.guardrail.GuardrailService"
+      },
+      "glob" : "META-INF/services/dev.langchain4j.service.guardrail.spi.GuardrailServiceBuilderFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.langchain4j.service.DefaultAiServices"
+      },
+      "glob" : "langchain4j-system-message.txt"
+    }
+  ]
+}

--- a/tests/src/dev.langchain4j/langchain4j/1.16.0/src/test/resources/langchain4j-system-message.txt
+++ b/tests/src/dev.langchain4j/langchain4j/1.16.0/src/test/resources/langchain4j-system-message.txt
@@ -1,0 +1,1 @@
+You must answer from the root classpath resource.

--- a/tests/src/dev.langchain4j/langchain4j/1.16.0/user-code-filter.json
+++ b/tests/src/dev.langchain4j/langchain4j/1.16.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "dev.langchain4j.**"
+    }
+  ]
+}

--- a/tests/src/dev.langchain4j/langchain4j/1.16.0/user-code-filter.json
+++ b/tests/src/dev.langchain4j/langchain4j/1.16.0/user-code-filter.json
@@ -5,6 +5,15 @@
     },
     {
       "includeClasses" : "dev.langchain4j.**"
+    },
+    {
+      "includeClasses" : "dev_langchain4j.langchain4j.**"
+    },
+    {
+      "includeClasses" : "dev.langchain4j.service.output.**"
+    },
+    {
+      "includeClasses" : "dev.langchain4j.service.guardrail.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #7872

This PR provides test fixes and new metadata for dev.langchain4j:langchain4j:1.16.0, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 26111
- Cached input tokens: 246784
- Output tokens: 1547
- Metadata entries: 47
- Test-only metadata entries: 11
- Iterations: 1
- Library coverage percentage: 23.11
- Previous library version metadata entries: 50
- Previous library version coverage percentage: 24.95

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `6f47d297244aefe22667588f47136d7b7443abb3`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- dev.langchain4j:langchain4j:1.9.0: 13/13 covered calls (100.00%)
- dev.langchain4j:langchain4j:1.16.0: 11/11 covered calls (100.00%)

**Reflection:**
- dev.langchain4j:langchain4j:1.9.0: 9/9 covered calls (100.00%)
- dev.langchain4j:langchain4j:1.16.0: 7/7 covered calls (100.00%)

**Resources:**
- dev.langchain4j:langchain4j:1.9.0: 4/4 covered calls (100.00%)
- dev.langchain4j:langchain4j:1.16.0: 4/4 covered calls (100.00%)

#### Library coverage

**Instruction:**
- dev.langchain4j:langchain4j:1.9.0: 3192/13121 (24.33%)
- dev.langchain4j:langchain4j:1.16.0: 3905/18044 (21.64%)

**Line:**
- dev.langchain4j:langchain4j:1.9.0: 768/3078 (24.95%)
- dev.langchain4j:langchain4j:1.16.0: 968/4188 (23.11%)

**Method:**
- dev.langchain4j:langchain4j:1.9.0: 219/888 (24.66%)
- dev.langchain4j:langchain4j:1.16.0: 272/1161 (23.43%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/dev.langchain4j/langchain4j/1.9.0/src/test/java/dev_langchain4j/langchain4j/Langchain4jTest.java 2/tests/src/dev.langchain4j/langchain4j/1.16.0/src/test/java/dev_langchain4j/langchain4j/Langchain4jTest.java
index f44e05fa04..a8166b78b8 100644
--- 1/tests/src/dev.langchain4j/langchain4j/1.9.0/src/test/java/dev_langchain4j/langchain4j/Langchain4jTest.java
+++ 2/tests/src/dev.langchain4j/langchain4j/1.16.0/src/test/java/dev_langchain4j/langchain4j/Langchain4jTest.java
@@ -83,7 +83,7 @@ class Langchain4jTest {
     }
 
     @Test
-    void registersOnlyDeclaredToolMethodsFromToolObjects() {
+    void registersAnnotatedToolMethodsFromToolObjects() {
         ToolCallingChatModel chatModel = new ToolCallingChatModel();
         Assistant assistant = AiServices.builder(Assistant.class)
                 .chatModel(chatModel)
@@ -162,7 +162,7 @@ class Langchain4jTest {
             if (invocationCount == 1) {
                 assertThat(chatRequest.toolSpecifications())
                         .extracting(ToolSpecification::name)
-                        .containsExactly("declaredTool");
+                        .containsExactly("declaredTool", "inheritedTool");
                 return ChatResponse.builder()
                         .aiMessage(AiMessage.from(ToolExecutionRequest.builder()
                                 .id("tool-call-2")
diff --git 1/tests/src/dev.langchain4j/langchain4j/1.9.0/user-code-filter.json 2/tests/src/dev.langchain4j/langchain4j/1.16.0/user-code-filter.json
index e7f496c452..1976ac1a9d 100644
--- 1/tests/src/dev.langchain4j/langchain4j/1.9.0/user-code-filter.json
+++ 2/tests/src/dev.langchain4j/langchain4j/1.16.0/user-code-filter.json
@@ -5,6 +5,15 @@
     },
     {
       "includeClasses" : "dev.langchain4j.**"
+    },
+    {
+      "includeClasses" : "dev_langchain4j.langchain4j.**"
+    },
+    {
+      "includeClasses" : "dev.langchain4j.service.output.**"
+    },
+    {
+      "includeClasses" : "dev.langchain4j.service.guardrail.**"
     }
   ]
-}
\ No newline at end of file
+}

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
