### PR TITLE
[GenAI] Test fix for org.fusesource.hawtjni:hawtjni-runtime:1.11 using gpt-5.5

### DIFF
--- a/metadata/org.fusesource.hawtjni/hawtjni-runtime/1.11/reachability-metadata.json
+++ b/metadata/org.fusesource.hawtjni/hawtjni-runtime/1.11/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.fusesource.hawtjni.runtime.Library"
+      },
+      "type": "java.lang.String[]"
+    }
+  ]
+}

--- a/metadata/org.fusesource.hawtjni/hawtjni-runtime/index.json
+++ b/metadata/org.fusesource.hawtjni/hawtjni-runtime/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.11",
+    "tested-versions" : [
+      "1.11"
+    ],
+    "allowed-packages" : [
+      "org.fusesource.hawtjni.runtime"
+    ]
+  },
+  {
     "metadata-version" : "1.9",
     "source-code-url" : "https://repo1.maven.org/maven2/org/fusesource/hawtjni/hawtjni-runtime/$version$/hawtjni-runtime-$version$-sources.jar",
     "repository-url" : "https://github.com/fusesource/hawtjni",

--- a/metadata/org.fusesource.hawtjni/hawtjni-runtime/index.json
+++ b/metadata/org.fusesource.hawtjni/hawtjni-runtime/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.11",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/fusesource/hawtjni/hawtjni-runtime/$version$/hawtjni-runtime-$version$-sources.jar",
+    "repository-url" : "https://github.com/fusesource/hawtjni",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/fusesource/hawtjni/hawtjni-runtime/$version$/hawtjni-runtime-$version$-javadoc.jar",
+    "description" : "HawtJNI Runtime provides the annotations and helper API that projects using HawtJNI compile against. It includes the runtime classes used to describe JNI bindings and load bundled native libraries from Java.",
     "tested-versions" : [
       "1.11"
     ],

--- a/stats/org.fusesource.hawtjni/hawtjni-runtime/1.11/execution-metrics.json
+++ b/stats/org.fusesource.hawtjni/hawtjni-runtime/1.11/execution-metrics.json
@@ -1,0 +1,99 @@
+{
+  "fix_java_run_fail:2026-06-05": {
+    "timestamp": "2026-06-05T21:09:14.422402Z",
+    "library": "org.fusesource.hawtjni:hawtjni-runtime:1.11",
+    "starting_commit": "0ce85012240c4ee1e7d1edba0165eb5222e27361",
+    "ending_commit": "2a686f2037793efdf9b6218dd89bf0df22367030",
+    "previous_library": "org.fusesource.hawtjni:hawtjni-runtime:1.9",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.11",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 228,
+          "missed": 1414,
+          "ratio": 0.138855,
+          "total": 1642
+        },
+        "line": {
+          "covered": 45,
+          "missed": 287,
+          "ratio": 0.135542,
+          "total": 332
+        },
+        "method": {
+          "covered": 14,
+          "missed": 44,
+          "ratio": 0.241379,
+          "total": 58
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.9",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 199,
+          "missed": 1408,
+          "ratio": 0.123833,
+          "total": 1607
+        },
+        "line": {
+          "covered": 43,
+          "missed": 284,
+          "ratio": 0.131498,
+          "total": 327
+        },
+        "method": {
+          "covered": 13,
+          "missed": 44,
+          "ratio": 0.22807,
+          "total": 57
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 21810,
+      "cached_input_tokens_used": 104448,
+      "output_tokens_used": 1236,
+      "iterations": 1,
+      "cost_usd": 0.0893,
+      "tested_library_loc": 45,
+      "metadata_entries": 1,
+      "previous_library_metadata_entries": 0,
+      "code_coverage_percent": 13.55,
+      "previous_library_coverage_percent": 13.15
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.fusesource.hawtjni/hawtjni-runtime/1.11/src/test/java/org_fusesource_hawtjni/hawtjni_runtime/LibraryTest.java",
+      "metadata_file": "metadata/org.fusesource.hawtjni/hawtjni-runtime/1.11/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.fusesource.hawtjni/hawtjni-runtime/1.11/stats.json
+++ b/stats/org.fusesource.hawtjni/hawtjni-runtime/1.11/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "1.11",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 1,
+      "totalCalls" : 1
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 228,
+        "missed" : 1414,
+        "ratio" : 0.138855,
+        "total" : 1642
+      },
+      "line" : {
+        "covered" : 45,
+        "missed" : 287,
+        "ratio" : 0.135542,
+        "total" : 332
+      },
+      "method" : {
+        "covered" : 14,
+        "missed" : 44,
+        "ratio" : 0.241379,
+        "total" : 58
+      }
+    }
+  } ]
+}

--- a/tests/src/org.fusesource.hawtjni/hawtjni-runtime/1.11/.gitignore
+++ b/tests/src/org.fusesource.hawtjni/hawtjni-runtime/1.11/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.fusesource.hawtjni/hawtjni-runtime/1.11/build.gradle
+++ b/tests/src/org.fusesource.hawtjni/hawtjni-runtime/1.11/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.fusesource.hawtjni:hawtjni-runtime:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.fusesource.hawtjni/hawtjni-runtime/1.11/gradle.properties
+++ b/tests/src/org.fusesource.hawtjni/hawtjni-runtime/1.11/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.fusesource.hawtjni:hawtjni-runtime:1.11
+library.version = 1.11
+metadata.dir = org.fusesource.hawtjni/hawtjni-runtime/1.11/

--- a/tests/src/org.fusesource.hawtjni/hawtjni-runtime/1.11/settings.gradle
+++ b/tests/src/org.fusesource.hawtjni/hawtjni-runtime/1.11/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.fusesource.hawtjni.hawtjni-runtime_tests'

--- a/tests/src/org.fusesource.hawtjni/hawtjni-runtime/1.11/src/test/java/org_fusesource_hawtjni/hawtjni_runtime/LibraryTest.java
+++ b/tests/src/org.fusesource.hawtjni/hawtjni-runtime/1.11/src/test/java/org_fusesource_hawtjni/hawtjni_runtime/LibraryTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_fusesource_hawtjni.hawtjni_runtime;
+
+import org.fusesource.hawtjni.runtime.Library;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class LibraryTest {
+    private static final String MISSING_LIBRARY_NAME = "hawtjni_runtime_coverage_probe_missing";
+
+    @Test
+    public void loadQueriesClasspathNativeLibraryResourcesWhenSystemLoadFails() {
+        RecordingClassLoader classLoader = new RecordingClassLoader();
+        Library library = new Library(MISSING_LIBRARY_NAME, null, classLoader);
+
+        UnsatisfiedLinkError error = assertThrows(UnsatisfiedLinkError.class, library::load);
+
+        assertThat(error).hasMessageContaining("Could not load library");
+        assertThat(classLoader.resourceNames()).containsExactly(
+                library.getPlatformSpecifcResourcePath(),
+                library.getOperatingSystemSpecifcResourcePath(),
+                library.getResorucePath());
+    }
+
+    private static final class RecordingClassLoader extends ClassLoader {
+        private final List<String> resourceNames = new ArrayList<>();
+
+        private RecordingClassLoader() {
+            super(null);
+        }
+
+        @Override
+        public URL getResource(String name) {
+            resourceNames.add(name);
+            return null;
+        }
+
+        private List<String> resourceNames() {
+            return resourceNames;
+        }
+    }
+}

--- a/tests/src/org.fusesource.hawtjni/hawtjni-runtime/1.11/src/test/java/org_fusesource_hawtjni/hawtjni_runtime/LibraryTest.java
+++ b/tests/src/org.fusesource.hawtjni/hawtjni-runtime/1.11/src/test/java/org_fusesource_hawtjni/hawtjni_runtime/LibraryTest.java
@@ -28,6 +28,7 @@ public class LibraryTest {
 
         assertThat(error).hasMessageContaining("Could not load library");
         assertThat(classLoader.resourceNames()).containsExactly(
+                library.getArchSpecifcResourcePath(),
                 library.getPlatformSpecifcResourcePath(),
                 library.getOperatingSystemSpecifcResourcePath(),
                 library.getResorucePath());

--- a/tests/src/org.fusesource.hawtjni/hawtjni-runtime/1.11/user-code-filter.json
+++ b/tests/src/org.fusesource.hawtjni/hawtjni-runtime/1.11/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.fusesource.hawtjni.runtime.**"
+    }
+  ]
+}

--- a/tests/src/org.fusesource.hawtjni/hawtjni-runtime/1.11/user-code-filter.json
+++ b/tests/src/org.fusesource.hawtjni/hawtjni-runtime/1.11/user-code-filter.json
@@ -5,6 +5,9 @@
     },
     {
       "includeClasses" : "org.fusesource.hawtjni.runtime.**"
+    },
+    {
+      "includeClasses" : "org_fusesource_hawtjni.hawtjni_runtime.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #4425

This PR provides test fixes and new metadata for org.fusesource.hawtjni:hawtjni-runtime:1.11, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 21810
- Cached input tokens: 104448
- Output tokens: 1236
- Metadata entries: 1
- Iterations: 1
- Library coverage percentage: 13.55
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 13.15

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `647e439f96c7a5e533f0d403760f5ced257ca2f2`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.fusesource.hawtjni:hawtjni-runtime:1.9: 1/1 covered calls (100.00%)
- org.fusesource.hawtjni:hawtjni-runtime:1.11: 1/1 covered calls (100.00%)

**Resources:**
- org.fusesource.hawtjni:hawtjni-runtime:1.9: 1/1 covered calls (100.00%)
- org.fusesource.hawtjni:hawtjni-runtime:1.11: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.fusesource.hawtjni:hawtjni-runtime:1.9: 199/1607 (12.38%)
- org.fusesource.hawtjni:hawtjni-runtime:1.11: 228/1642 (13.89%)

**Line:**
- org.fusesource.hawtjni:hawtjni-runtime:1.9: 43/327 (13.15%)
- org.fusesource.hawtjni:hawtjni-runtime:1.11: 45/332 (13.55%)

**Method:**
- org.fusesource.hawtjni:hawtjni-runtime:1.9: 13/57 (22.81%)
- org.fusesource.hawtjni:hawtjni-runtime:1.11: 14/58 (24.14%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.fusesource.hawtjni/hawtjni-runtime/1.9/src/test/java/org_fusesource_hawtjni/hawtjni_runtime/LibraryTest.java 2/tests/src/org.fusesource.hawtjni/hawtjni-runtime/1.11/src/test/java/org_fusesource_hawtjni/hawtjni_runtime/LibraryTest.java
index 6c9ac653c1..edce6bb9ba 100644
--- 1/tests/src/org.fusesource.hawtjni/hawtjni-runtime/1.9/src/test/java/org_fusesource_hawtjni/hawtjni_runtime/LibraryTest.java
+++ 2/tests/src/org.fusesource.hawtjni/hawtjni-runtime/1.11/src/test/java/org_fusesource_hawtjni/hawtjni_runtime/LibraryTest.java
@@ -28,6 +28,7 @@ public class LibraryTest {
 
         assertThat(error).hasMessageContaining("Could not load library");
         assertThat(classLoader.resourceNames()).containsExactly(
+                library.getArchSpecifcResourcePath(),
                 library.getPlatformSpecifcResourcePath(),
                 library.getOperatingSystemSpecifcResourcePath(),
                 library.getResorucePath());
diff --git 1/tests/src/org.fusesource.hawtjni/hawtjni-runtime/1.9/user-code-filter.json 2/tests/src/org.fusesource.hawtjni/hawtjni-runtime/1.11/user-code-filter.json
index 6f08ae6400..f5487c50b9 100644
--- 1/tests/src/org.fusesource.hawtjni/hawtjni-runtime/1.9/user-code-filter.json
+++ 2/tests/src/org.fusesource.hawtjni/hawtjni-runtime/1.11/user-code-filter.json
@@ -5,6 +5,9 @@
     },
     {
       "includeClasses" : "org.fusesource.hawtjni.runtime.**"
+    },
+    {
+      "includeClasses" : "org_fusesource_hawtjni.hawtjni_runtime.**"
     }
   ]
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
