### PR TITLE
[GenAI] Test fix for io.vertx:vertx-web-client:5.0.0 using gpt-5.5

### DIFF
--- a/metadata/io.vertx/vertx-web-client/5.0.0/reachability-metadata.json
+++ b/metadata/io.vertx/vertx-web-client/5.0.0/reachability-metadata.json
@@ -1,0 +1,290 @@
+{
+  "reflection" : [
+    {
+      "type" : "java.nio.ByteBuffer",
+      "methods" : [
+        {
+          "name" : "alignedSlice",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "java.nio.DirectByteBuffer",
+      "allDeclaredConstructors" : true
+    },
+    {
+      "type" : "sun.misc.Unsafe",
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "type" : "jdk.internal.misc.Unsafe",
+      "methods" : [
+        {
+          "name" : "copyMemory",
+          "parameterTypes" : [
+            "java.lang.Object",
+            "long",
+            "java.lang.Object",
+            "long",
+            "long"
+          ]
+        },
+        {
+          "name" : "objectFieldOffset",
+          "parameterTypes" : [
+            "java.lang.reflect.Field"
+          ]
+        },
+        {
+          "name" : "staticFieldOffset",
+          "parameterTypes" : [
+            "java.lang.reflect.Field"
+          ]
+        },
+        {
+          "name" : "staticFieldBase",
+          "parameterTypes" : [
+            "java.lang.reflect.Field"
+          ]
+        },
+        {
+          "name" : "arrayBaseOffset",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name" : "arrayIndexScale",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name" : "allocateMemory",
+          "parameterTypes" : [
+            "long"
+          ]
+        },
+        {
+          "name" : "reallocateMemory",
+          "parameterTypes" : [
+            "long",
+            "long"
+          ]
+        },
+        {
+          "name" : "freeMemory",
+          "parameterTypes" : [
+            "long"
+          ]
+        },
+        {
+          "name" : "setMemory",
+          "parameterTypes" : [
+            "long",
+            "long",
+            "byte"
+          ]
+        },
+        {
+          "name" : "setMemory",
+          "parameterTypes" : [
+            "java.lang.Object",
+            "long",
+            "long",
+            "byte"
+          ]
+        },
+        {
+          "name" : "getBoolean",
+          "parameterTypes" : [
+            "java.lang.Object",
+            "long"
+          ]
+        },
+        {
+          "name" : "getByte",
+          "parameterTypes" : [
+            "long"
+          ]
+        },
+        {
+          "name" : "getByte",
+          "parameterTypes" : [
+            "java.lang.Object",
+            "long"
+          ]
+        },
+        {
+          "name" : "getInt",
+          "parameterTypes" : [
+            "long"
+          ]
+        },
+        {
+          "name" : "getInt",
+          "parameterTypes" : [
+            "java.lang.Object",
+            "long"
+          ]
+        },
+        {
+          "name" : "getLong",
+          "parameterTypes" : [
+            "long"
+          ]
+        },
+        {
+          "name" : "getLong",
+          "parameterTypes" : [
+            "java.lang.Object",
+            "long"
+          ]
+        },
+        {
+          "name" : "putByte",
+          "parameterTypes" : [
+            "long",
+            "byte"
+          ]
+        },
+        {
+          "name" : "putByte",
+          "parameterTypes" : [
+            "java.lang.Object",
+            "long",
+            "byte"
+          ]
+        },
+        {
+          "name" : "putInt",
+          "parameterTypes" : [
+            "long",
+            "int"
+          ]
+        },
+        {
+          "name" : "putInt",
+          "parameterTypes" : [
+            "java.lang.Object",
+            "long",
+            "int"
+          ]
+        },
+        {
+          "name" : "putLong",
+          "parameterTypes" : [
+            "long",
+            "long"
+          ]
+        },
+        {
+          "name" : "putLong",
+          "parameterTypes" : [
+            "java.lang.Object",
+            "long",
+            "long"
+          ]
+        },
+        {
+          "name" : "addressSize",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : "java.lang.management.ManagementFactory",
+      "methods" : [
+        {
+          "name" : "getRuntimeMXBean",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : "java.lang.management.RuntimeMXBean",
+      "methods" : [
+        {
+          "name" : "getInputArguments",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : "io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueColdProducerFields",
+      "fields" : [
+        {
+          "name" : "producerLimit"
+        }
+      ]
+    },
+    {
+      "type" : "io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueConsumerFields",
+      "fields" : [
+        {
+          "name" : "consumerIndex"
+        }
+      ]
+    },
+    {
+      "type" : "io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueProducerFields",
+      "fields" : [
+        {
+          "name" : "producerIndex"
+        }
+      ]
+    },
+    {
+      "type" : "io.netty.util.internal.shaded.org.jctools.queues.MpmcArrayQueueConsumerIndexField",
+      "fields" : [
+        {
+          "name" : "consumerIndex"
+        }
+      ]
+    },
+    {
+      "type" : "io.netty.util.internal.shaded.org.jctools.queues.MpmcArrayQueueProducerIndexField",
+      "fields" : [
+        {
+          "name" : "producerIndex"
+        }
+      ]
+    },
+    {
+      "type" : "io.netty.buffer.AbstractByteBufAllocator",
+      "allDeclaredMethods" : true
+    },
+    {
+      "type" : "io.netty.buffer.AbstractReferenceCountedByteBuf",
+      "fields" : [
+        {
+          "name" : "refCnt"
+        }
+      ]
+    },
+    {
+      "type" : "io.netty.buffer.AdaptivePoolingAllocator$Chunk",
+      "fields" : [
+        {
+          "name" : "refCnt"
+        }
+      ]
+    },
+    {
+      "type" : "io.netty.buffer.AdaptivePoolingAllocator$Magazine",
+      "fields" : [
+        {
+          "name" : "nextInLine"
+        }
+      ]
+    },
+    {
+      "type" : "io.netty.util.ReferenceCountUtil",
+      "allDeclaredMethods" : true
+    }
+  ]
+}

--- a/metadata/io.vertx/vertx-web-client/index.json
+++ b/metadata/io.vertx/vertx-web-client/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "5.0.0",
+    "tested-versions" : [
+      "5.0.0"
+    ],
+    "allowed-packages" : [
+      "io.vertx.ext.web.client"
+    ]
+  },
+  {
     "metadata-version" : "4.5.24",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/vertx/vertx-web-client/$version$/vertx-web-client-$version$-sources.jar",
     "repository-url" : "https://github.com/vert-x3/vertx-web",

--- a/metadata/io.vertx/vertx-web-client/index.json
+++ b/metadata/io.vertx/vertx-web-client/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "5.0.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/vertx/vertx-web-client/$version$/vertx-web-client-$version$-sources.jar",
+    "repository-url" : "https://github.com/vert-x3/vertx-web",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/io/vertx/vertx-web-client/$version$/vertx-web-client-$version$-test-sources.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/vertx/vertx-web-client/$version$/vertx-web-client-$version$-javadoc.jar",
+    "description" : "Vert.x Web Client is an asynchronous HTTP and HTTP/2 client built on Vert.x for sending requests, handling responses, forms, redirects, cookies, sessions, and response predicates. It provides a higher-level API than the core Vert.x HTTP client for service-to-service calls and web integrations in JVM applications.",
     "tested-versions" : [
       "5.0.0"
     ],

--- a/stats/io.vertx/vertx-web-client/5.0.0/execution-metrics.json
+++ b/stats/io.vertx/vertx-web-client/5.0.0/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_javac_fail:2026-06-06": {
+    "timestamp": "2026-06-06T10:50:49.125616Z",
+    "library": "io.vertx:vertx-web-client:5.0.0",
+    "starting_commit": "2d43aef8f279135ba18d13046c78fc89b79aea9a",
+    "ending_commit": "0497faef98109ab6debed4b01e3228b1c2bb05a6",
+    "previous_library": "io.vertx:vertx-web-client:4.5.24",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "5.0.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3051,
+          "missed": 4056,
+          "ratio": 0.429295,
+          "total": 7107
+        },
+        "line": {
+          "covered": 747,
+          "missed": 904,
+          "ratio": 0.452453,
+          "total": 1651
+        },
+        "method": {
+          "covered": 182,
+          "missed": 375,
+          "ratio": 0.32675,
+          "total": 557
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "4.5.24",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3814,
+          "missed": 4689,
+          "ratio": 0.448548,
+          "total": 8503
+        },
+        "line": {
+          "covered": 955,
+          "missed": 1055,
+          "ratio": 0.475124,
+          "total": 2010
+        },
+        "method": {
+          "covered": 221,
+          "missed": 447,
+          "ratio": 0.330838,
+          "total": 668
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 28033,
+      "cached_input_tokens_used": 259584,
+      "output_tokens_used": 4751,
+      "iterations": 1,
+      "cost_usd": 0.2723,
+      "tested_library_loc": 747,
+      "metadata_entries": 57,
+      "previous_library_metadata_entries": 0,
+      "code_coverage_percent": 45.25,
+      "previous_library_coverage_percent": 47.51
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.vertx/vertx-web-client/5.0.0/src/test/java/io_vertx/vertx_web_client/Vertx_web_clientTest.java",
+      "metadata_file": "metadata/io.vertx/vertx-web-client/5.0.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.vertx/vertx-web-client/5.0.0/stats.json
+++ b/stats/io.vertx/vertx-web-client/5.0.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "5.0.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3051,
+        "missed" : 4056,
+        "ratio" : 0.429295,
+        "total" : 7107
+      },
+      "line" : {
+        "covered" : 747,
+        "missed" : 904,
+        "ratio" : 0.452453,
+        "total" : 1651
+      },
+      "method" : {
+        "covered" : 182,
+        "missed" : 375,
+        "ratio" : 0.32675,
+        "total" : 557
+      }
+    }
+  } ]
+}

--- a/tests/src/io.vertx/vertx-web-client/5.0.0/.gitignore
+++ b/tests/src/io.vertx/vertx-web-client/5.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.vertx/vertx-web-client/5.0.0/build.gradle
+++ b/tests/src/io.vertx/vertx-web-client/5.0.0/build.gradle
@@ -15,6 +15,16 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
+tasks.named("nativeTest") {
+    if (libraryVersion == '5.0.0') {
+        // Vert.x 5.0.0 pulls in Netty 4.2.x, which requires explicit unsafe access on Java 25 native runs.
+        runtimeArgs.addAll([
+                '-Dsun.misc.unsafe.memory.access=allow',
+                '-Dio.netty.tryReflectionSetAccessible=true'
+        ])
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.vertx/vertx-web-client/5.0.0/build.gradle
+++ b/tests/src/io.vertx/vertx-web-client/5.0.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.vertx:vertx-web-client:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.vertx/vertx-web-client/5.0.0/gradle.properties
+++ b/tests/src/io.vertx/vertx-web-client/5.0.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.vertx:vertx-web-client:5.0.0
+library.version = 5.0.0
+metadata.dir = io.vertx/vertx-web-client/5.0.0/

--- a/tests/src/io.vertx/vertx-web-client/5.0.0/settings.gradle
+++ b/tests/src/io.vertx/vertx-web-client/5.0.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.vertx.vertx-web-client_tests'

--- a/tests/src/io.vertx/vertx-web-client/5.0.0/src/test/java/io_vertx/vertx_web_client/Vertx_web_clientTest.java
+++ b/tests/src/io.vertx/vertx-web-client/5.0.0/src/test/java/io_vertx/vertx_web_client/Vertx_web_clientTest.java
@@ -23,7 +23,6 @@ import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.ext.web.client.WebClientSession;
-import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import io.vertx.ext.web.codec.BodyCodec;
 import io.vertx.ext.web.multipart.MultipartForm;
 import java.nio.charset.StandardCharsets;
@@ -61,11 +60,10 @@ public class Vertx_web_clientTest {
                     .addQueryParam("q", "native-image")
                     .putHeader("X-Client-Test", "web-client")
                     .as(BodyCodec.jsonObject())
-                    .expect(ResponsePredicate.SC_OK)
-                    .expect(ResponsePredicate.JSON)
                     .send());
 
-            assertThat(response.statusCode()).isEqualTo(200);
+            assertOk(response);
+            assertThat(response.getHeader("content-type")).startsWith("application/json");
             assertThat(response.getHeader("x-server-test")).isEqualTo("json-response");
             JsonObject responseBody = response.body();
             assertThat(responseBody.getString("method")).isEqualTo("GET");
@@ -106,10 +104,10 @@ public class Vertx_web_clientTest {
             HttpResponse<JsonObject> response = await(client.post("/json")
                     .basicAuthentication("tester", "secret")
                     .as(BodyCodec.jsonObject())
-                    .expect(ResponsePredicate.SC_SUCCESS)
-                    .expect(ResponsePredicate.contentType("application/json"))
                     .sendJsonObject(requestBody));
 
+            assertThat(response.statusCode()).isBetween(200, 299);
+            assertThat(response.getHeader("content-type")).startsWith("application/json");
             String credentials = Base64.getEncoder()
                     .encodeToString("tester:secret".getBytes(StandardCharsets.UTF_8));
             JsonObject responseBody = response.body();
@@ -152,9 +150,9 @@ public class Vertx_web_clientTest {
             HttpResponse<JsonObject> response = await(client.post("/stream")
                     .putHeader("content-type", "text/plain")
                     .as(BodyCodec.jsonObject())
-                    .expect(ResponsePredicate.SC_OK)
                     .sendStream(sourceFile));
 
+            assertOk(response);
             assertThat(response.body().getString("contentType")).isEqualTo("text/plain");
             assertThat(response.body().getString("body")).isEqualTo("streamed-request-body");
         } finally {
@@ -194,8 +192,8 @@ public class Vertx_web_clientTest {
                     .add("project", "native-image");
             HttpResponse<JsonObject> formResponse = await(client.post("/form")
                     .as(BodyCodec.jsonObject())
-                    .expect(ResponsePredicate.SC_OK)
                     .sendForm(form));
+            assertOk(formResponse);
             assertThat(formResponse.body().getString("contentType"))
                     .startsWith("application/x-www-form-urlencoded");
             assertThat(formResponse.body().getString("body"))
@@ -209,9 +207,9 @@ public class Vertx_web_clientTest {
                     .textFileUpload("attachment", "sample.txt", upload.toString(), "text/plain");
             HttpResponse<JsonObject> multipartResponse = await(client.post("/multipart")
                     .as(BodyCodec.jsonObject())
-                    .expect(ResponsePredicate.SC_OK)
                     .sendMultipartForm(multipartForm));
 
+            assertOk(multipartResponse);
             assertThat(multipartResponse.body().getString("contentType"))
                     .startsWith("multipart/form-data");
             assertThat(multipartResponse.body().getString("body"))
@@ -247,13 +245,13 @@ public class Vertx_web_clientTest {
 
             HttpResponse<Buffer> firstResponse = await(client.get("/cached-resource")
                     .as(BodyCodec.buffer())
-                    .expect(ResponsePredicate.SC_OK)
                     .send());
             HttpResponse<Buffer> secondResponse = await(client.get("/cached-resource")
                     .as(BodyCodec.buffer())
-                    .expect(ResponsePredicate.SC_OK)
                     .send());
 
+            assertOk(firstResponse);
+            assertOk(secondResponse);
             assertThat(firstResponse.bodyAsString()).isEqualTo("response-1");
             assertThat(secondResponse.bodyAsString()).isEqualTo("response-1");
             assertThat(secondResponse.getHeader("age")).isNotNull();
@@ -294,23 +292,27 @@ public class Vertx_web_clientTest {
 
             HttpResponse<String> loginResponse = await(session.get("/login")
                     .as(BodyCodec.string())
-                    .expect(ResponsePredicate.SC_OK)
                     .send());
+            assertOk(loginResponse);
             assertThat(loginResponse.body()).isEqualTo("logged-in");
 
             HttpResponse<JsonObject> profileResponse = await(session.get("/redirect")
                     .followRedirects(true)
                     .as(BodyCodec.jsonObject())
-                    .expect(ResponsePredicate.SC_OK)
-                    .expect(ResponsePredicate.JSON)
                     .send());
 
+            assertOk(profileResponse);
+            assertThat(profileResponse.getHeader("content-type")).startsWith("application/json");
             assertThat(profileResponse.followedRedirects()).isNotEmpty();
             assertThat(profileResponse.body().getString("cookie")).contains("sid=abc123");
             assertThat(profileResponse.body().getString("sessionHeader")).isEqualTo("present");
         } finally {
             close(session, server, vertx);
         }
+    }
+
+    private static void assertOk(HttpResponse<?> response) {
+        assertThat(response.statusCode()).isEqualTo(200);
     }
 
     private static WebClient createClient(Vertx vertx, int port) {

--- a/tests/src/io.vertx/vertx-web-client/5.0.0/src/test/java/io_vertx/vertx_web_client/Vertx_web_clientTest.java
+++ b/tests/src/io.vertx/vertx-web-client/5.0.0/src/test/java/io_vertx/vertx_web_client/Vertx_web_clientTest.java
@@ -1,0 +1,345 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_vertx.vertx_web_client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.file.AsyncFile;
+import io.vertx.core.file.OpenOptions;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.CachingWebClient;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+import io.vertx.ext.web.client.WebClientSession;
+import io.vertx.ext.web.client.predicate.ResponsePredicate;
+import io.vertx.ext.web.codec.BodyCodec;
+import io.vertx.ext.web.multipart.MultipartForm;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+public class Vertx_web_clientTest {
+    private static final String HOST = "127.0.0.1";
+    private static final int TIMEOUT_SECONDS = 10;
+
+    @Test
+    void getRequestSendsHeadersQueryParametersAndDecodesJsonBody() throws Exception {
+        Vertx vertx = Vertx.vertx();
+        HttpServer server = null;
+        WebClient client = null;
+        try {
+            server = startServer(vertx, request -> {
+                JsonObject payload = new JsonObject()
+                        .put("method", request.method().name())
+                        .put("path", request.path())
+                        .put("query", request.query())
+                        .put("clientHeader", request.getHeader("X-Client-Test"));
+                request.response()
+                        .putHeader("content-type", "application/json")
+                        .putHeader("x-server-test", "json-response")
+                        .end(payload.encode());
+            });
+            client = createClient(vertx, server.actualPort());
+
+            HttpResponse<JsonObject> response = await(client.get("/search")
+                    .addQueryParam("q", "native-image")
+                    .putHeader("X-Client-Test", "web-client")
+                    .as(BodyCodec.jsonObject())
+                    .expect(ResponsePredicate.SC_OK)
+                    .expect(ResponsePredicate.JSON)
+                    .send());
+
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.getHeader("x-server-test")).isEqualTo("json-response");
+            JsonObject responseBody = response.body();
+            assertThat(responseBody.getString("method")).isEqualTo("GET");
+            assertThat(responseBody.getString("path")).isEqualTo("/search");
+            assertThat(responseBody.getString("query")).isEqualTo("q=native-image");
+            assertThat(responseBody.getString("clientHeader")).isEqualTo("web-client");
+        } finally {
+            close(client, server, vertx);
+        }
+    }
+
+    @Test
+    void postJsonObjectUsesBasicAuthenticationAndMapsJsonResponse() throws Exception {
+        Vertx vertx = Vertx.vertx();
+        HttpServer server = null;
+        WebClient client = null;
+        try {
+            server = startServer(vertx, request -> request.body().onComplete(bodyResult -> {
+                if (bodyResult.failed()) {
+                    request.response().setStatusCode(500).end(bodyResult.cause().getMessage());
+                    return;
+                }
+                JsonObject requestBody = bodyResult.result().toJsonObject();
+                JsonObject responseBody = new JsonObject()
+                        .put("contentType", request.getHeader("content-type"))
+                        .put("authorization", request.getHeader("authorization"))
+                        .put("message", requestBody.getString("message"))
+                        .put("count", requestBody.getInteger("count"));
+                request.response()
+                        .putHeader("content-type", "application/json")
+                        .end(responseBody.encode());
+            }));
+            client = createClient(vertx, server.actualPort());
+
+            JsonObject requestBody = new JsonObject()
+                    .put("message", "hello")
+                    .put("count", 3);
+            HttpResponse<JsonObject> response = await(client.post("/json")
+                    .basicAuthentication("tester", "secret")
+                    .as(BodyCodec.jsonObject())
+                    .expect(ResponsePredicate.SC_SUCCESS)
+                    .expect(ResponsePredicate.contentType("application/json"))
+                    .sendJsonObject(requestBody));
+
+            String credentials = Base64.getEncoder()
+                    .encodeToString("tester:secret".getBytes(StandardCharsets.UTF_8));
+            JsonObject responseBody = response.body();
+            assertThat(responseBody.getString("contentType")).startsWith("application/json");
+            assertThat(responseBody.getString("authorization")).isEqualTo("Basic " + credentials);
+            assertThat(responseBody.getString("message")).isEqualTo("hello");
+            assertThat(responseBody.getInteger("count")).isEqualTo(3);
+        } finally {
+            close(client, server, vertx);
+        }
+    }
+
+    @Test
+    void streamsRequestBodyFromReadStream() throws Exception {
+        Vertx vertx = Vertx.vertx();
+        HttpServer server = null;
+        WebClient client = null;
+        AsyncFile sourceFile = null;
+        Path streamSource = null;
+        try {
+            server = startServer(vertx, request -> request.body().onComplete(bodyResult -> {
+                if (bodyResult.failed()) {
+                    request.response().setStatusCode(500).end(bodyResult.cause().getMessage());
+                    return;
+                }
+                JsonObject responseBody = new JsonObject()
+                        .put("contentType", request.getHeader("content-type"))
+                        .put("body", bodyResult.result().toString(StandardCharsets.UTF_8.name()));
+                request.response()
+                        .putHeader("content-type", "application/json")
+                        .end(responseBody.encode());
+            }));
+            client = createClient(vertx, server.actualPort());
+            streamSource = Files.createTempFile("vertx-web-client-stream", ".txt");
+            Files.writeString(streamSource, "streamed-request-body", StandardCharsets.UTF_8);
+            sourceFile = await(vertx.fileSystem().open(
+                    streamSource.toString(),
+                    new OpenOptions().setRead(true).setWrite(false)));
+
+            HttpResponse<JsonObject> response = await(client.post("/stream")
+                    .putHeader("content-type", "text/plain")
+                    .as(BodyCodec.jsonObject())
+                    .expect(ResponsePredicate.SC_OK)
+                    .sendStream(sourceFile));
+
+            assertThat(response.body().getString("contentType")).isEqualTo("text/plain");
+            assertThat(response.body().getString("body")).isEqualTo("streamed-request-body");
+        } finally {
+            if (sourceFile != null) {
+                await(sourceFile.close());
+            }
+            if (streamSource != null) {
+                Files.deleteIfExists(streamSource);
+            }
+            close(client, server, vertx);
+        }
+    }
+
+    @Test
+    void sendsUrlEncodedFormsAndMultipartUploads() throws Exception {
+        Vertx vertx = Vertx.vertx();
+        HttpServer server = null;
+        WebClient client = null;
+        Path upload = null;
+        try {
+            server = startServer(vertx, request -> request.body().onComplete(bodyResult -> {
+                if (bodyResult.failed()) {
+                    request.response().setStatusCode(500).end(bodyResult.cause().getMessage());
+                    return;
+                }
+                String contentType = request.getHeader("content-type");
+                String body = bodyResult.result().toString(StandardCharsets.UTF_8.name());
+                JsonObject responseBody = new JsonObject()
+                        .put("contentType", contentType)
+                        .put("body", body);
+                request.response().putHeader("content-type", "application/json").end(responseBody.encode());
+            }));
+            client = createClient(vertx, server.actualPort());
+
+            MultiMap form = MultiMap.caseInsensitiveMultiMap()
+                    .add("name", "Ada Lovelace")
+                    .add("project", "native-image");
+            HttpResponse<JsonObject> formResponse = await(client.post("/form")
+                    .as(BodyCodec.jsonObject())
+                    .expect(ResponsePredicate.SC_OK)
+                    .sendForm(form));
+            assertThat(formResponse.body().getString("contentType"))
+                    .startsWith("application/x-www-form-urlencoded");
+            assertThat(formResponse.body().getString("body"))
+                    .contains("name=Ada+Lovelace")
+                    .contains("project=native-image");
+
+            upload = Files.createTempFile("vertx-web-client-upload", ".txt");
+            Files.writeString(upload, "file-body", StandardCharsets.UTF_8);
+            MultipartForm multipartForm = MultipartForm.create()
+                    .attribute("description", "metadata test")
+                    .textFileUpload("attachment", "sample.txt", upload.toString(), "text/plain");
+            HttpResponse<JsonObject> multipartResponse = await(client.post("/multipart")
+                    .as(BodyCodec.jsonObject())
+                    .expect(ResponsePredicate.SC_OK)
+                    .sendMultipartForm(multipartForm));
+
+            assertThat(multipartResponse.body().getString("contentType"))
+                    .startsWith("multipart/form-data");
+            assertThat(multipartResponse.body().getString("body"))
+                    .contains("name=\"description\"")
+                    .contains("metadata test")
+                    .contains("name=\"attachment\"")
+                    .contains("filename=\"sample.txt\"")
+                    .contains("file-body");
+        } finally {
+            if (upload != null) {
+                Files.deleteIfExists(upload);
+            }
+            close(client, server, vertx);
+        }
+    }
+
+    @Test
+    void cachingClientServesFreshGetResponsesFromCache() throws Exception {
+        Vertx vertx = Vertx.vertx();
+        HttpServer server = null;
+        WebClient client = null;
+        AtomicInteger requestCount = new AtomicInteger();
+        try {
+            server = startServer(vertx, request -> {
+                int currentRequest = requestCount.incrementAndGet();
+                request.response()
+                        .putHeader("cache-control", "public, max-age=60")
+                        .putHeader("etag", "\"cached-resource\"")
+                        .putHeader("content-type", "text/plain")
+                        .end("response-" + currentRequest);
+            });
+            client = CachingWebClient.create(createClient(vertx, server.actualPort()));
+
+            HttpResponse<Buffer> firstResponse = await(client.get("/cached-resource")
+                    .as(BodyCodec.buffer())
+                    .expect(ResponsePredicate.SC_OK)
+                    .send());
+            HttpResponse<Buffer> secondResponse = await(client.get("/cached-resource")
+                    .as(BodyCodec.buffer())
+                    .expect(ResponsePredicate.SC_OK)
+                    .send());
+
+            assertThat(firstResponse.bodyAsString()).isEqualTo("response-1");
+            assertThat(secondResponse.bodyAsString()).isEqualTo("response-1");
+            assertThat(secondResponse.getHeader("age")).isNotNull();
+            assertThat(requestCount.get()).isEqualTo(1);
+        } finally {
+            close(client, server, vertx);
+        }
+    }
+
+    @Test
+    void sessionPersistsCookiesAndClientFollowsRedirects() throws Exception {
+        Vertx vertx = Vertx.vertx();
+        HttpServer server = null;
+        WebClientSession session = null;
+        try {
+            server = startServer(vertx, request -> {
+                if ("/login".equals(request.path())) {
+                    request.response()
+                            .putHeader("set-cookie", "sid=abc123; Path=/; HttpOnly")
+                            .end("logged-in");
+                    return;
+                }
+                if ("/redirect".equals(request.path())) {
+                    request.response()
+                            .setStatusCode(302)
+                            .putHeader("location", "/profile")
+                            .end();
+                    return;
+                }
+                JsonObject body = new JsonObject()
+                        .put("cookie", request.getHeader("cookie"))
+                        .put("sessionHeader", request.getHeader("X-Session-Header"));
+                request.response().putHeader("content-type", "application/json").end(body.encode());
+            });
+            WebClient baseClient = createClient(vertx, server.actualPort());
+            session = WebClientSession.create(baseClient)
+                    .addHeader("X-Session-Header", "present");
+
+            HttpResponse<String> loginResponse = await(session.get("/login")
+                    .as(BodyCodec.string())
+                    .expect(ResponsePredicate.SC_OK)
+                    .send());
+            assertThat(loginResponse.body()).isEqualTo("logged-in");
+
+            HttpResponse<JsonObject> profileResponse = await(session.get("/redirect")
+                    .followRedirects(true)
+                    .as(BodyCodec.jsonObject())
+                    .expect(ResponsePredicate.SC_OK)
+                    .expect(ResponsePredicate.JSON)
+                    .send());
+
+            assertThat(profileResponse.followedRedirects()).isNotEmpty();
+            assertThat(profileResponse.body().getString("cookie")).contains("sid=abc123");
+            assertThat(profileResponse.body().getString("sessionHeader")).isEqualTo("present");
+        } finally {
+            close(session, server, vertx);
+        }
+    }
+
+    private static WebClient createClient(Vertx vertx, int port) {
+        WebClientOptions options = new WebClientOptions()
+                .setDefaultHost(HOST)
+                .setDefaultPort(port)
+                .setConnectTimeout(2_000)
+                .setIdleTimeout(5)
+                .setFollowRedirects(false)
+                .setUserAgent("graalvm-reachability-metadata-test");
+        return WebClient.create(vertx, options);
+    }
+
+    private static HttpServer startServer(Vertx vertx, Handler<HttpServerRequest> handler) throws Exception {
+        HttpServer server = vertx.createHttpServer().requestHandler(handler);
+        return await(server.listen(0, HOST));
+    }
+
+    private static <T> T await(Future<T> future) throws Exception {
+        return future.toCompletionStage().toCompletableFuture().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    }
+
+    private static void close(WebClient client, HttpServer server, Vertx vertx) throws Exception {
+        if (client != null) {
+            client.close();
+        }
+        if (server != null) {
+            await(server.close());
+        }
+        await(vertx.close());
+    }
+}

--- a/tests/src/io.vertx/vertx-web-client/5.0.0/user-code-filter.json
+++ b/tests/src/io.vertx/vertx-web-client/5.0.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "io.vertx.ext.web.client.**"
+    },
+    {
+      "includeClasses" : "io_vertx.vertx_web_client.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7960

This PR provides test fixes and new metadata for io.vertx:vertx-web-client:5.0.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 28033
- Cached input tokens: 259584
- Output tokens: 4751
- Metadata entries: 57
- Iterations: 1
- Library coverage percentage: 45.25
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 47.51

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `9dfa17437a0630c9f15775fdfb46262998e5dfa0`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.vertx:vertx-web-client:4.5.24: 0/0 covered calls (100.00%)
- io.vertx:vertx-web-client:5.0.0: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.vertx:vertx-web-client:4.5.24: 3814/8503 (44.85%)
- io.vertx:vertx-web-client:5.0.0: 3051/7107 (42.93%)

**Line:**
- io.vertx:vertx-web-client:4.5.24: 955/2010 (47.51%)
- io.vertx:vertx-web-client:5.0.0: 747/1651 (45.25%)

**Method:**
- io.vertx:vertx-web-client:4.5.24: 221/668 (33.08%)
- io.vertx:vertx-web-client:5.0.0: 182/557 (32.67%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/io.vertx/vertx-web-client/4.5.24/build.gradle 2/tests/src/io.vertx/vertx-web-client/5.0.0/build.gradle
index 32509a01c7..c502d61cf4 100644
--- 1/tests/src/io.vertx/vertx-web-client/4.5.24/build.gradle
+++ 2/tests/src/io.vertx/vertx-web-client/5.0.0/build.gradle
@@ -15,6 +15,16 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
+tasks.named("nativeTest") {
+    if (libraryVersion == '5.0.0') {
+        // Vert.x 5.0.0 pulls in Netty 4.2.x, which requires explicit unsafe access on Java 25 native runs.
+        runtimeArgs.addAll([
+                '-Dsun.misc.unsafe.memory.access=allow',
+                '-Dio.netty.tryReflectionSetAccessible=true'
+        ])
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"
diff --git 1/tests/src/io.vertx/vertx-web-client/4.5.24/src/test/java/io_vertx/vertx_web_client/Vertx_web_clientTest.java 2/tests/src/io.vertx/vertx-web-client/5.0.0/src/test/java/io_vertx/vertx_web_client/Vertx_web_clientTest.java
index d03355b4c1..93a6f24b3e 100644
--- 1/tests/src/io.vertx/vertx-web-client/4.5.24/src/test/java/io_vertx/vertx_web_client/Vertx_web_clientTest.java
+++ 2/tests/src/io.vertx/vertx-web-client/5.0.0/src/test/java/io_vertx/vertx_web_client/Vertx_web_clientTest.java
@@ -23,7 +23,6 @@ import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.ext.web.client.WebClientSession;
-import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import io.vertx.ext.web.codec.BodyCodec;
 import io.vertx.ext.web.multipart.MultipartForm;
 import java.nio.charset.StandardCharsets;
@@ -61,11 +60,10 @@ public class Vertx_web_clientTest {
                     .addQueryParam("q", "native-image")
                     .putHeader("X-Client-Test", "web-client")
                     .as(BodyCodec.jsonObject())
-                    .expect(ResponsePredicate.SC_OK)
-                    .expect(ResponsePredicate.JSON)
                     .send());
 
-            assertThat(response.statusCode()).isEqualTo(200);
+            assertOk(response);
+            assertThat(response.getHeader("content-type")).startsWith("application/json");
             assertThat(response.getHeader("x-server-test")).isEqualTo("json-response");
             JsonObject responseBody = response.body();
             assertThat(responseBody.getString("method")).isEqualTo("GET");
@@ -106,10 +104,10 @@ public class Vertx_web_clientTest {
             HttpResponse<JsonObject> response = await(client.post("/json")
                     .basicAuthentication("tester", "secret")
                     .as(BodyCodec.jsonObject())
-                    .expect(ResponsePredicate.SC_SUCCESS)
-                    .expect(ResponsePredicate.contentType("application/json"))
                     .sendJsonObject(requestBody));
 
+            assertThat(response.statusCode()).isBetween(200, 299);
+            assertThat(response.getHeader("content-type")).startsWith("application/json");
             String credentials = Base64.getEncoder()
                     .encodeToString("tester:secret".getBytes(StandardCharsets.UTF_8));
             JsonObject responseBody = response.body();
@@ -152,9 +150,9 @@ public class Vertx_web_clientTest {
             HttpResponse<JsonObject> response = await(client.post("/stream")
                     .putHeader("content-type", "text/plain")
                     .as(BodyCodec.jsonObject())
-                    .expect(ResponsePredicate.SC_OK)
                     .sendStream(sourceFile));
 
+            assertOk(response);
             assertThat(response.body().getString("contentType")).isEqualTo("text/plain");
             assertThat(response.body().getString("body")).isEqualTo("streamed-request-body");
         } finally {
@@ -194,8 +192,8 @@ public class Vertx_web_clientTest {
                     .add("project", "native-image");
             HttpResponse<JsonObject> formResponse = await(client.post("/form")
                     .as(BodyCodec.jsonObject())
-                    .expect(ResponsePredicate.SC_OK)
                     .sendForm(form));
+            assertOk(formResponse);
             assertThat(formResponse.body().getString("contentType"))
                     .startsWith("application/x-www-form-urlencoded");
             assertThat(formResponse.body().getString("body"))
@@ -209,9 +207,9 @@ public class Vertx_web_clientTest {
                     .textFileUpload("attachment", "sample.txt", upload.toString(), "text/plain");
             HttpResponse<JsonObject> multipartResponse = await(client.post("/multipart")
                     .as(BodyCodec.jsonObject())
-                    .expect(ResponsePredicate.SC_OK)
                     .sendMultipartForm(multipartForm));
 
+            assertOk(multipartResponse);
             assertThat(multipartResponse.body().getString("contentType"))
                     .startsWith("multipart/form-data");
             assertThat(multipartResponse.body().getString("body"))
@@ -247,13 +245,13 @@ public class Vertx_web_clientTest {
 
             HttpResponse<Buffer> firstResponse = await(client.get("/cached-resource")
                     .as(BodyCodec.buffer())
-                    .expect(ResponsePredicate.SC_OK)
                     .send());
             HttpResponse<Buffer> secondResponse = await(client.get("/cached-resource")
                     .as(BodyCodec.buffer())
-                    .expect(ResponsePredicate.SC_OK)
                     .send());
 
+            assertOk(firstResponse);
+            assertOk(secondResponse);
             assertThat(firstResponse.bodyAsString()).isEqualTo("response-1");
             assertThat(secondResponse.bodyAsString()).isEqualTo("response-1");
             assertThat(secondResponse.getHeader("age")).isNotNull();
@@ -294,17 +292,17 @@ public class Vertx_web_clientTest {
 
             HttpResponse<String> loginResponse = await(session.get("/login")
                     .as(BodyCodec.string())
-                    .expect(ResponsePredicate.SC_OK)
                     .send());
+            assertOk(loginResponse);
             assertThat(loginResponse.body()).isEqualTo("logged-in");
 
             HttpResponse<JsonObject> profileResponse = await(session.get("/redirect")
                     .followRedirects(true)
                     .as(BodyCodec.jsonObject())
-                    .expect(ResponsePredicate.SC_OK)
-                    .expect(ResponsePredicate.JSON)
                     .send());
 
+            assertOk(profileResponse);
+            assertThat(profileResponse.getHeader("content-type")).startsWith("application/json");
             assertThat(profileResponse.followedRedirects()).isNotEmpty();
             assertThat(profileResponse.body().getString("cookie")).contains("sid=abc123");
             assertThat(profileResponse.body().getString("sessionHeader")).isEqualTo("present");
@@ -313,6 +311,10 @@ public class Vertx_web_clientTest {
         }
     }
 
+    private static void assertOk(HttpResponse<?> response) {
+        assertThat(response.statusCode()).isEqualTo(200);
+    }
+
     private static WebClient createClient(Vertx vertx, int port) {
         WebClientOptions options = new WebClientOptions()
                 .setDefaultHost(HOST)

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
