### PR TITLE
[GenAI] Test fix for org.scalatest:scalatest-refspec_2.13:3.3.0-SNAP2 using gpt-5.5

### DIFF
--- a/metadata/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/reachability-metadata.json
+++ b/metadata/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/reachability-metadata.json
@@ -1,184 +1,154 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org.scalatest.Resources$"
+      "condition" : {
+        "typeReached" : "org.scalatest.Resources$"
       },
-      "type": "java.lang.StackTraceElement[]"
+      "type" : "java.lang.StackTraceElement[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.Suite$"
+      "condition" : {
+        "typeReached" : "org.scalatest.Suite$"
       },
-      "type": "java.lang.String[]"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.refspec.RefSpecLike"
+      "condition" : {
+        "typeReached" : "org.scalatest.refspec.RefSpecLike"
       },
-      "type": "java.lang.String[]"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.refspec.RefSpecLike"
+      "condition" : {
+        "typeReached" : "org.scalatest.refspec.RefSpecLike"
       },
-      "type": "java.lang.annotation.Annotation[]"
+      "type" : "java.lang.annotation.Annotation[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.refspec.RefSpecLike"
+      "condition" : {
+        "typeReached" : "org.scalatest.refspec.RefSpecLike"
       },
-      "type": "java.lang.annotation.ElementType[]"
+      "type" : "java.lang.annotation.ElementType[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.Suite$"
+      "condition" : {
+        "typeReached" : "org.scalatest.Suite$"
       },
-      "type": "java.lang.reflect.Method[]"
+      "type" : "java.lang.reflect.Method[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.refspec.RefSpecLike"
+      "condition" : {
+        "typeReached" : "org.scalatest.refspec.RefSpecLike"
       },
-      "type": "java.lang.reflect.Method[]"
+      "type" : "java.lang.reflect.Method[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.Suite"
+      "condition" : {
+        "typeReached" : "org.scalatest.Suite"
       },
-      "type": "org.scalatest.Suite[]"
+      "type" : "org.scalatest.Suite[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.refspec.RefSpecLike"
+      "condition" : {
+        "typeReached" : "org.scalatest.refspec.RefSpecLike"
       },
-      "type": "org.scalatest.Tag[]"
+      "type" : "org.scalatest.Tag[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.refspec.RefSpecLike"
+      "condition" : {
+        "typeReached" : "org.scalatest.Suite$"
       },
-      "type": "org_scalatest.scalatest_refspec_2_13.RefSpecLikeTest$ReflectiveRefSpec"
+      "type" : "scala.Tuple2[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.tools.SuiteDiscoveryHelper$"
+      "condition" : {
+        "typeReached" : "org.scalatest.SuperEngine"
       },
-      "type": "org_scalatest.scalatest_refspec_2_13.RefSpecLikeTest$ReflectiveRefSpec"
+      "type" : "scala.Tuple2[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.refspec.RefSpecLike"
+      "condition" : {
+        "typeReached" : "org.scalatest.refspec.RefSpecLike"
       },
-      "type": "org_scalatest.scalatest_refspec_2_13.RefSpecLikeTest$ReflectiveRefSpec$A$u0020calculator$"
+      "type" : "scala.Tuple2[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.refspec.RefSpecLike"
+      "condition" : {
+        "typeReached" : "org.scalatest.Suite$"
       },
-      "type": "org_scalatest.scalatest_refspec_2_13.RefSpecLikeTest$ReflectiveRefSpec$A$u0020calculator$when$u0020adding$u0020numbers$"
-    },
-    {
-      "condition": {
-        "typeReached": "org.scalatest.refspec.RefSpecLike"
-      },
-      "type": "org_scalatest.scalatest_refspec_2_13.RefSpecLikeTest$ReflectiveRefSpec$A$u0020calculator$when$u0020multiplying$u0020numbers$"
-    },
-    {
-      "condition": {
-        "typeReached": "org.scalatest.Suite$"
-      },
-      "type": "scala.Tuple2[]"
-    },
-    {
-      "condition": {
-        "typeReached": "org.scalatest.SuperEngine"
-      },
-      "type": "scala.Tuple2[]"
-    },
-    {
-      "condition": {
-        "typeReached": "org.scalatest.refspec.RefSpecLike"
-      },
-      "type": "scala.Tuple2[]"
-    },
-    {
-      "condition": {
-        "typeReached": "org.scalatest.Suite$"
-      },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Retention"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.refspec.RefSpecLike"
+      "condition" : {
+        "typeReached" : "org.scalatest.refspec.RefSpecLike"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Retention"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.refspec.RefSpecLike"
+      "condition" : {
+        "typeReached" : "org.scalatest.refspec.RefSpecLike"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Target"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.Suite$"
+      "condition" : {
+        "typeReached" : "org.scalatest.Suite$"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "org.scalatest.Finders"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.refspec.RefSpecLike"
+      "condition" : {
+        "typeReached" : "org.scalatest.refspec.RefSpecLike"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "org.scalatest.Ignore"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.refspec.RefSpecLike"
+      "condition" : {
+        "typeReached" : "org.scalatest.refspec.RefSpecLike"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "org.scalatest.TagAnnotation"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.Suite$"
+      "condition" : {
+        "typeReached" : "org.scalatest.Suite$"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "scala.reflect.ScalaSignature"
         ]
       }
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "org.scalatest.Resources$"
+      "condition" : {
+        "typeReached" : "org.scalatest.Resources$"
       },
-      "bundle": "org.scalatest.ScalaTestBundle"
+      "bundle" : "org.scalatest.ScalaTestBundle"
     }
   ]
 }

--- a/metadata/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/reachability-metadata.json
+++ b/metadata/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/reachability-metadata.json
@@ -1,0 +1,184 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Resources$"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Suite$"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.refspec.RefSpecLike"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.refspec.RefSpecLike"
+      },
+      "type": "java.lang.annotation.Annotation[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.refspec.RefSpecLike"
+      },
+      "type": "java.lang.annotation.ElementType[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Suite$"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.refspec.RefSpecLike"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Suite"
+      },
+      "type": "org.scalatest.Suite[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.refspec.RefSpecLike"
+      },
+      "type": "org.scalatest.Tag[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.refspec.RefSpecLike"
+      },
+      "type": "org_scalatest.scalatest_refspec_2_13.RefSpecLikeTest$ReflectiveRefSpec"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.tools.SuiteDiscoveryHelper$"
+      },
+      "type": "org_scalatest.scalatest_refspec_2_13.RefSpecLikeTest$ReflectiveRefSpec"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.refspec.RefSpecLike"
+      },
+      "type": "org_scalatest.scalatest_refspec_2_13.RefSpecLikeTest$ReflectiveRefSpec$A$u0020calculator$"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.refspec.RefSpecLike"
+      },
+      "type": "org_scalatest.scalatest_refspec_2_13.RefSpecLikeTest$ReflectiveRefSpec$A$u0020calculator$when$u0020adding$u0020numbers$"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.refspec.RefSpecLike"
+      },
+      "type": "org_scalatest.scalatest_refspec_2_13.RefSpecLikeTest$ReflectiveRefSpec$A$u0020calculator$when$u0020multiplying$u0020numbers$"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Suite$"
+      },
+      "type": "scala.Tuple2[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.SuperEngine"
+      },
+      "type": "scala.Tuple2[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.refspec.RefSpecLike"
+      },
+      "type": "scala.Tuple2[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Suite$"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.refspec.RefSpecLike"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.refspec.RefSpecLike"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Target"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Suite$"
+      },
+      "type": {
+        "proxy": [
+          "org.scalatest.Finders"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.refspec.RefSpecLike"
+      },
+      "type": {
+        "proxy": [
+          "org.scalatest.Ignore"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.refspec.RefSpecLike"
+      },
+      "type": {
+        "proxy": [
+          "org.scalatest.TagAnnotation"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Suite$"
+      },
+      "type": {
+        "proxy": [
+          "scala.reflect.ScalaSignature"
+        ]
+      }
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Resources$"
+      },
+      "bundle": "org.scalatest.ScalaTestBundle"
+    }
+  ]
+}

--- a/metadata/org.scalatest/scalatest-refspec_2.13/index.json
+++ b/metadata/org.scalatest/scalatest-refspec_2.13/index.json
@@ -21,5 +21,19 @@
       "org.scalatest.refspec",
       "org.scalatest"
     ]
+  },
+  {
+    "metadata-version" : "3.3.0-SNAP2",
+    "language" : {
+      "name" : "scala",
+      "version" : "2"
+    },
+    "tested-versions" : [
+      "3.3.0-SNAP2"
+    ],
+    "allowed-packages" : [
+      "org.scalatest.refspec",
+      "org.scalatest"
+    ]
   }
 ]

--- a/metadata/org.scalatest/scalatest-refspec_2.13/index.json
+++ b/metadata/org.scalatest/scalatest-refspec_2.13/index.json
@@ -24,6 +24,11 @@
   },
   {
     "metadata-version" : "3.3.0-SNAP2",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-refspec_2.13/$version$/scalatest-refspec_2.13-$version$-sources.jar",
+    "repository-url" : "https://github.com/scalatest/scalatest",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-refspec_2.13/$version$/scalatest-refspec_2.13-$version$-javadoc.jar",
+    "description" : "ScalaTest RefSpec provides the RefSpec testing style for ScalaTest on the JVM, where tests are represented by methods and discovered via reflection. It integrates with ScalaTest's core assertions, tagging, fixtures, and reporting so Scala projects can define and run method-oriented test suites.",
     "language" : {
       "name" : "scala",
       "version" : "2"

--- a/stats/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/execution-metrics.json
+++ b/stats/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/execution-metrics.json
@@ -1,0 +1,101 @@
+{
+  "fix_java_run_fail:2026-06-06": {
+    "timestamp": "2026-06-06T03:03:50.356724Z",
+    "library": "org.scalatest:scalatest-refspec_2.13:3.3.0-SNAP2",
+    "starting_commit": "08a7cec2181cc0910760771b816365c2dde31490",
+    "ending_commit": "c713b172059bc23615af05f58a5aa2bbc92de10c",
+    "previous_library": "org.scalatest:scalatest-refspec_2.13:3.2.19",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.3.0-SNAP2",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 4,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 806,
+          "missed": 809,
+          "ratio": 0.499071,
+          "total": 1615
+        },
+        "line": {
+          "covered": 90,
+          "missed": 31,
+          "ratio": 0.743802,
+          "total": 121
+        },
+        "method": {
+          "covered": 62,
+          "missed": 110,
+          "ratio": 0.360465,
+          "total": 172
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.2.19",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 4,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 792,
+          "missed": 804,
+          "ratio": 0.496241,
+          "total": 1596
+        },
+        "line": {
+          "covered": 90,
+          "missed": 31,
+          "ratio": 0.743802,
+          "total": 121
+        },
+        "method": {
+          "covered": 62,
+          "missed": 110,
+          "ratio": 0.360465,
+          "total": 172
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 38331,
+      "cached_input_tokens_used": 560128,
+      "output_tokens_used": 4490,
+      "iterations": 1,
+      "cost_usd": 0.4148,
+      "tested_library_loc": 90,
+      "metadata_entries": 20,
+      "test_only_metadata_entries": 5,
+      "previous_library_metadata_entries": 20,
+      "previous_library_test_only_metadata_entries": 5,
+      "code_coverage_percent": 74.38,
+      "previous_library_coverage_percent": 74.38
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/src/test/scala/org_scalatest/scalatest_refspec_2_13/RefSpecLikeTest.scala",
+      "metadata_file": "metadata/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/stats.json
+++ b/stats/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "3.3.0-SNAP2",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 4,
+          "totalCalls" : 4
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 4,
+      "totalCalls" : 4
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 806,
+        "missed" : 809,
+        "ratio" : 0.499071,
+        "total" : 1615
+      },
+      "line" : {
+        "covered" : 90,
+        "missed" : 31,
+        "ratio" : 0.743802,
+        "total" : 121
+      },
+      "method" : {
+        "covered" : 62,
+        "missed" : 110,
+        "ratio" : 0.360465,
+        "total" : 172
+      }
+    }
+  } ]
+}

--- a/tests/src/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/.gitignore
+++ b/tests/src/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/build.gradle
+++ b/tests/src/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.scalatest:scalatest-refspec_2.13:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala-library:2.13.16'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/gradle.properties
+++ b/tests/src/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.scalatest:scalatest-refspec_2.13:3.3.0-SNAP2
+library.version = 3.3.0-SNAP2
+metadata.dir = org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/

--- a/tests/src/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/settings.gradle
+++ b/tests/src/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.scalatest.scalatest-refspec_2.13_tests'

--- a/tests/src/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,34 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.scalatest.refspec.RefSpecLike"
+      },
+      "type" : "org_scalatest.scalatest_refspec_2_13.RefSpecLikeTest$ReflectiveRefSpec"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.scalatest.tools.SuiteDiscoveryHelper$"
+      },
+      "type" : "org_scalatest.scalatest_refspec_2_13.RefSpecLikeTest$ReflectiveRefSpec"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.scalatest.refspec.RefSpecLike"
+      },
+      "type" : "org_scalatest.scalatest_refspec_2_13.RefSpecLikeTest$ReflectiveRefSpec$A$u0020calculator$"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.scalatest.refspec.RefSpecLike"
+      },
+      "type" : "org_scalatest.scalatest_refspec_2_13.RefSpecLikeTest$ReflectiveRefSpec$A$u0020calculator$when$u0020adding$u0020numbers$"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.scalatest.refspec.RefSpecLike"
+      },
+      "type" : "org_scalatest.scalatest_refspec_2_13.RefSpecLikeTest$ReflectiveRefSpec$A$u0020calculator$when$u0020multiplying$u0020numbers$"
+    }
+  ]
+}

--- a/tests/src/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/src/test/scala/org_scalatest/scalatest_refspec_2_13/RefSpecLikeTest.scala
+++ b/tests/src/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/src/test/scala/org_scalatest/scalatest_refspec_2_13/RefSpecLikeTest.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_scalatest.scalatest_refspec_2_13
+
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+import scala.jdk.CollectionConverters._
+import scala.util.Try
+
+import org.junit.jupiter.api.Test
+import org.scalatest.Args
+import org.scalatest.Ignore
+import org.scalatest.Reporter
+import org.scalatest.Suite
+import org.scalatest.events.Event
+import org.scalatest.events.TestIgnored
+import org.scalatest.events.TestSucceeded
+import org.scalatest.refspec.RefSpec
+
+class RefSpecLikeTest {
+  @Test
+  def discoversNestedScopesAndInvokesRegisteredTests(): Unit = {
+    val suite: ReflectiveRefSpec = new ReflectiveRefSpec
+    val testNames: Vector[String] = suite.testNames.toVector
+
+    val sumTestName: String = testNames.find(_.contains("should produce their sum")).get
+    val productTestName: String = testNames.find(_.contains("should produce their product")).get
+    val rootTestName: String = testNames.find(_.contains("root level test")).get
+    val ignoredTestName: String = testNames.find(_.contains("ignored tests registered")).get
+
+    assert(sumTestName == "A calculator when adding numbers should produce their sum")
+    assert(productTestName == "A calculator when multiplying numbers should produce their product")
+    assert(rootTestName == "A calculator should expose a root level test")
+    assert(suite.tags(ignoredTestName).contains("org.scalatest.Ignore"))
+
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(suite.executed.toSet == Set("sum", "product", "root"))
+    assert(succeededEvents(result.events).map(_.testName).toSet == Set(sumTestName, productTestName, rootTestName))
+    assert(ignoredEvents(result.events).map(_.testName) == Vector(ignoredTestName))
+  }
+
+  final class ReflectiveRefSpec extends RefSpec {
+    var executed: Vector[String] = Vector.empty
+
+    object `A calculator` {
+      object `when adding numbers` {
+        def `should produce their sum`: Unit = {
+          executed = executed :+ "sum"
+          assert(2 + 3 == 5)
+        }
+      }
+
+      object `when multiplying numbers` {
+        def `should produce their product`: Unit = {
+          executed = executed :+ "product"
+          assert(4 * 6 == 24)
+        }
+      }
+
+      @Ignore
+      def `should keep ignored tests registered`: Unit = {
+        executed = executed :+ "ignored"
+        fail("ignored RefSpec test was executed")
+      }
+    }
+
+    def `A calculator should expose a root level test`: Unit = {
+      executed = executed :+ "root"
+      assert("refspec".startsWith("ref"))
+    }
+  }
+
+  private def runSuite(suite: Suite): RunResult = {
+    val reporter: RecordingReporter = new RecordingReporter
+    val completion: AtomicReference[Try[Boolean]] = new AtomicReference[Try[Boolean]]()
+    val completed: CountDownLatch = new CountDownLatch(1)
+    val status = suite.run(None, Args(reporter = reporter))
+    status.whenCompleted { result: Try[Boolean] =>
+      completion.set(result)
+      completed.countDown()
+    }
+
+    assert(completed.await(30, TimeUnit.SECONDS), s"ScalaTest suite ${suite.suiteName} did not complete")
+    RunResult(completion.get().get, reporter.events)
+  }
+
+  private def succeededEvents(events: Vector[Event]): Vector[TestSucceeded] =
+    events.collect { case event: TestSucceeded => event }
+
+  private def ignoredEvents(events: Vector[Event]): Vector[TestIgnored] =
+    events.collect { case event: TestIgnored => event }
+
+  private final class RecordingReporter extends Reporter {
+    private val recordedEvents: CopyOnWriteArrayList[Event] = new CopyOnWriteArrayList[Event]()
+
+    override def apply(event: Event): Unit = {
+      recordedEvents.add(event)
+      ()
+    }
+
+    def events: Vector[Event] = recordedEvents.asScala.toVector
+  }
+
+  private final case class RunResult(succeeded: Boolean, events: Vector[Event])
+}

--- a/tests/src/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/src/test/scala/org_scalatest/scalatest_refspec_2_13/RefSpecLikeTest.scala
+++ b/tests/src/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/src/test/scala/org_scalatest/scalatest_refspec_2_13/RefSpecLikeTest.scala
@@ -20,6 +20,9 @@ import org.scalatest.Ignore
 import org.scalatest.Reporter
 import org.scalatest.Suite
 import org.scalatest.events.Event
+import org.scalatest.events.SuiteAborted
+import org.scalatest.events.TestCanceled
+import org.scalatest.events.TestFailed
 import org.scalatest.events.TestIgnored
 import org.scalatest.events.TestSucceeded
 import org.scalatest.refspec.RefSpec
@@ -42,7 +45,8 @@ class RefSpecLikeTest {
 
     val result: RunResult = runSuite(suite)
 
-    assert(result.succeeded)
+    assert(result.completed.isSuccess)
+    assert(failureEvents(result.events).isEmpty)
     assert(suite.executed.toSet == Set("sum", "product", "root"))
     assert(succeededEvents(result.events).map(_.testName).toSet == Set(sumTestName, productTestName, rootTestName))
     assert(ignoredEvents(result.events).map(_.testName) == Vector(ignoredTestName))
@@ -90,7 +94,7 @@ class RefSpecLikeTest {
     }
 
     assert(completed.await(30, TimeUnit.SECONDS), s"ScalaTest suite ${suite.suiteName} did not complete")
-    RunResult(completion.get().get, reporter.events)
+    RunResult(completion.get(), reporter.events)
   }
 
   private def succeededEvents(events: Vector[Event]): Vector[TestSucceeded] =
@@ -98,6 +102,14 @@ class RefSpecLikeTest {
 
   private def ignoredEvents(events: Vector[Event]): Vector[TestIgnored] =
     events.collect { case event: TestIgnored => event }
+
+  private def failureEvents(events: Vector[Event]): Vector[Event] =
+    events.filter {
+      case _: SuiteAborted => true
+      case _: TestCanceled => true
+      case _: TestFailed => true
+      case _ => false
+    }
 
   private final class RecordingReporter extends Reporter {
     private val recordedEvents: CopyOnWriteArrayList[Event] = new CopyOnWriteArrayList[Event]()
@@ -110,5 +122,5 @@ class RefSpecLikeTest {
     def events: Vector[Event] = recordedEvents.asScala.toVector
   }
 
-  private final case class RunResult(succeeded: Boolean, events: Vector[Event])
+  private final case class RunResult(completed: Try[Boolean], events: Vector[Event])
 }

--- a/tests/src/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/user-code-filter.json
+++ b/tests/src/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.scalatest.refspec.**"
+    },
+    {
+      "includeClasses" : "org_scalatest.scalatest_refspec_2_13.**"
+    }
+  ]
+}

--- a/tests/src/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/user-code-filter.json
+++ b/tests/src/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/user-code-filter.json
@@ -7,6 +7,9 @@
       "includeClasses" : "org.scalatest.refspec.**"
     },
     {
+      "includeClasses" : "org.scalatest.**"
+    },
+    {
       "includeClasses" : "org_scalatest.scalatest_refspec_2_13.**"
     }
   ]


### PR DESCRIPTION
## What does this PR do?

Fixes: #6323

This PR provides test fixes and new metadata for org.scalatest:scalatest-refspec_2.13:3.3.0-SNAP2, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 38331
- Cached input tokens: 560128
- Output tokens: 4490
- Metadata entries: 20
- Test-only metadata entries: 5
- Iterations: 1
- Library coverage percentage: 74.38
- Previous library version metadata entries: 20
- Previous library version test-only metadata entries: 5
- Previous library version coverage percentage: 74.38

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `5d4ee390b38c748b20cddeb04c40bb01812281e6`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.scalatest:scalatest-refspec_2.13:3.2.19: 4/4 covered calls (100.00%)
- org.scalatest:scalatest-refspec_2.13:3.3.0-SNAP2: 4/4 covered calls (100.00%)

**Reflection:**
- org.scalatest:scalatest-refspec_2.13:3.2.19: 4/4 covered calls (100.00%)
- org.scalatest:scalatest-refspec_2.13:3.3.0-SNAP2: 4/4 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.scalatest:scalatest-refspec_2.13:3.2.19: 792/1596 (49.62%)
- org.scalatest:scalatest-refspec_2.13:3.3.0-SNAP2: 806/1615 (49.91%)

**Line:**
- org.scalatest:scalatest-refspec_2.13:3.2.19: 90/121 (74.38%)
- org.scalatest:scalatest-refspec_2.13:3.3.0-SNAP2: 90/121 (74.38%)

**Method:**
- org.scalatest:scalatest-refspec_2.13:3.2.19: 62/172 (36.05%)
- org.scalatest:scalatest-refspec_2.13:3.3.0-SNAP2: 62/172 (36.05%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.scalatest/scalatest-refspec_2.13/3.2.19/user-code-filter.json 2/tests/src/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/user-code-filter.json
index 0442d6ed23..ce2f6adecc 100644
--- 1/tests/src/org.scalatest/scalatest-refspec_2.13/3.2.19/user-code-filter.json
+++ 2/tests/src/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/user-code-filter.json
@@ -6,6 +6,9 @@
     {
       "includeClasses" : "org.scalatest.refspec.**"
     },
+    {
+      "includeClasses" : "org.scalatest.**"
+    },
     {
       "includeClasses" : "org_scalatest.scalatest_refspec_2_13.**"
     }

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
