### PR TITLE
[GenAI] Test fix for org.javamoney.moneta:moneta-core:1.4.2 using gpt-5.5

### DIFF
--- a/metadata/org.javamoney.moneta/moneta-core/1.4.2/reachability-metadata.json
+++ b/metadata/org.javamoney.moneta/moneta-core/1.4.2/reachability-metadata.json
@@ -1,0 +1,128 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.javamoney.moneta.spi.loader.DefaultResourceCache"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.javamoney.moneta.spi.loader.LoaderConfigurator"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.javamoney.moneta.spi.loader.LoaderConfigurator"
+      },
+      "type": "java.util.logging.ConsoleHandler"
+    },
+    {
+      "condition": {
+        "typeReached": "org.javamoney.moneta.spi.loader.LoaderConfigurator"
+      },
+      "type": "java.util.logging.Handler[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.javamoney.moneta.spi.loader.LoaderConfigurator"
+      },
+      "type": "java.util.logging.SimpleFormatter"
+    },
+    {
+      "condition": {
+        "typeReached": "org.javamoney.moneta.spi.DefaultMonetaryAmountsSingletonSpi"
+      },
+      "type": "org.javamoney.moneta.FastMoney"
+    },
+    {
+      "condition": {
+        "typeReached": "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
+      },
+      "type": "org.javamoney.moneta.spi.ConfigurableCurrencyUnitProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
+      },
+      "type": "org.javamoney.moneta.spi.DefaultMonetaryCurrenciesSingletonSpi"
+    },
+    {
+      "condition": {
+        "typeReached": "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
+      },
+      "type": "org.javamoney.moneta.spi.FastMoneyAmountFactoryProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
+      },
+      "type": "org.javamoney.moneta.spi.JDKCurrencyProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
+      },
+      "type": "org.javamoney.moneta.spi.MoneyAmountFactoryProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.javamoney.moneta.FastMoney"
+      },
+      "type": "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
+      },
+      "type": "org.javamoney.moneta.spi.RoundedMoneyAmountFactoryProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.javamoney.moneta.spi.loader.LoaderConfigurator"
+      },
+      "type": "sun.util.logging.resources.logging"
+    },
+    {
+      "condition": {
+        "typeReached": "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
+      },
+      "type": {
+        "proxy": [
+          "javax.annotation.Priority"
+        ]
+      }
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
+      },
+      "glob": "META-INF/services/org.javamoney.moneta.spi.loader.ResourceCache"
+    }
+  ]
+}

--- a/metadata/org.javamoney.moneta/moneta-core/1.4.2/reachability-metadata.json
+++ b/metadata/org.javamoney.moneta/moneta-core/1.4.2/reachability-metadata.json
@@ -1,128 +1,128 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
       },
-      "type": "java.lang.StackTraceElement[]"
+      "type" : "java.lang.StackTraceElement[]"
     },
     {
-      "condition": {
-        "typeReached": "org.javamoney.moneta.spi.loader.DefaultResourceCache"
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.loader.DefaultResourceCache"
       },
-      "type": "java.lang.String[]"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "org.javamoney.moneta.spi.loader.LoaderConfigurator"
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.loader.LoaderConfigurator"
       },
-      "type": "java.lang.String[]"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
       },
-      "type": "java.lang.reflect.Method[]"
+      "type" : "java.lang.reflect.Method[]"
     },
     {
-      "condition": {
-        "typeReached": "org.javamoney.moneta.spi.loader.LoaderConfigurator"
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.loader.LoaderConfigurator"
       },
-      "type": "java.util.logging.ConsoleHandler"
+      "type" : "java.util.logging.ConsoleHandler"
     },
     {
-      "condition": {
-        "typeReached": "org.javamoney.moneta.spi.loader.LoaderConfigurator"
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.loader.LoaderConfigurator"
       },
-      "type": "java.util.logging.Handler[]"
+      "type" : "java.util.logging.Handler[]"
     },
     {
-      "condition": {
-        "typeReached": "org.javamoney.moneta.spi.loader.LoaderConfigurator"
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.loader.LoaderConfigurator"
       },
-      "type": "java.util.logging.SimpleFormatter"
+      "type" : "java.util.logging.SimpleFormatter"
     },
     {
-      "condition": {
-        "typeReached": "org.javamoney.moneta.spi.DefaultMonetaryAmountsSingletonSpi"
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.DefaultMonetaryAmountsSingletonSpi"
       },
-      "type": "org.javamoney.moneta.FastMoney"
+      "type" : "org.javamoney.moneta.FastMoney"
     },
     {
-      "condition": {
-        "typeReached": "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
       },
-      "type": "org.javamoney.moneta.spi.ConfigurableCurrencyUnitProvider"
+      "type" : "org.javamoney.moneta.spi.ConfigurableCurrencyUnitProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
       },
-      "type": "org.javamoney.moneta.spi.DefaultMonetaryCurrenciesSingletonSpi"
+      "type" : "org.javamoney.moneta.spi.DefaultMonetaryCurrenciesSingletonSpi"
     },
     {
-      "condition": {
-        "typeReached": "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
       },
-      "type": "org.javamoney.moneta.spi.FastMoneyAmountFactoryProvider"
+      "type" : "org.javamoney.moneta.spi.FastMoneyAmountFactoryProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
       },
-      "type": "org.javamoney.moneta.spi.JDKCurrencyProvider"
+      "type" : "org.javamoney.moneta.spi.JDKCurrencyProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
       },
-      "type": "org.javamoney.moneta.spi.MoneyAmountFactoryProvider"
+      "type" : "org.javamoney.moneta.spi.MoneyAmountFactoryProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.javamoney.moneta.FastMoney"
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.FastMoney"
       },
-      "type": "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
+      "type" : "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
       },
-      "type": "org.javamoney.moneta.spi.RoundedMoneyAmountFactoryProvider"
+      "type" : "org.javamoney.moneta.spi.RoundedMoneyAmountFactoryProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.javamoney.moneta.spi.loader.LoaderConfigurator"
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.loader.LoaderConfigurator"
       },
-      "type": "sun.util.logging.resources.logging"
+      "type" : "sun.util.logging.resources.logging"
     },
     {
-      "condition": {
-        "typeReached": "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Retention"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "javax.annotation.Priority"
         ]
       }
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.PriorityAwareServiceProvider"
       },
-      "glob": "META-INF/services/org.javamoney.moneta.spi.loader.ResourceCache"
+      "glob" : "META-INF/services/org.javamoney.moneta.spi.loader.ResourceCache"
     }
   ]
 }

--- a/metadata/org.javamoney.moneta/moneta-core/index.json
+++ b/metadata/org.javamoney.moneta/moneta-core/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.4.2",
+    "tested-versions" : [
+      "1.4.2"
+    ],
+    "allowed-packages" : [
+      "org.javamoney.moneta"
+    ]
+  },
+  {
     "metadata-version" : "1.4",
     "source-code-url" : "https://repo1.maven.org/maven2/org/javamoney/moneta/moneta-core/$version$/moneta-core-$version$-sources.jar",
     "repository-url" : "https://github.com/JavaMoney/jsr354-ri",

--- a/metadata/org.javamoney.moneta/moneta-core/index.json
+++ b/metadata/org.javamoney.moneta/moneta-core/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.4.2",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/javamoney/moneta/moneta-core/$version$/moneta-core-$version$-sources.jar",
+    "repository-url" : "https://github.com/JavaMoney/jsr354-ri",
+    "test-code-url" : "https://github.com/JavaMoney/jsr354-ri/tree/$version$/moneta-core/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/javamoney/moneta/moneta-core/$version$/moneta-core-$version$-javadoc.jar",
+    "description" : "Moneta Core is the core implementation module of JavaMoney's JSR 354 reference implementation. It provides monetary amount, currency, formatting, loading, and SPI support for Java applications that use the javax.money API.",
     "tested-versions" : [
       "1.4.2"
     ],

--- a/stats/org.javamoney.moneta/moneta-core/1.4.2/execution-metrics.json
+++ b/stats/org.javamoney.moneta/moneta-core/1.4.2/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_java_run_fail:2026-06-05": {
+    "timestamp": "2026-06-05T20:10:18.625093Z",
+    "library": "org.javamoney.moneta:moneta-core:1.4.2",
+    "starting_commit": "b86cf23819921f5f7718810e5ebf29b78990722c",
+    "ending_commit": "1ffef53d24e40ce14996857919d3dcbcc9e3055b",
+    "previous_library": "org.javamoney.moneta:moneta-core:1.4",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.4.2",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 5,
+        "totalCalls": 5
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1609,
+          "missed": 15673,
+          "ratio": 0.093103,
+          "total": 17282
+        },
+        "line": {
+          "covered": 393,
+          "missed": 3154,
+          "ratio": 0.110798,
+          "total": 3547
+        },
+        "method": {
+          "covered": 104,
+          "missed": 852,
+          "ratio": 0.108787,
+          "total": 956
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.4",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 4,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1479,
+          "missed": 15647,
+          "ratio": 0.08636,
+          "total": 17126
+        },
+        "line": {
+          "covered": 360,
+          "missed": 3150,
+          "ratio": 0.102564,
+          "total": 3510
+        },
+        "method": {
+          "covered": 101,
+          "missed": 853,
+          "ratio": 0.10587,
+          "total": 954
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 36724,
+      "cached_input_tokens_used": 385024,
+      "output_tokens_used": 4007,
+      "iterations": 2,
+      "cost_usd": 0.3127,
+      "tested_library_loc": 393,
+      "metadata_entries": 19,
+      "test_only_metadata_entries": 6,
+      "previous_library_metadata_entries": 11,
+      "previous_library_test_only_metadata_entries": 6,
+      "code_coverage_percent": 11.08,
+      "previous_library_coverage_percent": 10.26
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.javamoney.moneta/moneta-core/1.4.2/src/test/java/org_javamoney_moneta/moneta_core/DefaultMonetaryAmountsSingletonSpiTest.java",
+      "metadata_file": "metadata/org.javamoney.moneta/moneta-core/1.4.2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.javamoney.moneta/moneta-core/1.4.2/stats.json
+++ b/stats/org.javamoney.moneta/moneta-core/1.4.2/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "1.4.2",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 4,
+          "totalCalls" : 4
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 5,
+      "totalCalls" : 5
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1609,
+        "missed" : 15673,
+        "ratio" : 0.093103,
+        "total" : 17282
+      },
+      "line" : {
+        "covered" : 393,
+        "missed" : 3154,
+        "ratio" : 0.110798,
+        "total" : 3547
+      },
+      "method" : {
+        "covered" : 104,
+        "missed" : 852,
+        "ratio" : 0.108787,
+        "total" : 956
+      }
+    }
+  } ]
+}

--- a/tests/src/org.javamoney.moneta/moneta-core/1.4.2/.gitignore
+++ b/tests/src/org.javamoney.moneta/moneta-core/1.4.2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.javamoney.moneta/moneta-core/1.4.2/build.gradle
+++ b/tests/src/org.javamoney.moneta/moneta-core/1.4.2/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.javamoney.moneta:moneta-core:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.javamoney.moneta/moneta-core/1.4.2/gradle.properties
+++ b/tests/src/org.javamoney.moneta/moneta-core/1.4.2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.javamoney.moneta:moneta-core:1.4.2
+library.version = 1.4.2
+metadata.dir = org.javamoney.moneta/moneta-core/1.4.2/

--- a/tests/src/org.javamoney.moneta/moneta-core/1.4.2/settings.gradle
+++ b/tests/src/org.javamoney.moneta/moneta-core/1.4.2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.javamoney.moneta.moneta-core_tests'

--- a/tests/src/org.javamoney.moneta/moneta-core/1.4.2/src/test/java/org_javamoney_moneta/moneta_core/DefaultConfigProviderTest.java
+++ b/tests/src/org.javamoney.moneta/moneta-core/1.4.2/src/test/java/org_javamoney_moneta/moneta_core/DefaultConfigProviderTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_javamoney_moneta.moneta_core;
+
+import org.javamoney.moneta.spi.DefaultConfigProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+public class DefaultConfigProviderTest {
+    @Test
+    public void constructorLoadsJavamoneyPropertiesFromClasspath() {
+        DefaultConfigProvider provider = new DefaultConfigProvider();
+
+        assertThat(provider.getProperty("load.loader-configurator-absolute.type"))
+                .isEqualTo("LAZY");
+        assertThat(provider.getProperties())
+                .containsEntry("load.loader-configurator-absolute.resource", "/javamoney.properties");
+    }
+}

--- a/tests/src/org.javamoney.moneta/moneta-core/1.4.2/src/test/java/org_javamoney_moneta/moneta_core/DefaultMonetaryAmountsSingletonSpiTest.java
+++ b/tests/src/org.javamoney.moneta/moneta-core/1.4.2/src/test/java/org_javamoney_moneta/moneta_core/DefaultMonetaryAmountsSingletonSpiTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_javamoney_moneta.moneta_core;
+
+import org.javamoney.moneta.FastMoney;
+import org.javamoney.moneta.spi.DefaultMonetaryAmountsSingletonSpi;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DefaultMonetaryAmountsSingletonSpiTest {
+    private static final String DEFAULT_AMOUNT_TYPE_PROPERTY = "org.javamoney.moneta.Money.defaults.amountType";
+
+    @Test
+    public void getDefaultAmountTypeLoadsConfiguredAmountClass() {
+        String previousValue = System.getProperty(DEFAULT_AMOUNT_TYPE_PROPERTY);
+        try {
+            System.setProperty(DEFAULT_AMOUNT_TYPE_PROPERTY, FastMoney.class.getName());
+
+            DefaultMonetaryAmountsSingletonSpi amounts = new DefaultMonetaryAmountsSingletonSpi();
+
+            assertThat(amounts.getDefaultAmountType()).isEqualTo(FastMoney.class);
+            assertThat(amounts.getAmountTypes()).contains(FastMoney.class);
+        } finally {
+            if (previousValue == null) {
+                System.clearProperty(DEFAULT_AMOUNT_TYPE_PROPERTY);
+            } else {
+                System.setProperty(DEFAULT_AMOUNT_TYPE_PROPERTY, previousValue);
+            }
+        }
+    }
+}

--- a/tests/src/org.javamoney.moneta/moneta-core/1.4.2/src/test/java/org_javamoney_moneta/moneta_core/DefaultMonetaryAmountsSingletonSpiTest.java
+++ b/tests/src/org.javamoney.moneta/moneta-core/1.4.2/src/test/java/org_javamoney_moneta/moneta_core/DefaultMonetaryAmountsSingletonSpiTest.java
@@ -8,7 +8,10 @@ package org_javamoney_moneta.moneta_core;
 
 import org.javamoney.moneta.FastMoney;
 import org.javamoney.moneta.spi.DefaultMonetaryAmountsSingletonSpi;
+import org.javamoney.moneta.spi.MonetaryConfig;
 import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -17,20 +20,16 @@ public class DefaultMonetaryAmountsSingletonSpiTest {
 
     @Test
     public void getDefaultAmountTypeLoadsConfiguredAmountClass() {
-        String previousValue = System.getProperty(DEFAULT_AMOUNT_TYPE_PROPERTY);
+        Optional<String> previousValue = MonetaryConfig.getString(DEFAULT_AMOUNT_TYPE_PROPERTY);
         try {
-            System.setProperty(DEFAULT_AMOUNT_TYPE_PROPERTY, FastMoney.class.getName());
+            MonetaryConfig.setValue(DEFAULT_AMOUNT_TYPE_PROPERTY, FastMoney.class.getName());
 
             DefaultMonetaryAmountsSingletonSpi amounts = new DefaultMonetaryAmountsSingletonSpi();
 
             assertThat(amounts.getDefaultAmountType()).isEqualTo(FastMoney.class);
             assertThat(amounts.getAmountTypes()).contains(FastMoney.class);
         } finally {
-            if (previousValue == null) {
-                System.clearProperty(DEFAULT_AMOUNT_TYPE_PROPERTY);
-            } else {
-                System.setProperty(DEFAULT_AMOUNT_TYPE_PROPERTY, previousValue);
-            }
+            MonetaryConfig.setValue(DEFAULT_AMOUNT_TYPE_PROPERTY, previousValue.orElse(null));
         }
     }
 }

--- a/tests/src/org.javamoney.moneta/moneta-core/1.4.2/src/test/java/org_javamoney_moneta/moneta_core/LoaderConfiguratorTest.java
+++ b/tests/src/org.javamoney.moneta/moneta-core/1.4.2/src/test/java/org_javamoney_moneta/moneta_core/LoaderConfiguratorTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_javamoney_moneta.moneta_core;
+
+import org.javamoney.moneta.spi.loader.DefaultLoaderService;
+import org.javamoney.moneta.spi.loader.LoaderService;
+import org.javamoney.moneta.spi.loader.LoaderService.UpdatePolicy;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LoaderConfiguratorTest {
+    private static final String RESOURCE_ID = "loader-configurator-absolute";
+
+    @Test
+    public void loadRegistersResourceFoundThroughOwningClass() {
+        LoaderService loaderService = new DefaultLoaderService();
+
+        assertThat(loaderService.isResourceRegistered(RESOURCE_ID)).isTrue();
+        assertThat(loaderService.getUpdatePolicy(RESOURCE_ID)).isEqualTo(UpdatePolicy.LAZY);
+        assertThat(loaderService.getUpdateConfiguration(RESOURCE_ID))
+                .containsEntry("resource", "/javamoney.properties")
+                .containsEntry("type", "LAZY");
+    }
+}

--- a/tests/src/org.javamoney.moneta/moneta-core/1.4.2/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.javamoney.moneta/moneta-core/1.4.2/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,40 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.internal.loader.LoaderConfigurator"
+      },
+      "glob" : "/javamoney.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.internal.loader.LoaderConfigurator"
+      },
+      "glob" : "javamoney.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.MonetaryConfig"
+      },
+      "glob" : "javamoney.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.loader.LoaderConfigurator"
+      },
+      "glob" : "/javamoney.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.DefaultConfigProvider"
+      },
+      "glob" : "javamoney.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.javamoney.moneta.spi.loader.LoaderConfigurator"
+      },
+      "glob" : "javamoney.properties"
+    }
+  ]
+}

--- a/tests/src/org.javamoney.moneta/moneta-core/1.4.2/src/test/resources/javamoney.properties
+++ b/tests/src/org.javamoney.moneta/moneta-core/1.4.2/src/test/resources/javamoney.properties
@@ -1,0 +1,2 @@
+load.loader-configurator-absolute.type=LAZY
+load.loader-configurator-absolute.resource=/javamoney.properties

--- a/tests/src/org.javamoney.moneta/moneta-core/1.4.2/user-code-filter.json
+++ b/tests/src/org.javamoney.moneta/moneta-core/1.4.2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.javamoney.moneta.**"
+    }
+  ]
+}

--- a/tests/src/org.javamoney.moneta/moneta-core/1.4.2/user-code-filter.json
+++ b/tests/src/org.javamoney.moneta/moneta-core/1.4.2/user-code-filter.json
@@ -5,6 +5,9 @@
     },
     {
       "includeClasses" : "org.javamoney.moneta.**"
+    },
+    {
+      "includeClasses" : "org_javamoney_moneta.moneta_core.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #4264

This PR provides test fixes and new metadata for org.javamoney.moneta:moneta-core:1.4.2, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 36724
- Cached input tokens: 385024
- Output tokens: 4007
- Metadata entries: 19
- Test-only metadata entries: 6
- Iterations: 2
- Library coverage percentage: 11.08
- Previous library version metadata entries: 11
- Previous library version test-only metadata entries: 6
- Previous library version coverage percentage: 10.26

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `372d96d60413750c3664e0ed72c6237635497323`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.javamoney.moneta:moneta-core:1.4: 4/4 covered calls (100.00%)
- org.javamoney.moneta:moneta-core:1.4.2: 5/5 covered calls (100.00%)

**Reflection:**
- org.javamoney.moneta:moneta-core:1.4: 1/1 covered calls (100.00%)
- org.javamoney.moneta:moneta-core:1.4.2: 1/1 covered calls (100.00%)

**Resources:**
- org.javamoney.moneta:moneta-core:1.4: 3/3 covered calls (100.00%)
- org.javamoney.moneta:moneta-core:1.4.2: 4/4 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.javamoney.moneta:moneta-core:1.4: 1479/17126 (8.64%)
- org.javamoney.moneta:moneta-core:1.4.2: 1609/17282 (9.31%)

**Line:**
- org.javamoney.moneta:moneta-core:1.4: 360/3510 (10.26%)
- org.javamoney.moneta:moneta-core:1.4.2: 393/3547 (11.08%)

**Method:**
- org.javamoney.moneta:moneta-core:1.4: 101/954 (10.59%)
- org.javamoney.moneta:moneta-core:1.4.2: 104/956 (10.88%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.javamoney.moneta/moneta-core/1.4.2/src/test/java/org_javamoney_moneta/moneta_core/DefaultConfigProviderTest.java 2/tests/src/org.javamoney.moneta/moneta-core/1.4.2/src/test/java/org_javamoney_moneta/moneta_core/DefaultConfigProviderTest.java
new file mode 100644
index 0000000000..b89aa2b066
--- /dev/null
+++ 2/tests/src/org.javamoney.moneta/moneta-core/1.4.2/src/test/java/org_javamoney_moneta/moneta_core/DefaultConfigProviderTest.java
@@ -0,0 +1,25 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_javamoney_moneta.moneta_core;
+
+import org.javamoney.moneta.spi.DefaultConfigProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+public class DefaultConfigProviderTest {
+    @Test
+    public void constructorLoadsJavamoneyPropertiesFromClasspath() {
+        DefaultConfigProvider provider = new DefaultConfigProvider();
+
+        assertThat(provider.getProperty("load.loader-configurator-absolute.type"))
+                .isEqualTo("LAZY");
+        assertThat(provider.getProperties())
+                .containsEntry("load.loader-configurator-absolute.resource", "/javamoney.properties");
+    }
+}
diff --git 1/tests/src/org.javamoney.moneta/moneta-core/1.4/src/test/java/org_javamoney_moneta/moneta_core/DefaultMonetaryAmountsSingletonSpiTest.java 2/tests/src/org.javamoney.moneta/moneta-core/1.4.2/src/test/java/org_javamoney_moneta/moneta_core/DefaultMonetaryAmountsSingletonSpiTest.java
index 75d2f0c08c..2dcd2209bf 100644
--- 1/tests/src/org.javamoney.moneta/moneta-core/1.4/src/test/java/org_javamoney_moneta/moneta_core/DefaultMonetaryAmountsSingletonSpiTest.java
+++ 2/tests/src/org.javamoney.moneta/moneta-core/1.4.2/src/test/java/org_javamoney_moneta/moneta_core/DefaultMonetaryAmountsSingletonSpiTest.java
@@ -8,8 +8,11 @@ package org_javamoney_moneta.moneta_core;
 
 import org.javamoney.moneta.FastMoney;
 import org.javamoney.moneta.spi.DefaultMonetaryAmountsSingletonSpi;
+import org.javamoney.moneta.spi.MonetaryConfig;
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class DefaultMonetaryAmountsSingletonSpiTest {
@@ -17,20 +20,16 @@ public class DefaultMonetaryAmountsSingletonSpiTest {
 
     @Test
     public void getDefaultAmountTypeLoadsConfiguredAmountClass() {
-        String previousValue = System.getProperty(DEFAULT_AMOUNT_TYPE_PROPERTY);
+        Optional<String> previousValue = MonetaryConfig.getString(DEFAULT_AMOUNT_TYPE_PROPERTY);
         try {
-            System.setProperty(DEFAULT_AMOUNT_TYPE_PROPERTY, FastMoney.class.getName());
+            MonetaryConfig.setValue(DEFAULT_AMOUNT_TYPE_PROPERTY, FastMoney.class.getName());
 
             DefaultMonetaryAmountsSingletonSpi amounts = new DefaultMonetaryAmountsSingletonSpi();
 
             assertThat(amounts.getDefaultAmountType()).isEqualTo(FastMoney.class);
             assertThat(amounts.getAmountTypes()).contains(FastMoney.class);
         } finally {
-            if (previousValue == null) {
-                System.clearProperty(DEFAULT_AMOUNT_TYPE_PROPERTY);
-            } else {
-                System.setProperty(DEFAULT_AMOUNT_TYPE_PROPERTY, previousValue);
-            }
+            MonetaryConfig.setValue(DEFAULT_AMOUNT_TYPE_PROPERTY, previousValue.orElse(null));
         }
     }
 }
diff --git 1/tests/src/org.javamoney.moneta/moneta-core/1.4/user-code-filter.json 2/tests/src/org.javamoney.moneta/moneta-core/1.4.2/user-code-filter.json
index e5609bd76c..ef3c70f509 100644
--- 1/tests/src/org.javamoney.moneta/moneta-core/1.4/user-code-filter.json
+++ 2/tests/src/org.javamoney.moneta/moneta-core/1.4.2/user-code-filter.json
@@ -5,6 +5,9 @@
     },
     {
       "includeClasses" : "org.javamoney.moneta.**"
+    },
+    {
+      "includeClasses" : "org_javamoney_moneta.moneta_core.**"
     }
   ]
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
