### PR TITLE
[GenAI] Test fix for org.apache.pekko:pekko-protobuf-v3_3:2.0.0-M2 using gpt-5.5

### DIFF
--- a/metadata/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/reachability-metadata.json
+++ b/metadata/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/reachability-metadata.json
@@ -1,0 +1,420 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.RuntimeVersion"
+      },
+      "type" : "byte[][]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.ByteBufferWriter"
+      },
+      "type" : "java.io.FileOutputStream"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.UnsafeUtil$MemoryAccessor"
+      },
+      "type" : "java.io.FileOutputStream",
+      "fields" : [
+        {
+          "name" : "channel"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.ByteBufferWriter"
+      },
+      "type" : "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.GeneratedMessageLite$SerializedForm"
+      },
+      "type" : "java.lang.String",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.ExtensionRegistryLite"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.UnsafeUtil$1"
+      },
+      "type" : "java.lang.reflect.Field[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.UnsafeUtil"
+      },
+      "type" : "java.lang.reflect.Method[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.UnsafeUtil"
+      },
+      "type" : "libcore.io.Memory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.GeneratedMessage"
+      },
+      "type" : "org.apache.pekko.protobufv3.internal.Any",
+      "methods" : [
+        {
+          "name" : "getTypeUrl",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getTypeUrlBytes",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.GeneratedMessage"
+      },
+      "type" : "org.apache.pekko.protobufv3.internal.Any$Builder",
+      "methods" : [
+        {
+          "name" : "clearTypeUrl",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "clearValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getTypeUrl",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getTypeUrlBytes",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setTypeUrl",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setTypeUrlBytes",
+          "parameterTypes" : [
+            "org.apache.pekko.protobufv3.internal.ByteString"
+          ]
+        },
+        {
+          "name" : "setValue",
+          "parameterTypes" : [
+            "org.apache.pekko.protobufv3.internal.ByteString"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.ManifestSchemaFactory"
+      },
+      "type" : "org.apache.pekko.protobufv3.internal.DescriptorMessageInfoFactory",
+      "methods" : [
+        {
+          "name" : "getInstance",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.GeneratedMessage"
+      },
+      "type" : "org.apache.pekko.protobufv3.internal.DescriptorProtos$FeatureSet"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.GeneratedMessage"
+      },
+      "type" : "org.apache.pekko.protobufv3.internal.DescriptorProtos$FeatureSet$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.GeneratedMessage"
+      },
+      "type" : "org.apache.pekko.protobufv3.internal.DescriptorProtos$FeatureSet$EnforceNamingStyle"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.GeneratedMessage"
+      },
+      "type" : "org.apache.pekko.protobufv3.internal.DescriptorProtos$FeatureSet$EnumType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.GeneratedMessage"
+      },
+      "type" : "org.apache.pekko.protobufv3.internal.DescriptorProtos$FeatureSet$FieldPresence"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.GeneratedMessage"
+      },
+      "type" : "org.apache.pekko.protobufv3.internal.DescriptorProtos$FeatureSet$JsonFormat"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.GeneratedMessage"
+      },
+      "type" : "org.apache.pekko.protobufv3.internal.DescriptorProtos$FeatureSet$MessageEncoding"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.GeneratedMessage"
+      },
+      "type" : "org.apache.pekko.protobufv3.internal.DescriptorProtos$FeatureSet$RepeatedFieldEncoding"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.GeneratedMessage"
+      },
+      "type" : "org.apache.pekko.protobufv3.internal.DescriptorProtos$FeatureSet$Utf8Validation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.GeneratedMessage"
+      },
+      "type" : "org.apache.pekko.protobufv3.internal.DescriptorProtos$FeatureSet$VisibilityFeature$DefaultSymbolVisibility"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.GeneratedMessage"
+      },
+      "type" : "org.apache.pekko.protobufv3.internal.DescriptorProtos$FileDescriptorProto"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.DescriptorMessageInfoFactory"
+      },
+      "type" : "org.apache.pekko.protobufv3.internal.DescriptorProtos$FileDescriptorSet",
+      "methods" : [
+        {
+          "name" : "getDefaultInstance",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.GeneratedMessage"
+      },
+      "type" : "org.apache.pekko.protobufv3.internal.DescriptorProtos$FileDescriptorSet"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.UnsafeUtil$MemoryAccessor"
+      },
+      "type" : "org.apache.pekko.protobufv3.internal.DescriptorProtos$FileDescriptorSet",
+      "fields" : [
+        {
+          "name" : "file_"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.GeneratedMessage"
+      },
+      "type" : "org.apache.pekko.protobufv3.internal.DescriptorProtos$FileDescriptorSet$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.DynamicMessage$Builder"
+      },
+      "type" : "org.apache.pekko.protobufv3.internal.Descriptors$FieldDescriptor[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.Descriptors$FileDescriptor"
+      },
+      "type" : "org.apache.pekko.protobufv3.internal.Descriptors$FileDescriptor[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.ExtensionRegistryFactory"
+      },
+      "type" : "org.apache.pekko.protobufv3.internal.ExtensionRegistry",
+      "methods" : [
+        {
+          "name" : "getEmptyRegistry",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "newInstance",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.ExtensionRegistryLite"
+      },
+      "type" : "org.apache.pekko.protobufv3.internal.ExtensionRegistry",
+      "methods" : [
+        {
+          "name" : "add",
+          "parameterTypes" : [
+            "org.apache.pekko.protobufv3.internal.Extension"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.ExtensionSchemas"
+      },
+      "type" : "org.apache.pekko.protobufv3.internal.ExtensionSchemaFull",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.StructuralMessageInfo$Builder"
+      },
+      "type" : "org.apache.pekko.protobufv3.internal.FieldInfo[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.GeneratedMessageLite$SerializedForm"
+      },
+      "type" : "org.apache.pekko.protobufv3.internal.GeneratedMessageLite$SerializedForm",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.GeneratedFile"
+      },
+      "type" : "org.apache.pekko.protobufv3.internal.JavaFeaturesProto",
+      "fields" : [
+        {
+          "name" : "java_"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.ListFieldSchemas"
+      },
+      "type" : "org.apache.pekko.protobufv3.internal.ListFieldSchemaFull",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.MapFieldSchemas"
+      },
+      "type" : "org.apache.pekko.protobufv3.internal.MapFieldSchemaFull",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.NewInstanceSchemas"
+      },
+      "type" : "org.apache.pekko.protobufv3.internal.NewInstanceSchemaFull",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.SchemaUtil"
+      },
+      "type" : "org.apache.pekko.protobufv3.internal.UnknownFieldSetSchema",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.protobufv3.internal.UnsafeUtil$Android32MemoryAccessor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "sun.misc.Unsafe"
+          ]
+        },
+        {
+          "name" : "getStaticObject",
+          "parameterTypes" : [
+            "java.lang.reflect.Field"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.UnsafeUtil"
+      },
+      "type" : "sun.misc.Unsafe"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.UnsafeUtil$1"
+      },
+      "type" : "sun.misc.Unsafe",
+      "fields" : [
+        {
+          "name" : "theUnsafe"
+        }
+      ]
+    }
+  ],
+  "serialization" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.GeneratedMessageLite$SerializedForm"
+      },
+      "type" : "java.lang.String"
+    },
+    {
+      "type" : "org.apache.pekko.protobufv3.internal.GeneratedMessageLite$SerializedForm"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.GeneratedMessageLite$SerializedForm"
+      },
+      "type" : "org.apache.pekko.protobufv3.internal.GeneratedMessageLite$SerializedForm"
+    }
+  ]
+}

--- a/metadata/org.apache.pekko/pekko-protobuf-v3_3/index.json
+++ b/metadata/org.apache.pekko/pekko-protobuf-v3_3/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.0.0-M2",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/pekko/pekko-protobuf-v3_3/$version$/pekko-protobuf-v3_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/pekko",
+    "test-code-url" : "https://github.com/apache/pekko/blob/v$version$/remote/src/test/scala/org/apache/pekko/remote/serialization/ProtobufSerializerSpec.scala",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/pekko/pekko-protobuf-v3_3/$version$/pekko-protobuf-v3_3-$version$-javadoc.jar",
+    "description" : "Apache Pekko Protobuf V3 packages the Google Protocol Buffers Java runtime shaded under org.apache.pekko.protobufv3.internal for use by Pekko modules. The relocation lets Pekko depend on protobuf serialization internals without exposing or conflicting with applications' own com.google.protobuf dependencies.",
     "language" : {
       "name" : "scala",
       "version" : "3"

--- a/metadata/org.apache.pekko/pekko-protobuf-v3_3/index.json
+++ b/metadata/org.apache.pekko/pekko-protobuf-v3_3/index.json
@@ -1,6 +1,19 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.0.0-M2",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "2.0.0-M2"
+    ],
+    "allowed-packages" : [
+      "org.apache.pekko.protobufv3.internal"
+    ]
+  },
+  {
     "metadata-version" : "1.2.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/pekko/pekko-protobuf-v3_3/$version$/pekko-protobuf-v3_3-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/pekko",

--- a/stats/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/execution-metrics.json
+++ b/stats/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/execution-metrics.json
@@ -1,0 +1,101 @@
+{
+  "fix_javac_fail:2026-06-06": {
+    "timestamp": "2026-06-06T09:34:39.757620Z",
+    "library": "org.apache.pekko:pekko-protobuf-v3_3:2.0.0-M2",
+    "starting_commit": "a31d9b1c84cbd2ad9c7649c84cf7364dd1e0eca7",
+    "ending_commit": "19e0e91605a748bb0fa7defa250dea5acbe7c229",
+    "previous_library": "org.apache.pekko:pekko-protobuf-v3_3:1.2.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.0.0-M2",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 54,
+            "totalCalls": 54
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 54,
+        "totalCalls": 54
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 24311,
+          "missed": 183420,
+          "ratio": 0.117031,
+          "total": 207731
+        },
+        "line": {
+          "covered": 5986,
+          "missed": 45748,
+          "ratio": 0.115707,
+          "total": 51734
+        },
+        "method": {
+          "covered": 1340,
+          "missed": 9371,
+          "ratio": 0.125105,
+          "total": 10711
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.2.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 51,
+            "totalCalls": 51
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 51,
+        "totalCalls": 51
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 24758,
+          "missed": 187151,
+          "ratio": 0.116833,
+          "total": 211909
+        },
+        "line": {
+          "covered": 6079,
+          "missed": 46513,
+          "ratio": 0.115588,
+          "total": 52592
+        },
+        "method": {
+          "covered": 1352,
+          "missed": 9355,
+          "ratio": 0.126273,
+          "total": 10707
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 352173,
+      "cached_input_tokens_used": 4483584,
+      "output_tokens_used": 31798,
+      "iterations": 6,
+      "cost_usd": 3.1957,
+      "tested_library_loc": 5986,
+      "metadata_entries": 71,
+      "test_only_metadata_entries": 63,
+      "previous_library_metadata_entries": 71,
+      "previous_library_test_only_metadata_entries": 63,
+      "code_coverage_percent": 11.57,
+      "previous_library_coverage_percent": 11.56
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/ExtensionSchemasTest.scala",
+      "metadata_file": "metadata/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/stats.json
+++ b/stats/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "2.0.0-M2",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 54,
+          "totalCalls" : 54
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 54,
+      "totalCalls" : 54
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 24311,
+        "missed" : 183420,
+        "ratio" : 0.117031,
+        "total" : 207731
+      },
+      "line" : {
+        "covered" : 5986,
+        "missed" : 45748,
+        "ratio" : 0.115707,
+        "total" : 51734
+      },
+      "method" : {
+        "covered" : 1340,
+        "missed" : 9371,
+        "ratio" : 0.125105,
+        "total" : 10711
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/.gitignore
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/build.gradle
@@ -1,0 +1,41 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.pekko:pekko-protobuf-v3_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    binaries {
+        all {
+            buildArgs.add('--initialize-at-run-time=org.apache.pekko.protobufv3.internal.ByteBufferWriter')
+        }
+    }
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/gradle.properties
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.pekko:pekko-protobuf-v3_3:2.0.0-M2
+library.version = 2.0.0-M2
+metadata.dir = org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/settings.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.pekko.pekko-protobuf-v3_3_tests'

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/libcore/io/Memory.java
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/libcore/io/Memory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package libcore.io;
+
+public final class Memory {
+    private Memory() {
+    }
+
+    // Only int-address overloads are present so UnsafeUtil selects its Android 32-bit accessor.
+    public static long peekLong(int address, boolean swap) {
+        throw new UnsupportedOperationException("Test Android memory stub does not read native memory");
+    }
+
+    public static void pokeLong(int address, long value, boolean swap) {
+        throw new UnsupportedOperationException("Test Android memory stub does not write native memory");
+    }
+
+    public static int peekInt(int address, boolean swap) {
+        throw new UnsupportedOperationException("Test Android memory stub does not read native memory");
+    }
+
+    public static void pokeInt(int address, int value, boolean swap) {
+        throw new UnsupportedOperationException("Test Android memory stub does not write native memory");
+    }
+
+    public static byte peekByte(int address) {
+        throw new UnsupportedOperationException("Test Android memory stub does not read native memory");
+    }
+
+    public static void pokeByte(int address, byte value) {
+        throw new UnsupportedOperationException("Test Android memory stub does not write native memory");
+    }
+
+    public static void peekByteArray(int address, byte[] destination, int offset, int count) {
+        throw new UnsupportedOperationException("Test Android memory stub does not read native memory");
+    }
+
+    public static void pokeByteArray(int address, byte[] source, int offset, int count) {
+        throw new UnsupportedOperationException("Test Android memory stub does not write native memory");
+    }
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org/apache/pekko/protobufv3/internal/GeneratedMessageLiteReflectionProbe.java
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org/apache/pekko/protobufv3/internal/GeneratedMessageLiteReflectionProbe.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.apache.pekko.protobufv3.internal;
+
+import java.lang.reflect.Method;
+
+public final class GeneratedMessageLiteReflectionProbe {
+    private GeneratedMessageLiteReflectionProbe() {
+    }
+
+    public static String invokeGreeting(String name) {
+        Method method = GeneratedMessageLite.getMethodOrDie(Target.class, "greeting", String.class);
+        return (String) GeneratedMessageLite.invokeOrDie(method, new Target(), name);
+    }
+
+    public static final class Target {
+        public String greeting(String name) {
+            return "hello " + name;
+        }
+    }
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/DescriptorMessageInfoFactoryProbe.java
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/DescriptorMessageInfoFactoryProbe.java
@@ -9,10 +9,10 @@ package org_apache_pekko.pekko_protobuf_v3_3;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.pekko.protobufv3.internal.CodedInputStream;
 import org.apache.pekko.protobufv3.internal.DescriptorProtos;
 import org.apache.pekko.protobufv3.internal.Descriptors;
-import org.apache.pekko.protobufv3.internal.ExtensionRegistryLite;
+import org.apache.pekko.protobufv3.internal.DynamicMessage;
+import org.apache.pekko.protobufv3.internal.ExtensionRegistry;
 import org.apache.pekko.protobufv3.internal.GeneratedMessageV3;
 import org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException;
 import org.apache.pekko.protobufv3.internal.Message;
@@ -31,8 +31,13 @@ public final class DescriptorMessageInfoFactoryProbe extends GeneratedMessageV3 
     }
 
     public void initializeEmptyPayloadSchema() throws InvalidProtocolBufferException {
-        CodedInputStream input = CodedInputStream.newInstance(new byte[0]);
-        mergeFromAndMakeImmutableInternal(input, ExtensionRegistryLite.getEmptyRegistry());
+        DynamicMessage parsed = DynamicMessage.parseFrom(
+                getDescriptorForType(),
+                new byte[0],
+                ExtensionRegistry.getEmptyRegistry());
+        if (!parsed.getAllFields().isEmpty()) {
+            throw new InvalidProtocolBufferException("Empty input produced fields");
+        }
     }
 
     public Child getMessageChoice() {

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/DescriptorMessageInfoFactoryProbe.java
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/DescriptorMessageInfoFactoryProbe.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_pekko.pekko_protobuf_v3_3;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.pekko.protobufv3.internal.CodedInputStream;
+import org.apache.pekko.protobufv3.internal.DescriptorProtos;
+import org.apache.pekko.protobufv3.internal.Descriptors;
+import org.apache.pekko.protobufv3.internal.ExtensionRegistryLite;
+import org.apache.pekko.protobufv3.internal.GeneratedMessageV3;
+import org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException;
+import org.apache.pekko.protobufv3.internal.Message;
+
+public final class DescriptorMessageInfoFactoryProbe extends GeneratedMessageV3 {
+    private static final DescriptorMessageInfoFactoryProbe DEFAULT_INSTANCE = new DescriptorMessageInfoFactoryProbe();
+    private static final Descriptors.Descriptor DESCRIPTOR = buildDescriptor();
+
+    private int choiceCase_ = 0;
+    private Object choice_;
+    private List<Child> repeatedChild_ = Collections.emptyList();
+    private String regularText_ = "";
+
+    public static DescriptorMessageInfoFactoryProbe getDefaultInstance() {
+        return DEFAULT_INSTANCE;
+    }
+
+    public void initializeEmptyPayloadSchema() throws InvalidProtocolBufferException {
+        CodedInputStream input = CodedInputStream.newInstance(new byte[0]);
+        mergeFromAndMakeImmutableInternal(input, ExtensionRegistryLite.getEmptyRegistry());
+    }
+
+    public Child getMessageChoice() {
+        if (choiceCase_ == 1) {
+            return (Child) choice_;
+        }
+        return Child.getDefaultInstance();
+    }
+
+    public Child getRepeatedChild(int index) {
+        return repeatedChild_.get(index);
+    }
+
+    public List<Child> getRepeatedChildList() {
+        return repeatedChild_;
+    }
+
+    public String getRegularText() {
+        return regularText_;
+    }
+
+    @Override
+    public Descriptors.Descriptor getDescriptorForType() {
+        return DESCRIPTOR;
+    }
+
+    @Override
+    public DescriptorMessageInfoFactoryProbe getDefaultInstanceForType() {
+        return DEFAULT_INSTANCE;
+    }
+
+    @Override
+    public Message.Builder newBuilderForType() {
+        throw new UnsupportedOperationException("Builder is not needed for schema discovery coverage");
+    }
+
+    @Override
+    public Message.Builder toBuilder() {
+        throw new UnsupportedOperationException("Builder is not needed for schema discovery coverage");
+    }
+
+    @Override
+    protected FieldAccessorTable internalGetFieldAccessorTable() {
+        throw new UnsupportedOperationException("FieldAccessorTable is not needed for schema discovery coverage");
+    }
+
+    @Override
+    protected Message.Builder newBuilderForType(BuilderParent parent) {
+        throw new UnsupportedOperationException("Builder is not needed for schema discovery coverage");
+    }
+
+    private static Descriptors.Descriptor buildDescriptor() {
+        DescriptorProtos.DescriptorProto child = DescriptorProtos.DescriptorProto.newBuilder()
+                .setName("Child")
+                .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                        .setName("name")
+                        .setNumber(1)
+                        .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL)
+                        .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING))
+                .build();
+
+        DescriptorProtos.DescriptorProto probe = DescriptorProtos.DescriptorProto.newBuilder()
+                .setName("Probe")
+                .addOneofDecl(DescriptorProtos.OneofDescriptorProto.newBuilder().setName("choice"))
+                .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                        .setName("message_choice")
+                        .setNumber(1)
+                        .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL)
+                        .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_MESSAGE)
+                        .setTypeName(".coverage.Child")
+                        .setOneofIndex(0))
+                .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                        .setName("repeated_child")
+                        .setNumber(2)
+                        .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_REPEATED)
+                        .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_MESSAGE)
+                        .setTypeName(".coverage.Child"))
+                .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                        .setName("regular_text")
+                        .setNumber(3)
+                        .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL)
+                        .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING))
+                .build();
+
+        DescriptorProtos.FileDescriptorProto file = DescriptorProtos.FileDescriptorProto.newBuilder()
+                .setName("descriptor_message_info_factory_probe.proto")
+                .setPackage("coverage")
+                .setSyntax("proto3")
+                .addMessageType(child)
+                .addMessageType(probe)
+                .build();
+        try {
+            Descriptors.FileDescriptor descriptor = Descriptors.FileDescriptor.buildFrom(
+                    file,
+                    new Descriptors.FileDescriptor[0]);
+            return descriptor.findMessageTypeByName("Probe");
+        } catch (Descriptors.DescriptorValidationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    public static final class Child extends GeneratedMessageV3 {
+        private static final Child DEFAULT_INSTANCE = new Child();
+
+        public static Child getDefaultInstance() {
+            return DEFAULT_INSTANCE;
+        }
+
+        @Override
+        public Descriptors.Descriptor getDescriptorForType() {
+            return DescriptorMessageInfoFactoryProbe.getDefaultInstance()
+                    .getDescriptorForType()
+                    .getFile()
+                    .findMessageTypeByName("Child");
+        }
+
+        @Override
+        public Child getDefaultInstanceForType() {
+            return DEFAULT_INSTANCE;
+        }
+
+        @Override
+        public Message.Builder newBuilderForType() {
+            throw new UnsupportedOperationException("Builder is not needed for schema discovery coverage");
+        }
+
+        @Override
+        public Message.Builder toBuilder() {
+            throw new UnsupportedOperationException("Builder is not needed for schema discovery coverage");
+        }
+
+        @Override
+        protected FieldAccessorTable internalGetFieldAccessorTable() {
+            throw new UnsupportedOperationException("FieldAccessorTable is not needed for schema discovery coverage");
+        }
+
+        @Override
+        protected Message.Builder newBuilderForType(BuilderParent parent) {
+            throw new UnsupportedOperationException("Builder is not needed for schema discovery coverage");
+        }
+    }
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/ExtensionSchemasProto2Probe.java
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/ExtensionSchemasProto2Probe.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_pekko.pekko_protobuf_v3_3;
+
+import org.apache.pekko.protobufv3.internal.CodedInputStream;
+import org.apache.pekko.protobufv3.internal.DescriptorProtos;
+import org.apache.pekko.protobufv3.internal.Descriptors;
+import org.apache.pekko.protobufv3.internal.ExtensionRegistryLite;
+import org.apache.pekko.protobufv3.internal.GeneratedMessageV3;
+import org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException;
+import org.apache.pekko.protobufv3.internal.Message;
+
+public final class ExtensionSchemasProto2Probe extends GeneratedMessageV3 {
+    private static final ExtensionSchemasProto2Probe DEFAULT_INSTANCE = new ExtensionSchemasProto2Probe();
+    private static final Descriptors.Descriptor DESCRIPTOR = buildDescriptor();
+
+    public static ExtensionSchemasProto2Probe getDefaultInstance() {
+        return DEFAULT_INSTANCE;
+    }
+
+    public void initializeEmptyPayloadSchema() throws InvalidProtocolBufferException {
+        CodedInputStream input = CodedInputStream.newInstance(new byte[0]);
+        mergeFromAndMakeImmutableInternal(input, ExtensionRegistryLite.getEmptyRegistry());
+    }
+
+    @Override
+    public Descriptors.Descriptor getDescriptorForType() {
+        return DESCRIPTOR;
+    }
+
+    @Override
+    public ExtensionSchemasProto2Probe getDefaultInstanceForType() {
+        return DEFAULT_INSTANCE;
+    }
+
+    @Override
+    public Message.Builder newBuilderForType() {
+        throw new UnsupportedOperationException("Builder is not needed for schema discovery coverage");
+    }
+
+    @Override
+    public Message.Builder toBuilder() {
+        throw new UnsupportedOperationException("Builder is not needed for schema discovery coverage");
+    }
+
+    @Override
+    protected FieldAccessorTable internalGetFieldAccessorTable() {
+        throw new UnsupportedOperationException("FieldAccessorTable is not needed for schema discovery coverage");
+    }
+
+    @Override
+    protected Message.Builder newBuilderForType(BuilderParent parent) {
+        throw new UnsupportedOperationException("Builder is not needed for schema discovery coverage");
+    }
+
+    private static Descriptors.Descriptor buildDescriptor() {
+        DescriptorProtos.DescriptorProto probe = DescriptorProtos.DescriptorProto.newBuilder()
+                .setName("ExtensionSchemasProto2Probe")
+                .build();
+
+        DescriptorProtos.FileDescriptorProto file = DescriptorProtos.FileDescriptorProto.newBuilder()
+                .setName("extension_schemas_proto2_probe.proto")
+                .setPackage("coverage")
+                .addMessageType(probe)
+                .build();
+        try {
+            Descriptors.FileDescriptor descriptor = Descriptors.FileDescriptor.buildFrom(
+                    file,
+                    new Descriptors.FileDescriptor[0]);
+            return descriptor.findMessageTypeByName("ExtensionSchemasProto2Probe");
+        } catch (Descriptors.DescriptorValidationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/ExtensionSchemasProto2Probe.java
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/ExtensionSchemasProto2Probe.java
@@ -6,10 +6,10 @@
  */
 package org_apache_pekko.pekko_protobuf_v3_3;
 
-import org.apache.pekko.protobufv3.internal.CodedInputStream;
 import org.apache.pekko.protobufv3.internal.DescriptorProtos;
 import org.apache.pekko.protobufv3.internal.Descriptors;
-import org.apache.pekko.protobufv3.internal.ExtensionRegistryLite;
+import org.apache.pekko.protobufv3.internal.DynamicMessage;
+import org.apache.pekko.protobufv3.internal.ExtensionRegistry;
 import org.apache.pekko.protobufv3.internal.GeneratedMessageV3;
 import org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException;
 import org.apache.pekko.protobufv3.internal.Message;
@@ -23,8 +23,13 @@ public final class ExtensionSchemasProto2Probe extends GeneratedMessageV3 {
     }
 
     public void initializeEmptyPayloadSchema() throws InvalidProtocolBufferException {
-        CodedInputStream input = CodedInputStream.newInstance(new byte[0]);
-        mergeFromAndMakeImmutableInternal(input, ExtensionRegistryLite.getEmptyRegistry());
+        DynamicMessage parsed = DynamicMessage.parseFrom(
+                getDescriptorForType(),
+                new byte[0],
+                ExtensionRegistry.getEmptyRegistry());
+        if (!parsed.getAllFields().isEmpty()) {
+            throw new InvalidProtocolBufferException("Empty input produced fields");
+        }
     }
 
     @Override

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/ExtensionSchemasProto2Probe.java
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/ExtensionSchemasProto2Probe.java
@@ -10,9 +10,11 @@ import org.apache.pekko.protobufv3.internal.DescriptorProtos;
 import org.apache.pekko.protobufv3.internal.Descriptors;
 import org.apache.pekko.protobufv3.internal.DynamicMessage;
 import org.apache.pekko.protobufv3.internal.ExtensionRegistry;
+import org.apache.pekko.protobufv3.internal.GeneratedMessageLite;
 import org.apache.pekko.protobufv3.internal.GeneratedMessageV3;
 import org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException;
 import org.apache.pekko.protobufv3.internal.Message;
+import org.apache.pekko.protobufv3.internal.Parser;
 
 public final class ExtensionSchemasProto2Probe extends GeneratedMessageV3 {
     private static final ExtensionSchemasProto2Probe DEFAULT_INSTANCE = new ExtensionSchemasProto2Probe();
@@ -30,6 +32,11 @@ public final class ExtensionSchemasProto2Probe extends GeneratedMessageV3 {
         if (!parsed.getAllFields().isEmpty()) {
             throw new InvalidProtocolBufferException("Empty input produced fields");
         }
+    }
+
+    public static ExtendableLiteProbe parseExtendableLiteMessageWithUnknownField()
+            throws InvalidProtocolBufferException {
+        return ExtendableLiteProbe.parseFrom(new byte[] {8, 1});
     }
 
     @Override
@@ -60,6 +67,68 @@ public final class ExtensionSchemasProto2Probe extends GeneratedMessageV3 {
     @Override
     protected Message.Builder newBuilderForType(BuilderParent parent) {
         throw new UnsupportedOperationException("Builder is not needed for schema discovery coverage");
+    }
+
+    public static final class ExtendableLiteProbe
+            extends GeneratedMessageLite.ExtendableMessage<ExtendableLiteProbe, ExtendableLiteProbe.Builder> {
+        private static final ExtendableLiteProbe DEFAULT_INSTANCE;
+        private static volatile Parser<ExtendableLiteProbe> parser;
+
+        static {
+            ExtendableLiteProbe defaultInstance = new ExtendableLiteProbe();
+            DEFAULT_INSTANCE = defaultInstance;
+            registerDefaultInstance(ExtendableLiteProbe.class, defaultInstance);
+        }
+
+        private ExtendableLiteProbe() {
+        }
+
+        public static ExtendableLiteProbe getDefaultInstance() {
+            return DEFAULT_INSTANCE;
+        }
+
+        public static ExtendableLiteProbe parseFrom(byte[] data) throws InvalidProtocolBufferException {
+            return parseFrom(DEFAULT_INSTANCE, data);
+        }
+
+        @Override
+        protected Object dynamicMethod(MethodToInvoke method, Object arg0, Object arg1) {
+            switch (method) {
+                case NEW_MUTABLE_INSTANCE:
+                    return new ExtendableLiteProbe();
+                case NEW_BUILDER:
+                    return new Builder();
+                case BUILD_MESSAGE_INFO:
+                    return newMessageInfo(DEFAULT_INSTANCE, "\u0001\u0000", null);
+                case GET_DEFAULT_INSTANCE:
+                    return DEFAULT_INSTANCE;
+                case GET_PARSER:
+                    Parser<ExtendableLiteProbe> currentParser = parser;
+                    if (currentParser == null) {
+                        synchronized (ExtendableLiteProbe.class) {
+                            currentParser = parser;
+                            if (currentParser == null) {
+                                currentParser = new GeneratedMessageLite.DefaultInstanceBasedParser<>(DEFAULT_INSTANCE);
+                                parser = currentParser;
+                            }
+                        }
+                    }
+                    return currentParser;
+                case GET_MEMOIZED_IS_INITIALIZED:
+                    return (byte) 1;
+                case SET_MEMOIZED_IS_INITIALIZED:
+                    return null;
+                default:
+                    throw new UnsupportedOperationException();
+            }
+        }
+
+        public static final class Builder
+                extends GeneratedMessageLite.ExtendableBuilder<ExtendableLiteProbe, Builder> {
+            private Builder() {
+                super(DEFAULT_INSTANCE);
+            }
+        }
     }
 
     private static Descriptors.Descriptor buildDescriptor() {

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/FileDescriptorDependencyProbe.java
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/FileDescriptorDependencyProbe.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_pekko.pekko_protobuf_v3_3;
+
+import org.apache.pekko.protobufv3.internal.DescriptorProtos;
+import org.apache.pekko.protobufv3.internal.Descriptors;
+
+public final class FileDescriptorDependencyProbe {
+    public static Descriptors.FileDescriptor descriptor = buildDescriptor();
+
+    private FileDescriptorDependencyProbe() {
+    }
+
+    private static Descriptors.FileDescriptor buildDescriptor() {
+        DescriptorProtos.DescriptorProto message = DescriptorProtos.DescriptorProto.newBuilder()
+                .setName("DependencyMessage")
+                .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                        .setName("name")
+                        .setNumber(1)
+                        .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL)
+                        .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING))
+                .build();
+
+        DescriptorProtos.FileDescriptorProto file = DescriptorProtos.FileDescriptorProto.newBuilder()
+                .setName("file_descriptor_dependency_probe.proto")
+                .setPackage("coverage")
+                .setSyntax("proto3")
+                .addMessageType(message)
+                .build();
+        try {
+            return Descriptors.FileDescriptor.buildFrom(file, new Descriptors.FileDescriptor[0]);
+        } catch (Descriptors.DescriptorValidationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/GeneratedFileProbe.java
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/GeneratedFileProbe.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_pekko.pekko_protobuf_v3_3;
+
+import org.apache.pekko.protobufv3.internal.ExtensionRegistry;
+import org.apache.pekko.protobufv3.internal.GeneratedFile;
+
+public final class GeneratedFileProbe extends GeneratedFile {
+    private GeneratedFileProbe() {
+    }
+
+    public static void addExtensionByName(
+            ExtensionRegistry registry,
+            String className,
+            String fieldName) {
+        addOptionalExtension(registry, className, fieldName);
+    }
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/GeneratedMessageAccessorProbe.java
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/GeneratedMessageAccessorProbe.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_pekko.pekko_protobuf_v3_3;
+
+import java.io.IOException;
+
+import org.apache.pekko.protobufv3.internal.CodedInputStream;
+import org.apache.pekko.protobufv3.internal.DescriptorProtos;
+import org.apache.pekko.protobufv3.internal.Descriptors;
+import org.apache.pekko.protobufv3.internal.ExtensionRegistryLite;
+import org.apache.pekko.protobufv3.internal.GeneratedMessage;
+import org.apache.pekko.protobufv3.internal.Message;
+import org.apache.pekko.protobufv3.internal.UnknownFieldSet;
+
+public final class GeneratedMessageAccessorProbe extends GeneratedMessage {
+    private static final Descriptors.Descriptor DESCRIPTOR = buildDescriptor();
+    private static final GeneratedMessageAccessorProbe DEFAULT_INSTANCE = new GeneratedMessageAccessorProbe(false, 0);
+    private static final FieldAccessorTable FIELD_ACCESSOR_TABLE = new FieldAccessorTable(
+            DESCRIPTOR,
+            new String[] {"Number"})
+            .ensureFieldAccessorsInitialized(GeneratedMessageAccessorProbe.class, Builder.class);
+
+    private final boolean hasNumber;
+    private final int number;
+
+    private GeneratedMessageAccessorProbe(boolean hasNumber, int number) {
+        this.hasNumber = hasNumber;
+        this.number = number;
+        this.unknownFields = UnknownFieldSet.getDefaultInstance();
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static GeneratedMessageAccessorProbe getDefaultInstance() {
+        return DEFAULT_INSTANCE;
+    }
+
+    public static Descriptors.Descriptor getDescriptor() {
+        return DESCRIPTOR;
+    }
+
+    public boolean hasNumber() {
+        return hasNumber;
+    }
+
+    public int getNumber() {
+        return number;
+    }
+
+    @Override
+    public Descriptors.Descriptor getDescriptorForType() {
+        return DESCRIPTOR;
+    }
+
+    @Override
+    public GeneratedMessageAccessorProbe getDefaultInstanceForType() {
+        return DEFAULT_INSTANCE;
+    }
+
+    @Override
+    public Builder newBuilderForType() {
+        return new Builder();
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return newBuilder().mergeFrom(this);
+    }
+
+    @Override
+    protected FieldAccessorTable internalGetFieldAccessorTable() {
+        return FIELD_ACCESSOR_TABLE;
+    }
+
+    @Override
+    protected Message.Builder newBuilderForType(BuilderParent parent) {
+        return new Builder(parent);
+    }
+
+    private static Descriptors.Descriptor buildDescriptor() {
+        DescriptorProtos.DescriptorProto probe = DescriptorProtos.DescriptorProto.newBuilder()
+                .setName("Probe")
+                .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                        .setName("number")
+                        .setNumber(1)
+                        .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL)
+                        .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_INT32))
+                .build();
+
+        DescriptorProtos.FileDescriptorProto file = DescriptorProtos.FileDescriptorProto.newBuilder()
+                .setName("generated_message_accessor_probe.proto")
+                .setPackage("coverage.generated_message")
+                .setSyntax("proto2")
+                .addMessageType(probe)
+                .build();
+        try {
+            return Descriptors.FileDescriptor.buildFrom(file, new Descriptors.FileDescriptor[0])
+                    .findMessageTypeByName("Probe");
+        } catch (Descriptors.DescriptorValidationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    public static final class Builder extends GeneratedMessage.Builder<Builder> {
+        private boolean hasNumber;
+        private int number;
+
+        private Builder() {
+        }
+
+        private Builder(BuilderParent parent) {
+            super(parent);
+        }
+
+        public boolean hasNumber() {
+            return hasNumber;
+        }
+
+        public int getNumber() {
+            return number;
+        }
+
+        public Builder setNumber(int value) {
+            hasNumber = true;
+            number = value;
+            onChanged();
+            return this;
+        }
+
+        public Builder clearNumber() {
+            hasNumber = false;
+            number = 0;
+            onChanged();
+            return this;
+        }
+
+        @Override
+        public Descriptors.Descriptor getDescriptorForType() {
+            return DESCRIPTOR;
+        }
+
+        @Override
+        public GeneratedMessageAccessorProbe getDefaultInstanceForType() {
+            return DEFAULT_INSTANCE;
+        }
+
+        @Override
+        public Builder clear() {
+            super.clear();
+            hasNumber = false;
+            number = 0;
+            return this;
+        }
+
+        @Override
+        public GeneratedMessageAccessorProbe build() {
+            GeneratedMessageAccessorProbe result = buildPartial();
+            if (!result.isInitialized()) {
+                throw newUninitializedMessageException(result);
+            }
+            return result;
+        }
+
+        @Override
+        public GeneratedMessageAccessorProbe buildPartial() {
+            return new GeneratedMessageAccessorProbe(hasNumber, number);
+        }
+
+        @Override
+        public Builder clone() {
+            return newBuilder().mergeFrom(buildPartial());
+        }
+
+        @Override
+        public Builder mergeFrom(Message other) {
+            if (other instanceof GeneratedMessageAccessorProbe) {
+                return mergeFrom((GeneratedMessageAccessorProbe) other);
+            }
+            super.mergeFrom(other);
+            return this;
+        }
+
+        public Builder mergeFrom(GeneratedMessageAccessorProbe other) {
+            if (other.hasNumber()) {
+                setNumber(other.getNumber());
+            }
+            mergeUnknownFields(other.getUnknownFields());
+            return this;
+        }
+
+        @Override
+        public Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry) throws IOException {
+            throw new UnsupportedOperationException("Parsing is not needed for GeneratedMessage reflection coverage");
+        }
+
+        @Override
+        protected FieldAccessorTable internalGetFieldAccessorTable() {
+            return FIELD_ACCESSOR_TABLE;
+        }
+    }
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/GeneratedMessageAnonymous4DescriptorProbe.java
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/GeneratedMessageAnonymous4DescriptorProbe.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_pekko.pekko_protobuf_v3_3;
+
+import org.apache.pekko.protobufv3.internal.DescriptorProtos;
+import org.apache.pekko.protobufv3.internal.Descriptors;
+
+public final class GeneratedMessageAnonymous4DescriptorProbe {
+    public static Descriptors.FileDescriptor descriptor = buildDescriptor();
+
+    private GeneratedMessageAnonymous4DescriptorProbe() {
+    }
+
+    private static Descriptors.FileDescriptor buildDescriptor() {
+        DescriptorProtos.DescriptorProto extensibleMessage = DescriptorProtos.DescriptorProto.newBuilder()
+                .setName("ExtensibleMessage")
+                .addExtensionRange(DescriptorProtos.DescriptorProto.ExtensionRange.newBuilder()
+                        .setStart(100)
+                        .setEnd(536870912))
+                .build();
+
+        DescriptorProtos.FileDescriptorProto file = DescriptorProtos.FileDescriptorProto.newBuilder()
+                .setName("generated_message_anonymous_4_descriptor_probe.proto")
+                .setPackage("coverage.generated_message_anonymous_4")
+                .setSyntax("proto2")
+                .addMessageType(extensibleMessage)
+                .addExtension(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                        .setName("covered_extension")
+                        .setNumber(100)
+                        .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL)
+                        .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING)
+                        .setExtendee(".coverage.generated_message_anonymous_4.ExtensibleMessage"))
+                .build();
+        try {
+            return Descriptors.FileDescriptor.buildFrom(file, new Descriptors.FileDescriptor[0]);
+        } catch (Descriptors.DescriptorValidationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/GeneratedMessageLiteSerializedFormFallbackProbe.java
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/GeneratedMessageLiteSerializedFormFallbackProbe.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_pekko.pekko_protobuf_v3_3;
+
+import org.apache.pekko.protobufv3.internal.GeneratedMessageLite;
+
+public final class GeneratedMessageLiteSerializedFormFallbackProbe
+        extends GeneratedMessageLite<
+                GeneratedMessageLiteSerializedFormFallbackProbe,
+                GeneratedMessageLiteSerializedFormFallbackProbe.Builder> {
+    @SuppressWarnings("checkstyle:ConstantName")
+    private static final GeneratedMessageLiteSerializedFormFallbackProbe defaultInstance =
+            new GeneratedMessageLiteSerializedFormFallbackProbe();
+
+    static {
+        registerDefaultInstance(GeneratedMessageLiteSerializedFormFallbackProbe.class, defaultInstance);
+    }
+
+    private GeneratedMessageLiteSerializedFormFallbackProbe() {
+    }
+
+    public static GeneratedMessageLiteSerializedFormFallbackProbe getDefaultInstance() {
+        return defaultInstance;
+    }
+
+    @Override
+    protected Object dynamicMethod(MethodToInvoke method, Object arg0, Object arg1) {
+        switch (method) {
+            case BUILD_MESSAGE_INFO:
+                return newMessageInfo(defaultInstance, "\u0000\u0000", null);
+            case NEW_MUTABLE_INSTANCE:
+                return new GeneratedMessageLiteSerializedFormFallbackProbe();
+            case NEW_BUILDER:
+                return new Builder(defaultInstance);
+            case GET_DEFAULT_INSTANCE:
+                return defaultInstance;
+            case GET_PARSER:
+                return null;
+            case GET_MEMOIZED_IS_INITIALIZED:
+                return (byte) 1;
+            case SET_MEMOIZED_IS_INITIALIZED:
+                return null;
+            default:
+                throw new UnsupportedOperationException();
+        }
+    }
+
+    public static final class Builder
+            extends GeneratedMessageLite.Builder<GeneratedMessageLiteSerializedFormFallbackProbe, Builder> {
+        private Builder(GeneratedMessageLiteSerializedFormFallbackProbe defaultInstance) {
+            super(defaultInstance);
+        }
+    }
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/GeneratedMessageLiteSerializedFormProbe.java
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/GeneratedMessageLiteSerializedFormProbe.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_pekko.pekko_protobuf_v3_3;
+
+import org.apache.pekko.protobufv3.internal.GeneratedMessageLite;
+
+public final class GeneratedMessageLiteSerializedFormProbe
+        extends GeneratedMessageLite<
+                GeneratedMessageLiteSerializedFormProbe,
+                GeneratedMessageLiteSerializedFormProbe.Builder> {
+    private static final GeneratedMessageLiteSerializedFormProbe DEFAULT_INSTANCE =
+            new GeneratedMessageLiteSerializedFormProbe();
+
+    static {
+        registerDefaultInstance(GeneratedMessageLiteSerializedFormProbe.class, DEFAULT_INSTANCE);
+    }
+
+    private GeneratedMessageLiteSerializedFormProbe() {
+    }
+
+    public static GeneratedMessageLiteSerializedFormProbe getDefaultInstance() {
+        return DEFAULT_INSTANCE;
+    }
+
+    @Override
+    protected Object dynamicMethod(MethodToInvoke method, Object arg0, Object arg1) {
+        switch (method) {
+            case BUILD_MESSAGE_INFO:
+                return newMessageInfo(DEFAULT_INSTANCE, "\u0000\u0000", null);
+            case NEW_MUTABLE_INSTANCE:
+                return new GeneratedMessageLiteSerializedFormProbe();
+            case NEW_BUILDER:
+                return new Builder(DEFAULT_INSTANCE);
+            case GET_DEFAULT_INSTANCE:
+                return DEFAULT_INSTANCE;
+            case GET_PARSER:
+                return null;
+            case GET_MEMOIZED_IS_INITIALIZED:
+                return (byte) 1;
+            case SET_MEMOIZED_IS_INITIALIZED:
+                return null;
+            default:
+                throw new UnsupportedOperationException();
+        }
+    }
+
+    public static final class Builder
+            extends GeneratedMessageLite.Builder<GeneratedMessageLiteSerializedFormProbe, Builder> {
+        private Builder(GeneratedMessageLiteSerializedFormProbe defaultInstance) {
+            super(defaultInstance);
+        }
+    }
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/GeneratedMessageV3AccessorProbe.java
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/GeneratedMessageV3AccessorProbe.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_pekko.pekko_protobuf_v3_3;
+
+import java.io.IOException;
+
+import org.apache.pekko.protobufv3.internal.CodedInputStream;
+import org.apache.pekko.protobufv3.internal.DescriptorProtos;
+import org.apache.pekko.protobufv3.internal.Descriptors;
+import org.apache.pekko.protobufv3.internal.ExtensionRegistryLite;
+import org.apache.pekko.protobufv3.internal.GeneratedMessageV3;
+import org.apache.pekko.protobufv3.internal.Message;
+import org.apache.pekko.protobufv3.internal.UnknownFieldSet;
+
+public final class GeneratedMessageV3AccessorProbe extends GeneratedMessageV3 {
+    private static final Descriptors.Descriptor DESCRIPTOR = buildDescriptor();
+    private static final GeneratedMessageV3AccessorProbe DEFAULT_INSTANCE = new GeneratedMessageV3AccessorProbe(false, 0);
+    private static final FieldAccessorTable FIELD_ACCESSOR_TABLE = new FieldAccessorTable(
+            DESCRIPTOR,
+            new String[] {"Number"})
+            .ensureFieldAccessorsInitialized(GeneratedMessageV3AccessorProbe.class, Builder.class);
+
+    private final boolean hasNumber;
+    private final int number;
+
+    private GeneratedMessageV3AccessorProbe(boolean hasNumber, int number) {
+        this.hasNumber = hasNumber;
+        this.number = number;
+        this.unknownFields = UnknownFieldSet.getDefaultInstance();
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static GeneratedMessageV3AccessorProbe getDefaultInstance() {
+        return DEFAULT_INSTANCE;
+    }
+
+    public static Descriptors.Descriptor getDescriptor() {
+        return DESCRIPTOR;
+    }
+
+    public boolean hasNumber() {
+        return hasNumber;
+    }
+
+    public int getNumber() {
+        return number;
+    }
+
+    @Override
+    public Descriptors.Descriptor getDescriptorForType() {
+        return DESCRIPTOR;
+    }
+
+    @Override
+    public GeneratedMessageV3AccessorProbe getDefaultInstanceForType() {
+        return DEFAULT_INSTANCE;
+    }
+
+    @Override
+    public Builder newBuilderForType() {
+        return new Builder();
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return newBuilder().mergeFrom(this);
+    }
+
+    @Override
+    protected FieldAccessorTable internalGetFieldAccessorTable() {
+        return FIELD_ACCESSOR_TABLE;
+    }
+
+    @Override
+    protected Message.Builder newBuilderForType(BuilderParent parent) {
+        return new Builder(parent);
+    }
+
+    private static Descriptors.Descriptor buildDescriptor() {
+        DescriptorProtos.DescriptorProto probe = DescriptorProtos.DescriptorProto.newBuilder()
+                .setName("ProbeV3")
+                .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                        .setName("number")
+                        .setNumber(1)
+                        .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL)
+                        .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_INT32))
+                .build();
+
+        DescriptorProtos.FileDescriptorProto file = DescriptorProtos.FileDescriptorProto.newBuilder()
+                .setName("generated_message_v3_accessor_probe.proto")
+                .setPackage("coverage.generated_message_v3")
+                .setSyntax("proto2")
+                .addMessageType(probe)
+                .build();
+        try {
+            return Descriptors.FileDescriptor.buildFrom(file, new Descriptors.FileDescriptor[0])
+                    .findMessageTypeByName("ProbeV3");
+        } catch (Descriptors.DescriptorValidationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    public static final class Builder extends GeneratedMessageV3.Builder<Builder> {
+        private boolean hasNumber;
+        private int number;
+
+        private Builder() {
+        }
+
+        private Builder(BuilderParent parent) {
+            super(parent);
+        }
+
+        public boolean hasNumber() {
+            return hasNumber;
+        }
+
+        public int getNumber() {
+            return number;
+        }
+
+        public Builder setNumber(int value) {
+            hasNumber = true;
+            number = value;
+            onChanged();
+            return this;
+        }
+
+        public Builder clearNumber() {
+            hasNumber = false;
+            number = 0;
+            onChanged();
+            return this;
+        }
+
+        @Override
+        public Descriptors.Descriptor getDescriptorForType() {
+            return DESCRIPTOR;
+        }
+
+        @Override
+        public GeneratedMessageV3AccessorProbe getDefaultInstanceForType() {
+            return DEFAULT_INSTANCE;
+        }
+
+        @Override
+        public Builder clear() {
+            super.clear();
+            hasNumber = false;
+            number = 0;
+            return this;
+        }
+
+        @Override
+        public GeneratedMessageV3AccessorProbe build() {
+            GeneratedMessageV3AccessorProbe result = buildPartial();
+            if (!result.isInitialized()) {
+                throw newUninitializedMessageException(result);
+            }
+            return result;
+        }
+
+        @Override
+        public GeneratedMessageV3AccessorProbe buildPartial() {
+            return new GeneratedMessageV3AccessorProbe(hasNumber, number);
+        }
+
+        @Override
+        public Builder clone() {
+            return newBuilder().mergeFrom(buildPartial());
+        }
+
+        @Override
+        public Builder mergeFrom(Message other) {
+            if (other instanceof GeneratedMessageV3AccessorProbe) {
+                return mergeFrom((GeneratedMessageV3AccessorProbe) other);
+            }
+            super.mergeFrom(other);
+            return this;
+        }
+
+        public Builder mergeFrom(GeneratedMessageV3AccessorProbe other) {
+            if (other.hasNumber()) {
+                setNumber(other.getNumber());
+            }
+            mergeUnknownFields(other.getUnknownFields());
+            return this;
+        }
+
+        @Override
+        public Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry) throws IOException {
+            throw new UnsupportedOperationException("Parsing is not needed for GeneratedMessageV3 reflection coverage");
+        }
+
+        @Override
+        protected FieldAccessorTable internalGetFieldAccessorTable() {
+            return FIELD_ACCESSOR_TABLE;
+        }
+    }
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/MessageSchemaProbe.java
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/MessageSchemaProbe.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_pekko.pekko_protobuf_v3_3;
+
+import org.apache.pekko.protobufv3.internal.GeneratedMessageLite;
+import org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException;
+import org.apache.pekko.protobufv3.internal.Parser;
+
+public final class MessageSchemaProbe {
+    private MessageSchemaProbe() {
+    }
+
+    public static int parseValidMessageValue() throws InvalidProtocolBufferException {
+        return ValidMessage.parseFrom(new byte[] {8, 123}).getValue();
+    }
+
+    public static RuntimeException parseInvalidMessageWithMissingField() {
+        try {
+            InvalidMessage.parseFrom(new byte[] {8, 1});
+            throw new AssertionError("Expected schema creation to fail for a missing backing field");
+        } catch (ExceptionInInitializerError e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException) {
+                return (RuntimeException) cause;
+            }
+            throw e;
+        } catch (RuntimeException e) {
+            return e;
+        } catch (InvalidProtocolBufferException e) {
+            throw new AssertionError("Schema creation should fail before parsing completes", e);
+        }
+    }
+
+    public static final class ValidMessage extends GeneratedMessageLite<ValidMessage, ValidMessage.Builder> {
+        private static final ValidMessage DEFAULT_INSTANCE;
+        private static volatile Parser<ValidMessage> parser;
+
+        private int value_;
+
+        static {
+            ValidMessage defaultInstance = new ValidMessage();
+            DEFAULT_INSTANCE = defaultInstance;
+            registerDefaultInstance(ValidMessage.class, defaultInstance);
+        }
+
+        private ValidMessage() {
+        }
+
+        public int getValue() {
+            return value_;
+        }
+
+        public static ValidMessage parseFrom(byte[] data) throws InvalidProtocolBufferException {
+            return parseFrom(DEFAULT_INSTANCE, data);
+        }
+
+        @Override
+        protected Object dynamicMethod(MethodToInvoke method, Object arg0, Object arg1) {
+            switch (method) {
+                case NEW_MUTABLE_INSTANCE:
+                    return new ValidMessage();
+                case NEW_BUILDER:
+                    return new Builder();
+                case BUILD_MESSAGE_INFO:
+                    return newMessageInfo(DEFAULT_INSTANCE, rawMessageInfo(), new Object[] {"value_"});
+                case GET_DEFAULT_INSTANCE:
+                    return DEFAULT_INSTANCE;
+                case GET_PARSER:
+                    Parser<ValidMessage> currentParser = parser;
+                    if (currentParser == null) {
+                        synchronized (ValidMessage.class) {
+                            currentParser = parser;
+                            if (currentParser == null) {
+                                currentParser = new GeneratedMessageLite.DefaultInstanceBasedParser<>(DEFAULT_INSTANCE);
+                                parser = currentParser;
+                            }
+                        }
+                    }
+                    return currentParser;
+                case GET_MEMOIZED_IS_INITIALIZED:
+                    return (byte) 1;
+                case SET_MEMOIZED_IS_INITIALIZED:
+                    return null;
+                default:
+                    throw new UnsupportedOperationException();
+            }
+        }
+
+        public static final class Builder extends GeneratedMessageLite.Builder<ValidMessage, Builder> {
+            private Builder() {
+                super(DEFAULT_INSTANCE);
+            }
+        }
+    }
+
+    public static final class InvalidMessage extends GeneratedMessageLite<InvalidMessage, InvalidMessage.Builder> {
+        private static final InvalidMessage DEFAULT_INSTANCE;
+        private static volatile Parser<InvalidMessage> parser;
+
+        private int value_;
+
+        static {
+            InvalidMessage defaultInstance = new InvalidMessage();
+            DEFAULT_INSTANCE = defaultInstance;
+            registerDefaultInstance(InvalidMessage.class, defaultInstance);
+        }
+
+        private InvalidMessage() {
+        }
+
+        public static InvalidMessage parseFrom(byte[] data) throws InvalidProtocolBufferException {
+            return parseFrom(DEFAULT_INSTANCE, data);
+        }
+
+        @Override
+        protected Object dynamicMethod(MethodToInvoke method, Object arg0, Object arg1) {
+            switch (method) {
+                case NEW_MUTABLE_INSTANCE:
+                    return new InvalidMessage();
+                case NEW_BUILDER:
+                    return new Builder();
+                case BUILD_MESSAGE_INFO:
+                    return newMessageInfo(DEFAULT_INSTANCE, rawMessageInfo(), new Object[] {"missing_"});
+                case GET_DEFAULT_INSTANCE:
+                    return DEFAULT_INSTANCE;
+                case GET_PARSER:
+                    Parser<InvalidMessage> currentParser = parser;
+                    if (currentParser == null) {
+                        synchronized (InvalidMessage.class) {
+                            currentParser = parser;
+                            if (currentParser == null) {
+                                currentParser = new GeneratedMessageLite.DefaultInstanceBasedParser<>(DEFAULT_INSTANCE);
+                                parser = currentParser;
+                            }
+                        }
+                    }
+                    return currentParser;
+                case GET_MEMOIZED_IS_INITIALIZED:
+                    return (byte) 1;
+                case SET_MEMOIZED_IS_INITIALIZED:
+                    return null;
+                default:
+                    throw new UnsupportedOperationException();
+            }
+        }
+
+        public static final class Builder extends GeneratedMessageLite.Builder<InvalidMessage, Builder> {
+            private Builder() {
+                super(DEFAULT_INSTANCE);
+            }
+        }
+    }
+
+    private static String rawMessageInfo() {
+        return "\u0000\u0001\u0000\u0000\u0001\u0001\u0001\u0000\u0000\u0000\u0001\u0004";
+    }
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/SchemaUtilMapFieldProbe.java
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/SchemaUtilMapFieldProbe.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_pekko.pekko_protobuf_v3_3;
+
+import java.util.Map;
+
+import org.apache.pekko.protobufv3.internal.CodedInputStream;
+import org.apache.pekko.protobufv3.internal.DescriptorProtos;
+import org.apache.pekko.protobufv3.internal.Descriptors;
+import org.apache.pekko.protobufv3.internal.ExtensionRegistryLite;
+import org.apache.pekko.protobufv3.internal.GeneratedMessageV3;
+import org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException;
+import org.apache.pekko.protobufv3.internal.MapEntry;
+import org.apache.pekko.protobufv3.internal.MapField;
+import org.apache.pekko.protobufv3.internal.Message;
+import org.apache.pekko.protobufv3.internal.WireFormat;
+
+public final class SchemaUtilMapFieldProbe extends GeneratedMessageV3 {
+    private static final Descriptors.Descriptor DESCRIPTOR = buildDescriptor();
+    private static final SchemaUtilMapFieldProbe DEFAULT_INSTANCE = new SchemaUtilMapFieldProbe();
+
+    private MapField<String, String> entries_ = MapField.emptyMapField(EntriesDefaultEntryHolder.defaultEntry);
+
+    public static SchemaUtilMapFieldProbe getDefaultInstance() {
+        return DEFAULT_INSTANCE;
+    }
+
+    public void initializeEmptyMapSchema() throws InvalidProtocolBufferException {
+        CodedInputStream input = CodedInputStream.newInstance(new byte[0]);
+        mergeFromAndMakeImmutableInternal(input, ExtensionRegistryLite.getEmptyRegistry());
+    }
+
+    public Map<String, String> getEntriesMap() {
+        return entries_.getMap();
+    }
+
+    @Override
+    public Descriptors.Descriptor getDescriptorForType() {
+        return DESCRIPTOR;
+    }
+
+    @Override
+    public SchemaUtilMapFieldProbe getDefaultInstanceForType() {
+        return DEFAULT_INSTANCE;
+    }
+
+    @Override
+    public Message.Builder newBuilderForType() {
+        throw new UnsupportedOperationException("Builder is not needed for map schema coverage");
+    }
+
+    @Override
+    public Message.Builder toBuilder() {
+        throw new UnsupportedOperationException("Builder is not needed for map schema coverage");
+    }
+
+    @Override
+    protected FieldAccessorTable internalGetFieldAccessorTable() {
+        throw new UnsupportedOperationException("FieldAccessorTable is not needed for map schema coverage");
+    }
+
+    @Override
+    protected Message.Builder newBuilderForType(BuilderParent parent) {
+        throw new UnsupportedOperationException("Builder is not needed for map schema coverage");
+    }
+
+    private static Descriptors.Descriptor buildDescriptor() {
+        DescriptorProtos.DescriptorProto entriesEntry = DescriptorProtos.DescriptorProto.newBuilder()
+                .setName("EntriesEntry")
+                .setOptions(DescriptorProtos.MessageOptions.newBuilder().setMapEntry(true))
+                .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                        .setName("key")
+                        .setNumber(1)
+                        .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL)
+                        .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING))
+                .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                        .setName("value")
+                        .setNumber(2)
+                        .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL)
+                        .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING))
+                .build();
+
+        DescriptorProtos.DescriptorProto probe = DescriptorProtos.DescriptorProto.newBuilder()
+                .setName("MapProbe")
+                .addNestedType(entriesEntry)
+                .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                        .setName("entries")
+                        .setNumber(1)
+                        .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_REPEATED)
+                        .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_MESSAGE)
+                        .setTypeName(".schema_util_coverage.MapProbe.EntriesEntry"))
+                .build();
+
+        DescriptorProtos.FileDescriptorProto file = DescriptorProtos.FileDescriptorProto.newBuilder()
+                .setName("schema_util_map_field_probe.proto")
+                .setPackage("schema_util_coverage")
+                .setSyntax("proto3")
+                .addMessageType(probe)
+                .build();
+        try {
+            Descriptors.FileDescriptor descriptor = Descriptors.FileDescriptor.buildFrom(
+                    file,
+                    new Descriptors.FileDescriptor[0]);
+            return descriptor.findMessageTypeByName("MapProbe");
+        } catch (Descriptors.DescriptorValidationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    public static final class EntriesDefaultEntryHolder {
+        public static final MapEntry<String, String> defaultEntry = MapEntry.newDefaultInstance(
+                DESCRIPTOR.findNestedTypeByName("EntriesEntry"),
+                WireFormat.FieldType.STRING,
+                "",
+                WireFormat.FieldType.STRING,
+                "");
+    }
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/SchemaUtilMapFieldProbe.java
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/SchemaUtilMapFieldProbe.java
@@ -8,10 +8,10 @@ package org_apache_pekko.pekko_protobuf_v3_3;
 
 import java.util.Map;
 
-import org.apache.pekko.protobufv3.internal.CodedInputStream;
 import org.apache.pekko.protobufv3.internal.DescriptorProtos;
 import org.apache.pekko.protobufv3.internal.Descriptors;
-import org.apache.pekko.protobufv3.internal.ExtensionRegistryLite;
+import org.apache.pekko.protobufv3.internal.DynamicMessage;
+import org.apache.pekko.protobufv3.internal.ExtensionRegistry;
 import org.apache.pekko.protobufv3.internal.GeneratedMessageV3;
 import org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException;
 import org.apache.pekko.protobufv3.internal.MapEntry;
@@ -30,8 +30,13 @@ public final class SchemaUtilMapFieldProbe extends GeneratedMessageV3 {
     }
 
     public void initializeEmptyMapSchema() throws InvalidProtocolBufferException {
-        CodedInputStream input = CodedInputStream.newInstance(new byte[0]);
-        mergeFromAndMakeImmutableInternal(input, ExtensionRegistryLite.getEmptyRegistry());
+        DynamicMessage parsed = DynamicMessage.parseFrom(
+                getDescriptorForType(),
+                new byte[0],
+                ExtensionRegistry.getEmptyRegistry());
+        if (!parsed.getAllFields().isEmpty()) {
+            throw new InvalidProtocolBufferException("Empty input produced fields");
+        }
     }
 
     public Map<String, String> getEntriesMap() {

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/UnsafeUtilLiteMessageProbe.java
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/UnsafeUtilLiteMessageProbe.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_pekko.pekko_protobuf_v3_3;
+
+import org.apache.pekko.protobufv3.internal.GeneratedMessageLite;
+
+public final class UnsafeUtilLiteMessageProbe
+        extends GeneratedMessageLite<UnsafeUtilLiteMessageProbe, UnsafeUtilLiteMessageProbe.Builder> {
+    public UnsafeUtilLiteMessageProbe() {
+    }
+
+    @Override
+    protected Object dynamicMethod(MethodToInvoke method, Object arg0, Object arg1) {
+        switch (method) {
+            case BUILD_MESSAGE_INFO:
+                return newMessageInfo(this, "\u0000\u0000", null);
+            case NEW_MUTABLE_INSTANCE:
+                return new UnsafeUtilLiteMessageProbe();
+            case NEW_BUILDER:
+                return new Builder(this);
+            case GET_DEFAULT_INSTANCE:
+                return this;
+            case GET_PARSER:
+                return null;
+            case GET_MEMOIZED_IS_INITIALIZED:
+                return (byte) 1;
+            case SET_MEMOIZED_IS_INITIALIZED:
+                return null;
+            default:
+                throw new UnsupportedOperationException();
+        }
+    }
+
+    public static final class Builder extends GeneratedMessageLite.Builder<UnsafeUtilLiteMessageProbe, Builder> {
+        private Builder(UnsafeUtilLiteMessageProbe defaultInstance) {
+            super(defaultInstance);
+        }
+    }
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,314 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.DescriptorMessageInfoFactory"
+      },
+      "type" : "org_apache_pekko.pekko_protobuf_v3_3.DescriptorMessageInfoFactoryProbe"
+    },
+    {
+      "type" : "org_apache_pekko.pekko_protobuf_v3_3.DescriptorMessageInfoFactoryProbe",
+      "fields" : [
+        {
+          "name" : "choiceCase_"
+        },
+        {
+          "name" : "choice_"
+        },
+        {
+          "name" : "repeatedChild_"
+        },
+        {
+          "name" : "regularText_"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "getDefaultInstance",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getMessageChoice",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedChild",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.DescriptorMessageInfoFactory"
+      },
+      "type" : "org_apache_pekko.pekko_protobuf_v3_3.ExtensionSchemasProto2Probe",
+      "methods" : [
+        {
+          "name" : "getDefaultInstance",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.DescriptorMessageInfoFactory"
+      },
+      "type" : "org_apache_pekko.pekko_protobuf_v3_3.SchemaUtilMapFieldProbe",
+      "allDeclaredFields" : true,
+      "methods" : [
+        {
+          "name" : "getDefaultInstance",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.Descriptors$FileDescriptor"
+      },
+      "type" : "org_apache_pekko.pekko_protobuf_v3_3.FileDescriptorDependencyProbe",
+      "fields" : [
+        {
+          "name" : "descriptor"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.GeneratedMessage"
+      },
+      "type" : "org_apache_pekko.pekko_protobuf_v3_3.GeneratedMessageAccessorProbe"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.GeneratedMessage"
+      },
+      "type" : "org_apache_pekko.pekko_protobuf_v3_3.GeneratedMessageAccessorProbe$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.GeneratedMessage$4"
+      },
+      "type" : "org_apache_pekko.pekko_protobuf_v3_3.GeneratedMessageAnonymous4DescriptorProbe",
+      "fields" : [
+        {
+          "name" : "descriptor"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.GeneratedMessage$FieldAccessorTable$SingularFieldAccessor"
+      },
+      "type" : "org_apache_pekko.pekko_protobuf_v3_3.GeneratedMessageAccessorProbe",
+      "methods" : [
+        {
+          "name" : "getNumber",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasNumber",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : "org_apache_pekko.pekko_protobuf_v3_3.GeneratedMessageAccessorProbe$Builder",
+      "methods" : [
+        {
+          "name" : "getNumber",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasNumber",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setNumber",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "clearNumber",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.GeneratedMessageLite"
+      },
+      "type" : "org_apache_pekko.pekko_protobuf_v3_3.UnsafeUtilLiteMessageProbe"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.GeneratedMessageV3"
+      },
+      "type" : "org_apache_pekko.pekko_protobuf_v3_3.GeneratedMessageV3AccessorProbe"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.GeneratedMessageV3"
+      },
+      "type" : "org_apache_pekko.pekko_protobuf_v3_3.GeneratedMessageV3AccessorProbe$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.GeneratedMessage$FieldAccessorTable$SingularFieldAccessor"
+      },
+      "type" : "org_apache_pekko.pekko_protobuf_v3_3.GeneratedMessageV3AccessorProbe",
+      "methods" : [
+        {
+          "name" : "getNumber",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasNumber",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : "org_apache_pekko.pekko_protobuf_v3_3.GeneratedMessageV3AccessorProbe$Builder",
+      "methods" : [
+        {
+          "name" : "getNumber",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasNumber",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setNumber",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "clearNumber",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : "org_apache_pekko.pekko_protobuf_v3_3.GeneratedMessageLiteSerializedFormProbe",
+      "fields" : [
+        {
+          "name" : "DEFAULT_INSTANCE"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "getDefaultInstance",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : "org_apache_pekko.pekko_protobuf_v3_3.GeneratedMessageLiteSerializedFormFallbackProbe",
+      "fields" : [
+        {
+          "name" : "defaultInstance"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.Internal"
+      },
+      "type" : "org_apache_pekko.pekko_protobuf_v3_3.GeneratedMessageLiteSerializedFormProbe",
+      "methods" : [
+        {
+          "name" : "getDefaultInstance",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.MessageSchema"
+      },
+      "type" : "org_apache_pekko.pekko_protobuf_v3_3.MessageSchemaProbe$InvalidMessage",
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.MessageSchema"
+      },
+      "type" : "org_apache_pekko.pekko_protobuf_v3_3.MessageSchemaProbe$ValidMessage",
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.SchemaUtil"
+      },
+      "type" : "org_apache_pekko.pekko_protobuf_v3_3.SchemaUtilMapFieldProbe$EntriesDefaultEntryHolder",
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.UnsafeUtil"
+      },
+      "type" : "org_apache_pekko.pekko_protobuf_v3_3.UnsafeUtilLiteMessageProbe",
+      "unsafeAllocated" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.DescriptorMessageInfoFactory"
+      },
+      "type" : "org_apache_pekko.pekko_protobuf_v3_3.ExtensionSchemasProto2Probe"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.Descriptors$FileDescriptor"
+      },
+      "type" : "org_apache_pekko.pekko_protobuf_v3_3.FileDescriptorDependencyProbe"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.GeneratedMessageLite$SerializedForm"
+      },
+      "type" : "org_apache_pekko.pekko_protobuf_v3_3.GeneratedMessageLiteSerializedFormProbe"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.Internal"
+      },
+      "type" : "org_apache_pekko.pekko_protobuf_v3_3.GeneratedMessageLiteSerializedFormProbe"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.GeneratedMessage"
+      },
+      "type" : "org_apache_pekko.pekko_protobuf_v3_3.GeneratedMessageV3AccessorProbe"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.GeneratedMessage"
+      },
+      "type" : "org_apache_pekko.pekko_protobuf_v3_3.GeneratedMessageV3AccessorProbe$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.MessageSchema"
+      },
+      "type" : "org_apache_pekko.pekko_protobuf_v3_3.MessageSchemaProbe$InvalidMessage"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.MessageSchema"
+      },
+      "type" : "org_apache_pekko.pekko_protobuf_v3_3.MessageSchemaProbe$ValidMessage"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.pekko.protobufv3.internal.DescriptorMessageInfoFactory"
+      },
+      "type" : "org_apache_pekko.pekko_protobuf_v3_3.SchemaUtilMapFieldProbe"
+    }
+  ]
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/ByteBufferWriterTest.scala
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/ByteBufferWriterTest.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_pekko.pekko_protobuf_v3_3
+
+import org.apache.pekko.protobufv3.internal.ByteString
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ByteBufferWriterTest {
+  @Test
+  def initializesByteBufferWriterRuntimeSupport(): Unit = {
+    val className: String = "org.apache.pekko.protobufv3.internal.ByteBufferWriter"
+    val writerClass: Class[?] = Class.forName(className, true, classOf[ByteString].getClassLoader)
+
+    assertThat(writerClass.getName).isEqualTo(className)
+  }
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/DescriptorMessageInfoFactoryTest.scala
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/DescriptorMessageInfoFactoryTest.scala
@@ -6,6 +6,11 @@
  */
 package org_apache_pekko.pekko_protobuf_v3_3
 
+import java.lang.invoke.MethodHandle
+import java.lang.invoke.MethodHandles
+import java.lang.invoke.MethodType.methodType
+
+import org.apache.pekko.protobufv3.internal.GeneratedMessageV3
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -20,5 +25,58 @@ class DescriptorMessageInfoFactoryTest {
     assertThat(message.getDescriptorForType.findFieldByName("repeated_child").isRepeated).isTrue()
     assertThat(message.getMessageChoice).isSameAs(DescriptorMessageInfoFactoryProbe.Child.getDefaultInstance)
     assertThat(message.getRepeatedChildList).isEmpty()
+  }
+
+  @Test
+  def descriptorMessageInfoFactoryDiscoversGeneratedMessageLayout(): Unit = {
+    val factory: AnyRef = descriptorMessageInfoFactoryGetInstance.invokeWithArguments().asInstanceOf[AnyRef]
+    val messageInfo: AnyRef = descriptorMessageInfoFactoryMessageInfoFor.invokeWithArguments(
+      factory,
+      classOf[DescriptorMessageInfoFactoryProbe]
+    ).asInstanceOf[AnyRef]
+
+    assertThat(messageInfo).isNotNull
+    assertThat(DescriptorMessageInfoFactoryProbe.getDefaultInstance.getDescriptorForType
+      .findFieldByName("regular_text").getName).isEqualTo("regular_text")
+    assertThat(DescriptorMessageInfoFactoryProbe.getDefaultInstance.getDescriptorForType
+      .findFieldByName("repeated_child").isRepeated).isTrue()
+    assertThat(DescriptorMessageInfoFactoryProbe.getDefaultInstance.getDescriptorForType
+      .findFieldByName("message_choice").getRealContainingOneof.getName).isEqualTo("choice")
+  }
+
+  private def descriptorMessageInfoFactoryGetInstance: MethodHandle = {
+    descriptorMessageInfoFactoryLookup.findStatic(
+      descriptorMessageInfoFactoryClass,
+      "getInstance",
+      methodType(descriptorMessageInfoFactoryClass)
+    )
+  }
+
+  private def descriptorMessageInfoFactoryMessageInfoFor: MethodHandle = {
+    descriptorMessageInfoFactoryLookup.findVirtual(
+      descriptorMessageInfoFactoryClass,
+      "messageInfoFor",
+      methodType(messageInfoClass, classOf[Class[_]])
+    )
+  }
+
+  private def descriptorMessageInfoFactoryLookup: MethodHandles.Lookup = {
+    MethodHandles.privateLookupIn(descriptorMessageInfoFactoryClass, MethodHandles.lookup())
+  }
+
+  private def descriptorMessageInfoFactoryClass: Class[_] = {
+    Class.forName(
+      "org.apache.pekko.protobufv3.internal.DescriptorMessageInfoFactory",
+      true,
+      classOf[GeneratedMessageV3].getClassLoader
+    )
+  }
+
+  private def messageInfoClass: Class[_] = {
+    Class.forName(
+      "org.apache.pekko.protobufv3.internal.MessageInfo",
+      true,
+      classOf[GeneratedMessageV3].getClassLoader
+    )
   }
 }

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/DescriptorMessageInfoFactoryTest.scala
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/DescriptorMessageInfoFactoryTest.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_pekko.pekko_protobuf_v3_3
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class DescriptorMessageInfoFactoryTest {
+  @Test
+  def schemaDiscoveryHandlesGeneratedMessageFieldsOneofsAndRepeatedMessages(): Unit = {
+    val message: DescriptorMessageInfoFactoryProbe = new DescriptorMessageInfoFactoryProbe()
+
+    message.initializeEmptyPayloadSchema()
+
+    assertThat(message.getDescriptorForType.findFieldByName("regular_text").getName).isEqualTo("regular_text")
+    assertThat(message.getDescriptorForType.findFieldByName("repeated_child").isRepeated).isTrue()
+    assertThat(message.getMessageChoice).isSameAs(DescriptorMessageInfoFactoryProbe.Child.getDefaultInstance)
+    assertThat(message.getRepeatedChildList).isEmpty()
+  }
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/DescriptorsInnerFileDescriptorTest.scala
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/DescriptorsInnerFileDescriptorTest.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_pekko.pekko_protobuf_v3_3
+
+import java.nio.charset.StandardCharsets
+
+import org.apache.pekko.protobufv3.internal.DescriptorProtos
+import org.apache.pekko.protobufv3.internal.Descriptors
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class DescriptorsInnerFileDescriptorTest {
+  @Test
+  def generatedFileBuilderResolvesDependencyDescriptorsByGeneratedClassName(): Unit = {
+    val file: DescriptorProtos.FileDescriptorProto = DescriptorProtos.FileDescriptorProto.newBuilder()
+      .setName("file_descriptor_dynamic_access.proto")
+      .setPackage("coverage")
+      .setSyntax("proto3")
+      .addDependency(FileDescriptorDependencyProbe.descriptor.getName)
+      .addMessageType(DescriptorProtos.DescriptorProto.newBuilder()
+        .setName("CurrentMessage")
+        .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+          .setName("dependency")
+          .setNumber(1)
+          .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL)
+          .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_MESSAGE)
+          .setTypeName(".coverage.DependencyMessage")))
+      .build()
+
+    val descriptor: Descriptors.FileDescriptor = Descriptors.FileDescriptor.internalBuildGeneratedFileFrom(
+      encode(file),
+      classOf[FileDescriptorDependencyProbe],
+      Array(classOf[FileDescriptorDependencyProbe].getName),
+      Array(FileDescriptorDependencyProbe.descriptor.getName))
+
+    assertThat(descriptor.getName).isEqualTo("file_descriptor_dynamic_access.proto")
+    assertThat(descriptor.getDependencies).containsExactly(FileDescriptorDependencyProbe.descriptor)
+    assertThat(descriptor.findMessageTypeByName("CurrentMessage")
+      .findFieldByName("dependency")
+      .getMessageType).isEqualTo(FileDescriptorDependencyProbe.descriptor.findMessageTypeByName("DependencyMessage"))
+  }
+
+  private def encode(file: DescriptorProtos.FileDescriptorProto): Array[String] =
+    Array(new String(file.toByteArray, StandardCharsets.ISO_8859_1))
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/ExtensionRegistryLiteTest.scala
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/ExtensionRegistryLiteTest.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_pekko.pekko_protobuf_v3_3
+
+import org.apache.pekko.protobufv3.internal.DescriptorProtos
+import org.apache.pekko.protobufv3.internal.Descriptors
+import org.apache.pekko.protobufv3.internal.Extension
+import org.apache.pekko.protobufv3.internal.ExtensionRegistry
+import org.apache.pekko.protobufv3.internal.ExtensionRegistryLite
+import org.apache.pekko.protobufv3.internal.Message
+import org.apache.pekko.protobufv3.internal.MessageLite
+import org.apache.pekko.protobufv3.internal.WireFormat
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ExtensionRegistryLiteTest {
+  @Test
+  def addsFullRuntimeExtensionThroughLiteRegistryBridge(): Unit = {
+    val extensionField: Descriptors.FieldDescriptor = buildScalarExtensionDescriptor()
+    val fullRegistry: ExtensionRegistry = ExtensionRegistry.newInstance()
+    val liteRegistry: ExtensionRegistryLite = fullRegistry
+    val extension: ScalarExtension = new ScalarExtension(extensionField)
+
+    liteRegistry.add(extension)
+
+    val registeredExtension: ExtensionRegistry.ExtensionInfo = fullRegistry.findImmutableExtensionByNumber(
+      extensionField.getContainingType,
+      extensionField.getNumber)
+    assertThat(registeredExtension).isNotNull
+    assertThat(registeredExtension.descriptor).isSameAs(extensionField)
+  }
+
+  private def buildScalarExtensionDescriptor(): Descriptors.FieldDescriptor = {
+    val targetMessage: DescriptorProtos.DescriptorProto = DescriptorProtos.DescriptorProto.newBuilder()
+      .setName("Target")
+      .addExtensionRange(
+        DescriptorProtos.DescriptorProto.ExtensionRange.newBuilder()
+          .setStart(100)
+          .setEnd(200)
+          .build())
+      .build()
+    val scalarExtension: DescriptorProtos.FieldDescriptorProto = DescriptorProtos.FieldDescriptorProto.newBuilder()
+      .setName("sample_value")
+      .setNumber(100)
+      .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL)
+      .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_INT32)
+      .setExtendee(".coverage.Target")
+      .build()
+    val fileProto: DescriptorProtos.FileDescriptorProto = DescriptorProtos.FileDescriptorProto.newBuilder()
+      .setName("extension_registry_lite_test.proto")
+      .setPackage("coverage")
+      .addMessageType(targetMessage)
+      .addExtension(scalarExtension)
+      .build()
+    val fileDescriptor: Descriptors.FileDescriptor = Descriptors.FileDescriptor.buildFrom(
+      fileProto,
+      Array.empty[Descriptors.FileDescriptor])
+
+    fileDescriptor.findExtensionByName("sample_value")
+  }
+
+  private final class ScalarExtension(descriptor: Descriptors.FieldDescriptor) extends Extension[MessageLite, Integer] {
+    override def getNumber: Int = descriptor.getNumber
+
+    override def getLiteType: WireFormat.FieldType = WireFormat.FieldType.INT32
+
+    override def isRepeated: Boolean = false
+
+    override def getDefaultValue: Integer = Integer.valueOf(0)
+
+    override def getMessageDefaultInstance: Message = null
+
+    override def getDescriptor: Descriptors.FieldDescriptor = descriptor
+
+    override protected def getExtensionType: Extension.ExtensionType = Extension.ExtensionType.IMMUTABLE
+
+    override protected def fromReflectionType(value: AnyRef): AnyRef = value
+
+    override protected def singularFromReflectionType(value: AnyRef): AnyRef = value
+
+    override protected def toReflectionType(value: AnyRef): AnyRef = value
+
+    override protected def singularToReflectionType(value: AnyRef): AnyRef = value
+  }
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/ExtensionSchemasTest.scala
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/ExtensionSchemasTest.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_pekko.pekko_protobuf_v3_3
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ExtensionSchemasTest {
+  @Test
+  def initializesFullRuntimeExtensionSchemaForProto2GeneratedMessages(): Unit = {
+    val message: ExtensionSchemasProto2Probe = new ExtensionSchemasProto2Probe()
+
+    message.initializeEmptyPayloadSchema()
+
+    assertThat(message.getDescriptorForType.getFile.toProto.hasSyntax).isFalse
+    assertThat(message.getDescriptorForType.getName).isEqualTo("ExtensionSchemasProto2Probe")
+  }
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/ExtensionSchemasTest.scala
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/ExtensionSchemasTest.scala
@@ -15,8 +15,13 @@ class ExtensionSchemasTest {
     val message: ExtensionSchemasProto2Probe = new ExtensionSchemasProto2Probe()
 
     message.initializeEmptyPayloadSchema()
+    val liteMessage: ExtensionSchemasProto2Probe.ExtendableLiteProbe =
+      ExtensionSchemasProto2Probe.parseExtendableLiteMessageWithUnknownField()
 
     assertThat(message.getDescriptorForType.getFile.toProto.hasSyntax).isFalse
     assertThat(message.getDescriptorForType.getName).isEqualTo("ExtensionSchemasProto2Probe")
+    assertThat(liteMessage).isNotNull
+    assertThat(liteMessage.getDefaultInstanceForType)
+      .isSameAs(ExtensionSchemasProto2Probe.ExtendableLiteProbe.getDefaultInstance)
   }
 }

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/GeneratedFileTest.scala
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/GeneratedFileTest.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_pekko.pekko_protobuf_v3_3
+
+import org.apache.pekko.protobufv3.internal.ExtensionRegistry
+import org.apache.pekko.protobufv3.internal.JavaFeaturesProto
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class GeneratedFileTest {
+  @Test
+  def addOptionalExtensionLoadsPublicGeneratedExtensionField(): Unit = {
+    val registry: ExtensionRegistry = ExtensionRegistry.newInstance()
+
+    GeneratedFileProbe.addExtensionByName(
+      registry,
+      classOf[JavaFeaturesProto].getName,
+      "java_"
+    )
+
+    val extensionInfo: ExtensionRegistry.ExtensionInfo = registry.findExtensionByName(
+      JavaFeaturesProto.java_.getDescriptor.getFullName
+    )
+
+    assertThat(extensionInfo).isNotNull
+    assertThat(extensionInfo.descriptor).isSameAs(JavaFeaturesProto.java_.getDescriptor)
+  }
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/GeneratedMessageAnonymous4Test.scala
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/GeneratedMessageAnonymous4Test.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_pekko.pekko_protobuf_v3_3
+
+import org.apache.pekko.protobufv3.internal.Descriptors
+import org.apache.pekko.protobufv3.internal.GeneratedMessage
+import org.apache.pekko.protobufv3.internal.Message
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class GeneratedMessageAnonymous4Test {
+  @Test
+  def fileScopedExtensionLoadsDescriptorFromGeneratedDescriptorClass(): Unit = {
+    val extension: GeneratedMessage.GeneratedExtension[Message, String] =
+      GeneratedMessage.newFileScopedGeneratedExtension[Message, String](classOf[String], null)
+    val extensionDescriptor: Descriptors.FieldDescriptor =
+      GeneratedMessageAnonymous4DescriptorProbe.descriptor.findExtensionByName("covered_extension")
+    extension.internalInit(extensionDescriptor)
+
+    val descriptor: Descriptors.FieldDescriptor = extension.getDescriptor
+
+    assertThat(descriptor.getName).isEqualTo("covered_extension")
+    assertThat(descriptor.getNumber).isEqualTo(100)
+    assertThat(descriptor.getJavaType).isEqualTo(Descriptors.FieldDescriptor.JavaType.STRING)
+    assertThat(descriptor.getFile).isSameAs(GeneratedMessageAnonymous4DescriptorProbe.descriptor)
+  }
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/GeneratedMessageLiteInnerSerializedFormTest.scala
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/GeneratedMessageLiteInnerSerializedFormTest.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_pekko.pekko_protobuf_v3_3
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.DataOutputStream
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
+import java.io.ObjectStreamClass
+import java.io.ObjectStreamConstants
+
+import org.apache.pekko.protobufv3.internal.GeneratedMessageLite
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class GeneratedMessageLiteInnerSerializedFormTest {
+  @Test
+  def serializedFormRestoresLiteMessageThroughDefaultInstanceField(): Unit = {
+    val message: GeneratedMessageLiteSerializedFormProbe = GeneratedMessageLiteSerializedFormProbe.getDefaultInstance
+
+    val restored: AnyRef = deserialize(serialize(GeneratedMessageLite.SerializedForm.of(message)))
+
+    assertThat(restored).isInstanceOf(classOf[GeneratedMessageLiteSerializedFormProbe])
+    assertThat(restored.asInstanceOf[GeneratedMessageLiteSerializedFormProbe].getSerializedSize).isZero()
+  }
+
+  @Test
+  def serializedFormResolvesLegacyStreamWithoutSerializedMessageClass(): Unit = {
+    val message: GeneratedMessageLiteSerializedFormProbe = GeneratedMessageLiteSerializedFormProbe.getDefaultInstance
+    val restored: AnyRef = deserialize(serializeWithNullMessageClass(message))
+
+    assertThat(restored).isInstanceOf(classOf[GeneratedMessageLiteSerializedFormProbe])
+    assertThat(restored.asInstanceOf[GeneratedMessageLiteSerializedFormProbe].getSerializedSize).isZero()
+  }
+
+  private def serialize(value: AnyRef): Array[Byte] = {
+    val bytes: ByteArrayOutputStream = new ByteArrayOutputStream()
+    val output: ObjectOutputStream = new ObjectOutputStream(bytes)
+    try {
+      output.writeObject(value)
+    } finally {
+      output.close()
+    }
+    bytes.toByteArray
+  }
+
+  private def serializeWithNullMessageClass(
+      message: GeneratedMessageLiteSerializedFormProbe): Array[Byte] = {
+    val bytes: ByteArrayOutputStream = new ByteArrayOutputStream()
+    val output: DataOutputStream = new DataOutputStream(bytes)
+    try {
+      output.writeShort(ObjectStreamConstants.STREAM_MAGIC)
+      output.writeShort(ObjectStreamConstants.STREAM_VERSION)
+      writeSerializedForm(output)
+      writeByteArray(output, message.toByteArray)
+      output.writeByte(ObjectStreamConstants.TC_NULL)
+      writeString(output, message.getClass.getName)
+    } finally {
+      output.close()
+    }
+    bytes.toByteArray
+  }
+
+  private def writeSerializedForm(output: DataOutputStream): Unit = {
+    output.writeByte(ObjectStreamConstants.TC_OBJECT)
+    output.writeByte(ObjectStreamConstants.TC_CLASSDESC)
+    output.writeUTF("org.apache.pekko.protobufv3.internal.GeneratedMessageLite$SerializedForm")
+    output.writeLong(0L)
+    output.writeByte(ObjectStreamConstants.SC_SERIALIZABLE)
+    output.writeShort(3)
+    writeObjectField(output, '[', "asBytes", "[B")
+    writeObjectField(output, 'L', "messageClass", "Ljava/lang/Class;")
+    writeObjectField(output, 'L', "messageClassName", "Ljava/lang/String;")
+    output.writeByte(ObjectStreamConstants.TC_ENDBLOCKDATA)
+    output.writeByte(ObjectStreamConstants.TC_NULL)
+  }
+
+  private def writeObjectField(
+      output: DataOutputStream,
+      typeCode: Char,
+      name: String,
+      signature: String): Unit = {
+    output.writeByte(typeCode)
+    output.writeUTF(name)
+    writeString(output, signature)
+  }
+
+  private def writeByteArray(output: DataOutputStream, value: Array[Byte]): Unit = {
+    output.writeByte(ObjectStreamConstants.TC_ARRAY)
+    output.writeByte(ObjectStreamConstants.TC_CLASSDESC)
+    output.writeUTF("[B")
+    output.writeLong(ObjectStreamClass.lookup(classOf[Array[Byte]]).getSerialVersionUID)
+    output.writeByte(ObjectStreamConstants.SC_SERIALIZABLE)
+    output.writeShort(0)
+    output.writeByte(ObjectStreamConstants.TC_ENDBLOCKDATA)
+    output.writeByte(ObjectStreamConstants.TC_NULL)
+    output.writeInt(value.length)
+    output.write(value)
+  }
+
+  private def writeString(output: DataOutputStream, value: String): Unit = {
+    output.writeByte(ObjectStreamConstants.TC_STRING)
+    output.writeUTF(value)
+  }
+
+  private def deserialize(bytes: Array[Byte]): AnyRef = {
+    val input: ObjectInputStream = new ObjectInputStream(new ByteArrayInputStream(bytes))
+    try {
+      input.readObject()
+    } finally {
+      input.close()
+    }
+  }
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/GeneratedMessageLiteTest.scala
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/GeneratedMessageLiteTest.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_pekko.pekko_protobuf_v3_3
+
+import org.apache.pekko.protobufv3.internal.GeneratedMessageLiteReflectionProbe
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class GeneratedMessageLiteTest {
+  @Test
+  def invokesGeneratedMessageLiteAccessorMethod(): Unit = {
+    val greeting: String = GeneratedMessageLiteReflectionProbe.invokeGreeting("protobuf")
+
+    assertThat(greeting).isEqualTo("hello protobuf")
+  }
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/GeneratedMessageTest.scala
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/GeneratedMessageTest.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_pekko.pekko_protobuf_v3_3
+
+import org.apache.pekko.protobufv3.internal.Descriptors
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class GeneratedMessageTest {
+  @Test
+  def fieldAccessorTableInvokesGeneratedAccessors(): Unit = {
+    val numberField: Descriptors.FieldDescriptor = GeneratedMessageAccessorProbe.getDescriptor.findFieldByName("number")
+    val builder: GeneratedMessageAccessorProbe.Builder = GeneratedMessageAccessorProbe.newBuilder()
+
+    assertThat(builder.hasField(numberField)).isFalse()
+
+    builder.setField(numberField, Int.box(42))
+
+    assertThat(builder.hasField(numberField)).isTrue()
+    assertThat(builder.getField(numberField)).isEqualTo(42)
+
+    val message: GeneratedMessageAccessorProbe = builder.build()
+
+    assertThat(message.hasField(numberField)).isTrue()
+    assertThat(message.getField(numberField)).isEqualTo(42)
+
+    builder.clearField(numberField)
+
+    assertThat(builder.hasField(numberField)).isFalse()
+  }
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/GeneratedMessageV3Test.scala
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/GeneratedMessageV3Test.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_pekko.pekko_protobuf_v3_3
+
+import org.apache.pekko.protobufv3.internal.Descriptors
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class GeneratedMessageV3Test {
+  @Test
+  def fieldAccessorTableInvokesGeneratedAccessors(): Unit = {
+    val numberField: Descriptors.FieldDescriptor = GeneratedMessageV3AccessorProbe.getDescriptor.findFieldByName("number")
+    val builder: GeneratedMessageV3AccessorProbe.Builder = GeneratedMessageV3AccessorProbe.newBuilder()
+
+    assertThat(builder.hasField(numberField)).isFalse()
+
+    builder.setField(numberField, Int.box(42))
+
+    assertThat(builder.hasField(numberField)).isTrue()
+    assertThat(builder.getField(numberField)).isEqualTo(42)
+
+    val message: GeneratedMessageV3AccessorProbe = builder.build()
+
+    assertThat(message.hasField(numberField)).isTrue()
+    assertThat(message.getField(numberField)).isEqualTo(42)
+
+    builder.clearField(numberField)
+
+    assertThat(builder.hasField(numberField)).isFalse()
+  }
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/InternalTest.scala
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/InternalTest.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_pekko.pekko_protobuf_v3_3
+
+import org.apache.pekko.protobufv3.internal.Internal
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class InternalTest {
+  @Test
+  def getDefaultInstanceUsesMessageStaticAccessor(): Unit = {
+    val defaultInstance: GeneratedMessageLiteSerializedFormProbe =
+      Internal.getDefaultInstance(classOf[GeneratedMessageLiteSerializedFormProbe])
+
+    assertThat(defaultInstance).isSameAs(GeneratedMessageLiteSerializedFormProbe.getDefaultInstance())
+  }
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/MessageLiteToStringTest.scala
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/MessageLiteToStringTest.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_pekko.pekko_protobuf_v3_3
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class MessageLiteToStringTest {
+  @Test
+  def generatedMessageLiteToStringUsesReflectivePrinter(): Unit = {
+    val message: GeneratedMessageLiteSerializedFormProbe = GeneratedMessageLiteSerializedFormProbe.getDefaultInstance
+
+    val debugString: String = message.toString
+
+    assertThat(debugString).startsWith("# ")
+    assertThat(debugString).contains("GeneratedMessageLiteSerializedFormProbe")
+  }
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/MessageSchemaTest.scala
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/MessageSchemaTest.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_pekko.pekko_protobuf_v3_3
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class MessageSchemaTest {
+  @Test
+  def createsRawMessageSchemaFromGeneratedLiteFieldMetadata(): Unit = {
+    val parsedValue: Int = MessageSchemaProbe.parseValidMessageValue()
+
+    assertThat(parsedValue).isEqualTo(123)
+  }
+
+  @Test
+  def reportsKnownFieldsWhenRawMessageSchemaReferencesMissingField(): Unit = {
+    val failure: RuntimeException = MessageSchemaProbe.parseInvalidMessageWithMissingField()
+
+    assertThat(failure).hasMessageContaining("missing_")
+    assertThat(failure).hasMessageContaining("Known fields")
+  }
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/SchemaUtilTest.scala
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/SchemaUtilTest.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_pekko.pekko_protobuf_v3_3
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class SchemaUtilTest {
+  @Test
+  def mapSchemaDiscoveryLoadsGeneratedDefaultEntryHolder(): Unit = {
+    val message: SchemaUtilMapFieldProbe = new SchemaUtilMapFieldProbe()
+
+    message.initializeEmptyMapSchema()
+
+    val entriesField = message.getDescriptorForType.findFieldByName("entries")
+    assertThat(entriesField.isMapField).isTrue()
+    assertThat(message.getEntriesMap).isEmpty()
+  }
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/SchemaUtilTest.scala
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/SchemaUtilTest.scala
@@ -6,6 +6,11 @@
  */
 package org_apache_pekko.pekko_protobuf_v3_3
 
+import java.lang.invoke.MethodHandle
+import java.lang.invoke.MethodHandles
+import java.lang.invoke.MethodType.methodType
+
+import org.apache.pekko.protobufv3.internal.GeneratedMessageV3
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -15,9 +20,50 @@ class SchemaUtilTest {
     val message: SchemaUtilMapFieldProbe = new SchemaUtilMapFieldProbe()
 
     message.initializeEmptyMapSchema()
+    val messageInfo: AnyRef = descriptorMessageInfoFactoryMessageInfoFor.invokeWithArguments(
+      descriptorMessageInfoFactoryGetInstance.invokeWithArguments(),
+      classOf[SchemaUtilMapFieldProbe]
+    ).asInstanceOf[AnyRef]
 
     val entriesField = message.getDescriptorForType.findFieldByName("entries")
+    assertThat(messageInfo).isNotNull
     assertThat(entriesField.isMapField).isTrue()
     assertThat(message.getEntriesMap).isEmpty()
+  }
+
+  private def descriptorMessageInfoFactoryGetInstance: MethodHandle = {
+    descriptorMessageInfoFactoryLookup.findStatic(
+      descriptorMessageInfoFactoryClass,
+      "getInstance",
+      methodType(descriptorMessageInfoFactoryClass)
+    )
+  }
+
+  private def descriptorMessageInfoFactoryMessageInfoFor: MethodHandle = {
+    descriptorMessageInfoFactoryLookup.findVirtual(
+      descriptorMessageInfoFactoryClass,
+      "messageInfoFor",
+      methodType(messageInfoClass, classOf[Class[_]])
+    )
+  }
+
+  private def descriptorMessageInfoFactoryLookup: MethodHandles.Lookup = {
+    MethodHandles.privateLookupIn(descriptorMessageInfoFactoryClass, MethodHandles.lookup())
+  }
+
+  private def descriptorMessageInfoFactoryClass: Class[_] = {
+    Class.forName(
+      "org.apache.pekko.protobufv3.internal.DescriptorMessageInfoFactory",
+      true,
+      classOf[GeneratedMessageV3].getClassLoader
+    )
+  }
+
+  private def messageInfoClass: Class[_] = {
+    Class.forName(
+      "org.apache.pekko.protobufv3.internal.MessageInfo",
+      true,
+      classOf[GeneratedMessageV3].getClassLoader
+    )
   }
 }

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/UnsafeUtilInnerAndroid32MemoryAccessorTest.scala
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/UnsafeUtilInnerAndroid32MemoryAccessorTest.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_pekko.pekko_protobuf_v3_3
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class UnsafeUtilInnerAndroid32MemoryAccessorTest {
+  @Test
+  def android32AccessorReadsStaticMapDefaultEntryDuringSchemaDiscovery(): Unit = {
+    val message: SchemaUtilMapFieldProbe = new SchemaUtilMapFieldProbe()
+
+    message.initializeEmptyMapSchema()
+
+    assertThat(message.getEntriesMap).isEmpty()
+  }
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/UnsafeUtilInnerAndroid64MemoryAccessorTest.scala
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/UnsafeUtilInnerAndroid64MemoryAccessorTest.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_pekko.pekko_protobuf_v3_3
+
+import java.lang.Void
+import java.lang.invoke.MethodHandle
+import java.lang.invoke.MethodHandles
+import java.lang.invoke.MethodType.methodType
+import java.lang.reflect.Field
+
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+import sun.misc.Unsafe
+
+class UnsafeUtilInnerAndroid64MemoryAccessorTest {
+  @Test
+  def getStaticObjectReadsStaticFieldThroughAndroid64Accessor(): Unit = {
+    val accessorClass: Class[_] = Class.forName("org.apache.pekko.protobufv3.internal.UnsafeUtil$Android64MemoryAccessor")
+    val lookup: MethodHandles.Lookup = MethodHandles.privateLookupIn(
+      accessorClass,
+      MethodHandles.lookup()
+    )
+    val constructor: MethodHandle = lookup.findConstructor(
+      accessorClass,
+      methodType(Void.TYPE, classOf[Unsafe])
+    )
+    val accessor: Object = constructor.invokeWithArguments(null.asInstanceOf[Unsafe])
+    val getStaticObject: MethodHandle = lookup.findVirtual(
+      accessorClass,
+      "getStaticObject",
+      methodType(classOf[Object], classOf[Field])
+    )
+    val field: Field = classOf[java.lang.Boolean].getField("TRUE")
+
+    val value: Object = getStaticObject.invokeWithArguments(accessor, field)
+
+    assertSame(java.lang.Boolean.TRUE, value)
+  }
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/UnsafeUtilTest.scala
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/scala/org_apache_pekko/pekko_protobuf_v3_3/UnsafeUtilTest.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_pekko.pekko_protobuf_v3_3
+
+import org.apache.pekko.protobufv3.internal.CodedOutputStream
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class UnsafeUtilTest {
+  @Test
+  def codedOutputStreamInitializesUnsafeUtilAndroidSupportChecks(): Unit = {
+    val buffer: Array[Byte] = new Array[Byte](16)
+    val output: CodedOutputStream = CodedOutputStream.newInstance(buffer)
+
+    output.writeUInt32NoTag(150)
+    output.writeBoolNoTag(true)
+    output.flush()
+
+    assertThat(buffer.take(3)).containsExactly(0x96.toByte, 0x01.toByte, 0x01.toByte)
+  }
+
+  @Test
+  def generatedMessageLiteSchemaLookupAllocatesDefaultInstanceWithUnsafe(): Unit = {
+    val message: UnsafeUtilLiteMessageProbe = new UnsafeUtilLiteMessageProbe
+
+    assertThat(message.getSerializedSize()).isZero()
+  }
+}

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/user-code-filter.json
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/user-code-filter.json
@@ -1,0 +1,16 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.pekko.protobufv3.internal.**"
+    },
+    {
+      "includeClasses" : "org_apache_pekko.pekko_protobuf_v3_3.**"
+    },
+    {
+      "includeClasses" : "libcore.io.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7964

This PR provides test fixes and new metadata for org.apache.pekko:pekko-protobuf-v3_3:2.0.0-M2, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 352173
- Cached input tokens: 4483584
- Output tokens: 31798
- Metadata entries: 71
- Test-only metadata entries: 63
- Iterations: 6
- Library coverage percentage: 11.57
- Previous library version metadata entries: 71
- Previous library version test-only metadata entries: 63
- Previous library version coverage percentage: 11.56

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `d53dba89c234933503516add40e8ede138df9a69`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.pekko:pekko-protobuf-v3_3:1.2.0: 51/51 covered calls (100.00%)
- org.apache.pekko:pekko-protobuf-v3_3:2.0.0-M2: 54/54 covered calls (100.00%)

**Reflection:**
- org.apache.pekko:pekko-protobuf-v3_3:1.2.0: 51/51 covered calls (100.00%)
- org.apache.pekko:pekko-protobuf-v3_3:2.0.0-M2: 54/54 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.pekko:pekko-protobuf-v3_3:1.2.0: 24758/211909 (11.68%)
- org.apache.pekko:pekko-protobuf-v3_3:2.0.0-M2: 24311/207731 (11.70%)

**Line:**
- org.apache.pekko:pekko-protobuf-v3_3:1.2.0: 6079/52592 (11.56%)
- org.apache.pekko:pekko-protobuf-v3_3:2.0.0-M2: 5986/51734 (11.57%)

**Method:**
- org.apache.pekko:pekko-protobuf-v3_3:1.2.0: 1352/10707 (12.63%)
- org.apache.pekko:pekko-protobuf-v3_3:2.0.0-M2: 1340/10711 (12.51%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.pekko/pekko-protobuf-v3_3/1.2.0/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/DescriptorMessageInfoFactoryProbe.java 2/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/DescriptorMessageInfoFactoryProbe.java
index fd5d32fca9..a368e99a45 100644
--- 1/tests/src/org.apache.pekko/pekko-protobuf-v3_3/1.2.0/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/DescriptorMessageInfoFactoryProbe.java
+++ 2/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/DescriptorMessageInfoFactoryProbe.java
@@ -9,10 +9,10 @@ package org_apache_pekko.pekko_protobuf_v3_3;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.pekko.protobufv3.internal.CodedInputStream;
 import org.apache.pekko.protobufv3.internal.DescriptorProtos;
 import org.apache.pekko.protobufv3.internal.Descriptors;
-import org.apache.pekko.protobufv3.internal.ExtensionRegistryLite;
+import org.apache.pekko.protobufv3.internal.DynamicMessage;
+import org.apache.pekko.protobufv3.internal.ExtensionRegistry;
 import org.apache.pekko.protobufv3.internal.GeneratedMessageV3;
 import org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException;
 import org.apache.pekko.protobufv3.internal.Message;
@@ -31,8 +31,13 @@ public final class DescriptorMessageInfoFactoryProbe extends GeneratedMessageV3
     }
 
     public void initializeEmptyPayloadSchema() throws InvalidProtocolBufferException {
-        CodedInputStream input = CodedInputStream.newInstance(new byte[0]);
-        mergeFromAndMakeImmutableInternal(input, ExtensionRegistryLite.getEmptyRegistry());
+        DynamicMessage parsed = DynamicMessage.parseFrom(
+                getDescriptorForType(),
+                new byte[0],
+                ExtensionRegistry.getEmptyRegistry());
+        if (!parsed.getAllFields().isEmpty()) {
+            throw new InvalidProtocolBufferException("Empty input produced fields");
+        }
     }
 
     public Child getMessageChoice() {
diff --git 1/tests/src/org.apache.pekko/pekko-protobuf-v3_3/1.2.0/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/ExtensionSchemasProto2Probe.java 2/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/ExtensionSchemasProto2Probe.java
index 18bb791912..0833182e51 100644
--- 1/tests/src/org.apache.pekko/pekko-protobuf-v3_3/1.2.0/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/ExtensionSchemasProto2Probe.java
+++ 2/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/ExtensionSchemasProto2Probe.java
@@ -6,13 +6,15 @@
  */
 package org_apache_pekko.pekko_protobuf_v3_3;
 
-import org.apache.pekko.protobufv3.internal.CodedInputStream;
 import org.apache.pekko.protobufv3.internal.DescriptorProtos;
 import org.apache.pekko.protobufv3.internal.Descriptors;
-import org.apache.pekko.protobufv3.internal.ExtensionRegistryLite;
+import org.apache.pekko.protobufv3.internal.DynamicMessage;
+import org.apache.pekko.protobufv3.internal.ExtensionRegistry;
+import org.apache.pekko.protobufv3.internal.GeneratedMessageLite;
 import org.apache.pekko.protobufv3.internal.GeneratedMessageV3;
 import org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException;
 import org.apache.pekko.protobufv3.internal.Message;
+import org.apache.pekko.protobufv3.internal.Parser;
 
 public final class ExtensionSchemasProto2Probe extends GeneratedMessageV3 {
     private static final ExtensionSchemasProto2Probe DEFAULT_INSTANCE = new ExtensionSchemasProto2Probe();
@@ -23,8 +25,18 @@ public final class ExtensionSchemasProto2Probe extends GeneratedMessageV3 {
     }
 
     public void initializeEmptyPayloadSchema() throws InvalidProtocolBufferException {
-        CodedInputStream input = CodedInputStream.newInstance(new byte[0]);
-        mergeFromAndMakeImmutableInternal(input, ExtensionRegistryLite.getEmptyRegistry());
+        DynamicMessage parsed = DynamicMessage.parseFrom(
+                getDescriptorForType(),
+                new byte[0],
+                ExtensionRegistry.getEmptyRegistry());
+        if (!parsed.getAllFields().isEmpty()) {
+            throw new InvalidProtocolBufferException("Empty input produced fields");
+        }
+    }
+
+    public static ExtendableLiteProbe parseExtendableLiteMessageWithUnknownField()
+            throws InvalidProtocolBufferException {
+        return ExtendableLiteProbe.parseFrom(new byte[] {8, 1});
     }
 
     @Override
@@ -57,6 +69,68 @@ public final class ExtensionSchemasProto2Probe extends GeneratedMessageV3 {
         throw new UnsupportedOperationException("Builder is not needed for schema discovery coverage");
     }
 
+    public static final class ExtendableLiteProbe
+            extends GeneratedMessageLite.ExtendableMessage<ExtendableLiteProbe, ExtendableLiteProbe.Builder> {
+        private static final ExtendableLiteProbe DEFAULT_INSTANCE;
+        private static volatile Parser<ExtendableLiteProbe> parser;
+
+        static {
+            ExtendableLiteProbe defaultInstance = new ExtendableLiteProbe();
+            DEFAULT_INSTANCE = defaultInstance;
+            registerDefaultInstance(ExtendableLiteProbe.class, defaultInstance);
+        }
+
+        private ExtendableLiteProbe() {
+        }
+
+        public static ExtendableLiteProbe getDefaultInstance() {
+            return DEFAULT_INSTANCE;
+        }
+
+        public static ExtendableLiteProbe parseFrom(byte[] data) throws InvalidProtocolBufferException {
+            return parseFrom(DEFAULT_INSTANCE, data);
+        }
+
+        @Override
+        protected Object dynamicMethod(MethodToInvoke method, Object arg0, Object arg1) {
+            switch (method) {
+                case NEW_MUTABLE_INSTANCE:
+                    return new ExtendableLiteProbe();
+                case NEW_BUILDER:
+                    return new Builder();
+                case BUILD_MESSAGE_INFO:
+                    return newMessageInfo(DEFAULT_INSTANCE, "\u0001\u0000", null);
+                case GET_DEFAULT_INSTANCE:
+                    return DEFAULT_INSTANCE;
+                case GET_PARSER:
+                    Parser<ExtendableLiteProbe> currentParser = parser;
+                    if (currentParser == null) {
+                        synchronized (ExtendableLiteProbe.class) {
+                            currentParser = parser;
+                            if (currentParser == null) {
+                                currentParser = new GeneratedMessageLite.DefaultInstanceBasedParser<>(DEFAULT_INSTANCE);
+                                parser = currentParser;
+                            }
+                        }
+                    }
+                    return currentParser;
+                case GET_MEMOIZED_IS_INITIALIZED:
+                    return (byte) 1;
+                case SET_MEMOIZED_IS_INITIALIZED:
+                    return null;
+                default:
+                    throw new UnsupportedOperationException();
+            }
+        }
+
+        public static final class Builder
+                extends GeneratedMessageLite.ExtendableBuilder<ExtendableLiteProbe, Builder> {
+            private Builder() {
+                super(DEFAULT_INSTANCE);
+            }
+        }
+    }
+
     private static Descriptors.Descriptor buildDescriptor() {
         DescriptorProtos.DescriptorProto probe = DescriptorProtos.DescriptorProto.newBuilder()
                 .setName("ExtensionSchemasProto2Probe")
diff --git 1/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/GeneratedFileProbe.java 2/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/GeneratedFileProbe.java
new file mode 100644
index 0000000000..d7b24b8948
--- /dev/null
+++ 2/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/GeneratedFileProbe.java
@@ -0,0 +1,22 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_pekko.pekko_protobuf_v3_3;
+
+import org.apache.pekko.protobufv3.internal.ExtensionRegistry;
+import org.apache.pekko.protobufv3.internal.GeneratedFile;
+
+public final class GeneratedFileProbe extends GeneratedFile {
+    private GeneratedFileProbe() {
+    }
+
+    public static void addExtensionByName(
+            ExtensionRegistry registry,
+            String className,
+            String fieldName) {
+        addOptionalExtension(registry, className, fieldName);
+    }
+}
diff --git 1/tests/src/org.apache.pekko/pekko-protobuf-v3_3/1.2.0/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/SchemaUtilMapFieldProbe.java 2/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/SchemaUtilMapFieldProbe.java
index ad62abeca3..2adcd6de99 100644
--- 1/tests/src/org.apache.pekko/pekko-protobuf-v3_3/1.2.0/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/SchemaUtilMapFieldProbe.java
+++ 2/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/src/test/java/org_apache_pekko/pekko_protobuf_v3_3/SchemaUtilMapFieldProbe.java
@@ -8,10 +8,10 @@ package org_apache_pekko.pekko_protobuf_v3_3;
 
 import java.util.Map;
 
-import org.apache.pekko.protobufv3.internal.CodedInputStream;
 import org.apache.pekko.protobufv3.internal.DescriptorProtos;
 import org.apache.pekko.protobufv3.internal.Descriptors;
-import org.apache.pekko.protobufv3.internal.ExtensionRegistryLite;
+import org.apache.pekko.protobufv3.internal.DynamicMessage;
+import org.apache.pekko.protobufv3.internal.ExtensionRegistry;
 import org.apache.pekko.protobufv3.internal.GeneratedMessageV3;
 import org.apache.pekko.protobufv3.internal.InvalidProtocolBufferException;
 import org.apache.pekko.protobufv3.internal.MapEntry;
@@ -30,8 +30,13 @@ public final class SchemaUtilMapFieldProbe extends GeneratedMessageV3 {
     }
 
     public void initializeEmptyMapSchema() throws InvalidProtocolBufferException {
-        CodedInputStream input = CodedInputStream.newInstance(new byte[0]);
-        mergeFromAndMakeImmutableInternal(input, ExtensionRegistryLite.getEmptyRegistry());
+        DynamicMessage parsed = DynamicMessage.parseFrom(
+                getDescriptorForType(),
+                new byte[0],
+                ExtensionRegistry.getEmptyRegistry());
+        if (!parsed.getAllFields().isEmpty()) {
+            throw new InvalidProtocolBufferException("Empty input produced fields");
+        }
     }
 
     public Map<String, String> getEntriesMap() {

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
