### PR TITLE
[Automation] Generated metadata for com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.19.2

### DIFF
--- a/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.19.2/reachability-metadata.json
+++ b/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.19.2/reachability-metadata.json
@@ -1,0 +1,116 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type" : "com.google.api.FieldBehavior"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$EnforceNamingStyle"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$EnumType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$FieldPresence"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$JsonFormat"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$MessageEncoding"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$RepeatedFieldEncoding"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$Utf8Validation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$VisibilityFeature$DefaultSymbolVisibility"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type" : "com.google.protobuf.ExtensionRegistry",
+      "methods" : [
+        {
+          "name" : "getEmptyRegistry",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type" : "java.nio.Buffer",
+      "fields" : [
+        {
+          "name" : "address"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type" : "libcore.io.Memory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type" : "org.robolectric.Robolectric"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type" : "sun.misc.Unsafe",
+      "fields" : [
+        {
+          "name" : "theUnsafe"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/index.json
+++ b/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.19.2",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1alpha/$version$/proto-google-cloud-bigquerystorage-v1alpha-$version$-sources.jar",
+    "repository-url" : "https://github.com/googleapis/java-bigquerystorage",
+    "test-code-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1alpha/$version$/proto-google-cloud-bigquerystorage-v1alpha-$version$-tests.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1alpha/$version$/proto-google-cloud-bigquerystorage-v1alpha-$version$-javadoc.jar",
+    "description" : "This artifact provides generated Java Protocol Buffer classes and descriptors for the Google Cloud BigQuery Storage v1alpha API. It defines messages, resource names, and service-related types used by JVM clients and gRPC stubs to serialize BigQuery Storage requests and responses.",
+    "test-version" : "3.14.1",
+    "tested-versions" : [
+      "3.19.2"
+    ],
+    "allowed-packages" : [
+      "com.google.cloud.bigquery.storage.v1alpha"
+    ]
+  },
+  {
     "metadata-version" : "3.14.1",
     "source-code-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1alpha/$version$/proto-google-cloud-bigquerystorage-v1alpha-$version$-sources.jar",
     "repository-url" : "https://github.com/googleapis/java-bigquerystorage",

--- a/stats/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.19.2/stats.json
+++ b/stats/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.19.2/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.19.2",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 9190,
+        "missed" : 14312,
+        "ratio" : 0.391031,
+        "total" : 23502
+      },
+      "line" : {
+        "covered" : 2531,
+        "missed" : 3904,
+        "ratio" : 0.393318,
+        "total" : 6435
+      },
+      "method" : {
+        "covered" : 540,
+        "missed" : 1014,
+        "ratio" : 0.34749,
+        "total" : 1554
+      }
+    }
+  } ]
+}

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,152 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.api.FieldBehavior",
+      "methods" : [
+        {
+          "name" : "valueOf",
+          "parameterTypes" : [
+            "com.google.protobuf.Descriptors$EnumValueDescriptor"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FieldOptions"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FieldOptions$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FieldOptions$CType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FieldOptions$EditionDefault"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FieldOptions$FeatureSupport"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FieldOptions$JSType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FieldOptions$OptionRetention"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FieldOptions$OptionTargetType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FileOptions"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FileOptions$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FileOptions$OptimizeMode"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$MessageOptions"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$MessageOptions$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$MethodOptions"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$MethodOptions$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$MethodOptions$IdempotencyLevel"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$ServiceOptions"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$ServiceOptions$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$UninterpretedOption"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#5934

This PR provides new metadata needed for the com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.19.2, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.14.1`): 86
- Test-only metadata entries (previous `com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.14.1`): 24
- Metadata entries (new `com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.19.2`): 19
- Test-only metadata entries (new `com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.19.2`): 24
- Library coverage (previous): 38.08%
- Library coverage (new): 39.33%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `50b5cfa917d66dc87b8d70c7676c717db4970b5d`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.14.1: 0/0 covered calls (100.00%)
- com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.19.2: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.14.1: 9091/24328 (37.37%)
- com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.19.2: 9190/23502 (39.10%)

**Line:**
- com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.14.1: 2509/6589 (38.08%)
- com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.19.2: 2531/6435 (39.33%)

**Method:**
- com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.14.1: 543/1734 (31.31%)
- com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.19.2: 540/1554 (34.75%)


### Human Intervention: Severe Metadata Drop

Forge detected a severe drop in reachability metadata entries for this Native Image run fix. This PR needs human review unless the branch includes concrete proof that the new library version no longer needs the removed registrations.

- Previous metadata entries (`com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.14.1`): 86
- New metadata entries (`com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.19.2`): 19
- Retained metadata entries: 22.09%
### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
