### PR TITLE
[GenAI] Add support for io.helidon:helidon:4.3.4 using gpt-5.5

### DIFF
--- a/metadata/io.helidon/helidon/4.3.4/reachability-metadata.json
+++ b/metadata/io.helidon/helidon/4.3.4/reachability-metadata.json
@@ -1,0 +1,64 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "io.helidon.metadata.MetadataDiscoveryImpl"
+      },
+      "glob" : "META-INF/MANIFEST.MF"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.helidon.metadata.MetadataDiscoveryImpl"
+      },
+      "glob" : "META-INF/helidon/config-metadata.json"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.helidon.metadata.MetadataDiscoveryImpl"
+      },
+      "glob" : "META-INF/helidon/feature-metadata.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.helidon.metadata.MetadataDiscoveryImpl"
+      },
+      "glob" : "META-INF/helidon/feature-registry.json"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.helidon.metadata.MetadataDiscoveryImpl"
+      },
+      "glob" : "META-INF/helidon/manifest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.helidon.metadata.MetadataDiscoveryImpl"
+      },
+      "glob" : "META-INF/helidon/media-types.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.helidon.metadata.MetadataDiscoveryImpl"
+      },
+      "glob" : "META-INF/helidon/serial-config.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.helidon.metadata.MetadataDiscoveryImpl"
+      },
+      "glob" : "META-INF/helidon/service-registry.json"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.helidon.metadata.MetadataDiscoveryImpl"
+      },
+      "glob" : "META-INF/helidon/service.loader"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.helidon.logging.common.LogConfig"
+      },
+      "glob" : "META-INF/services/io.helidon.logging.common.spi.LoggingProvider"
+    }
+  ]
+}

--- a/metadata/io.helidon/helidon/index.json
+++ b/metadata/io.helidon/helidon/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.3.4",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/helidon/helidon/$version$/helidon-$version$-sources.jar",
+    "repository-url" : "https://github.com/helidon-io/helidon",
+    "test-code-url" : "https://github.com/helidon-io/helidon/tree/$version$/tests",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/helidon/helidon/$version$/helidon-$version$-javadoc.jar",
+    "description" : "Helidon is a set of Java libraries for building microservices and cloud native applications on Java 21. The io.helidon:helidon artifact is the main entry point module that pulls in Helidon common and logging support.",
+    "tested-versions" : [
+      "4.3.4"
+    ],
+    "allowed-packages" : [
+      "io.helidon"
+    ]
+  }
+]

--- a/stats/io.helidon/helidon/4.3.4/execution-metrics.json
+++ b/stats/io.helidon/helidon/4.3.4/execution-metrics.json
@@ -1,0 +1,57 @@
+{
+  "add_new_library_support:2026-06-06": {
+    "timestamp": "2026-06-06T07:01:26.250539Z",
+    "library": "io.helidon:helidon:4.3.4",
+    "starting_commit": "62fa6dc662a21664e3e305b5a50688b9f8ae7b1e",
+    "ending_commit": "f586aa4ebb0d97f3b9e50bca1a4033988c7894bc",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.3.4",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 200,
+          "missed": 38,
+          "ratio": 0.840336,
+          "total": 238
+        },
+        "line": {
+          "covered": 64,
+          "missed": 12,
+          "ratio": 0.842105,
+          "total": 76
+        },
+        "method": {
+          "covered": 9,
+          "missed": 2,
+          "ratio": 0.818182,
+          "total": 11
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 117114,
+      "cached_input_tokens_used": 1231872,
+      "output_tokens_used": 15833,
+      "iterations": 3,
+      "cost_usd": 1.0909,
+      "generated_loc": 121,
+      "tested_library_loc": 64,
+      "metadata_entries": 10,
+      "test_only_metadata_entries": 6,
+      "code_coverage_percent": 84.21
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.helidon/helidon/4.3.4/src/test/java/io_helidon/helidon/HelidonTest.java",
+      "metadata_file": "metadata/io.helidon/helidon/4.3.4/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.helidon/helidon/4.3.4/stats.json
+++ b/stats/io.helidon/helidon/4.3.4/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.3.4",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 200,
+        "missed" : 38,
+        "ratio" : 0.840336,
+        "total" : 238
+      },
+      "line" : {
+        "covered" : 64,
+        "missed" : 12,
+        "ratio" : 0.842105,
+        "total" : 76
+      },
+      "method" : {
+        "covered" : 9,
+        "missed" : 2,
+        "ratio" : 0.818182,
+        "total" : 11
+      }
+    }
+  } ]
+}

--- a/tests/src/io.helidon/helidon/4.3.4/.gitignore
+++ b/tests/src/io.helidon/helidon/4.3.4/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.helidon/helidon/4.3.4/build.gradle
+++ b/tests/src/io.helidon/helidon/4.3.4/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.helidon:helidon:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.helidon/helidon/4.3.4/gradle.properties
+++ b/tests/src/io.helidon/helidon/4.3.4/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.helidon:helidon:4.3.4
+library.version = 4.3.4
+metadata.dir = io.helidon/helidon/4.3.4/

--- a/tests/src/io.helidon/helidon/4.3.4/settings.gradle
+++ b/tests/src/io.helidon/helidon/4.3.4/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.helidon.helidon_tests'

--- a/tests/src/io.helidon/helidon/4.3.4/src/test/java/io_helidon/helidon/HelidonTest.java
+++ b/tests/src/io.helidon/helidon/4.3.4/src/test/java/io_helidon/helidon/HelidonTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_helidon.helidon;
+
+import org.junit.jupiter.api.Test;
+
+class HelidonTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.helidon/helidon/4.3.4/src/test/java/io_helidon/helidon/HelidonTest.java
+++ b/tests/src/io.helidon/helidon/4.3.4/src/test/java/io_helidon/helidon/HelidonTest.java
@@ -6,11 +6,97 @@
  */
 package io_helidon.helidon;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import io.helidon.Main;
+import io.helidon.common.Weight;
+import io.helidon.spi.HelidonShutdownHandler;
+import io.helidon.spi.HelidonStartupProvider;
 import org.junit.jupiter.api.Test;
 
-class HelidonTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HelidonTest {
+    private static final AtomicInteger START_COUNT = new AtomicInteger();
+    private static final AtomicReference<List<String>> START_ARGUMENTS = new AtomicReference<>();
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void serviceLoaderDiscoversStartupProvider() {
+        List<HelidonStartupProvider> providers = ServiceLoader.load(HelidonStartupProvider.class)
+                .stream()
+                .map(ServiceLoader.Provider::get)
+                .toList();
+
+        assertThat(providers.stream()
+                .anyMatch(provider -> provider instanceof RecordingStartupProvider))
+                .isTrue();
+    }
+
+    @Test
+    void mainDelegatesToDiscoveredStartupProvider() {
+        START_COUNT.set(0);
+        START_ARGUMENTS.set(List.of());
+
+        Main.main(new String[] {"--server.port=0", "app.message=hello"});
+
+        assertThat(START_COUNT).hasValue(1);
+        assertThat(START_ARGUMENTS.get())
+                .containsExactly("--server.port=0", "app.message=hello");
+    }
+
+    @Test
+    void shutdownHandlersCanBeRegisteredAndRemovedWithoutChangingExistingLogHandlers() {
+        Logger rootLogger = Logger.getLogger("");
+        Handler markerHandler = new RecordingHandler();
+        AtomicInteger shutdownCalls = new AtomicInteger();
+        HelidonShutdownHandler shutdownHandler = shutdownCalls::incrementAndGet;
+
+        rootLogger.addHandler(markerHandler);
+        try {
+            assertThat(Arrays.asList(rootLogger.getHandlers())).contains(markerHandler);
+
+            Main.addShutdownHandler(shutdownHandler);
+            assertThat(Arrays.asList(rootLogger.getHandlers())).contains(markerHandler);
+
+            Main.removeShutdownHandler(shutdownHandler);
+            assertThat(shutdownCalls).hasValue(0);
+        } finally {
+            Main.removeShutdownHandler(shutdownHandler);
+            rootLogger.removeHandler(markerHandler);
+            markerHandler.close();
+        }
+    }
+
+    @Weight(1_000.0)
+    public static final class RecordingStartupProvider implements HelidonStartupProvider {
+        public RecordingStartupProvider() {
+        }
+
+        @Override
+        public void start(String[] args) {
+            START_COUNT.incrementAndGet();
+            START_ARGUMENTS.set(List.copyOf(Arrays.asList(args)));
+        }
+    }
+
+    private static final class RecordingHandler extends Handler {
+        @Override
+        public void publish(LogRecord record) {
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
     }
 }

--- a/tests/src/io.helidon/helidon/4.3.4/src/test/java/io_helidon/helidon/HelidonTest.java
+++ b/tests/src/io.helidon/helidon/4.3.4/src/test/java/io_helidon/helidon/HelidonTest.java
@@ -16,12 +16,14 @@ import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
 import io.helidon.Main;
+import io.helidon.common.HelidonServiceLoader;
 import io.helidon.common.Weight;
 import io.helidon.spi.HelidonShutdownHandler;
 import io.helidon.spi.HelidonStartupProvider;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class HelidonTest {
     private static final AtomicInteger START_COUNT = new AtomicInteger();
@@ -49,6 +51,26 @@ public class HelidonTest {
         assertThat(START_COUNT).hasValue(1);
         assertThat(START_ARGUMENTS.get())
                 .containsExactly("--server.port=0", "app.message=hello");
+    }
+
+    @Test
+    void mainFailsWhenDiscoveredStartupProviderIsExcluded() {
+        START_COUNT.set(0);
+        START_ARGUMENTS.set(List.of());
+        String previousExcludes = System.getProperty(HelidonServiceLoader.SYSTEM_PROPERTY_EXCLUDE);
+        System.setProperty(HelidonServiceLoader.SYSTEM_PROPERTY_EXCLUDE, RecordingStartupProvider.class.getName());
+        try {
+            assertThatThrownBy(() -> Main.main(new String[] {"--server.port=0"}))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("startup provider");
+            assertThat(START_COUNT).hasValue(0);
+        } finally {
+            if (previousExcludes == null) {
+                System.clearProperty(HelidonServiceLoader.SYSTEM_PROPERTY_EXCLUDE);
+            } else {
+                System.setProperty(HelidonServiceLoader.SYSTEM_PROPERTY_EXCLUDE, previousExcludes);
+            }
+        }
     }
 
     @Test

--- a/tests/src/io.helidon/helidon/4.3.4/src/test/java/io_helidon/helidon/HelidonTest.java
+++ b/tests/src/io.helidon/helidon/4.3.4/src/test/java/io_helidon/helidon/HelidonTest.java
@@ -96,6 +96,26 @@ public class HelidonTest {
         }
     }
 
+    @Test
+    void registeringAdditionalShutdownHandlersDoesNotAddMoreLogHandlers() {
+        Logger rootLogger = Logger.getLogger("");
+        HelidonShutdownHandler firstHandler = () -> { };
+        HelidonShutdownHandler secondHandler = () -> { };
+
+        try {
+            Main.addShutdownHandler(firstHandler);
+            List<Handler> handlersAfterFirstRegistration = Arrays.asList(rootLogger.getHandlers());
+
+            Main.addShutdownHandler(secondHandler);
+
+            assertThat(Arrays.asList(rootLogger.getHandlers()))
+                    .containsExactlyElementsOf(handlersAfterFirstRegistration);
+        } finally {
+            Main.removeShutdownHandler(firstHandler);
+            Main.removeShutdownHandler(secondHandler);
+        }
+    }
+
     @Weight(1_000.0)
     public static final class RecordingStartupProvider implements HelidonStartupProvider {
         public RecordingStartupProvider() {

--- a/tests/src/io.helidon/helidon/4.3.4/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/io.helidon/helidon/4.3.4/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,42 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "io.helidon.Main"
+      },
+      "type" : "io_helidon.helidon.HelidonTest$RecordingStartupProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_helidon.helidon.HelidonTest"
+      },
+      "type" : "io_helidon.helidon.HelidonTest$RecordingStartupProvider"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "io.helidon.Main"
+      },
+      "glob" : "META-INF/services/io.helidon.spi.HelidonStartupProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_helidon.helidon.HelidonTest"
+      },
+      "glob" : "META-INF/services/io.helidon.spi.HelidonStartupProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_helidon.helidon.HelidonTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_helidon.helidon.HelidonTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/tests/src/io.helidon/helidon/4.3.4/src/test/resources/META-INF/services/io.helidon.spi.HelidonStartupProvider
+++ b/tests/src/io.helidon/helidon/4.3.4/src/test/resources/META-INF/services/io.helidon.spi.HelidonStartupProvider
@@ -1,0 +1,1 @@
+io_helidon.helidon.HelidonTest$RecordingStartupProvider

--- a/tests/src/io.helidon/helidon/4.3.4/user-code-filter.json
+++ b/tests/src/io.helidon/helidon/4.3.4/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.helidon.**"
+      "includeClasses" : "io.helidon.**"
+    },
+    {
+      "includeClasses" : "io_helidon.helidon.**"
     }
   ]
 }

--- a/tests/src/io.helidon/helidon/4.3.4/user-code-filter.json
+++ b/tests/src/io.helidon/helidon/4.3.4/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.helidon.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #7805

This PR introduces tests and metadata for io.helidon:helidon:4.3.4, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 117114
- Cached input tokens: 1231872
- Output tokens: 15833
- Metadata entries: 10
- Test-only metadata entries: 6
- Iterations: 3
- Library coverage percentage: 84.21
- Generated lines of code: 121
- Tested library lines of code: 64

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `e72a63dfddeb1835f99568ed2161a6ee335e2647`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 200/238 (84.03%)
- Line: 64/76 (84.21%)
- Method: 9/11 (81.82%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
