### PR TITLE
[Automation] Generated metadata for org.flywaydb:flyway-sqlserver:12.3.0

### DIFF
--- a/metadata/org.flywaydb/flyway-sqlserver/12.3.0/reachability-metadata.json
+++ b/metadata/org.flywaydb/flyway-sqlserver/12.3.0/reachability-metadata.json
@@ -1,0 +1,675 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      },
+      "type" : "com.sun.crypto.provider.GaloisCounterMode$AESGCM",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      },
+      "type" : "com.sun.crypto.provider.TlsKeyMaterialGenerator",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      },
+      "type" : "com.sun.crypto.provider.TlsMasterSecretGenerator",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      },
+      "type" : "com.sun.crypto.provider.TlsPrfGenerator$V12",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type" : "java.lang.Comparable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      },
+      "type" : "java.net.Socket",
+      "methods" : [
+        {
+          "name" : "setOption",
+          "parameterTypes" : [
+            "java.net.SocketOption",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.util.FeatureDetector"
+      },
+      "type" : "org.apache.commons.logging.Log"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.util.FeatureDetector"
+      },
+      "type" : "org.apache.logging.log4j.Logger"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.clean.CleanModeCommandExtension"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.clean.database.SQLServerCleanModePlugin"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.api.migration.baseline.BaselineAppliedMigration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.api.configuration.ClassicConfiguration"
+      },
+      "type" : "org.flywaydb.core.api.migration.baseline.BaselineMigrationConfigurationExtension"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type" : "org.flywaydb.core.api.migration.baseline.BaselineMigrationConfigurationExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getBaselineMigrationPrefix",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setBaselineMigrationPrefix",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.api.migration.baseline.BaselineMigrationConfigurationExtension"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.api.migration.baseline.BaselineMigrationResolver"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.api.migration.baseline.BaselineResourceTypeProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type" : "org.flywaydb.core.extensibility.ConfigurationExtension"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type" : "org.flywaydb.core.extensibility.Plugin"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.NullFlywayTelemetryManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type" : "org.flywaydb.core.internal.command.clean.CleanModel"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type" : "org.flywaydb.core.internal.command.clean.SchemaModel"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.configuration.resolvers.EnvironmentProvisionerNone"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.configuration.resolvers.EnvironmentVariableResolver"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.configuration.resolvers.PlaceholderPropertyResolver"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.database.base.TestContainersDatabaseType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.database.h2.H2DatabaseType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.database.sqlite.SQLiteDatabaseType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.jdbc.ErrorOverrideInitializerStub"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.AuthCommandExtensionStub"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.CheckCommandExtensionStub"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.DeployCommandExtensionStub"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.DiffCommandExtensionStub"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.DiffTextCommandExtensionStub"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.GenerateCommandExtensionStub"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.api.configuration.ClassicConfiguration"
+      },
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.LicensingConfigurationExtensionStub"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.LicensingConfigurationExtensionStub"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.ModelCommandExtensionStub"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.api.configuration.ClassicConfiguration"
+      },
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.OfflinePermitConfigurationExtensionStub"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.OfflinePermitConfigurationExtensionStub"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.api.configuration.ClassicConfiguration"
+      },
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.PATTokenConfigurationExtensionStub"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.PATTokenConfigurationExtensionStub"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.PrepareCommandExtensionStub"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.UndoCommandExtensionStub"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.api.configuration.ClassicConfiguration"
+      },
+      "type" : "org.flywaydb.core.internal.publishing.PublishingConfigurationExtension"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type" : "org.flywaydb.core.internal.publishing.PublishingConfigurationExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "isCheckDriftOnMigrate",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "isPublishResult",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setCheckDriftOnMigrate",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        },
+        {
+          "name" : "setPublishResult",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.publishing.PublishingConfigurationExtension"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.resource.CoreResourceTypeProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.scanner.classpath.ClasspathLocationHandlerImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.scanner.filesystem.FilesystemLocationHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.core.internal.schemahistory.BaseAppliedMigration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type" : "org.flywaydb.database.sqlserver.KerberosModel",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getLogin",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setLogin",
+          "parameterTypes" : [
+            "org.flywaydb.database.sqlserver.LoginModel"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type" : "org.flywaydb.database.sqlserver.LoginModel",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getFile",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setFile",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type" : "org.flywaydb.database.sqlserver.SQLServerConfigurationExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getClean",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getKerberos",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setClean",
+          "parameterTypes" : [
+            "org.flywaydb.core.internal.command.clean.CleanModel"
+          ]
+        },
+        {
+          "name" : "setKerberos",
+          "parameterTypes" : [
+            "org.flywaydb.database.sqlserver.KerberosModel"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.database.sqlserver.SQLServerConfigurationExtension"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.database.sqlserver.SQLServerDatabaseType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.database.sqlserver.babelfish.BabelfishDatabaseType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.database.sqlserver.fabricDataWarehouse.FabricDataWarehouseDatabaseType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "type" : "org.flywaydb.database.sqlserver.synapse.SynapseDatabaseType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.util.FeatureDetector"
+      },
+      "type" : "org.slf4j.Logger"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.util.ClassUtils"
+      },
+      "type" : "org.slf4j.spi.SLF4JServiceProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      },
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.jdbc.JdbcTemplate"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.schemahistory.JdbcTableSchemaHistory"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.database.sqlserver.SQLServerConnection"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.database.sqlserver.synapse.SynapseDatabaseType"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      },
+      "type" : "sun.security.provider.X509Factory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      },
+      "type" : "sun.security.rsa.RSAPSSSignature",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      },
+      "type" : "sun.security.ssl.SSLContextImpl$TLSContext",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type" : "tools.jackson.databind.deser.Deserializers[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type" : "tools.jackson.databind.deser.KeyDeserializers[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type" : "tools.jackson.databind.deser.ValueInstantiators[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
+      },
+      "type" : "tools.jackson.databind.ser.Serializers[]"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.util.FlywayDbWebsiteLinks"
+      },
+      "glob" : "META-INF/services/java.net.spi.URLStreamHandlerProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
+      },
+      "glob" : "META-INF/services/org.flywaydb.core.extensibility.Plugin"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.scanner.ClasspathClassScanner"
+      },
+      "glob" : "db/callback"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.scanner.classpath.ClasspathLocationHandlerImpl"
+      },
+      "glob" : "db/migration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.license.VersionPrinter"
+      },
+      "glob" : "org/flywaydb/core/internal/version.txt"
+    },
+    {
+      "bundle" : "com.microsoft.sqlserver.jdbc.SQLServerResource"
+    },
+    {
+      "bundle" : "sun.util.logging.resources.logging"
+    }
+  ]
+}

--- a/metadata/org.flywaydb/flyway-sqlserver/index.json
+++ b/metadata/org.flywaydb/flyway-sqlserver/index.json
@@ -1,6 +1,23 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "12.3.0",
+    "test-version" : "11.8.1",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/flywaydb/flyway-sqlserver/$version$/flyway-sqlserver-$version$-sources.jar",
+    "repository-url" : "https://github.com/flyway/flyway",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://github.com/flyway/flyway/blob/flyway-$version$/documentation/Reference/Database%20Driver%20Reference/SQL%20Server%20Database.md",
+    "description" : "Flyway SQL Server support module adds Microsoft SQL Server, Azure Synapse, and Microsoft Fabric Data Warehouse database support to Flyway. It provides the database type, parser, schema handling, and clean-mode integrations used to run Flyway migrations against those platforms.",
+    "tested-versions" : [
+      "12.3.0"
+    ],
+    "allowed-packages" : [
+      "org.flywaydb",
+      "org.flywaydb.clean",
+      "org.flywaydb.database.sqlserver"
+    ]
+  },
+  {
     "metadata-version" : "11.12.0",
     "test-version" : "11.8.1",
     "source-code-url" : "https://repo1.maven.org/maven2/org/flywaydb/flyway-sqlserver/$version$/flyway-sqlserver-$version$-sources.jar",

--- a/stats/org.flywaydb/flyway-sqlserver/12.3.0/stats.json
+++ b/stats/org.flywaydb/flyway-sqlserver/12.3.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "12.3.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1173,
+        "missed" : 3406,
+        "ratio" : 0.256169,
+        "total" : 4579
+      },
+      "line" : {
+        "covered" : 207,
+        "missed" : 587,
+        "ratio" : 0.260705,
+        "total" : 794
+      },
+      "method" : {
+        "covered" : 76,
+        "missed" : 169,
+        "ratio" : 0.310204,
+        "total" : 245
+      }
+    }
+  } ]
+}

--- a/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/build.gradle
+++ b/tests/src/org.flywaydb/flyway-sqlserver/11.8.1/build.gradle
@@ -22,6 +22,7 @@ graalvmNative {
     binaries {
         all {
             buildArgs.add("-H:+AddAllCharsets")
+            buildArgs.add("--enable-url-protocols=https")
         }
     }
     agent {


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7966

This PR provides new metadata needed for the org.flywaydb:flyway-sqlserver:12.3.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.flywaydb:flyway-sqlserver:11.8.1`): 118
- Test-only metadata entries (previous `org.flywaydb:flyway-sqlserver:11.8.1`): 95
- Metadata entries (new `org.flywaydb:flyway-sqlserver:12.3.0`): 114
- Test-only metadata entries (new `org.flywaydb:flyway-sqlserver:12.3.0`): 95
- Library coverage (previous): 27.71%
- Library coverage (new): 26.07%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `d53dba89c234933503516add40e8ede138df9a69`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.flywaydb:flyway-sqlserver:11.8.1: 0/0 covered calls (100.00%)
- org.flywaydb:flyway-sqlserver:12.3.0: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.flywaydb:flyway-sqlserver:11.8.1: 1154/4321 (26.71%)
- org.flywaydb:flyway-sqlserver:12.3.0: 1173/4579 (25.62%)

**Line:**
- org.flywaydb:flyway-sqlserver:11.8.1: 197/711 (27.71%)
- org.flywaydb:flyway-sqlserver:12.3.0: 207/794 (26.07%)

**Method:**
- org.flywaydb:flyway-sqlserver:11.8.1: 79/227 (34.80%)
- org.flywaydb:flyway-sqlserver:12.3.0: 76/245 (31.02%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
