### PR TITLE
[GenAI] Test fix for org.eclipse.jetty:jetty-alpn-client:12.1.5 using gpt-5.5

### DIFF
--- a/metadata/org.eclipse.jetty/jetty-alpn-client/12.1.5/reachability-metadata.json
+++ b/metadata/org.eclipse.jetty/jetty-alpn-client/12.1.5/reachability-metadata.json
@@ -1,0 +1,30 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.io.IdleTimeout"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.util.TypeUtil"
+      },
+      "type": "java.lang.invoke.MethodHandle[]"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.util.ServiceLoaderSpliterator"
+      },
+      "glob": "META-INF/services/org.eclipse.jetty.io.ssl.ALPNProcessor$Client"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.io.IdleTimeout"
+      },
+      "glob": "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
+    }
+  ]
+}

--- a/metadata/org.eclipse.jetty/jetty-alpn-client/index.json
+++ b/metadata/org.eclipse.jetty/jetty-alpn-client/index.json
@@ -1,6 +1,17 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "12.1.5",
+    "tested-versions" : [
+      "12.1.5"
+    ],
+    "allowed-packages" : [
+      "org.eclipse.jetty.alpn.client",
+      "org.eclipse.jetty.util",
+      "org.eclipse.jetty.io"
+    ]
+  },
+  {
     "metadata-version" : "12.1.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-alpn-client/$version$/jetty-alpn-client-$version$-sources.jar",
     "repository-url" : "https://github.com/jetty/jetty.project",

--- a/metadata/org.eclipse.jetty/jetty-alpn-client/index.json
+++ b/metadata/org.eclipse.jetty/jetty-alpn-client/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "12.1.5",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-alpn-client/$version$/jetty-alpn-client-$version$-sources.jar",
+    "repository-url" : "https://github.com/jetty/jetty.project",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-alpn-client/$version$/jetty-alpn-client-$version$-javadoc.jar",
+    "description" : "Jetty ALPN Client provides the client-side connection factory used by Eclipse Jetty to negotiate application protocols such as HTTP/1.1 and HTTP/2 during TLS handshakes. It discovers available Jetty ALPN processors and configures SSL client connections so the selected protocol can hand off to the appropriate client connection implementation.",
     "tested-versions" : [
       "12.1.5"
     ],

--- a/stats/org.eclipse.jetty/jetty-alpn-client/12.1.5/execution-metrics.json
+++ b/stats/org.eclipse.jetty/jetty-alpn-client/12.1.5/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_java_run_fail:2026-06-06": {
+    "timestamp": "2026-06-06T10:34:15.342254Z",
+    "library": "org.eclipse.jetty:jetty-alpn-client:12.1.5",
+    "starting_commit": "4b29819dd6904108c5485af57d145c39306af090",
+    "ending_commit": "da737e9d430195884bea7fca2b4ebddd5455acfe",
+    "previous_library": "org.eclipse.jetty:jetty-alpn-client:12.1.0",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "12.1.5",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 78,
+          "missed": 123,
+          "ratio": 0.38806,
+          "total": 201
+        },
+        "line": {
+          "covered": 21,
+          "missed": 28,
+          "ratio": 0.428571,
+          "total": 49
+        },
+        "method": {
+          "covered": 7,
+          "missed": 2,
+          "ratio": 0.777778,
+          "total": 9
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "12.1.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 78,
+          "missed": 119,
+          "ratio": 0.395939,
+          "total": 197
+        },
+        "line": {
+          "covered": 21,
+          "missed": 28,
+          "ratio": 0.428571,
+          "total": 49
+        },
+        "method": {
+          "covered": 7,
+          "missed": 2,
+          "ratio": 0.777778,
+          "total": 9
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 96021,
+      "cached_input_tokens_used": 692224,
+      "output_tokens_used": 3319,
+      "iterations": 1,
+      "cost_usd": 0.4457,
+      "tested_library_loc": 21,
+      "metadata_entries": 4,
+      "previous_library_metadata_entries": 4,
+      "code_coverage_percent": 42.86,
+      "previous_library_coverage_percent": 42.86
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.eclipse.jetty/jetty-alpn-client/12.1.5/src/test/java/org_eclipse_jetty/jetty_alpn_client/Jetty_alpn_clientTest.java",
+      "metadata_file": "metadata/org.eclipse.jetty/jetty-alpn-client/12.1.5/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.eclipse.jetty/jetty-alpn-client/12.1.5/stats.json
+++ b/stats/org.eclipse.jetty/jetty-alpn-client/12.1.5/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "12.1.5",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 78,
+        "missed" : 123,
+        "ratio" : 0.38806,
+        "total" : 201
+      },
+      "line" : {
+        "covered" : 21,
+        "missed" : 28,
+        "ratio" : 0.428571,
+        "total" : 49
+      },
+      "method" : {
+        "covered" : 7,
+        "missed" : 2,
+        "ratio" : 0.777778,
+        "total" : 9
+      }
+    }
+  } ]
+}

--- a/tests/src/org.eclipse.jetty/jetty-alpn-client/12.1.5/.gitignore
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-client/12.1.5/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.eclipse.jetty/jetty-alpn-client/12.1.5/build.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-client/12.1.5/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.eclipse.jetty:jetty-alpn-client:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-alpn-client/12.1.5/gradle.properties
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-client/12.1.5/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.eclipse.jetty:jetty-alpn-client:12.1.5
+library.version = 12.1.5
+metadata.dir = org.eclipse.jetty/jetty-alpn-client/12.1.5/

--- a/tests/src/org.eclipse.jetty/jetty-alpn-client/12.1.5/settings.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-client/12.1.5/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.eclipse.jetty.jetty-alpn-client_tests'

--- a/tests/src/org.eclipse.jetty/jetty-alpn-client/12.1.5/src/test/java/org_eclipse_jetty/jetty_alpn_client/Jetty_alpn_clientTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-client/12.1.5/src/test/java/org_eclipse_jetty/jetty_alpn_client/Jetty_alpn_clientTest.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.concurrent.Executor;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLHandshakeException;
 
 import org.eclipse.jetty.alpn.client.ALPNClientConnection;
 import org.eclipse.jetty.alpn.client.ALPNClientConnectionFactory;
@@ -122,7 +123,7 @@ public class Jetty_alpn_clientTest {
     }
 
     @Test
-    void endOfInputUpgradesEndPointWithoutNegotiatedProtocol() throws Exception {
+    void endOfInputFailsConnectionPromiseWithoutNegotiatedProtocol() throws Exception {
         ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
         RecordingPromise connectionPromise = new RecordingPromise();
         Map<String, Object> context = newContextWithConnectionPromise(connectionPromise);
@@ -134,13 +135,14 @@ public class Jetty_alpn_clientTest {
         connection.onFillable();
 
         assertThat(connection.getProtocol()).isNull();
-        assertThat(connectionFactory.createdConnections).hasSize(1);
-        RecordingConnection protocolConnection = connectionFactory.createdConnections.get(0);
-        assertThat(endPoint.getConnection()).isSameAs(protocolConnection);
-        assertThat(protocolConnection.opened).isTrue();
-        assertThat(connectionPromise.failure).isNull();
+        assertThat(connectionFactory.createdConnections).isEmpty();
+        assertThat(endPoint.getConnection()).isSameAs(connection);
+        assertThat(connectionPromise.failure)
+                .isInstanceOf(SSLHandshakeException.class)
+                .hasMessage("Abruptly closed by peer");
         assertThat(endPoint.isInputShutdown()).isTrue();
-        assertThat(endPoint.isOpen()).isTrue();
+        assertThat(endPoint.isOutputShutdown()).isTrue();
+        assertThat(endPoint.isOpen()).isFalse();
     }
 
     @Test
@@ -171,7 +173,9 @@ public class Jetty_alpn_clientTest {
         connection.onOpen();
 
         assertThat(connection.getProtocol()).isEqualTo("h2");
-        assertThat(connectionPromise.failure).isNull();
+        assertThat(connectionPromise.failure)
+                .isInstanceOf(IOException.class)
+                .hasMessage("Unable to create protocol connection");
         assertThat(endPoint.getConnection()).isSameAs(connection);
         assertThat(endPoint.isOutputShutdown()).isTrue();
         assertThat(endPoint.isOpen()).isFalse();

--- a/tests/src/org.eclipse.jetty/jetty-alpn-client/12.1.5/src/test/java/org_eclipse_jetty/jetty_alpn_client/Jetty_alpn_clientTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-client/12.1.5/src/test/java/org_eclipse_jetty/jetty_alpn_client/Jetty_alpn_clientTest.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_alpn_client;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+
+import org.eclipse.jetty.alpn.client.ALPNClientConnection;
+import org.eclipse.jetty.alpn.client.ALPNClientConnectionFactory;
+import org.eclipse.jetty.io.AbstractConnection;
+import org.eclipse.jetty.io.ByteArrayEndPoint;
+import org.eclipse.jetty.io.ClientConnectionFactory;
+import org.eclipse.jetty.io.ClientConnector;
+import org.eclipse.jetty.io.Connection;
+import org.eclipse.jetty.io.EndPoint;
+import org.eclipse.jetty.util.Promise;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+public class Jetty_alpn_clientTest {
+    private static final Executor DIRECT_EXECUTOR = Runnable::run;
+    private static final List<String> PROTOCOLS = List.of("h2", "http/1.1");
+
+    @Test
+    void clientConnectionExposesSslEngineAndConfiguredProtocols() throws Exception {
+        ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
+        TestClientConnectionFactory connectionFactory = new TestClientConnectionFactory();
+        SSLEngine sslEngine = newClientEngine();
+        Map<String, Object> context = new HashMap<>();
+        ALPNClientConnection connection = new ALPNClientConnection(
+                endPoint,
+                DIRECT_EXECUTOR,
+                connectionFactory,
+                sslEngine,
+                context,
+                PROTOCOLS);
+
+        assertThat(connection.getSSLEngine()).isSameAs(sslEngine);
+        assertThat(connection.getProtocols()).containsExactly("h2", "http/1.1");
+        assertThat(connection.getProtocol()).isNull();
+        assertThat(connectionFactory.createdConnections).isEmpty();
+    }
+
+    @Test
+    void selectedProtocolIsRecordedWithoutImmediatelyReplacingTheConnection() throws Exception {
+        ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
+        TestClientConnectionFactory connectionFactory = new TestClientConnectionFactory();
+        ALPNClientConnection connection = newAlpnConnection(endPoint, connectionFactory, new HashMap<>());
+        endPoint.setConnection(connection);
+
+        connection.selected("h2");
+
+        assertThat(connection.getProtocol()).isEqualTo("h2");
+        assertThat(endPoint.getConnection()).isSameAs(connection);
+        assertThat(connectionFactory.createdConnections).isEmpty();
+    }
+
+    @Test
+    void selectedProtocolBeforeOpenUpgradesEndPointToProtocolConnection() throws Exception {
+        ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
+        Map<String, Object> context = new HashMap<>();
+        context.put("test.name", "selectedProtocolBeforeOpenUpgradesEndPointToProtocolConnection");
+        TestClientConnectionFactory connectionFactory = new TestClientConnectionFactory();
+        ALPNClientConnection connection = newAlpnConnection(endPoint, connectionFactory, context);
+        endPoint.setConnection(connection);
+
+        connection.selected("http/1.1");
+        connection.onOpen();
+
+        assertThat(connection.getProtocol()).isEqualTo("http/1.1");
+        assertThat(connectionFactory.createdConnections).hasSize(1);
+        assertThat(connectionFactory.seenEndPoints).containsExactly(endPoint);
+        assertThat(connectionFactory.seenContexts).containsExactly(context);
+        assertThat(endPoint.getConnection()).isSameAs(connectionFactory.createdConnections.get(0));
+        assertThat(connectionFactory.createdConnections.get(0).opened).isTrue();
+    }
+
+    @Test
+    void selectedProtocolOnFillableUpgradesEndPointToProtocolConnection() throws Exception {
+        ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
+        Map<String, Object> context = new HashMap<>();
+        TestClientConnectionFactory connectionFactory = new TestClientConnectionFactory();
+        ALPNClientConnection connection = newAlpnConnection(endPoint, connectionFactory, context);
+        endPoint.setConnection(connection);
+
+        connection.selected("h2");
+        connection.onFillable();
+
+        assertThat(connection.getProtocol()).isEqualTo("h2");
+        assertThat(connectionFactory.createdConnections).hasSize(1);
+        assertThat(connectionFactory.seenEndPoints).containsExactly(endPoint);
+        assertThat(connectionFactory.seenContexts).containsExactly(context);
+        assertThat(endPoint.getConnection()).isSameAs(connectionFactory.createdConnections.get(0));
+        assertThat(connectionFactory.createdConnections.get(0).opened).isTrue();
+    }
+
+    @Test
+    void onFillableKeepsWaitingWhenNegotiationHasNotCompletedAndNoBytesAreAvailable() throws Exception {
+        ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
+        TestClientConnectionFactory connectionFactory = new TestClientConnectionFactory();
+        ALPNClientConnection connection = newAlpnConnection(endPoint, connectionFactory, new HashMap<>());
+        endPoint.setConnection(connection);
+
+        connection.onFillable();
+
+        assertThat(connection.getProtocol()).isNull();
+        assertThat(endPoint.getConnection()).isSameAs(connection);
+        assertThat(endPoint.isFillInterested()).isTrue();
+        assertThat(connectionFactory.createdConnections).isEmpty();
+    }
+
+    @Test
+    void endOfInputUpgradesEndPointWithoutNegotiatedProtocol() throws Exception {
+        ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
+        RecordingPromise connectionPromise = new RecordingPromise();
+        Map<String, Object> context = newContextWithConnectionPromise(connectionPromise);
+        TestClientConnectionFactory connectionFactory = new TestClientConnectionFactory();
+        ALPNClientConnection connection = newAlpnConnection(endPoint, connectionFactory, context);
+        endPoint.setConnection(connection);
+        endPoint.addInputEOF();
+
+        connection.onFillable();
+
+        assertThat(connection.getProtocol()).isNull();
+        assertThat(connectionFactory.createdConnections).hasSize(1);
+        RecordingConnection protocolConnection = connectionFactory.createdConnections.get(0);
+        assertThat(endPoint.getConnection()).isSameAs(protocolConnection);
+        assertThat(protocolConnection.opened).isTrue();
+        assertThat(connectionPromise.failure).isNull();
+        assertThat(endPoint.isInputShutdown()).isTrue();
+        assertThat(endPoint.isOpen()).isTrue();
+    }
+
+    @Test
+    void closeShutsDownEndPointOutput() throws Exception {
+        ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
+        TestClientConnectionFactory connectionFactory = new TestClientConnectionFactory();
+        ALPNClientConnection connection = newAlpnConnection(endPoint, connectionFactory, new HashMap<>());
+        endPoint.setConnection(connection);
+
+        connection.close();
+
+        assertThat(endPoint.isOutputShutdown()).isTrue();
+        assertThat(endPoint.isOpen()).isFalse();
+    }
+
+    @Test
+    void failedProtocolConnectionCreationClosesEndPoint() throws Exception {
+        ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
+        RecordingPromise connectionPromise = new RecordingPromise();
+        Map<String, Object> context = newContextWithConnectionPromise(connectionPromise);
+        ClientConnectionFactory failingConnectionFactory = (ignoredEndPoint, ignoredContext) -> {
+            throw new IOException("Unable to create protocol connection");
+        };
+        ALPNClientConnection connection = newAlpnConnection(endPoint, failingConnectionFactory, context);
+        endPoint.setConnection(connection);
+
+        connection.selected("h2");
+        connection.onOpen();
+
+        assertThat(connection.getProtocol()).isEqualTo("h2");
+        assertThat(connectionPromise.failure).isNull();
+        assertThat(endPoint.getConnection()).isSameAs(connection);
+        assertThat(endPoint.isOutputShutdown()).isTrue();
+        assertThat(endPoint.isOpen()).isFalse();
+    }
+
+    @Test
+    void clientConnectionFactoryRejectsEmptyProtocolListBeforeLookingUpProcessors() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> new ALPNClientConnectionFactory(
+                        DIRECT_EXECUTOR,
+                        new TestClientConnectionFactory(),
+                        List.of()))
+                .withMessage("ALPN protocol list cannot be empty");
+    }
+
+    @Test
+    void clientConnectionFactoryReportsMissingProcessorWhenNoClientAlpnProcessorServiceIsPresent() {
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> new ALPNClientConnectionFactory(
+                        DIRECT_EXECUTOR,
+                        new TestClientConnectionFactory(),
+                        PROTOCOLS))
+                .withMessage("No Client ALPNProcessors!");
+    }
+
+    private static ALPNClientConnection newAlpnConnection(
+            EndPoint endPoint,
+            ClientConnectionFactory connectionFactory,
+            Map<String, Object> context) throws Exception {
+        return new ALPNClientConnection(
+                endPoint,
+                DIRECT_EXECUTOR,
+                connectionFactory,
+                newClientEngine(),
+                context,
+                PROTOCOLS);
+    }
+
+    private static SSLEngine newClientEngine() throws Exception {
+        SSLEngine sslEngine = SSLContext.getDefault().createSSLEngine("localhost", 443);
+        sslEngine.setUseClientMode(true);
+        return sslEngine;
+    }
+
+    private static Map<String, Object> newContextWithConnectionPromise(RecordingPromise connectionPromise) {
+        Map<String, Object> context = new HashMap<>();
+        context.put(ClientConnector.CONNECTION_PROMISE_CONTEXT_KEY, connectionPromise);
+        return context;
+    }
+
+    private static final class RecordingPromise implements Promise<Connection> {
+        private Throwable failure;
+
+        @Override
+        public void failed(Throwable failure) {
+            this.failure = failure;
+        }
+    }
+
+    private static final class TestClientConnectionFactory implements ClientConnectionFactory {
+        private final List<EndPoint> seenEndPoints = new ArrayList<>();
+        private final List<Map<String, Object>> seenContexts = new ArrayList<>();
+        private final List<RecordingConnection> createdConnections = new ArrayList<>();
+
+        @Override
+        public Connection newConnection(EndPoint endPoint, Map<String, Object> context) throws IOException {
+            seenEndPoints.add(endPoint);
+            seenContexts.add(context);
+            RecordingConnection connection = new RecordingConnection(endPoint);
+            createdConnections.add(connection);
+            return connection;
+        }
+    }
+
+    private static final class RecordingConnection extends AbstractConnection {
+        private boolean opened;
+
+        private RecordingConnection(EndPoint endPoint) {
+            super(endPoint, DIRECT_EXECUTOR);
+        }
+
+        @Override
+        public void onOpen() {
+            super.onOpen();
+            opened = true;
+        }
+
+        @Override
+        public void onFillable() {
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-alpn-client/12.1.5/user-code-filter.json
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-client/12.1.5/user-code-filter.json
@@ -1,0 +1,19 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.eclipse.jetty.alpn.client.**"
+    },
+    {
+      "includeClasses" : "org.eclipse.jetty.util.**"
+    },
+    {
+      "includeClasses" : "org.eclipse.jetty.io.**"
+    },
+    {
+      "includeClasses" : "org_eclipse_jetty.jetty_alpn_client.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7965

This PR provides test fixes and new metadata for org.eclipse.jetty:jetty-alpn-client:12.1.5, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 96021
- Cached input tokens: 692224
- Output tokens: 3319
- Metadata entries: 4
- Iterations: 1
- Library coverage percentage: 42.86
- Previous library version metadata entries: 4
- Previous library version coverage percentage: 42.86

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `9dfa17437a0630c9f15775fdfb46262998e5dfa0`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.eclipse.jetty:jetty-alpn-client:12.1.0: 0/0 covered calls (100.00%)
- org.eclipse.jetty:jetty-alpn-client:12.1.5: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.eclipse.jetty:jetty-alpn-client:12.1.0: 78/197 (39.59%)
- org.eclipse.jetty:jetty-alpn-client:12.1.5: 78/201 (38.81%)

**Line:**
- org.eclipse.jetty:jetty-alpn-client:12.1.0: 21/49 (42.86%)
- org.eclipse.jetty:jetty-alpn-client:12.1.5: 21/49 (42.86%)

**Method:**
- org.eclipse.jetty:jetty-alpn-client:12.1.0: 7/9 (77.78%)
- org.eclipse.jetty:jetty-alpn-client:12.1.5: 7/9 (77.78%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.eclipse.jetty/jetty-alpn-client/12.1.0/src/test/java/org_eclipse_jetty/jetty_alpn_client/Jetty_alpn_clientTest.java 2/tests/src/org.eclipse.jetty/jetty-alpn-client/12.1.5/src/test/java/org_eclipse_jetty/jetty_alpn_client/Jetty_alpn_clientTest.java
index 41b9a40b80..bc021e8da8 100644
--- 1/tests/src/org.eclipse.jetty/jetty-alpn-client/12.1.0/src/test/java/org_eclipse_jetty/jetty_alpn_client/Jetty_alpn_clientTest.java
+++ 2/tests/src/org.eclipse.jetty/jetty-alpn-client/12.1.5/src/test/java/org_eclipse_jetty/jetty_alpn_client/Jetty_alpn_clientTest.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.concurrent.Executor;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLHandshakeException;
 
 import org.eclipse.jetty.alpn.client.ALPNClientConnection;
 import org.eclipse.jetty.alpn.client.ALPNClientConnectionFactory;
@@ -122,7 +123,7 @@ public class Jetty_alpn_clientTest {
     }
 
     @Test
-    void endOfInputUpgradesEndPointWithoutNegotiatedProtocol() throws Exception {
+    void endOfInputFailsConnectionPromiseWithoutNegotiatedProtocol() throws Exception {
         ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
         RecordingPromise connectionPromise = new RecordingPromise();
         Map<String, Object> context = newContextWithConnectionPromise(connectionPromise);
@@ -134,13 +135,14 @@ public class Jetty_alpn_clientTest {
         connection.onFillable();
 
         assertThat(connection.getProtocol()).isNull();
-        assertThat(connectionFactory.createdConnections).hasSize(1);
-        RecordingConnection protocolConnection = connectionFactory.createdConnections.get(0);
-        assertThat(endPoint.getConnection()).isSameAs(protocolConnection);
-        assertThat(protocolConnection.opened).isTrue();
-        assertThat(connectionPromise.failure).isNull();
+        assertThat(connectionFactory.createdConnections).isEmpty();
+        assertThat(endPoint.getConnection()).isSameAs(connection);
+        assertThat(connectionPromise.failure)
+                .isInstanceOf(SSLHandshakeException.class)
+                .hasMessage("Abruptly closed by peer");
         assertThat(endPoint.isInputShutdown()).isTrue();
-        assertThat(endPoint.isOpen()).isTrue();
+        assertThat(endPoint.isOutputShutdown()).isTrue();
+        assertThat(endPoint.isOpen()).isFalse();
     }
 
     @Test
@@ -171,7 +173,9 @@ public class Jetty_alpn_clientTest {
         connection.onOpen();
 
         assertThat(connection.getProtocol()).isEqualTo("h2");
-        assertThat(connectionPromise.failure).isNull();
+        assertThat(connectionPromise.failure)
+                .isInstanceOf(IOException.class)
+                .hasMessage("Unable to create protocol connection");
         assertThat(endPoint.getConnection()).isSameAs(connection);
         assertThat(endPoint.isOutputShutdown()).isTrue();
         assertThat(endPoint.isOpen()).isFalse();

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
