### PR TITLE
[GenAI] Test fix for org.scalatest:scalatest-featurespec_2.13:3.3.0-SNAP2 using gpt-5.5

### DIFF
--- a/metadata/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/reachability-metadata.json
+++ b/metadata/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/reachability-metadata.json
@@ -1,222 +1,186 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org.scalatest.Resources$"
+      "condition" : {
+        "typeReached" : "org.scalatest.Resources$"
       },
-      "type": "java.lang.StackTraceElement[]"
+      "type" : "java.lang.StackTraceElement[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.AsyncSuperEngine"
+      "condition" : {
+        "typeReached" : "org.scalatest.AsyncSuperEngine"
       },
-      "type": "java.lang.String[]"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.Suite$"
+      "condition" : {
+        "typeReached" : "org.scalatest.Suite$"
       },
-      "type": "java.lang.String[]"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.SuperEngine"
+      "condition" : {
+        "typeReached" : "org.scalatest.SuperEngine"
       },
-      "type": "java.lang.String[]"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.Suite$"
+      "condition" : {
+        "typeReached" : "org.scalatest.Suite$"
       },
-      "type": "java.lang.reflect.Method[]"
+      "type" : "java.lang.reflect.Method[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.Suite"
+      "condition" : {
+        "typeReached" : "org.scalatest.Suite"
       },
-      "type": "org.scalatest.Suite[]"
+      "type" : "org.scalatest.Suite[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.tools.SuiteDiscoveryHelper$"
+      "condition" : {
+        "typeReached" : "org.scalatest.Args"
       },
-      "type": "org_scalatest.scalatest_featurespec_2_13.Scalatest_featurespec_2_13Test$AsyncCalculationFeatureSpec"
+      "type" : "scala.Tuple2[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.tools.SuiteDiscoveryHelper$"
+      "condition" : {
+        "typeReached" : "org.scalatest.AsyncSuperEngine"
       },
-      "type": "org_scalatest.scalatest_featurespec_2_13.Scalatest_featurespec_2_13Test$AsyncTextFixtureFeatureSpec"
+      "type" : "scala.Tuple2[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.tools.SuiteDiscoveryHelper$"
+      "condition" : {
+        "typeReached" : "org.scalatest.DynaTags"
       },
-      "type": "org_scalatest.scalatest_featurespec_2_13.Scalatest_featurespec_2_13Test$CheckoutNarrativeFeatureSpec"
+      "type" : "scala.Tuple2[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.tools.SuiteDiscoveryHelper$"
+      "condition" : {
+        "typeReached" : "org.scalatest.Filter"
       },
-      "type": "org_scalatest.scalatest_featurespec_2_13.Scalatest_featurespec_2_13Test$PendingScenarioFeatureSpec"
+      "type" : "scala.Tuple2[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.tools.SuiteDiscoveryHelper$"
+      "condition" : {
+        "typeReached" : "org.scalatest.MessageRecorder"
       },
-      "type": "org_scalatest.scalatest_featurespec_2_13.Scalatest_featurespec_2_13Test$ShoppingCartFeatureSpec"
+      "type" : "scala.Tuple2[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.tools.SuiteDiscoveryHelper$"
+      "condition" : {
+        "typeReached" : "org.scalatest.Suite"
       },
-      "type": "org_scalatest.scalatest_featurespec_2_13.Scalatest_featurespec_2_13Test$TextFixtureFeatureSpec"
+      "type" : "scala.Tuple2[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.Args"
+      "condition" : {
+        "typeReached" : "org.scalatest.Suite$"
       },
-      "type": "scala.Tuple2[]"
+      "type" : "scala.Tuple2[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.AsyncSuperEngine"
+      "condition" : {
+        "typeReached" : "org.scalatest.SuperEngine"
       },
-      "type": "scala.Tuple2[]"
+      "type" : "scala.Tuple2[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.DynaTags"
+      "condition" : {
+        "typeReached" : "org.scalatest.events.InfoProvided"
       },
-      "type": "scala.Tuple2[]"
+      "type" : "scala.Tuple2[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.Filter"
+      "condition" : {
+        "typeReached" : "org.scalatest.events.ScopeClosed"
       },
-      "type": "scala.Tuple2[]"
+      "type" : "scala.Tuple2[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.MessageRecorder"
+      "condition" : {
+        "typeReached" : "org.scalatest.events.ScopeOpened"
       },
-      "type": "scala.Tuple2[]"
+      "type" : "scala.Tuple2[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.Suite"
+      "condition" : {
+        "typeReached" : "org.scalatest.events.TestIgnored"
       },
-      "type": "scala.Tuple2[]"
+      "type" : "scala.Tuple2[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.Suite$"
+      "condition" : {
+        "typeReached" : "org.scalatest.events.TestPending"
       },
-      "type": "scala.Tuple2[]"
+      "type" : "scala.Tuple2[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.SuperEngine"
+      "condition" : {
+        "typeReached" : "org.scalatest.events.TestStarting"
       },
-      "type": "scala.Tuple2[]"
+      "type" : "scala.Tuple2[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.events.InfoProvided"
+      "condition" : {
+        "typeReached" : "org.scalatest.events.TestSucceeded"
       },
-      "type": "scala.Tuple2[]"
+      "type" : "scala.Tuple2[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.events.ScopeClosed"
+      "condition" : {
+        "typeReached" : "org.scalatest.tools.TestSortingReporter"
       },
-      "type": "scala.Tuple2[]"
+      "type" : "scala.Tuple2[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.events.ScopeOpened"
+      "condition" : {
+        "typeReached" : "org.scalatest.tools.TestSortingReporter"
       },
-      "type": "scala.Tuple2[]"
+      "type" : "sun.security.provider.NativePRNG"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.events.TestIgnored"
+      "condition" : {
+        "typeReached" : "org.scalatest.tools.TestSortingReporter"
       },
-      "type": "scala.Tuple2[]"
+      "type" : "sun.security.provider.SHA"
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.events.TestPending"
+      "condition" : {
+        "typeReached" : "org.scalatest.Suite$"
       },
-      "type": "scala.Tuple2[]"
-    },
-    {
-      "condition": {
-        "typeReached": "org.scalatest.events.TestStarting"
-      },
-      "type": "scala.Tuple2[]"
-    },
-    {
-      "condition": {
-        "typeReached": "org.scalatest.events.TestSucceeded"
-      },
-      "type": "scala.Tuple2[]"
-    },
-    {
-      "condition": {
-        "typeReached": "org.scalatest.tools.TestSortingReporter"
-      },
-      "type": "scala.Tuple2[]"
-    },
-    {
-      "condition": {
-        "typeReached": "org.scalatest.tools.TestSortingReporter"
-      },
-      "type": "sun.security.provider.NativePRNG"
-    },
-    {
-      "condition": {
-        "typeReached": "org.scalatest.tools.TestSortingReporter"
-      },
-      "type": "sun.security.provider.SHA"
-    },
-    {
-      "condition": {
-        "typeReached": "org.scalatest.Suite$"
-      },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Retention"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.Suite$"
+      "condition" : {
+        "typeReached" : "org.scalatest.Suite$"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "org.scalatest.Finders"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.scalatest.Suite$"
+      "condition" : {
+        "typeReached" : "org.scalatest.Suite$"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "scala.reflect.ScalaSignature"
         ]
       }
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "org.scalatest.Resources$"
+      "condition" : {
+        "typeReached" : "org.scalatest.Resources$"
       },
-      "bundle": "org.scalatest.ScalaTestBundle"
+      "bundle" : "org.scalatest.ScalaTestBundle"
     }
   ]
 }

--- a/metadata/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/reachability-metadata.json
+++ b/metadata/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/reachability-metadata.json
@@ -1,0 +1,222 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Resources$"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.AsyncSuperEngine"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Suite$"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.SuperEngine"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Suite$"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Suite"
+      },
+      "type": "org.scalatest.Suite[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.tools.SuiteDiscoveryHelper$"
+      },
+      "type": "org_scalatest.scalatest_featurespec_2_13.Scalatest_featurespec_2_13Test$AsyncCalculationFeatureSpec"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.tools.SuiteDiscoveryHelper$"
+      },
+      "type": "org_scalatest.scalatest_featurespec_2_13.Scalatest_featurespec_2_13Test$AsyncTextFixtureFeatureSpec"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.tools.SuiteDiscoveryHelper$"
+      },
+      "type": "org_scalatest.scalatest_featurespec_2_13.Scalatest_featurespec_2_13Test$CheckoutNarrativeFeatureSpec"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.tools.SuiteDiscoveryHelper$"
+      },
+      "type": "org_scalatest.scalatest_featurespec_2_13.Scalatest_featurespec_2_13Test$PendingScenarioFeatureSpec"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.tools.SuiteDiscoveryHelper$"
+      },
+      "type": "org_scalatest.scalatest_featurespec_2_13.Scalatest_featurespec_2_13Test$ShoppingCartFeatureSpec"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.tools.SuiteDiscoveryHelper$"
+      },
+      "type": "org_scalatest.scalatest_featurespec_2_13.Scalatest_featurespec_2_13Test$TextFixtureFeatureSpec"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Args"
+      },
+      "type": "scala.Tuple2[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.AsyncSuperEngine"
+      },
+      "type": "scala.Tuple2[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.DynaTags"
+      },
+      "type": "scala.Tuple2[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Filter"
+      },
+      "type": "scala.Tuple2[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.MessageRecorder"
+      },
+      "type": "scala.Tuple2[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Suite"
+      },
+      "type": "scala.Tuple2[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Suite$"
+      },
+      "type": "scala.Tuple2[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.SuperEngine"
+      },
+      "type": "scala.Tuple2[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.events.InfoProvided"
+      },
+      "type": "scala.Tuple2[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.events.ScopeClosed"
+      },
+      "type": "scala.Tuple2[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.events.ScopeOpened"
+      },
+      "type": "scala.Tuple2[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.events.TestIgnored"
+      },
+      "type": "scala.Tuple2[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.events.TestPending"
+      },
+      "type": "scala.Tuple2[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.events.TestStarting"
+      },
+      "type": "scala.Tuple2[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.events.TestSucceeded"
+      },
+      "type": "scala.Tuple2[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.tools.TestSortingReporter"
+      },
+      "type": "scala.Tuple2[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.tools.TestSortingReporter"
+      },
+      "type": "sun.security.provider.NativePRNG"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.tools.TestSortingReporter"
+      },
+      "type": "sun.security.provider.SHA"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Suite$"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Suite$"
+      },
+      "type": {
+        "proxy": [
+          "org.scalatest.Finders"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Suite$"
+      },
+      "type": {
+        "proxy": [
+          "scala.reflect.ScalaSignature"
+        ]
+      }
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Resources$"
+      },
+      "bundle": "org.scalatest.ScalaTestBundle"
+    }
+  ]
+}

--- a/metadata/org.scalatest/scalatest-featurespec_2.13/index.json
+++ b/metadata/org.scalatest/scalatest-featurespec_2.13/index.json
@@ -21,5 +21,19 @@
       "org.scalatest.featurespec",
       "org.scalatest"
     ]
+  },
+  {
+    "metadata-version" : "3.3.0-SNAP2",
+    "language" : {
+      "name" : "scala",
+      "version" : "2"
+    },
+    "tested-versions" : [
+      "3.3.0-SNAP2"
+    ],
+    "allowed-packages" : [
+      "org.scalatest.featurespec",
+      "org.scalatest"
+    ]
   }
 ]

--- a/metadata/org.scalatest/scalatest-featurespec_2.13/index.json
+++ b/metadata/org.scalatest/scalatest-featurespec_2.13/index.json
@@ -24,6 +24,11 @@
   },
   {
     "metadata-version" : "3.3.0-SNAP2",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-featurespec_2.13/$version$/scalatest-featurespec_2.13-$version$-sources.jar",
+    "repository-url" : "https://github.com/scalatest/scalatest",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-featurespec_2.13/$version$/scalatest-featurespec_2.13-$version$-javadoc.jar",
+    "description" : "ScalaTest FeatureSpec provides the FeatureSpec and AsyncFeatureSpec testing style for organizing ScalaTest suites around named features and scenarios. It supplies synchronous, asynchronous, and fixture-based specs for behavior-driven Scala tests while integrating with ScalaTest's assertions, matchers, reporting, and runner infrastructure.",
     "language" : {
       "name" : "scala",
       "version" : "2"

--- a/stats/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/execution-metrics.json
+++ b/stats/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/execution-metrics.json
@@ -1,0 +1,88 @@
+{
+  "fix_java_run_fail:2026-06-06": {
+    "timestamp": "2026-06-06T03:18:35.156136Z",
+    "library": "org.scalatest:scalatest-featurespec_2.13:3.3.0-SNAP2",
+    "starting_commit": "1a553f286918fc1df79422c2882e6cae23db07fc",
+    "ending_commit": "eb5b246bafe9a2ac124799c3fc15bfa00482dad4",
+    "previous_library": "org.scalatest:scalatest-featurespec_2.13:3.2.19",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.3.0-SNAP2",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1392,
+          "missed": 2638,
+          "ratio": 0.345409,
+          "total": 4030
+        },
+        "line": {
+          "covered": 127,
+          "missed": 94,
+          "ratio": 0.574661,
+          "total": 221
+        },
+        "method": {
+          "covered": 177,
+          "missed": 404,
+          "ratio": 0.304647,
+          "total": 581
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.2.19",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1454,
+          "missed": 2712,
+          "ratio": 0.349016,
+          "total": 4166
+        },
+        "line": {
+          "covered": 134,
+          "missed": 107,
+          "ratio": 0.556017,
+          "total": 241
+        },
+        "method": {
+          "covered": 189,
+          "missed": 416,
+          "ratio": 0.312397,
+          "total": 605
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 133145,
+      "cached_input_tokens_used": 1724928,
+      "output_tokens_used": 11439,
+      "iterations": 2,
+      "cost_usd": 1.2057,
+      "tested_library_loc": 127,
+      "metadata_entries": 28,
+      "test_only_metadata_entries": 6,
+      "previous_library_metadata_entries": 1,
+      "code_coverage_percent": 57.47,
+      "previous_library_coverage_percent": 55.6
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/src/test/scala/org_scalatest/scalatest_featurespec_2_13/Scalatest_featurespec_2_13Test.scala",
+      "metadata_file": "metadata/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/stats.json
+++ b/stats/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.3.0-SNAP2",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1392,
+        "missed" : 2638,
+        "ratio" : 0.345409,
+        "total" : 4030
+      },
+      "line" : {
+        "covered" : 127,
+        "missed" : 94,
+        "ratio" : 0.574661,
+        "total" : 221
+      },
+      "method" : {
+        "covered" : 177,
+        "missed" : 404,
+        "ratio" : 0.304647,
+        "total" : 581
+      }
+    }
+  } ]
+}

--- a/tests/src/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/.gitignore
+++ b/tests/src/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/build.gradle
+++ b/tests/src/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.scalatest:scalatest-featurespec_2.13:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala-library:2.13.16'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/gradle.properties
+++ b/tests/src/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.scalatest:scalatest-featurespec_2.13:3.3.0-SNAP2
+library.version = 3.3.0-SNAP2
+metadata.dir = org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/

--- a/tests/src/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/settings.gradle
+++ b/tests/src/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.scalatest.scalatest-featurespec_2.13_tests'

--- a/tests/src/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,40 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.scalatest.tools.SuiteDiscoveryHelper$"
+      },
+      "type" : "org_scalatest.scalatest_featurespec_2_13.Scalatest_featurespec_2_13Test$AsyncCalculationFeatureSpec"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.scalatest.tools.SuiteDiscoveryHelper$"
+      },
+      "type" : "org_scalatest.scalatest_featurespec_2_13.Scalatest_featurespec_2_13Test$AsyncTextFixtureFeatureSpec"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.scalatest.tools.SuiteDiscoveryHelper$"
+      },
+      "type" : "org_scalatest.scalatest_featurespec_2_13.Scalatest_featurespec_2_13Test$CheckoutNarrativeFeatureSpec"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.scalatest.tools.SuiteDiscoveryHelper$"
+      },
+      "type" : "org_scalatest.scalatest_featurespec_2_13.Scalatest_featurespec_2_13Test$PendingScenarioFeatureSpec"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.scalatest.tools.SuiteDiscoveryHelper$"
+      },
+      "type" : "org_scalatest.scalatest_featurespec_2_13.Scalatest_featurespec_2_13Test$ShoppingCartFeatureSpec"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.scalatest.tools.SuiteDiscoveryHelper$"
+      },
+      "type" : "org_scalatest.scalatest_featurespec_2_13.Scalatest_featurespec_2_13Test$TextFixtureFeatureSpec"
+    }
+  ]
+}

--- a/tests/src/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/src/test/scala/org_scalatest/scalatest_featurespec_2_13/Scalatest_featurespec_2_13Test.scala
+++ b/tests/src/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/src/test/scala/org_scalatest/scalatest_featurespec_2_13/Scalatest_featurespec_2_13Test.scala
@@ -1,0 +1,291 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_scalatest.scalatest_featurespec_2_13
+
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+import scala.concurrent.Future
+import scala.jdk.CollectionConverters._
+import scala.util.Try
+
+import org.junit.jupiter.api.Test
+import org.scalatest.Args
+import org.scalatest.FutureOutcome
+import org.scalatest.GivenWhenThen
+import org.scalatest.Outcome
+import org.scalatest.Reporter
+import org.scalatest.Suite
+import org.scalatest.Tag
+import org.scalatest.events.Event
+import org.scalatest.events.InfoProvided
+import org.scalatest.events.TestIgnored
+import org.scalatest.events.TestPending
+import org.scalatest.events.TestSucceeded
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.featurespec.AsyncFeatureSpec
+import org.scalatest.featurespec.FixtureAnyFeatureSpec
+import org.scalatest.featurespec.FixtureAsyncFeatureSpec
+
+class Scalatest_featurespec_2_13Test {
+  @Test
+  def anyFeatureSpecRegistersTaggedAndIgnoredScenarios(): Unit = {
+    val suite: ShoppingCartFeatureSpec = new ShoppingCartFeatureSpec
+    val addItemTestName: String = findTestName(suite, "adds an item")
+    val removeItemTestName: String = findTestName(suite, "removes an item")
+    val ignoredTestName: String = findTestName(suite, "checks out without inventory")
+
+    assert(suite.testNames.size == 3)
+    assert(suite.tags(addItemTestName).contains(ShoppingCartFeatureSpec.Fast.name))
+    assert(suite.tags(ignoredTestName).contains(ShoppingCartFeatureSpec.Slow.name))
+
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(suite.executed.toSet == Set("add", "remove"))
+    assert(succeededEvents(result.events).map(_.testName).toSet == Set(addItemTestName, removeItemTestName))
+    assert(ignoredEvents(result.events).map(_.testName) == Vector(ignoredTestName))
+  }
+
+  @Test
+  def asyncFeatureSpecCompletesSuccessfulFutureScenarios(): Unit = {
+    val suite: AsyncCalculationFeatureSpec = new AsyncCalculationFeatureSpec
+    val additionTestName: String = findTestName(suite, "adds numbers asynchronously")
+    val multiplicationTestName: String = findTestName(suite, "multiplies numbers asynchronously")
+
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(suite.executed.toSet == Set("addition", "multiplication"))
+    assert(succeededEvents(result.events).map(_.testName).toSet == Set(additionTestName, multiplicationTestName))
+    assert(ignoredEvents(result.events).isEmpty)
+  }
+
+  @Test
+  def anyFeatureSpecReportsPendingScenariosWithoutFailingTheSuite(): Unit = {
+    val suite: PendingScenarioFeatureSpec = new PendingScenarioFeatureSpec
+    val pendingTestName: String = findTestName(suite, "captures an unfinished payment workflow")
+
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(suite.executed == Vector("pending"))
+    assert(pendingEvents(result.events).map(_.testName) == Vector(pendingTestName))
+    assert(succeededEvents(result.events).isEmpty)
+    assert(ignoredEvents(result.events).isEmpty)
+  }
+
+  @Test
+  def fixtureAnyFeatureSpecProvidesFixturesAndReportsIgnoredScenarios(): Unit = {
+    val suite: TextFixtureFeatureSpec = new TextFixtureFeatureSpec
+    val upperCaseTestName: String = findTestName(suite, "upper-cases fixture text")
+    val ignoredTestName: String = findTestName(suite, "keeps ignored fixture scenarios registered")
+
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(suite.fixtureNames.asScala.toVector == Vector(upperCaseTestName))
+    assert(suite.observedFixtures.asScala.toVector == Vector("feature-spec"))
+    assert(succeededEvents(result.events).map(_.testName) == Vector(upperCaseTestName))
+    assert(ignoredEvents(result.events).map(_.testName) == Vector(ignoredTestName))
+  }
+
+  @Test
+  def fixtureAsyncFeatureSpecProvidesFixturesToFutureScenarios(): Unit = {
+    val suite: AsyncTextFixtureFeatureSpec = new AsyncTextFixtureFeatureSpec
+    val scenarioTestName: String = findTestName(suite, "decorates fixture text asynchronously")
+
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(suite.fixtureNames.asScala.toVector == Vector(scenarioTestName))
+    assert(suite.observedFixtures.asScala.toVector == Vector("async-feature-spec"))
+    assert(succeededEvents(result.events).map(_.testName) == Vector(scenarioTestName))
+  }
+
+  @Test
+  def anyFeatureSpecPublishesGivenWhenThenMessages(): Unit = {
+    val suite: CheckoutNarrativeFeatureSpec = new CheckoutNarrativeFeatureSpec
+    val scenarioTestName: String = findTestName(suite, "describes checkout steps")
+
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(suite.executed == Vector("narrative"))
+    assert(succeededEvents(result.events).map(_.testName) == Vector(scenarioTestName))
+    assert(recordedInfoMessages(result.events) == Vector(
+      "Given a cart containing a guide",
+      "When the customer checks out",
+      "Then the order summary contains the guide"
+    ))
+  }
+
+  final class ShoppingCartFeatureSpec extends AnyFeatureSpec {
+    var executed: Vector[String] = Vector.empty
+
+    Feature("Shopping cart") {
+      Scenario("adds an item", ShoppingCartFeatureSpec.Fast) {
+        executed = executed :+ "add"
+        assert(Vector("book", "pen").contains("book"))
+      }
+
+      Scenario("removes an item") {
+        executed = executed :+ "remove"
+        assert(Vector("book", "pen").filterNot(_ == "pen") == Vector("book"))
+      }
+
+      ignore("checks out without inventory", ShoppingCartFeatureSpec.Slow) {
+        executed = executed :+ "ignored"
+        fail("ignored AnyFeatureSpec scenario was executed")
+      }
+    }
+  }
+
+  object ShoppingCartFeatureSpec {
+    val Fast: Tag = Tag("org.scalatest.featurespec.fast")
+    val Slow: Tag = Tag("org.scalatest.featurespec.slow")
+  }
+
+  final class AsyncCalculationFeatureSpec extends AsyncFeatureSpec {
+    var executed: Vector[String] = Vector.empty
+
+    Feature("Asynchronous calculations") {
+      Scenario("adds numbers asynchronously") {
+        Future.successful {
+          executed = executed :+ "addition"
+          assert(2 + 3 == 5)
+        }
+      }
+
+      Scenario("multiplies numbers asynchronously") {
+        Future.successful {
+          executed = executed :+ "multiplication"
+          assert(4 * 6 == 24)
+        }
+      }
+    }
+  }
+
+  final class PendingScenarioFeatureSpec extends AnyFeatureSpec {
+    var executed: Vector[String] = Vector.empty
+
+    Feature("Pending payment workflow") {
+      Scenario("captures an unfinished payment workflow") {
+        executed = executed :+ "pending"
+        pending
+      }
+    }
+  }
+
+  final class TextFixtureFeatureSpec extends FixtureAnyFeatureSpec {
+    type FixtureParam = String
+
+    val fixtureNames: CopyOnWriteArrayList[String] = new CopyOnWriteArrayList[String]()
+    val observedFixtures: CopyOnWriteArrayList[String] = new CopyOnWriteArrayList[String]()
+
+    override protected def withFixture(test: OneArgTest): Outcome = {
+      fixtureNames.add(test.name)
+      withFixture(test.toNoArgTest("feature-spec"))
+    }
+
+    Feature("Synchronous fixture scenarios") {
+      Scenario("upper-cases fixture text") { text: String =>
+        observedFixtures.add(text)
+        assert(text.toUpperCase == "FEATURE-SPEC")
+      }
+
+      ignore("keeps ignored fixture scenarios registered") { text: String =>
+        observedFixtures.add(text)
+        fail("ignored FixtureAnyFeatureSpec scenario was executed")
+      }
+    }
+  }
+
+  final class AsyncTextFixtureFeatureSpec extends FixtureAsyncFeatureSpec {
+    type FixtureParam = String
+
+    val fixtureNames: CopyOnWriteArrayList[String] = new CopyOnWriteArrayList[String]()
+    val observedFixtures: CopyOnWriteArrayList[String] = new CopyOnWriteArrayList[String]()
+
+    override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+      fixtureNames.add(test.name)
+      withFixture(test.toNoArgAsyncTest("async-feature-spec"))
+    }
+
+    Feature("Asynchronous fixture scenarios") {
+      Scenario("decorates fixture text asynchronously") { text: String =>
+        Future.successful {
+          observedFixtures.add(text)
+          assert(s"[$text]" == "[async-feature-spec]")
+        }
+      }
+    }
+  }
+
+  final class CheckoutNarrativeFeatureSpec extends AnyFeatureSpec with GivenWhenThen {
+    var executed: Vector[String] = Vector.empty
+
+    Feature("Checkout narrative") {
+      Scenario("describes checkout steps") {
+        Given("a cart containing a guide")
+        When("the customer checks out")
+        Then("the order summary contains the guide")
+        executed = executed :+ "narrative"
+        assert(Vector("guide").mkString(",") == "guide")
+      }
+    }
+  }
+
+  private def findTestName(suite: Suite, fragment: String): String = {
+    suite.testNames.find(_.contains(fragment)).getOrElse {
+      throw new AssertionError(s"Could not find test name containing '$fragment'")
+    }
+  }
+
+  private def runSuite(suite: Suite): RunResult = {
+    val reporter: RecordingReporter = new RecordingReporter
+    val completion: AtomicReference[Try[Boolean]] = new AtomicReference[Try[Boolean]]()
+    val completed: CountDownLatch = new CountDownLatch(1)
+    val status = suite.run(None, Args(reporter = reporter))
+    status.whenCompleted { result: Try[Boolean] =>
+      completion.set(result)
+      completed.countDown()
+    }
+
+    assert(completed.await(30, TimeUnit.SECONDS), s"ScalaTest suite ${suite.suiteName} did not complete")
+    RunResult(completion.get().get, reporter.events)
+  }
+
+  private def succeededEvents(events: Vector[Event]): Vector[TestSucceeded] =
+    events.collect { case event: TestSucceeded => event }
+
+  private def ignoredEvents(events: Vector[Event]): Vector[TestIgnored] =
+    events.collect { case event: TestIgnored => event }
+
+  private def pendingEvents(events: Vector[Event]): Vector[TestPending] =
+    events.collect { case event: TestPending => event }
+
+  private def recordedInfoMessages(events: Vector[Event]): Vector[String] =
+    succeededEvents(events).flatMap { event: TestSucceeded =>
+      event.recordedEvents.collect { case info: InfoProvided => info.message }.toVector
+    }
+
+  private final class RecordingReporter extends Reporter {
+    private val recordedEvents: CopyOnWriteArrayList[Event] = new CopyOnWriteArrayList[Event]()
+
+    override def apply(event: Event): Unit = {
+      recordedEvents.add(event)
+      ()
+    }
+
+    def events: Vector[Event] = recordedEvents.asScala.toVector
+  }
+
+  private final case class RunResult(succeeded: Boolean, events: Vector[Event])
+}

--- a/tests/src/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/src/test/scala/org_scalatest/scalatest_featurespec_2_13/Scalatest_featurespec_2_13Test.scala
+++ b/tests/src/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/src/test/scala/org_scalatest/scalatest_featurespec_2_13/Scalatest_featurespec_2_13Test.scala
@@ -22,9 +22,13 @@ import org.scalatest.GivenWhenThen
 import org.scalatest.Outcome
 import org.scalatest.Reporter
 import org.scalatest.Suite
+import org.scalatest.Succeeded
 import org.scalatest.Tag
 import org.scalatest.events.Event
 import org.scalatest.events.InfoProvided
+import org.scalatest.events.SuiteAborted
+import org.scalatest.events.TestCanceled
+import org.scalatest.events.TestFailed
 import org.scalatest.events.TestIgnored
 import org.scalatest.events.TestPending
 import org.scalatest.events.TestSucceeded
@@ -47,7 +51,7 @@ class Scalatest_featurespec_2_13Test {
 
     val result: RunResult = runSuite(suite)
 
-    assert(result.succeeded)
+    assert(failureEvents(result.events).isEmpty)
     assert(suite.executed.toSet == Set("add", "remove"))
     assert(succeededEvents(result.events).map(_.testName).toSet == Set(addItemTestName, removeItemTestName))
     assert(ignoredEvents(result.events).map(_.testName) == Vector(ignoredTestName))
@@ -61,7 +65,7 @@ class Scalatest_featurespec_2_13Test {
 
     val result: RunResult = runSuite(suite)
 
-    assert(result.succeeded)
+    assert(failureEvents(result.events).isEmpty)
     assert(suite.executed.toSet == Set("addition", "multiplication"))
     assert(succeededEvents(result.events).map(_.testName).toSet == Set(additionTestName, multiplicationTestName))
     assert(ignoredEvents(result.events).isEmpty)
@@ -74,7 +78,7 @@ class Scalatest_featurespec_2_13Test {
 
     val result: RunResult = runSuite(suite)
 
-    assert(result.succeeded)
+    assert(failureEvents(result.events).isEmpty)
     assert(suite.executed == Vector("pending"))
     assert(pendingEvents(result.events).map(_.testName) == Vector(pendingTestName))
     assert(succeededEvents(result.events).isEmpty)
@@ -89,7 +93,7 @@ class Scalatest_featurespec_2_13Test {
 
     val result: RunResult = runSuite(suite)
 
-    assert(result.succeeded)
+    assert(failureEvents(result.events).isEmpty)
     assert(suite.fixtureNames.asScala.toVector == Vector(upperCaseTestName))
     assert(suite.observedFixtures.asScala.toVector == Vector("feature-spec"))
     assert(succeededEvents(result.events).map(_.testName) == Vector(upperCaseTestName))
@@ -103,7 +107,7 @@ class Scalatest_featurespec_2_13Test {
 
     val result: RunResult = runSuite(suite)
 
-    assert(result.succeeded)
+    assert(failureEvents(result.events).isEmpty)
     assert(suite.fixtureNames.asScala.toVector == Vector(scenarioTestName))
     assert(suite.observedFixtures.asScala.toVector == Vector("async-feature-spec"))
     assert(succeededEvents(result.events).map(_.testName) == Vector(scenarioTestName))
@@ -116,7 +120,7 @@ class Scalatest_featurespec_2_13Test {
 
     val result: RunResult = runSuite(suite)
 
-    assert(result.succeeded)
+    assert(failureEvents(result.events).isEmpty)
     assert(suite.executed == Vector("narrative"))
     assert(succeededEvents(result.events).map(_.testName) == Vector(scenarioTestName))
     assert(recordedInfoMessages(result.events) == Vector(
@@ -132,12 +136,12 @@ class Scalatest_featurespec_2_13Test {
     Feature("Shopping cart") {
       Scenario("adds an item", ShoppingCartFeatureSpec.Fast) {
         executed = executed :+ "add"
-        assert(Vector("book", "pen").contains("book"))
+        scala.Predef.assert(Vector("book", "pen").contains("book"))
       }
 
       Scenario("removes an item") {
         executed = executed :+ "remove"
-        assert(Vector("book", "pen").filterNot(_ == "pen") == Vector("book"))
+        scala.Predef.assert(Vector("book", "pen").filterNot(_ == "pen") == Vector("book"))
       }
 
       ignore("checks out without inventory", ShoppingCartFeatureSpec.Slow) {
@@ -159,14 +163,16 @@ class Scalatest_featurespec_2_13Test {
       Scenario("adds numbers asynchronously") {
         Future.successful {
           executed = executed :+ "addition"
-          assert(2 + 3 == 5)
+          scala.Predef.assert(2 + 3 == 5)
+          Succeeded
         }
       }
 
       Scenario("multiplies numbers asynchronously") {
         Future.successful {
           executed = executed :+ "multiplication"
-          assert(4 * 6 == 24)
+          scala.Predef.assert(4 * 6 == 24)
+          Succeeded
         }
       }
     }
@@ -197,7 +203,7 @@ class Scalatest_featurespec_2_13Test {
     Feature("Synchronous fixture scenarios") {
       Scenario("upper-cases fixture text") { text: String =>
         observedFixtures.add(text)
-        assert(text.toUpperCase == "FEATURE-SPEC")
+        scala.Predef.assert(text.toUpperCase == "FEATURE-SPEC")
       }
 
       ignore("keeps ignored fixture scenarios registered") { text: String =>
@@ -222,7 +228,8 @@ class Scalatest_featurespec_2_13Test {
       Scenario("decorates fixture text asynchronously") { text: String =>
         Future.successful {
           observedFixtures.add(text)
-          assert(s"[$text]" == "[async-feature-spec]")
+          scala.Predef.assert(s"[$text]" == "[async-feature-spec]")
+          Succeeded
         }
       }
     }
@@ -237,7 +244,7 @@ class Scalatest_featurespec_2_13Test {
         When("the customer checks out")
         Then("the order summary contains the guide")
         executed = executed :+ "narrative"
-        assert(Vector("guide").mkString(",") == "guide")
+        scala.Predef.assert(Vector("guide").mkString(",") == "guide")
       }
     }
   }
@@ -259,8 +266,16 @@ class Scalatest_featurespec_2_13Test {
     }
 
     assert(completed.await(30, TimeUnit.SECONDS), s"ScalaTest suite ${suite.suiteName} did not complete")
-    RunResult(completion.get().get, reporter.events)
+    completion.get().get
+    RunResult(reporter.events)
   }
+
+  private def failureEvents(events: Vector[Event]): Vector[Event] =
+    events.collect {
+      case event: TestFailed => event
+      case event: TestCanceled => event
+      case event: SuiteAborted => event
+    }
 
   private def succeededEvents(events: Vector[Event]): Vector[TestSucceeded] =
     events.collect { case event: TestSucceeded => event }
@@ -287,5 +302,5 @@ class Scalatest_featurespec_2_13Test {
     def events: Vector[Event] = recordedEvents.asScala.toVector
   }
 
-  private final case class RunResult(succeeded: Boolean, events: Vector[Event])
+  private final case class RunResult(events: Vector[Event])
 }

--- a/tests/src/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/user-code-filter.json
+++ b/tests/src/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.scalatest.featurespec.**"
+    },
+    {
+      "includeClasses" : "org_scalatest.scalatest_featurespec_2_13.**"
+    }
+  ]
+}

--- a/tests/src/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/user-code-filter.json
+++ b/tests/src/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/user-code-filter.json
@@ -7,6 +7,9 @@
       "includeClasses" : "org.scalatest.featurespec.**"
     },
     {
+      "includeClasses" : "org.scalatest.**"
+    },
+    {
       "includeClasses" : "org_scalatest.scalatest_featurespec_2_13.**"
     }
   ]


### PR DESCRIPTION
## What does this PR do?

Fixes: #6322

This PR provides test fixes and new metadata for org.scalatest:scalatest-featurespec_2.13:3.3.0-SNAP2, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 133145
- Cached input tokens: 1724928
- Output tokens: 11439
- Metadata entries: 28
- Test-only metadata entries: 6
- Iterations: 2
- Library coverage percentage: 57.47
- Previous library version metadata entries: 1
- Previous library version coverage percentage: 55.6

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `6b03549fd308b6a8b84dfadec8d73a4e69045206`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.scalatest:scalatest-featurespec_2.13:3.2.19: 0/0 covered calls (100.00%)
- org.scalatest:scalatest-featurespec_2.13:3.3.0-SNAP2: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.scalatest:scalatest-featurespec_2.13:3.2.19: 1454/4166 (34.90%)
- org.scalatest:scalatest-featurespec_2.13:3.3.0-SNAP2: 1392/4030 (34.54%)

**Line:**
- org.scalatest:scalatest-featurespec_2.13:3.2.19: 134/241 (55.60%)
- org.scalatest:scalatest-featurespec_2.13:3.3.0-SNAP2: 127/221 (57.47%)

**Method:**
- org.scalatest:scalatest-featurespec_2.13:3.2.19: 189/605 (31.24%)
- org.scalatest:scalatest-featurespec_2.13:3.3.0-SNAP2: 177/581 (30.46%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/user-code-filter.json b/tests/src/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/user-code-filter.json
index 2b6b8887b7..45d20e3e16 100644
--- a/tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/user-code-filter.json
+++ b/tests/src/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/user-code-filter.json
@@ -6,6 +6,9 @@
     {
       "includeClasses" : "org.scalatest.featurespec.**"
     },
+    {
+      "includeClasses" : "org.scalatest.**"
+    },
     {
       "includeClasses" : "org_scalatest.scalatest_featurespec_2_13.**"
     }

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
