### PR TITLE
[GenAI] Test fix for org.apache.logging.log4j:log4j-1.2-api:2.18.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.logging.log4j/log4j-1.2-api/2.18.0/reachability-metadata.json
+++ b/metadata/org.apache.logging.log4j/log4j-1.2-api/2.18.0/reachability-metadata.json
@@ -34,7 +34,16 @@
       "condition" : {
         "typeReached" : "org.apache.logging.log4j.util.ServiceLoaderUtil"
       },
-      "type" : "java.util.ServiceLoader"
+      "type" : "java.util.ServiceLoader",
+      "methods" : [
+        {
+          "name" : "load",
+          "parameterTypes" : [
+            "java.lang.Class",
+            "java.lang.ClassLoader"
+          ]
+        }
+      ]
     },
     {
       "condition" : {
@@ -44,13 +53,25 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.logging.log4j.LogManager"
+      },
+      "type" : "org.apache.logging.log4j.core.impl.Log4jContextFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.logging.log4j.spi.AbstractLogger"
       },
       "type" : "org.apache.logging.log4j.message.DefaultFlowMessageFactory",
       "methods" : [
         {
           "name" : "<init>",
-          "parameterTypes" : []
+          "parameterTypes" : [ ]
         }
       ]
     },
@@ -74,7 +95,7 @@
       "methods" : [
         {
           "name" : "<init>",
-          "parameterTypes" : []
+          "parameterTypes" : [ ]
         }
       ]
     },
@@ -1150,7 +1171,15 @@
       "condition" : {
         "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
       },
-      "type" : "org.apache.logging.log4j.core.pattern.DatePatternConverter"
+      "type" : "org.apache.logging.log4j.core.pattern.DatePatternConverter",
+      "methods" : [
+        {
+          "name" : "newInstance",
+          "parameterTypes" : [
+            "java.lang.String[]"
+          ]
+        }
+      ]
     },
     {
       "condition" : {
@@ -1216,7 +1245,15 @@
       "condition" : {
         "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
       },
-      "type" : "org.apache.logging.log4j.core.pattern.LevelPatternConverter"
+      "type" : "org.apache.logging.log4j.core.pattern.LevelPatternConverter",
+      "methods" : [
+        {
+          "name" : "newInstance",
+          "parameterTypes" : [
+            "java.lang.String[]"
+          ]
+        }
+      ]
     },
     {
       "condition" : {
@@ -1228,7 +1265,15 @@
       "condition" : {
         "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
       },
-      "type" : "org.apache.logging.log4j.core.pattern.LineSeparatorPatternConverter"
+      "type" : "org.apache.logging.log4j.core.pattern.LineSeparatorPatternConverter",
+      "methods" : [
+        {
+          "name" : "newInstance",
+          "parameterTypes" : [
+            "java.lang.String[]"
+          ]
+        }
+      ]
     },
     {
       "condition" : {
@@ -1240,7 +1285,15 @@
       "condition" : {
         "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
       },
-      "type" : "org.apache.logging.log4j.core.pattern.LoggerPatternConverter"
+      "type" : "org.apache.logging.log4j.core.pattern.LoggerPatternConverter",
+      "methods" : [
+        {
+          "name" : "newInstance",
+          "parameterTypes" : [
+            "java.lang.String[]"
+          ]
+        }
+      ]
     },
     {
       "condition" : {
@@ -1252,7 +1305,15 @@
       "condition" : {
         "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
       },
-      "type" : "org.apache.logging.log4j.core.pattern.MarkerPatternConverter"
+      "type" : "org.apache.logging.log4j.core.pattern.MarkerPatternConverter",
+      "methods" : [
+        {
+          "name" : "newInstance",
+          "parameterTypes" : [
+            "java.lang.String[]"
+          ]
+        }
+      ]
     },
     {
       "condition" : {
@@ -1270,13 +1331,30 @@
       "condition" : {
         "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
       },
-      "type" : "org.apache.logging.log4j.core.pattern.MdcPatternConverter"
+      "type" : "org.apache.logging.log4j.core.pattern.MdcPatternConverter",
+      "methods" : [
+        {
+          "name" : "newInstance",
+          "parameterTypes" : [
+            "java.lang.String[]"
+          ]
+        }
+      ]
     },
     {
       "condition" : {
         "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
       },
-      "type" : "org.apache.logging.log4j.core.pattern.MessagePatternConverter"
+      "type" : "org.apache.logging.log4j.core.pattern.MessagePatternConverter",
+      "methods" : [
+        {
+          "name" : "newInstance",
+          "parameterTypes" : [
+            "org.apache.logging.log4j.core.config.Configuration",
+            "java.lang.String[]"
+          ]
+        }
+      ]
     },
     {
       "condition" : {
@@ -1354,7 +1432,15 @@
       "condition" : {
         "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
       },
-      "type" : "org.apache.logging.log4j.core.pattern.ThreadNamePatternConverter"
+      "type" : "org.apache.logging.log4j.core.pattern.ThreadNamePatternConverter",
+      "methods" : [
+        {
+          "name" : "newInstance",
+          "parameterTypes" : [
+            "java.lang.String[]"
+          ]
+        }
+      ]
     },
     {
       "condition" : {
@@ -1366,7 +1452,16 @@
       "condition" : {
         "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
       },
-      "type" : "org.apache.logging.log4j.core.pattern.ThrowablePatternConverter"
+      "type" : "org.apache.logging.log4j.core.pattern.ThrowablePatternConverter",
+      "methods" : [
+        {
+          "name" : "newInstance",
+          "parameterTypes" : [
+            "org.apache.logging.log4j.core.config.Configuration",
+            "java.lang.String[]"
+          ]
+        }
+      ]
     },
     {
       "condition" : {
@@ -1480,7 +1575,16 @@
       "condition" : {
         "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
       },
-      "type" : "org.apache.log4j.builders.appender.ConsoleAppenderBuilder"
+      "type" : "org.apache.log4j.builders.appender.ConsoleAppenderBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "java.util.Properties"
+          ]
+        }
+      ]
     },
     {
       "condition" : {
@@ -1564,7 +1668,16 @@
       "condition" : {
         "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
       },
-      "type" : "org.apache.log4j.builders.layout.PatternLayoutBuilder"
+      "type" : "org.apache.log4j.builders.layout.PatternLayoutBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "java.util.Properties"
+          ]
+        }
+      ]
     },
     {
       "condition" : {
@@ -1606,7 +1719,13 @@
       "condition" : {
         "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
       },
-      "type" : "org.apache.log4j.config.PropertiesConfigurationFactory"
+      "type" : "org.apache.log4j.config.PropertiesConfigurationFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
     },
     {
       "condition" : {
@@ -1652,46 +1771,109 @@
     },
     {
       "condition" : {
-        "typeReached" : "org.apache.log4j.jmx.AppenderDynamicMBean"
+        "typeReached" : "org.apache.log4j.AppenderSkeleton"
       },
       "type" : "org.apache.log4j.jmx.AppenderDynamicMBean",
       "allPublicConstructors" : true
     },
     {
       "condition" : {
-        "typeReached" : "org.apache.log4j.jmx.AppenderDynamicMBean"
+        "typeReached" : "org.apache.log4j.AppenderSkeleton"
       },
       "type" : "org.apache.log4j.ConsoleAppenderBeanInfo"
     },
     {
       "condition" : {
-        "typeReached" : "org.apache.log4j.jmx.AppenderDynamicMBean"
+        "typeReached" : "org.apache.log4j.AppenderSkeleton"
+      },
+      "type" : "org.apache.log4j.ConsoleAppender",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log4j.AppenderSkeleton"
+      },
+      "type" : "org.apache.log4j.ConsoleAppender",
+      "methods" : [
+        {
+          "name" : "setTarget",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log4j.AppenderSkeleton"
       },
       "type" : "org.apache.log4j.WriterAppenderBeanInfo"
     },
     {
       "condition" : {
-        "typeReached" : "org.apache.log4j.jmx.AppenderDynamicMBean"
+        "typeReached" : "org.apache.log4j.AppenderSkeleton"
+      },
+      "type" : "org.apache.log4j.WriterAppender",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log4j.AppenderSkeleton"
       },
       "type" : "org.apache.log4j.AppenderSkeletonBeanInfo"
     },
     {
       "condition" : {
-        "typeReached" : "org.apache.log4j.jmx.AppenderDynamicMBean"
+        "typeReached" : "org.apache.log4j.AppenderSkeleton"
+      },
+      "type" : "org.apache.log4j.AppenderSkeleton",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log4j.AppenderSkeleton"
       },
       "type" : "org.apache.log4j.ConsoleAppenderCustomizer"
     },
     {
       "condition" : {
-        "typeReached" : "org.apache.log4j.jmx.AppenderDynamicMBean"
+        "typeReached" : "org.apache.log4j.AppenderSkeleton"
       },
       "type" : "org.apache.log4j.WriterAppenderCustomizer"
     },
     {
       "condition" : {
-        "typeReached" : "org.apache.log4j.jmx.AppenderDynamicMBean"
+        "typeReached" : "org.apache.log4j.AppenderSkeleton"
       },
       "type" : "org.apache.log4j.AppenderSkeletonCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log4j.PatternLayout"
+      },
+      "type" : "org.apache.log4j.jmx.LayoutDynamicMBean",
+      "allPublicConstructors" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log4j.PatternLayout"
+      },
+      "type" : "org.apache.log4j.PatternLayout",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log4j.Logger"
+      },
+      "type" : "org.apache.log4j.jmx.LoggerDynamicMBean",
+      "allPublicConstructors" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log4j.LogManager"
+      },
+      "type" : "org.apache.log4j.jmx.HierarchyDynamicMBean",
+      "allPublicConstructors" : true
     },
     {
       "condition" : {
@@ -1889,7 +2071,13 @@
       "condition" : {
         "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
       },
-      "type" : "org.apache.log4j.xml.XmlConfigurationFactory"
+      "type" : "org.apache.log4j.xml.XmlConfigurationFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
     },
     {
       "condition" : {
@@ -1901,11 +2089,97 @@
       "condition" : {
         "typeReached" : "org.apache.logging.log4j.core.util.ReflectionUtil"
       },
+      "type" : "org.apache.logging.log4j.core.config.json.JsonConfigurationFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.util.ReflectionUtil"
+      },
+      "type" : "org.apache.logging.log4j.core.config.properties.PropertiesConfigurationFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.util.ReflectionUtil"
+      },
+      "type" : "org.apache.logging.log4j.core.config.xml.XmlConfigurationFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.util.ReflectionUtil"
+      },
+      "type" : "org.apache.logging.log4j.core.config.yaml.YamlConfigurationFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.util.ReflectionUtil"
+      },
       "type" : "org.apache.logging.log4j.core.lookup.ContextMapLookup",
       "methods" : [
         {
           "name" : "<init>",
-          "parameterTypes" : []
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.util.Loader"
+      },
+      "type" : "com.fasterxml.jackson.core.JsonParser"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.util.Loader"
+      },
+      "type" : "com.fasterxml.jackson.databind.JsonNode"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.util.Loader"
+      },
+      "type" : "com.fasterxml.jackson.databind.ObjectMapper"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.util.Loader"
+      },
+      "type" : "com.fasterxml.jackson.dataformat.yaml.YAMLFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.pattern.PatternParser"
+      },
+      "type" : "org.apache.log4j.pattern.Log4j1LevelPatternConverter",
+      "methods" : [
+        {
+          "name" : "newInstance",
+          "parameterTypes" : [
+            "java.lang.String[]"
+          ]
         }
       ]
     },
@@ -1917,7 +2191,7 @@
       "methods" : [
         {
           "name" : "<init>",
-          "parameterTypes" : []
+          "parameterTypes" : [ ]
         }
       ]
     },
@@ -1929,7 +2203,7 @@
       "methods" : [
         {
           "name" : "<init>",
-          "parameterTypes" : []
+          "parameterTypes" : [ ]
         }
       ]
     },
@@ -1941,7 +2215,7 @@
       "methods" : [
         {
           "name" : "<init>",
-          "parameterTypes" : []
+          "parameterTypes" : [ ]
         }
       ]
     },
@@ -1953,7 +2227,7 @@
       "methods" : [
         {
           "name" : "<init>",
-          "parameterTypes" : []
+          "parameterTypes" : [ ]
         }
       ]
     },
@@ -1965,7 +2239,7 @@
       "methods" : [
         {
           "name" : "<init>",
-          "parameterTypes" : []
+          "parameterTypes" : [ ]
         }
       ]
     },
@@ -1977,7 +2251,7 @@
       "methods" : [
         {
           "name" : "<init>",
-          "parameterTypes" : []
+          "parameterTypes" : [ ]
         }
       ]
     },
@@ -1989,7 +2263,7 @@
       "methods" : [
         {
           "name" : "<init>",
-          "parameterTypes" : []
+          "parameterTypes" : [ ]
         }
       ]
     },
@@ -2001,7 +2275,7 @@
       "methods" : [
         {
           "name" : "<init>",
-          "parameterTypes" : []
+          "parameterTypes" : [ ]
         }
       ]
     },
@@ -2013,7 +2287,7 @@
       "methods" : [
         {
           "name" : "<init>",
-          "parameterTypes" : []
+          "parameterTypes" : [ ]
         }
       ]
     },
@@ -2025,7 +2299,7 @@
       "methods" : [
         {
           "name" : "<init>",
-          "parameterTypes" : []
+          "parameterTypes" : [ ]
         }
       ]
     },
@@ -2037,7 +2311,7 @@
       "methods" : [
         {
           "name" : "<init>",
-          "parameterTypes" : []
+          "parameterTypes" : [ ]
         }
       ]
     },
@@ -2049,7 +2323,7 @@
       "methods" : [
         {
           "name" : "<init>",
-          "parameterTypes" : []
+          "parameterTypes" : [ ]
         }
       ]
     },
@@ -2061,7 +2335,7 @@
       "methods" : [
         {
           "name" : "<init>",
-          "parameterTypes" : []
+          "parameterTypes" : [ ]
         }
       ]
     },
@@ -2073,7 +2347,7 @@
       "methods" : [
         {
           "name" : "<init>",
-          "parameterTypes" : []
+          "parameterTypes" : [ ]
         }
       ]
     },
@@ -2085,7 +2359,7 @@
       "methods" : [
         {
           "name" : "<init>",
-          "parameterTypes" : []
+          "parameterTypes" : [ ]
         }
       ]
     },
@@ -2109,19 +2383,61 @@
     },
     {
       "condition" : {
-        "typeReached" : "org.apache.log4j.jmx.AppenderDynamicMBean"
+        "typeReached" : "org.apache.log4j.config.PropertySetter"
+      },
+      "type" : "org.apache.log4j.ConsoleAppender",
+      "methods" : [
+        {
+          "name" : "setTarget",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log4j.config.PropertySetter"
+      },
+      "type" : "org.apache.log4j.WriterAppender",
+      "methods" : [
+        {
+          "name" : "setImmediateFlush",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log4j.config.PropertySetter"
+      },
+      "type" : "org.apache.log4j.PatternLayout",
+      "methods" : [
+        {
+          "name" : "setConversionPattern",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log4j.AppenderSkeleton"
       },
       "type" : "java.lang.Object"
     },
     {
       "condition" : {
-        "typeReached" : "org.apache.log4j.jmx.AppenderDynamicMBean"
+        "typeReached" : "org.apache.log4j.AppenderSkeleton"
       },
       "type" : "java.lang.ObjectBeanInfo"
     },
     {
       "condition" : {
-        "typeReached" : "org.apache.log4j.jmx.AppenderDynamicMBean"
+        "typeReached" : "org.apache.log4j.AppenderSkeleton"
       },
       "type" : "java.lang.ObjectCustomizer"
     }
@@ -2185,13 +2501,43 @@
       "condition" : {
         "typeReached" : "org.apache.logging.log4j.util.LoaderUtil"
       },
-      "glob" : "log4j2.component.properties"
+      "glob" : "log4j2.system.properties"
     },
     {
       "condition" : {
-        "typeReached" : "org.apache.logging.log4j.util.LoaderUtil"
+        "typeReached" : "org.apache.logging.log4j.core.config.ConfigurationSource"
       },
-      "glob" : "log4j2.system.properties"
+      "glob" : "log4j2*.json"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.ConfigurationSource"
+      },
+      "glob" : "log4j2*.jsn"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.ConfigurationSource"
+      },
+      "glob" : "log4j2*.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.ConfigurationSource"
+      },
+      "glob" : "log4j2*.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.ConfigurationSource"
+      },
+      "glob" : "log4j2*.yaml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.ConfigurationSource"
+      },
+      "glob" : "log4j2*.yml"
     }
   ]
 }

--- a/metadata/org.apache.logging.log4j/log4j-1.2-api/2.18.0/reachability-metadata.json
+++ b/metadata/org.apache.logging.log4j/log4j-1.2-api/2.18.0/reachability-metadata.json
@@ -50,7 +50,7 @@
       "methods" : [
         {
           "name" : "<init>",
-          "parameterTypes" : [ ]
+          "parameterTypes" : []
         }
       ]
     },
@@ -74,7 +74,7 @@
       "methods" : [
         {
           "name" : "<init>",
-          "parameterTypes" : [ ]
+          "parameterTypes" : []
         }
       ]
     },
@@ -98,6 +98,1999 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.db.jdbc.JdbcAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.mom.jeromq.JeroMqAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.AppenderSet"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.AsyncAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.ConsoleAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.CountingNoOpAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.FailoverAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.FailoversPlugin"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.FileAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.HttpAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.MemoryMappedFileAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.NullAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.OutputStreamAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.RandomAccessFileAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.RollingFileAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.RollingRandomAccessFileAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.ScriptAppenderSelector"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.SmtpAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.SocketAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.SyslogAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.WriterAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.db.ColumnMapping"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.db.jdbc.ColumnConfig"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.db.jdbc.DataSourceConnectionSource"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.db.jdbc.DriverManagerConnectionSource"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.db.jdbc.FactoryMethodConnectionSource"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.mom.JmsAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.mom.kafka.KafkaAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.nosql.NoSqlAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.rewrite.LoggerNameLevelRewritePolicy"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.rewrite.MapRewritePolicy"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.rewrite.PropertiesRewritePolicy"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.rewrite.RewriteAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.rolling.CompositeTriggeringPolicy"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.rolling.CronTriggeringPolicy"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.rolling.DefaultRolloverStrategy"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.rolling.DirectWriteRolloverStrategy"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.rolling.NoOpTriggeringPolicy"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.rolling.OnStartupTriggeringPolicy"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.rolling.SizeBasedTriggeringPolicy"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.rolling.TimeBasedTriggeringPolicy"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.rolling.action.DeleteAction"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.rolling.action.IfAccumulatedFileCount"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.rolling.action.IfAccumulatedFileSize"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.rolling.action.IfAll"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.rolling.action.IfAny"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.rolling.action.IfFileName"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.rolling.action.IfLastModified"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.rolling.action.IfNot"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.rolling.action.PathSortByModificationTime"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.rolling.action.PosixViewAttributeAction"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.rolling.action.ScriptCondition"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.routing.IdlePurgePolicy"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.routing.Route"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.routing.Routes"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.appender.routing.RoutingAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.async.ArrayBlockingQueueFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.async.AsyncLoggerConfig"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.async.AsyncLoggerConfig$RootLogger"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.async.AsyncWaitStrategyFactoryConfig"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.async.DisruptorBlockingQueueFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.async.LinkedTransferQueueFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.AppenderRef"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.AppendersPlugin"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.CustomLevelConfig"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.CustomLevels"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.DefaultAdvertiser"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.HttpWatcher"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.LoggerConfig"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.LoggerConfig$RootLogger"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.LoggersPlugin"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.PropertiesPlugin"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.Property"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.ScriptsPlugin"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.arbiters.ClassArbiter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.arbiters.DefaultArbiter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.arbiters.ScriptArbiter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.arbiters.SelectArbiter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.arbiters.SystemPropertyArbiter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.json.JsonConfigurationFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.plugins.convert.TypeConverters$BigDecimalConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.plugins.convert.TypeConverters$BigIntegerConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.plugins.convert.TypeConverters$BooleanConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.plugins.convert.TypeConverters$ByteArrayConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.plugins.convert.TypeConverters$ByteConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.plugins.convert.TypeConverters$CharArrayConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.plugins.convert.TypeConverters$CharacterConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.plugins.convert.TypeConverters$CharsetConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.plugins.convert.TypeConverters$ClassConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.plugins.convert.TypeConverters$CronExpressionConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.plugins.convert.TypeConverters$DoubleConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.plugins.convert.TypeConverters$DurationConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.plugins.convert.TypeConverters$FileConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.plugins.convert.TypeConverters$FloatConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.plugins.convert.TypeConverters$InetAddressConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.plugins.convert.TypeConverters$IntegerConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.plugins.convert.TypeConverters$LevelConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.plugins.convert.TypeConverters$LongConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.plugins.convert.TypeConverters$PathConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.plugins.convert.TypeConverters$PatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.plugins.convert.TypeConverters$SecurityProviderConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.plugins.convert.TypeConverters$ShortConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.plugins.convert.TypeConverters$StringConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.plugins.convert.TypeConverters$UriConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.plugins.convert.TypeConverters$UrlConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.plugins.convert.TypeConverters$UuidConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.properties.PropertiesConfigurationFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.xml.XmlConfigurationFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.config.yaml.YamlConfigurationFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.filter.BurstFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.filter.CompositeFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.filter.DenyAllFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.filter.DynamicThresholdFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.filter.LevelMatchFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.filter.LevelRangeFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.filter.MapFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.filter.MarkerFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.filter.MutableThreadContextMapFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.filter.NoMarkerFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.filter.RegexFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.filter.ScriptFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.filter.StringMatchFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.filter.StructuredDataFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.filter.ThreadContextMapFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.filter.ThresholdFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.filter.TimeFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.layout.CsvLogEventLayout"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.layout.CsvParameterLayout"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.layout.GelfLayout"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.layout.HtmlLayout"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.layout.JsonLayout"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.layout.LevelPatternSelector"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.layout.LoggerFields"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.layout.MarkerPatternSelector"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.layout.MessageLayout"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.layout.PatternLayout"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.layout.PatternMatch"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.layout.Rfc5424Layout"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.layout.ScriptPatternSelector"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.layout.SerializedLayout"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.layout.SyslogLayout"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.layout.XmlLayout"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.layout.YamlLayout"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.lookup.ContextMapLookup"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.lookup.DateLookup"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.lookup.EnvironmentLookup"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.lookup.EventLookup"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.lookup.JavaLookup"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.lookup.JmxRuntimeInputArgumentsLookup"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.lookup.JndiLookup"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.lookup.Log4jLookup"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.lookup.LowerLookup"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.lookup.MainMapLookup"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.lookup.MapLookup"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.lookup.MarkerLookup"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.lookup.ResourceBundleLookup"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.lookup.StructuredDataLookup"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.lookup.SystemPropertiesLookup"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.lookup.UpperLookup"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.net.MulticastDnsAdvertiser"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.net.SocketAddress"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.net.SocketOptions"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.net.SocketPerformancePreferences"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.net.ssl.KeyStoreConfiguration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.net.ssl.SslConfiguration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.net.ssl.TrustStoreConfiguration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.AbstractStyleNameConverter$Black"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.AbstractStyleNameConverter$Blue"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.AbstractStyleNameConverter$Cyan"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.AbstractStyleNameConverter$Green"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.AbstractStyleNameConverter$Magenta"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.AbstractStyleNameConverter$Red"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.AbstractStyleNameConverter$White"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.AbstractStyleNameConverter$Yellow"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.ClassNamePatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.DatePatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.EncodingPatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.EndOfBatchPatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.EqualsIgnoreCaseReplacementConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.EqualsReplacementConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.ExtendedThrowablePatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.FileDatePatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.FileLocationPatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.FullLocationPatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.HighlightConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.IntegerPatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.LevelPatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.LineLocationPatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.LineSeparatorPatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.LoggerFqcnPatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.LoggerPatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.MapPatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.MarkerPatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.MarkerSimpleNamePatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.MaxLengthConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.MdcPatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.MessagePatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.MethodLocationPatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.NanoTimePatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.NdcPatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.ProcessIdPatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.RegexReplacement"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.RegexReplacementConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.RelativeTimePatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.RepeatPatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.RootThrowablePatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.SequenceNumberPatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.StyleConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.ThreadIdPatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.ThreadNamePatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.ThreadPriorityPatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.ThrowablePatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.UuidPatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.pattern.VariablesNotEmptyReplacementConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.script.Script"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.script.ScriptFile"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.script.ScriptRef"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.util.KeyValuePair"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.AsyncAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.ConsoleAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.DailyRollingFileAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.EnhancedPatternLayout"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.FileAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.HTMLLayout"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.PatternLayout"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.RollingFileAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.SimpleLayout"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.TTCCLayout"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.asyncappender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.builders.appender.AsyncAppenderBuilder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.builders.appender.ConsoleAppenderBuilder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.builders.appender.DailyRollingFileAppenderBuilder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.builders.appender.EnhancedRollingFileAppenderBuilder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.builders.appender.FileAppenderBuilder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.builders.appender.NullAppenderBuilder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.builders.appender.RewriteAppenderBuilder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.builders.appender.RollingFileAppenderBuilder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.builders.appender.SocketAppenderBuilder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.builders.appender.SyslogAppenderBuilder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.builders.filter.DenyAllFilterBuilder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.builders.filter.LevelMatchFilterBuilder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.builders.filter.LevelRangeFilterBuilder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.builders.filter.StringMatchFilterBuilder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.builders.layout.HtmlLayoutBuilder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.builders.layout.PatternLayoutBuilder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.builders.layout.SimpleLayoutBuilder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.builders.layout.TTCCLayoutBuilder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.builders.layout.XmlLayoutBuilder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.builders.rolling.CompositeTriggeringPolicyBuilder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.builders.rolling.SizeBasedTriggeringPolicyBuilder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.builders.rolling.TimeBasedRollingPolicyBuilder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.config.PropertiesConfigurationFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.consoleappender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.dailyrollingfileappender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.enhancedpatternlayout"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.fileappender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.htmllayout"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.layout.Log4j1SyslogLayout"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.layout.Log4j1XmlLayout"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log4j.jmx.AppenderDynamicMBean"
+      },
+      "type" : "org.apache.log4j.jmx.AppenderDynamicMBean",
+      "allPublicConstructors" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log4j.jmx.AppenderDynamicMBean"
+      },
+      "type" : "org.apache.log4j.ConsoleAppenderBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log4j.jmx.AppenderDynamicMBean"
+      },
+      "type" : "org.apache.log4j.WriterAppenderBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log4j.jmx.AppenderDynamicMBean"
+      },
+      "type" : "org.apache.log4j.AppenderSkeletonBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log4j.jmx.AppenderDynamicMBean"
+      },
+      "type" : "org.apache.log4j.ConsoleAppenderCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log4j.jmx.AppenderDynamicMBean"
+      },
+      "type" : "org.apache.log4j.WriterAppenderCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log4j.jmx.AppenderDynamicMBean"
+      },
+      "type" : "org.apache.log4j.AppenderSkeletonCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.net.SocketAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.net.SyslogAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.net.socketappender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.net.syslogappender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.pattern.Log4j1LevelPatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.pattern.Log4j1MdcPatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.pattern.Log4j1NdcPatternConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.patternlayout"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.rewrite.RewriteAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.rewrite.rewriteappender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.rolling.CompositeTriggeringPolicy"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.rolling.RollingFileAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.rolling.SizeBasedTriggeringPolicy"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.rolling.TimeBasedRollingPolicy"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.rolling.compositetriggeringpolicy"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.rolling.rollingfileappender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.rolling.sizebasedtriggeringpolicy"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.rolling.timebasedrollingpolicy"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.rollingfileappender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.simplelayout"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.ttcclayout"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.varia.DenyAllFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.varia.LevelMatchFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.varia.LevelRangeFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.varia.NullAppender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.varia.StringMatchFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.varia.denyallfilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.varia.levelmatchfilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.varia.levelrangefilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.varia.nullappender"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.varia.stringmatchfilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.xml.XMLLayout"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.xml.XmlConfigurationFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.log4j.xml.xmllayout"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.util.ReflectionUtil"
+      },
+      "type" : "org.apache.logging.log4j.core.lookup.ContextMapLookup",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : []
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.util.ReflectionUtil"
+      },
+      "type" : "org.apache.logging.log4j.core.lookup.DateLookup",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : []
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.util.ReflectionUtil"
+      },
+      "type" : "org.apache.logging.log4j.core.lookup.EnvironmentLookup",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : []
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.util.ReflectionUtil"
+      },
+      "type" : "org.apache.logging.log4j.core.lookup.EventLookup",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : []
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.util.ReflectionUtil"
+      },
+      "type" : "org.apache.logging.log4j.core.lookup.JavaLookup",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : []
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.util.ReflectionUtil"
+      },
+      "type" : "org.apache.logging.log4j.core.lookup.JmxRuntimeInputArgumentsLookup",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : []
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.util.ReflectionUtil"
+      },
+      "type" : "org.apache.logging.log4j.core.lookup.JndiLookup",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : []
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.util.ReflectionUtil"
+      },
+      "type" : "org.apache.logging.log4j.core.lookup.Log4jLookup",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : []
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.util.ReflectionUtil"
+      },
+      "type" : "org.apache.logging.log4j.core.lookup.LowerLookup",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : []
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.util.ReflectionUtil"
+      },
+      "type" : "org.apache.logging.log4j.core.lookup.MainMapLookup",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : []
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.util.ReflectionUtil"
+      },
+      "type" : "org.apache.logging.log4j.core.lookup.MapLookup",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : []
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.util.ReflectionUtil"
+      },
+      "type" : "org.apache.logging.log4j.core.lookup.MarkerLookup",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : []
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.util.ReflectionUtil"
+      },
+      "type" : "org.apache.logging.log4j.core.lookup.ResourceBundleLookup",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : []
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.util.ReflectionUtil"
+      },
+      "type" : "org.apache.logging.log4j.core.lookup.StructuredDataLookup",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : []
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.util.ReflectionUtil"
+      },
+      "type" : "org.apache.logging.log4j.core.lookup.SystemPropertiesLookup",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : []
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.util.ReflectionUtil"
+      },
+      "type" : "org.apache.logging.log4j.core.lookup.UpperLookup",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : []
+        }
+      ]
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.log4j.config.PropertySetter"
       },
       "type" : "java.lang.Object"
@@ -113,6 +2106,24 @@
         "typeReached" : "org.apache.log4j.config.PropertySetter"
       },
       "type" : "java.lang.ObjectCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log4j.jmx.AppenderDynamicMBean"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log4j.jmx.AppenderDynamicMBean"
+      },
+      "type" : "java.lang.ObjectBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log4j.jmx.AppenderDynamicMBean"
+      },
+      "type" : "java.lang.ObjectCustomizer"
     }
   ],
   "resources" : [
@@ -121,6 +2132,18 @@
         "typeReached" : "org.apache.log4j.helpers.Loader"
       },
       "glob" : "org_apache_logging_log4j/log4j_1_2_api/missing-loader-resource.txt"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.util.ProviderUtil"
+      },
+      "glob" : "META-INF/log4j-provider.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.util.LoaderUtil"
+      },
+      "glob" : "log4j2.simplelog.properties"
     },
     {
       "condition" : {

--- a/metadata/org.apache.logging.log4j/log4j-1.2-api/2.18.0/reachability-metadata.json
+++ b/metadata/org.apache.logging.log4j/log4j-1.2-api/2.18.0/reachability-metadata.json
@@ -1,0 +1,174 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.util.EnvironmentPropertySource"
+      },
+      "type" : "byte[][]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.util.LoaderUtil"
+      },
+      "type" : "jakarta.servlet.Servlet"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.util.LoaderUtil"
+      },
+      "type" : "java.lang.ClassLoader[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.util.LoaderUtil"
+      },
+      "type" : "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.util.ServiceLoaderUtil"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.util.ServiceLoaderUtil"
+      },
+      "type" : "java.util.ServiceLoader"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.util.LoaderUtil"
+      },
+      "type" : "javax.servlet.Servlet"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.spi.AbstractLogger"
+      },
+      "type" : "org.apache.logging.log4j.message.DefaultFlowMessageFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.util.LoaderUtil"
+      },
+      "type" : "org.apache.logging.log4j.message.DefaultFlowMessageFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.util.LoaderUtil"
+      },
+      "type" : "org.apache.logging.log4j.message.ReusableMessageFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.spi.AbstractLogger"
+      },
+      "type" : "org.apache.logging.log4j.message.ReusableMessageFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.util.PropertiesUtil$Environment"
+      },
+      "type" : "org.apache.logging.log4j.util.EnvironmentPropertySource"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.util.PropertiesUtil$Environment"
+      },
+      "type" : "org.apache.logging.log4j.util.SystemPropertiesPropertySource"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "type" : "org.apache.logging.log4j.core.async.JCToolsBlockingQueueFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log4j.config.PropertySetter"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log4j.config.PropertySetter"
+      },
+      "type" : "java.lang.ObjectBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log4j.config.PropertySetter"
+      },
+      "type" : "java.lang.ObjectCustomizer"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log4j.helpers.Loader"
+      },
+      "glob" : "org_apache_logging_log4j/log4j_1_2_api/missing-loader-resource.txt"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.LogManager"
+      },
+      "glob" : "META-INF/services/org.apache.logging.log4j.spi.Provider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.impl.ThreadContextDataInjector"
+      },
+      "glob" : "META-INF/services/org.apache.logging.log4j.core.util.ContextDataProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.util.LoaderUtil"
+      },
+      "glob" : "META-INF/services/org.apache.logging.log4j.util.PropertySource"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.core.config.plugins.util.PluginRegistry"
+      },
+      "glob" : "META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.util.LoaderUtil"
+      },
+      "glob" : "log4j2.StatusLogger.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log4j.xml.Log4jEntityResolver"
+      },
+      "glob" : "org/apache/log4j/xml/log4j.dtd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.util.LoaderUtil"
+      },
+      "glob" : "log4j2.component.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.util.LoaderUtil"
+      },
+      "glob" : "log4j2.system.properties"
+    }
+  ]
+}

--- a/metadata/org.apache.logging.log4j/log4j-1.2-api/index.json
+++ b/metadata/org.apache.logging.log4j/log4j-1.2-api/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.18.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-1.2-api/$version$/log4j-1.2-api-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/logging-log4j2",
+    "test-code-url" : "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-1.2-api/$version$/log4j-1.2-api-$version$-test-sources.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-1.2-api/$version$/log4j-1.2-api-$version$-javadoc.jar",
+    "description" : "Apache Log4j 1.2 API provides a compatibility layer that implements the legacy Log4j 1.x API on top of Log4j 2. It lets applications and libraries compiled against Log4j 1.x continue to run with Log4j 2 while routing logging through the Log4j 2 API and core implementation.",
     "tested-versions" : [
       "2.18.0"
     ],

--- a/metadata/org.apache.logging.log4j/log4j-1.2-api/index.json
+++ b/metadata/org.apache.logging.log4j/log4j-1.2-api/index.json
@@ -1,6 +1,16 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.18.0",
+    "tested-versions" : [
+      "2.18.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.log4j",
+      "org.apache.logging.log4j"
+    ]
+  },
+  {
     "metadata-version" : "2.17.2",
     "source-code-url" : "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-1.2-api/$version$/log4j-1.2-api-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/logging-log4j2",

--- a/stats/org.apache.logging.log4j/log4j-1.2-api/2.18.0/execution-metrics.json
+++ b/stats/org.apache.logging.log4j/log4j-1.2-api/2.18.0/execution-metrics.json
@@ -1,0 +1,100 @@
+{
+  "fix_java_run_fail:2026-06-06": {
+    "timestamp": "2026-06-06T10:22:24.463174Z",
+    "library": "org.apache.logging.log4j:log4j-1.2-api:2.18.0",
+    "starting_commit": "371f67ba8a869c82581b4133d5234d57bafc7242",
+    "ending_commit": "a7114acaea9a3799d85197cf15aec145e17587ae",
+    "previous_library": "org.apache.logging.log4j:log4j-1.2-api:2.17.2",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.18.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4069,
+          "missed": 20742,
+          "ratio": 0.164,
+          "total": 24811
+        },
+        "line": {
+          "covered": 984,
+          "missed": 5007,
+          "ratio": 0.164246,
+          "total": 5991
+        },
+        "method": {
+          "covered": 258,
+          "missed": 1060,
+          "ratio": 0.195751,
+          "total": 1318
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.17.2",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 6,
+            "totalCalls": 6
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 10,
+        "totalCalls": 10
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 663,
+          "missed": 20215,
+          "ratio": 0.031756,
+          "total": 20878
+        },
+        "line": {
+          "covered": 155,
+          "missed": 5010,
+          "ratio": 0.03001,
+          "total": 5165
+        },
+        "method": {
+          "covered": 29,
+          "missed": 1149,
+          "ratio": 0.024618,
+          "total": 1178
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 428381,
+      "cached_input_tokens_used": 3982336,
+      "output_tokens_used": 42871,
+      "iterations": 12,
+      "cost_usd": 3.2773,
+      "tested_library_loc": 984,
+      "metadata_entries": 423,
+      "test_only_metadata_entries": 15,
+      "previous_library_metadata_entries": 19,
+      "previous_library_test_only_metadata_entries": 14,
+      "code_coverage_percent": 16.42,
+      "previous_library_coverage_percent": 3.0
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/HierarchyDynamicMBeanTest.java",
+      "metadata_file": "metadata/org.apache.logging.log4j/log4j-1.2-api/2.18.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.logging.log4j/log4j-1.2-api/2.18.0/stats.json
+++ b/stats/org.apache.logging.log4j/log4j-1.2-api/2.18.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.18.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 4069,
+        "missed" : 20742,
+        "ratio" : 0.164,
+        "total" : 24811
+      },
+      "line" : {
+        "covered" : 984,
+        "missed" : 5007,
+        "ratio" : 0.164246,
+        "total" : 5991
+      },
+      "method" : {
+        "covered" : 258,
+        "missed" : 1060,
+        "ratio" : 0.195751,
+        "total" : 1318
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/.gitignore
+++ b/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/build.gradle
+++ b/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.logging.log4j:log4j-1.2-api:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/build.gradle
+++ b/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.apache.logging.log4j:log4j-1.2-api:$libraryVersion"
+    testImplementation "org.apache.logging.log4j:log4j-core:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/gradle.properties
+++ b/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.logging.log4j:log4j-1.2-api:2.18.0
+library.version = 2.18.0
+metadata.dir = org.apache.logging.log4j/log4j-1.2-api/2.18.0/

--- a/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/settings.gradle
+++ b/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.logging.log4j.log4j-1.2-api_tests'

--- a/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/AppenderDynamicMBeanTest.java
+++ b/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/AppenderDynamicMBeanTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_logging_log4j.log4j_1_2_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+
+import javax.management.Attribute;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanInfo;
+
+import org.apache.log4j.ConsoleAppender;
+import org.apache.log4j.Level;
+import org.apache.log4j.jmx.AppenderDynamicMBean;
+import org.junit.jupiter.api.Test;
+
+public class AppenderDynamicMBeanTest {
+
+    @Test
+    void exposesAndUpdatesSupportedAppenderProperties() throws Exception {
+        ConsoleAppender appender = new ConsoleAppender();
+        appender.setName("managed-console");
+
+        AppenderDynamicMBean mbean = new AppenderDynamicMBean(appender);
+        MBeanInfo mbeanInfo = mbean.getMBeanInfo();
+
+        assertThat(Arrays.stream(mbeanInfo.getAttributes())
+            .map(MBeanAttributeInfo::getName))
+            .contains("follow", "name", "target", "threshold");
+
+        mbean.setAttribute(new Attribute("target", ConsoleAppender.SYSTEM_ERR));
+        mbean.setAttribute(new Attribute("follow", true));
+        mbean.setAttribute(new Attribute("threshold", "WARN"));
+
+        assertThat(appender.getTarget()).isEqualTo(ConsoleAppender.SYSTEM_ERR);
+        assertThat(appender.getFollow()).isTrue();
+        assertThat(appender.getThreshold()).isEqualTo(Level.WARN);
+        assertThat(mbean.getAttribute("target")).isEqualTo(ConsoleAppender.SYSTEM_ERR);
+    }
+}

--- a/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/BuilderManagerTest.java
+++ b/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/BuilderManagerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_logging_log4j.log4j_1_2_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+
+import org.apache.log4j.Appender;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.log4j.PropertyConfigurator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+public class BuilderManagerTest {
+
+    private static final String APPENDER_NAME = "builderManagerConsole";
+    private final PrintStream originalErr = System.err;
+
+    @AfterEach
+    void resetLogging() {
+        LogManager.resetConfiguration();
+        System.setErr(originalErr);
+    }
+
+    @Test
+    void configuresConsoleAppenderAndPatternLayoutFromProperties() {
+        ByteArrayOutputStream loggingOutput = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(loggingOutput, true, StandardCharsets.UTF_8));
+
+        PropertyConfigurator.configure(consoleAppenderProperties());
+
+        Logger rootLogger = Logger.getRootLogger();
+        Appender appender = rootLogger.getAppender(APPENDER_NAME);
+        assertThat(appender).isNotNull();
+        assertThat(appender.getLayout()).isNotNull();
+
+        rootLogger.info("builder manager message");
+
+        assertThat(loggingOutput.toString(StandardCharsets.UTF_8))
+                .contains("BUILDER INFO|builder manager message");
+    }
+
+    private static Properties consoleAppenderProperties() {
+        Properties properties = new Properties();
+        properties.setProperty("log4j.rootLogger", "INFO, " + APPENDER_NAME);
+        properties.setProperty("log4j.appender." + APPENDER_NAME, "org.apache.log4j.ConsoleAppender");
+        properties.setProperty("log4j.appender." + APPENDER_NAME + ".Target", "System.err");
+        properties.setProperty("log4j.appender." + APPENDER_NAME + ".ImmediateFlush", "true");
+        properties.setProperty("log4j.appender." + APPENDER_NAME + ".layout", "org.apache.log4j.PatternLayout");
+        properties.setProperty("log4j.appender." + APPENDER_NAME + ".layout.ConversionPattern", "BUILDER %p|%m%n");
+        return properties;
+    }
+}

--- a/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/HierarchyDynamicMBeanTest.java
+++ b/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/HierarchyDynamicMBeanTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_logging_log4j.log4j_1_2_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+
+import javax.management.Attribute;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanConstructorInfo;
+import javax.management.MBeanInfo;
+import javax.management.MBeanOperationInfo;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.jmx.HierarchyDynamicMBean;
+import org.apache.log4j.spi.LoggerRepository;
+import org.junit.jupiter.api.Test;
+
+public class HierarchyDynamicMBeanTest {
+
+    @Test
+    void exposesConstructorsOperationsAndThresholdAttribute() throws Exception {
+        LoggerRepository repository = LogManager.getLoggerRepository();
+        Level previousThreshold = repository.getThreshold();
+
+        try {
+            HierarchyDynamicMBean mbean = new HierarchyDynamicMBean();
+            MBeanInfo mbeanInfo = mbean.getMBeanInfo();
+
+            assertThat(Arrays.stream(mbeanInfo.getConstructors())
+                    .map(MBeanConstructorInfo::getName))
+                    .contains(HierarchyDynamicMBean.class.getName());
+            assertThat(Arrays.stream(mbeanInfo.getAttributes())
+                    .map(MBeanAttributeInfo::getName))
+                    .contains("threshold");
+            assertThat(Arrays.stream(mbeanInfo.getOperations())
+                    .map(MBeanOperationInfo::getName))
+                    .contains("addLoggerMBean");
+
+            mbean.setAttribute(new Attribute("threshold", "WARN"));
+
+            assertThat(mbean.getAttribute("threshold")).isEqualTo(Level.WARN);
+            assertThat(repository.getThreshold()).isEqualTo(Level.WARN);
+        } finally {
+            repository.setThreshold(previousThreshold);
+        }
+    }
+}

--- a/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/LayoutDynamicMBeanTest.java
+++ b/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/LayoutDynamicMBeanTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_logging_log4j.log4j_1_2_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+
+import javax.management.Attribute;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanInfo;
+
+import org.apache.log4j.PatternLayout;
+import org.apache.log4j.jmx.LayoutDynamicMBean;
+import org.junit.jupiter.api.Test;
+
+public class LayoutDynamicMBeanTest {
+
+    @Test
+    void exposesAndUpdatesSupportedLayoutProperties() throws Exception {
+        PatternLayout layout = new PatternLayout("%m%n");
+
+        LayoutDynamicMBean mbean = new LayoutDynamicMBean(layout);
+        MBeanInfo mbeanInfo = mbean.getMBeanInfo();
+
+        assertThat(Arrays.stream(mbeanInfo.getAttributes())
+                .map(MBeanAttributeInfo::getName))
+                .contains("conversionPattern", "contentType", "header", "footer");
+
+        mbean.setAttribute(new Attribute("conversionPattern", "%p - %m%n"));
+
+        assertThat(layout.getConversionPattern()).isEqualTo("%p - %m%n");
+        assertThat(mbean.getAttribute("conversionPattern")).isEqualTo("%p - %m%n");
+    }
+}

--- a/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/LoaderTest.java
+++ b/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/LoaderTest.java
@@ -1,0 +1,326 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_logging_log4j.log4j_1_2_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.JarURLConnection;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.security.CodeSource;
+import java.util.LinkedHashSet;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import org.apache.log4j.helpers.Loader;
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class LoaderTest {
+
+    private static final String IGNORE_TCL_PROPERTY_NAME = "log4j.ignoreTCL";
+    private static final String TEST_RESOURCE = "org_apache_logging_log4j/log4j_1_2_api/loader-test-resource.txt";
+    private static final String MISSING_RESOURCE = "org_apache_logging_log4j/log4j_1_2_api/missing-loader-resource.txt";
+    private static final String LOG4J1_PACKAGE = "org.apache.log4j.";
+    private static final String CALLABLE_SERVICE_RESOURCE = "META-INF/services/java.util.concurrent.Callable";
+    private static final String ISOLATED_ACTION_CLASS_NAME = Log4jLoaderIsolatedAction.class.getName();
+
+    @BeforeAll
+    static void initializeLoaderWithThreadContextClassLoaderEnabled() {
+        System.clearProperty(IGNORE_TCL_PROPERTY_NAME);
+
+        assertThat(Loader.isJava1()).isFalse();
+    }
+
+    @Test
+    void findsResourceWithThreadContextClassLoader() {
+        Thread thread = Thread.currentThread();
+        ClassLoader previousClassLoader = thread.getContextClassLoader();
+        TrackingResourceClassLoader classLoader = new TrackingResourceClassLoader(
+                LoaderTest.class.getClassLoader(),
+                TEST_RESOURCE
+        );
+        thread.setContextClassLoader(classLoader);
+
+        URL resource;
+        try {
+            resource = Loader.getResource(TEST_RESOURCE);
+        } finally {
+            thread.setContextClassLoader(previousClassLoader);
+        }
+
+        assertThat(resource).isNotNull();
+        assertThat(classLoader.getRequestedResources()).contains(TEST_RESOURCE);
+    }
+
+    @Test
+    void fallsBackToLoaderClassLoaderWhenThreadContextClassLoaderCannotFindResource() {
+        Thread thread = Thread.currentThread();
+        ClassLoader previousClassLoader = thread.getContextClassLoader();
+        RejectingResourceClassLoader classLoader = new RejectingResourceClassLoader(
+                LoaderTest.class.getClassLoader(),
+                Set.of(TEST_RESOURCE)
+        );
+        thread.setContextClassLoader(classLoader);
+
+        URL resource;
+        try {
+            resource = Loader.getResource(TEST_RESOURCE);
+        } finally {
+            thread.setContextClassLoader(previousClassLoader);
+        }
+
+        assertThat(resource).isNotNull();
+        assertThat(classLoader.getRejectedResources()).contains(TEST_RESOURCE);
+    }
+
+    @Test
+    void fallsBackToSystemResourceLookupWhenClassLoadersCannotFindResource() {
+        Thread thread = Thread.currentThread();
+        ClassLoader previousClassLoader = thread.getContextClassLoader();
+        RejectingResourceClassLoader classLoader = new RejectingResourceClassLoader(
+                LoaderTest.class.getClassLoader(),
+                Set.of(MISSING_RESOURCE)
+        );
+        thread.setContextClassLoader(classLoader);
+
+        URL resource;
+        try {
+            resource = Loader.getResource(MISSING_RESOURCE);
+        } finally {
+            thread.setContextClassLoader(previousClassLoader);
+        }
+
+        assertThat(resource).isNull();
+        assertThat(classLoader.getRejectedResources()).contains(MISSING_RESOURCE);
+    }
+
+    @Test
+    void loadsClassThroughThreadContextClassLoader() throws Exception {
+        Thread thread = Thread.currentThread();
+        ClassLoader previousClassLoader = thread.getContextClassLoader();
+        TrackingClassLoader classLoader = new TrackingClassLoader(
+                LoaderTest.class.getClassLoader(),
+                Set.of(String.class.getName())
+        );
+        thread.setContextClassLoader(classLoader);
+
+        Class<?> loadedClass;
+        try {
+            loadedClass = Loader.loadClass(String.class.getName());
+        } finally {
+            thread.setContextClassLoader(previousClassLoader);
+        }
+
+        assertThat(loadedClass).isEqualTo(String.class);
+        assertThat(classLoader.getDelegatedLoads()).contains(String.class.getName());
+    }
+
+    @Test
+    void fallsBackToClassForNameWhenThreadContextClassLoaderCannotLoadClass() throws Exception {
+        Thread thread = Thread.currentThread();
+        ClassLoader previousClassLoader = thread.getContextClassLoader();
+        RejectingClassLoader classLoader = new RejectingClassLoader(
+                LoaderTest.class.getClassLoader(),
+                Set.of(String.class.getName())
+        );
+        thread.setContextClassLoader(classLoader);
+
+        Class<?> loadedClass;
+        try {
+            loadedClass = Loader.loadClass(String.class.getName());
+        } finally {
+            thread.setContextClassLoader(previousClassLoader);
+        }
+
+        assertThat(loadedClass).isEqualTo(String.class);
+        assertThat(classLoader.getRejectedLoads()).contains(String.class.getName());
+    }
+
+    @Test
+    void canIgnoreThreadContextClassLoaderWhenConfiguredBeforeLoaderInitialization() throws Exception {
+        String previousValue = System.getProperty(IGNORE_TCL_PROPERTY_NAME);
+        System.setProperty(IGNORE_TCL_PROPERTY_NAME, Boolean.TRUE.toString());
+
+        try (ChildFirstClassLoader classLoader = new ChildFirstClassLoader(new URL[] {
+                codeSourceUrl(LoaderTest.class),
+                resourceRootUrl(CALLABLE_SERVICE_RESOURCE),
+                codeSourceUrl(Loader.class)
+        }, LoaderTest.class.getClassLoader())) {
+            Callable<?> action = ServiceLoader.load(Callable.class, classLoader).stream()
+                    .map(ServiceLoader.Provider::get)
+                    .filter(provider -> provider.getClass().getName().equals(ISOLATED_ACTION_CLASS_NAME))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("Expected an isolated Loader callable provider"));
+
+            assertThat(action.call()).isEqualTo(String.class.getName());
+        } catch (Error error) {
+            if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                throw error;
+            }
+        } finally {
+            restoreSystemProperty(previousValue);
+        }
+    }
+
+    private static URL codeSourceUrl(Class<?> type) {
+        CodeSource codeSource = type.getProtectionDomain().getCodeSource();
+
+        assertThat(codeSource).isNotNull();
+        return codeSource.getLocation();
+    }
+
+    private static URL resourceRootUrl(String resourceName) throws IOException {
+        URL resourceUrl = LoaderTest.class.getClassLoader().getResource(resourceName);
+
+        assertThat(resourceUrl).isNotNull();
+        if ("jar".equals(resourceUrl.getProtocol())) {
+            JarURLConnection connection = (JarURLConnection) resourceUrl.openConnection();
+            return connection.getJarFileURL();
+        }
+        String externalForm = resourceUrl.toExternalForm();
+        assertThat(externalForm).endsWith(resourceName);
+        return new URL(externalForm.substring(0, externalForm.length() - resourceName.length()));
+    }
+
+    private static void restoreSystemProperty(String previousValue) {
+        if (previousValue == null) {
+            System.clearProperty(IGNORE_TCL_PROPERTY_NAME);
+        } else {
+            System.setProperty(IGNORE_TCL_PROPERTY_NAME, previousValue);
+        }
+    }
+
+    private static final class TrackingResourceClassLoader extends ClassLoader {
+
+        private final Set<String> requestedResources = new LinkedHashSet<>();
+        private final String trackedResource;
+
+        private TrackingResourceClassLoader(ClassLoader parent, String trackedResource) {
+            super(parent);
+            this.trackedResource = trackedResource;
+        }
+
+        @Override
+        public URL getResource(String name) {
+            if (trackedResource.equals(name)) {
+                requestedResources.add(name);
+            }
+            return super.getResource(name);
+        }
+
+        private Set<String> getRequestedResources() {
+            return requestedResources;
+        }
+    }
+
+    private static final class RejectingResourceClassLoader extends ClassLoader {
+
+        private final Set<String> rejectedResources = new LinkedHashSet<>();
+        private final Set<String> rejectedResourceNames;
+
+        private RejectingResourceClassLoader(ClassLoader parent, Set<String> rejectedResourceNames) {
+            super(parent);
+            this.rejectedResourceNames = rejectedResourceNames;
+        }
+
+        @Override
+        public URL getResource(String name) {
+            if (rejectedResourceNames.contains(name)) {
+                rejectedResources.add(name);
+                return null;
+            }
+            return super.getResource(name);
+        }
+
+        private Set<String> getRejectedResources() {
+            return rejectedResources;
+        }
+    }
+
+    private static final class TrackingClassLoader extends ClassLoader {
+
+        private final Set<String> delegatedLoads = new LinkedHashSet<>();
+        private final Set<String> trackedClassNames;
+
+        private TrackingClassLoader(ClassLoader parent, Set<String> trackedClassNames) {
+            super(parent);
+            this.trackedClassNames = trackedClassNames;
+        }
+
+        @Override
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            if (trackedClassNames.contains(name)) {
+                delegatedLoads.add(name);
+            }
+            return super.loadClass(name);
+        }
+
+        private Set<String> getDelegatedLoads() {
+            return delegatedLoads;
+        }
+    }
+
+    private static final class RejectingClassLoader extends ClassLoader {
+
+        private final Set<String> rejectedLoads = new LinkedHashSet<>();
+        private final Set<String> rejectedClassNames;
+
+        private RejectingClassLoader(ClassLoader parent, Set<String> rejectedClassNames) {
+            super(parent);
+            this.rejectedClassNames = rejectedClassNames;
+        }
+
+        @Override
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            if (rejectedClassNames.contains(name)) {
+                rejectedLoads.add(name);
+                throw new ClassNotFoundException(name);
+            }
+            return super.loadClass(name);
+        }
+
+        private Set<String> getRejectedLoads() {
+            return rejectedLoads;
+        }
+    }
+
+    private static final class ChildFirstClassLoader extends URLClassLoader {
+
+        private ChildFirstClassLoader(URL[] urls, ClassLoader parent) {
+            super(urls, parent);
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            synchronized (getClassLoadingLock(name)) {
+                Class<?> loadedClass = findLoadedClass(name);
+                if (loadedClass == null) {
+                    if (isChildFirst(name)) {
+                        try {
+                            loadedClass = findClass(name);
+                        } catch (ClassNotFoundException ignored) {
+                            loadedClass = super.loadClass(name, false);
+                        }
+                    } else {
+                        loadedClass = super.loadClass(name, false);
+                    }
+                }
+                if (resolve) {
+                    resolveClass(loadedClass);
+                }
+                return loadedClass;
+            }
+        }
+
+        private boolean isChildFirst(String className) {
+            return className.startsWith(LOG4J1_PACKAGE) || className.equals(ISOLATED_ACTION_CLASS_NAME);
+        }
+    }
+}

--- a/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/Log4jEntityResolverTest.java
+++ b/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/Log4jEntityResolverTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_logging_log4j.log4j_1_2_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.log4j.xml.Log4jEntityResolver;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.InputSource;
+
+public class Log4jEntityResolverTest {
+
+    @Test
+    void resolvesLog4jDtdFromClasspathResource() throws IOException {
+        Log4jEntityResolver resolver = new Log4jEntityResolver();
+
+        InputSource inputSource = resolver.resolveEntity(null, "https://example.invalid/log4j.dtd");
+
+        assertThat(inputSource).isNotNull();
+        try (InputStream byteStream = inputSource.getByteStream()) {
+            assertThat(byteStream).isNotNull();
+            assertThat(byteStream.readAllBytes()).isNotNull();
+        }
+    }
+
+    @Test
+    void ignoresUnrelatedExternalEntity() {
+        Log4jEntityResolver resolver = new Log4jEntityResolver();
+
+        InputSource inputSource = resolver.resolveEntity(null, "https://example.invalid/not-logging.dtd");
+
+        assertThat(inputSource).isNull();
+    }
+}

--- a/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/Log4jLoaderIsolatedAction.java
+++ b/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/Log4jLoaderIsolatedAction.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_logging_log4j.log4j_1_2_api;
+
+import java.util.concurrent.Callable;
+import org.apache.log4j.helpers.Loader;
+
+public final class Log4jLoaderIsolatedAction implements Callable<String> {
+
+    @Override
+    public String call() throws ClassNotFoundException {
+        return Loader.loadClass(String.class.getName()).getName();
+    }
+}

--- a/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/LogEventAdapterTest.java
+++ b/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/LogEventAdapterTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_logging_log4j.log4j_1_2_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.log4j.bridge.LogEventAdapter;
+import org.junit.jupiter.api.Test;
+
+public class LogEventAdapterTest {
+
+    @Test
+    void returnsStartTime() {
+        long startTime = LogEventAdapter.getStartTime();
+        long afterLookup = System.currentTimeMillis();
+
+        assertThat(startTime).isPositive();
+        assertThat(startTime).isLessThanOrEqualTo(afterLookup);
+    }
+}

--- a/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/LoggerDynamicMBeanTest.java
+++ b/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/LoggerDynamicMBeanTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_logging_log4j.log4j_1_2_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+
+import javax.management.Attribute;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanConstructorInfo;
+import javax.management.MBeanInfo;
+import javax.management.MBeanOperationInfo;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.jmx.LoggerDynamicMBean;
+import org.junit.jupiter.api.Test;
+
+public class LoggerDynamicMBeanTest {
+
+    @Test
+    void exposesConstructorsOperationsAndLoggerAttributes() throws Exception {
+        Logger logger = Logger.getLogger("org_apache_logging_log4j.log4j_1_2_api.managedLogger");
+        Level previousLevel = logger.getLevel();
+
+        try {
+            LoggerDynamicMBean mbean = new LoggerDynamicMBean(logger);
+            MBeanInfo mbeanInfo = mbean.getMBeanInfo();
+
+            assertThat(Arrays.stream(mbeanInfo.getConstructors())
+                    .map(MBeanConstructorInfo::getName))
+                    .contains(LoggerDynamicMBean.class.getName());
+            assertThat(Arrays.stream(mbeanInfo.getAttributes())
+                    .map(MBeanAttributeInfo::getName))
+                    .contains("name", "priority");
+            assertThat(Arrays.stream(mbeanInfo.getOperations())
+                    .map(MBeanOperationInfo::getName))
+                    .contains("addAppender");
+
+            mbean.setAttribute(new Attribute("priority", "ERROR"));
+
+            assertThat(mbean.getAttribute("name")).isEqualTo(logger.getName());
+            assertThat(mbean.getAttribute("priority")).isEqualTo("ERROR");
+            assertThat(logger.getLevel()).isEqualTo(Level.ERROR);
+        } finally {
+            logger.setLevel(previousLevel);
+        }
+    }
+}

--- a/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/OptionConverterTest.java
+++ b/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/OptionConverterTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_logging_log4j.log4j_1_2_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.helpers.OptionConverter;
+import org.junit.jupiter.api.Test;
+
+public class OptionConverterTest {
+
+    private static final String CUSTOM_LEVEL_NAME = "AUDIT";
+
+    @Test
+    void convertsCustomLevelThroughConfiguredLevelClass() {
+        Level defaultLevel = Level.DEBUG;
+
+        Level convertedLevel = OptionConverter.toLevel(
+                CUSTOM_LEVEL_NAME + "#" + OptionConverterTest.class.getName(),
+                defaultLevel
+        );
+
+        assertThat(convertedLevel).isSameAs(Level.FATAL);
+    }
+
+    public static Level toLevel(String levelName, Level defaultLevel) {
+        if (CUSTOM_LEVEL_NAME.equals(levelName)) {
+            return Level.FATAL;
+        }
+        return defaultLevel;
+    }
+}

--- a/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/PropertySetterTest.java
+++ b/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/PropertySetterTest.java
@@ -8,7 +8,10 @@ package org_apache_logging_log4j.log4j_1_2_api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Properties;
+
 import org.apache.log4j.config.PropertySetter;
+import org.apache.log4j.spi.OptionHandler;
 import org.junit.jupiter.api.Test;
 
 public class PropertySetterTest {
@@ -29,12 +32,28 @@ public class PropertySetterTest {
         assertThat(target.isEnabled()).isTrue();
     }
 
+    @Test
+    void setsNestedOptionHandlerPropertyFromProperties() {
+        ConfigurableTarget target = new ConfigurableTarget();
+        Properties properties = new Properties();
+        properties.setProperty("log4j.appender.test.handler", RecordingOptionHandler.class.getName());
+        properties.setProperty("log4j.appender.test.handler.message", "configured-handler");
+
+        PropertySetter.setProperties(target, properties, "log4j.appender.test.");
+
+        assertThat(target.getHandler()).isInstanceOf(RecordingOptionHandler.class);
+        RecordingOptionHandler handler = (RecordingOptionHandler) target.getHandler();
+        assertThat(handler.getMessage()).isEqualTo("configured-handler");
+        assertThat(handler.isActivated()).isTrue();
+    }
+
     public static final class ConfigurableTarget {
 
         private String name;
         private int count;
         private long timeout;
         private boolean enabled;
+        private OptionHandler handler;
 
         public String getName() {
             return name;
@@ -68,5 +87,36 @@ public class PropertySetterTest {
             this.enabled = enabled;
         }
 
+        public OptionHandler getHandler() {
+            return handler;
+        }
+
+        public void setHandler(OptionHandler handler) {
+            this.handler = handler;
+        }
+
+    }
+
+    public static final class RecordingOptionHandler implements OptionHandler {
+
+        private String message;
+        private boolean activated;
+
+        public String getMessage() {
+            return message;
+        }
+
+        public void setMessage(String message) {
+            this.message = message;
+        }
+
+        public boolean isActivated() {
+            return activated;
+        }
+
+        @Override
+        public void activateOptions() {
+            activated = true;
+        }
     }
 }

--- a/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/PropertySetterTest.java
+++ b/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/PropertySetterTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_logging_log4j.log4j_1_2_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.config.PropertySetter;
+import org.junit.jupiter.api.Test;
+
+public class PropertySetterTest {
+
+    @Test
+    void setsBeanPropertiesFromStringValues() {
+        ConfigurableTarget target = new ConfigurableTarget();
+        PropertySetter setter = new PropertySetter(target);
+
+        setter.setProperty("name", "example-appender");
+        setter.setProperty("count", "42");
+        setter.setProperty("timeout", "123456789");
+        setter.setProperty("enabled", "true");
+        setter.setProperty("threshold", "ERROR");
+
+        assertThat(target.getName()).isEqualTo("example-appender");
+        assertThat(target.getCount()).isEqualTo(42);
+        assertThat(target.getTimeout()).isEqualTo(123456789L);
+        assertThat(target.isEnabled()).isTrue();
+        assertThat(target.getThreshold()).isEqualTo(Level.ERROR);
+    }
+
+    public static final class ConfigurableTarget {
+
+        private String name;
+        private int count;
+        private long timeout;
+        private boolean enabled;
+        private Level threshold;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public int getCount() {
+            return count;
+        }
+
+        public void setCount(int count) {
+            this.count = count;
+        }
+
+        public long getTimeout() {
+            return timeout;
+        }
+
+        public void setTimeout(long timeout) {
+            this.timeout = timeout;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public Level getThreshold() {
+            return threshold;
+        }
+
+        public void setThreshold(Level threshold) {
+            this.threshold = threshold;
+        }
+    }
+}

--- a/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/PropertySetterTest.java
+++ b/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/PropertySetterTest.java
@@ -8,7 +8,6 @@ package org_apache_logging_log4j.log4j_1_2_api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.apache.log4j.Level;
 import org.apache.log4j.config.PropertySetter;
 import org.junit.jupiter.api.Test;
 
@@ -23,13 +22,11 @@ public class PropertySetterTest {
         setter.setProperty("count", "42");
         setter.setProperty("timeout", "123456789");
         setter.setProperty("enabled", "true");
-        setter.setProperty("threshold", "ERROR");
 
         assertThat(target.getName()).isEqualTo("example-appender");
         assertThat(target.getCount()).isEqualTo(42);
         assertThat(target.getTimeout()).isEqualTo(123456789L);
         assertThat(target.isEnabled()).isTrue();
-        assertThat(target.getThreshold()).isEqualTo(Level.ERROR);
     }
 
     public static final class ConfigurableTarget {
@@ -38,7 +35,6 @@ public class PropertySetterTest {
         private int count;
         private long timeout;
         private boolean enabled;
-        private Level threshold;
 
         public String getName() {
             return name;
@@ -72,12 +68,5 @@ public class PropertySetterTest {
             this.enabled = enabled;
         }
 
-        public Level getThreshold() {
-            return threshold;
-        }
-
-        public void setThreshold(Level threshold) {
-            this.threshold = threshold;
-        }
     }
 }

--- a/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/ThrowableInformationTest.java
+++ b/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/ThrowableInformationTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_logging_log4j.log4j_1_2_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.log4j.spi.ThrowableInformation;
+import org.junit.jupiter.api.Test;
+
+public class ThrowableInformationTest {
+
+    @Test
+    void rendersThrowableUsingCoreThrowablesWhenCoreIsAvailable() {
+        Throwable throwable = new IllegalStateException("expected throwable message");
+        ThrowableInformation information = new ThrowableInformation(throwable);
+
+        String[] representation = information.getThrowableStrRep();
+
+        assertThat(representation).isNotEmpty();
+        assertThat(representation[0]).contains(IllegalStateException.class.getName(), "expected throwable message");
+    }
+}

--- a/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -77,6 +77,12 @@
         "typeReached" : "org.apache.log4j.helpers.Loader"
       },
       "glob" : "org_apache_logging_log4j/log4j_1_2_api/loader-test-resource.txt"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.logging.log4j.util.LoaderUtil"
+      },
+      "glob" : "log4j2.component.properties"
     }
   ]
 }

--- a/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,82 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log4j.config.PropertySetter"
+      },
+      "type" : "org_apache_logging_log4j.log4j_1_2_api.PropertySetterTest$ConfigurableTarget",
+      "methods" : [
+        {
+          "name" : "getCount",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getName",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getThreshold",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getTimeout",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "isEnabled",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setCount",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "setEnabled",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        },
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setThreshold",
+          "parameterTypes" : [
+            "org.apache.log4j.Level"
+          ]
+        },
+        {
+          "name" : "setTimeout",
+          "parameterTypes" : [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log4j.config.PropertySetter"
+      },
+      "type" : "org_apache_logging_log4j.log4j_1_2_api.PropertySetterTest$ConfigurableTargetBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log4j.config.PropertySetter"
+      },
+      "type" : "org_apache_logging_log4j.log4j_1_2_api.PropertySetterTest$ConfigurableTargetCustomizer"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.log4j.helpers.Loader"
+      },
+      "glob" : "org_apache_logging_log4j/log4j_1_2_api/loader-test-resource.txt"
+    }
+  ]
+}

--- a/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/resources/META-INF/services/java.util.concurrent.Callable
+++ b/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/resources/META-INF/services/java.util.concurrent.Callable
@@ -1,0 +1,1 @@
+org_apache_logging_log4j.log4j_1_2_api.Log4jLoaderIsolatedAction

--- a/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/resources/log4j2.component.properties
+++ b/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/resources/log4j2.component.properties
@@ -1,0 +1,1 @@
+log4j2.loggerContextFactory=org.apache.logging.log4j.core.impl.Log4jContextFactory

--- a/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/resources/org_apache_logging_log4j/log4j_1_2_api/loader-test-resource.txt
+++ b/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/resources/org_apache_logging_log4j/log4j_1_2_api/loader-test-resource.txt
@@ -1,0 +1,1 @@
+loader test resource

--- a/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/user-code-filter.json
+++ b/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/user-code-filter.json
@@ -7,6 +7,9 @@
       "includeClasses" : "org.apache.log4j.**"
     },
     {
+      "includeClasses" : "org.apache.logging.log4j.**"
+    },
+    {
       "includeClasses" : "org_apache_logging_log4j.log4j_1_2_api.**"
     }
   ]

--- a/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/user-code-filter.json
+++ b/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.log4j.**"
+    },
+    {
+      "includeClasses" : "org_apache_logging_log4j.log4j_1_2_api.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6772

This PR provides test fixes and new metadata for org.apache.logging.log4j:log4j-1.2-api:2.18.0, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 428381
- Cached input tokens: 3982336
- Output tokens: 42871
- Metadata entries: 423
- Test-only metadata entries: 15
- Iterations: 12
- Library coverage percentage: 16.42
- Previous library version metadata entries: 19
- Previous library version test-only metadata entries: 14
- Previous library version coverage percentage: 3.0

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `464f9ce106663cceda87c6a83a37c8d01da59eb7`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.logging.log4j:log4j-1.2-api:2.17.2: 10/10 covered calls (100.00%)
- org.apache.logging.log4j:log4j-1.2-api:2.18.0: 0/0 covered calls (100.00%)

**Reflection:**
- org.apache.logging.log4j:log4j-1.2-api:2.17.2: 6/6 covered calls (100.00%)
- org.apache.logging.log4j:log4j-1.2-api:2.18.0: N/A

**Resources:**
- org.apache.logging.log4j:log4j-1.2-api:2.17.2: 4/4 covered calls (100.00%)
- org.apache.logging.log4j:log4j-1.2-api:2.18.0: N/A

#### Library coverage

**Instruction:**
- org.apache.logging.log4j:log4j-1.2-api:2.17.2: 663/20878 (3.18%)
- org.apache.logging.log4j:log4j-1.2-api:2.18.0: 4069/24811 (16.40%)

**Line:**
- org.apache.logging.log4j:log4j-1.2-api:2.17.2: 155/5165 (3.00%)
- org.apache.logging.log4j:log4j-1.2-api:2.18.0: 984/5991 (16.42%)

**Method:**
- org.apache.logging.log4j:log4j-1.2-api:2.17.2: 29/1178 (2.46%)
- org.apache.logging.log4j:log4j-1.2-api:2.18.0: 258/1318 (19.58%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.17.2/build.gradle 2/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/build.gradle
index 4fc653602a..c77af20d96 100644
--- 1/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.17.2/build.gradle
+++ 2/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.apache.logging.log4j:log4j-1.2-api:$libraryVersion"
+    testImplementation "org.apache.logging.log4j:log4j-core:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
diff --git 1/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/AppenderDynamicMBeanTest.java 2/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/AppenderDynamicMBeanTest.java
new file mode 100644
index 0000000000..648e51abff
--- /dev/null
+++ 2/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/AppenderDynamicMBeanTest.java
@@ -0,0 +1,45 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_logging_log4j.log4j_1_2_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+
+import javax.management.Attribute;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanInfo;
+
+import org.apache.log4j.ConsoleAppender;
+import org.apache.log4j.Level;
+import org.apache.log4j.jmx.AppenderDynamicMBean;
+import org.junit.jupiter.api.Test;
+
+public class AppenderDynamicMBeanTest {
+
+    @Test
+    void exposesAndUpdatesSupportedAppenderProperties() throws Exception {
+        ConsoleAppender appender = new ConsoleAppender();
+        appender.setName("managed-console");
+
+        AppenderDynamicMBean mbean = new AppenderDynamicMBean(appender);
+        MBeanInfo mbeanInfo = mbean.getMBeanInfo();
+
+        assertThat(Arrays.stream(mbeanInfo.getAttributes())
+            .map(MBeanAttributeInfo::getName))
+            .contains("follow", "name", "target", "threshold");
+
+        mbean.setAttribute(new Attribute("target", ConsoleAppender.SYSTEM_ERR));
+        mbean.setAttribute(new Attribute("follow", true));
+        mbean.setAttribute(new Attribute("threshold", "WARN"));
+
+        assertThat(appender.getTarget()).isEqualTo(ConsoleAppender.SYSTEM_ERR);
+        assertThat(appender.getFollow()).isTrue();
+        assertThat(appender.getThreshold()).isEqualTo(Level.WARN);
+        assertThat(mbean.getAttribute("target")).isEqualTo(ConsoleAppender.SYSTEM_ERR);
+    }
+}
diff --git 1/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/BuilderManagerTest.java 2/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/BuilderManagerTest.java
new file mode 100644
index 0000000000..5667d41d07
--- /dev/null
+++ 2/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/BuilderManagerTest.java
@@ -0,0 +1,62 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_logging_log4j.log4j_1_2_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+
+import org.apache.log4j.Appender;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.log4j.PropertyConfigurator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+public class BuilderManagerTest {
+
+    private static final String APPENDER_NAME = "builderManagerConsole";
+    private final PrintStream originalErr = System.err;
+
+    @AfterEach
+    void resetLogging() {
+        LogManager.resetConfiguration();
+        System.setErr(originalErr);
+    }
+
+    @Test
+    void configuresConsoleAppenderAndPatternLayoutFromProperties() {
+        ByteArrayOutputStream loggingOutput = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(loggingOutput, true, StandardCharsets.UTF_8));
+
+        PropertyConfigurator.configure(consoleAppenderProperties());
+
+        Logger rootLogger = Logger.getRootLogger();
+        Appender appender = rootLogger.getAppender(APPENDER_NAME);
+        assertThat(appender).isNotNull();
+        assertThat(appender.getLayout()).isNotNull();
+
+        rootLogger.info("builder manager message");
+
+        assertThat(loggingOutput.toString(StandardCharsets.UTF_8))
+                .contains("BUILDER INFO|builder manager message");
+    }
+
+    private static Properties consoleAppenderProperties() {
+        Properties properties = new Properties();
+        properties.setProperty("log4j.rootLogger", "INFO, " + APPENDER_NAME);
+        properties.setProperty("log4j.appender." + APPENDER_NAME, "org.apache.log4j.ConsoleAppender");
+        properties.setProperty("log4j.appender." + APPENDER_NAME + ".Target", "System.err");
+        properties.setProperty("log4j.appender." + APPENDER_NAME + ".ImmediateFlush", "true");
+        properties.setProperty("log4j.appender." + APPENDER_NAME + ".layout", "org.apache.log4j.PatternLayout");
+        properties.setProperty("log4j.appender." + APPENDER_NAME + ".layout.ConversionPattern", "BUILDER %p|%m%n");
+        return properties;
+    }
+}
diff --git 1/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/HierarchyDynamicMBeanTest.java 2/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/HierarchyDynamicMBeanTest.java
new file mode 100644
index 0000000000..98f982dc84
--- /dev/null
+++ 2/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/HierarchyDynamicMBeanTest.java
@@ -0,0 +1,54 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_logging_log4j.log4j_1_2_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+
+import javax.management.Attribute;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanConstructorInfo;
+import javax.management.MBeanInfo;
+import javax.management.MBeanOperationInfo;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.jmx.HierarchyDynamicMBean;
+import org.apache.log4j.spi.LoggerRepository;
+import org.junit.jupiter.api.Test;
+
+public class HierarchyDynamicMBeanTest {
+
+    @Test
+    void exposesConstructorsOperationsAndThresholdAttribute() throws Exception {
+        LoggerRepository repository = LogManager.getLoggerRepository();
+        Level previousThreshold = repository.getThreshold();
+
+        try {
+            HierarchyDynamicMBean mbean = new HierarchyDynamicMBean();
+            MBeanInfo mbeanInfo = mbean.getMBeanInfo();
+
+            assertThat(Arrays.stream(mbeanInfo.getConstructors())
+                    .map(MBeanConstructorInfo::getName))
+                    .contains(HierarchyDynamicMBean.class.getName());
+            assertThat(Arrays.stream(mbeanInfo.getAttributes())
+                    .map(MBeanAttributeInfo::getName))
+                    .contains("threshold");
+            assertThat(Arrays.stream(mbeanInfo.getOperations())
+                    .map(MBeanOperationInfo::getName))
+                    .contains("addLoggerMBean");
+
+            mbean.setAttribute(new Attribute("threshold", "WARN"));
+
+            assertThat(mbean.getAttribute("threshold")).isEqualTo(Level.WARN);
+            assertThat(repository.getThreshold()).isEqualTo(Level.WARN);
+        } finally {
+            repository.setThreshold(previousThreshold);
+        }
+    }
+}
diff --git 1/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/LayoutDynamicMBeanTest.java 2/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/LayoutDynamicMBeanTest.java
new file mode 100644
index 0000000000..0932ac4034
--- /dev/null
+++ 2/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/LayoutDynamicMBeanTest.java
@@ -0,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_logging_log4j.log4j_1_2_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+
+import javax.management.Attribute;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanInfo;
+
+import org.apache.log4j.PatternLayout;
+import org.apache.log4j.jmx.LayoutDynamicMBean;
+import org.junit.jupiter.api.Test;
+
+public class LayoutDynamicMBeanTest {
+
+    @Test
+    void exposesAndUpdatesSupportedLayoutProperties() throws Exception {
+        PatternLayout layout = new PatternLayout("%m%n");
+
+        LayoutDynamicMBean mbean = new LayoutDynamicMBean(layout);
+        MBeanInfo mbeanInfo = mbean.getMBeanInfo();
+
+        assertThat(Arrays.stream(mbeanInfo.getAttributes())
+                .map(MBeanAttributeInfo::getName))
+                .contains("conversionPattern", "contentType", "header", "footer");
+
+        mbean.setAttribute(new Attribute("conversionPattern", "%p - %m%n"));
+
+        assertThat(layout.getConversionPattern()).isEqualTo("%p - %m%n");
+        assertThat(mbean.getAttribute("conversionPattern")).isEqualTo("%p - %m%n");
+    }
+}
diff --git 1/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/LogEventAdapterTest.java 2/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/LogEventAdapterTest.java
new file mode 100644
index 0000000000..99b67841d1
--- /dev/null
+++ 2/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/LogEventAdapterTest.java
@@ -0,0 +1,24 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_logging_log4j.log4j_1_2_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.log4j.bridge.LogEventAdapter;
+import org.junit.jupiter.api.Test;
+
+public class LogEventAdapterTest {
+
+    @Test
+    void returnsStartTime() {
+        long startTime = LogEventAdapter.getStartTime();
+        long afterLookup = System.currentTimeMillis();
+
+        assertThat(startTime).isPositive();
+        assertThat(startTime).isLessThanOrEqualTo(afterLookup);
+    }
+}
diff --git 1/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/LoggerDynamicMBeanTest.java 2/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/LoggerDynamicMBeanTest.java
new file mode 100644
index 0000000000..7f13d0cdcf
--- /dev/null
+++ 2/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/LoggerDynamicMBeanTest.java
@@ -0,0 +1,54 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_logging_log4j.log4j_1_2_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+
+import javax.management.Attribute;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanConstructorInfo;
+import javax.management.MBeanInfo;
+import javax.management.MBeanOperationInfo;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.jmx.LoggerDynamicMBean;
+import org.junit.jupiter.api.Test;
+
+public class LoggerDynamicMBeanTest {
+
+    @Test
+    void exposesConstructorsOperationsAndLoggerAttributes() throws Exception {
+        Logger logger = Logger.getLogger("org_apache_logging_log4j.log4j_1_2_api.managedLogger");
+        Level previousLevel = logger.getLevel();
+
+        try {
+            LoggerDynamicMBean mbean = new LoggerDynamicMBean(logger);
+            MBeanInfo mbeanInfo = mbean.getMBeanInfo();
+
+            assertThat(Arrays.stream(mbeanInfo.getConstructors())
+                    .map(MBeanConstructorInfo::getName))
+                    .contains(LoggerDynamicMBean.class.getName());
+            assertThat(Arrays.stream(mbeanInfo.getAttributes())
+                    .map(MBeanAttributeInfo::getName))
+                    .contains("name", "priority");
+            assertThat(Arrays.stream(mbeanInfo.getOperations())
+                    .map(MBeanOperationInfo::getName))
+                    .contains("addAppender");
+
+            mbean.setAttribute(new Attribute("priority", "ERROR"));
+
+            assertThat(mbean.getAttribute("name")).isEqualTo(logger.getName());
+            assertThat(mbean.getAttribute("priority")).isEqualTo("ERROR");
+            assertThat(logger.getLevel()).isEqualTo(Level.ERROR);
+        } finally {
+            logger.setLevel(previousLevel);
+        }
+    }
+}
diff --git 1/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.17.2/src/test/java/org_apache_logging_log4j/log4j_1_2_api/PropertySetterTest.java 2/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/PropertySetterTest.java
index 93434f19a1..7be87f3bdf 100644
--- 1/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.17.2/src/test/java/org_apache_logging_log4j/log4j_1_2_api/PropertySetterTest.java
+++ 2/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/PropertySetterTest.java
@@ -8,8 +8,10 @@ package org_apache_logging_log4j.log4j_1_2_api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.apache.log4j.Level;
+import java.util.Properties;
+
 import org.apache.log4j.config.PropertySetter;
+import org.apache.log4j.spi.OptionHandler;
 import org.junit.jupiter.api.Test;
 
 public class PropertySetterTest {
@@ -23,13 +25,26 @@ public class PropertySetterTest {
         setter.setProperty("count", "42");
         setter.setProperty("timeout", "123456789");
         setter.setProperty("enabled", "true");
-        setter.setProperty("threshold", "ERROR");
 
         assertThat(target.getName()).isEqualTo("example-appender");
         assertThat(target.getCount()).isEqualTo(42);
         assertThat(target.getTimeout()).isEqualTo(123456789L);
         assertThat(target.isEnabled()).isTrue();
-        assertThat(target.getThreshold()).isEqualTo(Level.ERROR);
+    }
+
+    @Test
+    void setsNestedOptionHandlerPropertyFromProperties() {
+        ConfigurableTarget target = new ConfigurableTarget();
+        Properties properties = new Properties();
+        properties.setProperty("log4j.appender.test.handler", RecordingOptionHandler.class.getName());
+        properties.setProperty("log4j.appender.test.handler.message", "configured-handler");
+
+        PropertySetter.setProperties(target, properties, "log4j.appender.test.");
+
+        assertThat(target.getHandler()).isInstanceOf(RecordingOptionHandler.class);
+        RecordingOptionHandler handler = (RecordingOptionHandler) target.getHandler();
+        assertThat(handler.getMessage()).isEqualTo("configured-handler");
+        assertThat(handler.isActivated()).isTrue();
     }
 
     public static final class ConfigurableTarget {
@@ -38,7 +53,7 @@ public class PropertySetterTest {
         private int count;
         private long timeout;
         private boolean enabled;
-        private Level threshold;
+        private OptionHandler handler;
 
         public String getName() {
             return name;
@@ -72,12 +87,36 @@ public class PropertySetterTest {
             this.enabled = enabled;
         }
 
-        public Level getThreshold() {
-            return threshold;
+        public OptionHandler getHandler() {
+            return handler;
+        }
+
+        public void setHandler(OptionHandler handler) {
+            this.handler = handler;
+        }
+
+    }
+
+    public static final class RecordingOptionHandler implements OptionHandler {
+
+        private String message;
+        private boolean activated;
+
+        public String getMessage() {
+            return message;
+        }
+
+        public void setMessage(String message) {
+            this.message = message;
+        }
+
+        public boolean isActivated() {
+            return activated;
         }
 
-        public void setThreshold(Level threshold) {
-            this.threshold = threshold;
+        @Override
+        public void activateOptions() {
+            activated = true;
         }
     }
 }
diff --git 1/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/ThrowableInformationTest.java 2/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/ThrowableInformationTest.java
new file mode 100644
index 0000000000..1c88e2ccb3
--- /dev/null
+++ 2/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/src/test/java/org_apache_logging_log4j/log4j_1_2_api/ThrowableInformationTest.java
@@ -0,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_logging_log4j.log4j_1_2_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.log4j.spi.ThrowableInformation;
+import org.junit.jupiter.api.Test;
+
+public class ThrowableInformationTest {
+
+    @Test
+    void rendersThrowableUsingCoreThrowablesWhenCoreIsAvailable() {
+        Throwable throwable = new IllegalStateException("expected throwable message");
+        ThrowableInformation information = new ThrowableInformation(throwable);
+
+        String[] representation = information.getThrowableStrRep();
+
+        assertThat(representation).isNotEmpty();
+        assertThat(representation[0]).contains(IllegalStateException.class.getName(), "expected throwable message");
+    }
+}
diff --git 1/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.17.2/user-code-filter.json 2/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/user-code-filter.json
index 9e224895ee..20b29a8d1b 100644
--- 1/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.17.2/user-code-filter.json
+++ 2/tests/src/org.apache.logging.log4j/log4j-1.2-api/2.18.0/user-code-filter.json
@@ -6,6 +6,9 @@
     {
       "includeClasses" : "org.apache.log4j.**"
     },
+    {
+      "includeClasses" : "org.apache.logging.log4j.**"
+    },
     {
       "includeClasses" : "org_apache_logging_log4j.log4j_1_2_api.**"
     }

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
