### PR TITLE
[GenAI] Test fix for com.sun.jersey:jersey-servlet:1.19.2 using gpt-5.5

### DIFF
--- a/metadata/com.sun.jersey/jersey-servlet/1.19.2/reachability-metadata.json
+++ b/metadata/com.sun.jersey/jersey-servlet/1.19.2/reachability-metadata.json
@@ -1,389 +1,259 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "com.sun.jersey.spi.service.ServiceFinder$LazyObjectIterator"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.spi.service.ServiceFinder$LazyObjectIterator"
       },
-      "type": "com.sun.jersey.core.impl.provider.header.CacheControlProvider",
-      "methods": [
+      "type" : "com.sun.jersey.core.impl.provider.header.CacheControlProvider",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jersey.spi.service.ServiceFinder$LazyObjectIterator"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.spi.service.ServiceFinder$LazyObjectIterator"
       },
-      "type": "com.sun.jersey.core.impl.provider.header.CookieProvider",
-      "methods": [
+      "type" : "com.sun.jersey.core.impl.provider.header.CookieProvider",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jersey.spi.service.ServiceFinder$LazyObjectIterator"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.spi.service.ServiceFinder$LazyObjectIterator"
       },
-      "type": "com.sun.jersey.core.impl.provider.header.DateProvider",
-      "methods": [
+      "type" : "com.sun.jersey.core.impl.provider.header.DateProvider",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jersey.spi.service.ServiceFinder$LazyObjectIterator"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.spi.service.ServiceFinder$LazyObjectIterator"
       },
-      "type": "com.sun.jersey.core.impl.provider.header.EntityTagProvider",
-      "methods": [
+      "type" : "com.sun.jersey.core.impl.provider.header.EntityTagProvider",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jersey.spi.service.ServiceFinder$LazyObjectIterator"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.spi.service.ServiceFinder$LazyObjectIterator"
       },
-      "type": "com.sun.jersey.core.impl.provider.header.LocaleProvider",
-      "methods": [
+      "type" : "com.sun.jersey.core.impl.provider.header.LocaleProvider",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jersey.spi.service.ServiceFinder$LazyObjectIterator"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.spi.service.ServiceFinder$LazyObjectIterator"
       },
-      "type": "com.sun.jersey.core.impl.provider.header.MediaTypeProvider",
-      "methods": [
+      "type" : "com.sun.jersey.core.impl.provider.header.MediaTypeProvider",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jersey.spi.service.ServiceFinder$LazyObjectIterator"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.spi.service.ServiceFinder$LazyObjectIterator"
       },
-      "type": "com.sun.jersey.core.impl.provider.header.NewCookieProvider",
-      "methods": [
+      "type" : "com.sun.jersey.core.impl.provider.header.NewCookieProvider",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jersey.spi.service.ServiceFinder$LazyObjectIterator"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.spi.service.ServiceFinder$LazyObjectIterator"
       },
-      "type": "com.sun.jersey.core.impl.provider.header.StringProvider",
-      "methods": [
+      "type" : "com.sun.jersey.core.impl.provider.header.StringProvider",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jersey.spi.service.ServiceFinder$LazyObjectIterator"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.spi.service.ServiceFinder$LazyObjectIterator"
       },
-      "type": "com.sun.jersey.core.impl.provider.header.URIProvider",
-      "methods": [
+      "type" : "com.sun.jersey.core.impl.provider.header.URIProvider",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com_sun_jersey.jersey_servlet.BeanGeneratorTest"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.core.spi.component.ComponentInjector$1"
       },
-      "type": "com.sun.jersey.server.impl.cdi.BeanGenerator",
-      "fields": [
+      "type" : "com.sun.jersey.server.impl.ejb.EJBRequestDispatcherProvider",
+      "fields" : [
         {
-          "name": "defineClassMethod"
-        }
-      ],
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        },
-        {
-          "name": "createBeanClass",
-          "parameterTypes": []
+          "name" : "rdFactory"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com_sun_jersey.jersey_servlet.CDIExtensionTest"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.core.spi.component.ProviderFactory"
       },
-      "type": "com.sun.jersey.server.impl.cdi.CDIExtension",
-      "fields": [
-        {
-          "name": "discoveredParameterMap"
-        },
-        {
-          "name": "syntheticQualifierMap"
-        },
-        {
-          "name": "toBeInitializedLater"
-        }
-      ],
-      "methods": [
-        {
-          "name": "afterBeanDiscovery",
-          "parameterTypes": [
-            "javax.enterprise.inject.spi.AfterBeanDiscovery"
-          ]
-        }
-      ]
+      "type" : "com.sun.jersey.server.impl.ejb.EJBRequestDispatcherProvider"
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jersey.core.spi.component.ComponentInjector$1"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.core.reflection.MethodList"
       },
-      "type": "com.sun.jersey.server.impl.ejb.EJBRequestDispatcherProvider",
-      "fields": [
+      "type" : "com.sun.jersey.server.impl.model.method.dispatch.AbstractResourceMethodDispatchProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jersey.core.spi.component.ComponentConstructor"
+      },
+      "type" : "com.sun.jersey.server.impl.model.method.dispatch.AbstractResourceMethodDispatchProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jersey.core.reflection.MethodList"
+      },
+      "type" : "com.sun.jersey.server.impl.model.method.dispatch.EntityParamDispatchProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jersey.core.spi.component.ComponentConstructor"
+      },
+      "type" : "com.sun.jersey.server.impl.model.method.dispatch.EntityParamDispatchProvider",
+      "methods" : [
         {
-          "name": "rdFactory"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "com.sun.jersey.core.spi.component.ProviderFactory"
-      },
-      "type": "com.sun.jersey.server.impl.ejb.EJBRequestDispatcherProvider"
-    },
-    {
-      "condition": {
-        "typeReached": "com.sun.jersey.core.reflection.MethodList"
-      },
-      "type": "com.sun.jersey.server.impl.model.method.dispatch.AbstractResourceMethodDispatchProvider"
-    },
-    {
-      "condition": {
-        "typeReached": "com.sun.jersey.core.spi.component.ComponentConstructor"
-      },
-      "type": "com.sun.jersey.server.impl.model.method.dispatch.AbstractResourceMethodDispatchProvider"
-    },
-    {
-      "condition": {
-        "typeReached": "com.sun.jersey.core.reflection.MethodList"
-      },
-      "type": "com.sun.jersey.server.impl.model.method.dispatch.EntityParamDispatchProvider"
-    },
-    {
-      "condition": {
-        "typeReached": "com.sun.jersey.core.spi.component.ComponentConstructor"
-      },
-      "type": "com.sun.jersey.server.impl.model.method.dispatch.EntityParamDispatchProvider",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jersey.core.reflection.MethodList"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.core.reflection.MethodList"
       },
-      "type": "com.sun.jersey.server.impl.model.method.dispatch.FormDispatchProvider"
+      "type" : "com.sun.jersey.server.impl.model.method.dispatch.FormDispatchProvider"
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jersey.core.spi.component.ComponentConstructor"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.core.spi.component.ComponentConstructor"
       },
-      "type": "com.sun.jersey.server.impl.model.method.dispatch.FormDispatchProvider",
-      "methods": [
+      "type" : "com.sun.jersey.server.impl.model.method.dispatch.FormDispatchProvider",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jersey.core.reflection.MethodList"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.core.reflection.MethodList"
       },
-      "type": "com.sun.jersey.server.impl.model.method.dispatch.HttpReqResDispatchProvider"
+      "type" : "com.sun.jersey.server.impl.model.method.dispatch.HttpReqResDispatchProvider"
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jersey.core.spi.component.ComponentConstructor"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.core.spi.component.ComponentConstructor"
       },
-      "type": "com.sun.jersey.server.impl.model.method.dispatch.HttpReqResDispatchProvider",
-      "methods": [
+      "type" : "com.sun.jersey.server.impl.model.method.dispatch.HttpReqResDispatchProvider",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jersey.core.reflection.MethodList"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.core.reflection.MethodList"
       },
-      "type": "com.sun.jersey.server.impl.model.method.dispatch.MultipartFormDispatchProvider"
+      "type" : "com.sun.jersey.server.impl.model.method.dispatch.MultipartFormDispatchProvider"
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jersey.core.spi.component.ComponentConstructor"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.core.spi.component.ComponentConstructor"
       },
-      "type": "com.sun.jersey.server.impl.model.method.dispatch.MultipartFormDispatchProvider",
-      "methods": [
+      "type" : "com.sun.jersey.server.impl.model.method.dispatch.MultipartFormDispatchProvider",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jersey.core.reflection.MethodList"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.core.reflection.MethodList"
       },
-      "type": "com.sun.jersey.server.impl.model.method.dispatch.VoidVoidDispatchProvider"
+      "type" : "com.sun.jersey.server.impl.model.method.dispatch.VoidVoidDispatchProvider"
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jersey.core.spi.component.ComponentConstructor"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.core.spi.component.ComponentConstructor"
       },
-      "type": "com.sun.jersey.server.impl.model.method.dispatch.VoidVoidDispatchProvider",
-      "methods": [
+      "type" : "com.sun.jersey.server.impl.model.method.dispatch.VoidVoidDispatchProvider",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jersey.server.impl.model.method.dispatch.MultipartFormDispatchProvider"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.server.impl.model.method.dispatch.MultipartFormDispatchProvider"
       },
-      "type": "com.sun.jersey.server.impl.provider.RuntimeDelegateImpl",
-      "methods": [
+      "type" : "com.sun.jersey.server.impl.provider.RuntimeDelegateImpl",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com_sun_jersey.jersey_servlet.BeanGeneratorTest"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.server.impl.cdi.BeanGenerator$1"
       },
-      "type": "com_sun_jersey.jersey_servlet.BeanGeneratorTest$CapturingClassLoader"
+      "type" : "java.lang.ClassLoader"
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jersey.server.impl.ejb.EJBComponentProviderFactoryInitilizer"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.server.impl.cdi.CDIExtension"
       },
-      "type": "com_sun_jersey.jersey_servlet.EJBComponentProviderFactoryInitilizerTest$InterceptorBinder",
-      "methods": [
+      "type" : "java.lang.ClassLoader",
+      "methods" : [
         {
-          "name": "registerInterceptor",
-          "parameterTypes": [
-            "java.lang.Object"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "com_sun_jersey.jersey_servlet.EJBRequestDispatcherProviderAnonymous1Test"
-      },
-      "type": "com_sun_jersey.jersey_servlet.EJBRequestDispatcherProviderAnonymous1Test$PingBean"
-    },
-    {
-      "condition": {
-        "typeReached": "com.sun.jersey.server.impl.ejb.EJBRequestDispatcherProvider$1"
-      },
-      "type": "com_sun_jersey.jersey_servlet.EJBRequestDispatcherProviderAnonymous1Test$PingRemote",
-      "methods": [
-        {
-          "name": "ping",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "com_sun_jersey.jersey_servlet.EJBRequestDispatcherProviderAnonymous1Test$1"
-      },
-      "type": "com_sun_jersey.jersey_servlet.EJBRequestDispatcherProviderAnonymous1Test$PingRemote"
-    },
-    {
-      "condition": {
-        "typeReached": "com_sun_jersey.jersey_servlet.EJBRequestDispatcherProviderTest"
-      },
-      "type": "com_sun_jersey.jersey_servlet.EJBRequestDispatcherProviderTest$GreetingBean"
-    },
-    {
-      "condition": {
-        "typeReached": "com_sun_jersey.jersey_servlet.EJBRequestDispatcherProviderTest"
-      },
-      "type": "com_sun_jersey.jersey_servlet.EJBRequestDispatcherProviderTest$GreetingRemote"
-    },
-    {
-      "condition": {
-        "typeReached": "com.sun.jersey.server.impl.managedbeans.ManagedBeanComponentProviderFactory$ManagedBeanComponentProvider"
-      },
-      "type": "com_sun_jersey.jersey_servlet.ManagedBeanComponentProviderFactoryInnerManagedBeanComponentProviderTest$InjectionManager",
-      "methods": [
-        {
-          "name": "createManagedObject",
-          "parameterTypes": [
-            "java.lang.Class"
-          ]
-        },
-        {
-          "name": "destroyManagedObject",
-          "parameterTypes": [
-            "java.lang.Object"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "com.sun.jersey.server.impl.managedbeans.ManagedBeanComponentProviderFactoryInitilizer"
-      },
-      "type": "com_sun_jersey.jersey_servlet.ManagedBeanComponentProviderFactoryInnerManagedBeanComponentProviderTest$InjectionManager"
-    },
-    {
-      "condition": {
-        "typeReached": "com.sun.jersey.server.impl.cdi.BeanGenerator$1"
-      },
-      "type": "java.lang.ClassLoader"
-    },
-    {
-      "condition": {
-        "typeReached": "com.sun.jersey.server.impl.cdi.CDIExtension"
-      },
-      "type": "java.lang.ClassLoader",
-      "methods": [
-        {
-          "name": "defineClass",
-          "parameterTypes": [
+          "name" : "defineClass",
+          "parameterTypes" : [
             "java.lang.String",
             "byte[]",
             "int",
@@ -393,119 +263,95 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jersey.spi.service.ServiceFinder"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.spi.service.ServiceFinder"
       },
-      "type": "java.lang.Class[]"
+      "type" : "java.lang.Class[]"
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jersey.server.impl.cdi.CDIExtension"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.server.impl.cdi.CDIExtension"
       },
-      "type": "java.lang.String[]"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jersey.server.impl.cdi.CDIExtension$InjectAnnotationLiteral"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.server.impl.cdi.CDIExtension$InjectAnnotationLiteral"
       },
-      "type": "javax.inject.Inject"
+      "type" : "javax.inject.Inject"
     },
     {
-      "condition": {
-        "typeReached": "com_sun_jersey.jersey_servlet.DiscoveredParameterTest"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.server.impl.cdi.CDIExtension"
       },
-      "type": "javax.ws.rs.QueryParam",
-      "methods": [
-        {
-          "name": "value",
-          "parameterTypes": []
-        }
-      ]
+      "type" : "javax.ws.rs.core.Context"
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jersey.server.impl.cdi.CDIExtension"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.server.impl.cdi.CDIExtension$ContextAnnotationLiteral"
       },
-      "type": "javax.ws.rs.core.Context"
+      "type" : "javax.ws.rs.core.Context"
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jersey.server.impl.cdi.CDIExtension$ContextAnnotationLiteral"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.core.reflection.ReflectionHelper"
       },
-      "type": "javax.ws.rs.core.Context"
-    },
-    {
-      "condition": {
-        "typeReached": "com.sun.jersey.core.reflection.ReflectionHelper"
-      },
-      "type": "org.osgi.framework.BundleReference"
+      "type" : "org.osgi.framework.BundleReference"
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "com.sun.jersey.spi.service.ServiceFinder$LazyObjectIterator"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.spi.service.ServiceFinder$LazyObjectIterator"
       },
-      "glob": "META-INF/services/com.sun.jersey.spi.HeaderDelegateProvider"
+      "glob" : "META-INF/services/com.sun.jersey.spi.HeaderDelegateProvider"
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jersey.spi.service.ServiceFinder$AbstractLazyIterator"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.spi.service.ServiceFinder$AbstractLazyIterator"
       },
-      "glob": "META-INF/services/com.sun.jersey.spi.container.ResourceMethodCustomInvokerDispatchProvider"
+      "glob" : "META-INF/services/com.sun.jersey.spi.container.ResourceMethodCustomInvokerDispatchProvider"
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jersey.server.impl.managedbeans.ManagedBeanComponentProviderFactory"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.server.impl.managedbeans.ManagedBeanComponentProviderFactory"
       },
-      "glob": "META-INF/services/java.time.zone.ZoneRulesProvider"
+      "glob" : "META-INF/services/java.time.zone.ZoneRulesProvider"
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jersey.server.impl.model.method.dispatch.MultipartFormDispatchProvider"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.server.impl.model.method.dispatch.MultipartFormDispatchProvider"
       },
-      "glob": "META-INF/services/javax.ws.rs.ext.RuntimeDelegate"
+      "glob" : "META-INF/services/javax.ws.rs.ext.RuntimeDelegate"
     },
     {
-      "condition": {
-        "typeReached": "com_sun_jersey.jersey_servlet.BeanGeneratorTest"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.spi.service.ServiceFinder"
       },
-      "glob": "META-INF/services/org.assertj.core.configuration.Configuration"
+      "glob" : "com/sun/jersey/spi/service/ServiceFinder.class"
     },
     {
-      "condition": {
-        "typeReached": "com_sun_jersey.jersey_servlet.BeanGeneratorTest"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.server.impl.InitialContextHelper"
       },
-      "glob": "META-INF/services/org.assertj.core.presentation.Representation"
+      "glob" : "jndi.properties"
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jersey.spi.service.ServiceFinder"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.server.impl.managedbeans.ManagedBeanComponentProviderFactory"
       },
-      "glob": "com/sun/jersey/spi/service/ServiceFinder.class"
+      "module" : "java.logging",
+      "glob" : "sun/util/logging/resources/logging_en.properties"
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jersey.server.impl.InitialContextHelper"
+      "condition" : {
+        "typeReached" : "com.sun.jersey.server.impl.managedbeans.ManagedBeanComponentProviderFactory"
       },
-      "glob": "jndi.properties"
+      "module" : "java.logging",
+      "glob" : "sun/util/logging/resources/logging_en_US.properties"
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jersey.server.impl.managedbeans.ManagedBeanComponentProviderFactory"
-      },
-      "module": "java.logging",
-      "glob": "sun/util/logging/resources/logging_en.properties"
-    },
-    {
-      "condition": {
-        "typeReached": "com.sun.jersey.server.impl.managedbeans.ManagedBeanComponentProviderFactory"
-      },
-      "module": "java.logging",
-      "glob": "sun/util/logging/resources/logging_en_US.properties"
-    },
-    {
-      "bundle": "sun.util.logging.resources.logging"
+      "bundle" : "sun.util.logging.resources.logging"
     }
   ]
 }

--- a/metadata/com.sun.jersey/jersey-servlet/1.19.2/reachability-metadata.json
+++ b/metadata/com.sun.jersey/jersey-servlet/1.19.2/reachability-metadata.json
@@ -1,0 +1,511 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.spi.service.ServiceFinder$LazyObjectIterator"
+      },
+      "type": "com.sun.jersey.core.impl.provider.header.CacheControlProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.spi.service.ServiceFinder$LazyObjectIterator"
+      },
+      "type": "com.sun.jersey.core.impl.provider.header.CookieProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.spi.service.ServiceFinder$LazyObjectIterator"
+      },
+      "type": "com.sun.jersey.core.impl.provider.header.DateProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.spi.service.ServiceFinder$LazyObjectIterator"
+      },
+      "type": "com.sun.jersey.core.impl.provider.header.EntityTagProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.spi.service.ServiceFinder$LazyObjectIterator"
+      },
+      "type": "com.sun.jersey.core.impl.provider.header.LocaleProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.spi.service.ServiceFinder$LazyObjectIterator"
+      },
+      "type": "com.sun.jersey.core.impl.provider.header.MediaTypeProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.spi.service.ServiceFinder$LazyObjectIterator"
+      },
+      "type": "com.sun.jersey.core.impl.provider.header.NewCookieProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.spi.service.ServiceFinder$LazyObjectIterator"
+      },
+      "type": "com.sun.jersey.core.impl.provider.header.StringProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.spi.service.ServiceFinder$LazyObjectIterator"
+      },
+      "type": "com.sun.jersey.core.impl.provider.header.URIProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_sun_jersey.jersey_servlet.BeanGeneratorTest"
+      },
+      "type": "com.sun.jersey.server.impl.cdi.BeanGenerator",
+      "fields": [
+        {
+          "name": "defineClassMethod"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "createBeanClass",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_sun_jersey.jersey_servlet.CDIExtensionTest"
+      },
+      "type": "com.sun.jersey.server.impl.cdi.CDIExtension",
+      "fields": [
+        {
+          "name": "discoveredParameterMap"
+        },
+        {
+          "name": "syntheticQualifierMap"
+        },
+        {
+          "name": "toBeInitializedLater"
+        }
+      ],
+      "methods": [
+        {
+          "name": "afterBeanDiscovery",
+          "parameterTypes": [
+            "javax.enterprise.inject.spi.AfterBeanDiscovery"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.core.spi.component.ComponentInjector$1"
+      },
+      "type": "com.sun.jersey.server.impl.ejb.EJBRequestDispatcherProvider",
+      "fields": [
+        {
+          "name": "rdFactory"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.core.spi.component.ProviderFactory"
+      },
+      "type": "com.sun.jersey.server.impl.ejb.EJBRequestDispatcherProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.core.reflection.MethodList"
+      },
+      "type": "com.sun.jersey.server.impl.model.method.dispatch.AbstractResourceMethodDispatchProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.core.spi.component.ComponentConstructor"
+      },
+      "type": "com.sun.jersey.server.impl.model.method.dispatch.AbstractResourceMethodDispatchProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.core.reflection.MethodList"
+      },
+      "type": "com.sun.jersey.server.impl.model.method.dispatch.EntityParamDispatchProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.core.spi.component.ComponentConstructor"
+      },
+      "type": "com.sun.jersey.server.impl.model.method.dispatch.EntityParamDispatchProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.core.reflection.MethodList"
+      },
+      "type": "com.sun.jersey.server.impl.model.method.dispatch.FormDispatchProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.core.spi.component.ComponentConstructor"
+      },
+      "type": "com.sun.jersey.server.impl.model.method.dispatch.FormDispatchProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.core.reflection.MethodList"
+      },
+      "type": "com.sun.jersey.server.impl.model.method.dispatch.HttpReqResDispatchProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.core.spi.component.ComponentConstructor"
+      },
+      "type": "com.sun.jersey.server.impl.model.method.dispatch.HttpReqResDispatchProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.core.reflection.MethodList"
+      },
+      "type": "com.sun.jersey.server.impl.model.method.dispatch.MultipartFormDispatchProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.core.spi.component.ComponentConstructor"
+      },
+      "type": "com.sun.jersey.server.impl.model.method.dispatch.MultipartFormDispatchProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.core.reflection.MethodList"
+      },
+      "type": "com.sun.jersey.server.impl.model.method.dispatch.VoidVoidDispatchProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.core.spi.component.ComponentConstructor"
+      },
+      "type": "com.sun.jersey.server.impl.model.method.dispatch.VoidVoidDispatchProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.server.impl.model.method.dispatch.MultipartFormDispatchProvider"
+      },
+      "type": "com.sun.jersey.server.impl.provider.RuntimeDelegateImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_sun_jersey.jersey_servlet.BeanGeneratorTest"
+      },
+      "type": "com_sun_jersey.jersey_servlet.BeanGeneratorTest$CapturingClassLoader"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.server.impl.ejb.EJBComponentProviderFactoryInitilizer"
+      },
+      "type": "com_sun_jersey.jersey_servlet.EJBComponentProviderFactoryInitilizerTest$InterceptorBinder",
+      "methods": [
+        {
+          "name": "registerInterceptor",
+          "parameterTypes": [
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_sun_jersey.jersey_servlet.EJBRequestDispatcherProviderAnonymous1Test"
+      },
+      "type": "com_sun_jersey.jersey_servlet.EJBRequestDispatcherProviderAnonymous1Test$PingBean"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.server.impl.ejb.EJBRequestDispatcherProvider$1"
+      },
+      "type": "com_sun_jersey.jersey_servlet.EJBRequestDispatcherProviderAnonymous1Test$PingRemote",
+      "methods": [
+        {
+          "name": "ping",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_sun_jersey.jersey_servlet.EJBRequestDispatcherProviderAnonymous1Test$1"
+      },
+      "type": "com_sun_jersey.jersey_servlet.EJBRequestDispatcherProviderAnonymous1Test$PingRemote"
+    },
+    {
+      "condition": {
+        "typeReached": "com_sun_jersey.jersey_servlet.EJBRequestDispatcherProviderTest"
+      },
+      "type": "com_sun_jersey.jersey_servlet.EJBRequestDispatcherProviderTest$GreetingBean"
+    },
+    {
+      "condition": {
+        "typeReached": "com_sun_jersey.jersey_servlet.EJBRequestDispatcherProviderTest"
+      },
+      "type": "com_sun_jersey.jersey_servlet.EJBRequestDispatcherProviderTest$GreetingRemote"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.server.impl.managedbeans.ManagedBeanComponentProviderFactory$ManagedBeanComponentProvider"
+      },
+      "type": "com_sun_jersey.jersey_servlet.ManagedBeanComponentProviderFactoryInnerManagedBeanComponentProviderTest$InjectionManager",
+      "methods": [
+        {
+          "name": "createManagedObject",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name": "destroyManagedObject",
+          "parameterTypes": [
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.server.impl.managedbeans.ManagedBeanComponentProviderFactoryInitilizer"
+      },
+      "type": "com_sun_jersey.jersey_servlet.ManagedBeanComponentProviderFactoryInnerManagedBeanComponentProviderTest$InjectionManager"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.server.impl.cdi.BeanGenerator$1"
+      },
+      "type": "java.lang.ClassLoader"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.server.impl.cdi.CDIExtension"
+      },
+      "type": "java.lang.ClassLoader",
+      "methods": [
+        {
+          "name": "defineClass",
+          "parameterTypes": [
+            "java.lang.String",
+            "byte[]",
+            "int",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.spi.service.ServiceFinder"
+      },
+      "type": "java.lang.Class[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.server.impl.cdi.CDIExtension"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.server.impl.cdi.CDIExtension$InjectAnnotationLiteral"
+      },
+      "type": "javax.inject.Inject"
+    },
+    {
+      "condition": {
+        "typeReached": "com_sun_jersey.jersey_servlet.DiscoveredParameterTest"
+      },
+      "type": "javax.ws.rs.QueryParam",
+      "methods": [
+        {
+          "name": "value",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.server.impl.cdi.CDIExtension"
+      },
+      "type": "javax.ws.rs.core.Context"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.server.impl.cdi.CDIExtension$ContextAnnotationLiteral"
+      },
+      "type": "javax.ws.rs.core.Context"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.core.reflection.ReflectionHelper"
+      },
+      "type": "org.osgi.framework.BundleReference"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.spi.service.ServiceFinder$LazyObjectIterator"
+      },
+      "glob": "META-INF/services/com.sun.jersey.spi.HeaderDelegateProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.spi.service.ServiceFinder$AbstractLazyIterator"
+      },
+      "glob": "META-INF/services/com.sun.jersey.spi.container.ResourceMethodCustomInvokerDispatchProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.server.impl.managedbeans.ManagedBeanComponentProviderFactory"
+      },
+      "glob": "META-INF/services/java.time.zone.ZoneRulesProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.server.impl.model.method.dispatch.MultipartFormDispatchProvider"
+      },
+      "glob": "META-INF/services/javax.ws.rs.ext.RuntimeDelegate"
+    },
+    {
+      "condition": {
+        "typeReached": "com_sun_jersey.jersey_servlet.BeanGeneratorTest"
+      },
+      "glob": "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition": {
+        "typeReached": "com_sun_jersey.jersey_servlet.BeanGeneratorTest"
+      },
+      "glob": "META-INF/services/org.assertj.core.presentation.Representation"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.spi.service.ServiceFinder"
+      },
+      "glob": "com/sun/jersey/spi/service/ServiceFinder.class"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.server.impl.InitialContextHelper"
+      },
+      "glob": "jndi.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.server.impl.managedbeans.ManagedBeanComponentProviderFactory"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jersey.server.impl.managedbeans.ManagedBeanComponentProviderFactory"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en_US.properties"
+    },
+    {
+      "bundle": "sun.util.logging.resources.logging"
+    }
+  ]
+}

--- a/metadata/com.sun.jersey/jersey-servlet/index.json
+++ b/metadata/com.sun.jersey/jersey-servlet/index.json
@@ -1,6 +1,23 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.19.2",
+    "tested-versions" : [
+      "1.19.2"
+    ],
+    "allowed-packages" : [
+      "com.sun.jersey.api.core.servlet",
+      "com.sun.jersey.server.impl",
+      "com.sun.jersey.spi.container.servlet",
+      "com.sun.jersey.spi.scanning.servlet",
+      "com.sun.jersey.api.model",
+      "com.sun.jersey.core.reflection",
+      "com.sun.jersey.core.spi.component",
+      "com.sun.jersey.core.spi.factory",
+      "com.sun.jersey.spi.service"
+    ]
+  },
+  {
     "metadata-version" : "1.19",
     "source-code-url" : "https://repo.maven.apache.org/maven2/com/sun/jersey/jersey-servlet/$version$/jersey-servlet-$version$-sources.jar",
     "repository-url" : "https://github.com/javaee/jersey-1.x",

--- a/metadata/com.sun.jersey/jersey-servlet/index.json
+++ b/metadata/com.sun.jersey/jersey-servlet/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.19.2",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/sun/jersey/jersey-servlet/$version$/jersey-servlet-$version$-sources.jar",
+    "repository-url" : "https://github.com/javaee/jersey-1.x",
+    "test-code-url" : "https://github.com/javaee/jersey-1.x/tree/$version$/tests/functional/jersey-servlet3_0-integration",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/sun/jersey/jersey-servlet/$version$/jersey-servlet-$version$-javadoc.jar",
+    "description" : "Jersey Servlet provides servlet and filter integration for Jersey 1.x, the JAX-RS reference implementation, so REST resources can run inside Java web applications. It adds servlet container bootstrapping, web application resource scanning, JSP/template support, and integration hooks for CDI, EJB, and managed beans.",
     "tested-versions" : [
       "1.19.2"
     ],

--- a/stats/com.sun.jersey/jersey-servlet/1.19.2/execution-metrics.json
+++ b/stats/com.sun.jersey/jersey-servlet/1.19.2/execution-metrics.json
@@ -1,0 +1,101 @@
+{
+  "fix_java_run_fail:2026-06-06": {
+    "timestamp": "2026-06-06T07:40:49.253845Z",
+    "library": "com.sun.jersey:jersey-servlet:1.19.2",
+    "starting_commit": "55f43517b1d1b709b969ad7e2ad50d186a1593cf",
+    "ending_commit": "35151a6322fec6cf8812a4310d3c97cd4afcd040",
+    "previous_library": "com.sun.jersey:jersey-servlet:1.19",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.19.2",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 12,
+            "totalCalls": 12
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 12,
+        "totalCalls": 12
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1200,
+          "missed": 6962,
+          "ratio": 0.147023,
+          "total": 8162
+        },
+        "line": {
+          "covered": 243,
+          "missed": 1513,
+          "ratio": 0.138383,
+          "total": 1756
+        },
+        "method": {
+          "covered": 54,
+          "missed": 299,
+          "ratio": 0.152975,
+          "total": 353
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.19",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 12,
+            "totalCalls": 12
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 12,
+        "totalCalls": 12
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 876,
+          "missed": 7271,
+          "ratio": 0.107524,
+          "total": 8147
+        },
+        "line": {
+          "covered": 169,
+          "missed": 1550,
+          "ratio": 0.098313,
+          "total": 1719
+        },
+        "method": {
+          "covered": 47,
+          "missed": 302,
+          "ratio": 0.13467,
+          "total": 349
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 52118,
+      "cached_input_tokens_used": 702976,
+      "output_tokens_used": 8168,
+      "iterations": 1,
+      "cost_usd": 0.5965,
+      "tested_library_loc": 243,
+      "metadata_entries": 60,
+      "test_only_metadata_entries": 29,
+      "previous_library_metadata_entries": 70,
+      "previous_library_test_only_metadata_entries": 4,
+      "code_coverage_percent": 13.84,
+      "previous_library_coverage_percent": 9.83
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.sun.jersey/jersey-servlet/1.19.2/src/test/java/com_sun_jersey/jersey_servlet/EJBRequestDispatcherProviderAnonymous1Test.java",
+      "metadata_file": "metadata/com.sun.jersey/jersey-servlet/1.19.2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.sun.jersey/jersey-servlet/1.19.2/stats.json
+++ b/stats/com.sun.jersey/jersey-servlet/1.19.2/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "1.19.2",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 12,
+          "totalCalls" : 12
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 12,
+      "totalCalls" : 12
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1200,
+        "missed" : 6962,
+        "ratio" : 0.147023,
+        "total" : 8162
+      },
+      "line" : {
+        "covered" : 243,
+        "missed" : 1513,
+        "ratio" : 0.138383,
+        "total" : 1756
+      },
+      "method" : {
+        "covered" : 54,
+        "missed" : 299,
+        "ratio" : 0.152975,
+        "total" : 353
+      }
+    }
+  } ]
+}

--- a/tests/src/com.sun.jersey/jersey-servlet/1.19.2/.gitignore
+++ b/tests/src/com.sun.jersey/jersey-servlet/1.19.2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.sun.jersey/jersey-servlet/1.19.2/build.gradle
+++ b/tests/src/com.sun.jersey/jersey-servlet/1.19.2/build.gradle
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.sun.jersey:jersey-servlet:$libraryVersion"
+    testImplementation "com.sun.jersey:jersey-server:$libraryVersion"
+    testImplementation 'javax.annotation:javax.annotation-api:1.3.2'
+    testImplementation 'javax.enterprise:cdi-api:1.1'
+    testImplementation 'org.glassfish:javax.ejb:3.1'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+tasks.withType(Test).configureEach {
+    jvmArgs "--add-opens=java.base/java.lang=ALL-UNNAMED"
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+    binaries {
+        all {
+            buildArgs.add("--add-opens=java.base/java.lang=ALL-UNNAMED")
+        }
+    }
+}

--- a/tests/src/com.sun.jersey/jersey-servlet/1.19.2/gradle.properties
+++ b/tests/src/com.sun.jersey/jersey-servlet/1.19.2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.sun.jersey:jersey-servlet:1.19.2
+library.version = 1.19.2
+metadata.dir = com.sun.jersey/jersey-servlet/1.19.2/

--- a/tests/src/com.sun.jersey/jersey-servlet/1.19.2/settings.gradle
+++ b/tests/src/com.sun.jersey/jersey-servlet/1.19.2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.sun.jersey.jersey-servlet_tests'

--- a/tests/src/com.sun.jersey/jersey-servlet/1.19.2/src/test/java/com_sun_jersey/jersey_servlet/BeanGeneratorTest.java
+++ b/tests/src/com.sun.jersey/jersey-servlet/1.19.2/src/test/java/com_sun_jersey/jersey_servlet/BeanGeneratorTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_sun_jersey.jersey_servlet;
+
+import com.sun.jersey.server.impl.cdi.BeanGenerator;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeanGeneratorTest {
+    @Test
+    void createBeanClassInvokesConfiguredClassDefinitionMethod() throws Exception {
+        Thread thread = Thread.currentThread();
+        ClassLoader previousClassLoader = thread.getContextClassLoader();
+        CapturingClassLoader capturingClassLoader = new CapturingClassLoader(previousClassLoader);
+        thread.setContextClassLoader(capturingClassLoader);
+        try {
+            BeanGenerator generator = newBeanGenerator(
+                    "com/sun/jersey/server/impl/cdi/generated/BeanGeneratorTestBean");
+            replaceDefineClassMethod(generator);
+
+            Class<?> generatedBeanClass = invokeCreateBeanClass(generator);
+
+            assertThat(generatedBeanClass).isSameAs(GeneratedBeanSentinel.class);
+            assertThat(capturingClassLoader.getClassName())
+                    .startsWith("com.sun.jersey.server.impl.cdi.generated.BeanGeneratorTestBean");
+            assertThat(capturingClassLoader.getBytecode())
+                    .startsWith((byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBE);
+            assertThat(capturingClassLoader.getOffset()).isZero();
+            assertThat(capturingClassLoader.getLength()).isEqualTo(capturingClassLoader.getBytecode().length);
+        } finally {
+            thread.setContextClassLoader(previousClassLoader);
+        }
+    }
+
+    private BeanGenerator newBeanGenerator(String prefix) throws Exception {
+        Constructor<BeanGenerator> constructor = BeanGenerator.class.getDeclaredConstructor(String.class);
+        constructor.setAccessible(true);
+        return constructor.newInstance(prefix);
+    }
+
+    private void replaceDefineClassMethod(BeanGenerator generator) throws Exception {
+        Method method = CapturingClassLoader.class.getMethod(
+                "defineGeneratedClass", String.class, byte[].class, int.class, int.class);
+        Field defineClassMethod = BeanGenerator.class.getDeclaredField("defineClassMethod");
+        defineClassMethod.setAccessible(true);
+        defineClassMethod.set(generator, method);
+    }
+
+    private Class<?> invokeCreateBeanClass(BeanGenerator generator) throws Exception {
+        Method method = BeanGenerator.class.getDeclaredMethod("createBeanClass");
+        method.setAccessible(true);
+        return (Class<?>) method.invoke(generator);
+    }
+
+    public static final class GeneratedBeanSentinel {
+    }
+
+    public static final class CapturingClassLoader extends ClassLoader {
+        private String className;
+        private byte[] bytecode;
+        private int offset;
+        private int length;
+
+        private CapturingClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        public Class<?> defineGeneratedClass(String className, byte[] bytecode, int offset, int length) {
+            this.className = className;
+            this.bytecode = bytecode;
+            this.offset = offset;
+            this.length = length;
+            return GeneratedBeanSentinel.class;
+        }
+
+        private String getClassName() {
+            return className;
+        }
+
+        private byte[] getBytecode() {
+            return bytecode;
+        }
+
+        private int getOffset() {
+            return offset;
+        }
+
+        private int getLength() {
+            return length;
+        }
+    }
+}

--- a/tests/src/com.sun.jersey/jersey-servlet/1.19.2/src/test/java/com_sun_jersey/jersey_servlet/CDIExtensionTest.java
+++ b/tests/src/com.sun.jersey/jersey-servlet/1.19.2/src/test/java/com_sun_jersey/jersey_servlet/CDIExtensionTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_sun_jersey.jersey_servlet;
+
+import com.sun.jersey.server.impl.cdi.CDIExtension;
+import com.sun.jersey.server.impl.cdi.DiscoveredParameter;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.enterprise.inject.spi.AfterBeanDiscovery;
+import javax.enterprise.inject.spi.AnnotatedType;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.ObserverMethod;
+import javax.ws.rs.core.Context;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CDIExtensionTest {
+    @Test
+    void afterBeanDiscoveryRecognizesDiscoveredContextGenericArrayTypes() throws Exception {
+        CDIExtension extension = new CDIExtension();
+        DiscoveredParameter parameter = new DiscoveredParameter(
+                new ContextAnnotation(), new GenericArrayClassType(String.class), null, false);
+        RecordingAfterBeanDiscovery event = new RecordingAfterBeanDiscovery();
+
+        setField(extension, "discoveredParameterMap", Collections.singletonMap(Context.class,
+                Collections.singleton(parameter)));
+        setField(extension, "staticallyDefinedContextBeans", Collections.singleton(String[].class));
+
+        Method afterBeanDiscovery = CDIExtension.class.getDeclaredMethod(
+                "afterBeanDiscovery", AfterBeanDiscovery.class);
+        afterBeanDiscovery.setAccessible(true);
+        afterBeanDiscovery.invoke(extension, event);
+
+        assertThat(event.getDefinitionErrors()).isEmpty();
+        assertThat(event.getBeans()).hasSize(15);
+        assertThat(event.getBeans())
+                .allSatisfy(bean -> assertThat(bean.getBeanClass()).isNotEqualTo(String[].class));
+    }
+
+    private static void setField(CDIExtension extension, String name, Object value) throws Exception {
+        Field field = CDIExtension.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(extension, value);
+    }
+
+    private static final class GenericArrayClassType implements GenericArrayType {
+        private final Class<?> componentType;
+
+        private GenericArrayClassType(Class<?> componentType) {
+            this.componentType = componentType;
+        }
+
+        @Override
+        public Type getGenericComponentType() {
+            return componentType;
+        }
+    }
+
+    private static final class ContextAnnotation implements Context {
+        @Override
+        public Class<? extends Annotation> annotationType() {
+            return Context.class;
+        }
+    }
+
+    private static final class RecordingAfterBeanDiscovery implements AfterBeanDiscovery {
+        private final List<Bean<?>> beans = new ArrayList<Bean<?>>();
+        private final List<Throwable> definitionErrors = new ArrayList<Throwable>();
+
+        @Override
+        public void addDefinitionError(Throwable throwable) {
+            definitionErrors.add(throwable);
+        }
+
+        @Override
+        public void addBean(Bean<?> bean) {
+            beans.add(bean);
+        }
+
+        @Override
+        public void addObserverMethod(ObserverMethod<?> observerMethod) {
+            throw new UnsupportedOperationException("Observer methods are not used by this test");
+        }
+
+        @Override
+        public void addContext(javax.enterprise.context.spi.Context context) {
+            throw new UnsupportedOperationException("Contexts are not used by this test");
+        }
+
+        @Override
+        public <T> AnnotatedType<T> getAnnotatedType(Class<T> type, String id) {
+            throw new UnsupportedOperationException("Annotated types are not used by this test");
+        }
+
+        @Override
+        public <T> Iterable<AnnotatedType<T>> getAnnotatedTypes(Class<T> type) {
+            throw new UnsupportedOperationException("Annotated types are not used by this test");
+        }
+
+        private List<Bean<?>> getBeans() {
+            return beans;
+        }
+
+        private List<Throwable> getDefinitionErrors() {
+            return definitionErrors;
+        }
+    }
+}

--- a/tests/src/com.sun.jersey/jersey-servlet/1.19.2/src/test/java/com_sun_jersey/jersey_servlet/CDIExtensionTest.java
+++ b/tests/src/com.sun.jersey/jersey-servlet/1.19.2/src/test/java/com_sun_jersey/jersey_servlet/CDIExtensionTest.java
@@ -8,19 +8,24 @@ package com_sun_jersey.jersey_servlet;
 
 import com.sun.jersey.server.impl.cdi.CDIExtension;
 import com.sun.jersey.server.impl.cdi.DiscoveredParameter;
+import com.sun.jersey.server.impl.cdi.InitializedLater;
+import com.sun.jersey.server.impl.cdi.SyntheticQualifier;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import javax.enterprise.inject.spi.AfterBeanDiscovery;
 import javax.enterprise.inject.spi.AnnotatedType;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.ObserverMethod;
 import javax.ws.rs.core.Context;
+import org.graalvm.internal.tck.NativeImageSupport;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,23 +40,54 @@ public class CDIExtensionTest {
 
         setField(extension, "discoveredParameterMap", Collections.singletonMap(Context.class,
                 Collections.singleton(parameter)));
-        setField(extension, "staticallyDefinedContextBeans", Collections.singleton(String[].class));
+        setField(extension, "syntheticQualifierMap",
+                new HashMap<DiscoveredParameter, SyntheticQualifier>());
+        setField(extension, "toBeInitializedLater", new ArrayList<InitializedLater>());
 
         Method afterBeanDiscovery = CDIExtension.class.getDeclaredMethod(
                 "afterBeanDiscovery", AfterBeanDiscovery.class);
         afterBeanDiscovery.setAccessible(true);
-        afterBeanDiscovery.invoke(extension, event);
+        try {
+            afterBeanDiscovery.invoke(extension, event);
 
-        assertThat(event.getDefinitionErrors()).isEmpty();
-        assertThat(event.getBeans()).hasSize(15);
-        assertThat(event.getBeans())
-                .allSatisfy(bean -> assertThat(bean.getBeanClass()).isNotEqualTo(String[].class));
+            assertThat(event.getDefinitionErrors()).isEmpty();
+            assertThat(event.getBeans()).hasSize(16);
+            assertThat(event.getBeans()).anySatisfy(bean -> {
+                assertThat(bean.getTypes()).contains(parameter.getType());
+                assertThat(bean.getQualifiers()).anySatisfy(qualifier ->
+                        assertThat(qualifier.annotationType()).isEqualTo(Context.class));
+            });
+        } catch (Error error) {
+            if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                throw error;
+            }
+        } catch (InvocationTargetException exception) {
+            Error unsupportedFeatureError = findUnsupportedFeatureError(exception);
+            if (unsupportedFeatureError == null) {
+                throw exception;
+            }
+        }
     }
 
-    private static void setField(CDIExtension extension, String name, Object value) throws Exception {
+    private static void setField(
+            CDIExtension extension, String name, Object value) throws Exception {
         Field field = CDIExtension.class.getDeclaredField(name);
         field.setAccessible(true);
         field.set(extension, value);
+    }
+
+    private static Error findUnsupportedFeatureError(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof Error) {
+                Error error = (Error) current;
+                if (NativeImageSupport.isUnsupportedFeatureError(error)) {
+                    return error;
+                }
+            }
+            current = current.getCause();
+        }
+        return null;
     }
 
     private static final class GenericArrayClassType implements GenericArrayType {

--- a/tests/src/com.sun.jersey/jersey-servlet/1.19.2/src/test/java/com_sun_jersey/jersey_servlet/DiscoveredParameterTest.java
+++ b/tests/src/com.sun.jersey/jersey-servlet/1.19.2/src/test/java/com_sun_jersey/jersey_servlet/DiscoveredParameterTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_sun_jersey.jersey_servlet;
+
+import com.sun.jersey.server.impl.cdi.DiscoveredParameter;
+import java.lang.annotation.Annotation;
+import javax.ws.rs.QueryParam;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DiscoveredParameterTest {
+    @Test
+    void getValueReadsValueFromJaxRsAnnotation() {
+        QueryParam annotation = new QueryParamAnnotation("customerId");
+        DiscoveredParameter parameter = new DiscoveredParameter(annotation, String.class, null, false);
+
+        assertThat(parameter.getValue()).isEqualTo("customerId");
+        assertThat(parameter).extracting(DiscoveredParameter::getAnnotation).isSameAs(annotation);
+        assertThat(parameter.getType()).isEqualTo(String.class);
+        assertThat(parameter.getDefaultValue()).isNull();
+        assertThat(parameter.isEncoded()).isFalse();
+    }
+
+    private static final class QueryParamAnnotation implements QueryParam {
+        private final String value;
+
+        private QueryParamAnnotation(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public Class<? extends Annotation> annotationType() {
+            return QueryParam.class;
+        }
+    }
+}

--- a/tests/src/com.sun.jersey/jersey-servlet/1.19.2/src/test/java/com_sun_jersey/jersey_servlet/EJBComponentProviderFactoryInitilizerTest.java
+++ b/tests/src/com.sun.jersey/jersey-servlet/1.19.2/src/test/java/com_sun_jersey/jersey_servlet/EJBComponentProviderFactoryInitilizerTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_sun_jersey.jersey_servlet;
+
+import com.sun.jersey.api.core.DefaultResourceConfig;
+import com.sun.jersey.api.core.ResourceConfig;
+import com.sun.jersey.server.impl.ejb.EJBComponentProviderFactoryInitilizer;
+import com.sun.jersey.server.impl.ejb.EJBExceptionMapper;
+import javax.naming.NamingException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EJBComponentProviderFactoryInitilizerTest {
+    private InterceptorBinder interceptorBinder;
+
+    @BeforeAll
+    static void installInitialContextFactory() throws NamingException {
+        ManagedBeanComponentProviderFactoryInnerManagedBeanComponentProviderTest.InitialContextSupport.install();
+    }
+
+    @BeforeEach
+    void setUp() {
+        interceptorBinder = new InterceptorBinder();
+        ManagedBeanComponentProviderFactoryInnerManagedBeanComponentProviderTest.InitialContextSupport
+                .setInterceptorBinder(interceptorBinder);
+    }
+
+    @Test
+    void initializeRegistersEjbInterceptorAndResourceConfigProviders() {
+        ResourceConfig resourceConfig = new DefaultResourceConfig();
+
+        EJBComponentProviderFactoryInitilizer.initialize(resourceConfig);
+
+        assertThat(interceptorBinder.getInterceptor())
+                .isNotNull()
+                .extracting(interceptor -> interceptor.getClass().getName())
+                .isEqualTo("com.sun.jersey.server.impl.ejb.EJBInjectionInterceptor");
+        assertThat(resourceConfig.getSingletons())
+                .singleElement()
+                .extracting(singleton -> singleton.getClass().getName())
+                .isEqualTo("com.sun.jersey.server.impl.ejb.EJBComponentProviderFactory");
+        assertThat(resourceConfig.getClasses()).contains(EJBExceptionMapper.class);
+    }
+
+    public static final class InterceptorBinder {
+        private Object interceptor;
+
+        public void registerInterceptor(Object interceptor) {
+            this.interceptor = interceptor;
+        }
+
+        private Object getInterceptor() {
+            return interceptor;
+        }
+    }
+
+}

--- a/tests/src/com.sun.jersey/jersey-servlet/1.19.2/src/test/java/com_sun_jersey/jersey_servlet/EJBRequestDispatcherProviderAnonymous1Test.java
+++ b/tests/src/com.sun.jersey/jersey-servlet/1.19.2/src/test/java/com_sun_jersey/jersey_servlet/EJBRequestDispatcherProviderAnonymous1Test.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_sun_jersey.jersey_servlet;
+
+import com.sun.jersey.api.core.HttpContext;
+import com.sun.jersey.api.model.AbstractResource;
+import com.sun.jersey.api.model.AbstractResourceMethod;
+import com.sun.jersey.core.spi.component.ProviderFactory;
+import com.sun.jersey.core.spi.component.ProviderServices;
+import com.sun.jersey.core.spi.factory.InjectableProviderFactory;
+import com.sun.jersey.server.impl.ejb.EJBRequestDispatcherProvider;
+import com.sun.jersey.spi.container.JavaMethodInvoker;
+import com.sun.jersey.spi.container.ResourceMethodCustomInvokerDispatchFactory;
+import com.sun.jersey.spi.container.ResourceMethodCustomInvokerDispatchProvider;
+import com.sun.jersey.spi.dispatch.RequestDispatcher;
+import com.sun.jersey.spi.inject.Errors;
+import com.sun.jersey.spi.inject.SingletonTypeInjectableProvider;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+import javax.ws.rs.core.Context;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EJBRequestDispatcherProviderAnonymous1Test {
+    @Test
+    void dispatcherInvokesMatchedRemoteInterfaceMethod() throws NoSuchMethodException {
+        Method method = PingBean.class.getMethod("ping");
+        AbstractResource resource = new AbstractResource(PingBean.class);
+        AbstractResourceMethod resourceMethod = new AbstractResourceMethod(
+                resource,
+                method,
+                void.class,
+                void.class,
+                "GET",
+                new java.lang.annotation.Annotation[0]);
+        EJBRequestDispatcherProvider provider = new EJBRequestDispatcherProvider();
+        injectDispatcherFactory(provider);
+
+        RequestDispatcher dispatcher = Errors.processWithErrors(new Errors.Closure<RequestDispatcher>() {
+            @Override
+            public RequestDispatcher f() {
+                return provider.create(resourceMethod);
+            }
+        });
+        assertThat(dispatcher).isNotNull();
+        PingBean bean = new PingBean();
+        dispatcher.dispatch(bean, null);
+
+        assertThat(bean.isPinged()).isTrue();
+    }
+
+    private static void injectDispatcherFactory(EJBRequestDispatcherProvider provider) {
+        InjectableProviderFactory injectableProviderFactory = new InjectableProviderFactory();
+        ProviderFactory providerFactory = new ProviderFactory(injectableProviderFactory);
+        ResourceMethodCustomInvokerDispatchFactory dispatchFactory = createDispatchFactory(providerFactory);
+        injectableProviderFactory.add(
+                new SingletonTypeInjectableProvider<Context, ResourceMethodCustomInvokerDispatchFactory>(
+                        ResourceMethodCustomInvokerDispatchFactory.class,
+                        dispatchFactory) {
+                });
+        providerFactory.injectOnProviderInstance(provider);
+    }
+
+    private static ResourceMethodCustomInvokerDispatchFactory createDispatchFactory(ProviderFactory providerFactory) {
+        Set<Object> providerInstances = new LinkedHashSet<Object>();
+        providerInstances.add(new InvokingDispatchProvider());
+        ProviderServices providerServices = new ProviderServices(
+                providerFactory,
+                Collections.<Class<?>>emptySet(),
+                providerInstances);
+        return new ResourceMethodCustomInvokerDispatchFactory(providerServices);
+    }
+
+    public interface PingRemote {
+        void ping();
+    }
+
+    @Stateless
+    @Remote(PingRemote.class)
+    public static final class PingBean implements PingRemote {
+        private boolean pinged;
+
+        @Override
+        public void ping() {
+            pinged = true;
+        }
+
+        private boolean isPinged() {
+            return pinged;
+        }
+    }
+
+    private static final class InvokingDispatchProvider implements ResourceMethodCustomInvokerDispatchProvider {
+        @Override
+        public RequestDispatcher create(AbstractResourceMethod resourceMethod, JavaMethodInvoker invoker) {
+            return new InvokingRequestDispatcher(resourceMethod, invoker);
+        }
+    }
+
+    private static final class InvokingRequestDispatcher implements RequestDispatcher {
+        private final AbstractResourceMethod resourceMethod;
+        private final JavaMethodInvoker invoker;
+
+        private InvokingRequestDispatcher(AbstractResourceMethod resourceMethod, JavaMethodInvoker invoker) {
+            this.resourceMethod = resourceMethod;
+            this.invoker = invoker;
+        }
+
+        @Override
+        public void dispatch(Object resource, HttpContext context) {
+            try {
+                invoker.invoke(resourceMethod.getMethod(), resource);
+            } catch (InvocationTargetException | IllegalAccessException ex) {
+                throw new AssertionError(ex);
+            }
+        }
+    }
+}

--- a/tests/src/com.sun.jersey/jersey-servlet/1.19.2/src/test/java/com_sun_jersey/jersey_servlet/EJBRequestDispatcherProviderTest.java
+++ b/tests/src/com.sun.jersey/jersey-servlet/1.19.2/src/test/java/com_sun_jersey/jersey_servlet/EJBRequestDispatcherProviderTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_sun_jersey.jersey_servlet;
+
+import com.sun.jersey.api.model.AbstractResource;
+import com.sun.jersey.api.model.AbstractResourceMethod;
+import com.sun.jersey.server.impl.ejb.EJBRequestDispatcherProvider;
+import java.lang.reflect.Method;
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class EJBRequestDispatcherProviderTest {
+    @Test
+    void createFindsMatchingRemoteInterfaceMethod() throws NoSuchMethodException {
+        Method method = GreetingBean.class.getMethod("greet", String.class);
+        AbstractResource resource = new AbstractResource(GreetingBean.class);
+        AbstractResourceMethod resourceMethod = new AbstractResourceMethod(
+                resource,
+                method,
+                String.class,
+                String.class,
+                "GET",
+                new java.lang.annotation.Annotation[0]);
+
+        EJBRequestDispatcherProvider provider = new EJBRequestDispatcherProvider();
+
+        assertThatThrownBy(() -> provider.create(resourceMethod))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    public interface GreetingRemote {
+        String greet(String name);
+    }
+
+    @Stateless
+    @Remote(GreetingRemote.class)
+    public static final class GreetingBean implements GreetingRemote {
+        @Override
+        public String greet(String name) {
+            return "Hello " + name;
+        }
+    }
+}

--- a/tests/src/com.sun.jersey/jersey-servlet/1.19.2/src/test/java/com_sun_jersey/jersey_servlet/ManagedBeanComponentProviderFactoryInnerManagedBeanComponentProviderTest.java
+++ b/tests/src/com.sun.jersey/jersey-servlet/1.19.2/src/test/java/com_sun_jersey/jersey_servlet/ManagedBeanComponentProviderFactoryInnerManagedBeanComponentProviderTest.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_sun_jersey.jersey_servlet;
+
+import com.sun.jersey.api.core.DefaultResourceConfig;
+import com.sun.jersey.api.core.ResourceConfig;
+import com.sun.jersey.core.spi.component.ioc.IoCComponentProvider;
+import com.sun.jersey.core.spi.component.ioc.IoCComponentProviderFactory;
+import com.sun.jersey.core.spi.component.ioc.IoCDestroyable;
+import com.sun.jersey.core.spi.component.ioc.IoCInstantiatedComponentProvider;
+import com.sun.jersey.server.impl.managedbeans.ManagedBeanComponentProviderFactoryInitilizer;
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.ManagedBean;
+import javax.naming.Binding;
+import javax.naming.CompositeName;
+import javax.naming.Context;
+import javax.naming.Name;
+import javax.naming.NameClassPair;
+import javax.naming.NameNotFoundException;
+import javax.naming.NameParser;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.spi.InitialContextFactory;
+import javax.naming.spi.InitialContextFactoryBuilder;
+import javax.naming.spi.NamingManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ManagedBeanComponentProviderFactoryInnerManagedBeanComponentProviderTest {
+    private InjectionManager injectionManager;
+
+    @BeforeAll
+    static void installInitialContextFactory() throws NamingException {
+        InitialContextSupport.install();
+    }
+
+    @BeforeEach
+    void setUp() {
+        injectionManager = new InjectionManager();
+        InitialContextSupport.setInjectionManager(injectionManager);
+    }
+
+    @Test
+    void providerCreatesAndDestroysManagedBeanThroughInjectionManager() {
+        ResourceConfig resourceConfig = new DefaultResourceConfig();
+
+        ManagedBeanComponentProviderFactoryInitilizer.initialize(resourceConfig);
+
+        assertThat(resourceConfig.getSingletons()).hasSize(1);
+        Object factoryObject = resourceConfig.getSingletons().iterator().next();
+        assertThat(factoryObject).isInstanceOf(IoCComponentProviderFactory.class);
+        IoCComponentProviderFactory factory = (IoCComponentProviderFactory) factoryObject;
+        IoCComponentProvider provider = factory.getComponentProvider(ManagedResource.class);
+        assertThat(provider)
+                .isInstanceOf(IoCInstantiatedComponentProvider.class)
+                .isInstanceOf(IoCDestroyable.class);
+
+        Object instance = ((IoCInstantiatedComponentProvider) provider).getInstance();
+        assertThat(instance).isInstanceOf(ManagedResource.class);
+        assertThat(injectionManager.getCreatedTypes()).containsExactly(ManagedResource.class);
+
+        ((IoCDestroyable) provider).destroy(instance);
+        assertThat(injectionManager.getDestroyedObjects()).containsExactly(instance);
+    }
+
+    @ManagedBean
+    public static final class ManagedResource {
+    }
+
+    public static final class InjectionManager {
+        private final List<Class<?>> createdTypes = new ArrayList<Class<?>>();
+        private final List<Object> destroyedObjects = new ArrayList<Object>();
+
+        public Object createManagedObject(Class<?> type) {
+            createdTypes.add(type);
+            if (type == ManagedResource.class) {
+                return new ManagedResource();
+            }
+            throw new IllegalArgumentException(type.getName());
+        }
+
+        public void destroyManagedObject(Object object) {
+            destroyedObjects.add(object);
+        }
+
+        private List<Class<?>> getCreatedTypes() {
+            return createdTypes;
+        }
+
+        private List<Object> getDestroyedObjects() {
+            return destroyedObjects;
+        }
+    }
+
+    public static final class InitialContextSupport {
+        private static final String INTERCEPTOR_BINDER_NAME =
+                "java:org.glassfish.ejb.container.interceptor_binding_spi";
+        private static final String INJECTION_MANAGER_NAME =
+                "com.sun.enterprise.container.common.spi.util.InjectionManager";
+        private static final AtomicBoolean INSTALLED = new AtomicBoolean();
+        private static final AtomicReference<Object> INTERCEPTOR_BINDER = new AtomicReference<Object>();
+        private static final AtomicReference<InjectionManager> INJECTION_MANAGER =
+                new AtomicReference<InjectionManager>();
+
+        private InitialContextSupport() {
+        }
+
+        public static void install() throws NamingException {
+            if (INSTALLED.compareAndSet(false, true)) {
+                NamingManager.setInitialContextFactoryBuilder(new TestInitialContextFactoryBuilder());
+            }
+        }
+
+        public static void setInterceptorBinder(Object interceptorBinder) {
+            INTERCEPTOR_BINDER.set(interceptorBinder);
+        }
+
+        private static void setInjectionManager(InjectionManager injectionManager) {
+            INJECTION_MANAGER.set(injectionManager);
+        }
+
+        private static final class TestInitialContextFactoryBuilder implements InitialContextFactoryBuilder {
+            @Override
+            public InitialContextFactory createInitialContextFactory(Hashtable<?, ?> environment) {
+                return new TestInitialContextFactory();
+            }
+        }
+
+        private static final class TestInitialContextFactory implements InitialContextFactory {
+            @Override
+            public Context getInitialContext(Hashtable<?, ?> environment) {
+                return new TestContext();
+            }
+        }
+
+        private static final class TestContext implements Context {
+            @Override
+            public Object lookup(Name name) throws NamingException {
+                return lookup(name.toString());
+            }
+
+            @Override
+            public Object lookup(String name) throws NamingException {
+                if (INTERCEPTOR_BINDER_NAME.equals(name)) {
+                    return requireBound(INTERCEPTOR_BINDER.get(), name);
+                }
+                if (INJECTION_MANAGER_NAME.equals(name)) {
+                    return requireBound(INJECTION_MANAGER.get(), name);
+                }
+                throw new NameNotFoundException(name);
+            }
+
+            private Object requireBound(Object object, String name) throws NamingException {
+                if (object == null) {
+                    throw new NameNotFoundException(name);
+                }
+                return object;
+            }
+
+            @Override
+            public void bind(Name name, Object obj) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void bind(String name, Object obj) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void rebind(Name name, Object obj) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void rebind(String name, Object obj) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void unbind(Name name) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void unbind(String name) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void rename(Name oldName, Name newName) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void rename(String oldName, String newName) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public NamingEnumeration<NameClassPair> list(Name name) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public NamingEnumeration<NameClassPair> list(String name) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public NamingEnumeration<Binding> listBindings(Name name) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public NamingEnumeration<Binding> listBindings(String name) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void destroySubcontext(Name name) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void destroySubcontext(String name) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Context createSubcontext(Name name) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Context createSubcontext(String name) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Object lookupLink(Name name) throws NamingException {
+                return lookup(name);
+            }
+
+            @Override
+            public Object lookupLink(String name) throws NamingException {
+                return lookup(name);
+            }
+
+            @Override
+            public NameParser getNameParser(Name name) {
+                return CompositeName::new;
+            }
+
+            @Override
+            public NameParser getNameParser(String name) {
+                return CompositeName::new;
+            }
+
+            @Override
+            public Name composeName(Name name, Name prefix) throws NamingException {
+                Name composedName = (Name) prefix.clone();
+                composedName.addAll(name);
+                return composedName;
+            }
+
+            @Override
+            public String composeName(String name, String prefix) {
+                return prefix + name;
+            }
+
+            @Override
+            public Object addToEnvironment(String propName, Object propVal) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Object removeFromEnvironment(String propName) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Hashtable<?, ?> getEnvironment() {
+                return new java.util.Properties();
+            }
+
+            @Override
+            public void close() {
+                // No resources to release.
+            }
+
+            @Override
+            public String getNameInNamespace() {
+                return "";
+            }
+        }
+    }
+}

--- a/tests/src/com.sun.jersey/jersey-servlet/1.19.2/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.sun.jersey/jersey-servlet/1.19.2/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -23,6 +23,156 @@
         "typeReached" : "com.sun.jersey.server.impl.managedbeans.ManagedBeanComponentProviderFactoryInitilizer"
       },
       "type" : "com_sun_jersey.jersey_servlet.ManagedBeanComponentProviderFactoryInnerManagedBeanComponentProviderTest$InjectionManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_sun_jersey.jersey_servlet.BeanGeneratorTest"
+      },
+      "type" : "com.sun.jersey.server.impl.cdi.BeanGenerator",
+      "fields" : [
+        {
+          "name" : "defineClassMethod"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "createBeanClass",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_sun_jersey.jersey_servlet.CDIExtensionTest"
+      },
+      "type" : "com.sun.jersey.server.impl.cdi.CDIExtension",
+      "fields" : [
+        {
+          "name" : "discoveredParameterMap"
+        },
+        {
+          "name" : "syntheticQualifierMap"
+        },
+        {
+          "name" : "toBeInitializedLater"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "afterBeanDiscovery",
+          "parameterTypes" : [
+            "javax.enterprise.inject.spi.AfterBeanDiscovery"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_sun_jersey.jersey_servlet.BeanGeneratorTest"
+      },
+      "type" : "com_sun_jersey.jersey_servlet.BeanGeneratorTest$CapturingClassLoader"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jersey.server.impl.ejb.EJBComponentProviderFactoryInitilizer"
+      },
+      "type" : "com_sun_jersey.jersey_servlet.EJBComponentProviderFactoryInitilizerTest$InterceptorBinder",
+      "methods" : [
+        {
+          "name" : "registerInterceptor",
+          "parameterTypes" : [
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_sun_jersey.jersey_servlet.EJBRequestDispatcherProviderAnonymous1Test"
+      },
+      "type" : "com_sun_jersey.jersey_servlet.EJBRequestDispatcherProviderAnonymous1Test$PingBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jersey.server.impl.ejb.EJBRequestDispatcherProvider$1"
+      },
+      "type" : "com_sun_jersey.jersey_servlet.EJBRequestDispatcherProviderAnonymous1Test$PingRemote",
+      "methods" : [
+        {
+          "name" : "ping",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_sun_jersey.jersey_servlet.EJBRequestDispatcherProviderAnonymous1Test$1"
+      },
+      "type" : "com_sun_jersey.jersey_servlet.EJBRequestDispatcherProviderAnonymous1Test$PingRemote"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_sun_jersey.jersey_servlet.EJBRequestDispatcherProviderTest"
+      },
+      "type" : "com_sun_jersey.jersey_servlet.EJBRequestDispatcherProviderTest$GreetingBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_sun_jersey.jersey_servlet.EJBRequestDispatcherProviderTest"
+      },
+      "type" : "com_sun_jersey.jersey_servlet.EJBRequestDispatcherProviderTest$GreetingRemote"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jersey.server.impl.managedbeans.ManagedBeanComponentProviderFactory$ManagedBeanComponentProvider"
+      },
+      "type" : "com_sun_jersey.jersey_servlet.ManagedBeanComponentProviderFactoryInnerManagedBeanComponentProviderTest$InjectionManager",
+      "methods" : [
+        {
+          "name" : "createManagedObject",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name" : "destroyManagedObject",
+          "parameterTypes" : [
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_sun_jersey.jersey_servlet.DiscoveredParameterTest"
+      },
+      "type" : "javax.ws.rs.QueryParam",
+      "methods" : [
+        {
+          "name" : "value",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com_sun_jersey.jersey_servlet.BeanGeneratorTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_sun_jersey.jersey_servlet.BeanGeneratorTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
     }
   ]
 }

--- a/tests/src/com.sun.jersey/jersey-servlet/1.19.2/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.sun.jersey/jersey-servlet/1.19.2/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,28 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jersey.server.impl.ejb.EJBComponentProviderFactoryInitilizer"
+      },
+      "type" : "com_sun_jersey.jersey_servlet.EJBComponentProviderFactoryInitilizerTest$InterceptorBinder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jersey.server.impl.ejb.EJBRequestDispatcherProvider"
+      },
+      "type" : "com_sun_jersey.jersey_servlet.EJBRequestDispatcherProviderAnonymous1Test$PingRemote"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jersey.server.impl.ejb.EJBRequestDispatcherProvider"
+      },
+      "type" : "com_sun_jersey.jersey_servlet.EJBRequestDispatcherProviderTest$GreetingRemote"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jersey.server.impl.managedbeans.ManagedBeanComponentProviderFactoryInitilizer"
+      },
+      "type" : "com_sun_jersey.jersey_servlet.ManagedBeanComponentProviderFactoryInnerManagedBeanComponentProviderTest$InjectionManager"
+    }
+  ]
+}

--- a/tests/src/com.sun.jersey/jersey-servlet/1.19.2/user-code-filter.json
+++ b/tests/src/com.sun.jersey/jersey-servlet/1.19.2/user-code-filter.json
@@ -1,0 +1,22 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.sun.jersey.api.core.servlet.**"
+    },
+    {
+      "includeClasses" : "com.sun.jersey.server.impl.**"
+    },
+    {
+      "includeClasses" : "com.sun.jersey.spi.container.servlet.**"
+    },
+    {
+      "includeClasses" : "com.sun.jersey.spi.scanning.servlet.**"
+    },
+    {
+      "includeClasses" : "com_sun_jersey.jersey_servlet.**"
+    }
+  ]
+}

--- a/tests/src/com.sun.jersey/jersey-servlet/1.19.2/user-code-filter.json
+++ b/tests/src/com.sun.jersey/jersey-servlet/1.19.2/user-code-filter.json
@@ -16,6 +16,21 @@
       "includeClasses" : "com.sun.jersey.spi.scanning.servlet.**"
     },
     {
+      "includeClasses" : "com.sun.jersey.api.model.**"
+    },
+    {
+      "includeClasses" : "com.sun.jersey.core.reflection.**"
+    },
+    {
+      "includeClasses" : "com.sun.jersey.core.spi.component.**"
+    },
+    {
+      "includeClasses" : "com.sun.jersey.core.spi.factory.**"
+    },
+    {
+      "includeClasses" : "com.sun.jersey.spi.service.**"
+    },
+    {
       "includeClasses" : "com_sun_jersey.jersey_servlet.**"
     }
   ]


### PR DESCRIPTION
## What does this PR do?

Fixes: #6770

This PR provides test fixes and new metadata for com.sun.jersey:jersey-servlet:1.19.2, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 52118
- Cached input tokens: 702976
- Output tokens: 8168
- Metadata entries: 60
- Test-only metadata entries: 29
- Iterations: 1
- Library coverage percentage: 13.84
- Previous library version metadata entries: 70
- Previous library version test-only metadata entries: 4
- Previous library version coverage percentage: 9.83

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `dc564e269eb68aecf66d03797ed7cd2393002f17`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.sun.jersey:jersey-servlet:1.19: 12/12 covered calls (100.00%)
- com.sun.jersey:jersey-servlet:1.19.2: 12/12 covered calls (100.00%)

**Reflection:**
- com.sun.jersey:jersey-servlet:1.19: 12/12 covered calls (100.00%)
- com.sun.jersey:jersey-servlet:1.19.2: 12/12 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.sun.jersey:jersey-servlet:1.19: 876/8147 (10.75%)
- com.sun.jersey:jersey-servlet:1.19.2: 1200/8162 (14.70%)

**Line:**
- com.sun.jersey:jersey-servlet:1.19: 169/1719 (9.83%)
- com.sun.jersey:jersey-servlet:1.19.2: 243/1756 (13.84%)

**Method:**
- com.sun.jersey:jersey-servlet:1.19: 47/349 (13.47%)
- com.sun.jersey:jersey-servlet:1.19.2: 54/353 (15.30%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/com.sun.jersey/jersey-servlet/1.19/src/test/java/com_sun_jersey/jersey_servlet/CDIExtensionTest.java b/tests/src/com.sun.jersey/jersey-servlet/1.19.2/src/test/java/com_sun_jersey/jersey_servlet/CDIExtensionTest.java
index fdeade7417..d060dc89d5 100644
--- a/tests/src/com.sun.jersey/jersey-servlet/1.19/src/test/java/com_sun_jersey/jersey_servlet/CDIExtensionTest.java
+++ b/tests/src/com.sun.jersey/jersey-servlet/1.19.2/src/test/java/com_sun_jersey/jersey_servlet/CDIExtensionTest.java
@@ -8,19 +8,24 @@ package com_sun_jersey.jersey_servlet;
 
 import com.sun.jersey.server.impl.cdi.CDIExtension;
 import com.sun.jersey.server.impl.cdi.DiscoveredParameter;
+import com.sun.jersey.server.impl.cdi.InitializedLater;
+import com.sun.jersey.server.impl.cdi.SyntheticQualifier;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import javax.enterprise.inject.spi.AfterBeanDiscovery;
 import javax.enterprise.inject.spi.AnnotatedType;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.ObserverMethod;
 import javax.ws.rs.core.Context;
+import org.graalvm.internal.tck.NativeImageSupport;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,25 +40,56 @@ public class CDIExtensionTest {
 
         setField(extension, "discoveredParameterMap", Collections.singletonMap(Context.class,
                 Collections.singleton(parameter)));
-        setField(extension, "staticallyDefinedContextBeans", Collections.singleton(String[].class));
+        setField(extension, "syntheticQualifierMap",
+                new HashMap<DiscoveredParameter, SyntheticQualifier>());
+        setField(extension, "toBeInitializedLater", new ArrayList<InitializedLater>());
 
         Method afterBeanDiscovery = CDIExtension.class.getDeclaredMethod(
                 "afterBeanDiscovery", AfterBeanDiscovery.class);
         afterBeanDiscovery.setAccessible(true);
-        afterBeanDiscovery.invoke(extension, event);
-
-        assertThat(event.getDefinitionErrors()).isEmpty();
-        assertThat(event.getBeans()).hasSize(15);
-        assertThat(event.getBeans())
-                .allSatisfy(bean -> assertThat(bean.getBeanClass()).isNotEqualTo(String[].class));
+        try {
+            afterBeanDiscovery.invoke(extension, event);
+
+            assertThat(event.getDefinitionErrors()).isEmpty();
+            assertThat(event.getBeans()).hasSize(16);
+            assertThat(event.getBeans()).anySatisfy(bean -> {
+                assertThat(bean.getTypes()).contains(parameter.getType());
+                assertThat(bean.getQualifiers()).anySatisfy(qualifier ->
+                        assertThat(qualifier.annotationType()).isEqualTo(Context.class));
+            });
+        } catch (Error error) {
+            if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                throw error;
+            }
+        } catch (InvocationTargetException exception) {
+            Error unsupportedFeatureError = findUnsupportedFeatureError(exception);
+            if (unsupportedFeatureError == null) {
+                throw exception;
+            }
+        }
     }
 
-    private static void setField(CDIExtension extension, String name, Object value) throws Exception {
+    private static void setField(
+            CDIExtension extension, String name, Object value) throws Exception {
         Field field = CDIExtension.class.getDeclaredField(name);
         field.setAccessible(true);
         field.set(extension, value);
     }
 
+    private static Error findUnsupportedFeatureError(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof Error) {
+                Error error = (Error) current;
+                if (NativeImageSupport.isUnsupportedFeatureError(error)) {
+                    return error;
+                }
+            }
+            current = current.getCause();
+        }
+        return null;
+    }
+
     private static final class GenericArrayClassType implements GenericArrayType {
         private final Class<?> componentType;
 
diff --git a/tests/src/com.sun.jersey/jersey-servlet/1.19/user-code-filter.json b/tests/src/com.sun.jersey/jersey-servlet/1.19.2/user-code-filter.json
index 3bf3257c6a..0cdf8c9a87 100644
--- a/tests/src/com.sun.jersey/jersey-servlet/1.19/user-code-filter.json
+++ b/tests/src/com.sun.jersey/jersey-servlet/1.19.2/user-code-filter.json
@@ -15,6 +15,21 @@
     {
       "includeClasses" : "com.sun.jersey.spi.scanning.servlet.**"
     },
+    {
+      "includeClasses" : "com.sun.jersey.api.model.**"
+    },
+    {
+      "includeClasses" : "com.sun.jersey.core.reflection.**"
+    },
+    {
+      "includeClasses" : "com.sun.jersey.core.spi.component.**"
+    },
+    {
+      "includeClasses" : "com.sun.jersey.core.spi.factory.**"
+    },
+    {
+      "includeClasses" : "com.sun.jersey.spi.service.**"
+    },
     {
       "includeClasses" : "com_sun_jersey.jersey_servlet.**"
     }

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
