### PR TITLE
[GenAI] Test fix for net.bytebuddy:byte-buddy-agent:1.11.17 using gpt-5.5

### DIFF
--- a/metadata/net.bytebuddy/byte-buddy-agent/1.11.17/reachability-metadata.json
+++ b/metadata/net.bytebuddy/byte-buddy-agent/1.11.17/reachability-metadata.json
@@ -1,86 +1,74 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "net.bytebuddy.agent.ByteBuddyAgent"
+      "condition" : {
+        "typeReached" : "net.bytebuddy.agent.ByteBuddyAgent"
       },
-      "type": "byte[][]"
+      "type" : "byte[][]"
     },
     {
-      "condition": {
-        "typeReached": "net.bytebuddy.agent.ByteBuddyAgent$AgentProvider$ForByteBuddyAgent"
+      "condition" : {
+        "typeReached" : "net.bytebuddy.agent.ByteBuddyAgent$AgentProvider$ForByteBuddyAgent"
       },
-      "type": "java.lang.StackTraceElement[]"
+      "type" : "java.lang.StackTraceElement[]"
     },
     {
-      "condition": {
-        "typeReached": "net.bytebuddy.agent.Attacher"
+      "condition" : {
+        "typeReached" : "net.bytebuddy.agent.Attacher"
       },
-      "type": "java.lang.reflect.Method[]"
+      "type" : "java.lang.reflect.Method[]"
     },
     {
-      "condition": {
-        "typeReached": "net.bytebuddy.agent.Installer"
+      "condition" : {
+        "typeReached" : "net.bytebuddy.agent.Installer"
       },
-      "type": "java.lang.reflect.Method[]"
+      "type" : "java.lang.reflect.Method[]"
     },
     {
-      "condition": {
-        "typeReached": "net.bytebuddy.agent.Attacher"
+      "condition" : {
+        "typeReached" : "net.bytebuddy.agent.ByteBuddyAgent$AgentProvider$ForByteBuddyAgent"
       },
-      "type": "net_bytebuddy.byte_buddy_agent.AttacherTest$RecordingVirtualMachine"
+      "type" : "sun.security.provider.NativePRNG"
     },
     {
-      "condition": {
-        "typeReached": "net.bytebuddy.agent.Attacher"
+      "condition" : {
+        "typeReached" : "net.bytebuddy.agent.ByteBuddyAgent$AgentProvider$ForByteBuddyAgent"
       },
-      "type": "net_bytebuddy.byte_buddy_agent.ByteBuddyAgentInnerAgentProviderInnerForByteBuddyAgentTest$RecordingVirtualMachine"
+      "type" : "sun.security.provider.SHA"
     },
     {
-      "condition": {
-        "typeReached": "net.bytebuddy.agent.ByteBuddyAgent$AgentProvider$ForByteBuddyAgent"
+      "condition" : {
+        "typeReached" : "net.bytebuddy.agent.Installer"
       },
-      "type": "sun.security.provider.NativePRNG"
-    },
-    {
-      "condition": {
-        "typeReached": "net.bytebuddy.agent.ByteBuddyAgent$AgentProvider$ForByteBuddyAgent"
-      },
-      "type": "sun.security.provider.SHA"
-    },
-    {
-      "condition": {
-        "typeReached": "net.bytebuddy.agent.Installer"
-      },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.Deprecated"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "net.bytebuddy.agent.Installer"
+      "condition" : {
+        "typeReached" : "net.bytebuddy.agent.Installer"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Retention"
         ]
       }
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "net.bytebuddy.agent.ByteBuddyAgent"
+      "condition" : {
+        "typeReached" : "net.bytebuddy.agent.ByteBuddyAgent"
       },
-      "glob": "net/bytebuddy/agent/Attacher.class"
+      "glob" : "net/bytebuddy/agent/Attacher.class"
     },
     {
-      "condition": {
-        "typeReached": "net.bytebuddy.agent.ByteBuddyAgent$AgentProvider$ForByteBuddyAgent"
+      "condition" : {
+        "typeReached" : "net.bytebuddy.agent.ByteBuddyAgent$AgentProvider$ForByteBuddyAgent"
       },
-      "glob": "net/bytebuddy/agent/Installer.class"
+      "glob" : "net/bytebuddy/agent/Installer.class"
     }
   ]
 }

--- a/metadata/net.bytebuddy/byte-buddy-agent/1.11.17/reachability-metadata.json
+++ b/metadata/net.bytebuddy/byte-buddy-agent/1.11.17/reachability-metadata.json
@@ -1,0 +1,86 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "net.bytebuddy.agent.ByteBuddyAgent"
+      },
+      "type": "byte[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "net.bytebuddy.agent.ByteBuddyAgent$AgentProvider$ForByteBuddyAgent"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "net.bytebuddy.agent.Attacher"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "net.bytebuddy.agent.Installer"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "net.bytebuddy.agent.Attacher"
+      },
+      "type": "net_bytebuddy.byte_buddy_agent.AttacherTest$RecordingVirtualMachine"
+    },
+    {
+      "condition": {
+        "typeReached": "net.bytebuddy.agent.Attacher"
+      },
+      "type": "net_bytebuddy.byte_buddy_agent.ByteBuddyAgentInnerAgentProviderInnerForByteBuddyAgentTest$RecordingVirtualMachine"
+    },
+    {
+      "condition": {
+        "typeReached": "net.bytebuddy.agent.ByteBuddyAgent$AgentProvider$ForByteBuddyAgent"
+      },
+      "type": "sun.security.provider.NativePRNG"
+    },
+    {
+      "condition": {
+        "typeReached": "net.bytebuddy.agent.ByteBuddyAgent$AgentProvider$ForByteBuddyAgent"
+      },
+      "type": "sun.security.provider.SHA"
+    },
+    {
+      "condition": {
+        "typeReached": "net.bytebuddy.agent.Installer"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.Deprecated"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "net.bytebuddy.agent.Installer"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "net.bytebuddy.agent.ByteBuddyAgent"
+      },
+      "glob": "net/bytebuddy/agent/Attacher.class"
+    },
+    {
+      "condition": {
+        "typeReached": "net.bytebuddy.agent.ByteBuddyAgent$AgentProvider$ForByteBuddyAgent"
+      },
+      "glob": "net/bytebuddy/agent/Installer.class"
+    }
+  ]
+}

--- a/metadata/net.bytebuddy/byte-buddy-agent/index.json
+++ b/metadata/net.bytebuddy/byte-buddy-agent/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.11.17",
+    "tested-versions" : [
+      "1.11.17"
+    ],
+    "allowed-packages" : [
+      "net.bytebuddy.agent"
+    ]
+  },
+  {
     "metadata-version" : "1.10.9",
     "source-code-url" : "https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy-agent/$version$/byte-buddy-agent-$version$-sources.jar",
     "repository-url" : "https://github.com/raphw/byte-buddy",

--- a/metadata/net.bytebuddy/byte-buddy-agent/index.json
+++ b/metadata/net.bytebuddy/byte-buddy-agent/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.11.17",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy-agent/$version$/byte-buddy-agent-$version$-sources.jar",
+    "repository-url" : "https://github.com/raphw/byte-buddy",
+    "test-code-url" : "https://github.com/raphw/byte-buddy/tree/byte-buddy-$version$/byte-buddy-agent/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy-agent/$version$/byte-buddy-agent-$version$-javadoc.jar",
+    "description" : "Byte Buddy Agent provides APIs and a Java agent for attaching instrumentation to the current JVM or to another running JVM. It is used to install Java instrumentation at runtime so applications and frameworks can redefine, rebase, or transform classes through Byte Buddy.",
     "tested-versions" : [
       "1.11.17"
     ],

--- a/stats/net.bytebuddy/byte-buddy-agent/1.11.17/execution-metrics.json
+++ b/stats/net.bytebuddy/byte-buddy-agent/1.11.17/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_java_run_fail:2026-06-06": {
+    "timestamp": "2026-06-06T02:16:24.200372Z",
+    "library": "net.bytebuddy:byte-buddy-agent:1.11.17",
+    "starting_commit": "fa910a47157029bb7b33bcd85363457b5b7059db",
+    "ending_commit": "c57069286ee5bd133a35db3a805837babc5f1345",
+    "previous_library": "net.bytebuddy:byte-buddy-agent:1.10.9",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.11.17",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 15,
+            "totalCalls": 15
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 17,
+        "totalCalls": 17
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 821,
+          "missed": 4044,
+          "ratio": 0.168756,
+          "total": 4865
+        },
+        "line": {
+          "covered": 167,
+          "missed": 823,
+          "ratio": 0.168687,
+          "total": 990
+        },
+        "method": {
+          "covered": 42,
+          "missed": 149,
+          "ratio": 0.219895,
+          "total": 191
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.10.9",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 14,
+            "totalCalls": 14
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 16,
+        "totalCalls": 16
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 761,
+          "missed": 3990,
+          "ratio": 0.160177,
+          "total": 4751
+        },
+        "line": {
+          "covered": 158,
+          "missed": 808,
+          "ratio": 0.163561,
+          "total": 966
+        },
+        "method": {
+          "covered": 40,
+          "missed": 150,
+          "ratio": 0.210526,
+          "total": 190
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 157491,
+      "cached_input_tokens_used": 790528,
+      "output_tokens_used": 14401,
+      "iterations": 3,
+      "cost_usd": 0.8273,
+      "tested_library_loc": 167,
+      "metadata_entries": 10,
+      "test_only_metadata_entries": 2,
+      "previous_library_metadata_entries": 11,
+      "previous_library_test_only_metadata_entries": 3,
+      "code_coverage_percent": 16.87,
+      "previous_library_coverage_percent": 16.36
+    },
+    "artifacts": {
+      "test_file": "tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/src/test/java/com/ibm/tools/attach/VirtualMachine.java",
+      "metadata_file": "metadata/net.bytebuddy/byte-buddy-agent/1.11.17/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/net.bytebuddy/byte-buddy-agent/1.11.17/stats.json
+++ b/stats/net.bytebuddy/byte-buddy-agent/1.11.17/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "1.11.17",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 15,
+          "totalCalls" : 15
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 17,
+      "totalCalls" : 17
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 821,
+        "missed" : 4044,
+        "ratio" : 0.168756,
+        "total" : 4865
+      },
+      "line" : {
+        "covered" : 167,
+        "missed" : 823,
+        "ratio" : 0.168687,
+        "total" : 990
+      },
+      "method" : {
+        "covered" : 42,
+        "missed" : 149,
+        "ratio" : 0.219895,
+        "total" : 191
+      }
+    }
+  } ]
+}

--- a/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/.gitignore
+++ b/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/build.gradle
+++ b/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/build.gradle
@@ -15,6 +15,12 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"
@@ -24,4 +30,8 @@ graalvmNative {
             }
         }
     }
+}
+
+tasks.named("test") {
+    jvmArgs += ["-Djava.security.manager=allow"]
 }

--- a/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/build.gradle
+++ b/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "net.bytebuddy:byte-buddy-agent:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/gradle.properties
+++ b/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = net.bytebuddy:byte-buddy-agent:1.11.17
+library.version = 1.11.17
+metadata.dir = net.bytebuddy/byte-buddy-agent/1.11.17/

--- a/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/settings.gradle
+++ b/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'net.bytebuddy.byte-buddy-agent_tests'

--- a/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/src/test/java/com/ibm/tools/attach/VirtualMachine.java
+++ b/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/src/test/java/com/ibm/tools/attach/VirtualMachine.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com.ibm.tools.attach;
+
+public final class VirtualMachine {
+    private VirtualMachine() {
+    }
+}

--- a/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/src/test/java/net_bytebuddy/byte_buddy_agent/AttacherTest.java
+++ b/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/src/test/java/net_bytebuddy/byte_buddy_agent/AttacherTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_bytebuddy.byte_buddy_agent;
+
+import net.bytebuddy.agent.Attacher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AttacherTest {
+    @BeforeEach
+    void resetVirtualMachine() {
+        RecordingVirtualMachine.reset();
+    }
+
+    @Test
+    void mainLoadsJavaAgentAndCombinesArguments() {
+        Attacher.main(new String[] {
+                RecordingVirtualMachine.class.getName(),
+                "1234",
+                "agent.jar",
+                "false",
+                "=first",
+                "second",
+                "third"
+        });
+
+        assertThat(RecordingVirtualMachine.attachedProcessId).isEqualTo("1234");
+        assertThat(RecordingVirtualMachine.loadedAgent).isEqualTo("agent.jar");
+        assertThat(RecordingVirtualMachine.loadedAgentArgument).isEqualTo("first second third");
+        assertThat(RecordingVirtualMachine.loadedNativeAgent).isNull();
+        assertThat(RecordingVirtualMachine.detached).isTrue();
+    }
+
+    @Test
+    void mainLoadsNativeAgentWithNullArgument() {
+        Attacher.main(new String[] {
+                RecordingVirtualMachine.class.getName(),
+                "5678",
+                "native-agent.so",
+                "true",
+                ""
+        });
+
+        assertThat(RecordingVirtualMachine.attachedProcessId).isEqualTo("5678");
+        assertThat(RecordingVirtualMachine.loadedNativeAgent).isEqualTo("native-agent.so");
+        assertThat(RecordingVirtualMachine.loadedNativeAgentArgument).isNull();
+        assertThat(RecordingVirtualMachine.loadedAgent).isNull();
+        assertThat(RecordingVirtualMachine.detached).isTrue();
+    }
+
+    public static class RecordingVirtualMachine {
+        private static String attachedProcessId;
+        private static String loadedAgent;
+        private static String loadedAgentArgument;
+        private static String loadedNativeAgent;
+        private static String loadedNativeAgentArgument;
+        private static boolean detached;
+
+        public static RecordingVirtualMachine attach(String processId) {
+            attachedProcessId = processId;
+            return new RecordingVirtualMachine();
+        }
+
+        public void loadAgent(String agent, String argument) {
+            loadedAgent = agent;
+            loadedAgentArgument = argument;
+        }
+
+        public void loadAgentPath(String agent, String argument) {
+            loadedNativeAgent = agent;
+            loadedNativeAgentArgument = argument;
+        }
+
+        public void detach() {
+            detached = true;
+        }
+
+        private static void reset() {
+            attachedProcessId = null;
+            loadedAgent = null;
+            loadedAgentArgument = null;
+            loadedNativeAgent = null;
+            loadedNativeAgentArgument = null;
+            detached = false;
+        }
+    }
+}

--- a/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/src/test/java/net_bytebuddy/byte_buddy_agent/ByteBuddyAgentInnerAgentProviderInnerForByteBuddyAgentTest.java
+++ b/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/src/test/java/net_bytebuddy/byte_buddy_agent/ByteBuddyAgentInnerAgentProviderInnerForByteBuddyAgentTest.java
@@ -13,8 +13,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.lang.instrument.ClassDefinition;
+import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.Instrumentation;
+import java.lang.instrument.UnmodifiableClassException;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.jar.JarFile;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,7 +53,7 @@ public class ByteBuddyAgentInnerAgentProviderInnerForByteBuddyAgentTest {
     void installCreatesTemporaryAgentJarFromInstallerClassResource() throws Exception {
         Instrumentation instrumentation = ByteBuddyAgent.install(new RecordingAttachmentProvider(), () -> PROCESS_ID);
 
-        assertThat(instrumentation).isNull();
+        assertThat(instrumentation).isSameAs(RecordingVirtualMachine.instrumentation);
         assertThat(RecordingVirtualMachine.attachedProcessId).isEqualTo(PROCESS_ID);
         assertThat(RecordingVirtualMachine.loadedAgentArgument).isNull();
         assertThat(RecordingVirtualMachine.detached).isTrue();
@@ -91,6 +97,8 @@ public class ByteBuddyAgentInnerAgentProviderInnerForByteBuddyAgentTest {
     }
 
     public static final class RecordingVirtualMachine {
+        private static final Instrumentation instrumentation = new RecordingInstrumentation();
+
         private static String attachedProcessId;
         private static String loadedAgent;
         private static String loadedAgentArgument;
@@ -104,6 +112,7 @@ public class ByteBuddyAgentInnerAgentProviderInnerForByteBuddyAgentTest {
         public void loadAgent(String agent, String argument) {
             loadedAgent = agent;
             loadedAgentArgument = argument;
+            Installer.agentmain(argument, instrumentation);
         }
 
         public void detach() {
@@ -115,6 +124,91 @@ public class ByteBuddyAgentInnerAgentProviderInnerForByteBuddyAgentTest {
             loadedAgent = null;
             loadedAgentArgument = null;
             detached = false;
+        }
+    }
+
+    private static final class RecordingInstrumentation implements Instrumentation {
+        @Override
+        public void addTransformer(ClassFileTransformer transformer, boolean canRetransform) {
+        }
+
+        @Override
+        public void addTransformer(ClassFileTransformer transformer) {
+        }
+
+        @Override
+        public boolean removeTransformer(ClassFileTransformer transformer) {
+            return false;
+        }
+
+        @Override
+        public boolean isRetransformClassesSupported() {
+            return false;
+        }
+
+        @Override
+        public void retransformClasses(Class<?>... classes) throws UnmodifiableClassException {
+        }
+
+        @Override
+        public boolean isRedefineClassesSupported() {
+            return false;
+        }
+
+        @Override
+        public void redefineClasses(ClassDefinition... definitions)
+                throws ClassNotFoundException, UnmodifiableClassException {
+        }
+
+        @Override
+        public boolean isModifiableClass(Class<?> type) {
+            return false;
+        }
+
+        @Override
+        public Class<?>[] getAllLoadedClasses() {
+            return new Class<?>[0];
+        }
+
+        @Override
+        public Class<?>[] getInitiatedClasses(ClassLoader loader) {
+            return new Class<?>[0];
+        }
+
+        @Override
+        public long getObjectSize(Object object) {
+            return 0L;
+        }
+
+        @Override
+        public void appendToBootstrapClassLoaderSearch(JarFile jarFile) {
+        }
+
+        @Override
+        public void appendToSystemClassLoaderSearch(JarFile jarFile) {
+        }
+
+        @Override
+        public boolean isNativeMethodPrefixSupported() {
+            return false;
+        }
+
+        @Override
+        public void setNativeMethodPrefix(ClassFileTransformer transformer, String prefix) {
+        }
+
+        @Override
+        public void redefineModule(Module module,
+                                   Set<Module> extraReads,
+                                   Map<String, Set<Module>> extraExports,
+                                   Map<String, Set<Module>> extraOpens,
+                                   Set<Class<?>> extraUses,
+                                   Map<Class<?>, List<Class<?>>> extraProvides) {
+        }
+
+        @Override
+        public boolean isModifiableModule(Module module) {
+            return false;
         }
     }
 }

--- a/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/src/test/java/net_bytebuddy/byte_buddy_agent/ByteBuddyAgentInnerAgentProviderInnerForByteBuddyAgentTest.java
+++ b/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/src/test/java/net_bytebuddy/byte_buddy_agent/ByteBuddyAgentInnerAgentProviderInnerForByteBuddyAgentTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_bytebuddy.byte_buddy_agent;
+
+import net.bytebuddy.agent.ByteBuddyAgent;
+import net.bytebuddy.agent.Installer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.lang.instrument.Instrumentation;
+import java.util.Collections;
+import java.util.jar.JarFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ByteBuddyAgentInnerAgentProviderInnerForByteBuddyAgentTest {
+    private static final String PROCESS_ID = "4711";
+
+    private String originalLatentResolve;
+
+    @BeforeEach
+    void resetState() {
+        originalLatentResolve = System.getProperty(ByteBuddyAgent.LATENT_RESOLVE);
+        System.setProperty(ByteBuddyAgent.LATENT_RESOLVE, Boolean.TRUE.toString());
+        Installer.premain(null, null);
+        RecordingVirtualMachine.reset();
+    }
+
+    @AfterEach
+    void restoreState() {
+        Installer.premain(null, null);
+        RecordingVirtualMachine.reset();
+        if (originalLatentResolve == null) {
+            System.clearProperty(ByteBuddyAgent.LATENT_RESOLVE);
+        } else {
+            System.setProperty(ByteBuddyAgent.LATENT_RESOLVE, originalLatentResolve);
+        }
+    }
+
+    @Test
+    void installCreatesTemporaryAgentJarFromInstallerClassResource() throws Exception {
+        Instrumentation instrumentation = ByteBuddyAgent.install(new RecordingAttachmentProvider(), () -> PROCESS_ID);
+
+        assertThat(instrumentation).isNull();
+        assertThat(RecordingVirtualMachine.attachedProcessId).isEqualTo(PROCESS_ID);
+        assertThat(RecordingVirtualMachine.loadedAgentArgument).isNull();
+        assertThat(RecordingVirtualMachine.detached).isTrue();
+
+        File agentJar = new File(RecordingVirtualMachine.loadedAgent);
+        assertThat(agentJar).isFile();
+        try (JarFile jarFile = new JarFile(agentJar)) {
+            assertThat(jarFile.getEntry(Installer.class.getName().replace('.', '/') + ".class")).isNotNull();
+            assertThat(jarFile.getManifest().getMainAttributes().getValue("Agent-Class"))
+                    .isEqualTo(Installer.class.getName());
+        }
+    }
+
+    private static final class RecordingAttachmentProvider implements ByteBuddyAgent.AttachmentProvider {
+        @Override
+        public ByteBuddyAgent.AttachmentProvider.Accessor attempt() {
+            return new RecordingAccessor();
+        }
+    }
+
+    private static final class RecordingAccessor implements ByteBuddyAgent.AttachmentProvider.Accessor {
+        @Override
+        public boolean isAvailable() {
+            return true;
+        }
+
+        @Override
+        public boolean isExternalAttachmentRequired() {
+            return false;
+        }
+
+        @Override
+        public Class<?> getVirtualMachineType() {
+            return RecordingVirtualMachine.class;
+        }
+
+        @Override
+        public ExternalAttachment getExternalAttachment() {
+            return new ExternalAttachment(RecordingVirtualMachine.class.getName(), Collections.<File>emptyList());
+        }
+    }
+
+    public static final class RecordingVirtualMachine {
+        private static String attachedProcessId;
+        private static String loadedAgent;
+        private static String loadedAgentArgument;
+        private static boolean detached;
+
+        public static RecordingVirtualMachine attach(String processId) {
+            attachedProcessId = processId;
+            return new RecordingVirtualMachine();
+        }
+
+        public void loadAgent(String agent, String argument) {
+            loadedAgent = agent;
+            loadedAgentArgument = argument;
+        }
+
+        public void detach() {
+            detached = true;
+        }
+
+        private static void reset() {
+            attachedProcessId = null;
+            loadedAgent = null;
+            loadedAgentArgument = null;
+            detached = false;
+        }
+    }
+}

--- a/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/src/test/java/net_bytebuddy/byte_buddy_agent/ByteBuddyAgentInnerAttachmentProviderInnerAccessorInnerSimpleTest.java
+++ b/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/src/test/java/net_bytebuddy/byte_buddy_agent/ByteBuddyAgentInnerAttachmentProviderInnerAccessorInnerSimpleTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_bytebuddy.byte_buddy_agent;
+
+import com.ibm.tools.attach.VirtualMachine;
+import net.bytebuddy.agent.ByteBuddyAgent;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ByteBuddyAgentInnerAttachmentProviderInnerAccessorInnerSimpleTest {
+    @Test
+    void createsExternalAttachmentAccessorFromProvidedClassLoader(@TempDir Path temporaryDirectory) {
+        File toolsJar = temporaryDirectory.resolve("tools.jar").toFile();
+        RecordingClassLoader classLoader = new RecordingClassLoader();
+
+        ByteBuddyAgent.AttachmentProvider.Accessor accessor =
+                ByteBuddyAgent.AttachmentProvider.Accessor.Simple.of(classLoader, toolsJar);
+
+        assertThat(classLoader.requestedName)
+                .isEqualTo(ByteBuddyAgent.AttachmentProvider.Accessor.VIRTUAL_MACHINE_TYPE_NAME);
+        assertThat(accessor.isAvailable()).isTrue();
+        assertThat(accessor.isExternalAttachmentRequired()).isTrue();
+        assertThat(accessor.getVirtualMachineType()).isEqualTo(RecordingVirtualMachine.class);
+        assertThat(accessor.getExternalAttachment().getVirtualMachineType())
+                .isEqualTo(RecordingVirtualMachine.class.getName());
+        assertThat(accessor.getExternalAttachment().getClassPath()).containsExactly(toolsJar);
+    }
+
+    @Test
+    void createsExternalAttachmentAccessorForJ9VirtualMachineClassFromSystemClassLoader() {
+        ByteBuddyAgent.AttachmentProvider.Accessor accessor =
+                ByteBuddyAgent.AttachmentProvider.Accessor.Simple.ofJ9();
+
+        assertThat(accessor.isAvailable()).isTrue();
+        assertThat(accessor.isExternalAttachmentRequired()).isTrue();
+        assertThat(accessor.getVirtualMachineType()).isEqualTo(VirtualMachine.class);
+        assertThat(accessor.getExternalAttachment().getVirtualMachineType())
+                .isEqualTo(ByteBuddyAgent.AttachmentProvider.Accessor.VIRTUAL_MACHINE_TYPE_NAME_J9);
+        assertThat(accessor.getExternalAttachment().getClassPath()).isEmpty();
+    }
+
+    private static final class RecordingClassLoader extends ClassLoader {
+        private String requestedName;
+
+        private RecordingClassLoader() {
+            super(null);
+        }
+
+        @Override
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            requestedName = name;
+            if (ByteBuddyAgent.AttachmentProvider.Accessor.VIRTUAL_MACHINE_TYPE_NAME.equals(name)) {
+                return RecordingVirtualMachine.class;
+            }
+            throw new ClassNotFoundException(name);
+        }
+    }
+
+    public static final class RecordingVirtualMachine {
+    }
+}

--- a/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/src/test/java/net_bytebuddy/byte_buddy_agent/ByteBuddyAgentTest.java
+++ b/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/src/test/java/net_bytebuddy/byte_buddy_agent/ByteBuddyAgentTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_bytebuddy.byte_buddy_agent;
+
+import net.bytebuddy.agent.ByteBuddyAgent;
+import net.bytebuddy.agent.Installer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.instrument.ClassDefinition;
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.Instrumentation;
+import java.lang.instrument.UnmodifiableClassException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.jar.JarFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ByteBuddyAgentTest {
+    private static final String ALLOW_SELF_ATTACH = "jdk.attach.allowAttachSelf";
+    private static final String JAVA_HOME = "java.home";
+
+    private static String originalAllowSelfAttach;
+
+    @BeforeAll
+    static void requireExternalSelfAttachment() {
+        originalAllowSelfAttach = System.getProperty(ALLOW_SELF_ATTACH);
+        System.setProperty(ALLOW_SELF_ATTACH, Boolean.FALSE.toString());
+    }
+
+    @AfterAll
+    static void restoreSelfAttachmentProperty() {
+        restoreProperty(ALLOW_SELF_ATTACH, originalAllowSelfAttach);
+    }
+
+    @BeforeEach
+    void resetInstaller() {
+        Installer.premain(null, null);
+    }
+
+    @Test
+    void getInstrumentationLooksUpInstallerViaSystemClassLoader() {
+        assertThatThrownBy(ByteBuddyAgent::getInstrumentation)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("not initialized");
+    }
+
+    @Test
+    void getInstrumentationInvokesInstallerMethodSuccessfully() {
+        Instrumentation instrumentation = new RecordingInstrumentation();
+
+        Installer.premain(null, instrumentation);
+
+        assertThat(ByteBuddyAgent.getInstrumentation()).isSameAs(instrumentation);
+    }
+
+    @Test
+    void externalAttachmentCopiesAttacherClassResource(@TempDir Path temporaryDirectory) throws IOException {
+        Path agentJar = Files.createFile(temporaryDirectory.resolve("agent.jar"));
+        String originalLatentResolve = System.getProperty(ByteBuddyAgent.LATENT_RESOLVE);
+        String originalJavaHome = System.getProperty(JAVA_HOME);
+        System.setProperty(ByteBuddyAgent.LATENT_RESOLVE, Boolean.TRUE.toString());
+        System.setProperty(JAVA_HOME, temporaryDirectory.resolve("missing-java-home").toString());
+        try {
+            assertThatThrownBy(() -> ByteBuddyAgent.attach(agentJar.toFile(),
+                    ByteBuddyAgent.ProcessProvider.ForCurrentVm.INSTANCE,
+                    new AlwaysExternalAttachmentProvider()))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Error during attachment");
+        } finally {
+            restoreProperty(ByteBuddyAgent.LATENT_RESOLVE, originalLatentResolve);
+            restoreProperty(JAVA_HOME, originalJavaHome);
+        }
+    }
+
+    private static void restoreProperty(String name, String value) {
+        if (value == null) {
+            System.clearProperty(name);
+        } else {
+            System.setProperty(name, value);
+        }
+    }
+
+    private static final class AlwaysExternalAttachmentProvider implements ByteBuddyAgent.AttachmentProvider {
+        @Override
+        public ByteBuddyAgent.AttachmentProvider.Accessor attempt() {
+            return new AlwaysExternalAccessor();
+        }
+    }
+
+    private static final class AlwaysExternalAccessor implements ByteBuddyAgent.AttachmentProvider.Accessor {
+        @Override
+        public boolean isAvailable() {
+            return true;
+        }
+
+        @Override
+        public boolean isExternalAttachmentRequired() {
+            return true;
+        }
+
+        @Override
+        public Class<?> getVirtualMachineType() {
+            return RecordingVirtualMachine.class;
+        }
+
+        @Override
+        public ExternalAttachment getExternalAttachment() {
+            return new ExternalAttachment(RecordingVirtualMachine.class.getName(), Collections.<File>emptyList());
+        }
+    }
+
+    private static final class RecordingInstrumentation implements Instrumentation {
+        @Override
+        public void addTransformer(ClassFileTransformer transformer, boolean canRetransform) {
+        }
+
+        @Override
+        public void addTransformer(ClassFileTransformer transformer) {
+        }
+
+        @Override
+        public boolean removeTransformer(ClassFileTransformer transformer) {
+            return false;
+        }
+
+        @Override
+        public boolean isRetransformClassesSupported() {
+            return false;
+        }
+
+        @Override
+        public void retransformClasses(Class<?>... classes) throws UnmodifiableClassException {
+        }
+
+        @Override
+        public boolean isRedefineClassesSupported() {
+            return false;
+        }
+
+        @Override
+        public void redefineClasses(ClassDefinition... definitions)
+                throws ClassNotFoundException, UnmodifiableClassException {
+        }
+
+        @Override
+        public boolean isModifiableClass(Class<?> type) {
+            return false;
+        }
+
+        @Override
+        public Class<?>[] getAllLoadedClasses() {
+            return new Class<?>[0];
+        }
+
+        @Override
+        public Class<?>[] getInitiatedClasses(ClassLoader loader) {
+            return new Class<?>[0];
+        }
+
+        @Override
+        public long getObjectSize(Object object) {
+            return 0L;
+        }
+
+        @Override
+        public void appendToBootstrapClassLoaderSearch(JarFile jarFile) {
+        }
+
+        @Override
+        public void appendToSystemClassLoaderSearch(JarFile jarFile) {
+        }
+
+        @Override
+        public boolean isNativeMethodPrefixSupported() {
+            return false;
+        }
+
+        @Override
+        public void setNativeMethodPrefix(ClassFileTransformer transformer, String prefix) {
+        }
+
+        @Override
+        public void redefineModule(Module module,
+                                   Set<Module> extraReads,
+                                   Map<String, Set<Module>> extraExports,
+                                   Map<String, Set<Module>> extraOpens,
+                                   Set<Class<?>> extraUses,
+                                   Map<Class<?>, List<Class<?>>> extraProvides) {
+        }
+
+        @Override
+        public boolean isModifiableModule(Module module) {
+            return false;
+        }
+    }
+
+    public static final class RecordingVirtualMachine {
+        private static String attachedProcessId;
+        private static String loadedAgent;
+        private static String loadedAgentArgument;
+        private static boolean detached;
+
+        public static RecordingVirtualMachine attach(String processId) {
+            attachedProcessId = processId;
+            return new RecordingVirtualMachine();
+        }
+
+        public void loadAgent(String agent, String argument) {
+            loadedAgent = agent;
+            loadedAgentArgument = argument;
+        }
+
+        public void detach() {
+            detached = true;
+        }
+    }
+}

--- a/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/src/test/java/net_bytebuddy/byte_buddy_agent/InstallerTest.java
+++ b/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/src/test/java/net_bytebuddy/byte_buddy_agent/InstallerTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_bytebuddy.byte_buddy_agent;
+
+import net.bytebuddy.agent.Installer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.instrument.ClassDefinition;
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.Instrumentation;
+import java.lang.instrument.UnmodifiableClassException;
+import java.security.Permission;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.jar.JarFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InstallerTest {
+    @BeforeEach
+    void resetInstaller() {
+        Installer.premain(null, null);
+    }
+
+    @AfterEach
+    void clearInstaller() {
+        Installer.premain(null, null);
+    }
+
+    @Test
+    @SuppressWarnings("removal")
+    void getInstrumentationChecksPermissionWhenSecurityManagerIsInstalled() {
+        SecurityManager previousSecurityManager = System.getSecurityManager();
+        RecordingSecurityManager securityManager = new RecordingSecurityManager();
+        boolean securityManagerInstalled = installSecurityManagerIfSupported(securityManager);
+        Instrumentation instrumentation = new RecordingInstrumentation();
+        Installer.premain(null, instrumentation);
+
+        try {
+            assertThat(Installer.getInstrumentation()).isSameAs(instrumentation);
+            if (securityManagerInstalled) {
+                assertThat(securityManager.wasInstrumentationPermissionChecked()).isTrue();
+            }
+        } finally {
+            if (securityManagerInstalled) {
+                System.setSecurityManager(previousSecurityManager);
+            }
+        }
+    }
+
+    @SuppressWarnings("removal")
+    private static boolean installSecurityManagerIfSupported(SecurityManager securityManager) {
+        try {
+            System.setSecurityManager(securityManager);
+            return System.getSecurityManager() == securityManager;
+        } catch (UnsupportedOperationException unsupportedOperationException) {
+            return false;
+        }
+    }
+
+    @SuppressWarnings("removal")
+    private static final class RecordingSecurityManager extends SecurityManager {
+        private boolean instrumentationPermissionChecked;
+
+        @Override
+        public void checkPermission(Permission permission) {
+            if ("net.bytebuddy.agent.getInstrumentation".equals(permission.getName())) {
+                instrumentationPermissionChecked = true;
+            }
+        }
+
+        private boolean wasInstrumentationPermissionChecked() {
+            return instrumentationPermissionChecked;
+        }
+    }
+
+    private static final class RecordingInstrumentation implements Instrumentation {
+        @Override
+        public void addTransformer(ClassFileTransformer transformer, boolean canRetransform) {
+        }
+
+        @Override
+        public void addTransformer(ClassFileTransformer transformer) {
+        }
+
+        @Override
+        public boolean removeTransformer(ClassFileTransformer transformer) {
+            return false;
+        }
+
+        @Override
+        public boolean isRetransformClassesSupported() {
+            return false;
+        }
+
+        @Override
+        public void retransformClasses(Class<?>... classes) throws UnmodifiableClassException {
+        }
+
+        @Override
+        public boolean isRedefineClassesSupported() {
+            return false;
+        }
+
+        @Override
+        public void redefineClasses(ClassDefinition... definitions)
+                throws ClassNotFoundException, UnmodifiableClassException {
+        }
+
+        @Override
+        public boolean isModifiableClass(Class<?> type) {
+            return false;
+        }
+
+        @Override
+        public Class<?>[] getAllLoadedClasses() {
+            return new Class<?>[0];
+        }
+
+        @Override
+        public Class<?>[] getInitiatedClasses(ClassLoader loader) {
+            return new Class<?>[0];
+        }
+
+        @Override
+        public long getObjectSize(Object object) {
+            return 0L;
+        }
+
+        @Override
+        public void appendToBootstrapClassLoaderSearch(JarFile jarFile) {
+        }
+
+        @Override
+        public void appendToSystemClassLoaderSearch(JarFile jarFile) {
+        }
+
+        @Override
+        public boolean isNativeMethodPrefixSupported() {
+            return false;
+        }
+
+        @Override
+        public void setNativeMethodPrefix(ClassFileTransformer transformer, String prefix) {
+        }
+
+        @Override
+        public void redefineModule(Module module,
+                                   Set<Module> extraReads,
+                                   Map<String, Set<Module>> extraExports,
+                                   Map<String, Set<Module>> extraOpens,
+                                   Set<Class<?>> extraUses,
+                                   Map<Class<?>, List<Class<?>>> extraProvides) {
+        }
+
+        @Override
+        public boolean isModifiableModule(Module module) {
+            return false;
+        }
+    }
+}

--- a/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,22 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "net.bytebuddy.agent.ByteBuddyAgent$AttachmentProvider$Accessor$Simple"
+      },
+      "type" : "com.ibm.tools.attach.VirtualMachine"
+    },
+    {
+      "condition" : {
+        "typeReached" : "net.bytebuddy.agent.Attacher"
+      },
+      "type" : "net_bytebuddy.byte_buddy_agent.AttacherTest$RecordingVirtualMachine"
+    },
+    {
+      "condition" : {
+        "typeReached" : "net.bytebuddy.agent.Attacher"
+      },
+      "type" : "net_bytebuddy.byte_buddy_agent.ByteBuddyAgentInnerAgentProviderInnerForByteBuddyAgentTest$RecordingVirtualMachine"
+    }
+  ]
+}

--- a/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -2,12 +2,6 @@
   "reflection" : [
     {
       "condition" : {
-        "typeReached" : "net.bytebuddy.agent.ByteBuddyAgent$AttachmentProvider$Accessor$Simple"
-      },
-      "type" : "com.ibm.tools.attach.VirtualMachine"
-    },
-    {
-      "condition" : {
         "typeReached" : "net.bytebuddy.agent.Attacher"
       },
       "type" : "net_bytebuddy.byte_buddy_agent.AttacherTest$RecordingVirtualMachine"

--- a/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/user-code-filter.json
+++ b/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/user-code-filter.json
@@ -1,0 +1,16 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "net.bytebuddy.agent.**"
+    },
+    {
+      "includeClasses" : "com.ibm.tools.attach.**"
+    },
+    {
+      "includeClasses" : "net_bytebuddy.byte_buddy_agent.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6309

This PR provides test fixes and new metadata for net.bytebuddy:byte-buddy-agent:1.11.17, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 157491
- Cached input tokens: 790528
- Output tokens: 14401
- Metadata entries: 10
- Test-only metadata entries: 2
- Iterations: 3
- Library coverage percentage: 16.87
- Previous library version metadata entries: 11
- Previous library version test-only metadata entries: 3
- Previous library version coverage percentage: 16.36

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `508b5cfd17c6716c9e9ed5eac52c7180ad44adbf`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- net.bytebuddy:byte-buddy-agent:1.10.9: 16/16 covered calls (100.00%)
- net.bytebuddy:byte-buddy-agent:1.11.17: 17/17 covered calls (100.00%)

**Reflection:**
- net.bytebuddy:byte-buddy-agent:1.10.9: 14/14 covered calls (100.00%)
- net.bytebuddy:byte-buddy-agent:1.11.17: 15/15 covered calls (100.00%)

**Resources:**
- net.bytebuddy:byte-buddy-agent:1.10.9: 2/2 covered calls (100.00%)
- net.bytebuddy:byte-buddy-agent:1.11.17: 2/2 covered calls (100.00%)

#### Library coverage

**Instruction:**
- net.bytebuddy:byte-buddy-agent:1.10.9: 761/4751 (16.02%)
- net.bytebuddy:byte-buddy-agent:1.11.17: 821/4865 (16.88%)

**Line:**
- net.bytebuddy:byte-buddy-agent:1.10.9: 158/966 (16.36%)
- net.bytebuddy:byte-buddy-agent:1.11.17: 167/990 (16.87%)

**Method:**
- net.bytebuddy:byte-buddy-agent:1.10.9: 40/190 (21.05%)
- net.bytebuddy:byte-buddy-agent:1.11.17: 42/191 (21.99%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/net.bytebuddy/byte-buddy-agent/1.10.9/build.gradle 2/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/build.gradle
index 419ca3f8eb..5648f45808 100644
--- 1/tests/src/net.bytebuddy/byte-buddy-agent/1.10.9/build.gradle
+++ 2/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/build.gradle
@@ -15,6 +15,12 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"
@@ -25,3 +31,7 @@ graalvmNative {
         }
     }
 }
+
+tasks.named("test") {
+    jvmArgs += ["-Djava.security.manager=allow"]
+}
diff --git 1/tests/src/net.bytebuddy/byte-buddy-agent/1.10.9/src/test/java/net_bytebuddy/byte_buddy_agent/ByteBuddyAgentInnerAgentProviderInnerForByteBuddyAgentTest.java 2/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/src/test/java/net_bytebuddy/byte_buddy_agent/ByteBuddyAgentInnerAgentProviderInnerForByteBuddyAgentTest.java
index cf5c038a3e..68d20460bb 100644
--- 1/tests/src/net.bytebuddy/byte-buddy-agent/1.10.9/src/test/java/net_bytebuddy/byte_buddy_agent/ByteBuddyAgentInnerAgentProviderInnerForByteBuddyAgentTest.java
+++ 2/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/src/test/java/net_bytebuddy/byte_buddy_agent/ByteBuddyAgentInnerAgentProviderInnerForByteBuddyAgentTest.java
@@ -13,8 +13,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.lang.instrument.ClassDefinition;
+import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.Instrumentation;
+import java.lang.instrument.UnmodifiableClassException;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.jar.JarFile;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,7 +53,7 @@ public class ByteBuddyAgentInnerAgentProviderInnerForByteBuddyAgentTest {
     void installCreatesTemporaryAgentJarFromInstallerClassResource() throws Exception {
         Instrumentation instrumentation = ByteBuddyAgent.install(new RecordingAttachmentProvider(), () -> PROCESS_ID);
 
-        assertThat(instrumentation).isNull();
+        assertThat(instrumentation).isSameAs(RecordingVirtualMachine.instrumentation);
         assertThat(RecordingVirtualMachine.attachedProcessId).isEqualTo(PROCESS_ID);
         assertThat(RecordingVirtualMachine.loadedAgentArgument).isNull();
         assertThat(RecordingVirtualMachine.detached).isTrue();
@@ -91,6 +97,8 @@ public class ByteBuddyAgentInnerAgentProviderInnerForByteBuddyAgentTest {
     }
 
     public static final class RecordingVirtualMachine {
+        private static final Instrumentation instrumentation = new RecordingInstrumentation();
+
         private static String attachedProcessId;
         private static String loadedAgent;
         private static String loadedAgentArgument;
@@ -104,6 +112,7 @@ public class ByteBuddyAgentInnerAgentProviderInnerForByteBuddyAgentTest {
         public void loadAgent(String agent, String argument) {
             loadedAgent = agent;
             loadedAgentArgument = argument;
+            Installer.agentmain(argument, instrumentation);
         }
 
         public void detach() {
@@ -117,4 +126,89 @@ public class ByteBuddyAgentInnerAgentProviderInnerForByteBuddyAgentTest {
             detached = false;
         }
     }
+
+    private static final class RecordingInstrumentation implements Instrumentation {
+        @Override
+        public void addTransformer(ClassFileTransformer transformer, boolean canRetransform) {
+        }
+
+        @Override
+        public void addTransformer(ClassFileTransformer transformer) {
+        }
+
+        @Override
+        public boolean removeTransformer(ClassFileTransformer transformer) {
+            return false;
+        }
+
+        @Override
+        public boolean isRetransformClassesSupported() {
+            return false;
+        }
+
+        @Override
+        public void retransformClasses(Class<?>... classes) throws UnmodifiableClassException {
+        }
+
+        @Override
+        public boolean isRedefineClassesSupported() {
+            return false;
+        }
+
+        @Override
+        public void redefineClasses(ClassDefinition... definitions)
+                throws ClassNotFoundException, UnmodifiableClassException {
+        }
+
+        @Override
+        public boolean isModifiableClass(Class<?> type) {
+            return false;
+        }
+
+        @Override
+        public Class<?>[] getAllLoadedClasses() {
+            return new Class<?>[0];
+        }
+
+        @Override
+        public Class<?>[] getInitiatedClasses(ClassLoader loader) {
+            return new Class<?>[0];
+        }
+
+        @Override
+        public long getObjectSize(Object object) {
+            return 0L;
+        }
+
+        @Override
+        public void appendToBootstrapClassLoaderSearch(JarFile jarFile) {
+        }
+
+        @Override
+        public void appendToSystemClassLoaderSearch(JarFile jarFile) {
+        }
+
+        @Override
+        public boolean isNativeMethodPrefixSupported() {
+            return false;
+        }
+
+        @Override
+        public void setNativeMethodPrefix(ClassFileTransformer transformer, String prefix) {
+        }
+
+        @Override
+        public void redefineModule(Module module,
+                                   Set<Module> extraReads,
+                                   Map<String, Set<Module>> extraExports,
+                                   Map<String, Set<Module>> extraOpens,
+                                   Set<Class<?>> extraUses,
+                                   Map<Class<?>, List<Class<?>>> extraProvides) {
+        }
+
+        @Override
+        public boolean isModifiableModule(Module module) {
+            return false;
+        }
+    }
 }
diff --git 1/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/src/test/java/net_bytebuddy/byte_buddy_agent/InstallerTest.java 2/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/src/test/java/net_bytebuddy/byte_buddy_agent/InstallerTest.java
new file mode 100644
index 0000000000..779bd41319
--- /dev/null
+++ 2/tests/src/net.bytebuddy/byte-buddy-agent/1.11.17/src/test/java/net_bytebuddy/byte_buddy_agent/InstallerTest.java
@@ -0,0 +1,168 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_bytebuddy.byte_buddy_agent;
+
+import net.bytebuddy.agent.Installer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.instrument.ClassDefinition;
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.Instrumentation;
+import java.lang.instrument.UnmodifiableClassException;
+import java.security.Permission;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.jar.JarFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InstallerTest {
+    @BeforeEach
+    void resetInstaller() {
+        Installer.premain(null, null);
+    }
+
+    @AfterEach
+    void clearInstaller() {
+        Installer.premain(null, null);
+    }
+
+    @Test
+    @SuppressWarnings("removal")
+    void getInstrumentationChecksPermissionWhenSecurityManagerIsInstalled() {
+        SecurityManager previousSecurityManager = System.getSecurityManager();
+        RecordingSecurityManager securityManager = new RecordingSecurityManager();
+        boolean securityManagerInstalled = installSecurityManagerIfSupported(securityManager);
+        Instrumentation instrumentation = new RecordingInstrumentation();
+        Installer.premain(null, instrumentation);
+
+        try {
+            assertThat(Installer.getInstrumentation()).isSameAs(instrumentation);
+            if (securityManagerInstalled) {
+                assertThat(securityManager.wasInstrumentationPermissionChecked()).isTrue();
+            }
+        } finally {
+            if (securityManagerInstalled) {
+                System.setSecurityManager(previousSecurityManager);
+            }
+        }
+    }
+
+    @SuppressWarnings("removal")
+    private static boolean installSecurityManagerIfSupported(SecurityManager securityManager) {
+        try {
+            System.setSecurityManager(securityManager);
+            return System.getSecurityManager() == securityManager;
+        } catch (UnsupportedOperationException unsupportedOperationException) {
+            return false;
+        }
+    }
+
+    @SuppressWarnings("removal")
+    private static final class RecordingSecurityManager extends SecurityManager {
+        private boolean instrumentationPermissionChecked;
+
+        @Override
+        public void checkPermission(Permission permission) {
+            if ("net.bytebuddy.agent.getInstrumentation".equals(permission.getName())) {
+                instrumentationPermissionChecked = true;
+            }
+        }
+
+        private boolean wasInstrumentationPermissionChecked() {
+            return instrumentationPermissionChecked;
+        }
+    }
+
+    private static final class RecordingInstrumentation implements Instrumentation {
+        @Override
+        public void addTransformer(ClassFileTransformer transformer, boolean canRetransform) {
+        }
+
+        @Override
+        public void addTransformer(ClassFileTransformer transformer) {
+        }
+
+        @Override
+        public boolean removeTransformer(ClassFileTransformer transformer) {
+            return false;
+        }
+
+        @Override
+        public boolean isRetransformClassesSupported() {
+            return false;
+        }
+
+        @Override
+        public void retransformClasses(Class<?>... classes) throws UnmodifiableClassException {
+        }
+
+        @Override
+        public boolean isRedefineClassesSupported() {
+            return false;
+        }
+
+        @Override
+        public void redefineClasses(ClassDefinition... definitions)
+                throws ClassNotFoundException, UnmodifiableClassException {
+        }
+
+        @Override
+        public boolean isModifiableClass(Class<?> type) {
+            return false;
+        }
+
+        @Override
+        public Class<?>[] getAllLoadedClasses() {
+            return new Class<?>[0];
+        }
+
+        @Override
+        public Class<?>[] getInitiatedClasses(ClassLoader loader) {
+            return new Class<?>[0];
+        }
+
+        @Override
+        public long getObjectSize(Object object) {
+            return 0L;
+        }
+
+        @Override
+        public void appendToBootstrapClassLoaderSearch(JarFile jarFile) {
+        }
+
+        @Override
+        public void appendToSystemClassLoaderSearch(JarFile jarFile) {
+        }
+
+        @Override
+        public boolean isNativeMethodPrefixSupported() {
+            return false;
+        }
+
+        @Override
+        public void setNativeMethodPrefix(ClassFileTransformer transformer, String prefix) {
+        }
+
+        @Override
+        public void redefineModule(Module module,
+                                   Set<Module> extraReads,
+                                   Map<String, Set<Module>> extraExports,
+                                   Map<String, Set<Module>> extraOpens,
+                                   Set<Class<?>> extraUses,
+                                   Map<Class<?>, List<Class<?>>> extraProvides) {
+        }
+
+        @Override
+        public boolean isModifiableModule(Module module) {
+            return false;
+        }
+    }
+}

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
