### PR TITLE
[Automation] Generated metadata for io.netty:netty-codec-mqtt:4.1.79.Final

### DIFF
--- a/metadata/io.netty/netty-codec-mqtt/4.1.79.Final/reachability-metadata.json
+++ b/metadata/io.netty/netty-codec-mqtt/4.1.79.Final/reachability-metadata.json
@@ -25,39 +25,6 @@
         "typeReached": "io.netty.handler.codec.mqtt.MqttCodecUtil"
       },
       "type": "io.netty.util.DefaultAttributeMap$DefaultAttribute"
-    },
-    {
-      "condition": {
-        "typeReached": "io.netty.handler.codec.mqtt.MqttEncoder"
-      },
-      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueConsumerIndexField",
-      "fields": [
-        {
-          "name": "consumerIndex"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "io.netty.handler.codec.mqtt.MqttEncoder"
-      },
-      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerIndexField",
-      "fields": [
-        {
-          "name": "producerIndex"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "io.netty.handler.codec.mqtt.MqttEncoder"
-      },
-      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerLimitField",
-      "fields": [
-        {
-          "name": "producerLimit"
-        }
-      ]
     }
   ]
 }


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#4374

This PR provides new metadata needed for the io.netty:netty-codec-mqtt:4.1.79.Final, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `io.netty:netty-codec-mqtt:4.1.74.Final`): 7
- Metadata entries (new `io.netty:netty-codec-mqtt:4.1.79.Final`): 4
- Library coverage (previous): 72.74%
- Library coverage (new): 72.74%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `372d96d60413750c3664e0ed72c6237635497323`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.netty:netty-codec-mqtt:4.1.74.Final: 0/0 covered calls (100.00%)
- io.netty:netty-codec-mqtt:4.1.79.Final: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.netty:netty-codec-mqtt:4.1.74.Final: 5741/8139 (70.54%)
- io.netty:netty-codec-mqtt:4.1.79.Final: 5741/8139 (70.54%)

**Line:**
- io.netty:netty-codec-mqtt:4.1.74.Final: 1302/1790 (72.74%)
- io.netty:netty-codec-mqtt:4.1.79.Final: 1302/1790 (72.74%)

**Method:**
- io.netty:netty-codec-mqtt:4.1.74.Final: 301/384 (78.39%)
- io.netty:netty-codec-mqtt:4.1.79.Final: 301/384 (78.39%)

### Local CI Verification

- Status: `success`
- Commands run: 0
- Fixup attempts: 0
