### PR TITLE
[GenAI] Test fix for com.squareup.okio:okio-jvm:3.6.0 using gpt-5.5

### DIFF
--- a/metadata/com.squareup.okio/okio-jvm/3.6.0/reachability-metadata.json
+++ b/metadata/com.squareup.okio/okio-jvm/3.6.0/reachability-metadata.json
@@ -1,0 +1,11 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "okio.ByteString"
+      },
+      "type" : "okio.ByteString",
+      "serializable" : true
+    }
+  ]
+}

--- a/metadata/com.squareup.okio/okio-jvm/index.json
+++ b/metadata/com.squareup.okio/okio-jvm/index.json
@@ -1,6 +1,19 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.6.0",
+    "language" : {
+      "name" : "kotlin",
+      "version" : "1.5"
+    },
+    "tested-versions" : [
+      "3.6.0"
+    ],
+    "allowed-packages" : [
+      "okio"
+    ]
+  },
+  {
     "metadata-version" : "3.0.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/com/squareup/okio/okio-jvm/$version$/okio-jvm-$version$-sources.jar",
     "repository-url" : "https://github.com/square/okio",

--- a/metadata/com.squareup.okio/okio-jvm/index.json
+++ b/metadata/com.squareup.okio/okio-jvm/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "3.6.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/squareup/okio/okio-jvm/$version$/okio-jvm-$version$-sources.jar",
+    "repository-url" : "https://github.com/square/okio",
+    "test-code-url" : "https://github.com/square/okio/tree/parent-$version$/okio/src/jvmTest",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/squareup/okio/okio-jvm/$version$/okio-jvm-$version$-javadoc.jar",
+    "description" : "Okio is a Kotlin/JVM I/O library that provides buffered sources, sinks, file-system APIs, byte strings, and compression utilities. It is designed as a modern, efficient layer over Java I/O for reading, writing, and transforming byte streams.",
     "language" : {
       "name" : "kotlin",
       "version" : "1.5"

--- a/stats/com.squareup.okio/okio-jvm/3.6.0/execution-metrics.json
+++ b/stats/com.squareup.okio/okio-jvm/3.6.0/execution-metrics.json
@@ -1,0 +1,109 @@
+{
+  "fix_java_run_fail:2026-06-06": {
+    "timestamp": "2026-06-06T00:45:30.751868Z",
+    "library": "com.squareup.okio:okio-jvm:3.6.0",
+    "starting_commit": "e3895add1345d0f82976415d4539af69355dfbdf",
+    "ending_commit": "936c6e9a7bed6de90f5915cd9b1f0b6ec75d3923",
+    "previous_library": "com.squareup.okio:okio-jvm:3.0.0",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.6.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 4,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1952,
+          "missed": 18857,
+          "ratio": 0.093806,
+          "total": 20809
+        },
+        "line": {
+          "covered": 567,
+          "missed": 4236,
+          "ratio": 0.118051,
+          "total": 4803
+        },
+        "method": {
+          "covered": 189,
+          "missed": 975,
+          "ratio": 0.162371,
+          "total": 1164
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.0.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 3,
+        "totalCalls": 3
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2094,
+          "missed": 19411,
+          "ratio": 0.097373,
+          "total": 21505
+        },
+        "line": {
+          "covered": 560,
+          "missed": 4049,
+          "ratio": 0.121501,
+          "total": 4609
+        },
+        "method": {
+          "covered": 188,
+          "missed": 940,
+          "ratio": 0.166667,
+          "total": 1128
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 19984,
+      "cached_input_tokens_used": 113152,
+      "output_tokens_used": 1217,
+      "iterations": 1,
+      "cost_usd": 0.0931,
+      "tested_library_loc": 567,
+      "metadata_entries": 2,
+      "previous_library_metadata_entries": 2,
+      "code_coverage_percent": 11.81,
+      "previous_library_coverage_percent": 12.15
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.squareup.okio/okio-jvm/3.6.0/src/test/kotlin/com_squareup_okio/okio_jvm/ResourceFileSystemInnerCompanionTest.kt",
+      "metadata_file": "metadata/com.squareup.okio/okio-jvm/3.6.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.squareup.okio/okio-jvm/3.6.0/stats.json
+++ b/stats/com.squareup.okio/okio-jvm/3.6.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "3.6.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 3,
+          "totalCalls" : 3
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 4,
+      "totalCalls" : 4
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1952,
+        "missed" : 18857,
+        "ratio" : 0.093806,
+        "total" : 20809
+      },
+      "line" : {
+        "covered" : 567,
+        "missed" : 4236,
+        "ratio" : 0.118051,
+        "total" : 4803
+      },
+      "method" : {
+        "covered" : 189,
+        "missed" : 975,
+        "ratio" : 0.162371,
+        "total" : 1164
+      }
+    }
+  } ]
+}

--- a/tests/src/com.squareup.okio/okio-jvm/3.6.0/.gitignore
+++ b/tests/src/com.squareup.okio/okio-jvm/3.6.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.squareup.okio/okio-jvm/3.6.0/build.gradle
+++ b/tests/src/com.squareup.okio/okio-jvm/3.6.0/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.squareup.okio:okio-jvm:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "21"
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.squareup.okio/okio-jvm/3.6.0/gradle.properties
+++ b/tests/src/com.squareup.okio/okio-jvm/3.6.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.squareup.okio:okio-jvm:3.6.0
+library.version = 3.6.0
+metadata.dir = com.squareup.okio/okio-jvm/3.6.0/

--- a/tests/src/com.squareup.okio/okio-jvm/3.6.0/settings.gradle
+++ b/tests/src/com.squareup.okio/okio-jvm/3.6.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.squareup.okio.okio-jvm_tests'

--- a/tests/src/com.squareup.okio/okio-jvm/3.6.0/src/test/kotlin/com_squareup_okio/okio_jvm/Okio_jvmTest.kt
+++ b/tests/src/com.squareup.okio/okio-jvm/3.6.0/src/test/kotlin/com_squareup_okio/okio_jvm/Okio_jvmTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_squareup_okio.okio_jvm
+
+import okio.ByteString
+import okio.ByteString.Companion.encodeUtf8
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
+
+class Okio_jvmTest {
+    @Test
+    fun deserializesSerializedByteString(): Unit {
+        val original: ByteString = "ByteString serialization preserves data".encodeUtf8()
+
+        val restored: ByteString = deserialize(serialize(original))
+
+        assertThat(restored).isEqualTo(original)
+        assertThat(restored.utf8()).isEqualTo(original.utf8())
+        assertThat(restored.toByteArray()).containsExactly(*original.toByteArray())
+    }
+
+    private fun serialize(value: ByteString): ByteArray {
+        val outputStream = ByteArrayOutputStream()
+
+        ObjectOutputStream(outputStream).use { objectOutputStream ->
+            objectOutputStream.writeObject(value)
+        }
+
+        return outputStream.toByteArray()
+    }
+
+    private fun deserialize(serialized: ByteArray): ByteString {
+        ObjectInputStream(ByteArrayInputStream(serialized)).use { objectInputStream ->
+            return objectInputStream.readObject() as ByteString
+        }
+    }
+}

--- a/tests/src/com.squareup.okio/okio-jvm/3.6.0/src/test/kotlin/com_squareup_okio/okio_jvm/ResourceFileSystemInnerCompanionTest.kt
+++ b/tests/src/com.squareup.okio/okio-jvm/3.6.0/src/test/kotlin/com_squareup_okio/okio_jvm/ResourceFileSystemInnerCompanionTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_squareup_okio.okio_jvm
+
+import okio.FileSystem
+import okio.Path.Companion.toPath
+import okio.asResourceFileSystem
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.net.URL
+import java.nio.file.Files
+import java.nio.file.Path as NioPath
+import java.util.Collections
+import java.util.Enumeration
+
+public class ResourceFileSystemInnerCompanionTest {
+    @Test
+    fun classLoaderResourceFileSystemIndexesClasspathRoots(@TempDir temporaryDirectory: NioPath): Unit {
+        Files.writeString(temporaryDirectory.resolve("okio-resource-file-system.txt"), "indexed resource")
+        Files.createDirectories(temporaryDirectory.resolve("META-INF"))
+        Files.writeString(temporaryDirectory.resolve("META-INF").resolve("MANIFEST.MF"), "Manifest-Version: 1.0\n")
+
+        val classLoader: ClassLoader = DirectoryResourceClassLoader(temporaryDirectory)
+        val resources: FileSystem = classLoader.asResourceFileSystem()
+
+        val content: String = resources.read("/okio-resource-file-system.txt".toPath()) {
+            readUtf8()
+        }
+
+        assertThat(content).isEqualTo("indexed resource")
+        assertThat(resources.list("/".toPath()))
+            .contains("/okio-resource-file-system.txt".toPath(), "/META-INF".toPath())
+    }
+
+    private class DirectoryResourceClassLoader(
+        private val root: NioPath,
+    ) : ClassLoader(null) {
+        override fun findResources(name: String): Enumeration<URL> {
+            val urls: List<URL> = when (name) {
+                "" -> listOf(root.toUri().toURL())
+                "META-INF/MANIFEST.MF" -> listOf(root.resolve(name).toUri().toURL())
+                else -> {
+                    val candidate: NioPath = root.resolve(name)
+                    if (Files.exists(candidate)) listOf(candidate.toUri().toURL()) else emptyList()
+                }
+            }
+            return Collections.enumeration(urls)
+        }
+    }
+}

--- a/tests/src/com.squareup.okio/okio-jvm/3.6.0/src/test/kotlin/com_squareup_okio/okio_jvm/ResourceFileSystemInnerCompanionTest.kt
+++ b/tests/src/com.squareup.okio/okio-jvm/3.6.0/src/test/kotlin/com_squareup_okio/okio_jvm/ResourceFileSystemInnerCompanionTest.kt
@@ -40,16 +40,19 @@ public class ResourceFileSystemInnerCompanionTest {
     private class DirectoryResourceClassLoader(
         private val root: NioPath,
     ) : ClassLoader(null) {
+        override fun findResource(name: String): URL? = resourceUrl(name)
+
         override fun findResources(name: String): Enumeration<URL> {
             val urls: List<URL> = when (name) {
                 "" -> listOf(root.toUri().toURL())
-                "META-INF/MANIFEST.MF" -> listOf(root.resolve(name).toUri().toURL())
-                else -> {
-                    val candidate: NioPath = root.resolve(name)
-                    if (Files.exists(candidate)) listOf(candidate.toUri().toURL()) else emptyList()
-                }
+                else -> listOfNotNull(resourceUrl(name))
             }
             return Collections.enumeration(urls)
+        }
+
+        private fun resourceUrl(name: String): URL? {
+            val candidate: NioPath = root.resolve(name)
+            return if (Files.exists(candidate)) candidate.toUri().toURL() else null
         }
     }
 }

--- a/tests/src/com.squareup.okio/okio-jvm/3.6.0/user-code-filter.json
+++ b/tests/src/com.squareup.okio/okio-jvm/3.6.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "okio.**"
+    },
+    {
+      "includeClasses" : "com_squareup_okio.okio_jvm.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #5878

This PR provides test fixes and new metadata for com.squareup.okio:okio-jvm:3.6.0, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 19984
- Cached input tokens: 113152
- Output tokens: 1217
- Metadata entries: 2
- Iterations: 1
- Library coverage percentage: 11.81
- Previous library version metadata entries: 2
- Previous library version coverage percentage: 12.15

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `8af8997320646a04896aa588c1d722067e2bdbc5`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.squareup.okio:okio-jvm:3.0.0: 3/3 covered calls (100.00%)
- com.squareup.okio:okio-jvm:3.6.0: 4/4 covered calls (100.00%)

**Reflection:**
- com.squareup.okio:okio-jvm:3.0.0: 1/1 covered calls (100.00%)
- com.squareup.okio:okio-jvm:3.6.0: 1/1 covered calls (100.00%)

**Resources:**
- com.squareup.okio:okio-jvm:3.0.0: 2/2 covered calls (100.00%)
- com.squareup.okio:okio-jvm:3.6.0: 3/3 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.squareup.okio:okio-jvm:3.0.0: 2094/21505 (9.74%)
- com.squareup.okio:okio-jvm:3.6.0: 1952/20809 (9.38%)

**Line:**
- com.squareup.okio:okio-jvm:3.0.0: 560/4609 (12.15%)
- com.squareup.okio:okio-jvm:3.6.0: 567/4803 (11.81%)

**Method:**
- com.squareup.okio:okio-jvm:3.0.0: 188/1128 (16.67%)
- com.squareup.okio:okio-jvm:3.6.0: 189/1164 (16.24%)

**Comparison between existing test version and AI-Generated update**

```diff

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
