### PR TITLE
[GenAI] Test fix for com.typesafe.akka:akka-protobuf-v3_2.13:2.9.0-M1 using gpt-5.5

### DIFF
--- a/metadata/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/reachability-metadata.json
+++ b/metadata/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/reachability-metadata.json
@@ -1,0 +1,304 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.GeneratedMessageLite$SerializedForm"
+      },
+      "type" : "akka.protobufv3.internal.GeneratedMessageLite$SerializedForm",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.GeneratedMessageLite$SerializedForm"
+      },
+      "type" : "java.lang.String",
+      "fields" : [
+        {
+          "name" : "serialVersionUID"
+        },
+        {
+          "name" : "serialPersistentFields"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.GeneratedMessage"
+      },
+      "type" : "akka.protobufv3.internal.DescriptorProtos$FieldDescriptorProto$Type",
+      "methods" : [
+        {
+          "name" : "getValueDescriptor",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "valueOf",
+          "parameterTypes" : [
+            "akka.protobufv3.internal.Descriptors$EnumValueDescriptor"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.GeneratedMessageV3"
+      },
+      "type" : "akka.protobufv3.internal.DescriptorProtos$FieldDescriptorProto",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.GeneratedMessageV3"
+      },
+      "type" : "akka.protobufv3.internal.DescriptorProtos$FieldDescriptorProto$Builder",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.GeneratedMessageV3"
+      },
+      "type" : "akka.protobufv3.internal.DescriptorProtos$FieldDescriptorProto$Label",
+      "methods" : [
+        {
+          "name" : "getValueDescriptor",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "valueOf",
+          "parameterTypes" : [
+            "akka.protobufv3.internal.Descriptors$EnumValueDescriptor"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.GeneratedMessageV3"
+      },
+      "type" : "akka.protobufv3.internal.DescriptorProtos$FieldDescriptorProto$Type",
+      "methods" : [
+        {
+          "name" : "getValueDescriptor",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "valueOf",
+          "parameterTypes" : [
+            "akka.protobufv3.internal.Descriptors$EnumValueDescriptor"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.GeneratedMessageV3"
+      },
+      "type" : "akka.protobufv3.internal.DescriptorProtos$FieldOptions",
+      "methods" : [
+        {
+          "name" : "newBuilder",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.ExtensionRegistryLite"
+      },
+      "type" : "akka.protobufv3.internal.ExtensionRegistry",
+      "methods" : [
+        {
+          "name" : "add",
+          "parameterTypes" : [
+            "akka.protobufv3.internal.Extension"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.GeneratedMessageLite"
+      },
+      "type" : "akka.protobufv3.internal.GeneratedMessageLiteTestSupport",
+      "methods" : [
+        {
+          "name" : "publicAccessor",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.Internal"
+      },
+      "type" : "akka.protobufv3.internal.Empty",
+      "methods" : [
+        {
+          "name" : "getDefaultInstance",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.ExtensionSchemas"
+      },
+      "type" : "akka.protobufv3.internal.ExtensionSchemaFull",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.ExtensionRegistryFactory"
+      },
+      "type" : "akka.protobufv3.internal.ExtensionRegistry",
+      "methods" : [
+        {
+          "name" : "getEmptyRegistry",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "newInstance",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.ExtensionSchemaFull"
+      },
+      "type" : "akka.protobufv3.internal.GeneratedMessageV3$ExtendableMessage",
+      "fields" : [
+        {
+          "name" : "extensions"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.UnsafeUtil"
+      },
+      "type" : "java.nio.Buffer",
+      "fields" : [
+        {
+          "name" : "address"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.UnsafeUtil"
+      },
+      "type" : "libcore.io.Memory",
+      "methods" : [
+        {
+          "name" : "peekLong",
+          "parameterTypes" : [
+            "long",
+            "boolean"
+          ]
+        },
+        {
+          "name" : "pokeLong",
+          "parameterTypes" : [
+            "long",
+            "long",
+            "boolean"
+          ]
+        },
+        {
+          "name" : "pokeInt",
+          "parameterTypes" : [
+            "long",
+            "int",
+            "boolean"
+          ]
+        },
+        {
+          "name" : "peekInt",
+          "parameterTypes" : [
+            "long",
+            "boolean"
+          ]
+        },
+        {
+          "name" : "pokeByte",
+          "parameterTypes" : [
+            "long",
+            "byte"
+          ]
+        },
+        {
+          "name" : "peekByte",
+          "parameterTypes" : [
+            "long"
+          ]
+        },
+        {
+          "name" : "pokeByteArray",
+          "parameterTypes" : [
+            "long",
+            "byte[]",
+            "int",
+            "int"
+          ]
+        },
+        {
+          "name" : "peekByteArray",
+          "parameterTypes" : [
+            "long",
+            "byte[]",
+            "int",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.UnsafeUtil"
+      },
+      "type" : "sun.misc.Unsafe"
+    },
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.UnsafeUtil$1"
+      },
+      "type" : "sun.misc.Unsafe",
+      "fields" : [
+        {
+          "name" : "theUnsafe"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.ByteBufferWriter"
+      },
+      "type" : "java.io.FileOutputStream",
+      "fields" : [
+        {
+          "name" : "channel"
+        }
+      ]
+    }
+  ],
+  "serialization" : [
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.GeneratedMessageLite$SerializedForm"
+      },
+      "type" : "java.lang.String"
+    },
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.GeneratedMessageLite$SerializedForm"
+      },
+      "type" : "akka.protobufv3.internal.GeneratedMessageLite$SerializedForm"
+    }
+  ]
+}

--- a/metadata/com.typesafe.akka/akka-protobuf-v3_2.13/index.json
+++ b/metadata/com.typesafe.akka/akka-protobuf-v3_2.13/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.9.0-M1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/typesafe/akka/akka-protobuf-v3_2.13/$version$/akka-protobuf-v3_2.13-$version$-sources.jar",
+    "repository-url" : "https://github.com/akka/akka",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/typesafe/akka/akka-protobuf-v3_2.13/$version$/akka-protobuf-v3_2.13-$version$-javadoc.jar",
+    "description" : "akka-protobuf-v3 is Akka's shaded copy of the Google Protocol Buffers v3 Java runtime, relocated under akka.protobufv3.internal for Akka internals. It lets Akka modules parse, build, and serialize protobuf messages without exposing or conflicting with an application's own protobuf-java dependency.",
     "language" : {
       "name" : "scala",
       "version" : "2"

--- a/metadata/com.typesafe.akka/akka-protobuf-v3_2.13/index.json
+++ b/metadata/com.typesafe.akka/akka-protobuf-v3_2.13/index.json
@@ -1,6 +1,19 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.9.0-M1",
+    "language" : {
+      "name" : "scala",
+      "version" : "2"
+    },
+    "tested-versions" : [
+      "2.9.0-M1"
+    ],
+    "allowed-packages" : [
+      "akka.protobufv3.internal"
+    ]
+  },
+  {
     "metadata-version" : "2.8.8",
     "source-code-url" : "https://repo.maven.apache.org/maven2/com/typesafe/akka/akka-protobuf-v3_2.13/$version$/akka-protobuf-v3_2.13-$version$-sources.jar",
     "repository-url" : "https://github.com/akka/akka-core",

--- a/stats/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/execution-metrics.json
+++ b/stats/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/execution-metrics.json
@@ -1,0 +1,101 @@
+{
+  "fix_java_run_fail:2026-06-06": {
+    "timestamp": "2026-06-06T01:18:48.151473Z",
+    "library": "com.typesafe.akka:akka-protobuf-v3_2.13:2.9.0-M1",
+    "starting_commit": "bc81204f105ccdb114b7d52a51e903fe0e80444d",
+    "ending_commit": "7181e1785ec47d76498cf97e1a8547effbe8f93e",
+    "previous_library": "com.typesafe.akka:akka-protobuf-v3_2.13:2.8.8",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.9.0-M1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 56,
+            "totalCalls": 56
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 56,
+        "totalCalls": 56
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 16597,
+          "missed": 177349,
+          "ratio": 0.085575,
+          "total": 193946
+        },
+        "line": {
+          "covered": 3633,
+          "missed": 43829,
+          "ratio": 0.076545,
+          "total": 47462
+        },
+        "method": {
+          "covered": 854,
+          "missed": 9330,
+          "ratio": 0.083857,
+          "total": 10184
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.8.8",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 56,
+            "totalCalls": 56
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 56,
+        "totalCalls": 56
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 17715,
+          "missed": 175080,
+          "ratio": 0.091885,
+          "total": 192795
+        },
+        "line": {
+          "covered": 3960,
+          "missed": 43135,
+          "ratio": 0.084085,
+          "total": 47095
+        },
+        "method": {
+          "covered": 934,
+          "missed": 9203,
+          "ratio": 0.092138,
+          "total": 10137
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 22776,
+      "cached_input_tokens_used": 174080,
+      "output_tokens_used": 1781,
+      "iterations": 1,
+      "cost_usd": 0.1404,
+      "tested_library_loc": 3633,
+      "metadata_entries": 49,
+      "test_only_metadata_entries": 27,
+      "previous_library_metadata_entries": 41,
+      "previous_library_test_only_metadata_entries": 27,
+      "code_coverage_percent": 7.65,
+      "previous_library_coverage_percent": 8.41
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/ExtensionSchemasTest.scala",
+      "metadata_file": "metadata/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/stats.json
+++ b/stats/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "2.9.0-M1",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 56,
+          "totalCalls" : 56
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 56,
+      "totalCalls" : 56
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 16597,
+        "missed" : 177349,
+        "ratio" : 0.085575,
+        "total" : 193946
+      },
+      "line" : {
+        "covered" : 3633,
+        "missed" : 43829,
+        "ratio" : 0.076545,
+        "total" : 47462
+      },
+      "method" : {
+        "covered" : 854,
+        "missed" : 9330,
+        "ratio" : 0.083857,
+        "total" : 10184
+      }
+    }
+  } ]
+}

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/.gitignore
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/build.gradle
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.typesafe.akka:akka-protobuf-v3_2.13:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala-library:2.13.16'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/gradle.properties
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.typesafe.akka:akka-protobuf-v3_2.13:2.9.0-M1
+library.version = 2.9.0-M1
+metadata.dir = com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/settings.gradle
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.typesafe.akka.akka-protobuf-v3_2.13_tests'

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/java/akka/protobufv3/internal/GeneratedMessageLiteTestSupport.java
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/java/akka/protobufv3/internal/GeneratedMessageLiteTestSupport.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package akka.protobufv3.internal;
+
+import java.lang.reflect.Method;
+
+public final class GeneratedMessageLiteTestSupport {
+    private GeneratedMessageLiteTestSupport() {
+    }
+
+    public static boolean lookupDefaultInstanceInitializesGeneratedMessageClass() {
+        GeneratedMessageLite<?, ?> defaultInstance =
+                GeneratedMessageLite.getDefaultInstance(UninitializedDefaultInstanceMessage.class);
+        return defaultInstance == UninitializedDefaultInstanceMessage.defaultInstance();
+    }
+
+    public static String invokePublicAccessorThroughGeneratedMessageLite() {
+        Method method = GeneratedMessageLite.getMethodOrDie(GeneratedMessageLiteTestSupport.class, "publicAccessor");
+        return (String) GeneratedMessageLite.invokeOrDie(method, null);
+    }
+
+    public static String publicAccessor() {
+        return "invoked through GeneratedMessageLite";
+    }
+}
+
+final class UninitializedDefaultInstanceMessage extends GeneratedMessageLite<
+        UninitializedDefaultInstanceMessage, UninitializedDefaultInstanceMessage.Builder> {
+    private static final UninitializedDefaultInstanceMessage DEFAULT_INSTANCE;
+    private static volatile Parser<UninitializedDefaultInstanceMessage> PARSER;
+
+    static {
+        DEFAULT_INSTANCE = new UninitializedDefaultInstanceMessage();
+        registerDefaultInstance(UninitializedDefaultInstanceMessage.class, DEFAULT_INSTANCE);
+    }
+
+    private UninitializedDefaultInstanceMessage() {
+    }
+
+    static UninitializedDefaultInstanceMessage defaultInstance() {
+        return DEFAULT_INSTANCE;
+    }
+
+    @Override
+    protected Object dynamicMethod(MethodToInvoke method, Object arg0, Object arg1) {
+        switch (method) {
+            case NEW_MUTABLE_INSTANCE:
+                return new UninitializedDefaultInstanceMessage();
+            case NEW_BUILDER:
+                return new Builder();
+            case BUILD_MESSAGE_INFO:
+                return newMessageInfo(DEFAULT_INSTANCE, "\u0000\u0000", new Object[0]);
+            case GET_DEFAULT_INSTANCE:
+                return DEFAULT_INSTANCE;
+            case GET_PARSER:
+                return parser();
+            case GET_MEMOIZED_IS_INITIALIZED:
+                return (byte) 1;
+            case SET_MEMOIZED_IS_INITIALIZED:
+                return null;
+            default:
+                throw new UnsupportedOperationException("Unsupported GeneratedMessageLite method: " + method);
+        }
+    }
+
+    private static Parser<UninitializedDefaultInstanceMessage> parser() {
+        Parser<UninitializedDefaultInstanceMessage> result = PARSER;
+        if (result == null) {
+            synchronized (UninitializedDefaultInstanceMessage.class) {
+                result = PARSER;
+                if (result == null) {
+                    result = new GeneratedMessageLite.DefaultInstanceBasedParser<>(DEFAULT_INSTANCE);
+                    PARSER = result;
+                }
+            }
+        }
+        return result;
+    }
+
+    static final class Builder extends GeneratedMessageLite.Builder<UninitializedDefaultInstanceMessage, Builder> {
+        private Builder() {
+            super(DEFAULT_INSTANCE);
+        }
+    }
+}

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/java/com_typesafe_akka/akka_protobuf_v3_2_13/BrokenRawInfoLiteMessage.java
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/java/com_typesafe_akka/akka_protobuf_v3_2_13/BrokenRawInfoLiteMessage.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_akka.akka_protobuf_v3_2_13;
+
+import akka.protobufv3.internal.GeneratedMessageLite;
+import akka.protobufv3.internal.GeneratedMessageLite.MethodToInvoke;
+
+public final class BrokenRawInfoLiteMessage extends GeneratedMessageLite<
+        BrokenRawInfoLiteMessage, BrokenRawInfoLiteMessage.Builder> {
+    private static final String MALFORMED_FIELD_INFO = new String(
+            new char[] {0, 1, 0, 0, 1, 1, 1, 0, 0, 0, 1, 4}
+    );
+    private static final BrokenRawInfoLiteMessage DEFAULT_INSTANCE;
+    private int value_;
+
+    static {
+        DEFAULT_INSTANCE = new BrokenRawInfoLiteMessage();
+        registerDefaultInstance(BrokenRawInfoLiteMessage.class, DEFAULT_INSTANCE);
+    }
+
+    private BrokenRawInfoLiteMessage() {
+    }
+
+    public static BrokenRawInfoLiteMessage defaultInstance() {
+        return DEFAULT_INSTANCE;
+    }
+
+    @Override
+    protected Object dynamicMethod(MethodToInvoke method, Object firstArgument, Object secondArgument) {
+        switch (method) {
+            case NEW_MUTABLE_INSTANCE:
+                return new BrokenRawInfoLiteMessage();
+            case NEW_BUILDER:
+                return new Builder();
+            case BUILD_MESSAGE_INFO:
+                return newMessageInfo(DEFAULT_INSTANCE, MALFORMED_FIELD_INFO, new Object[] {"missing_"});
+            case GET_DEFAULT_INSTANCE:
+                return DEFAULT_INSTANCE;
+            case GET_PARSER:
+                return null;
+            case GET_MEMOIZED_IS_INITIALIZED:
+                return (byte) 1;
+            case SET_MEMOIZED_IS_INITIALIZED:
+                return null;
+            default:
+                throw new UnsupportedOperationException("Unsupported GeneratedMessageLite method: " + method);
+        }
+    }
+
+    public static final class Builder extends GeneratedMessageLite.Builder<BrokenRawInfoLiteMessage, Builder> {
+        private Builder() {
+            super(DEFAULT_INSTANCE);
+        }
+    }
+}

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/java/com_typesafe_akka/akka_protobuf_v3_2_13/GeneratedDescriptorDependency.java
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/java/com_typesafe_akka/akka_protobuf_v3_2_13/GeneratedDescriptorDependency.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_akka.akka_protobuf_v3_2_13;
+
+import akka.protobufv3.internal.DescriptorProtos;
+import akka.protobufv3.internal.Descriptors;
+
+public final class GeneratedDescriptorDependency {
+    @SuppressWarnings("checkstyle:ConstantName")
+    public static final Descriptors.FileDescriptor descriptor = buildDescriptor();
+
+    private GeneratedDescriptorDependency() {
+    }
+
+    private static Descriptors.FileDescriptor buildDescriptor() {
+        DescriptorProtos.FileDescriptorProto proto = DescriptorProtos.FileDescriptorProto.newBuilder()
+                .setName("coverage/dependency.proto")
+                .setPackage("coverage.dependency")
+                .addMessageType(DescriptorProtos.DescriptorProto.newBuilder()
+                        .setName("DependencyMessage")
+                        .build())
+                .addMessageType(DescriptorProtos.DescriptorProto.newBuilder()
+                        .setName("ExtensibleMessage")
+                        .addExtensionRange(DescriptorProtos.DescriptorProto.ExtensionRange.newBuilder()
+                                .setStart(100)
+                                .setEnd(536870912)
+                                .build())
+                        .build())
+                .addExtension(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                        .setName("covered_extension")
+                        .setNumber(100)
+                        .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL)
+                        .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING)
+                        .setExtendee(".coverage.dependency.ExtensibleMessage")
+                        .build())
+                .build();
+
+        try {
+            return Descriptors.FileDescriptor.buildFrom(proto, new Descriptors.FileDescriptor[0]);
+        } catch (Descriptors.DescriptorValidationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+}

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/java/com_typesafe_akka/akka_protobuf_v3_2_13/Proto2FullRuntimeMessage.java
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/java/com_typesafe_akka/akka_protobuf_v3_2_13/Proto2FullRuntimeMessage.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_akka.akka_protobuf_v3_2_13;
+
+import akka.protobufv3.internal.CodedInputStream;
+import akka.protobufv3.internal.DescriptorProtos;
+import akka.protobufv3.internal.Descriptors;
+import akka.protobufv3.internal.ExtensionRegistryLite;
+import akka.protobufv3.internal.GeneratedMessageV3;
+import akka.protobufv3.internal.InvalidProtocolBufferException;
+import akka.protobufv3.internal.Message;
+
+/**
+ * Minimal proto2 full-runtime message used to drive schema creation through public/protected APIs.
+ */
+public final class Proto2FullRuntimeMessage extends GeneratedMessageV3 {
+    private static final Descriptors.Descriptor DESCRIPTOR;
+    private static final FieldAccessorTable ACCESSOR_TABLE;
+    private static final Proto2FullRuntimeMessage DEFAULT_INSTANCE = new Proto2FullRuntimeMessage();
+
+    static {
+        DescriptorProtos.DescriptorProto messageType = DescriptorProtos.DescriptorProto.newBuilder()
+                .setName("Proto2FullRuntimeMessage")
+                .build();
+        DescriptorProtos.FileDescriptorProto file = DescriptorProtos.FileDescriptorProto.newBuilder()
+                .setName("extension_schemas_probe.proto")
+                .addMessageType(messageType)
+                .build();
+        try {
+            Descriptors.FileDescriptor fileDescriptor = Descriptors.FileDescriptor.buildFrom(
+                    file,
+                    new Descriptors.FileDescriptor[0]);
+            DESCRIPTOR = fileDescriptor.findMessageTypeByName("Proto2FullRuntimeMessage");
+            ACCESSOR_TABLE = new FieldAccessorTable(DESCRIPTOR, new String[0]);
+        } catch (Descriptors.DescriptorValidationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private Proto2FullRuntimeMessage() {
+    }
+
+    public static Proto2FullRuntimeMessage getDefaultInstance() {
+        return DEFAULT_INSTANCE;
+    }
+
+    public void mergeEmptyPayloadWithFullRuntimeSchema() throws InvalidProtocolBufferException {
+        CodedInputStream input = CodedInputStream.newInstance(new byte[0]);
+        mergeFromAndMakeImmutableInternal(input, ExtensionRegistryLite.getEmptyRegistry());
+    }
+
+    @Override
+    protected FieldAccessorTable internalGetFieldAccessorTable() {
+        return ACCESSOR_TABLE;
+    }
+
+    @Override
+    public Descriptors.Descriptor getDescriptorForType() {
+        return DESCRIPTOR;
+    }
+
+    @Override
+    public Proto2FullRuntimeMessage getDefaultInstanceForType() {
+        return DEFAULT_INSTANCE;
+    }
+
+    @Override
+    public Message.Builder newBuilderForType() {
+        throw new UnsupportedOperationException("Builder is not needed by this schema probe.");
+    }
+
+    @Override
+    public Message.Builder toBuilder() {
+        throw new UnsupportedOperationException("Builder is not needed by this schema probe.");
+    }
+
+    @Override
+    protected Message.Builder newBuilderForType(BuilderParent parent) {
+        throw new UnsupportedOperationException("Builder is not needed by this schema probe.");
+    }
+}

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/java/com_typesafe_akka/akka_protobuf_v3_2_13/SerializedFormProbeMessages.java
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/java/com_typesafe_akka/akka_protobuf_v3_2_13/SerializedFormProbeMessages.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_akka.akka_protobuf_v3_2_13;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Arrays;
+
+import akka.protobufv3.internal.ByteString;
+import akka.protobufv3.internal.CodedInputStream;
+import akka.protobufv3.internal.CodedOutputStream;
+import akka.protobufv3.internal.ExtensionRegistryLite;
+import akka.protobufv3.internal.InvalidProtocolBufferException;
+import akka.protobufv3.internal.MessageLite;
+import akka.protobufv3.internal.Parser;
+
+final class DefaultInstanceLiteMessage extends BaseLiteMessage {
+    public static final DefaultInstanceLiteMessage DEFAULT_INSTANCE = new DefaultInstanceLiteMessage(new byte[0]);
+
+    DefaultInstanceLiteMessage(byte[] payload) {
+        super(payload);
+    }
+
+    @Override
+    public MessageLite.Builder newBuilderForType() {
+        return new DefaultInstanceBuilder();
+    }
+
+    @Override
+    public MessageLite.Builder toBuilder() {
+        return new DefaultInstanceBuilder().mergeFrom(payload());
+    }
+
+    @Override
+    public MessageLite getDefaultInstanceForType() {
+        return DEFAULT_INSTANCE;
+    }
+}
+
+final class LegacyDefaultInstanceLiteMessage extends BaseLiteMessage {
+    @SuppressWarnings("checkstyle:ConstantName")
+    public static final LegacyDefaultInstanceLiteMessage defaultInstance =
+            new LegacyDefaultInstanceLiteMessage(new byte[0]);
+
+    LegacyDefaultInstanceLiteMessage(byte[] payload) {
+        super(payload);
+    }
+
+    @Override
+    public MessageLite.Builder newBuilderForType() {
+        return new LegacyDefaultInstanceBuilder();
+    }
+
+    @Override
+    public MessageLite.Builder toBuilder() {
+        return new LegacyDefaultInstanceBuilder().mergeFrom(payload());
+    }
+
+    @Override
+    public MessageLite getDefaultInstanceForType() {
+        return defaultInstance;
+    }
+}
+
+abstract class BaseLiteMessage implements MessageLite {
+    private final byte[] payload;
+
+    BaseLiteMessage(byte[] payload) {
+        this.payload = Arrays.copyOf(payload, payload.length);
+    }
+
+    byte[] payload() {
+        return Arrays.copyOf(payload, payload.length);
+    }
+
+    @Override
+    public void writeTo(CodedOutputStream output) throws IOException {
+        output.writeRawBytes(payload);
+    }
+
+    @Override
+    public int getSerializedSize() {
+        return payload.length;
+    }
+
+    @Override
+    public Parser<? extends MessageLite> getParserForType() {
+        throw new UnsupportedOperationException("Parsing is exercised through the builder");
+    }
+
+    @Override
+    public ByteString toByteString() {
+        return ByteString.copyFrom(payload);
+    }
+
+    @Override
+    public byte[] toByteArray() {
+        return payload();
+    }
+
+    @Override
+    public void writeTo(OutputStream output) throws IOException {
+        output.write(payload);
+    }
+
+    @Override
+    public void writeDelimitedTo(OutputStream output) throws IOException {
+        output.write(payload.length);
+        output.write(payload);
+    }
+
+    @Override
+    public boolean isInitialized() {
+        return true;
+    }
+}
+
+abstract class BaseLiteMessageBuilder implements MessageLite.Builder {
+    private byte[] payload = new byte[0];
+
+    @Override
+    public MessageLite.Builder clear() {
+        payload = new byte[0];
+        return this;
+    }
+
+    @Override
+    public MessageLite build() {
+        return buildPartial();
+    }
+
+    @Override
+    public MessageLite.Builder clone() {
+        BaseLiteMessageBuilder clone = newBuilder();
+        clone.payload = Arrays.copyOf(payload, payload.length);
+        return clone;
+    }
+
+    @Override
+    public MessageLite.Builder mergeFrom(CodedInputStream input) throws IOException {
+        return mergeFrom(input, ExtensionRegistryLite.getEmptyRegistry());
+    }
+
+    @Override
+    public MessageLite.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)
+            throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        while (!input.isAtEnd()) {
+            bytes.write(input.readRawByte());
+        }
+        return mergeFrom(bytes.toByteArray());
+    }
+
+    @Override
+    public MessageLite.Builder mergeFrom(ByteString data) throws InvalidProtocolBufferException {
+        return mergeFrom(data.toByteArray());
+    }
+
+    @Override
+    public MessageLite.Builder mergeFrom(ByteString data, ExtensionRegistryLite extensionRegistry)
+            throws InvalidProtocolBufferException {
+        return mergeFrom(data);
+    }
+
+    @Override
+    public MessageLite.Builder mergeFrom(byte[] data) {
+        payload = Arrays.copyOf(data, data.length);
+        return this;
+    }
+
+    @Override
+    public MessageLite.Builder mergeFrom(byte[] data, int offset, int length) {
+        payload = Arrays.copyOfRange(data, offset, offset + length);
+        return this;
+    }
+
+    @Override
+    public MessageLite.Builder mergeFrom(byte[] data, ExtensionRegistryLite extensionRegistry) {
+        return mergeFrom(data);
+    }
+
+    @Override
+    public MessageLite.Builder mergeFrom(byte[] data, int offset, int length, ExtensionRegistryLite extensionRegistry) {
+        return mergeFrom(data, offset, length);
+    }
+
+    @Override
+    public MessageLite.Builder mergeFrom(InputStream input) throws IOException {
+        return mergeFrom(input.readAllBytes());
+    }
+
+    @Override
+    public MessageLite.Builder mergeFrom(InputStream input, ExtensionRegistryLite extensionRegistry)
+            throws IOException {
+        return mergeFrom(input);
+    }
+
+    @Override
+    public MessageLite.Builder mergeFrom(MessageLite message) {
+        return mergeFrom(message.toByteArray());
+    }
+
+    @Override
+    public boolean mergeDelimitedFrom(InputStream input) throws IOException {
+        int length = input.read();
+        if (length < 0) {
+            return false;
+        }
+        return mergeFrom(input.readNBytes(length)) != null;
+    }
+
+    @Override
+    public boolean mergeDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry) throws IOException {
+        return mergeDelimitedFrom(input);
+    }
+
+    @Override
+    public boolean isInitialized() {
+        return true;
+    }
+
+    byte[] payload() {
+        return Arrays.copyOf(payload, payload.length);
+    }
+
+    abstract BaseLiteMessageBuilder newBuilder();
+}
+
+final class DefaultInstanceBuilder extends BaseLiteMessageBuilder {
+    @Override
+    public MessageLite buildPartial() {
+        return new DefaultInstanceLiteMessage(payload());
+    }
+
+    @Override
+    public MessageLite getDefaultInstanceForType() {
+        return DefaultInstanceLiteMessage.DEFAULT_INSTANCE;
+    }
+
+    @Override
+    BaseLiteMessageBuilder newBuilder() {
+        return new DefaultInstanceBuilder();
+    }
+}
+
+final class LegacyDefaultInstanceBuilder extends BaseLiteMessageBuilder {
+    @Override
+    public MessageLite buildPartial() {
+        return new LegacyDefaultInstanceLiteMessage(payload());
+    }
+
+    @Override
+    public MessageLite getDefaultInstanceForType() {
+        return LegacyDefaultInstanceLiteMessage.defaultInstance;
+    }
+
+    @Override
+    BaseLiteMessageBuilder newBuilder() {
+        return new LegacyDefaultInstanceBuilder();
+    }
+}

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/java/com_typesafe_akka/akka_protobuf_v3_2_13/StructMapFieldProbeMessage.java
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/java/com_typesafe_akka/akka_protobuf_v3_2_13/StructMapFieldProbeMessage.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_akka.akka_protobuf_v3_2_13;
+
+import java.io.IOException;
+
+import akka.protobufv3.internal.AbstractParser;
+import akka.protobufv3.internal.CodedInputStream;
+import akka.protobufv3.internal.Descriptors;
+import akka.protobufv3.internal.ExtensionRegistryLite;
+import akka.protobufv3.internal.GeneratedMessageV3;
+import akka.protobufv3.internal.MapEntry;
+import akka.protobufv3.internal.MapField;
+import akka.protobufv3.internal.Message;
+import akka.protobufv3.internal.Parser;
+import akka.protobufv3.internal.Struct;
+import akka.protobufv3.internal.UnknownFieldSet;
+import akka.protobufv3.internal.Value;
+import akka.protobufv3.internal.WireFormat;
+
+public final class StructMapFieldProbeMessage extends GeneratedMessageV3 {
+    private static final StructMapFieldProbeMessage DEFAULT_INSTANCE = new StructMapFieldProbeMessage();
+    private static final Parser<StructMapFieldProbeMessage> PARSER = new AbstractParser<StructMapFieldProbeMessage>() {
+        @Override
+        public StructMapFieldProbeMessage parsePartialFrom(
+                CodedInputStream input,
+                ExtensionRegistryLite extensionRegistry
+        ) {
+            return new StructMapFieldProbeMessage();
+        }
+    };
+
+    private MapField<String, Value> fields_ = MapField.emptyMapField(FieldsDefaultEntryHolder.defaultEntry);
+
+    public void mergeEmptyInputThroughRuntimeSchema() throws IOException {
+        mergeFromAndMakeImmutableInternal(
+                CodedInputStream.newInstance(new byte[0]),
+                ExtensionRegistryLite.getEmptyRegistry()
+        );
+    }
+
+    public int getFieldsCount() {
+        return fields_.getMap().size();
+    }
+
+    public static StructMapFieldProbeMessage getDefaultInstance() {
+        return DEFAULT_INSTANCE;
+    }
+
+    @Override
+    public Descriptors.Descriptor getDescriptorForType() {
+        return Struct.getDescriptor();
+    }
+
+    @Override
+    public StructMapFieldProbeMessage getDefaultInstanceForType() {
+        return DEFAULT_INSTANCE;
+    }
+
+    @Override
+    public Parser<StructMapFieldProbeMessage> getParserForType() {
+        return PARSER;
+    }
+
+    @Override
+    public UnknownFieldSet getUnknownFields() {
+        return UnknownFieldSet.getDefaultInstance();
+    }
+
+    @Override
+    public Message.Builder newBuilderForType() {
+        return unsupportedBuilder();
+    }
+
+    @Override
+    public Message.Builder toBuilder() {
+        return unsupportedBuilder();
+    }
+
+    @Override
+    protected Message.Builder newBuilderForType(BuilderParent parent) {
+        return unsupportedBuilder();
+    }
+
+    @Override
+    protected FieldAccessorTable internalGetFieldAccessorTable() {
+        throw new UnsupportedOperationException("The schema probe is not built via generated accessors");
+    }
+
+    @Override
+    protected MapField internalGetMapField(int number) {
+        if (number == Struct.FIELDS_FIELD_NUMBER) {
+            return fields_;
+        }
+        throw new IllegalArgumentException("Unsupported map field number: " + number);
+    }
+
+    private Message.Builder unsupportedBuilder() {
+        throw new UnsupportedOperationException("The schema probe is not built via protobuf builders");
+    }
+
+    public static final class FieldsDefaultEntryHolder {
+        public static final MapEntry<String, Value> defaultEntry = MapEntry.newDefaultInstance(
+                Struct.getDescriptor().findFieldByNumber(Struct.FIELDS_FIELD_NUMBER).getMessageType(),
+                WireFormat.FieldType.STRING,
+                "",
+                WireFormat.FieldType.MESSAGE,
+                Value.getDefaultInstance()
+        );
+
+        private FieldsDefaultEntryHolder() {
+        }
+    }
+}

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/java/com_typesafe_akka/akka_protobuf_v3_2_13/ValidRawInfoLiteMessage.java
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/java/com_typesafe_akka/akka_protobuf_v3_2_13/ValidRawInfoLiteMessage.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_akka.akka_protobuf_v3_2_13;
+
+import akka.protobufv3.internal.GeneratedMessageLite;
+import akka.protobufv3.internal.GeneratedMessageLite.MethodToInvoke;
+
+public final class ValidRawInfoLiteMessage extends GeneratedMessageLite<
+        ValidRawInfoLiteMessage, ValidRawInfoLiteMessage.Builder> {
+    private static final String FIELD_INFO = new String(
+            new char[] {0, 1, 0, 0, 1, 1, 1, 0, 0, 0, 1, 4}
+    );
+    private static final ValidRawInfoLiteMessage DEFAULT_INSTANCE;
+    private int value_;
+
+    static {
+        DEFAULT_INSTANCE = new ValidRawInfoLiteMessage();
+        registerDefaultInstance(ValidRawInfoLiteMessage.class, DEFAULT_INSTANCE);
+    }
+
+    private ValidRawInfoLiteMessage() {
+    }
+
+    public static ValidRawInfoLiteMessage defaultInstance() {
+        return DEFAULT_INSTANCE;
+    }
+
+    @Override
+    protected Object dynamicMethod(MethodToInvoke method, Object firstArgument, Object secondArgument) {
+        switch (method) {
+            case NEW_MUTABLE_INSTANCE:
+                return new ValidRawInfoLiteMessage();
+            case NEW_BUILDER:
+                return new Builder();
+            case BUILD_MESSAGE_INFO:
+                return newMessageInfo(DEFAULT_INSTANCE, FIELD_INFO, new Object[] {"value_"});
+            case GET_DEFAULT_INSTANCE:
+                return DEFAULT_INSTANCE;
+            case GET_PARSER:
+                return null;
+            case GET_MEMOIZED_IS_INITIALIZED:
+                return (byte) 1;
+            case SET_MEMOIZED_IS_INITIALIZED:
+                return null;
+            default:
+                throw new UnsupportedOperationException("Unsupported GeneratedMessageLite method: " + method);
+        }
+    }
+
+    public static final class Builder extends GeneratedMessageLite.Builder<ValidRawInfoLiteMessage, Builder> {
+        private Builder() {
+            super(DEFAULT_INSTANCE);
+        }
+    }
+}

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,123 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.GeneratedMessageLite$SerializedForm"
+      },
+      "type" : "com_typesafe_akka.akka_protobuf_v3_2_13.DefaultInstanceLiteMessage",
+      "fields" : [
+        {
+          "name" : "DEFAULT_INSTANCE"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.GeneratedMessageLite$SerializedForm"
+      },
+      "type" : "com_typesafe_akka.akka_protobuf_v3_2_13.LegacyDefaultInstanceLiteMessage",
+      "fields" : [
+        {
+          "name" : "defaultInstance"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.Descriptors$FileDescriptor"
+      },
+      "type" : "com_typesafe_akka.akka_protobuf_v3_2_13.GeneratedDescriptorDependency",
+      "fields" : [
+        {
+          "name" : "descriptor"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.MessageLiteToString"
+      },
+      "type" : "com_typesafe_akka.akka_protobuf_v3_2_13.PrintableLiteMessageForMessageLiteToStringTest",
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.MessageSchema"
+      },
+      "type" : "com_typesafe_akka.akka_protobuf_v3_2_13.BrokenRawInfoLiteMessage",
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.MessageSchema"
+      },
+      "type" : "com_typesafe_akka.akka_protobuf_v3_2_13.ValidRawInfoLiteMessage",
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.DescriptorMessageInfoFactory"
+      },
+      "type" : "com_typesafe_akka.akka_protobuf_v3_2_13.TypeSchemaProbeMessage",
+      "allDeclaredFields" : true,
+      "methods" : [
+        {
+          "name" : "getDefaultInstance",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.DescriptorMessageInfoFactory"
+      },
+      "type" : "com_typesafe_akka.akka_protobuf_v3_2_13.ValueSchemaProbeMessage",
+      "allDeclaredFields" : true,
+      "methods" : [
+        {
+          "name" : "getDefaultInstance",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.DescriptorMessageInfoFactory"
+      },
+      "type" : "com_typesafe_akka.akka_protobuf_v3_2_13.StructMapFieldProbeMessage",
+      "allDeclaredFields" : true,
+      "methods" : [
+        {
+          "name" : "getDefaultInstance",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.DescriptorMessageInfoFactory"
+      },
+      "type" : "com_typesafe_akka.akka_protobuf_v3_2_13.Proto2FullRuntimeMessage",
+      "methods" : [
+        {
+          "name" : "getDefaultInstance",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.SchemaUtil"
+      },
+      "type" : "com_typesafe_akka.akka_protobuf_v3_2_13.StructMapFieldProbeMessage$FieldsDefaultEntryHolder",
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "akka.protobufv3.internal.UnsafeUtil"
+      },
+      "type" : "com_typesafe_akka.akka_protobuf_v3_2_13.ConstructorGuardedType",
+      "unsafeAllocated" : true
+    }
+  ]
+}

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/ByteBufferWriterTest.scala
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/ByteBufferWriterTest.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_akka.akka_protobuf_v3_2_13
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+import akka.protobufv3.internal.ByteString
+
+class ByteBufferWriterTest {
+  @Test
+  def classInitializationDiscoversFileOutputStreamChannelField(): Unit = {
+    val writerClass: Class[_] = Class.forName(
+      "akka.protobufv3.internal.ByteBufferWriter",
+      true,
+      classOf[ByteString].getClassLoader
+    )
+
+    assertEquals("akka.protobufv3.internal.ByteBufferWriter", writerClass.getName)
+  }
+}

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/DescriptorMessageInfoFactoryTest.scala
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/DescriptorMessageInfoFactoryTest.scala
@@ -1,0 +1,168 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_akka.akka_protobuf_v3_2_13
+
+import java.util.Collections
+
+import akka.protobufv3.internal.AbstractParser
+import akka.protobufv3.internal.CodedInputStream
+import akka.protobufv3.internal.Descriptors
+import akka.protobufv3.internal.ExtensionRegistryLite
+import akka.protobufv3.internal.Field
+import akka.protobufv3.internal.GeneratedMessageV3
+import akka.protobufv3.internal.ListValue
+import akka.protobufv3.internal.Message
+import akka.protobufv3.internal.Parser
+import akka.protobufv3.internal.SourceContext
+import akka.protobufv3.internal.Struct
+import akka.protobufv3.internal.Type
+import akka.protobufv3.internal.UnknownFieldSet
+import akka.protobufv3.internal.Value
+import akka.protobufv3.internal.{Option => ProtoOption}
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class DescriptorMessageInfoFactoryTest {
+  @Test
+  def schemaCreationForProto3RepeatedMessageFieldsUsesDescriptorReflection(): Unit = {
+    val message: TypeSchemaProbeMessage = new TypeSchemaProbeMessage()
+
+    message.mergeEmptyInputThroughRuntimeSchema()
+
+    assertSame(Type.getDescriptor, message.getDescriptorForType)
+    assertEquals("google.protobuf.Type", message.getDescriptorForType.getFullName)
+  }
+
+  @Test
+  def schemaCreationForProto3MessageOneofsUsesDescriptorReflection(): Unit = {
+    val message: ValueSchemaProbeMessage = new ValueSchemaProbeMessage()
+
+    message.mergeEmptyInputThroughRuntimeSchema()
+
+    assertSame(Value.getDescriptor, message.getDescriptorForType)
+    assertEquals("google.protobuf.Value", message.getDescriptorForType.getFullName)
+  }
+}
+
+final class TypeSchemaProbeMessage extends GeneratedMessageV3 {
+  private var name_ : AnyRef = ""
+  private var fields_ : java.util.List[Field] = Collections.emptyList[Field]()
+  private var oneofs_ : java.util.List[String] = Collections.emptyList[String]()
+  private var options_ : java.util.List[ProtoOption] = Collections.emptyList[ProtoOption]()
+  private var sourceContext_ : SourceContext = _
+  private var syntax_ : Int = 0
+
+  def mergeEmptyInputThroughRuntimeSchema(): Unit = {
+    mergeFromAndMakeImmutableInternal(
+      CodedInputStream.newInstance(Array.emptyByteArray),
+      ExtensionRegistryLite.getEmptyRegistry
+    )
+  }
+
+  def getFields(index: Int): Field = fields_.get(index)
+
+  def getOptions(index: Int): ProtoOption = options_.get(index)
+
+  override def getDescriptorForType: Descriptors.Descriptor = Type.getDescriptor
+
+  override def getDefaultInstanceForType: Message = TypeSchemaProbeMessage.getDefaultInstance()
+
+  override def getParserForType: Parser[_ <: GeneratedMessageV3] = TypeSchemaProbeMessage.ParserInstance
+
+  override def getUnknownFields: UnknownFieldSet = UnknownFieldSet.getDefaultInstance
+
+  override def newBuilderForType(): Message.Builder = unsupportedBuilder()
+
+  override def toBuilder(): Message.Builder = unsupportedBuilder()
+
+  override protected def newBuilderForType(parent: GeneratedMessageV3.BuilderParent): Message.Builder = unsupportedBuilder()
+
+  override protected def internalGetFieldAccessorTable(): GeneratedMessageV3.FieldAccessorTable = {
+    throw new UnsupportedOperationException("The runtime schema path does not use field accessor tables")
+  }
+
+  private def unsupportedBuilder(): Message.Builder = {
+    throw new UnsupportedOperationException("The schema probe is not built via protobuf builders")
+  }
+}
+
+object TypeSchemaProbeMessage {
+  private val DefaultInstance: TypeSchemaProbeMessage = new TypeSchemaProbeMessage()
+
+  val ParserInstance: Parser[TypeSchemaProbeMessage] = new AbstractParser[TypeSchemaProbeMessage] {
+    override def parsePartialFrom(
+      input: CodedInputStream,
+      extensionRegistry: ExtensionRegistryLite
+    ): TypeSchemaProbeMessage = new TypeSchemaProbeMessage()
+  }
+
+  def getDefaultInstance(): TypeSchemaProbeMessage = DefaultInstance
+}
+
+final class ValueSchemaProbeMessage extends GeneratedMessageV3 {
+  private var kindCase_ : Int = 0
+  private var kind_ : AnyRef = _
+
+  def mergeEmptyInputThroughRuntimeSchema(): Unit = {
+    mergeFromAndMakeImmutableInternal(
+      CodedInputStream.newInstance(Array.emptyByteArray),
+      ExtensionRegistryLite.getEmptyRegistry
+    )
+  }
+
+  def getStructValue(): Struct = {
+    if (kindCase_ == Value.STRUCT_VALUE_FIELD_NUMBER) {
+      kind_.asInstanceOf[Struct]
+    } else {
+      Struct.getDefaultInstance
+    }
+  }
+
+  def getListValue(): ListValue = {
+    if (kindCase_ == Value.LIST_VALUE_FIELD_NUMBER) {
+      kind_.asInstanceOf[ListValue]
+    } else {
+      ListValue.getDefaultInstance
+    }
+  }
+
+  override def getDescriptorForType: Descriptors.Descriptor = Value.getDescriptor
+
+  override def getDefaultInstanceForType: Message = ValueSchemaProbeMessage.getDefaultInstance()
+
+  override def getParserForType: Parser[_ <: GeneratedMessageV3] = ValueSchemaProbeMessage.ParserInstance
+
+  override def getUnknownFields: UnknownFieldSet = UnknownFieldSet.getDefaultInstance
+
+  override def newBuilderForType(): Message.Builder = unsupportedBuilder()
+
+  override def toBuilder(): Message.Builder = unsupportedBuilder()
+
+  override protected def newBuilderForType(parent: GeneratedMessageV3.BuilderParent): Message.Builder = unsupportedBuilder()
+
+  override protected def internalGetFieldAccessorTable(): GeneratedMessageV3.FieldAccessorTable = {
+    throw new UnsupportedOperationException("The runtime schema path does not use field accessor tables")
+  }
+
+  private def unsupportedBuilder(): Message.Builder = {
+    throw new UnsupportedOperationException("The schema probe is not built via protobuf builders")
+  }
+}
+
+object ValueSchemaProbeMessage {
+  private val DefaultInstance: ValueSchemaProbeMessage = new ValueSchemaProbeMessage()
+
+  val ParserInstance: Parser[ValueSchemaProbeMessage] = new AbstractParser[ValueSchemaProbeMessage] {
+    override def parsePartialFrom(
+      input: CodedInputStream,
+      extensionRegistry: ExtensionRegistryLite
+    ): ValueSchemaProbeMessage = new ValueSchemaProbeMessage()
+  }
+
+  def getDefaultInstance(): ValueSchemaProbeMessage = DefaultInstance
+}

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/DescriptorsInnerFileDescriptorTest.scala
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/DescriptorsInnerFileDescriptorTest.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_akka.akka_protobuf_v3_2_13
+
+import java.nio.charset.StandardCharsets
+
+import akka.protobufv3.internal.DescriptorProtos
+import akka.protobufv3.internal.Descriptors
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class DescriptorsInnerFileDescriptorTest {
+  @Test
+  def generatedFileBuildsDependenciesFromPublicDescriptorFields(): Unit = {
+    val descriptor: Descriptors.FileDescriptor = Descriptors.FileDescriptor.internalBuildGeneratedFileFrom(
+      encodedDescriptorData(ownerFileProto()),
+      classOf[DescriptorsInnerFileDescriptorTest],
+      Array(classOf[GeneratedDescriptorDependency].getName),
+      Array("coverage/dependency.proto")
+    )
+
+    val ownerMessage: Descriptors.Descriptor = descriptor.findMessageTypeByName("OwnerMessage")
+    val dependencyField: Descriptors.FieldDescriptor = ownerMessage.findFieldByName("dependency")
+
+    assertEquals("coverage/owner.proto", descriptor.getName)
+    assertSame(GeneratedDescriptorDependency.descriptor, descriptor.getDependencies.get(0))
+    assertSame(
+      GeneratedDescriptorDependency.descriptor.findMessageTypeByName("DependencyMessage"),
+      dependencyField.getMessageType
+    )
+  }
+
+  private def ownerFileProto(): DescriptorProtos.FileDescriptorProto = {
+    DescriptorProtos.FileDescriptorProto.newBuilder()
+      .setName("coverage/owner.proto")
+      .setPackage("coverage.owner")
+      .addDependency("coverage/dependency.proto")
+      .addMessageType(
+        DescriptorProtos.DescriptorProto.newBuilder()
+          .setName("OwnerMessage")
+          .addField(
+            DescriptorProtos.FieldDescriptorProto.newBuilder()
+              .setName("dependency")
+              .setNumber(1)
+              .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL)
+              .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_MESSAGE)
+              .setTypeName(".coverage.dependency.DependencyMessage")
+              .build()
+          )
+          .build()
+      )
+      .build()
+  }
+
+  private def encodedDescriptorData(proto: DescriptorProtos.FileDescriptorProto): Array[String] = {
+    Array(new String(proto.toByteArray, StandardCharsets.ISO_8859_1))
+  }
+}

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/ExtensionRegistryLiteTest.scala
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/ExtensionRegistryLiteTest.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_akka.akka_protobuf_v3_2_13
+
+import akka.protobufv3.internal.ExtensionLite
+import akka.protobufv3.internal.ExtensionRegistry
+import akka.protobufv3.internal.ExtensionRegistryLite
+import akka.protobufv3.internal.GeneratedMessage
+import akka.protobufv3.internal.Message
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class ExtensionRegistryLiteTest {
+  @Test
+  def addFullRuntimeExtensionThroughLiteApiRegistersItInFullRegistry(): Unit = {
+    val extension: GeneratedMessage.GeneratedExtension[Message, GeneratedDescriptorDependency] =
+      GeneratedMessage.newFileScopedGeneratedExtension(
+        classOf[GeneratedDescriptorDependency],
+        null,
+        classOf[GeneratedDescriptorDependency].getName,
+        "covered_extension"
+      )
+    val registry: ExtensionRegistryLite = ExtensionRegistry.newInstance()
+
+    registry.add(extension: ExtensionLite[Message, GeneratedDescriptorDependency])
+
+    val fullRegistry: ExtensionRegistry = registry.asInstanceOf[ExtensionRegistry]
+    val descriptor = extension.getDescriptor
+    val infoByName = fullRegistry.findMutableExtensionByName(descriptor.getFullName)
+    assertNotNull(infoByName)
+    assertSame(descriptor, infoByName.descriptor)
+    assertSame(infoByName, fullRegistry.findMutableExtensionByNumber(descriptor.getContainingType, descriptor.getNumber))
+  }
+}

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/ExtensionSchemasTest.scala
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/ExtensionSchemasTest.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_akka.akka_protobuf_v3_2_13
+
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class ExtensionSchemasTest {
+  @Test
+  def fullRuntimeProto2SchemaUsesLoadedExtensionSchema(): Unit = {
+    val message: Proto2FullRuntimeMessage = Proto2FullRuntimeMessage.getDefaultInstance
+
+    message.mergeEmptyPayloadWithFullRuntimeSchema()
+
+    assertSame(message, message.getDefaultInstanceForType)
+  }
+}

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/GeneratedMessageAnonymous4Test.scala
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/GeneratedMessageAnonymous4Test.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_akka.akka_protobuf_v3_2_13
+
+import akka.protobufv3.internal.Descriptors
+import akka.protobufv3.internal.GeneratedMessage
+import akka.protobufv3.internal.Message
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class GeneratedMessageAnonymous4Test {
+  @Test
+  def fileScopedExtensionLoadsDescriptorFromGeneratedDescriptorClass(): Unit = {
+    val extension: GeneratedMessage.GeneratedExtension[Message, GeneratedDescriptorDependency] =
+      GeneratedMessage.newFileScopedGeneratedExtension(
+        classOf[GeneratedDescriptorDependency],
+        null,
+        classOf[GeneratedDescriptorDependency].getName,
+        "covered_extension"
+      )
+
+    val descriptor: Descriptors.FieldDescriptor = extension.getDescriptor
+
+    assertEquals("covered_extension", descriptor.getName)
+    assertEquals(100, descriptor.getNumber)
+    assertEquals(Descriptors.FieldDescriptor.JavaType.STRING, descriptor.getJavaType)
+    assertSame(GeneratedDescriptorDependency.descriptor, descriptor.getFile)
+  }
+}

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/GeneratedMessageLiteInnerSerializedFormTest.scala
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/GeneratedMessageLiteInnerSerializedFormTest.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_akka.akka_protobuf_v3_2_13
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
+import java.io.OutputStream
+
+import akka.protobufv3.internal.GeneratedMessageLite
+import akka.protobufv3.internal.MessageLite
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class GeneratedMessageLiteInnerSerializedFormTest {
+  @Test
+  def serializedFormUsesDefaultInstanceFieldWhenResolvingMessage(): Unit = {
+    val payload: Array[Byte] = Array[Byte](1, 3, 5, 7)
+    val resolvedMessage: AnyRef = serializeFormAndReadBackWithClassNameLookup(
+      new DefaultInstanceLiteMessage(payload)
+    )
+
+    assertEquals(classOf[DefaultInstanceLiteMessage], resolvedMessage.getClass)
+    assertArrayEquals(payload, resolvedMessage.asInstanceOf[DefaultInstanceLiteMessage].payload())
+  }
+
+  @Test
+  def serializedFormFallsBackToLegacyDefaultInstanceField(): Unit = {
+    val payload: Array[Byte] = Array[Byte](2, 4, 6, 8)
+    val resolvedMessage: AnyRef = serializeFormAndReadBackWithClassNameLookup(
+      new LegacyDefaultInstanceLiteMessage(payload)
+    )
+
+    assertEquals(classOf[LegacyDefaultInstanceLiteMessage], resolvedMessage.getClass)
+    assertArrayEquals(payload, resolvedMessage.asInstanceOf[LegacyDefaultInstanceLiteMessage].payload())
+  }
+
+  private def serializeFormAndReadBackWithClassNameLookup(message: MessageLite): AnyRef = {
+    val out = new ByteArrayOutputStream()
+    val objectOut = new ClassNullingObjectOutputStream(out, message.getClass)
+    try {
+      objectOut.writeObject(GeneratedMessageLite.SerializedForm.of(message))
+    } finally {
+      objectOut.close()
+    }
+
+    val objectIn = new ObjectInputStream(new ByteArrayInputStream(out.toByteArray))
+    try {
+      objectIn.readObject()
+    } finally {
+      objectIn.close()
+    }
+  }
+}
+
+private final class ClassNullingObjectOutputStream(output: OutputStream, classToNull: Class[_])
+    extends ObjectOutputStream(output) {
+  enableReplaceObject(true)
+
+  override protected def replaceObject(obj: AnyRef): AnyRef = {
+    if (obj eq classToNull) {
+      null
+    } else {
+      super.replaceObject(obj)
+    }
+  }
+}

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/GeneratedMessageLiteTest.scala
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/GeneratedMessageLiteTest.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_akka.akka_protobuf_v3_2_13
+
+import akka.protobufv3.internal.GeneratedMessageLiteTestSupport
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class GeneratedMessageLiteTest {
+  @Test
+  def getDefaultInstanceInitializesGeneratedMessageClassByName(): Unit = {
+    assertTrue(GeneratedMessageLiteTestSupport.lookupDefaultInstanceInitializesGeneratedMessageClass())
+  }
+
+  @Test
+  def reflectiveGeneratedAccessorHelpersInvokePublicMethod(): Unit = {
+    val value: String = GeneratedMessageLiteTestSupport.invokePublicAccessorThroughGeneratedMessageLite()
+
+    assertEquals("invoked through GeneratedMessageLite", value)
+  }
+}

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/GeneratedMessageTest.scala
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/GeneratedMessageTest.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_akka.akka_protobuf_v3_2_13
+
+import akka.protobufv3.internal.DescriptorProtos
+import akka.protobufv3.internal.Descriptors
+import akka.protobufv3.internal.GeneratedMessage
+import akka.protobufv3.internal.Message
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class GeneratedMessageTest {
+  @Test
+  def enumExtensionDefaultValueUsesGeneratedEnumAccessors(): Unit = {
+    val extension: GeneratedMessage.GeneratedExtension[Message, DescriptorProtos.FieldDescriptorProto.Type] =
+      GeneratedMessage.newFileScopedGeneratedExtension[Message, DescriptorProtos.FieldDescriptorProto.Type](
+        classOf[DescriptorProtos.FieldDescriptorProto.Type],
+        null
+      )
+    val enumField: Descriptors.FieldDescriptor = DescriptorProtos.FieldDescriptorProto.getDescriptor.findFieldByName("type")
+
+    extension.internalInit(enumField)
+    val defaultValue: DescriptorProtos.FieldDescriptorProto.Type = extension.getDefaultValue
+
+    assertEquals(Descriptors.FieldDescriptor.JavaType.ENUM, enumField.getJavaType)
+    assertSame(DescriptorProtos.FieldDescriptorProto.Type.TYPE_DOUBLE, defaultValue)
+  }
+}

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/GeneratedMessageV3Test.scala
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/GeneratedMessageV3Test.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_akka.akka_protobuf_v3_2_13
+
+import akka.protobufv3.internal.DescriptorProtos
+import akka.protobufv3.internal.Descriptors
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class GeneratedMessageV3Test {
+  @Test
+  def descriptorProtoReflectionApiUsesGeneratedAccessors(): Unit = {
+    val descriptor: Descriptors.Descriptor = DescriptorProtos.FieldDescriptorProto.getDescriptor
+    val nameField: Descriptors.FieldDescriptor = descriptor.findFieldByName("name")
+    val numberField: Descriptors.FieldDescriptor = descriptor.findFieldByName("number")
+    val typeField: Descriptors.FieldDescriptor = descriptor.findFieldByName("type")
+
+    val builder: DescriptorProtos.FieldDescriptorProto.Builder = DescriptorProtos.FieldDescriptorProto.newBuilder()
+    assertFalse(builder.hasField(nameField))
+
+    builder.setField(nameField, "field_name")
+    builder.setField(numberField, Integer.valueOf(7))
+    builder.setField(typeField, DescriptorProtos.FieldDescriptorProto.Type.TYPE_INT32.getValueDescriptor)
+
+    assertTrue(builder.hasField(nameField))
+    assertEquals("field_name", builder.getField(nameField))
+
+    val message: DescriptorProtos.FieldDescriptorProto = builder.build()
+    assertTrue(message.hasField(nameField))
+    assertEquals("field_name", message.getField(nameField))
+    assertEquals(Integer.valueOf(7), message.getAllFields.get(numberField))
+    assertEquals(DescriptorProtos.FieldDescriptorProto.Type.TYPE_INT32.getValueDescriptor, message.getField(typeField))
+  }
+}

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/InternalTest.scala
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/InternalTest.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_akka.akka_protobuf_v3_2_13
+
+import akka.protobufv3.internal.Empty
+import akka.protobufv3.internal.Internal
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class InternalTest {
+  @Test
+  def getDefaultInstanceUsesMessageStaticAccessor(): Unit = {
+    val defaultInstance: Empty = Internal.getDefaultInstance(classOf[Empty])
+
+    assertSame(Empty.getDefaultInstance, defaultInstance)
+  }
+}

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/MessageLiteToStringTest.scala
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/MessageLiteToStringTest.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_akka.akka_protobuf_v3_2_13
+
+import akka.protobufv3.internal.CodedOutputStream
+import akka.protobufv3.internal.GeneratedMessageLite
+import akka.protobufv3.internal.GeneratedMessageLite.MethodToInvoke
+import java.util.Arrays
+import java.util.Collections
+import java.util.LinkedHashMap
+import java.util.{Map => JavaMap}
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class MessageLiteToStringTest {
+  @Test
+  def toStringReflectivelyPrintsGeneratedLiteAccessors(): Unit = {
+    val printed: String = new PrintableLiteMessageForMessageLiteToStringTest().toString
+
+    assertTrue(printed.contains("label: \"visible\""), printed)
+    assertTrue(printed.contains("tags: \"red\""), printed)
+    assertTrue(printed.contains("tags: \"blue\""), printed)
+    assertTrue(printed.contains("key: \"errors\""), printed)
+    assertTrue(printed.contains("value: 7"), printed)
+    assertTrue(printed.contains("key: \"warnings\""), printed)
+    assertTrue(printed.contains("value: 3"), printed)
+  }
+}
+
+final class PrintableLiteMessageForMessageLiteToStringTest
+    extends GeneratedMessageLite[
+      PrintableLiteMessageForMessageLiteToStringTest,
+      PrintableLiteMessageForMessageLiteToStringTestBuilder
+    ] {
+  import PrintableLiteMessageForMessageLiteToStringTest._
+
+  def getLabel: String = Label
+
+  def hasLabel: Boolean = true
+
+  def setLabel(label: String): Unit = throw new UnsupportedOperationException(
+    "Setter exists only to mirror generated message accessors"
+  )
+
+  def getTagsList: java.util.List[String] = Tags
+
+  def getCountsMap: JavaMap[String, Integer] = Counts
+
+  override def writeTo(output: CodedOutputStream): Unit = output.writeString(1, getLabel)
+
+  override def getSerializedSize: Int = CodedOutputStream.computeStringSize(1, getLabel)
+
+  override def hashCode: Int = 31
+
+  override protected def dynamicMethod(
+      method: MethodToInvoke,
+      firstArgument: Object,
+      secondArgument: Object
+  ): Object =
+    method match {
+      case MethodToInvoke.GET_DEFAULT_INSTANCE => DefaultInstance
+      case MethodToInvoke.GET_MEMOIZED_IS_INITIALIZED => Byte.box(1.toByte)
+      case MethodToInvoke.NEW_MUTABLE_INSTANCE => new PrintableLiteMessageForMessageLiteToStringTest()
+      case MethodToInvoke.NEW_BUILDER => new PrintableLiteMessageForMessageLiteToStringTestBuilder()
+      case MethodToInvoke.BUILD_MESSAGE_INFO => null
+      case MethodToInvoke.GET_PARSER => null
+      case MethodToInvoke.SET_MEMOIZED_IS_INITIALIZED => null
+    }
+}
+
+object PrintableLiteMessageForMessageLiteToStringTest {
+  val Label: String = "visible"
+  val Tags: java.util.List[String] = Collections.unmodifiableList(Arrays.asList("red", "blue"))
+  val Counts: JavaMap[String, Integer] = {
+    val counts: LinkedHashMap[String, Integer] = new LinkedHashMap[String, Integer]()
+    counts.put("errors", Integer.valueOf(7))
+    counts.put("warnings", Integer.valueOf(3))
+    Collections.unmodifiableMap(counts)
+  }
+  val DefaultInstance: PrintableLiteMessageForMessageLiteToStringTest =
+    new PrintableLiteMessageForMessageLiteToStringTest()
+}
+
+final class PrintableLiteMessageForMessageLiteToStringTestBuilder
+    extends GeneratedMessageLite.Builder[
+      PrintableLiteMessageForMessageLiteToStringTest,
+      PrintableLiteMessageForMessageLiteToStringTestBuilder
+    ](PrintableLiteMessageForMessageLiteToStringTest.DefaultInstance)

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/MessageSchemaTest.scala
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/MessageSchemaTest.scala
@@ -21,13 +21,11 @@ class MessageSchemaTest {
 
   @Test
   def rawMessageInfoSchemaCreationReportsMissingReflectedField(): Unit = {
-    val initializerError: ExceptionInInitializerError = assertThrows(
-      classOf[ExceptionInInitializerError],
+    val error: RuntimeException = assertThrows(
+      classOf[RuntimeException],
       () => BrokenRawInfoLiteMessage.defaultInstance().getSerializedSize
     )
-    val error: Throwable = initializerError.getCause
 
-    assertTrue(error.isInstanceOf[RuntimeException])
     assertTrue(error.getMessage.contains("Field missing_"))
     assertTrue(error.getMessage.contains(classOf[BrokenRawInfoLiteMessage].getName))
   }

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/MessageSchemaTest.scala
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/MessageSchemaTest.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_akka.akka_protobuf_v3_2_13
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class MessageSchemaTest {
+  @Test
+  def rawMessageInfoSchemaCreationReflectsExistingField(): Unit = {
+    val size: Int = ValidRawInfoLiteMessage.defaultInstance().getSerializedSize
+
+    assertEquals(0, size)
+  }
+
+  @Test
+  def rawMessageInfoSchemaCreationReportsMissingReflectedField(): Unit = {
+    val initializerError: ExceptionInInitializerError = assertThrows(
+      classOf[ExceptionInInitializerError],
+      () => BrokenRawInfoLiteMessage.defaultInstance().getSerializedSize
+    )
+    val error: Throwable = initializerError.getCause
+
+    assertTrue(error.isInstanceOf[RuntimeException])
+    assertTrue(error.getMessage.contains("Field missing_"))
+    assertTrue(error.getMessage.contains(classOf[BrokenRawInfoLiteMessage].getName))
+  }
+}

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/SchemaUtilTest.scala
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/SchemaUtilTest.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_akka.akka_protobuf_v3_2_13
+
+import akka.protobufv3.internal.Struct
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class SchemaUtilTest {
+  @Test
+  def schemaCreationForProto3MapFieldsLoadsGeneratedDefaultEntryHolder(): Unit = {
+    val message: StructMapFieldProbeMessage = new StructMapFieldProbeMessage()
+
+    message.mergeEmptyInputThroughRuntimeSchema()
+
+    assertSame(Struct.getDescriptor, message.getDescriptorForType)
+    assertEquals(0, message.getFieldsCount)
+  }
+}

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/UnsafeUtilInnerAndroid32MemoryAccessorTest.scala
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/UnsafeUtilInnerAndroid32MemoryAccessorTest.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_akka.akka_protobuf_v3_2_13
+
+import java.lang.Void
+import java.lang.invoke.MethodHandle
+import java.lang.invoke.MethodHandles
+import java.lang.invoke.MethodType.methodType
+import java.lang.reflect.Field
+
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+import sun.misc.Unsafe
+
+class UnsafeUtilInnerAndroid32MemoryAccessorTest {
+  @Test
+  def getStaticObjectReadsStaticFieldThroughAndroid32Accessor(): Unit = {
+    val accessorClass: Class[_] = Class.forName("akka.protobufv3.internal.UnsafeUtil$Android32MemoryAccessor")
+    val lookup: MethodHandles.Lookup = MethodHandles.privateLookupIn(
+      accessorClass,
+      MethodHandles.lookup()
+    )
+    val constructor: MethodHandle = lookup.findConstructor(
+      accessorClass,
+      methodType(Void.TYPE, classOf[Unsafe])
+    )
+    val accessor: Object = constructor.invokeWithArguments(null.asInstanceOf[Unsafe])
+    val getStaticObject: MethodHandle = lookup.findVirtual(
+      accessorClass,
+      "getStaticObject",
+      methodType(classOf[Object], classOf[Field])
+    )
+    val field: Field = classOf[java.lang.Boolean].getField("TRUE")
+
+    val value: Object = getStaticObject.invokeWithArguments(accessor, field)
+
+    assertSame(java.lang.Boolean.TRUE, value)
+  }
+}

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/UnsafeUtilTest.scala
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/src/test/scala/com_typesafe_akka/akka_protobuf_v3_2_13/UnsafeUtilTest.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package libcore.io {
+  class Memory {
+    def peekLong(address: Long, swap: Boolean): Long = 0L
+
+    def peekLong(address: Int, swap: Boolean): Long = 0L
+
+    def pokeLong(address: Long, value: Long, swap: Boolean): Unit = ()
+
+    def pokeLong(address: Int, value: Long, swap: Boolean): Unit = ()
+
+    def pokeInt(address: Long, value: Int, swap: Boolean): Unit = ()
+
+    def pokeInt(address: Int, value: Int, swap: Boolean): Unit = ()
+
+    def peekInt(address: Long, swap: Boolean): Int = 0
+
+    def peekInt(address: Int, swap: Boolean): Int = 0
+
+    def pokeByte(address: Long, value: Byte): Unit = ()
+
+    def pokeByte(address: Int, value: Byte): Unit = ()
+
+    def peekByte(address: Long): Byte = 0.toByte
+
+    def peekByte(address: Int): Byte = 0.toByte
+
+    def pokeByteArray(address: Long, bytes: Array[Byte], offset: Int, count: Int): Unit = ()
+
+    def pokeByteArray(address: Int, bytes: Array[Byte], offset: Int, count: Int): Unit = ()
+
+    def peekByteArray(address: Long, bytes: Array[Byte], offset: Int, count: Int): Unit = ()
+
+    def peekByteArray(address: Int, bytes: Array[Byte], offset: Int, count: Int): Unit = ()
+  }
+}
+
+package com_typesafe_akka.akka_protobuf_v3_2_13 {
+  import java.lang.invoke.MethodHandles
+  import java.lang.invoke.MethodType.methodType
+
+  import org.junit.jupiter.api.Assertions.assertEquals
+
+  import akka.protobufv3.internal.ByteString
+  import org.junit.jupiter.api.Test
+
+  class UnsafeUtilTest {
+    @Test
+    def allocateInstanceInitializesUnsafeUtilAndBypassesConstructors(): Unit = {
+      assertEquals("libcore.io.Memory", classOf[libcore.io.Memory].getName)
+
+      val unsafeUtilClass: Class[_] = Class.forName(
+        "akka.protobufv3.internal.UnsafeUtil",
+        true,
+        classOf[ByteString].getClassLoader
+      )
+      val lookup: MethodHandles.Lookup = MethodHandles.privateLookupIn(
+        unsafeUtilClass,
+        MethodHandles.lookup()
+      )
+      val allocateInstance = lookup.findStatic(
+        unsafeUtilClass,
+        "allocateInstance",
+        methodType(classOf[Object], classOf[Class[_]])
+      )
+
+      val instance = allocateInstance.invokeWithArguments(classOf[ConstructorGuardedType]).asInstanceOf[ConstructorGuardedType]
+
+      assertEquals(0, instance.constructorValue)
+    }
+  }
+
+  final class ConstructorGuardedType private () {
+    private val initializedValue: Int = 42
+
+    throw new AssertionError("Unsafe allocation must not invoke constructors")
+
+    def constructorValue: Int = initializedValue
+  }
+}

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/user-code-filter.json
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "akka.protobufv3.internal.**"
+    },
+    {
+      "includeClasses" : "com_typesafe_akka.akka_protobuf_v3_2_13.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6207

This PR provides test fixes and new metadata for com.typesafe.akka:akka-protobuf-v3_2.13:2.9.0-M1, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 22776
- Cached input tokens: 174080
- Output tokens: 1781
- Metadata entries: 49
- Test-only metadata entries: 27
- Iterations: 1
- Library coverage percentage: 7.65
- Previous library version metadata entries: 41
- Previous library version test-only metadata entries: 27
- Previous library version coverage percentage: 8.41

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `f9254d630a4125e442a7760fe42ab0f5387d0883`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.typesafe.akka:akka-protobuf-v3_2.13:2.8.8: 56/56 covered calls (100.00%)
- com.typesafe.akka:akka-protobuf-v3_2.13:2.9.0-M1: 56/56 covered calls (100.00%)

**Reflection:**
- com.typesafe.akka:akka-protobuf-v3_2.13:2.8.8: 56/56 covered calls (100.00%)
- com.typesafe.akka:akka-protobuf-v3_2.13:2.9.0-M1: 56/56 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.typesafe.akka:akka-protobuf-v3_2.13:2.8.8: 17715/192795 (9.19%)
- com.typesafe.akka:akka-protobuf-v3_2.13:2.9.0-M1: 16597/193946 (8.56%)

**Line:**
- com.typesafe.akka:akka-protobuf-v3_2.13:2.8.8: 3960/47095 (8.41%)
- com.typesafe.akka:akka-protobuf-v3_2.13:2.9.0-M1: 3633/47462 (7.65%)

**Method:**
- com.typesafe.akka:akka-protobuf-v3_2.13:2.8.8: 934/10137 (9.21%)
- com.typesafe.akka:akka-protobuf-v3_2.13:2.9.0-M1: 854/10184 (8.39%)

**Comparison between existing test version and AI-Generated update**

```diff

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
