### PR TITLE
[GenAI] Test fix for org.jboss.logmanager:jboss-logmanager:1.4.1.Final using gpt-5.5

### DIFF
--- a/metadata/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/reachability-metadata.json
+++ b/metadata/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/reachability-metadata.json
@@ -1,0 +1,427 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.LogManager$1"
+      },
+      "type": "com.sun.jmx.trace.Trace"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type": "java.lang.Enum",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.formatters.Formatters$11"
+      },
+      "type": "java.lang.StackWalker"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type": "java.lang.String",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "serialPersistentFields"
+        },
+        {
+          "name": "serialVersionUID"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.FastCopyHashMap"
+      },
+      "type": "java.lang.String",
+      "fields": [
+        {
+          "name": "serialPersistentFields"
+        },
+        {
+          "name": "serialVersionUID"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.formatters.Formatters$11"
+      },
+      "type": "java.lang.String"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.AtomicArray"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type": "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type": "java.lang.reflect.Field[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.config.AbstractPropertyConfiguration"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.config.AbstractPropertyConfiguration$2"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.config.AbstractPropertyConfiguration$3"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type": "java.util.concurrent.locks.AbstractOwnableSynchronizer",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type": "java.util.concurrent.locks.AbstractQueuedSynchronizer",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type": "java.util.concurrent.locks.ReentrantLock",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type": "java.util.concurrent.locks.ReentrantLock$NonfairSync",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type": "java.util.concurrent.locks.ReentrantLock$Sync",
+      "allDeclaredFields": true,
+      "serializable": true,
+      "methods": [
+        {
+          "name": "readObject",
+          "parameterTypes": [
+            "java.io.ObjectInputStream"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.LogManager$1"
+      },
+      "type": "java.util.logging.Level"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.LogManager$1"
+      },
+      "type": "java.util.logging.LogManager"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.formatters.Formatters$11"
+      },
+      "type": "missing.example.FrameClass"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.AtomicArray"
+      },
+      "type": "org.jboss.logmanager.AtomicArray",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.util.concurrent.atomic.AtomicReferenceFieldUpdater",
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name": "add",
+          "parameterTypes": [
+            "java.lang.Object",
+            "java.lang.Object"
+          ]
+        },
+        {
+          "name": "clear",
+          "parameterTypes": [
+            "java.lang.Object"
+          ]
+        },
+        {
+          "name": "remove",
+          "parameterTypes": [
+            "java.lang.Object",
+            "java.lang.Object",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type": "org.jboss.logmanager.ConcurrentReferenceHashMap$ReferenceType",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type": "org.jboss.logmanager.ConcurrentReferenceHashMap$Segment",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type": "org.jboss.logmanager.ConcurrentReferenceHashMap$Segment[]",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.LogContext"
+      },
+      "type": "org.jboss.logmanager.LogContext"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.LoggerNode"
+      },
+      "type": "org.jboss.logmanager.LoggerNode"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.formatters.Formatters$11"
+      },
+      "type": "org.jboss.logmanager.formatters.Formatters$11"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.formatters.Formatters$11"
+      },
+      "type": "org.jboss.logmanager.formatters.Formatters$11$3",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.jboss.logmanager.formatters.Formatters$11",
+            "java.lang.ClassLoader",
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.formatters.PatternFormatter"
+      },
+      "type": "org.jboss.logmanager.formatters.PatternFormatter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.config.AbstractPropertyConfiguration$2"
+      },
+      "type": "org_jboss_logmanager.jboss_logmanager.AbstractPropertyConfigurationAnonymous2Test$PostConfiguredHandler"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.config.AbstractPropertyConfiguration$ConstructAction"
+      },
+      "type": "org_jboss_logmanager.jboss_logmanager.AbstractPropertyConfigurationAnonymous2Test$PostConfiguredHandler"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.config.AbstractPropertyConfiguration$3"
+      },
+      "type": "org_jboss_logmanager.jboss_logmanager.AbstractPropertyConfigurationAnonymous3Test$MultiStepPostConfiguredHandler"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.config.AbstractPropertyConfiguration$ConstructAction"
+      },
+      "type": "org_jboss_logmanager.jboss_logmanager.AbstractPropertyConfigurationAnonymous3Test$MultiStepPostConfiguredHandler"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.config.AbstractPropertyConfiguration$ConstructAction"
+      },
+      "type": "org_jboss_logmanager.jboss_logmanager.AbstractPropertyConfigurationTest$CapturingHandler"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.config.AbstractPropertyConfiguration$ConstructAction"
+      },
+      "type": "org_jboss_logmanager.jboss_logmanager.AbstractPropertyConfigurationTest$PrefixFormatter"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.LogManager"
+      },
+      "type": "org_jboss_logmanager.jboss_logmanager.LogManagerTest$FallbackConfigurationLocator"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.LogManager"
+      },
+      "type": "org_jboss_logmanager.jboss_logmanager.LogManagerTest$TcclConfigurationLocator"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.config.AbstractPropertyConfiguration$ConstructAction"
+      },
+      "type": "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingErrorManager"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.config.AbstractPropertyConfiguration$ConstructAction"
+      },
+      "type": "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFilter"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.config.AbstractPropertyConfiguration$ConstructAction"
+      },
+      "type": "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFormatter"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.config.AbstractPropertyConfiguration$ConstructAction"
+      },
+      "type": "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingHandler"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type": "sun.security.provider.SHA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.formatters.Formatters$11"
+      },
+      "glob": "java/lang/StackWalker.class"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.formatters.Formatters$11"
+      },
+      "glob": "java/lang/String.class"
+    }
+  ],
+  "serialization": [
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type": "java.lang.String"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.FastCopyHashMap"
+      },
+      "type": "java.lang.String"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type": "java.util.concurrent.locks.AbstractOwnableSynchronizer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type": "java.util.concurrent.locks.AbstractQueuedSynchronizer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type": "java.util.concurrent.locks.ReentrantLock"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type": "java.util.concurrent.locks.ReentrantLock$NonfairSync"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type": "java.util.concurrent.locks.ReentrantLock$Sync"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      },
+      "type": "org.jboss.logmanager.ConcurrentReferenceHashMap$Segment"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.logmanager.FastCopyHashMap"
+      },
+      "type": "org.jboss.logmanager.FastCopyHashMap"
+    }
+  ]
+}

--- a/metadata/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/reachability-metadata.json
+++ b/metadata/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/reachability-metadata.json
@@ -1,192 +1,192 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.LogManager$1"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.LogManager$1"
       },
-      "type": "com.sun.jmx.trace.Trace"
+      "type" : "com.sun.jmx.trace.Trace"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
       },
-      "type": "java.lang.Enum",
-      "serializable": true
+      "type" : "java.lang.Enum",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
       },
-      "type": "java.lang.Object"
+      "type" : "java.lang.Object"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.formatters.Formatters$11"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters$11"
       },
-      "type": "java.lang.StackWalker"
+      "type" : "java.lang.StackWalker"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
       },
-      "type": "java.lang.String",
-      "serializable": true,
-      "fields": [
+      "type" : "java.lang.String",
+      "serializable" : true,
+      "fields" : [
         {
-          "name": "serialPersistentFields"
+          "name" : "serialPersistentFields"
         },
         {
-          "name": "serialVersionUID"
+          "name" : "serialVersionUID"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.FastCopyHashMap"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.FastCopyHashMap"
       },
-      "type": "java.lang.String",
-      "fields": [
+      "type" : "java.lang.String",
+      "fields" : [
         {
-          "name": "serialPersistentFields"
+          "name" : "serialPersistentFields"
         },
         {
-          "name": "serialVersionUID"
+          "name" : "serialVersionUID"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.formatters.Formatters$11"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters$11"
       },
-      "type": "java.lang.String"
+      "type" : "java.lang.String"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.AtomicArray"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.AtomicArray"
       },
-      "type": "java.lang.String[]"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
       },
-      "type": "java.lang.reflect.Constructor[]"
+      "type" : "java.lang.reflect.Constructor[]"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
       },
-      "type": "java.lang.reflect.Field[]"
+      "type" : "java.lang.reflect.Field[]"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.config.AbstractPropertyConfiguration"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration"
       },
-      "type": "java.lang.reflect.Method[]"
+      "type" : "java.lang.reflect.Method[]"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.config.AbstractPropertyConfiguration$2"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$2"
       },
-      "type": "java.lang.reflect.Method[]"
+      "type" : "java.lang.reflect.Method[]"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.config.AbstractPropertyConfiguration$3"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$3"
       },
-      "type": "java.lang.reflect.Method[]"
+      "type" : "java.lang.reflect.Method[]"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
       },
-      "type": "java.util.concurrent.locks.AbstractOwnableSynchronizer",
-      "serializable": true
+      "type" : "java.util.concurrent.locks.AbstractOwnableSynchronizer",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
       },
-      "type": "java.util.concurrent.locks.AbstractQueuedSynchronizer",
-      "serializable": true
+      "type" : "java.util.concurrent.locks.AbstractQueuedSynchronizer",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
       },
-      "type": "java.util.concurrent.locks.ReentrantLock",
-      "serializable": true
+      "type" : "java.util.concurrent.locks.ReentrantLock",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
       },
-      "type": "java.util.concurrent.locks.ReentrantLock$NonfairSync",
-      "serializable": true
+      "type" : "java.util.concurrent.locks.ReentrantLock$NonfairSync",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
       },
-      "type": "java.util.concurrent.locks.ReentrantLock$Sync",
-      "allDeclaredFields": true,
-      "serializable": true,
-      "methods": [
+      "type" : "java.util.concurrent.locks.ReentrantLock$Sync",
+      "allDeclaredFields" : true,
+      "serializable" : true,
+      "methods" : [
         {
-          "name": "readObject",
-          "parameterTypes": [
+          "name" : "readObject",
+          "parameterTypes" : [
             "java.io.ObjectInputStream"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.LogManager$1"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.LogManager$1"
       },
-      "type": "java.util.logging.Level"
+      "type" : "java.util.logging.Level"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.LogManager$1"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.LogManager$1"
       },
-      "type": "java.util.logging.LogManager"
+      "type" : "java.util.logging.LogManager"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.formatters.Formatters$11"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters$11"
       },
-      "type": "missing.example.FrameClass"
+      "type" : "missing.example.FrameClass"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.AtomicArray"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.AtomicArray"
       },
-      "type": "org.jboss.logmanager.AtomicArray",
-      "methods": [
+      "type" : "org.jboss.logmanager.AtomicArray",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.concurrent.atomic.AtomicReferenceFieldUpdater",
             "java.lang.Class"
           ]
         },
         {
-          "name": "add",
-          "parameterTypes": [
+          "name" : "add",
+          "parameterTypes" : [
             "java.lang.Object",
             "java.lang.Object"
           ]
         },
         {
-          "name": "clear",
-          "parameterTypes": [
+          "name" : "clear",
+          "parameterTypes" : [
             "java.lang.Object"
           ]
         },
         {
-          "name": "remove",
-          "parameterTypes": [
+          "name" : "remove",
+          "parameterTypes" : [
             "java.lang.Object",
             "java.lang.Object",
             "boolean"
@@ -195,53 +195,53 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
       },
-      "type": "org.jboss.logmanager.ConcurrentReferenceHashMap$ReferenceType",
-      "serializable": true
+      "type" : "org.jboss.logmanager.ConcurrentReferenceHashMap$ReferenceType",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
       },
-      "type": "org.jboss.logmanager.ConcurrentReferenceHashMap$Segment",
-      "serializable": true
+      "type" : "org.jboss.logmanager.ConcurrentReferenceHashMap$Segment",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
       },
-      "type": "org.jboss.logmanager.ConcurrentReferenceHashMap$Segment[]",
-      "serializable": true
+      "type" : "org.jboss.logmanager.ConcurrentReferenceHashMap$Segment[]",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.LogContext"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.LogContext"
       },
-      "type": "org.jboss.logmanager.LogContext"
+      "type" : "org.jboss.logmanager.LogContext"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.LoggerNode"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.LoggerNode"
       },
-      "type": "org.jboss.logmanager.LoggerNode"
+      "type" : "org.jboss.logmanager.LoggerNode"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.formatters.Formatters$11"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters$11"
       },
-      "type": "org.jboss.logmanager.formatters.Formatters$11"
+      "type" : "org.jboss.logmanager.formatters.Formatters$11"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.formatters.Formatters$11"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters$11"
       },
-      "type": "org.jboss.logmanager.formatters.Formatters$11$3",
-      "methods": [
+      "type" : "org.jboss.logmanager.formatters.Formatters$11$3",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logmanager.formatters.Formatters$11",
             "java.lang.ClassLoader",
             "java.lang.String"
@@ -250,178 +250,106 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.formatters.PatternFormatter"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.PatternFormatter"
       },
-      "type": "org.jboss.logmanager.formatters.PatternFormatter",
-      "methods": [
+      "type" : "org.jboss.logmanager.formatters.PatternFormatter",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.String"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.config.AbstractPropertyConfiguration$2"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
       },
-      "type": "org_jboss_logmanager.jboss_logmanager.AbstractPropertyConfigurationAnonymous2Test$PostConfiguredHandler"
-    },
-    {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.config.AbstractPropertyConfiguration$ConstructAction"
-      },
-      "type": "org_jboss_logmanager.jboss_logmanager.AbstractPropertyConfigurationAnonymous2Test$PostConfiguredHandler"
-    },
-    {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.config.AbstractPropertyConfiguration$3"
-      },
-      "type": "org_jboss_logmanager.jboss_logmanager.AbstractPropertyConfigurationAnonymous3Test$MultiStepPostConfiguredHandler"
-    },
-    {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.config.AbstractPropertyConfiguration$ConstructAction"
-      },
-      "type": "org_jboss_logmanager.jboss_logmanager.AbstractPropertyConfigurationAnonymous3Test$MultiStepPostConfiguredHandler"
-    },
-    {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.config.AbstractPropertyConfiguration$ConstructAction"
-      },
-      "type": "org_jboss_logmanager.jboss_logmanager.AbstractPropertyConfigurationTest$CapturingHandler"
-    },
-    {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.config.AbstractPropertyConfiguration$ConstructAction"
-      },
-      "type": "org_jboss_logmanager.jboss_logmanager.AbstractPropertyConfigurationTest$PrefixFormatter"
-    },
-    {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.LogManager"
-      },
-      "type": "org_jboss_logmanager.jboss_logmanager.LogManagerTest$FallbackConfigurationLocator"
-    },
-    {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.LogManager"
-      },
-      "type": "org_jboss_logmanager.jboss_logmanager.LogManagerTest$TcclConfigurationLocator"
-    },
-    {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.config.AbstractPropertyConfiguration$ConstructAction"
-      },
-      "type": "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingErrorManager"
-    },
-    {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.config.AbstractPropertyConfiguration$ConstructAction"
-      },
-      "type": "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFilter"
-    },
-    {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.config.AbstractPropertyConfiguration$ConstructAction"
-      },
-      "type": "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFormatter"
-    },
-    {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.config.AbstractPropertyConfiguration$ConstructAction"
-      },
-      "type": "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingHandler"
-    },
-    {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
-      },
-      "type": "sun.security.provider.SHA",
-      "methods": [
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.formatters.Formatters$11"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters$11"
       },
-      "glob": "java/lang/StackWalker.class"
+      "glob" : "java/lang/StackWalker.class"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.formatters.Formatters$11"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters$11"
       },
-      "glob": "java/lang/String.class"
+      "glob" : "java/lang/String.class"
     }
   ],
-  "serialization": [
+  "serialization" : [
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
       },
-      "type": "java.lang.String"
+      "type" : "java.lang.String"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.FastCopyHashMap"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.FastCopyHashMap"
       },
-      "type": "java.lang.String"
+      "type" : "java.lang.String"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
       },
-      "type": "java.util.concurrent.locks.AbstractOwnableSynchronizer"
+      "type" : "java.util.concurrent.locks.AbstractOwnableSynchronizer"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
       },
-      "type": "java.util.concurrent.locks.AbstractQueuedSynchronizer"
+      "type" : "java.util.concurrent.locks.AbstractQueuedSynchronizer"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
       },
-      "type": "java.util.concurrent.locks.ReentrantLock"
+      "type" : "java.util.concurrent.locks.ReentrantLock"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
       },
-      "type": "java.util.concurrent.locks.ReentrantLock$NonfairSync"
+      "type" : "java.util.concurrent.locks.ReentrantLock$NonfairSync"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
       },
-      "type": "java.util.concurrent.locks.ReentrantLock$Sync"
+      "type" : "java.util.concurrent.locks.ReentrantLock$Sync"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
       },
-      "type": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      "type" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.ConcurrentReferenceHashMap"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.ConcurrentReferenceHashMap"
       },
-      "type": "org.jboss.logmanager.ConcurrentReferenceHashMap$Segment"
+      "type" : "org.jboss.logmanager.ConcurrentReferenceHashMap$Segment"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.logmanager.FastCopyHashMap"
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.FastCopyHashMap"
       },
-      "type": "org.jboss.logmanager.FastCopyHashMap"
+      "type" : "org.jboss.logmanager.FastCopyHashMap"
     }
   ]
 }

--- a/metadata/org.jboss.logmanager/jboss-logmanager/index.json
+++ b/metadata/org.jboss.logmanager/jboss-logmanager/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.4.1.Final",
+    "tested-versions" : [
+      "1.4.1.Final"
+    ],
+    "allowed-packages" : [
+      "org.jboss.logmanager"
+    ]
+  },
+  {
     "metadata-version" : "1.3.0.Final",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/jboss/logmanager/jboss-logmanager/$version$/jboss-logmanager-$version$-sources.jar",
     "repository-url" : "https://github.com/jboss-logging/jboss-logmanager",

--- a/metadata/org.jboss.logmanager/jboss-logmanager/index.json
+++ b/metadata/org.jboss.logmanager/jboss-logmanager/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.4.1.Final",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/jboss/logmanager/jboss-logmanager/$version$/jboss-logmanager-$version$-sources.jar",
+    "repository-url" : "https://github.com/jboss-logging/jboss-logmanager",
+    "test-code-url" : "https://github.com/jboss-logging/jboss-logmanager/tree/$version$/src/test",
+    "documentation-url" : "https://javadoc.io/doc/org.jboss.logmanager/jboss-logmanager/$version$/index.html",
+    "description" : "JBoss Log Manager is an implementation of java.util.logging.LogManager for applications and containers that need a replacement for the JDK log manager. It provides JBoss-specific logging infrastructure, including logger, handler, formatter, and configuration support.",
     "tested-versions" : [
       "1.4.1.Final"
     ],

--- a/stats/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/execution-metrics.json
+++ b/stats/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_java_run_fail:2026-06-05": {
+    "timestamp": "2026-06-05T20:03:50.554645Z",
+    "library": "org.jboss.logmanager:jboss-logmanager:1.4.1.Final",
+    "starting_commit": "ae56ee6ebe21be0fb9b29bc90313f5f7f70a2b52",
+    "ending_commit": "c58c35e9021955b55a55e9b905d2799e3374fbf0",
+    "previous_library": "org.jboss.logmanager:jboss-logmanager:1.3.0.Final",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.4.1.Final",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 27,
+            "totalCalls": 27
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 5,
+            "totalCalls": 5
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 32,
+        "totalCalls": 32
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 6549,
+          "missed": 17567,
+          "ratio": 0.271562,
+          "total": 24116
+        },
+        "line": {
+          "covered": 1477,
+          "missed": 4020,
+          "ratio": 0.268692,
+          "total": 5497
+        },
+        "method": {
+          "covered": 363,
+          "missed": 902,
+          "ratio": 0.286957,
+          "total": 1265
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.3.0.Final",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 24,
+            "totalCalls": 24
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 5,
+            "totalCalls": 5
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 29,
+        "totalCalls": 29
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5515,
+          "missed": 14320,
+          "ratio": 0.278044,
+          "total": 19835
+        },
+        "line": {
+          "covered": 1258,
+          "missed": 3350,
+          "ratio": 0.273003,
+          "total": 4608
+        },
+        "method": {
+          "covered": 316,
+          "missed": 767,
+          "ratio": 0.291782,
+          "total": 1083
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 149177,
+      "cached_input_tokens_used": 1404928,
+      "output_tokens_used": 12671,
+      "iterations": 3,
+      "cost_usd": 1.0826,
+      "tested_library_loc": 1477,
+      "metadata_entries": 56,
+      "test_only_metadata_entries": 42,
+      "previous_library_metadata_entries": 48,
+      "previous_library_test_only_metadata_entries": 30,
+      "code_coverage_percent": 26.87,
+      "previous_library_coverage_percent": 27.3
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/LogManagerTest.java",
+      "metadata_file": "metadata/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/stats.json
+++ b/stats/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "1.4.1.Final",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 27,
+          "totalCalls" : 27
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 5,
+          "totalCalls" : 5
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 32,
+      "totalCalls" : 32
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 6549,
+        "missed" : 17567,
+        "ratio" : 0.271562,
+        "total" : 24116
+      },
+      "line" : {
+        "covered" : 1477,
+        "missed" : 4020,
+        "ratio" : 0.268692,
+        "total" : 5497
+      },
+      "method" : {
+        "covered" : 363,
+        "missed" : 902,
+        "ratio" : 0.286957,
+        "total" : 1265
+      }
+    }
+  } ]
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/.gitignore
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/build.gradle
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.jboss.logmanager:jboss-logmanager:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/gradle.properties
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.jboss.logmanager:jboss-logmanager:1.4.1.Final
+library.version = 1.4.1.Final
+metadata.dir = org.jboss.logmanager/jboss-logmanager/1.4.1.Final/

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/settings.gradle
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.jboss.logmanager.jboss-logmanager_tests'

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationAnonymous2Test.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationAnonymous2Test.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+
+import org.jboss.logmanager.LogContext;
+import org.jboss.logmanager.Logger;
+import org.jboss.logmanager.config.HandlerConfiguration;
+import org.jboss.logmanager.config.LogContextConfiguration;
+import org.jboss.logmanager.config.LoggerConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AbstractPropertyConfigurationAnonymous2Test {
+
+    @Test
+    void addPostConfigurationMethodResolvesPublicNoArgMethodDuringCommit() {
+        String loggerName = AbstractPropertyConfigurationAnonymous2Test.class.getName() + ".postConfiguration";
+        String handlerName = "postConfiguredHandler";
+        LogContext context = LogContext.create();
+        LogContextConfiguration configuration = LogContextConfiguration.Factory.create(context);
+
+        HandlerConfiguration handler = configuration.addHandlerConfiguration(
+                null,
+                PostConfiguredHandler.class.getName(),
+                handlerName
+        );
+        assertThat(handler.addPostConfigurationMethod("activate")).isTrue();
+
+        LoggerConfiguration loggerConfiguration = configuration.addLoggerConfiguration(loggerName);
+        loggerConfiguration.setUseParentHandlers(false);
+        loggerConfiguration.addHandlerName(handlerName);
+
+        configuration.commit();
+
+        Logger logger = context.getLogger(loggerName);
+        assertThat(logger.getHandlers()).singleElement().isInstanceOfSatisfying(PostConfiguredHandler.class,
+                postConfiguredHandler -> assertThat(postConfiguredHandler.isActivated()).isTrue());
+    }
+
+    public static final class PostConfiguredHandler extends Handler {
+        private boolean activated;
+
+        public void activate() {
+            activated = true;
+        }
+
+        public boolean isActivated() {
+            return activated;
+        }
+
+        @Override
+        public void publish(final LogRecord record) {
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationAnonymous3Test.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationAnonymous3Test.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+
+import org.jboss.logmanager.LogContext;
+import org.jboss.logmanager.Logger;
+import org.jboss.logmanager.config.HandlerConfiguration;
+import org.jboss.logmanager.config.LogContextConfiguration;
+import org.jboss.logmanager.config.LoggerConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AbstractPropertyConfigurationAnonymous3Test {
+
+    @Test
+    void setPostConfigurationMethodsResolvesPublicMethodsDuringCommit() {
+        String loggerName = AbstractPropertyConfigurationAnonymous3Test.class.getName() + ".postConfigurationMethods";
+        String handlerName = "multiStepPostConfiguredHandler";
+        LogContext context = LogContext.create();
+        LogContextConfiguration configuration = LogContextConfiguration.Factory.create(context);
+
+        HandlerConfiguration handler = configuration.addHandlerConfiguration(
+                null,
+                MultiStepPostConfiguredHandler.class.getName(),
+                handlerName
+        );
+        handler.setPostConfigurationMethods("prepare", "activate");
+
+        LoggerConfiguration loggerConfiguration = configuration.addLoggerConfiguration(loggerName);
+        loggerConfiguration.setUseParentHandlers(false);
+        loggerConfiguration.addHandlerName(handlerName);
+
+        configuration.commit();
+
+        Logger logger = context.getLogger(loggerName);
+        assertThat(handler.getPostConfigurationMethods()).containsExactly("prepare", "activate");
+        assertThat(logger.getHandlers()).singleElement().isInstanceOfSatisfying(MultiStepPostConfiguredHandler.class,
+                postConfiguredHandler -> assertThat(postConfiguredHandler.getLifecycleEvents())
+                        .containsExactly("prepared", "activated"));
+    }
+
+    public static final class MultiStepPostConfiguredHandler extends Handler {
+        private final List<String> lifecycleEvents = new ArrayList<>();
+
+        public void prepare() {
+            lifecycleEvents.add("prepared");
+        }
+
+        public void activate() {
+            lifecycleEvents.add("activated");
+        }
+
+        public List<String> getLifecycleEvents() {
+            return lifecycleEvents;
+        }
+
+        @Override
+        public void publish(final LogRecord record) {
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationTest.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+
+import org.jboss.logmanager.LogContext;
+import org.jboss.logmanager.Logger;
+import org.jboss.logmanager.config.FormatterConfiguration;
+import org.jboss.logmanager.config.HandlerConfiguration;
+import org.jboss.logmanager.config.LogContextConfiguration;
+import org.jboss.logmanager.config.LoggerConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AbstractPropertyConfigurationTest {
+
+    @Test
+    void constructorPropertyTypeCanBeResolvedFromPublicGetter() {
+        String loggerName = AbstractPropertyConfigurationTest.class.getName() + ".constructorProperty";
+        String formatterName = "constructorFormatter";
+        String handlerName = "capturingHandler";
+        LogContext context = LogContext.create();
+        LogContextConfiguration configuration = LogContextConfiguration.Factory.create(context);
+
+        FormatterConfiguration formatter = configuration.addFormatterConfiguration(
+                null,
+                PrefixFormatter.class.getName(),
+                formatterName,
+                "prefix"
+        );
+        formatter.setPropertyValueString("prefix", "constructed:");
+
+        HandlerConfiguration handler = configuration.addHandlerConfiguration(
+                null,
+                CapturingHandler.class.getName(),
+                handlerName
+        );
+        handler.setFormatterName(formatterName);
+
+        LoggerConfiguration loggerConfiguration = configuration.addLoggerConfiguration(loggerName);
+        loggerConfiguration.setUseParentHandlers(false);
+        loggerConfiguration.addHandlerName(handlerName);
+
+        configuration.commit();
+
+        Logger logger = context.getLogger(loggerName);
+        logger.info("message");
+
+        assertThat(logger.getHandlers()).singleElement().isInstanceOfSatisfying(CapturingHandler.class,
+                capturingHandler -> assertThat(capturingHandler.getLastPublishedMessage())
+                        .isEqualTo("constructed:message"));
+    }
+
+    public static final class PrefixFormatter extends Formatter {
+        private final String prefix;
+
+        public PrefixFormatter(final String prefix) {
+            this.prefix = prefix;
+        }
+
+        public String getPrefix() {
+            return prefix;
+        }
+
+        @Override
+        public String format(final LogRecord record) {
+            return prefix + record.getMessage();
+        }
+    }
+
+    public static final class CapturingHandler extends Handler {
+        private String lastPublishedMessage;
+
+        public String getLastPublishedMessage() {
+            return lastPublishedMessage;
+        }
+
+        @Override
+        public void publish(final LogRecord record) {
+            if (!isLoggable(record)) {
+                return;
+            }
+            Formatter formatter = getFormatter();
+            lastPublishedMessage = formatter == null ? record.getMessage() : formatter.format(record);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AtomicArrayTest.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AtomicArrayTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AtomicArrayTest {
+
+    @Test
+    void addAndRemoveSupportNonHandlerComponentTypes() throws Exception {
+        Holder holder = new Holder();
+        AtomicReferenceFieldUpdater<Holder, String[]> updater =
+                AtomicReferenceFieldUpdater.newUpdater(Holder.class, String[].class, "values");
+        Object atomicArray = newAtomicArray(updater, String.class);
+
+        invokeMethod(atomicArray, "add", new Class<?>[] {Object.class, Object.class }, holder, "console");
+        invokeMethod(atomicArray, "add", new Class<?>[] {Object.class, Object.class }, holder, "file");
+
+        assertThat(holder.values).containsExactly("console", "file");
+        assertThat(invokeMethod(
+                atomicArray,
+                "remove",
+                new Class<?>[] {Object.class, Object.class, boolean.class },
+                holder,
+                "console",
+                false
+        )).isEqualTo(Boolean.TRUE);
+        assertThat(holder.values).containsExactly("file");
+
+        invokeMethod(atomicArray, "clear", new Class<?>[] {Object.class }, holder);
+        assertThat(holder.values).isEmpty();
+    }
+
+    private static Object newAtomicArray(
+            final AtomicReferenceFieldUpdater<Holder, String[]> updater,
+            final Class<String> componentType
+    ) throws Exception {
+        Class<?> atomicArrayType = Class.forName("org.jboss.logmanager.AtomicArray");
+        Constructor<?> constructor = atomicArrayType.getDeclaredConstructor(AtomicReferenceFieldUpdater.class, Class.class);
+        constructor.setAccessible(true);
+        return constructor.newInstance(updater, componentType);
+    }
+
+    private static Object invokeMethod(
+            final Object target,
+            final String methodName,
+            final Class<?>[] parameterTypes,
+            final Object... arguments
+    ) throws Exception {
+        Method method = target.getClass().getDeclaredMethod(methodName, parameterTypes);
+        method.setAccessible(true);
+        return method.invoke(target, arguments);
+    }
+
+    private static final class Holder {
+        volatile String[] values = new String[0];
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/ConcurrentReferenceHashMapTest.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/ConcurrentReferenceHashMapTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.lang.reflect.Constructor;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConcurrentReferenceHashMapTest {
+
+    @Test
+    void serializationRoundTripPreservesEntries() throws Exception {
+        Map<String, String> map = newConcurrentReferenceHashMap();
+        Map<String, String> expectedEntries = new LinkedHashMap<>();
+        expectedEntries.put("logger", "main");
+        expectedEntries.put("handler", "console");
+        map.putAll(expectedEntries);
+
+        byte[] serialized;
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+             ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream)) {
+            objectOutputStream.writeObject(map);
+            objectOutputStream.flush();
+            serialized = outputStream.toByteArray();
+        }
+
+        Object restored;
+        try (ObjectInputStream objectInputStream = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            restored = objectInputStream.readObject();
+        }
+
+        assertThat(restored.getClass().getName()).isEqualTo("org.jboss.logmanager.ConcurrentReferenceHashMap");
+        @SuppressWarnings("unchecked")
+        Map<String, String> restoredMap = (Map<String, String>) restored;
+        assertThat(restoredMap)
+                .hasSize(expectedEntries.size())
+                .containsAllEntriesOf(expectedEntries);
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private static Map<String, String> newConcurrentReferenceHashMap() throws Exception {
+        Class<?> mapType = Class.forName("org.jboss.logmanager.ConcurrentReferenceHashMap");
+        Class enumType = Class.forName("org.jboss.logmanager.ConcurrentReferenceHashMap$ReferenceType");
+        Object strongReference = Enum.valueOf(enumType, "STRONG");
+        Constructor<?> constructor = mapType.getDeclaredConstructor(int.class, enumType, enumType);
+        constructor.setAccessible(true);
+        return (Map<String, String>) constructor.newInstance(4, strongReference, strongReference);
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/DefaultConfigurationLocatorTest.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/DefaultConfigurationLocatorTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.jboss.logmanager.DefaultConfigurationLocator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DefaultConfigurationLocatorTest {
+
+    @Test
+    void findConfigurationLoadsLoggingPropertiesFromThreadContextClassLoader() throws Exception {
+        String originalConfiguration = System.getProperty("logging.configuration");
+        ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
+        try {
+            System.clearProperty("logging.configuration");
+            Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+
+            DefaultConfigurationLocator locator = new DefaultConfigurationLocator();
+            try (InputStream stream = locator.findConfiguration()) {
+                assertThat(stream).isNotNull();
+                assertThat(new String(stream.readAllBytes(), StandardCharsets.UTF_8))
+                        .contains("test.resource=thread-context-class-loader");
+            }
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalTccl);
+            if (originalConfiguration == null) {
+                System.clearProperty("logging.configuration");
+            } else {
+                System.setProperty("logging.configuration", originalConfiguration);
+            }
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FastCopyHashMapTest.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FastCopyHashMapTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.jboss.logmanager.MDC;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FastCopyHashMapTest {
+
+    @Test
+    void mdcCopySerializationRoundTripPreservesEntries() throws Exception {
+        Map<String, String> originalMdc = MDC.copy();
+        try {
+            MDC.clear();
+            Map<String, String> expectedEntries = new LinkedHashMap<>();
+            expectedEntries.put("logger", "main");
+            expectedEntries.put("handler", "console");
+            expectedEntries.forEach(MDC::put);
+
+            Map<String, String> map = MDC.copy();
+            assertThat(map.getClass().getName()).isEqualTo("org.jboss.logmanager.FastCopyHashMap");
+
+            byte[] serialized = serialize(map);
+            Object restored = deserialize(serialized);
+
+            assertThat(restored.getClass().getName()).isEqualTo("org.jboss.logmanager.FastCopyHashMap");
+            assertThat(restored).isInstanceOf(Map.class);
+            @SuppressWarnings("unchecked")
+            Map<String, String> restoredMap = (Map<String, String>) restored;
+            assertThat(restoredMap).isEqualTo(expectedEntries);
+        } finally {
+            MDC.clear();
+            originalMdc.forEach(MDC::put);
+        }
+    }
+
+    private static byte[] serialize(final Object value) throws IOException {
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+             ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream)) {
+            objectOutputStream.writeObject(value);
+            objectOutputStream.flush();
+            return outputStream.toByteArray();
+        }
+    }
+
+    private static Object deserialize(final byte[] serialized) throws IOException, ClassNotFoundException {
+        try (ObjectInputStream objectInputStream = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            return objectInputStream.readObject();
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Anonymous2Test.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Anonymous2Test.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.net.URI;
+import java.net.URL;
+import java.security.PrivilegedAction;
+
+import org.jboss.logmanager.formatters.Formatters;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FormattersAnonymous12Anonymous2Test {
+
+    @Test
+    void resourceActionUsesClassLoaderResourceWhenFrameClassHasAClassLoader() throws Throwable {
+        final String resourceName = "org/example/FrameClass.class";
+        final URL resourceUrl = URI.create("file:/active-class-loader-resource").toURL();
+        final TrackingResourceClassLoader classLoader = new TrackingResourceClassLoader(resourceName, resourceUrl);
+
+        final URL result = newResourceLookupAction(classLoader, resourceName).run();
+
+        assertThat(result).isSameAs(resourceUrl);
+        assertThat(classLoader.requestedResource()).isEqualTo(resourceName);
+    }
+
+    @Test
+    void resourceActionUsesSystemResourceWhenFrameClassIsLoadedByBootstrapLoader() throws Throwable {
+        final String resourceName = "logging.properties";
+        final URL expected = ClassLoader.getSystemResource(resourceName);
+
+        final URL result = newResourceLookupAction(null, resourceName).run();
+
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static PrivilegedAction<URL> newResourceLookupAction(
+            final ClassLoader classLoader,
+            final String resourceName
+    ) throws Throwable {
+        final Class<?> enclosingFormatterStepClass = Class.forName(Formatters.class.getName() + "$12");
+        final Class<?> resourceActionClass = Class.forName(enclosingFormatterStepClass.getName() + "$2");
+        final MethodHandle constructor = MethodHandles.privateLookupIn(resourceActionClass, MethodHandles.lookup())
+                .findConstructor(
+                        resourceActionClass,
+                        MethodType.methodType(
+                                void.class,
+                                enclosingFormatterStepClass,
+                                ClassLoader.class,
+                                String.class
+                        )
+                );
+        return (PrivilegedAction<URL>) constructor.invoke(null, classLoader, resourceName);
+    }
+
+    private static final class TrackingResourceClassLoader extends ClassLoader {
+        private final String expectedResource;
+        private final URL resourceUrl;
+        private String requestedResource;
+
+        private TrackingResourceClassLoader(final String expectedResource, final URL resourceUrl) {
+            super(FormattersAnonymous12Anonymous2Test.class.getClassLoader());
+            this.expectedResource = expectedResource;
+            this.resourceUrl = resourceUrl;
+        }
+
+        String requestedResource() {
+            return requestedResource;
+        }
+
+        @Override
+        public URL getResource(final String name) {
+            requestedResource = name;
+            if (expectedResource.equals(name)) {
+                return resourceUrl;
+            }
+            return super.getResource(name);
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Anonymous2Test.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Anonymous2Test.java
@@ -47,8 +47,8 @@ public class FormattersAnonymous12Anonymous2Test {
             final ClassLoader classLoader,
             final String resourceName
     ) throws Throwable {
-        final Class<?> enclosingFormatterStepClass = Class.forName(Formatters.class.getName() + "$12");
-        final Class<?> resourceActionClass = Class.forName(enclosingFormatterStepClass.getName() + "$2");
+        final Class<?> enclosingFormatterStepClass = Class.forName(Formatters.class.getName() + "$11");
+        final Class<?> resourceActionClass = Class.forName(enclosingFormatterStepClass.getName() + "$3");
         final MethodHandle constructor = MethodHandles.privateLookupIn(resourceActionClass, MethodHandles.lookup())
                 .findConstructor(
                         resourceActionClass,

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Test.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Test.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.logging.Formatter;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.jboss.logmanager.formatters.PatternFormatter;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FormattersAnonymous12Test {
+    private static final String BOOTSTRAP_FRAME_CLASS = String.class.getName();
+    private static final String BOOTSTRAP_FALLBACK_FRAME_CLASS = StackWalker.class.getName();
+
+    @Test
+    void extendedExceptionFormattingUsesThreadContextClassLoaderForBootstrapFrameClass() {
+        String className = BOOTSTRAP_FRAME_CLASS;
+
+        String formatted = formatWithTccl(FormattersAnonymous12Test.class.getClassLoader(), newFailure(className));
+
+        assertThat(formatted).contains("\tat " + className + ".invoke");
+    }
+
+    @Test
+    void extendedExceptionFormattingFallsBackToDefaultClassLookupWhenThreadContextLoaderCannotLoadFrameClass() {
+        String className = FormattersAnonymous12Test.class.getName();
+        ClassLoader rejectingClassLoader = new RejectingClassLoader(className);
+
+        String formatted = formatWithTccl(rejectingClassLoader, newFailure(className));
+
+        assertThat(formatted).contains("\tat " + className + ".invoke");
+    }
+
+    @Test
+    void extendedExceptionFormattingAttemptsBootstrapLookupWhenOtherClassLookupsFail() {
+        String className = "missing.example.FrameClass";
+        ClassLoader rejectingClassLoader = new RejectingClassLoader(className);
+
+        String formatted = formatWithTccl(rejectingClassLoader, newFailure(className));
+
+        assertThat(formatted).contains("\tat " + className + ".invoke");
+    }
+
+    @Test
+    void extendedExceptionFormattingUsesBootstrapLookupWhenFormatterLoaderRejectsFrameClass() throws Exception {
+        try (IsolatedLogManagerClassLoader classLoader = new IsolatedLogManagerClassLoader(libraryUrls())) {
+            Class<?> formatterClass = classLoader.loadClass(PatternFormatter.class.getName());
+            Formatter formatter = (Formatter) formatterClass.getConstructor(String.class).newInstance("%E");
+
+            String formatted = formatWithTccl(null, formatter, newFailure(BOOTSTRAP_FALLBACK_FRAME_CLASS));
+
+            assertThat(formatted).contains("\tat " + BOOTSTRAP_FALLBACK_FRAME_CLASS + ".invoke");
+            if (formatterClass.getClassLoader() != classLoader) {
+                assertThat(System.getProperty("org.graalvm.nativeimage.imagecode")).isEqualTo("runtime");
+            } else {
+                assertThat(classLoader.rejectedBootstrapLookupCount()).isPositive();
+            }
+        } catch (Error error) {
+            if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                throw error;
+            }
+        }
+    }
+
+    private static String formatWithTccl(final ClassLoader contextClassLoader, final Throwable thrown) {
+        return formatWithTccl(contextClassLoader, new PatternFormatter("%E"), thrown);
+    }
+
+    private static String formatWithTccl(
+            final ClassLoader contextClassLoader,
+            final Formatter formatter,
+            final Throwable thrown
+    ) {
+        ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(contextClassLoader);
+            LogRecord record = new LogRecord(Level.SEVERE, "coverage");
+            record.setLoggerName(FormattersAnonymous12Test.class.getName());
+            record.setThrown(thrown);
+            return formatter.format(record);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalTccl);
+        }
+    }
+
+    private static URL[] libraryUrls() {
+        return new URL[] {PatternFormatter.class.getProtectionDomain().getCodeSource().getLocation() };
+    }
+
+    private static IllegalStateException newFailure(final String className) {
+        IllegalStateException failure = new IllegalStateException("boom");
+        failure.setStackTrace(new StackTraceElement[] {
+                new StackTraceElement(className, "invoke", "GeneratedFrame.java", 17)
+        });
+        return failure;
+    }
+
+    private static final class IsolatedLogManagerClassLoader extends URLClassLoader {
+        private int rejectedBootstrapLookupCount;
+
+        private IsolatedLogManagerClassLoader(final URL[] urls) {
+            super(urls, FormattersAnonymous12Test.class.getClassLoader());
+        }
+
+        @Override
+        protected Class<?> loadClass(final String name, final boolean resolve) throws ClassNotFoundException {
+            synchronized (getClassLoadingLock(name)) {
+                if (BOOTSTRAP_FALLBACK_FRAME_CLASS.equals(name) && isGuessClassLookup()) {
+                    rejectedBootstrapLookupCount++;
+                    throw new ClassNotFoundException(name);
+                }
+                Class<?> loadedClass = findLoadedClass(name);
+                if (loadedClass == null && name.startsWith("org.jboss.logmanager.")) {
+                    try {
+                        loadedClass = findClass(name);
+                    } catch (ClassNotFoundException ignored) {
+                        // Delegate to the parent class loader below.
+                    }
+                }
+                if (loadedClass == null) {
+                    loadedClass = super.loadClass(name, false);
+                }
+                if (resolve) {
+                    resolveClass(loadedClass);
+                }
+                return loadedClass;
+            }
+        }
+
+        private int rejectedBootstrapLookupCount() {
+            return rejectedBootstrapLookupCount;
+        }
+
+        private boolean isGuessClassLookup() {
+            for (StackTraceElement element : Thread.currentThread().getStackTrace()) {
+                if ("guessClass".equals(element.getMethodName())
+                        && element.getClassName().startsWith("org.jboss.logmanager.formatters.Formatters")) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    private static final class RejectingClassLoader extends ClassLoader {
+        private final String rejectedClassName;
+
+        private RejectingClassLoader(final String rejectedClassName) {
+            super(FormattersAnonymous12Test.class.getClassLoader());
+            this.rejectedClassName = rejectedClassName;
+        }
+
+        @Override
+        protected Class<?> loadClass(final String name, final boolean resolve) throws ClassNotFoundException {
+            if (rejectedClassName.equals(name)) {
+                throw new ClassNotFoundException(name);
+            }
+            return super.loadClass(name, resolve);
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/LogManagerTest.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/LogManagerTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.io.InputStream;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.jboss.logmanager.ConfigurationLocator;
+import org.jboss.logmanager.LogManager;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LogManagerTest {
+
+    @Test
+    void readConfigurationLoadsLocatorFromThreadContextClassLoader() throws Exception {
+        String locatorPropertyName = "org.jboss.logmanager.configurationLocator";
+        String originalLocatorProperty = System.getProperty(locatorPropertyName);
+        ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
+        TcclConfigurationLocator.reset();
+        try {
+            System.setProperty(locatorPropertyName, TcclConfigurationLocator.class.getName());
+            Thread.currentThread().setContextClassLoader(TcclConfigurationLocator.class.getClassLoader());
+
+            new LogManager().readConfiguration();
+
+            assertThat(TcclConfigurationLocator.CONSTRUCTED).isTrue();
+            assertThat(TcclConfigurationLocator.FIND_CONFIGURATION_CALLED).isTrue();
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalTccl);
+            if (originalLocatorProperty == null) {
+                System.clearProperty(locatorPropertyName);
+            } else {
+                System.setProperty(locatorPropertyName, originalLocatorProperty);
+            }
+            TcclConfigurationLocator.reset();
+        }
+    }
+
+    @Test
+    void readConfigurationFallsBackToLogManagerClassLoaderWhenTcclCannotLoadLocator() throws Exception {
+        String locatorPropertyName = "org.jboss.logmanager.configurationLocator";
+        String originalLocatorProperty = System.getProperty(locatorPropertyName);
+        ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
+        FallbackConfigurationLocator.reset();
+        try {
+            System.setProperty(locatorPropertyName, FallbackConfigurationLocator.class.getName());
+            Thread.currentThread().setContextClassLoader(
+                    new RejectingClassLoader(originalTccl, FallbackConfigurationLocator.class.getName())
+            );
+
+            new LogManager().readConfiguration();
+
+            assertThat(FallbackConfigurationLocator.CONSTRUCTED).isTrue();
+            assertThat(FallbackConfigurationLocator.FIND_CONFIGURATION_CALLED).isTrue();
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalTccl);
+            if (originalLocatorProperty == null) {
+                System.clearProperty(locatorPropertyName);
+            } else {
+                System.setProperty(locatorPropertyName, originalLocatorProperty);
+            }
+            FallbackConfigurationLocator.reset();
+        }
+    }
+
+    public static final class TcclConfigurationLocator implements ConfigurationLocator {
+        private static final AtomicBoolean CONSTRUCTED = new AtomicBoolean();
+        private static final AtomicBoolean FIND_CONFIGURATION_CALLED = new AtomicBoolean();
+
+        public TcclConfigurationLocator() {
+            CONSTRUCTED.set(true);
+        }
+
+        @Override
+        public InputStream findConfiguration() {
+            FIND_CONFIGURATION_CALLED.set(true);
+            return null;
+        }
+
+        private static void reset() {
+            CONSTRUCTED.set(false);
+            FIND_CONFIGURATION_CALLED.set(false);
+        }
+    }
+
+    public static final class FallbackConfigurationLocator implements ConfigurationLocator {
+        private static final AtomicBoolean CONSTRUCTED = new AtomicBoolean();
+        private static final AtomicBoolean FIND_CONFIGURATION_CALLED = new AtomicBoolean();
+
+        public FallbackConfigurationLocator() {
+            CONSTRUCTED.set(true);
+        }
+
+        @Override
+        public InputStream findConfiguration() {
+            FIND_CONFIGURATION_CALLED.set(true);
+            return null;
+        }
+
+        private static void reset() {
+            CONSTRUCTED.set(false);
+            FIND_CONFIGURATION_CALLED.set(false);
+        }
+    }
+
+    private static final class RejectingClassLoader extends ClassLoader {
+        private final String rejectedClassName;
+
+        private RejectingClassLoader(final ClassLoader parent, final String rejectedClassName) {
+            super(parent);
+            this.rejectedClassName = rejectedClassName;
+        }
+
+        @Override
+        protected Class<?> loadClass(final String name, final boolean resolve) throws ClassNotFoundException {
+            if (rejectedClassName.equals(name)) {
+                throw new ClassNotFoundException(name);
+            }
+            return super.loadClass(name, resolve);
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/PropertyConfiguratorTest.java
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/PropertyConfiguratorTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.logging.ErrorManager;
+import java.util.logging.Filter;
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import org.jboss.logmanager.LogContext;
+import org.jboss.logmanager.Logger;
+import org.jboss.logmanager.PropertyConfigurator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PropertyConfiguratorTest {
+
+    @Test
+    void configureInstantiatesAndConfiguresNamedComponents() throws IOException {
+        String loggerName = PropertyConfiguratorTest.class.getName() + ".configured";
+        Logger logger = LogContext.getSystemLogContext().getLogger(loggerName);
+        cleanup(logger);
+        try {
+            String configuration = """
+                    loggers=%1$s
+                    filters=coverageFilter
+                    logger.%1$s.level=INFO
+                    logger.%1$s.handlers=coverageHandler
+                    logger.%1$s.useParentHandlers=false
+                    handler.coverageHandler=%2$s
+                    handler.coverageHandler.level=INFO
+                    handler.coverageHandler.encoding=UTF-8
+                    handler.coverageHandler.errorManager=coverageErrorManager
+                    handler.coverageHandler.filter=filter coverageFilter
+                    handler.coverageHandler.formatter=coverageFormatter
+                    handler.coverageHandler.properties=label
+                    handler.coverageHandler.label=primary
+                    filter.coverageFilter=%3$s
+                    filter.coverageFilter.properties=enabled
+                    filter.coverageFilter.enabled=true
+                    formatter.coverageFormatter=%4$s
+                    formatter.coverageFormatter.properties=prefix
+                    formatter.coverageFormatter.prefix=formatted:
+                    errorManager.coverageErrorManager=%5$s
+                    errorManager.coverageErrorManager.properties=name
+                    errorManager.coverageErrorManager.name=once
+                    """.formatted(
+                    loggerName,
+                    TrackingHandler.class.getName(),
+                    TrackingFilter.class.getName(),
+                    TrackingFormatter.class.getName(),
+                    TrackingErrorManager.class.getName()
+            );
+
+            new PropertyConfigurator().configure(
+                    new ByteArrayInputStream(configuration.getBytes(StandardCharsets.UTF_8))
+            );
+
+            assertThat(logger.getUseParentHandlers()).isFalse();
+            assertThat(logger.getLevel()).isEqualTo(Level.INFO);
+            assertThat(logger.getHandlers()).singleElement().isInstanceOfSatisfying(TrackingHandler.class, handler -> {
+                assertThat(handler.getLevel()).isEqualTo(Level.INFO);
+                assertThat(handler.getEncoding()).isEqualTo("UTF-8");
+                assertThat(handler.getLabel()).isEqualTo("primary");
+                assertThat(handler.getFilter()).isInstanceOfSatisfying(TrackingFilter.class,
+                        filter -> assertThat(filter.isEnabled()).isTrue());
+                assertThat(handler.getFormatter()).isInstanceOfSatisfying(TrackingFormatter.class,
+                        formatter -> assertThat(formatter.getPrefix()).isEqualTo("formatted:"));
+                assertThat(handler.getConfiguredErrorManager()).isInstanceOfSatisfying(TrackingErrorManager.class,
+                        errorManager -> assertThat(errorManager.getName()).isEqualTo("once"));
+            });
+
+            TrackingHandler handler = (TrackingHandler) logger.getHandlers()[0];
+            logger.info("hello");
+            assertThat(handler.getLastPublishedMessage()).isEqualTo("formatted:hello");
+        } finally {
+            cleanup(logger);
+        }
+    }
+
+    private static void cleanup(final Logger logger) {
+        logger.setFilter(null);
+        logger.setUseParentHandlers(true);
+        for (Handler handler : logger.clearHandlers()) {
+            handler.close();
+        }
+    }
+
+    public static final class TrackingHandler extends Handler {
+        private String label;
+        private String lastPublishedMessage;
+
+        public String getLabel() {
+            return label;
+        }
+
+        public void setLabel(final String label) {
+            this.label = label;
+        }
+
+        public String getLastPublishedMessage() {
+            return lastPublishedMessage;
+        }
+
+        public ErrorManager getConfiguredErrorManager() {
+            return getErrorManager();
+        }
+
+        @Override
+        public void publish(final LogRecord record) {
+            if (!isLoggable(record)) {
+                return;
+            }
+            Formatter formatter = getFormatter();
+            lastPublishedMessage = formatter == null ? record.getMessage() : formatter.format(record);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    public static final class TrackingFilter implements Filter {
+        private boolean enabled;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(final boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        @Override
+        public boolean isLoggable(final LogRecord record) {
+            return enabled;
+        }
+    }
+
+    public static final class TrackingFormatter extends Formatter {
+        private String prefix = "";
+
+        public String getPrefix() {
+            return prefix;
+        }
+
+        public void setPrefix(final String prefix) {
+            this.prefix = prefix;
+        }
+
+        @Override
+        public String format(final LogRecord record) {
+            return prefix + record.getMessage();
+        }
+    }
+
+    public static final class TrackingErrorManager extends ErrorManager {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(final String name) {
+            this.name = name;
+        }
+    }
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,194 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.AbstractPropertyConfigurationTest$PrefixFormatter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters$12"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.FormattersAnonymous12Test"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.LogManager"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.LogManagerTest$FallbackConfigurationLocator",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.LogManager"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.LogManagerTest$TcclConfigurationLocator",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.PropertyConfigurator"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingErrorManager",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingErrorManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$1"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingErrorManager",
+      "methods" : [
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.ErrorManagerConfigurationImpl"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingErrorManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.PropertyConfigurator"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFilter",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$1"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFilter",
+      "methods" : [
+        {
+          "name" : "setEnabled",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.FilterConfigurationImpl"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.PropertyConfigurator"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFormatter",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFormatter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$1"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFormatter",
+      "methods" : [
+        {
+          "name" : "setPrefix",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.PropertyConfigurator"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingHandler",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$1"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingHandler",
+      "methods" : [
+        {
+          "name" : "setLabel",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.DefaultConfigurationLocator"
+      },
+      "glob" : "logging.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters$12$2"
+      },
+      "glob" : "logging.properties"
+    }
+  ]
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -175,6 +175,78 @@
           ]
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$2"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.AbstractPropertyConfigurationAnonymous2Test$PostConfiguredHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$ConstructAction"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.AbstractPropertyConfigurationAnonymous2Test$PostConfiguredHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$3"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.AbstractPropertyConfigurationAnonymous3Test$MultiStepPostConfiguredHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$ConstructAction"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.AbstractPropertyConfigurationAnonymous3Test$MultiStepPostConfiguredHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$ConstructAction"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.AbstractPropertyConfigurationTest$CapturingHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$ConstructAction"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.AbstractPropertyConfigurationTest$PrefixFormatter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.LogManager"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.LogManagerTest$FallbackConfigurationLocator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.LogManager"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.LogManagerTest$TcclConfigurationLocator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$ConstructAction"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingErrorManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$ConstructAction"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$ConstructAction"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingFormatter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.logmanager.config.AbstractPropertyConfiguration$ConstructAction"
+      },
+      "type" : "org_jboss_logmanager.jboss_logmanager.PropertyConfiguratorTest$TrackingHandler"
     }
   ],
   "resources" : [

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -8,7 +8,7 @@
     },
     {
       "condition" : {
-        "typeReached" : "org.jboss.logmanager.formatters.Formatters$12"
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters$11"
       },
       "type" : "org_jboss_logmanager.jboss_logmanager.FormattersAnonymous12Test"
     },
@@ -186,7 +186,7 @@
     },
     {
       "condition" : {
-        "typeReached" : "org.jboss.logmanager.formatters.Formatters$12$2"
+        "typeReached" : "org.jboss.logmanager.formatters.Formatters$11$3"
       },
       "glob" : "logging.properties"
     }

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/resources/logging.properties
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/resources/logging.properties
@@ -1,0 +1,1 @@
+test.resource=thread-context-class-loader

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/user-code-filter.json
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.jboss.logmanager.**"
+    }
+  ]
+}

--- a/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/user-code-filter.json
+++ b/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/user-code-filter.json
@@ -5,6 +5,9 @@
     },
     {
       "includeClasses" : "org.jboss.logmanager.**"
+    },
+    {
+      "includeClasses" : "org_jboss_logmanager.jboss_logmanager.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #4113

This PR provides test fixes and new metadata for org.jboss.logmanager:jboss-logmanager:1.4.1.Final, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 149177
- Cached input tokens: 1404928
- Output tokens: 12671
- Metadata entries: 56
- Test-only metadata entries: 42
- Iterations: 3
- Library coverage percentage: 26.87
- Previous library version metadata entries: 48
- Previous library version test-only metadata entries: 30
- Previous library version coverage percentage: 27.3

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `372d96d60413750c3664e0ed72c6237635497323`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.jboss.logmanager:jboss-logmanager:1.3.0.Final: 29/29 covered calls (100.00%)
- org.jboss.logmanager:jboss-logmanager:1.4.1.Final: 32/32 covered calls (100.00%)

**Reflection:**
- org.jboss.logmanager:jboss-logmanager:1.3.0.Final: 24/24 covered calls (100.00%)
- org.jboss.logmanager:jboss-logmanager:1.4.1.Final: 27/27 covered calls (100.00%)

**Resources:**
- org.jboss.logmanager:jboss-logmanager:1.3.0.Final: 5/5 covered calls (100.00%)
- org.jboss.logmanager:jboss-logmanager:1.4.1.Final: 5/5 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.jboss.logmanager:jboss-logmanager:1.3.0.Final: 5515/19835 (27.80%)
- org.jboss.logmanager:jboss-logmanager:1.4.1.Final: 6549/24116 (27.16%)

**Line:**
- org.jboss.logmanager:jboss-logmanager:1.3.0.Final: 1258/4608 (27.30%)
- org.jboss.logmanager:jboss-logmanager:1.4.1.Final: 1477/5497 (26.87%)

**Method:**
- org.jboss.logmanager:jboss-logmanager:1.3.0.Final: 316/1083 (29.18%)
- org.jboss.logmanager:jboss-logmanager:1.4.1.Final: 363/1265 (28.70%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationAnonymous2Test.java 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationAnonymous2Test.java
new file mode 100644
index 0000000000..8c39d1c1b7
--- /dev/null
+++ 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationAnonymous2Test.java
@@ -0,0 +1,71 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+
+import org.jboss.logmanager.LogContext;
+import org.jboss.logmanager.Logger;
+import org.jboss.logmanager.config.HandlerConfiguration;
+import org.jboss.logmanager.config.LogContextConfiguration;
+import org.jboss.logmanager.config.LoggerConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AbstractPropertyConfigurationAnonymous2Test {
+
+    @Test
+    void addPostConfigurationMethodResolvesPublicNoArgMethodDuringCommit() {
+        String loggerName = AbstractPropertyConfigurationAnonymous2Test.class.getName() + ".postConfiguration";
+        String handlerName = "postConfiguredHandler";
+        LogContext context = LogContext.create();
+        LogContextConfiguration configuration = LogContextConfiguration.Factory.create(context);
+
+        HandlerConfiguration handler = configuration.addHandlerConfiguration(
+                null,
+                PostConfiguredHandler.class.getName(),
+                handlerName
+        );
+        assertThat(handler.addPostConfigurationMethod("activate")).isTrue();
+
+        LoggerConfiguration loggerConfiguration = configuration.addLoggerConfiguration(loggerName);
+        loggerConfiguration.setUseParentHandlers(false);
+        loggerConfiguration.addHandlerName(handlerName);
+
+        configuration.commit();
+
+        Logger logger = context.getLogger(loggerName);
+        assertThat(logger.getHandlers()).singleElement().isInstanceOfSatisfying(PostConfiguredHandler.class,
+                postConfiguredHandler -> assertThat(postConfiguredHandler.isActivated()).isTrue());
+    }
+
+    public static final class PostConfiguredHandler extends Handler {
+        private boolean activated;
+
+        public void activate() {
+            activated = true;
+        }
+
+        public boolean isActivated() {
+            return activated;
+        }
+
+        @Override
+        public void publish(final LogRecord record) {
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}
diff --git 1/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationAnonymous3Test.java 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationAnonymous3Test.java
new file mode 100644
index 0000000000..a20990cefe
--- /dev/null
+++ 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/AbstractPropertyConfigurationAnonymous3Test.java
@@ -0,0 +1,79 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_logmanager.jboss_logmanager;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+
+import org.jboss.logmanager.LogContext;
+import org.jboss.logmanager.Logger;
+import org.jboss.logmanager.config.HandlerConfiguration;
+import org.jboss.logmanager.config.LogContextConfiguration;
+import org.jboss.logmanager.config.LoggerConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AbstractPropertyConfigurationAnonymous3Test {
+
+    @Test
+    void setPostConfigurationMethodsResolvesPublicMethodsDuringCommit() {
+        String loggerName = AbstractPropertyConfigurationAnonymous3Test.class.getName() + ".postConfigurationMethods";
+        String handlerName = "multiStepPostConfiguredHandler";
+        LogContext context = LogContext.create();
+        LogContextConfiguration configuration = LogContextConfiguration.Factory.create(context);
+
+        HandlerConfiguration handler = configuration.addHandlerConfiguration(
+                null,
+                MultiStepPostConfiguredHandler.class.getName(),
+                handlerName
+        );
+        handler.setPostConfigurationMethods("prepare", "activate");
+
+        LoggerConfiguration loggerConfiguration = configuration.addLoggerConfiguration(loggerName);
+        loggerConfiguration.setUseParentHandlers(false);
+        loggerConfiguration.addHandlerName(handlerName);
+
+        configuration.commit();
+
+        Logger logger = context.getLogger(loggerName);
+        assertThat(handler.getPostConfigurationMethods()).containsExactly("prepare", "activate");
+        assertThat(logger.getHandlers()).singleElement().isInstanceOfSatisfying(MultiStepPostConfiguredHandler.class,
+                postConfiguredHandler -> assertThat(postConfiguredHandler.getLifecycleEvents())
+                        .containsExactly("prepared", "activated"));
+    }
+
+    public static final class MultiStepPostConfiguredHandler extends Handler {
+        private final List<String> lifecycleEvents = new ArrayList<>();
+
+        public void prepare() {
+            lifecycleEvents.add("prepared");
+        }
+
+        public void activate() {
+            lifecycleEvents.add("activated");
+        }
+
+        public List<String> getLifecycleEvents() {
+            return lifecycleEvents;
+        }
+
+        @Override
+        public void publish(final LogRecord record) {
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}
diff --git 1/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Anonymous2Test.java 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Anonymous2Test.java
index 86e4a5868b..fe0a819ccb 100644
--- 1/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Anonymous2Test.java
+++ 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/src/test/java/org_jboss_logmanager/jboss_logmanager/FormattersAnonymous12Anonymous2Test.java
@@ -47,8 +47,8 @@ public class FormattersAnonymous12Anonymous2Test {
             final ClassLoader classLoader,
             final String resourceName
     ) throws Throwable {
-        final Class<?> enclosingFormatterStepClass = Class.forName(Formatters.class.getName() + "$12");
-        final Class<?> resourceActionClass = Class.forName(enclosingFormatterStepClass.getName() + "$2");
+        final Class<?> enclosingFormatterStepClass = Class.forName(Formatters.class.getName() + "$11");
+        final Class<?> resourceActionClass = Class.forName(enclosingFormatterStepClass.getName() + "$3");
         final MethodHandle constructor = MethodHandles.privateLookupIn(resourceActionClass, MethodHandles.lookup())
                 .findConstructor(
                         resourceActionClass,
diff --git 1/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/user-code-filter.json 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/user-code-filter.json
index 013f719e78..af1223daa8 100644
--- 1/tests/src/org.jboss.logmanager/jboss-logmanager/1.3.0.Final/user-code-filter.json
+++ 2/tests/src/org.jboss.logmanager/jboss-logmanager/1.4.1.Final/user-code-filter.json
@@ -5,6 +5,9 @@
     },
     {
       "includeClasses" : "org.jboss.logmanager.**"
+    },
+    {
+      "includeClasses" : "org_jboss_logmanager.jboss_logmanager.**"
     }
   ]
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
