### PR TITLE
[GenAI] Test fix for com.ongres.stringprep:saslprep:2.0 using gpt-5.5

### DIFF
--- a/metadata/com.ongres.stringprep/saslprep/2.0/reachability-metadata.json
+++ b/metadata/com.ongres.stringprep/saslprep/2.0/reachability-metadata.json
@@ -1,0 +1,11 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com.ongres.saslprep.SASLprep"
+      },
+      "module" : "java.base",
+      "glob" : "jdk/internal/icu/impl/data/icudt76b/nfkc.nrm"
+    }
+  ]
+}

--- a/metadata/com.ongres.stringprep/saslprep/index.json
+++ b/metadata/com.ongres.stringprep/saslprep/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.0",
+    "tested-versions" : [
+      "2.0"
+    ],
+    "allowed-packages" : [
+      "com.ongres.saslprep"
+    ]
+  },
+  {
     "metadata-version" : "1.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/com/ongres/stringprep/saslprep/$version$/saslprep-$version$-sources.jar",
     "repository-url" : "https://github.com/ongres/stringprep",

--- a/metadata/com.ongres.stringprep/saslprep/index.json
+++ b/metadata/com.ongres.stringprep/saslprep/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/ongres/stringprep/saslprep/$version$/saslprep-$version$-sources.jar",
+    "repository-url" : "https://github.com/ongres/stringprep",
+    "test-code-url" : "https://github.com/ongres/stringprep/tree/$version$/saslprep/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/ongres/stringprep/saslprep/$version$/saslprep-$version$-javadoc.jar",
+    "description" : "SASLprep implements the RFC 4013 profile of StringPrep for preparing user names and passwords in Java applications. It maps, normalizes, validates, and checks bidirectional text rules for strings before they are used in SASL authentication flows.",
     "tested-versions" : [
       "2.0"
     ],

--- a/stats/com.ongres.stringprep/saslprep/2.0/execution-metrics.json
+++ b/stats/com.ongres.stringprep/saslprep/2.0/execution-metrics.json
@@ -1,0 +1,88 @@
+{
+  "fix_javac_fail:2026-06-06": {
+    "timestamp": "2026-06-06T06:16:06.859019Z",
+    "library": "com.ongres.stringprep:saslprep:2.0",
+    "starting_commit": "0cad58abf642dd87ae2cd32d766081d29bf8107c",
+    "ending_commit": "40bb601603166640197c21b74609650b1d30f047",
+    "previous_library": "com.ongres.stringprep:saslprep:1.1",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 85,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 85
+        },
+        "line": {
+          "covered": 7,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 7
+        },
+        "method": {
+          "covered": 5,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 5
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 183,
+          "missed": 3,
+          "ratio": 0.983871,
+          "total": 186
+        },
+        "line": {
+          "covered": 44,
+          "missed": 1,
+          "ratio": 0.977778,
+          "total": 45
+        },
+        "method": {
+          "covered": 1,
+          "missed": 1,
+          "ratio": 0.5,
+          "total": 2
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 35272,
+      "cached_input_tokens_used": 211456,
+      "output_tokens_used": 3103,
+      "iterations": 2,
+      "cost_usd": 0.1988,
+      "tested_library_loc": 7,
+      "metadata_entries": 2,
+      "test_only_metadata_entries": 2,
+      "previous_library_metadata_entries": 0,
+      "code_coverage_percent": 100.0,
+      "previous_library_coverage_percent": 97.78
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.ongres.stringprep/saslprep/2.0/src/test/java/com_ongres_stringprep/saslprep/SaslprepTest.java",
+      "metadata_file": "metadata/com.ongres.stringprep/saslprep/2.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.ongres.stringprep/saslprep/2.0/stats.json
+++ b/stats/com.ongres.stringprep/saslprep/2.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 85,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 85
+      },
+      "line" : {
+        "covered" : 7,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 7
+      },
+      "method" : {
+        "covered" : 5,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 5
+      }
+    }
+  } ]
+}

--- a/tests/src/com.ongres.stringprep/saslprep/2.0/.gitignore
+++ b/tests/src/com.ongres.stringprep/saslprep/2.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.ongres.stringprep/saslprep/2.0/build.gradle
+++ b/tests/src/com.ongres.stringprep/saslprep/2.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.ongres.stringprep:saslprep:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.ongres.stringprep/saslprep/2.0/gradle.properties
+++ b/tests/src/com.ongres.stringprep/saslprep/2.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.ongres.stringprep:saslprep:2.0
+library.version = 2.0
+metadata.dir = com.ongres.stringprep/saslprep/2.0/

--- a/tests/src/com.ongres.stringprep/saslprep/2.0/settings.gradle
+++ b/tests/src/com.ongres.stringprep/saslprep/2.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.ongres.stringprep.saslprep_tests'

--- a/tests/src/com.ongres.stringprep/saslprep/2.0/src/test/java/com_ongres_stringprep/saslprep/SaslprepTest.java
+++ b/tests/src/com.ongres.stringprep/saslprep/2.0/src/test/java/com_ongres_stringprep/saslprep/SaslprepTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_ongres_stringprep.saslprep;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.ongres.saslprep.SaslPrep;
+import org.junit.jupiter.api.Test;
+
+public class SaslprepTest {
+    @Test
+    void preparesRfc4013Examples() {
+        assertThat(SaslPrep.saslPrep("I\u00ADX", true)).isEqualTo("IX");
+        assertThat(SaslPrep.saslPrep("user", true)).isEqualTo("user");
+        assertThat(SaslPrep.saslPrep("USER", true)).isEqualTo("USER");
+        assertThat(SaslPrep.saslPrep("\u00AA", true)).isEqualTo("a");
+        assertThat(SaslPrep.saslPrep("\u2168", true)).isEqualTo("IX");
+        assertThat(SaslPrep.saslPrep("\uD840\uDC00", true)).isEqualTo("\uD840\uDC00");
+    }
+
+    @Test
+    void removesCharactersCommonlyMappedToNothingBeforeValidation() {
+        String prepared = SaslPrep.saslPrep("pass\u00AD\u034Fword\u200B\uFE00", true);
+
+        assertThat(prepared).isEqualTo("password");
+    }
+
+    @Test
+    void appliesNfkcCompatibilityNormalizationWithoutCaseFolding() {
+        String fullwidthUserWithDigits = "\uFF35\uFF53\uFF45\uFF52\uFF11\uFF12\uFF13";
+        String ligatureAndRomanNumeral = "\uFB01-\u2168";
+
+        assertThat(SaslPrep.saslPrep(fullwidthUserWithDigits, true)).isEqualTo("User123");
+        assertThat(SaslPrep.saslPrep(ligatureAndRomanNumeral, true)).isEqualTo("fi-IX");
+    }
+
+    @Test
+    void mapsNonAsciiSpaceCharactersToAsciiSpaceDuringPreparation() {
+        assertThat(SaslPrep.saslPrep("first\u00A0second", true)).isEqualTo("first second");
+        assertThat(SaslPrep.saslPrep("first\u2007second", true)).isEqualTo("first second");
+        assertThat(SaslPrep.saslPrep("first\u202Fsecond", true)).isEqualTo("first second");
+    }
+
+    @Test
+    void preservesAsciiSpacesWithoutTrimmingOrCollapsing() {
+        assertThat(SaslPrep.saslPrep(" leading  inner  trailing ", true))
+                .isEqualTo(" leading  inner  trailing ");
+    }
+
+    @Test
+    void handlesSupplementaryCodePointsWithoutSplittingSurrogatePairs() {
+        String cjkExtensionB = "\uD840\uDC00";
+        String deseretCapitalLetterLongI = "\uD801\uDC00";
+
+        assertThat(SaslPrep.saslPrep("a" + cjkExtensionB + "\u00AD" + deseretCapitalLetterLongI + "b", true))
+                .isEqualTo("a" + cjkExtensionB + deseretCapitalLetterLongI + "b");
+    }
+
+    @Test
+    void rejectsProhibitedCharactersFromEachSaslprepCategory() {
+        assertProhibited("ASCII control", "ok\u0007");
+        assertProhibited("non-ASCII control", "ok\u0080");
+        assertProhibited("private use", "ok\uE000");
+        assertProhibited("non-character code point", "ok\uFDD0");
+        assertProhibited("surrogate code point", "ok\uD800");
+        assertProhibited("plain text inappropriate", "ok\uFFF9");
+        assertProhibited("canonical representation inappropriate", "ok\u2FF0");
+        assertProhibited("display property changing", "ok\u200E");
+        assertProhibited("tagging", "ok\uDB40\uDC01");
+    }
+
+    @Test
+    void rejectsUnassignedCodePointsOnlyForStoredStrings() {
+        String stringWithUnassignedCodePoint = "user\u0221";
+
+        assertThat(SaslPrep.saslPrep(stringWithUnassignedCodePoint, false)).isEqualTo(stringWithUnassignedCodePoint);
+        assertThatThrownBy(() -> SaslPrep.saslPrep(stringWithUnassignedCodePoint, true))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Prohibited character")
+                .hasMessageContaining("\u0221");
+    }
+
+    @Test
+    void enforcesBidirectionalRuleForRandAlCatCharacters() {
+        assertThat(SaslPrep.saslPrep("\u0627\u0661\u0628", true)).isEqualTo("\u0627\u0661\u0628");
+        assertThat(SaslPrep.saslPrep("\u05D0\u05D1", true)).isEqualTo("\u05D0\u05D1");
+
+        assertThatThrownBy(() -> SaslPrep.saslPrep("\u0627A\u0628", true))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("RandALCat and LCat");
+
+        assertThatThrownBy(() -> SaslPrep.saslPrep("\u06271", true))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("RandALCat character is not the first and the last characters");
+
+        assertThatThrownBy(() -> SaslPrep.saslPrep("1\u0627", true))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("RandALCat character is not the first and the last characters");
+    }
+
+    @Test
+    void appliesBidirectionalRuleAfterCompatibilityNormalization() {
+        assertThat(SaslPrep.saslPrep("\u0627\uFF11\u0628", true)).isEqualTo("\u06271\u0628");
+
+        assertThatThrownBy(() -> SaslPrep.saslPrep("\u0627\uFF21\u0628", true))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("RandALCat and LCat");
+    }
+
+    @Test
+    void rejectsNullInput() {
+        assertThatNullPointerException().isThrownBy(() -> SaslPrep.saslPrep(null, true));
+    }
+
+    private static void assertProhibited(String description, String value) {
+        assertThatThrownBy(() -> SaslPrep.saslPrep(value, true))
+                .as(description)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Prohibited character");
+    }
+}

--- a/tests/src/com.ongres.stringprep/saslprep/2.0/src/test/java/com_ongres_stringprep/saslprep/SaslprepTest.java
+++ b/tests/src/com.ongres.stringprep/saslprep/2.0/src/test/java/com_ongres_stringprep/saslprep/SaslprepTest.java
@@ -10,23 +10,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.ongres.saslprep.SaslPrep;
+import com.ongres.saslprep.SASLprep;
 import org.junit.jupiter.api.Test;
 
 public class SaslprepTest {
+    private static final SASLprep SASL_PREP = new SASLprep();
+
     @Test
     void preparesRfc4013Examples() {
-        assertThat(SaslPrep.saslPrep("I\u00ADX", true)).isEqualTo("IX");
-        assertThat(SaslPrep.saslPrep("user", true)).isEqualTo("user");
-        assertThat(SaslPrep.saslPrep("USER", true)).isEqualTo("USER");
-        assertThat(SaslPrep.saslPrep("\u00AA", true)).isEqualTo("a");
-        assertThat(SaslPrep.saslPrep("\u2168", true)).isEqualTo("IX");
-        assertThat(SaslPrep.saslPrep("\uD840\uDC00", true)).isEqualTo("\uD840\uDC00");
+        assertThat(prepare("I\u00ADX", true)).isEqualTo("IX");
+        assertThat(prepare("user", true)).isEqualTo("user");
+        assertThat(prepare("USER", true)).isEqualTo("USER");
+        assertThat(prepare("\u00AA", true)).isEqualTo("a");
+        assertThat(prepare("\u2168", true)).isEqualTo("IX");
+        assertThat(prepare("\uD840\uDC00", true)).isEqualTo("\uD840\uDC00");
     }
 
     @Test
     void removesCharactersCommonlyMappedToNothingBeforeValidation() {
-        String prepared = SaslPrep.saslPrep("pass\u00AD\u034Fword\u200B\uFE00", true);
+        String prepared = prepare("pass\u00AD\u034Fword\u200B\uFE00", true);
 
         assertThat(prepared).isEqualTo("password");
     }
@@ -36,20 +38,20 @@ public class SaslprepTest {
         String fullwidthUserWithDigits = "\uFF35\uFF53\uFF45\uFF52\uFF11\uFF12\uFF13";
         String ligatureAndRomanNumeral = "\uFB01-\u2168";
 
-        assertThat(SaslPrep.saslPrep(fullwidthUserWithDigits, true)).isEqualTo("User123");
-        assertThat(SaslPrep.saslPrep(ligatureAndRomanNumeral, true)).isEqualTo("fi-IX");
+        assertThat(prepare(fullwidthUserWithDigits, true)).isEqualTo("User123");
+        assertThat(prepare(ligatureAndRomanNumeral, true)).isEqualTo("fi-IX");
     }
 
     @Test
     void mapsNonAsciiSpaceCharactersToAsciiSpaceDuringPreparation() {
-        assertThat(SaslPrep.saslPrep("first\u00A0second", true)).isEqualTo("first second");
-        assertThat(SaslPrep.saslPrep("first\u2007second", true)).isEqualTo("first second");
-        assertThat(SaslPrep.saslPrep("first\u202Fsecond", true)).isEqualTo("first second");
+        assertThat(prepare("first\u00A0second", true)).isEqualTo("first second");
+        assertThat(prepare("first\u2007second", true)).isEqualTo("first second");
+        assertThat(prepare("first\u202Fsecond", true)).isEqualTo("first second");
     }
 
     @Test
     void preservesAsciiSpacesWithoutTrimmingOrCollapsing() {
-        assertThat(SaslPrep.saslPrep(" leading  inner  trailing ", true))
+        assertThat(prepare(" leading  inner  trailing ", true))
                 .isEqualTo(" leading  inner  trailing ");
     }
 
@@ -58,7 +60,7 @@ public class SaslprepTest {
         String cjkExtensionB = "\uD840\uDC00";
         String deseretCapitalLetterLongI = "\uD801\uDC00";
 
-        assertThat(SaslPrep.saslPrep("a" + cjkExtensionB + "\u00AD" + deseretCapitalLetterLongI + "b", true))
+        assertThat(prepare("a" + cjkExtensionB + "\u00AD" + deseretCapitalLetterLongI + "b", true))
                 .isEqualTo("a" + cjkExtensionB + deseretCapitalLetterLongI + "b");
     }
 
@@ -79,49 +81,56 @@ public class SaslprepTest {
     void rejectsUnassignedCodePointsOnlyForStoredStrings() {
         String stringWithUnassignedCodePoint = "user\u0221";
 
-        assertThat(SaslPrep.saslPrep(stringWithUnassignedCodePoint, false)).isEqualTo(stringWithUnassignedCodePoint);
-        assertThatThrownBy(() -> SaslPrep.saslPrep(stringWithUnassignedCodePoint, true))
+        assertThat(prepare(stringWithUnassignedCodePoint, false)).isEqualTo(stringWithUnassignedCodePoint);
+        assertThatThrownBy(() -> prepare(stringWithUnassignedCodePoint, true))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Prohibited character")
-                .hasMessageContaining("\u0221");
+                .hasMessageContaining("Unassigned code point")
+                .hasMessageContaining("0x0221");
     }
 
     @Test
     void enforcesBidirectionalRuleForRandAlCatCharacters() {
-        assertThat(SaslPrep.saslPrep("\u0627\u0661\u0628", true)).isEqualTo("\u0627\u0661\u0628");
-        assertThat(SaslPrep.saslPrep("\u05D0\u05D1", true)).isEqualTo("\u05D0\u05D1");
+        assertThat(prepare("\u0627\u0661\u0628", true)).isEqualTo("\u0627\u0661\u0628");
+        assertThat(prepare("\u05D0\u05D1", true)).isEqualTo("\u05D0\u05D1");
 
-        assertThatThrownBy(() -> SaslPrep.saslPrep("\u0627A\u0628", true))
+        assertThatThrownBy(() -> prepare("\u0627A\u0628", true))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("RandALCat and LCat");
 
-        assertThatThrownBy(() -> SaslPrep.saslPrep("\u06271", true))
+        assertThatThrownBy(() -> prepare("\u06271", true))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("RandALCat character is not the first and the last characters");
+                .hasMessageContaining("RandALCat character is not the first and the last character");
 
-        assertThatThrownBy(() -> SaslPrep.saslPrep("1\u0627", true))
+        assertThatThrownBy(() -> prepare("1\u0627", true))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("RandALCat character is not the first and the last characters");
+                .hasMessageContaining("RandALCat character is not the first and the last character");
     }
 
     @Test
     void appliesBidirectionalRuleAfterCompatibilityNormalization() {
-        assertThat(SaslPrep.saslPrep("\u0627\uFF11\u0628", true)).isEqualTo("\u06271\u0628");
+        assertThat(prepare("\u0627\uFF11\u0628", true)).isEqualTo("\u06271\u0628");
 
-        assertThatThrownBy(() -> SaslPrep.saslPrep("\u0627\uFF21\u0628", true))
+        assertThatThrownBy(() -> prepare("\u0627\uFF21\u0628", true))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("RandALCat and LCat");
     }
 
     @Test
     void rejectsNullInput() {
-        assertThatNullPointerException().isThrownBy(() -> SaslPrep.saslPrep(null, true));
+        assertThatNullPointerException().isThrownBy(() -> prepare(null, true));
     }
 
     private static void assertProhibited(String description, String value) {
-        assertThatThrownBy(() -> SaslPrep.saslPrep(value, true))
+        assertThatThrownBy(() -> prepare(value, true))
                 .as(description)
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Prohibited character");
+                .hasMessageContaining("Prohibited");
+    }
+
+    private static String prepare(String value, boolean stored) {
+        if (stored) {
+            return SASL_PREP.prepareStored(value);
+        }
+        return SASL_PREP.prepareQuery(value);
     }
 }

--- a/tests/src/com.ongres.stringprep/saslprep/2.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.ongres.stringprep/saslprep/2.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com_ongres_stringprep.saslprep.SaslprepTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_ongres_stringprep.saslprep.SaslprepTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/tests/src/com.ongres.stringprep/saslprep/2.0/user-code-filter.json
+++ b/tests/src/com.ongres.stringprep/saslprep/2.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.ongres.saslprep.**"
+    },
+    {
+      "includeClasses" : "com_ongres_stringprep.saslprep.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #5705

This PR provides test fixes and new metadata for com.ongres.stringprep:saslprep:2.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 35272
- Cached input tokens: 211456
- Output tokens: 3103
- Metadata entries: 2
- Test-only metadata entries: 2
- Iterations: 2
- Library coverage percentage: 100.0
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 97.78

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `21babaec45e00787265473fd489505132ac30ef1`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.ongres.stringprep:saslprep:1.1: 0/0 covered calls (100.00%)
- com.ongres.stringprep:saslprep:2.0: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.ongres.stringprep:saslprep:1.1: 183/186 (98.39%)
- com.ongres.stringprep:saslprep:2.0: 85/85 (100.00%)

**Line:**
- com.ongres.stringprep:saslprep:1.1: 44/45 (97.78%)
- com.ongres.stringprep:saslprep:2.0: 7/7 (100.00%)

**Method:**
- com.ongres.stringprep:saslprep:1.1: 1/2 (50.00%)
- com.ongres.stringprep:saslprep:2.0: 5/5 (100.00%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/com.ongres.stringprep/saslprep/1.1/src/test/java/com_ongres_stringprep/saslprep/SaslprepTest.java b/tests/src/com.ongres.stringprep/saslprep/2.0/src/test/java/com_ongres_stringprep/saslprep/SaslprepTest.java
index c030fbb1da..2bfe88b3c1 100644
--- a/tests/src/com.ongres.stringprep/saslprep/1.1/src/test/java/com_ongres_stringprep/saslprep/SaslprepTest.java
+++ b/tests/src/com.ongres.stringprep/saslprep/2.0/src/test/java/com_ongres_stringprep/saslprep/SaslprepTest.java
@@ -10,23 +10,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.ongres.saslprep.SaslPrep;
+import com.ongres.saslprep.SASLprep;
 import org.junit.jupiter.api.Test;
 
 public class SaslprepTest {
+    private static final SASLprep SASL_PREP = new SASLprep();
+
     @Test
     void preparesRfc4013Examples() {
-        assertThat(SaslPrep.saslPrep("I\u00ADX", true)).isEqualTo("IX");
-        assertThat(SaslPrep.saslPrep("user", true)).isEqualTo("user");
-        assertThat(SaslPrep.saslPrep("USER", true)).isEqualTo("USER");
-        assertThat(SaslPrep.saslPrep("\u00AA", true)).isEqualTo("a");
-        assertThat(SaslPrep.saslPrep("\u2168", true)).isEqualTo("IX");
-        assertThat(SaslPrep.saslPrep("\uD840\uDC00", true)).isEqualTo("\uD840\uDC00");
+        assertThat(prepare("I\u00ADX", true)).isEqualTo("IX");
+        assertThat(prepare("user", true)).isEqualTo("user");
+        assertThat(prepare("USER", true)).isEqualTo("USER");
+        assertThat(prepare("\u00AA", true)).isEqualTo("a");
+        assertThat(prepare("\u2168", true)).isEqualTo("IX");
+        assertThat(prepare("\uD840\uDC00", true)).isEqualTo("\uD840\uDC00");
     }
 
     @Test
     void removesCharactersCommonlyMappedToNothingBeforeValidation() {
-        String prepared = SaslPrep.saslPrep("pass\u00AD\u034Fword\u200B\uFE00", true);
+        String prepared = prepare("pass\u00AD\u034Fword\u200B\uFE00", true);
 
         assertThat(prepared).isEqualTo("password");
     }
@@ -36,20 +38,20 @@ public class SaslprepTest {
         String fullwidthUserWithDigits = "\uFF35\uFF53\uFF45\uFF52\uFF11\uFF12\uFF13";
         String ligatureAndRomanNumeral = "\uFB01-\u2168";
 
-        assertThat(SaslPrep.saslPrep(fullwidthUserWithDigits, true)).isEqualTo("User123");
-        assertThat(SaslPrep.saslPrep(ligatureAndRomanNumeral, true)).isEqualTo("fi-IX");
+        assertThat(prepare(fullwidthUserWithDigits, true)).isEqualTo("User123");
+        assertThat(prepare(ligatureAndRomanNumeral, true)).isEqualTo("fi-IX");
     }
 
     @Test
     void mapsNonAsciiSpaceCharactersToAsciiSpaceDuringPreparation() {
-        assertThat(SaslPrep.saslPrep("first\u00A0second", true)).isEqualTo("first second");
-        assertThat(SaslPrep.saslPrep("first\u2007second", true)).isEqualTo("first second");
-        assertThat(SaslPrep.saslPrep("first\u202Fsecond", true)).isEqualTo("first second");
+        assertThat(prepare("first\u00A0second", true)).isEqualTo("first second");
+        assertThat(prepare("first\u2007second", true)).isEqualTo("first second");
+        assertThat(prepare("first\u202Fsecond", true)).isEqualTo("first second");
     }
 
     @Test
     void preservesAsciiSpacesWithoutTrimmingOrCollapsing() {
-        assertThat(SaslPrep.saslPrep(" leading  inner  trailing ", true))
+        assertThat(prepare(" leading  inner  trailing ", true))
                 .isEqualTo(" leading  inner  trailing ");
     }
 
@@ -58,7 +60,7 @@ public class SaslprepTest {
         String cjkExtensionB = "\uD840\uDC00";
         String deseretCapitalLetterLongI = "\uD801\uDC00";
 
-        assertThat(SaslPrep.saslPrep("a" + cjkExtensionB + "\u00AD" + deseretCapitalLetterLongI + "b", true))
+        assertThat(prepare("a" + cjkExtensionB + "\u00AD" + deseretCapitalLetterLongI + "b", true))
                 .isEqualTo("a" + cjkExtensionB + deseretCapitalLetterLongI + "b");
     }
 
@@ -79,49 +81,56 @@ public class SaslprepTest {
     void rejectsUnassignedCodePointsOnlyForStoredStrings() {
         String stringWithUnassignedCodePoint = "user\u0221";
 
-        assertThat(SaslPrep.saslPrep(stringWithUnassignedCodePoint, false)).isEqualTo(stringWithUnassignedCodePoint);
-        assertThatThrownBy(() -> SaslPrep.saslPrep(stringWithUnassignedCodePoint, true))
+        assertThat(prepare(stringWithUnassignedCodePoint, false)).isEqualTo(stringWithUnassignedCodePoint);
+        assertThatThrownBy(() -> prepare(stringWithUnassignedCodePoint, true))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Prohibited character")
-                .hasMessageContaining("\u0221");
+                .hasMessageContaining("Unassigned code point")
+                .hasMessageContaining("0x0221");
     }
 
     @Test
     void enforcesBidirectionalRuleForRandAlCatCharacters() {
-        assertThat(SaslPrep.saslPrep("\u0627\u0661\u0628", true)).isEqualTo("\u0627\u0661\u0628");
-        assertThat(SaslPrep.saslPrep("\u05D0\u05D1", true)).isEqualTo("\u05D0\u05D1");
+        assertThat(prepare("\u0627\u0661\u0628", true)).isEqualTo("\u0627\u0661\u0628");
+        assertThat(prepare("\u05D0\u05D1", true)).isEqualTo("\u05D0\u05D1");
 
-        assertThatThrownBy(() -> SaslPrep.saslPrep("\u0627A\u0628", true))
+        assertThatThrownBy(() -> prepare("\u0627A\u0628", true))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("RandALCat and LCat");
 
-        assertThatThrownBy(() -> SaslPrep.saslPrep("\u06271", true))
+        assertThatThrownBy(() -> prepare("\u06271", true))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("RandALCat character is not the first and the last characters");
+                .hasMessageContaining("RandALCat character is not the first and the last character");
 
-        assertThatThrownBy(() -> SaslPrep.saslPrep("1\u0627", true))
+        assertThatThrownBy(() -> prepare("1\u0627", true))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("RandALCat character is not the first and the last characters");
+                .hasMessageContaining("RandALCat character is not the first and the last character");
     }
 
     @Test
     void appliesBidirectionalRuleAfterCompatibilityNormalization() {
-        assertThat(SaslPrep.saslPrep("\u0627\uFF11\u0628", true)).isEqualTo("\u06271\u0628");
+        assertThat(prepare("\u0627\uFF11\u0628", true)).isEqualTo("\u06271\u0628");
 
-        assertThatThrownBy(() -> SaslPrep.saslPrep("\u0627\uFF21\u0628", true))
+        assertThatThrownBy(() -> prepare("\u0627\uFF21\u0628", true))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("RandALCat and LCat");
     }
 
     @Test
     void rejectsNullInput() {
-        assertThatNullPointerException().isThrownBy(() -> SaslPrep.saslPrep(null, true));
+        assertThatNullPointerException().isThrownBy(() -> prepare(null, true));
     }
 
     private static void assertProhibited(String description, String value) {
-        assertThatThrownBy(() -> SaslPrep.saslPrep(value, true))
+        assertThatThrownBy(() -> prepare(value, true))
                 .as(description)
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Prohibited character");
+                .hasMessageContaining("Prohibited");
+    }
+
+    private static String prepare(String value, boolean stored) {
+        if (stored) {
+            return SASL_PREP.prepareStored(value);
+        }
+        return SASL_PREP.prepareQuery(value);
     }
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
