### PR TITLE
[Automation] Generated metadata for com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.191.2

### DIFF
--- a/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.191.2/reachability-metadata.json
+++ b/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.191.2/reachability-metadata.json
@@ -1,0 +1,170 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type" : "com.google.api.FieldBehavior"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type" : "com.google.cloud.bigquery.storage.v1beta2.ArrowSchema"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type" : "com.google.cloud.bigquery.storage.v1beta2.AvroSchema"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type" : "com.google.cloud.bigquery.storage.v1beta2.DataFormat"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type" : "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type" : "com.google.cloud.bigquery.storage.v1beta2.ReadSession$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type" : "com.google.cloud.bigquery.storage.v1beta2.ReadSession$TableModifiers"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type" : "com.google.cloud.bigquery.storage.v1beta2.ReadSession$TableReadOptions"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type" : "com.google.cloud.bigquery.storage.v1beta2.ReadStream"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$EnforceNamingStyle"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$EnumType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$FieldPresence"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$JsonFormat"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$MessageEncoding"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$RepeatedFieldEncoding"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$Utf8Validation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$VisibilityFeature$DefaultSymbolVisibility"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.ReadRowsRequest"
+      },
+      "type" : "com.google.protobuf.ExtensionRegistry",
+      "methods" : [
+        {
+          "name" : "getEmptyRegistry",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type" : "com.google.protobuf.Timestamp"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.ReadRowsRequest"
+      },
+      "type" : "java.nio.Buffer",
+      "fields" : [
+        {
+          "name" : "address"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.ReadRowsRequest"
+      },
+      "type" : "libcore.io.Memory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.ReadRowsRequest"
+      },
+      "type" : "org.robolectric.Robolectric"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.ReadRowsRequest"
+      },
+      "type" : "sun.misc.Unsafe",
+      "fields" : [
+        {
+          "name" : "theUnsafe"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/index.json
+++ b/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "0.191.2",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1beta2/$version$/proto-google-cloud-bigquerystorage-v1beta2-$version$-sources.jar",
+    "repository-url" : "https://github.com/googleapis/java-bigquerystorage",
+    "test-code-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1beta2/$version$/proto-google-cloud-bigquerystorage-v1beta2-$version$-tests.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1beta2/$version$/proto-google-cloud-bigquerystorage-v1beta2-$version$-javadoc.jar",
+    "description" : "This artifact provides the Java Protocol Buffer message classes and descriptors for the BigQuery Storage API v1beta2. JVM and gRPC clients use it to serialize requests and responses for reading from and writing to BigQuery table storage.",
+    "test-version" : "0.186.1",
+    "tested-versions" : [
+      "0.191.2"
+    ],
+    "allowed-packages" : [
+      "com.google.cloud.bigquery.storage.v1beta2"
+    ]
+  },
+  {
     "metadata-version" : "0.186.1",
     "source-code-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1beta2/$version$/proto-google-cloud-bigquerystorage-v1beta2-$version$-sources.jar",
     "repository-url" : "https://github.com/googleapis/java-bigquerystorage",

--- a/stats/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.191.2/stats.json
+++ b/stats/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.191.2/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "0.191.2",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 15464,
+        "missed" : 23337,
+        "ratio" : 0.398546,
+        "total" : 38801
+      },
+      "line" : {
+        "covered" : 4283,
+        "missed" : 6344,
+        "ratio" : 0.40303,
+        "total" : 10627
+      },
+      "method" : {
+        "covered" : 1007,
+        "missed" : 1659,
+        "ratio" : 0.377719,
+        "total" : 2666
+      }
+    }
+  } ]
+}

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,138 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.api.FieldBehavior",
+      "methods" : [
+        {
+          "name" : "valueOf",
+          "parameterTypes" : [
+            "com.google.protobuf.Descriptors$EnumValueDescriptor"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FieldOptions"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FieldOptions$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FieldOptions$CType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FieldOptions$EditionDefault"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FieldOptions$FeatureSupport"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FieldOptions$JSType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FieldOptions$OptionRetention"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FieldOptions$OptionTargetType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FileOptions"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FileOptions$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FileOptions$OptimizeMode"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$MessageOptions"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$MessageOptions$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$MethodOptions"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$MethodOptions$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$MethodOptions$IdempotencyLevel"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$ServiceOptions"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$ServiceOptions$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$UninterpretedOption"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#5777

This PR provides new metadata needed for the com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.191.2, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.186.1`): 120
- Test-only metadata entries (previous `com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.186.1`): 22
- Metadata entries (new `com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.191.2`): 28
- Test-only metadata entries (new `com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.191.2`): 22
- Library coverage (previous): 38.80%
- Library coverage (new): 40.30%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `8af8997320646a04896aa588c1d722067e2bdbc5`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.186.1: 0/0 covered calls (100.00%)
- com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.191.2: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.186.1: 15203/40172 (37.84%)
- com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.191.2: 15464/38801 (39.85%)

**Line:**
- com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.186.1: 4217/10869 (38.80%)
- com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.191.2: 4283/10627 (40.30%)

**Method:**
- com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.186.1: 1009/2981 (33.85%)
- com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.191.2: 1007/2666 (37.77%)


### Human Intervention: Severe Metadata Drop

Forge detected a severe drop in reachability metadata entries for this Native Image run fix. This PR needs human review unless the branch includes concrete proof that the new library version no longer needs the removed registrations.

- Previous metadata entries (`com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.186.1`): 120
- New metadata entries (`com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.191.2`): 28
- Retained metadata entries: 23.33%
### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
