### PR TITLE
[Automation] Generated metadata for org.apache.avro:avro-ipc:1.12.0

### DIFF
--- a/metadata/org.apache.avro/avro-ipc/1.12.0/reachability-metadata.json
+++ b/metadata/org.apache.avro/avro-ipc/1.12.0/reachability-metadata.json
@@ -1,0 +1,160 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.avro.ipc.Requestor"
+      },
+      "type" : "org.apache.avro.ipc.HandshakeRequest",
+      "fields" : [
+        {
+          "name" : "MODEL$"
+        },
+        {
+          "name" : "SCHEMA$"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.avro.ipc.Responder"
+      },
+      "type" : "org.apache.avro.ipc.HandshakeRequest",
+      "fields" : [
+        {
+          "name" : "SCHEMA$"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.avro.ipc.Requestor"
+      },
+      "type" : "org.apache.avro.ipc.HandshakeResponse",
+      "fields" : [
+        {
+          "name" : "MODEL$"
+        },
+        {
+          "name" : "SCHEMA$"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.avro.ipc.Responder"
+      },
+      "type" : "org.apache.avro.ipc.HandshakeResponse",
+      "fields" : [
+        {
+          "name" : "SCHEMA$"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.avro.ipc.reflect.ReflectRequestor"
+      },
+      "type" : "org.apache.avro.reflect.ReflectionUtil$AccessorTestClass",
+      "fields" : [
+        {
+          "name" : "b"
+        },
+        {
+          "name" : "by"
+        },
+        {
+          "name" : "c"
+        },
+        {
+          "name" : "d"
+        },
+        {
+          "name" : "f"
+        },
+        {
+          "name" : "i"
+        },
+        {
+          "name" : "i2"
+        },
+        {
+          "name" : "l"
+        },
+        {
+          "name" : "o"
+        },
+        {
+          "name" : "s"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.avro.ipc.HandshakeRequest"
+      },
+      "type" : "org.apache.avro.util.springframework.ConcurrentReferenceHashMap$Segment[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.avro.ipc.HandshakeResponse"
+      },
+      "type" : "org.apache.avro.util.springframework.ConcurrentReferenceHashMap$Segment[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.avro.ipc.specific.SpecificRequestor"
+      },
+      "type" : "org.apache.avro.util.springframework.ConcurrentReferenceHashMap$Segment[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.avro.ipc.specific.SpecificResponder"
+      },
+      "type" : "org.apache.avro.util.springframework.ConcurrentReferenceHashMap$Segment[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.avro.ipc.Responder"
+      },
+      "type" : "sun.security.provider.MD5",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.avro.ipc.HandshakeRequest"
+      },
+      "glob" : "META-INF/services/org.apache.avro.Conversion"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.avro.ipc.HandshakeResponse"
+      },
+      "glob" : "META-INF/services/org.apache.avro.Conversion"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.avro.ipc.specific.SpecificRequestor"
+      },
+      "glob" : "META-INF/services/org.apache.avro.Conversion"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.avro.ipc.specific.SpecificResponder"
+      },
+      "glob" : "META-INF/services/org.apache.avro.Conversion"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.avro.ipc.HandshakeRequest"
+      },
+      "glob" : "META-INF/services/org.apache.avro.LogicalTypes$LogicalTypeFactory"
+    }
+  ]
+}

--- a/metadata/org.apache.avro/avro-ipc/index.json
+++ b/metadata/org.apache.avro/avro-ipc/index.json
@@ -1,6 +1,24 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.12.0",
+    "test-version" : "1.10.2",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/avro/avro-ipc/$version$/avro-ipc-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/avro",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/avro/avro-ipc/$version$/avro-ipc-$version$-tests.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/avro/avro-ipc/$version$/avro-ipc-$version$-javadoc.jar",
+    "description" : "Apache Avro IPC provides Java inter-process communication and RPC components for Avro protocols. It includes client and server transports, request and response handling, servlet support, and plugins for building Avro-based remote services.",
+    "tested-versions" : [
+      "1.12.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.avro.ipc",
+      "org.apache.avro",
+      "org.apache.avro.reflect",
+      "org.apache.avro.specific"
+    ]
+  },
+  {
     "metadata-version" : "1.10.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/avro/avro-ipc/$version$/avro-ipc-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/avro",

--- a/stats/org.apache.avro/avro-ipc/1.12.0/stats.json
+++ b/stats/org.apache.avro/avro-ipc/1.12.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "1.12.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 7,
+          "totalCalls" : 7
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 7,
+      "totalCalls" : 7
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 378,
+        "missed" : 5653,
+        "ratio" : 0.062676,
+        "total" : 6031
+      },
+      "line" : {
+        "covered" : 84,
+        "missed" : 1319,
+        "ratio" : 0.059872,
+        "total" : 1403
+      },
+      "method" : {
+        "covered" : 23,
+        "missed" : 299,
+        "ratio" : 0.071429,
+        "total" : 322
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.avro/avro-ipc/1.10.2/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.avro/avro-ipc/1.10.2/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -31,6 +31,99 @@
           "org_apache_avro.avro_ipc.SpecificRequestorTest$AvroIpcGreetingService"
         ]
       }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_avro.avro_ipc.ReflectRequestorTest"
+      },
+      "type" : "com.fasterxml.jackson.databind.ext.Java7SupportImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_avro.avro_ipc.ReflectRequestorTest"
+      },
+      "type" : "org.apache.avro.util.springframework.ConcurrentReferenceHashMap$Segment[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_avro.avro_ipc.SpecificRequestorTest"
+      },
+      "type" : "org.apache.avro.util.springframework.ConcurrentReferenceHashMap$Segment[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.avro.ipc.reflect.ReflectRequestor"
+      },
+      "type" : "org_apache_avro.avro_ipc.ReflectRequestorTest$AvroIpcReflectGreetingService"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.avro.ipc.specific.SpecificRequestor"
+      },
+      "type" : "org_apache_avro.avro_ipc.SpecificRequestorTest$AvroIpcGreetingService",
+      "fields" : [
+        {
+          "name" : "PROTOCOL"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.avro.ipc.specific.SpecificResponder"
+      },
+      "type" : "org_apache_avro.avro_ipc.SpecificResponderTest$GreetingEndpoint",
+      "methods" : [
+        {
+          "name" : "greet",
+          "parameterTypes" : [
+            "java.lang.CharSequence"
+          ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org_apache_avro.avro_ipc.ReflectRequestorTest"
+      },
+      "glob" : "META-INF/services/org.apache.avro.Conversion"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_avro.avro_ipc.SpecificRequestorTest"
+      },
+      "glob" : "META-INF/services/org.apache.avro.Conversion"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_avro.avro_ipc.ReflectRequestorTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_avro.avro_ipc.ReflectRequestorTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_avro.avro_ipc.ReflectRequestorTest"
+      },
+      "glob" : "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_avro.avro_ipc.ReflectRequestorTest"
+      },
+      "glob" : "org/slf4j/impl/StaticLoggerBinder.class"
     }
   ]
 }


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#6665

This PR provides new metadata needed for the org.apache.avro:avro-ipc:1.12.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.apache.avro:avro-ipc:1.10.2`): 34
- Test-only metadata entries (previous `org.apache.avro:avro-ipc:1.10.2`): 19
- Metadata entries (new `org.apache.avro:avro-ipc:1.12.0`): 32
- Test-only metadata entries (new `org.apache.avro:avro-ipc:1.12.0`): 19
- Library coverage (previous): 5.98%
- Library coverage (new): 5.99%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `fb7898be5d19414e4a2d445a7de78b801754ea84`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.avro:avro-ipc:1.10.2: 7/7 covered calls (100.00%)
- org.apache.avro:avro-ipc:1.12.0: 7/7 covered calls (100.00%)

**Reflection:**
- org.apache.avro:avro-ipc:1.10.2: 7/7 covered calls (100.00%)
- org.apache.avro:avro-ipc:1.12.0: 7/7 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.avro:avro-ipc:1.10.2: 389/6260 (6.21%)
- org.apache.avro:avro-ipc:1.12.0: 378/6031 (6.27%)

**Line:**
- org.apache.avro:avro-ipc:1.10.2: 84/1404 (5.98%)
- org.apache.avro:avro-ipc:1.12.0: 84/1403 (5.99%)

**Method:**
- org.apache.avro:avro-ipc:1.10.2: 23/322 (7.14%)
- org.apache.avro:avro-ipc:1.12.0: 23/322 (7.14%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
