### PR TITLE
[Automation] Generated metadata for org.codehaus.jackson:jackson-mapper-asl:1.9.0

### DIFF
--- a/metadata/org.codehaus.jackson/jackson-mapper-asl/1.9.0/reachability-metadata.json
+++ b/metadata/org.codehaus.jackson/jackson-mapper-asl/1.9.0/reachability-metadata.json
@@ -1,0 +1,278 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.introspect.BasicClassIntrospector"
+      },
+      "type" : "java.io.Serializable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.ser.impl.PropertySerializerMap"
+      },
+      "type" : "java.io.Serializable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.ser.impl.PropertySerializerMap"
+      },
+      "type" : "java.lang.Boolean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type" : "java.lang.Cloneable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type" : "java.lang.Comparable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.ser.impl.PropertySerializerMap"
+      },
+      "type" : "java.lang.Comparable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type" : "java.lang.Enum"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.ser.impl.PropertySerializerMap"
+      },
+      "type" : "java.lang.Integer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.type.TypeParser"
+      },
+      "type" : "java.lang.Integer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type" : "java.lang.Iterable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.ser.impl.PropertySerializerMap"
+      },
+      "type" : "java.lang.Number"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.introspect.AnnotatedClass"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.std.ClassDeserializer"
+      },
+      "type" : "java.lang.String"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.type.TypeParser"
+      },
+      "type" : "java.lang.String"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.util.ArrayBuilders"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.util.ObjectBuffer"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type" : "java.lang.constant.Constable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.ser.impl.PropertySerializerMap"
+      },
+      "type" : "java.lang.constant.Constable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.ser.impl.PropertySerializerMap"
+      },
+      "type" : "java.lang.constant.ConstantDesc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type" : "java.util.AbstractCollection"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type" : "java.util.AbstractList"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type" : "java.util.AbstractMap"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type" : "java.util.ArrayList"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type" : "java.util.Collection"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type" : "java.util.ConcurrentNavigableMap"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.util.ClassUtil$EnumTypeLocator"
+      },
+      "type" : "java.util.EnumMap",
+      "fields" : [
+        {
+          "name" : "keyType"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.util.ClassUtil$EnumTypeLocator"
+      },
+      "type" : "java.util.EnumSet",
+      "fields" : [
+        {
+          "name" : "elementType"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.std.CalendarDeserializer"
+      },
+      "type" : "java.util.GregorianCalendar",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type" : "java.util.HashMap"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type" : "java.util.LinkedHashMap"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.std.MapDeserializer"
+      },
+      "type" : "java.util.LinkedHashMap",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type" : "java.util.List"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.type.TypeParser"
+      },
+      "type" : "java.util.List"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type" : "java.util.Map"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.type.TypeParser"
+      },
+      "type" : "java.util.Map"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type" : "java.util.RandomAccess"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type" : "java.util.SequencedCollection"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type" : "java.util.SequencedMap"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.ext.OptionalHandlerFactory"
+      },
+      "type" : "org.codehaus.jackson.map.ext.CoreXMLSerializers",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.ser.BasicSerializerFactory"
+      },
+      "type" : "org.codehaus.jackson.map.ser.std.TokenBufferSerializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.codehaus.jackson/jackson-mapper-asl/index.json
+++ b/metadata/org.codehaus.jackson/jackson-mapper-asl/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.9.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/codehaus/jackson/jackson-mapper-asl/$version$/jackson-mapper-asl-$version$-sources.jar",
+    "repository-url" : "https://github.com/codehaus/jackson",
+    "test-code-url" : "https://github.com/codehaus/jackson/tree/refs/tags/1.9/$version$/src/test/org/codehaus/jackson/map",
+    "documentation-url" : "https://javadoc.io/doc/org.codehaus.jackson/jackson-mapper-asl/$version$",
+    "description" : "Jackson Mapper ASL 1.x provides the data-binding layer for the original Jackson JSON processor. It maps JSON to and from Java objects using ObjectMapper, serializers, deserializers, annotations, and type introspection built on jackson-core-asl.",
+    "test-version" : "1.8.3",
+    "tested-versions" : [
+      "1.9.0"
+    ],
+    "allowed-packages" : [
+      "org.codehaus.jackson"
+    ]
+  },
+  {
     "metadata-version" : "1.8.3",
     "source-code-url" : "https://repo1.maven.org/maven2/org/codehaus/jackson/jackson-mapper-asl/$version$/jackson-mapper-asl-$version$-sources.jar",
     "repository-url" : "https://github.com/codehaus/jackson",

--- a/stats/org.codehaus.jackson/jackson-mapper-asl/1.9.0/stats.json
+++ b/stats/org.codehaus.jackson/jackson-mapper-asl/1.9.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "1.9.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.901961,
+          "coveredCalls" : 46,
+          "totalCalls" : 51
+        }
+      },
+      "coverageRatio" : 0.901961,
+      "coveredCalls" : 46,
+      "totalCalls" : 51
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 17729,
+        "missed" : 42506,
+        "ratio" : 0.294331,
+        "total" : 60235
+      },
+      "line" : {
+        "covered" : 4190,
+        "missed" : 9403,
+        "ratio" : 0.308247,
+        "total" : 13593
+      },
+      "method" : {
+        "covered" : 1035,
+        "missed" : 2386,
+        "ratio" : 0.302543,
+        "total" : 3421
+      }
+    }
+  } ]
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.8.3/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.8.3/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,760 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.BasicSerializerFactoryTest"
+      },
+      "type" : "java.io.Closeable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest"
+      },
+      "type" : "java.io.Serializable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerCalendarDeserializerTest"
+      },
+      "type" : "java.io.Serializable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerClassDeserializerTest"
+      },
+      "type" : "java.io.Serializable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.BasicSerializerFactoryTest"
+      },
+      "type" : "java.lang.AutoCloseable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerClassDeserializerTest"
+      },
+      "type" : "java.lang.Class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerCalendarDeserializerTest"
+      },
+      "type" : "java.lang.Cloneable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest"
+      },
+      "type" : "java.lang.Comparable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerCalendarDeserializerTest"
+      },
+      "type" : "java.lang.Comparable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest"
+      },
+      "type" : "java.lang.Integer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest"
+      },
+      "type" : "java.lang.Number"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerDelegatingTest"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.SettableAnyPropertyTest"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest"
+      },
+      "type" : "java.lang.constant.Constable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerClassDeserializerTest"
+      },
+      "type" : "java.lang.constant.Constable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest"
+      },
+      "type" : "java.lang.constant.ConstantDesc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerClassDeserializerTest"
+      },
+      "type" : "java.lang.invoke.TypeDescriptor"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerClassDeserializerTest"
+      },
+      "type" : "java.lang.invoke.TypeDescriptor$OfField"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerClassDeserializerTest"
+      },
+      "type" : "java.lang.reflect.AnnotatedElement"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerClassDeserializerTest"
+      },
+      "type" : "java.lang.reflect.GenericDeclaration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerClassDeserializerTest"
+      },
+      "type" : "java.lang.reflect.Type"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerCalendarDeserializerTest"
+      },
+      "type" : "java.util.Calendar"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerCalendarDeserializerTest"
+      },
+      "type" : "java.util.GregorianCalendar"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.SettableBeanPropertyInnerSetterlessPropertyTest"
+      },
+      "type" : "java.util.List"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerDelegatingTest"
+      },
+      "type" : "java.util.Map"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.BasicSerializerFactoryTest"
+      },
+      "type" : "org.codehaus.jackson.JsonGenerator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.BasicSerializerFactoryTest"
+      },
+      "type" : "org.codehaus.jackson.Versioned"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.BasicSerializerFactoryTest"
+      },
+      "type" : "org.codehaus.jackson.util.TokenBuffer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.introspect.AnnotatedClass"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest$BaseTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.introspect.AnnotatedClass"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest$CreatorTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest$CreatorTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.introspect.AnnotatedClass"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest$CreatorTargetMixIn"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.introspect.AnnotatedClass"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest$ObjectMixIn"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.ser.AnyGetterWriter"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.AnyGetterWriterTest$BeanWithAnyGetter",
+      "methods" : [
+        {
+          "name" : "anyProperties",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.AnyGetterWriterTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.AnyGetterWriterTest$BeanWithAnyGetter",
+      "methods" : [
+        {
+          "name" : "getName",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.ArrayDeserializerTest$Value"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.std.ObjectArrayDeserializer"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.ArrayDeserializerTest$Value",
+      "fields" : [
+        {
+          "name" : "name"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.std.ObjectArrayDeserializer"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.ArrayDeserializerTest$Value[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.type.ArrayType"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.ArrayDeserializerTest$Value[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.BeanPropertyWriterTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.BeanPropertyWriterTest$AccessorBackedProperty",
+      "methods" : [
+        {
+          "name" : "getMethodValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.BeanPropertyWriterTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.BeanPropertyWriterTest$FieldBackedProperty",
+      "fields" : [
+        {
+          "name" : "fieldValue"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.jsontype.impl.TypeDeserializerBase"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.ClassNameIdResolverTest$Animal"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.ClassNameIdResolverTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.ClassNameIdResolverTest$Animal"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.jsontype.impl.AsPropertyTypeDeserializer"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.ClassNameIdResolverTest$Dog",
+      "fields" : [
+        {
+          "name" : "name"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.jsontype.impl.ClassNameIdResolver"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.ClassNameIdResolverTest$Dog"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.jsontype.impl.TypeDeserializerBase"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.ClassNameIdResolverTest$Dog"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.util.ClassUtil"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.ClassUtilTest$PublicDefaultConstructor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.std.CollectionDeserializer"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest$NumericValues",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest$NumericValues"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerDelegatingTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerDelegatingTest$MapConstructorTarget",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.util.Map"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerDelegatingTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerDelegatingTest$MapFactoryTarget",
+      "methods" : [
+        {
+          "name" : "from",
+          "parameterTypes" : [
+            "java.util.Map"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerNumberBasedTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerNumberBasedTest$IntegerConstructorTarget",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerNumberBasedTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerNumberBasedTest$IntegerFactoryTarget",
+      "methods" : [
+        {
+          "name" : "fromNumber",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerNumberBasedTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerNumberBasedTest$LongConstructorTarget",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerNumberBasedTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerNumberBasedTest$LongFactoryTarget",
+      "methods" : [
+        {
+          "name" : "fromNumber",
+          "parameterTypes" : [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.introspect.AnnotatedConstructor"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerPropertyBasedTest$ConstructorTarget",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerPropertyBasedTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerPropertyBasedTest$ConstructorTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.introspect.AnnotatedMethod"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerPropertyBasedTest$FactoryTarget",
+      "methods" : [
+        {
+          "name" : "fromProperties",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerPropertyBasedTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerPropertyBasedTest$FactoryTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerStringBasedTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerStringBasedTest$ConstructorTarget",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerStringBasedTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerStringBasedTest$FactoryTarget",
+      "methods" : [
+        {
+          "name" : "fromString",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.EnumDeserializerInnerFactoryBasedDeserializerTest$FactoryBackedEnum"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.std.EnumDeserializer$FactoryBasedDeserializer"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.EnumDeserializerInnerFactoryBasedDeserializerTest$FactoryBackedEnum",
+      "methods" : [
+        {
+          "name" : "fromJson",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.ser.std.JsonValueSerializer"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.JsonValueSerializerTest$DefaultTypedJsonValue",
+      "methods" : [
+        {
+          "name" : "asJsonValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.JsonValueSerializerTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.JsonValueSerializerTest$DefaultTypedJsonValue"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.ser.std.JsonValueSerializer"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.JsonValueSerializerTest$JsonValueBackedObject",
+      "methods" : [
+        {
+          "name" : "asJsonValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.JsonValueSerializerTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.JsonValueSerializerTest$JsonValueBackedObject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.PropertyBuilderTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.PropertyBuilderTest$FieldBackedNonDefaultValue",
+      "fields" : [
+        {
+          "name" : "value"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.PropertyBuilderTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.PropertyBuilderTest$MethodBackedNonDefaultValue",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.SettableAnyProperty"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.SettableAnyPropertyTest$AnySetterBean",
+      "methods" : [
+        {
+          "name" : "putUnknownValue",
+          "parameterTypes" : [
+            "java.lang.String",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.SettableAnyPropertyTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.SettableAnyPropertyTest$AnySetterBean",
+      "fields" : [
+        {
+          "name" : "name"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.SettableBeanProperty$MethodProperty"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.SettableBeanPropertyInnerMethodPropertyTest$SetterBackedBean",
+      "methods" : [
+        {
+          "name" : "setCount",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.SettableBeanPropertyInnerMethodPropertyTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.SettableBeanPropertyInnerMethodPropertyTest$SetterBackedBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.SettableBeanProperty$SetterlessProperty"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.SettableBeanPropertyInnerSetterlessPropertyTest$GetterBackedBean",
+      "methods" : [
+        {
+          "name" : "getItems",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.SettableBeanPropertyInnerSetterlessPropertyTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.SettableBeanPropertyInnerSetterlessPropertyTest$GetterBackedBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.std.StdKeyDeserializer$StringCtorKeyDeserializer"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.StdKeyDeserializerInnerStringCtorKeyDeserializerTest$StringConstructorKey",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.StdKeyDeserializerInnerStringCtorKeyDeserializerTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.StdKeyDeserializerInnerStringCtorKeyDeserializerTest$StringConstructorKey"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.std.StdKeyDeserializer$StringFactoryKeyDeserializer"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.StdKeyDeserializerInnerStringFactoryKeyDeserializerTest$StringFactoryKey",
+      "methods" : [
+        {
+          "name" : "valueOf",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.StdKeyDeserializerInnerStringFactoryKeyDeserializerTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.StdKeyDeserializerInnerStringFactoryKeyDeserializerTest$StringFactoryKey"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.std.StringCollectionDeserializer"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.StringCollectionDeserializerTest$StringValues",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.StringCollectionDeserializerTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.StringCollectionDeserializerTest$StringValues"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#6264

This PR provides new metadata needed for the org.codehaus.jackson:jackson-mapper-asl:1.9.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.codehaus.jackson:jackson-mapper-asl:1.8.3`): 12
- Test-only metadata entries (previous `org.codehaus.jackson:jackson-mapper-asl:1.8.3`): 121
- Metadata entries (new `org.codehaus.jackson:jackson-mapper-asl:1.9.0`): 46
- Test-only metadata entries (new `org.codehaus.jackson:jackson-mapper-asl:1.9.0`): 121
- Library coverage (previous): 32.92%
- Library coverage (new): 30.82%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `08e69f7fa448a7b93e0bf06802eefe65add6d45b`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.codehaus.jackson:jackson-mapper-asl:1.8.3: 55/55 covered calls (100.00%)
- org.codehaus.jackson:jackson-mapper-asl:1.9.0: 46/51 covered calls (90.20%)

**Reflection:**
- org.codehaus.jackson:jackson-mapper-asl:1.8.3: 55/55 covered calls (100.00%)
- org.codehaus.jackson:jackson-mapper-asl:1.9.0: 46/51 covered calls (90.20%)

#### Library coverage

**Instruction:**
- org.codehaus.jackson:jackson-mapper-asl:1.8.3: 16051/51096 (31.41%)
- org.codehaus.jackson:jackson-mapper-asl:1.9.0: 17729/60235 (29.43%)

**Line:**
- org.codehaus.jackson:jackson-mapper-asl:1.8.3: 3824/11617 (32.92%)
- org.codehaus.jackson:jackson-mapper-asl:1.9.0: 4190/13593 (30.82%)

**Method:**
- org.codehaus.jackson:jackson-mapper-asl:1.8.3: 923/2923 (31.58%)
- org.codehaus.jackson:jackson-mapper-asl:1.9.0: 1035/3421 (30.25%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
