### PR TITLE
[Automation] Generated metadata for io.netty:netty-codec-memcache:4.2.1.Final

### DIFF
--- a/metadata/io.netty/netty-codec-memcache/4.2.1.Final/reachability-metadata.json
+++ b/metadata/io.netty/netty-codec-memcache/4.2.1.Final/reachability-metadata.json
@@ -1,0 +1,55 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.memcache.binary.BinaryMemcacheRequestDecoder"
+      },
+      "type": "io.netty.buffer.AbstractByteBufAllocator",
+      "allDeclaredMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.memcache.binary.BinaryMemcacheRequestDecoder"
+      },
+      "type": "io.netty.util.AbstractReferenceCounted",
+      "fields": [
+        {
+          "name": "refCnt"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.memcache.binary.AbstractBinaryMemcacheEncoder"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueConsumerIndexField",
+      "fields": [
+        {
+          "name": "consumerIndex"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.memcache.binary.AbstractBinaryMemcacheEncoder"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerIndexField",
+      "fields": [
+        {
+          "name": "producerIndex"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.memcache.binary.AbstractBinaryMemcacheEncoder"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerLimitField",
+      "fields": [
+        {
+          "name": "producerLimit"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/io.netty/netty-codec-memcache/index.json
+++ b/metadata/io.netty/netty-codec-memcache/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "4.2.1.Final",
+    "test-version" : "4.1.74.Final",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-codec-memcache/$version$/netty-codec-memcache-$version$-sources.jar",
+    "repository-url" : "https://github.com/netty/netty",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-codec-memcache/$version$/netty-codec-memcache-$version$-test-sources.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-codec-memcache/$version$/netty-codec-memcache-$version$-javadoc.jar",
+    "description" : "Netty Codec Memcache provides encoders, decoders, message types, and aggregation support for the memcached binary and text protocols. It lets Netty-based clients and servers parse and produce Memcache requests and responses in asynchronous channel pipelines.",
+    "tested-versions" : [
+      "4.2.1.Final"
+    ],
+    "allowed-packages" : [
+      "io.netty.handler.codec.memcache"
+    ]
+  },
+  {
     "metadata-version" : "4.1.79.Final",
     "test-version" : "4.1.74.Final",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-codec-memcache/$version$/netty-codec-memcache-$version$-sources.jar",

--- a/stats/io.netty/netty-codec-memcache/4.2.1.Final/stats.json
+++ b/stats/io.netty/netty-codec-memcache/4.2.1.Final/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.2.1.Final",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1417,
+        "missed" : 552,
+        "ratio" : 0.719655,
+        "total" : 1969
+      },
+      "line" : {
+        "covered" : 372,
+        "missed" : 158,
+        "ratio" : 0.701887,
+        "total" : 530
+      },
+      "method" : {
+        "covered" : 109,
+        "missed" : 58,
+        "ratio" : 0.652695,
+        "total" : 167
+      }
+    }
+  } ]
+}

--- a/tests/src/io.netty/netty-codec-memcache/4.1.74.Final/build.gradle
+++ b/tests/src/io.netty/netty-codec-memcache/4.1.74.Final/build.gradle
@@ -15,6 +15,16 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
+tasks.named("nativeTest") {
+    if (libraryVersion == '4.2.1.Final') {
+        // Netty 4.2.x requires explicit unsafe access on Java 25 native runs.
+        runtimeArgs.addAll([
+                '-Dsun.misc.unsafe.memory.access=allow',
+                '-Dio.netty.tryReflectionSetAccessible=true'
+        ])
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#5595

This PR provides new metadata needed for the io.netty:netty-codec-memcache:4.2.1.Final, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `io.netty:netty-codec-memcache:4.1.74.Final`): 8
- Metadata entries (new `io.netty:netty-codec-memcache:4.2.1.Final`): 10
- Library coverage (previous): 70.19%
- Library coverage (new): 70.19%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `994959bcde866445a2ce0715127edbfd2b92e0d0`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.netty:netty-codec-memcache:4.1.74.Final: 0/0 covered calls (100.00%)
- io.netty:netty-codec-memcache:4.2.1.Final: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.netty:netty-codec-memcache:4.1.74.Final: 1417/1969 (71.97%)
- io.netty:netty-codec-memcache:4.2.1.Final: 1417/1969 (71.97%)

**Line:**
- io.netty:netty-codec-memcache:4.1.74.Final: 372/530 (70.19%)
- io.netty:netty-codec-memcache:4.2.1.Final: 372/530 (70.19%)

**Method:**
- io.netty:netty-codec-memcache:4.1.74.Final: 109/167 (65.27%)
- io.netty:netty-codec-memcache:4.2.1.Final: 109/167 (65.27%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
