### PR TITLE
[GenAI] Add support for io.sundr:sundr-codegen-api:0.230.1 using gpt-5.5

### DIFF
--- a/metadata/io.sundr/sundr-codegen-api/0.230.1/reachability-metadata.json
+++ b/metadata/io.sundr/sundr-codegen-api/0.230.1/reachability-metadata.json
@@ -1,0 +1,30 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.codegen.api.Identifiers"
+      },
+      "type" : "io.sundr.codegen.api.TypeDefIdentifier"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.codegen.api.Renderers"
+      },
+      "type" : "io.sundr.codegen.api.TypeDefRenderer"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.codegen.api.Identifiers"
+      },
+      "glob" : "META-INF/services/io.sundr.codegen.api.Identifier"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.codegen.api.Renderers"
+      },
+      "glob" : "META-INF/services/io.sundr.codegen.api.Renderer"
+    }
+  ]
+}

--- a/metadata/io.sundr/sundr-codegen-api/index.json
+++ b/metadata/io.sundr/sundr-codegen-api/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "0.230.1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/sundr/sundr-codegen-api/$version$/sundr-codegen-api-$version$-sources.jar",
+    "repository-url" : "https://github.com/sundrio/sundrio",
+    "test-code-url" : "https://github.com/sundrio/sundrio/tree/$version$/tests",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/sundr/sundr-codegen-api/$version$/sundr-codegen-api-$version$-javadoc.jar",
+    "description" : "Sundr Codegen API provides the core Java interfaces and utilities for defining code generators, renderers, output targets, and generated type identifiers. It is part of Sundrio's Java code generation toolkit, which represents and manipulates Java code to generate builders, fluent APIs, DSLs, and related boilerplate.",
+    "tested-versions" : [
+      "0.230.1"
+    ],
+    "allowed-packages" : [
+      "io.sundr.codegen.api"
+    ]
+  }
+]

--- a/stats/io.sundr/sundr-codegen-api/0.230.1/execution-metrics.json
+++ b/stats/io.sundr/sundr-codegen-api/0.230.1/execution-metrics.json
@@ -1,0 +1,57 @@
+{
+  "add_new_library_support:2026-06-06": {
+    "timestamp": "2026-06-06T08:10:43.026688Z",
+    "library": "io.sundr:sundr-codegen-api:0.230.1",
+    "starting_commit": "1652f287c9d5d604a039bf4e6ceebcd794f839a7",
+    "ending_commit": "00f9e7b62afc59c6d3d135cb57bb833c8faf7673",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "0.230.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 412,
+          "missed": 51,
+          "ratio": 0.889849,
+          "total": 463
+        },
+        "line": {
+          "covered": 85,
+          "missed": 11,
+          "ratio": 0.885417,
+          "total": 96
+        },
+        "method": {
+          "covered": 46,
+          "missed": 6,
+          "ratio": 0.884615,
+          "total": 52
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 185658,
+      "cached_input_tokens_used": 1349120,
+      "output_tokens_used": 15680,
+      "iterations": 5,
+      "cost_usd": 1.145,
+      "generated_loc": 221,
+      "tested_library_loc": 85,
+      "metadata_entries": 4,
+      "test_only_metadata_entries": 5,
+      "code_coverage_percent": 88.54
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.sundr/sundr-codegen-api/0.230.1/src/test/java/io_sundr/sundr_codegen_api/Sundr_codegen_apiTest.java",
+      "metadata_file": "metadata/io.sundr/sundr-codegen-api/0.230.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.sundr/sundr-codegen-api/0.230.1/stats.json
+++ b/stats/io.sundr/sundr-codegen-api/0.230.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "0.230.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 412,
+        "missed" : 51,
+        "ratio" : 0.889849,
+        "total" : 463
+      },
+      "line" : {
+        "covered" : 85,
+        "missed" : 11,
+        "ratio" : 0.885417,
+        "total" : 96
+      },
+      "method" : {
+        "covered" : 46,
+        "missed" : 6,
+        "ratio" : 0.884615,
+        "total" : 52
+      }
+    }
+  } ]
+}

--- a/tests/src/io.sundr/sundr-codegen-api/0.230.1/.gitignore
+++ b/tests/src/io.sundr/sundr-codegen-api/0.230.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.sundr/sundr-codegen-api/0.230.1/build.gradle
+++ b/tests/src/io.sundr/sundr-codegen-api/0.230.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.sundr:sundr-codegen-api:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.sundr/sundr-codegen-api/0.230.1/gradle.properties
+++ b/tests/src/io.sundr/sundr-codegen-api/0.230.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.sundr:sundr-codegen-api:0.230.1
+library.version = 0.230.1
+metadata.dir = io.sundr/sundr-codegen-api/0.230.1/

--- a/tests/src/io.sundr/sundr-codegen-api/0.230.1/settings.gradle
+++ b/tests/src/io.sundr/sundr-codegen-api/0.230.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.sundr.sundr-codegen-api_tests'

--- a/tests/src/io.sundr/sundr-codegen-api/0.230.1/src/test/java/io_sundr/sundr_codegen_api/Sundr_codegen_apiTest.java
+++ b/tests/src/io.sundr/sundr-codegen-api/0.230.1/src/test/java/io_sundr/sundr_codegen_api/Sundr_codegen_apiTest.java
@@ -180,6 +180,19 @@ public class Sundr_codegen_apiTest {
         assertThat(Identifiers.getIdentifier()).isNull();
     }
 
+    @Test
+    void functionBasedIdentifierScopeSupportsCallableExecution() {
+        assertThat(Identifiers.getIdentifier()).isNull();
+
+        String result = Identifiers.withIdentifier((String item) -> "function:" + item).call(() -> {
+            assertThat(Identifiers.getIdentifier().id("payload")).isEqualTo("function:payload");
+            return Identifiers.getIdentifier().id("callable");
+        });
+
+        assertThat(result).isEqualTo("function:callable");
+        assertThat(Identifiers.getIdentifier()).isNull();
+    }
+
     private static final class TestCodeGeneratorContext implements CodeGeneratorContext {
     }
 

--- a/tests/src/io.sundr/sundr-codegen-api/0.230.1/src/test/java/io_sundr/sundr_codegen_api/Sundr_codegen_apiTest.java
+++ b/tests/src/io.sundr/sundr-codegen-api/0.230.1/src/test/java/io_sundr/sundr_codegen_api/Sundr_codegen_apiTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_sundr.sundr_codegen_api;
+
+import org.junit.jupiter.api.Test;
+
+class Sundr_codegen_apiTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.sundr/sundr-codegen-api/0.230.1/src/test/java/io_sundr/sundr_codegen_api/Sundr_codegen_apiTest.java
+++ b/tests/src/io.sundr/sundr-codegen-api/0.230.1/src/test/java/io_sundr/sundr_codegen_api/Sundr_codegen_apiTest.java
@@ -130,6 +130,30 @@ public class Sundr_codegen_apiTest {
     }
 
     @Test
+    void codeGeneratorCanUseStrategyObjectsAndClosesOpenedWriters() {
+        List<CloseTrackingWriter> writers = new ArrayList<>();
+        Output<String> output = () -> item -> {
+            CloseTrackingWriter writer = new CloseTrackingWriter();
+            writers.add(writer);
+            return writer;
+        };
+
+        boolean generated = CodeGenerator.newGenerator(String.class)
+                .withOutput(output)
+                .withIdentifier(new StringIdentifier())
+                .withRenderer(new StringRenderer())
+                .skipping(item -> false)
+                .build()
+                .generate("payload");
+
+        assertThat(generated).isTrue();
+        assertThat(writers).hasSize(1);
+        assertThat(writers.get(0).toString()).isEqualTo("rendered:payload");
+        assertThat(writers.get(0).isClosed()).isTrue();
+        assertThat(Identifiers.getIdentifier()).isNull();
+    }
+
+    @Test
     void outputImplementationsCreateWritableDestinations(@TempDir Path tempDir) throws IOException {
         File outputFile = tempDir.resolve("generated.txt").toFile();
         FileOutput<String> fileOutput = new FileOutput<>(outputFile);
@@ -194,6 +218,20 @@ public class Sundr_codegen_apiTest {
     }
 
     private static final class TestCodeGeneratorContext implements CodeGeneratorContext {
+    }
+
+    private static final class CloseTrackingWriter extends StringWriter {
+        private boolean closed;
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+            super.close();
+        }
+
+        boolean isClosed() {
+            return closed;
+        }
     }
 
     private static final class StringIdentifier implements Identifier<String> {

--- a/tests/src/io.sundr/sundr-codegen-api/0.230.1/src/test/java/io_sundr/sundr_codegen_api/Sundr_codegen_apiTest.java
+++ b/tests/src/io.sundr/sundr-codegen-api/0.230.1/src/test/java/io_sundr/sundr_codegen_api/Sundr_codegen_apiTest.java
@@ -6,11 +6,206 @@
  */
 package io_sundr.sundr_codegen_api;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
-class Sundr_codegen_apiTest {
+import io.sundr.codegen.api.CodeGenerator;
+import io.sundr.codegen.api.CodeGeneratorContext;
+import io.sundr.codegen.api.FileOutput;
+import io.sundr.codegen.api.Filter;
+import io.sundr.codegen.api.Identifier;
+import io.sundr.codegen.api.Identifiers;
+import io.sundr.codegen.api.Output;
+import io.sundr.codegen.api.Renderer;
+import io.sundr.codegen.api.Renderers;
+import io.sundr.codegen.api.SystemOutput;
+import io.sundr.codegen.api.TypeDefIdentifier;
+import io.sundr.codegen.api.TypeDefRenderer;
+import io.sundr.model.TypeDef;
+import java.io.File;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class Sundr_codegen_apiTest {
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void serviceLoaderDiscoversTypeDefIdentifierAndRenderer() {
+        TypeDef typeDef = TypeDef.forName("com.example.Widget");
+
+        assertThat(Identifiers.findIdentifier(TypeDef.class))
+                .hasValueSatisfying(identifier -> {
+                    assertThat(identifier.getType()).isEqualTo(TypeDef.class);
+                    assertThat(identifier.id(typeDef)).isEqualTo("com.example.Widget");
+                });
+        assertThat(Renderers.findRenderer(TypeDef.class))
+                .hasValueSatisfying(renderer -> {
+                    assertThat(renderer.getType()).isEqualTo(TypeDef.class);
+                    assertThat(renderer.render(typeDef))
+                            .contains("package com.example;")
+                            .contains("public class Widget");
+                });
+    }
+
+    @Test
+    void typeDefIdentifierAndRendererImplementTheirConvenienceMethods() {
+        TypeDef typeDef = TypeDef.forName("com.example.api.Sample");
+        TypeDefIdentifier identifier = new TypeDefIdentifier();
+        TypeDefRenderer renderer = new TypeDefRenderer();
+
+        assertThat(identifier.getType()).isEqualTo(TypeDef.class);
+        assertThat(identifier.getFunction().apply(typeDef)).isEqualTo("com.example.api.Sample");
+        assertThat(identifier.id(typeDef)).isEqualTo("com.example.api.Sample");
+        assertThat(renderer.getType()).isEqualTo(TypeDef.class);
+        assertThat(renderer.getFunction().apply(typeDef))
+                .contains("package com.example.api;")
+                .contains("public class Sample");
+        assertThat(renderer.render(typeDef))
+                .contains("package com.example.api;")
+                .contains("public class Sample");
+    }
+
+    @Test
+    void codeGeneratorUsesDiscoveredServicesAndPublishesActiveIdentifierScope() {
+        TypeDef first = TypeDef.forName("com.example.First");
+        TypeDef second = TypeDef.forName("com.example.Second");
+        Map<String, StringWriter> writersById = new LinkedHashMap<>();
+        List<String> activeIdentifiersSeenByOutput = new ArrayList<>();
+
+        CodeGenerator<TypeDef> generator = CodeGenerator.newGenerator(TypeDef.class)
+                .withOutput(item -> {
+                    String activeId = Identifiers.getIdentifier().id(item);
+                    activeIdentifiersSeenByOutput.add(activeId);
+                    StringWriter writer = new StringWriter();
+                    writersById.put(activeId, writer);
+                    return writer;
+                })
+                .skipping(item -> false)
+                .build();
+
+        assertThat(generator.generate(first, second)).isTrue();
+
+        assertThat(activeIdentifiersSeenByOutput).containsExactly("com.example.First", "com.example.Second");
+        assertThat(writersById).containsOnlyKeys("com.example.First", "com.example.Second");
+        assertThat(writersById.get("com.example.First").toString())
+                .contains("package com.example;")
+                .contains("public class First");
+        assertThat(writersById.get("com.example.Second").toString())
+                .contains("package com.example;")
+                .contains("public class Second");
+        assertThat(Identifiers.getIdentifier()).isNull();
+    }
+
+    @Test
+    void codeGeneratorBuilderSupportsCustomOutputIdentifierRendererSkipAndDuplicateSuppression() {
+        List<String> openedForItems = new ArrayList<>();
+        List<StringWriter> writers = new ArrayList<>();
+
+        boolean generated = CodeGenerator.newGenerator(String.class)
+                .withOutput(item -> {
+                    openedForItems.add(item);
+                    StringWriter writer = new StringWriter();
+                    writers.add(writer);
+                    return writer;
+                })
+                .withIdentifier(item -> item.substring(0, 1))
+                .withRenderer(item -> "item=" + item + ", id=" + Identifiers.getIdentifier().id(item))
+                .skipping("skip"::equals)
+                .generate("alpha", "aardvark", "skip", "beta");
+
+        assertThat(generated).isTrue();
+        assertThat(openedForItems).containsExactly("alpha", "beta");
+        assertThat(writers).extracting(StringWriter::toString)
+                .containsExactly("item=alpha, id=a", "item=beta, id=b");
+        assertThat(Identifiers.getIdentifier()).isNull();
+    }
+
+    @Test
+    void outputImplementationsCreateWritableDestinations(@TempDir Path tempDir) throws IOException {
+        File outputFile = tempDir.resolve("generated.txt").toFile();
+        FileOutput<String> fileOutput = new FileOutput<>(outputFile);
+
+        try (Writer writer = fileOutput.create("ignored")) {
+            writer.write("file payload");
+        }
+
+        assertThat(Files.readString(outputFile.toPath(), StandardCharsets.UTF_8)).isEqualTo("file payload");
+        assertThat(new SystemOutput<String>().create("console")).isNotNull();
+    }
+
+    @Test
+    void markerTypesCanBeUsedByApplicationCode() {
+        CodeGeneratorContext context = new TestCodeGeneratorContext();
+
+        assertThat(context).isInstanceOf(CodeGeneratorContext.class);
+        assertThat(new Filter()).isNotNull();
+    }
+
+    @Test
+    void functionalInterfacesExposeConvenienceMethods() {
+        StringIdentifier identifier = new StringIdentifier();
+        StringRenderer renderer = new StringRenderer();
+        Output<String> output = () -> item -> new StringWriter();
+
+        Writer writer = output.create("payload");
+
+        assertThat(identifier.getType()).isEqualTo(String.class);
+        assertThat(identifier.id("payload")).isEqualTo("id:payload");
+        assertThat(renderer.getType()).isEqualTo(String.class);
+        assertThat(renderer.render("payload")).isEqualTo("rendered:payload");
+        assertThat(writer).isInstanceOf(StringWriter.class);
+    }
+
+    @Test
+    void withIdentifierTemporarilyExposesScopeAndClearsItAfterCompletion() {
+        StringIdentifier identifier = new StringIdentifier();
+
+        assertThat(Identifiers.getIdentifier()).isNull();
+        String result = Identifiers.withIdentifier(identifier).apply(activeIdentifier -> {
+            assertThat(activeIdentifier).isSameAs(identifier);
+            assertThat(Identifiers.getIdentifier()).isSameAs(identifier);
+            return activeIdentifier.id("sample");
+        });
+
+        assertThat(result).isEqualTo("id:sample");
+        assertThat(Identifiers.getIdentifier()).isNull();
+    }
+
+    private static final class TestCodeGeneratorContext implements CodeGeneratorContext {
+    }
+
+    private static final class StringIdentifier implements Identifier<String> {
+
+        @Override
+        public Class<String> getType() {
+            return String.class;
+        }
+
+        @Override
+        public Function<String, String> getFunction() {
+            return item -> "id:" + item;
+        }
+    }
+
+    private static final class StringRenderer implements Renderer<String> {
+
+        @Override
+        public Class<String> getType() {
+            return String.class;
+        }
+
+        @Override
+        public Function<String, String> getFunction() {
+            return item -> "rendered:" + item;
+        }
     }
 }

--- a/tests/src/io.sundr/sundr-codegen-api/0.230.1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/io.sundr/sundr-codegen-api/0.230.1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,36 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "io_sundr.sundr_codegen_api.Sundr_codegen_apiTest"
+      },
+      "type" : "java.util.HashMap",
+      "methods" : [
+        {
+          "name" : "clone",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_sundr.sundr_codegen_api.Sundr_codegen_apiTest"
+      },
+      "type" : "java.util.LinkedHashMap"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "io_sundr.sundr_codegen_api.Sundr_codegen_apiTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_sundr.sundr_codegen_api.Sundr_codegen_apiTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/tests/src/io.sundr/sundr-codegen-api/0.230.1/user-code-filter.json
+++ b/tests/src/io.sundr/sundr-codegen-api/0.230.1/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.sundr.codegen.api.**"
+      "includeClasses" : "io.sundr.codegen.api.**"
+    },
+    {
+      "includeClasses" : "io_sundr.sundr_codegen_api.**"
     }
   ]
 }

--- a/tests/src/io.sundr/sundr-codegen-api/0.230.1/user-code-filter.json
+++ b/tests/src/io.sundr/sundr-codegen-api/0.230.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.sundr.codegen.api.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #7798

This PR introduces tests and metadata for io.sundr:sundr-codegen-api:0.230.1, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 185658
- Cached input tokens: 1349120
- Output tokens: 15680
- Metadata entries: 4
- Test-only metadata entries: 5
- Iterations: 5
- Library coverage percentage: 88.54
- Generated lines of code: 221
- Tested library lines of code: 85

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `ab4b0fc036db929152b3c830e93ac5c488866423`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 412/463 (88.98%)
- Line: 85/96 (88.54%)
- Method: 46/52 (88.46%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
