### PR TITLE
[GenAI] Test fix for org.scalatest:scalatest-wordspec_2.13:3.3.0-SNAP2 using gpt-5.5

### DIFF
--- a/metadata/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/reachability-metadata.json
+++ b/metadata/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/reachability-metadata.json
@@ -1,0 +1,96 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Resources$"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.AsyncSuperEngine"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Suite$"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.SuperEngine"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Suite$"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Suite"
+      },
+      "type": "org.scalatest.Suite[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.SuperEngine"
+      },
+      "type": "scala.Tuple2[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.tools.TestSortingReporter"
+      },
+      "type": "sun.security.provider.NativePRNG"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.tools.TestSortingReporter"
+      },
+      "type": "sun.security.provider.SHA"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Suite$"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Suite$"
+      },
+      "type": {
+        "proxy": [
+          "org.scalatest.Finders"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Suite$"
+      },
+      "type": {
+        "proxy": [
+          "scala.reflect.ScalaSignature"
+        ]
+      }
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Resources$"
+      },
+      "bundle": "org.scalatest.ScalaTestBundle"
+    }
+  ]
+}

--- a/metadata/org.scalatest/scalatest-wordspec_2.13/index.json
+++ b/metadata/org.scalatest/scalatest-wordspec_2.13/index.json
@@ -21,5 +21,19 @@
       "org.scalatest.wordspec",
       "org.scalatest"
     ]
+  },
+  {
+    "metadata-version" : "3.3.0-SNAP2",
+    "language" : {
+      "name" : "scala",
+      "version" : "2"
+    },
+    "tested-versions" : [
+      "3.3.0-SNAP2"
+    ],
+    "allowed-packages" : [
+      "org.scalatest.wordspec",
+      "org.scalatest"
+    ]
   }
 ]

--- a/metadata/org.scalatest/scalatest-wordspec_2.13/index.json
+++ b/metadata/org.scalatest/scalatest-wordspec_2.13/index.json
@@ -24,6 +24,11 @@
   },
   {
     "metadata-version" : "3.3.0-SNAP2",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-wordspec_2.13/$version$/scalatest-wordspec_2.13-$version$-sources.jar",
+    "repository-url" : "https://github.com/scalatest/scalatest",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-wordspec_2.13/$version$/scalatest-wordspec_2.13-$version$-javadoc.jar",
+    "description" : "ScalaTest WordSpec provides the WordSpec style for writing behavior-driven ScalaTest suites using nested words and sentences to describe the system under test. It includes synchronous, asynchronous, and fixture-based suite classes that integrate with ScalaTest assertions, matchers, tagging, and lifecycle features.",
     "language" : {
       "name" : "scala",
       "version" : "2"

--- a/stats/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/execution-metrics.json
+++ b/stats/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_java_run_fail:2026-06-06": {
+    "timestamp": "2026-06-06T03:28:31.592100Z",
+    "library": "org.scalatest:scalatest-wordspec_2.13:3.3.0-SNAP2",
+    "starting_commit": "a3508ce9f8591c785441b6f78442b39deb15487c",
+    "ending_commit": "2ba14b7cd8454d107f35bffdf706bba1a4efc374",
+    "previous_library": "org.scalatest:scalatest-wordspec_2.13:3.2.19",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.3.0-SNAP2",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2022,
+          "missed": 6327,
+          "ratio": 0.242185,
+          "total": 8349
+        },
+        "line": {
+          "covered": 192,
+          "missed": 344,
+          "ratio": 0.358209,
+          "total": 536
+        },
+        "method": {
+          "covered": 250,
+          "missed": 567,
+          "ratio": 0.305998,
+          "total": 817
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.2.19",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2027,
+          "missed": 6486,
+          "ratio": 0.238106,
+          "total": 8513
+        },
+        "line": {
+          "covered": 189,
+          "missed": 417,
+          "ratio": 0.311881,
+          "total": 606
+        },
+        "method": {
+          "covered": 253,
+          "missed": 601,
+          "ratio": 0.296253,
+          "total": 854
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 78448,
+      "cached_input_tokens_used": 1032704,
+      "output_tokens_used": 6794,
+      "iterations": 1,
+      "cost_usd": 0.7202,
+      "tested_library_loc": 192,
+      "metadata_entries": 13,
+      "previous_library_metadata_entries": 1,
+      "code_coverage_percent": 35.82,
+      "previous_library_coverage_percent": 31.19
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/src/test/scala/org_scalatest/scalatest_wordspec_2_13/Scalatest_wordspec_2_13Test.scala",
+      "metadata_file": "metadata/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/stats.json
+++ b/stats/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.3.0-SNAP2",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2022,
+        "missed" : 6327,
+        "ratio" : 0.242185,
+        "total" : 8349
+      },
+      "line" : {
+        "covered" : 192,
+        "missed" : 344,
+        "ratio" : 0.358209,
+        "total" : 536
+      },
+      "method" : {
+        "covered" : 250,
+        "missed" : 567,
+        "ratio" : 0.305998,
+        "total" : 817
+      }
+    }
+  } ]
+}

--- a/tests/src/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/.gitignore
+++ b/tests/src/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/build.gradle
+++ b/tests/src/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.scalatest:scalatest-wordspec_2.13:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala-library:2.13.16'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/gradle.properties
+++ b/tests/src/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.scalatest:scalatest-wordspec_2.13:3.3.0-SNAP2
+library.version = 3.3.0-SNAP2
+metadata.dir = org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/

--- a/tests/src/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/settings.gradle
+++ b/tests/src/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.scalatest.scalatest-wordspec_2.13_tests'

--- a/tests/src/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/src/test/scala/org_scalatest/scalatest_wordspec_2_13/Scalatest_wordspec_2_13Test.scala
+++ b/tests/src/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/src/test/scala/org_scalatest/scalatest_wordspec_2_13/Scalatest_wordspec_2_13Test.scala
@@ -9,11 +9,9 @@ package org_scalatest.scalatest_wordspec_2_13
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicReference
 
 import scala.concurrent.Future
 import scala.jdk.CollectionConverters._
-import scala.util.Try
 
 import org.junit.jupiter.api.Test
 import org.scalatest.Args
@@ -21,6 +19,7 @@ import org.scalatest.Filter
 import org.scalatest.FutureOutcome
 import org.scalatest.Outcome
 import org.scalatest.Reporter
+import org.scalatest.Status
 import org.scalatest.Suite
 import org.scalatest.Tag
 import org.scalatest.events.Event
@@ -357,16 +356,14 @@ class Scalatest_wordspec_2_13Test {
       filter: Filter = Filter.default,
       testName: Option[String] = None): RunResult = {
     val reporter: RecordingReporter = new RecordingReporter
-    val completion: AtomicReference[Try[Boolean]] = new AtomicReference[Try[Boolean]]()
     val completed: CountDownLatch = new CountDownLatch(1)
-    val status = suite.run(testName, Args(reporter = reporter, filter = filter))
-    status.whenCompleted { result: Try[Boolean] =>
-      completion.set(result)
+    val status: Status = suite.run(testName, Args(reporter = reporter, filter = filter))
+    status.whenCompleted { _ =>
       completed.countDown()
     }
 
     assert(completed.await(30, TimeUnit.SECONDS), s"ScalaTest suite ${suite.suiteName} did not complete")
-    RunResult(completion.get().get, reporter.events)
+    RunResult(status.succeeds(), reporter.events)
   }
 
   private def succeededEvents(events: Vector[Event]): Vector[TestSucceeded] =

--- a/tests/src/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/src/test/scala/org_scalatest/scalatest_wordspec_2_13/Scalatest_wordspec_2_13Test.scala
+++ b/tests/src/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/src/test/scala/org_scalatest/scalatest_wordspec_2_13/Scalatest_wordspec_2_13Test.scala
@@ -1,0 +1,403 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_scalatest.scalatest_wordspec_2_13
+
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+import scala.concurrent.Future
+import scala.jdk.CollectionConverters._
+import scala.util.Try
+
+import org.junit.jupiter.api.Test
+import org.scalatest.Args
+import org.scalatest.Filter
+import org.scalatest.FutureOutcome
+import org.scalatest.Outcome
+import org.scalatest.Reporter
+import org.scalatest.Suite
+import org.scalatest.Tag
+import org.scalatest.events.Event
+import org.scalatest.events.InfoProvided
+import org.scalatest.events.TestCanceled
+import org.scalatest.events.TestFailed
+import org.scalatest.events.TestIgnored
+import org.scalatest.events.TestPending
+import org.scalatest.events.TestSucceeded
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.wordspec.AsyncWordSpec
+import org.scalatest.wordspec.FixtureAnyWordSpec
+import org.scalatest.wordspec.FixtureAsyncWordSpec
+
+class Scalatest_wordspec_2_13Test {
+  @Test
+  def registersNestedWordSpecClausesAndRunsSelectedTestByName(): Unit = {
+    val suite: CalculatorWordSpec = new CalculatorWordSpec
+    val names: Vector[String] = suite.testNames.toVector
+
+    assert(names.exists(_.contains("return the sum")))
+    assert(names.exists(_.contains("formatted total")))
+    assert(names.exists(_.contains("support shorthand subjects")))
+    assert(names.exists(_.contains("report pending work")))
+    assert(names.exists(_.contains("not execute ignored examples")))
+
+    val selectedName: String = names.find(_.contains("return the sum")).get
+    val result: RunResult = runSuite(suite, testName = Some(selectedName))
+
+    assert(result.succeeded)
+    assert(suite.executed == Vector("sum"))
+    assert(succeededEvents(result.events).map(_.testName) == Vector(selectedName))
+  }
+
+  @Test
+  def reportsSucceededPendingCanceledAndIgnoredTests(): Unit = {
+    val suite: LifecycleWordSpec = new LifecycleWordSpec
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(succeededEvents(result.events).exists(_.testName.contains("ordinary successes")))
+    assert(pendingEvents(result.events).exists(_.testName.contains("document future behaviour")))
+    assert(canceledEvents(result.events).exists(_.testName.contains("cancel unavailable work")))
+    assert(ignoredEvents(result.events).exists(_.testName.contains("remain registered while ignored")))
+    assert(suite.executed == Vector("success", "canceled"))
+  }
+
+  @Test
+  def reportsFailedTestsThroughEventsAndStatus(): Unit = {
+    val suite: FailingWordSpec = new FailingWordSpec
+    val result: RunResult = runSuite(suite)
+    val failures: Vector[TestFailed] = failedEvents(result.events)
+
+    assert(!result.succeeded)
+    assert(failures.size == 1)
+    assert(failures.head.testName.contains("publish assertion failures"))
+    assert(failures.head.message.contains("numbers did not match"))
+  }
+
+  @Test
+  def recordsInformationalMessagesWithSucceededWordSpecTests(): Unit = {
+    val suite: InformingWordSpec = new InformingWordSpec
+    val result: RunResult = runSuite(suite)
+    val success: TestSucceeded = succeededEvents(result.events).head
+    val messages: Vector[String] = success.recordedEvents.collect {
+      case event: InfoProvided => event.message
+    }.toVector
+
+    assert(result.succeeded)
+    assert(success.testName.contains("attach progress messages"))
+    assert(messages == Vector("prepared a sample value", "verified transformed value"))
+    assert(suite.observed == Vector("message-start", "message-end"))
+  }
+
+  @Test
+  def exposesTagsAndHonorsTagFilters(): Unit = {
+    val suite: TaggedWordSpec = new TaggedWordSpec
+    val taggedName: String = suite.testNames.find(_.contains("run selected fast examples")).get
+    val slowName: String = suite.testNames.find(_.contains("run slow examples")).get
+    val ignoredName: String = suite.testNames.find(_.contains("keep ignored tagged examples registered")).get
+
+    assert(suite.tags(taggedName).contains(FastTag.name))
+    assert(suite.tags(slowName).contains(SlowTag.name))
+    assert(suite.tags(ignoredName).contains(SlowTag.name))
+    assert(suite.tags(ignoredName).contains("org.scalatest.Ignore"))
+
+    val result: RunResult = runSuite(
+      suite,
+      filter = Filter(tagsToInclude = Some(Set(FastTag.name)), tagsToExclude = Set.empty)
+    )
+
+    assert(result.succeeded)
+    assert(succeededEvents(result.events).map(_.testName) == Vector(taggedName))
+    assert(suite.executed == Vector("fast"))
+  }
+
+  @Test
+  def passesFreshFixturesToFixtureAnyWordSpecTests(): Unit = {
+    val suite: MutableBufferFixtureWordSpec = new MutableBufferFixtureWordSpec
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(succeededEvents(result.events).size == 2)
+    assert(suite.finishedFixtures == Vector("seed-alpha", "seed-beta"))
+  }
+
+  @Test
+  def registersAndRunsSharedWordSpecBehaviorsInDifferentContexts(): Unit = {
+    val suite: SharedBehaviorWordSpec = new SharedBehaviorWordSpec
+    val names: Vector[String] = suite.testNames.toVector
+    val result: RunResult = runSuite(suite)
+
+    assert(names.count(_.contains("keep the first element available")) == 2)
+    assert(names.exists(_.contains("List-based collection")))
+    assert(names.exists(_.contains("Vector-based collection")))
+    assert(result.succeeded)
+    assert(succeededEvents(result.events).size == 4)
+    assert(suite.observed == Vector("list:first", "list:size", "vector:first", "vector:size"))
+  }
+
+  @Test
+  def runsAsyncWordSpecAndFixtureAsyncWordSpecTests(): Unit = {
+    val asyncSuite: FutureWordSpec = new FutureWordSpec
+    val asyncResult: RunResult = runSuite(asyncSuite)
+    val fixtureSuite: AsyncFixtureWordSpec = new AsyncFixtureWordSpec
+    val fixtureResult: RunResult = runSuite(fixtureSuite)
+
+    assert(asyncResult.succeeded)
+    assert(succeededEvents(asyncResult.events).size == 2)
+    assert(asyncSuite.executed == Vector("future-value", "recovered-failure"))
+    assert(fixtureResult.succeeded)
+    assert(succeededEvents(fixtureResult.events).size == 1)
+    assert(fixtureSuite.seenFixtures == Vector("async-fixture-used"))
+  }
+
+  private final class CalculatorWordSpec extends AnyWordSpec {
+    var executed: Vector[String] = Vector.empty
+
+    private val display = afterWord("display output")
+
+    "A calculator" when {
+      "adding numbers" should {
+        "return the sum" in {
+          executed = executed :+ "sum"
+          assert(2 + 3 == 5)
+        }
+
+        "report pending work" is pending
+
+        "not execute ignored examples" ignore {
+          executed = executed :+ "ignored"
+          fail("ignored example was executed")
+        }
+      }
+
+      "the display" should display {
+        "formatted total" in {
+          executed = executed :+ "display"
+          assert(f"${2.5}%.1f" == "2.5")
+        }
+      }
+    }
+
+    it must {
+      "support shorthand subjects" in {
+        executed = executed :+ "shorthand"
+        assert("scala".startsWith("sca"))
+      }
+    }
+  }
+
+  private final class LifecycleWordSpec extends AnyWordSpec {
+    var executed: Vector[String] = Vector.empty
+
+    "A lifecycle word spec" should {
+      "record ordinary successes" in {
+        executed = executed :+ "success"
+        assert(List(1, 2, 3).sum == 6)
+      }
+
+      "document future behaviour" is pending
+
+      "cancel unavailable work" in {
+        executed = executed :+ "canceled"
+        cancel("external service is intentionally unavailable")
+      }
+
+      "remain registered while ignored" ignore {
+        executed = executed :+ "ignored"
+        fail("ignored test body ran")
+      }
+    }
+  }
+
+  private final class FailingWordSpec extends AnyWordSpec {
+    "A failing word spec" should {
+      "publish assertion failures" in {
+        assert(1 == 2, "numbers did not match")
+      }
+    }
+  }
+
+  private final class InformingWordSpec extends AnyWordSpec {
+    var observed: Vector[String] = Vector.empty
+
+    "An informing word spec" should {
+      "attach progress messages to a successful test" in {
+        observed = observed :+ "message-start"
+        info("prepared a sample value")
+        val transformed: String = "scala".reverse.reverse
+        info("verified transformed value")
+        observed = observed :+ "message-end"
+        assert(transformed == "scala")
+      }
+    }
+  }
+
+  private final class TaggedWordSpec extends AnyWordSpec {
+    var executed: Vector[String] = Vector.empty
+
+    "A tagged word spec" should {
+      "run selected fast examples" taggedAs FastTag in {
+        executed = executed :+ "fast"
+        assert(true)
+      }
+
+      "run slow examples" taggedAs SlowTag in {
+        executed = executed :+ "slow"
+        assert(true)
+      }
+
+      "keep ignored tagged examples registered" taggedAs SlowTag ignore {
+        executed = executed :+ "ignored"
+        fail("ignored tagged test body ran")
+      }
+    }
+  }
+
+  private final class MutableBufferFixtureWordSpec extends FixtureAnyWordSpec {
+    type FixtureParam = StringBuilder
+
+    var finishedFixtures: Vector[String] = Vector.empty
+
+    override protected def withFixture(test: OneArgTest): Outcome = {
+      val fixture: StringBuilder = new StringBuilder("seed")
+      try {
+        withFixture(test.toNoArgTest(fixture))
+      } finally {
+        finishedFixtures = finishedFixtures :+ fixture.toString()
+      }
+    }
+
+    "A fixture word spec" should {
+      "receive a mutable builder" in { builder: StringBuilder =>
+        builder.append("-alpha")
+        assert(builder.toString() == "seed-alpha")
+      }
+
+      "receive a fresh builder for each test" in { builder: StringBuilder =>
+        builder.append("-beta")
+        assert(builder.toString() == "seed-beta")
+      }
+    }
+  }
+
+  private final class SharedBehaviorWordSpec extends AnyWordSpec {
+    var observed: Vector[String] = Vector.empty
+
+    private def behaveLikeNonEmptyCollection(label: String, values: Seq[String]): Unit = {
+      "keep the first element available" in {
+        observed = observed :+ s"$label:first"
+        assert(values.headOption.contains("alpha"))
+      }
+
+      "report the collection size" in {
+        observed = observed :+ s"$label:size"
+        assert(values.size == 2)
+      }
+    }
+
+    "A List-based collection" should {
+      behave like behaveLikeNonEmptyCollection("list", List("alpha", "beta"))
+    }
+
+    "A Vector-based collection" should {
+      behave like behaveLikeNonEmptyCollection("vector", Vector("alpha", "beta"))
+    }
+  }
+
+  private final class FutureWordSpec extends AsyncWordSpec {
+    var executed: Vector[String] = Vector.empty
+
+    "An async word spec" should {
+      "complete successful futures" in {
+        Future.successful {
+          executed = executed :+ "future-value"
+          assert(21 * 2 == 42)
+          succeed
+        }
+      }
+
+      "recover expected failed futures" in {
+        executed = executed :+ "recovered-failure"
+        recoverToSucceededIf[IllegalArgumentException] {
+          Future.failed(new IllegalArgumentException("invalid async input"))
+        }
+      }
+    }
+  }
+
+  private final class AsyncFixtureWordSpec extends FixtureAsyncWordSpec {
+    type FixtureParam = StringBuilder
+
+    var seenFixtures: Vector[String] = Vector.empty
+
+    override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+      withFixture(test.toNoArgAsyncTest(new StringBuilder("async-fixture")))
+    }
+
+    "An async fixture word spec" should {
+      "receive an asynchronous fixture" in { builder: StringBuilder =>
+        Future.successful {
+          builder.append("-used")
+          seenFixtures = seenFixtures :+ builder.toString()
+          assert(builder.toString() == "async-fixture-used")
+          succeed
+        }
+      }
+    }
+  }
+
+  private def runSuite(
+      suite: Suite,
+      filter: Filter = Filter.default,
+      testName: Option[String] = None): RunResult = {
+    val reporter: RecordingReporter = new RecordingReporter
+    val completion: AtomicReference[Try[Boolean]] = new AtomicReference[Try[Boolean]]()
+    val completed: CountDownLatch = new CountDownLatch(1)
+    val status = suite.run(testName, Args(reporter = reporter, filter = filter))
+    status.whenCompleted { result: Try[Boolean] =>
+      completion.set(result)
+      completed.countDown()
+    }
+
+    assert(completed.await(30, TimeUnit.SECONDS), s"ScalaTest suite ${suite.suiteName} did not complete")
+    RunResult(completion.get().get, reporter.events)
+  }
+
+  private def succeededEvents(events: Vector[Event]): Vector[TestSucceeded] =
+    events.collect { case event: TestSucceeded => event }
+
+  private def pendingEvents(events: Vector[Event]): Vector[TestPending] =
+    events.collect { case event: TestPending => event }
+
+  private def canceledEvents(events: Vector[Event]): Vector[TestCanceled] =
+    events.collect { case event: TestCanceled => event }
+
+  private def ignoredEvents(events: Vector[Event]): Vector[TestIgnored] =
+    events.collect { case event: TestIgnored => event }
+
+  private def failedEvents(events: Vector[Event]): Vector[TestFailed] =
+    events.collect { case event: TestFailed => event }
+
+  private final class RecordingReporter extends Reporter {
+    private val recordedEvents: CopyOnWriteArrayList[Event] = new CopyOnWriteArrayList[Event]()
+
+    override def apply(event: Event): Unit = {
+      recordedEvents.add(event)
+      ()
+    }
+
+    def events: Vector[Event] = recordedEvents.asScala.toVector
+  }
+
+  private final case class RunResult(succeeded: Boolean, events: Vector[Event])
+
+  private object FastTag extends Tag("org.scalatest.wordspec.generated.Fast")
+
+  private object SlowTag extends Tag("org.scalatest.wordspec.generated.Slow")
+}

--- a/tests/src/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/user-code-filter.json
+++ b/tests/src/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/user-code-filter.json
@@ -1,10 +1,16 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.scalatest.wordspec.**"
+      "includeClasses" : "org.scalatest.wordspec.**"
+    },
+    {
+      "includeClasses" : "org.scalatest.**"
+    },
+    {
+      "includeClasses" : "org_scalatest.scalatest_wordspec_2_13.**"
     }
   ]
 }

--- a/tests/src/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/user-code-filter.json
+++ b/tests/src/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.scalatest.wordspec.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6324

This PR provides test fixes and new metadata for org.scalatest:scalatest-wordspec_2.13:3.3.0-SNAP2, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 78448
- Cached input tokens: 1032704
- Output tokens: 6794
- Metadata entries: 13
- Iterations: 1
- Library coverage percentage: 35.82
- Previous library version metadata entries: 1
- Previous library version coverage percentage: 31.19

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `6b03549fd308b6a8b84dfadec8d73a4e69045206`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.scalatest:scalatest-wordspec_2.13:3.2.19: 0/0 covered calls (100.00%)
- org.scalatest:scalatest-wordspec_2.13:3.3.0-SNAP2: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.scalatest:scalatest-wordspec_2.13:3.2.19: 2027/8513 (23.81%)
- org.scalatest:scalatest-wordspec_2.13:3.3.0-SNAP2: 2022/8349 (24.22%)

**Line:**
- org.scalatest:scalatest-wordspec_2.13:3.2.19: 189/606 (31.19%)
- org.scalatest:scalatest-wordspec_2.13:3.3.0-SNAP2: 192/536 (35.82%)

**Method:**
- org.scalatest:scalatest-wordspec_2.13:3.2.19: 253/854 (29.63%)
- org.scalatest:scalatest-wordspec_2.13:3.3.0-SNAP2: 250/817 (30.60%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.scalatest/scalatest-wordspec_2.13/3.2.19/user-code-filter.json 2/tests/src/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/user-code-filter.json
index 91daeb52cd..a0feb7c044 100644
--- 1/tests/src/org.scalatest/scalatest-wordspec_2.13/3.2.19/user-code-filter.json
+++ 2/tests/src/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/user-code-filter.json
@@ -1,10 +1,16 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.scalatest.wordspec.**"
+      "includeClasses" : "org.scalatest.wordspec.**"
+    },
+    {
+      "includeClasses" : "org.scalatest.**"
+    },
+    {
+      "includeClasses" : "org_scalatest.scalatest_wordspec_2_13.**"
     }
   ]
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
