### PR TITLE
[GenAI] Test fix for com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:2.22.0 using gpt-5.5

### DIFF
--- a/metadata/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.22.0/reachability-metadata.json
+++ b/metadata/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.22.0/reachability-metadata.json
@@ -1,0 +1,58 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntrospector"
+      },
+      "type": "java.lang.annotation.Annotation[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntrospector"
+      },
+      "type": "java.lang.annotation.ElementType[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntrospector"
+      },
+      "type": "java.lang.reflect.Field[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntrospector"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntrospector"
+      },
+      "type": {
+        "proxy": [
+          "jakarta.xml.bind.annotation.XmlEnumValue"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntrospector"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntrospector"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Target"
+        ]
+      }
+    }
+  ]
+}

--- a/metadata/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/index.json
+++ b/metadata/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.22.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/module/jackson-module-jakarta-xmlbind-annotations/$version$/jackson-module-jakarta-xmlbind-annotations-$version$-sources.jar",
+    "repository-url" : "https://github.com/FasterXML/jackson-modules-base",
+    "test-code-url" : "https://github.com/FasterXML/jackson-modules-base/tree/jackson-modules-base-$version$/jakarta-xmlbind/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/module/jackson-module-jakarta-xmlbind-annotations/$version$/jackson-module-jakarta-xmlbind-annotations-$version$-javadoc.jar",
+    "description" : "Jackson Module Jakarta XML Bind Annotations lets Jackson use Jakarta XML Bind annotations as an alternative to native Jackson annotations for configuring data binding. It integrates with jackson-databind so Java classes annotated with Jakarta XML Bind/JAXB 3 annotations can be serialized and deserialized by Jackson.",
     "tested-versions" : [
       "2.22.0"
     ],

--- a/metadata/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/index.json
+++ b/metadata/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.22.0",
+    "tested-versions" : [
+      "2.22.0"
+    ],
+    "allowed-packages" : [
+      "com.fasterxml.jackson.module.jakarta.xmlbind"
+    ]
+  },
+  {
     "metadata-version" : "2.18.5",
     "source-code-url" : "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/module/jackson-module-jakarta-xmlbind-annotations/$version$/jackson-module-jakarta-xmlbind-annotations-$version$-sources.jar",
     "repository-url" : "https://github.com/FasterXML/jackson-modules-base",

--- a/stats/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.22.0/execution-metrics.json
+++ b/stats/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.22.0/execution-metrics.json
@@ -1,0 +1,99 @@
+{
+  "fix_javac_fail:2026-06-05": {
+    "timestamp": "2026-06-05T20:32:12.515693Z",
+    "library": "com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:2.22.0",
+    "starting_commit": "ce08a53c0198e2e542a9d6cd19bff8c55d499aa7",
+    "ending_commit": "240aaada909d046ee265a276b3c53db16e02501b",
+    "previous_library": "com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:2.18.5",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.22.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 3,
+        "totalCalls": 3
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 817,
+          "missed": 1868,
+          "ratio": 0.304283,
+          "total": 2685
+        },
+        "line": {
+          "covered": 208,
+          "missed": 456,
+          "ratio": 0.313253,
+          "total": 664
+        },
+        "method": {
+          "covered": 44,
+          "missed": 65,
+          "ratio": 0.40367,
+          "total": 109
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.18.5",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 3,
+        "totalCalls": 3
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 200,
+          "missed": 2475,
+          "ratio": 0.074766,
+          "total": 2675
+        },
+        "line": {
+          "covered": 52,
+          "missed": 612,
+          "ratio": 0.078313,
+          "total": 664
+        },
+        "method": {
+          "covered": 11,
+          "missed": 98,
+          "ratio": 0.100917,
+          "total": 109
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 57578,
+      "cached_input_tokens_used": 417792,
+      "output_tokens_used": 3866,
+      "iterations": 2,
+      "cost_usd": 0.3249,
+      "tested_library_loc": 208,
+      "metadata_entries": 7,
+      "previous_library_metadata_entries": 9,
+      "code_coverage_percent": 31.33,
+      "previous_library_coverage_percent": 7.83
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.22.0/src/test/java/com_fasterxml_jackson_module/jackson_module_jakarta_xmlbind_annotations/JakartaXmlBindAnnotationIntrospectorTest.java",
+      "metadata_file": "metadata/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.22.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.22.0/stats.json
+++ b/stats/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.22.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "2.22.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 3,
+          "totalCalls" : 3
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 3,
+      "totalCalls" : 3
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 817,
+        "missed" : 1868,
+        "ratio" : 0.304283,
+        "total" : 2685
+      },
+      "line" : {
+        "covered" : 208,
+        "missed" : 456,
+        "ratio" : 0.313253,
+        "total" : 664
+      },
+      "method" : {
+        "covered" : 44,
+        "missed" : 65,
+        "ratio" : 0.40367,
+        "total" : 109
+      }
+    }
+  } ]
+}

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.22.0/.gitignore
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.22.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.22.0/build.gradle
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.22.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.22.0/gradle.properties
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.22.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:2.22.0
+library.version = 2.22.0
+metadata.dir = com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.22.0/

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.22.0/settings.gradle
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.22.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.fasterxml.jackson.module.jackson-module-jakarta-xmlbind-annotations_tests'

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.22.0/src/test/java/com_fasterxml_jackson_module/jackson_module_jakarta_xmlbind_annotations/JakartaXmlBindAnnotationIntrospectorTest.java
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.22.0/src/test/java/com_fasterxml_jackson_module/jackson_module_jakarta_xmlbind_annotations/JakartaXmlBindAnnotationIntrospectorTest.java
@@ -13,9 +13,11 @@ import java.util.Collections;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.introspect.Annotated;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntrospector;
+import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationModule;
 import jakarta.activation.DataHandler;
 import jakarta.xml.bind.annotation.XmlEnumValue;
 import org.junit.jupiter.api.Test;
@@ -35,6 +37,19 @@ public class JakartaXmlBindAnnotationIntrospectorTest {
 
         assertThat(serializer).isNotNull();
         assertThat(deserializer).isInstanceOf(JsonDeserializer.class);
+    }
+
+    @Test
+    void resolvesEnumValuesFromXmlEnumValueAnnotations() throws Exception {
+        ObjectMapper mapper = new ObjectMapper().registerModule(new JakartaXmlBindAnnotationModule());
+
+        String activeValue = mapper.writeValueAsString(Status.ACTIVE);
+        String unknownValue = mapper.writeValueAsString(Status.UNKNOWN);
+        Status inactiveStatus = mapper.readValue("\"inactive-status\"", Status.class);
+
+        assertThat(activeValue).isEqualTo("\"active-status\"");
+        assertThat(unknownValue).isEqualTo("\"UNKNOWN\"");
+        assertThat(inactiveStatus).isEqualTo(Status.INACTIVE);
     }
 
     @Test

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.22.0/src/test/java/com_fasterxml_jackson_module/jackson_module_jakarta_xmlbind_annotations/JakartaXmlBindAnnotationIntrospectorTest.java
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.22.0/src/test/java/com_fasterxml_jackson_module/jackson_module_jakarta_xmlbind_annotations/JakartaXmlBindAnnotationIntrospectorTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_module.jackson_module_jakarta_xmlbind_annotations;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.util.Collections;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.introspect.Annotated;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntrospector;
+import jakarta.activation.DataHandler;
+import jakarta.xml.bind.annotation.XmlEnumValue;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JakartaXmlBindAnnotationIntrospectorTest {
+
+    @Test
+    void createsDefaultDataHandlerConverters() {
+        JakartaXmlBindAnnotationIntrospector introspector = new JakartaXmlBindAnnotationIntrospector(
+                TypeFactory.defaultInstance());
+        Annotated dataHandlerType = new RawTypeAnnotated(DataHandler.class);
+
+        JsonSerializer<?> serializer = introspector.findSerializer(dataHandlerType);
+        Object deserializer = introspector.findDeserializer(dataHandlerType);
+
+        assertThat(serializer).isNotNull();
+        assertThat(deserializer).isInstanceOf(JsonDeserializer.class);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void resolvesLegacyEnumValuesFromXmlEnumValueAnnotations() {
+        JakartaXmlBindAnnotationIntrospector introspector = new JakartaXmlBindAnnotationIntrospector(
+                TypeFactory.defaultInstance());
+        String[] names = new String[] {"ACTIVE", "INACTIVE", "UNKNOWN"};
+
+        String[] resolvedNames = introspector.findEnumValues(Status.class, Status.values(), names);
+
+        assertThat(resolvedNames).containsExactly("active-status", "inactive-status", "UNKNOWN");
+    }
+
+    private static final class RawTypeAnnotated extends Annotated {
+        private final Class<?> rawType;
+        private final JavaType type;
+
+        private RawTypeAnnotated(Class<?> rawType) {
+            this.rawType = rawType;
+            this.type = TypeFactory.defaultInstance().constructType(rawType);
+        }
+
+        @Override
+        public <A extends Annotation> A getAnnotation(Class<A> annotationClass) {
+            return null;
+        }
+
+        @Override
+        public boolean hasAnnotation(Class<?> annotationClass) {
+            return false;
+        }
+
+        @Override
+        public boolean hasOneOf(Class<? extends Annotation>[] annotationClasses) {
+            return false;
+        }
+
+        @Override
+        public AnnotatedElement getAnnotated() {
+            return rawType;
+        }
+
+        @Override
+        protected int getModifiers() {
+            return 0;
+        }
+
+        @Override
+        public String getName() {
+            return rawType.getName();
+        }
+
+        @Override
+        public JavaType getType() {
+            return type;
+        }
+
+        @Override
+        public Class<?> getRawType() {
+            return rawType;
+        }
+
+        @Override
+        public Iterable<Annotation> annotations() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (!(other instanceof RawTypeAnnotated)) {
+                return false;
+            }
+            RawTypeAnnotated that = (RawTypeAnnotated) other;
+            return rawType.equals(that.rawType);
+        }
+
+        @Override
+        public int hashCode() {
+            return rawType.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return rawType.getName();
+        }
+    }
+
+    private enum Status {
+        @XmlEnumValue("active-status")
+        ACTIVE,
+
+        @XmlEnumValue("inactive-status")
+        INACTIVE,
+
+        UNKNOWN
+    }
+}

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.22.0/user-code-filter.json
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.22.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.fasterxml.jackson.module.jakarta.xmlbind.**"
+    },
+    {
+      "includeClasses" : "com_fasterxml_jackson_module.jackson_module_jakarta_xmlbind_annotations.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7720

This PR provides test fixes and new metadata for com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:2.22.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 57578
- Cached input tokens: 417792
- Output tokens: 3866
- Metadata entries: 7
- Iterations: 2
- Library coverage percentage: 31.33
- Previous library version metadata entries: 9
- Previous library version coverage percentage: 7.83

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `03357419513e39cf0347ab3c21b1f671b36df8b1`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:2.18.5: 3/3 covered calls (100.00%)
- com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:2.22.0: 3/3 covered calls (100.00%)

**Reflection:**
- com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:2.18.5: 3/3 covered calls (100.00%)
- com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:2.22.0: 3/3 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:2.18.5: 200/2675 (7.48%)
- com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:2.22.0: 817/2685 (30.43%)

**Line:**
- com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:2.18.5: 52/664 (7.83%)
- com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:2.22.0: 208/664 (31.33%)

**Method:**
- com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:2.18.5: 11/109 (10.09%)
- com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:2.22.0: 44/109 (40.37%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.18.5/src/test/java/com_fasterxml_jackson_module/jackson_module_jakarta_xmlbind_annotations/JakartaXmlBindAnnotationIntrospectorTest.java 2/tests/src/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.22.0/src/test/java/com_fasterxml_jackson_module/jackson_module_jakarta_xmlbind_annotations/JakartaXmlBindAnnotationIntrospectorTest.java
index be78f24403..03973f5569 100644
--- 1/tests/src/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.18.5/src/test/java/com_fasterxml_jackson_module/jackson_module_jakarta_xmlbind_annotations/JakartaXmlBindAnnotationIntrospectorTest.java
+++ 2/tests/src/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.22.0/src/test/java/com_fasterxml_jackson_module/jackson_module_jakarta_xmlbind_annotations/JakartaXmlBindAnnotationIntrospectorTest.java
@@ -13,9 +13,11 @@ import java.util.Collections;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.introspect.Annotated;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntrospector;
+import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationModule;
 import jakarta.activation.DataHandler;
 import jakarta.xml.bind.annotation.XmlEnumValue;
 import org.junit.jupiter.api.Test;
@@ -37,6 +39,19 @@ public class JakartaXmlBindAnnotationIntrospectorTest {
         assertThat(deserializer).isInstanceOf(JsonDeserializer.class);
     }
 
+    @Test
+    void resolvesEnumValuesFromXmlEnumValueAnnotations() throws Exception {
+        ObjectMapper mapper = new ObjectMapper().registerModule(new JakartaXmlBindAnnotationModule());
+
+        String activeValue = mapper.writeValueAsString(Status.ACTIVE);
+        String unknownValue = mapper.writeValueAsString(Status.UNKNOWN);
+        Status inactiveStatus = mapper.readValue("\"inactive-status\"", Status.class);
+
+        assertThat(activeValue).isEqualTo("\"active-status\"");
+        assertThat(unknownValue).isEqualTo("\"UNKNOWN\"");
+        assertThat(inactiveStatus).isEqualTo(Status.INACTIVE);
+    }
+
     @Test
     @SuppressWarnings("deprecation")
     void resolvesLegacyEnumValuesFromXmlEnumValueAnnotations() {

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
