### PR TITLE
[GenAI] Test fix for org.apache.maven:maven-builder-support:4.0.0-alpha-2 using gpt-5.5

### DIFF
--- a/metadata/org.apache.maven/maven-builder-support/4.0.0-alpha-2/reachability-metadata.json
+++ b/metadata/org.apache.maven/maven-builder-support/4.0.0-alpha-2/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org_apache_maven.maven_builder_support.Maven_builder_supportTest"
+      },
+      "glob": "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition": {
+        "typeReached": "org_apache_maven.maven_builder_support.Maven_builder_supportTest"
+      },
+      "glob": "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/metadata/org.apache.maven/maven-builder-support/4.0.0-alpha-2/reachability-metadata.json
+++ b/metadata/org.apache.maven/maven-builder-support/4.0.0-alpha-2/reachability-metadata.json
@@ -1,16 +1,1 @@
-{
-  "resources": [
-    {
-      "condition": {
-        "typeReached": "org_apache_maven.maven_builder_support.Maven_builder_supportTest"
-      },
-      "glob": "META-INF/services/org.assertj.core.configuration.Configuration"
-    },
-    {
-      "condition": {
-        "typeReached": "org_apache_maven.maven_builder_support.Maven_builder_supportTest"
-      },
-      "glob": "META-INF/services/org.assertj.core.presentation.Representation"
-    }
-  ]
-}
+{ }

--- a/metadata/org.apache.maven/maven-builder-support/index.json
+++ b/metadata/org.apache.maven/maven-builder-support/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "4.0.0-alpha-2",
+    "tested-versions" : [
+      "4.0.0-alpha-2"
+    ],
+    "allowed-packages" : [
+      "org.apache.maven.building"
+    ]
+  },
+  {
     "metadata-version" : "3.3.9",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/maven-builder-support/$version$/maven-builder-support-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/maven",

--- a/metadata/org.apache.maven/maven-builder-support/index.json
+++ b/metadata/org.apache.maven/maven-builder-support/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "4.0.0-alpha-2",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/maven-builder-support/$version$/maven-builder-support-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/maven",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/$version$/apache-maven-$version$-src.zip",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/maven-builder-support/$version$/maven-builder-support-$version$-javadoc.jar",
+    "description" : "Apache Maven Builder Support provides shared building-block classes for Maven descriptor builders for project models, settings, and toolchains. It supplies common source abstractions and problem-reporting utilities used while reading, validating, and constructing Maven descriptor data.",
     "tested-versions" : [
       "4.0.0-alpha-2"
     ],

--- a/stats/org.apache.maven/maven-builder-support/4.0.0-alpha-2/execution-metrics.json
+++ b/stats/org.apache.maven/maven-builder-support/4.0.0-alpha-2/execution-metrics.json
@@ -1,0 +1,88 @@
+{
+  "fix_java_run_fail:2026-06-06": {
+    "timestamp": "2026-06-06T11:32:49.824546Z",
+    "library": "org.apache.maven:maven-builder-support:4.0.0-alpha-2",
+    "starting_commit": "8d8c5137be493b3be6fd38c3d9376695587630b8",
+    "ending_commit": "a55f8298fa9e0e04dd6a4dd77e95bda77f8dc457",
+    "previous_library": "org.apache.maven:maven-builder-support:3.3.9",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.0.0-alpha-2",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 337,
+          "missed": 91,
+          "ratio": 0.787383,
+          "total": 428
+        },
+        "line": {
+          "covered": 81,
+          "missed": 29,
+          "ratio": 0.736364,
+          "total": 110
+        },
+        "method": {
+          "covered": 31,
+          "missed": 7,
+          "ratio": 0.815789,
+          "total": 38
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.3.9",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 316,
+          "missed": 7,
+          "ratio": 0.978328,
+          "total": 323
+        },
+        "line": {
+          "covered": 75,
+          "missed": 2,
+          "ratio": 0.974026,
+          "total": 77
+        },
+        "method": {
+          "covered": 31,
+          "missed": 1,
+          "ratio": 0.96875,
+          "total": 32
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 13207,
+      "cached_input_tokens_used": 103424,
+      "output_tokens_used": 736,
+      "iterations": 1,
+      "cost_usd": 0.0738,
+      "tested_library_loc": 81,
+      "metadata_entries": 0,
+      "test_only_metadata_entries": 2,
+      "previous_library_metadata_entries": 0,
+      "code_coverage_percent": 73.64,
+      "previous_library_coverage_percent": 97.4
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.maven/maven-builder-support/4.0.0-alpha-2/src/test/java/org_apache_maven/maven_builder_support/Maven_builder_supportTest.java",
+      "metadata_file": "metadata/org.apache.maven/maven-builder-support/4.0.0-alpha-2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.maven/maven-builder-support/4.0.0-alpha-2/stats.json
+++ b/stats/org.apache.maven/maven-builder-support/4.0.0-alpha-2/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.0.0-alpha-2",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 337,
+        "missed" : 91,
+        "ratio" : 0.787383,
+        "total" : 428
+      },
+      "line" : {
+        "covered" : 81,
+        "missed" : 29,
+        "ratio" : 0.736364,
+        "total" : 110
+      },
+      "method" : {
+        "covered" : 31,
+        "missed" : 7,
+        "ratio" : 0.815789,
+        "total" : 38
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.maven/maven-builder-support/4.0.0-alpha-2/.gitignore
+++ b/tests/src/org.apache.maven/maven-builder-support/4.0.0-alpha-2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.maven/maven-builder-support/4.0.0-alpha-2/build.gradle
+++ b/tests/src/org.apache.maven/maven-builder-support/4.0.0-alpha-2/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.maven:maven-builder-support:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.maven/maven-builder-support/4.0.0-alpha-2/gradle.properties
+++ b/tests/src/org.apache.maven/maven-builder-support/4.0.0-alpha-2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.maven:maven-builder-support:4.0.0-alpha-2
+library.version = 4.0.0-alpha-2
+metadata.dir = org.apache.maven/maven-builder-support/4.0.0-alpha-2/

--- a/tests/src/org.apache.maven/maven-builder-support/4.0.0-alpha-2/settings.gradle
+++ b/tests/src/org.apache.maven/maven-builder-support/4.0.0-alpha-2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.maven.maven-builder-support_tests'

--- a/tests/src/org.apache.maven/maven-builder-support/4.0.0-alpha-2/src/test/java/org_apache_maven/maven_builder_support/Maven_builder_supportTest.java
+++ b/tests/src/org.apache.maven/maven-builder-support/4.0.0-alpha-2/src/test/java/org_apache_maven/maven_builder_support/Maven_builder_supportTest.java
@@ -166,7 +166,7 @@ public class Maven_builder_supportTest {
         assertThat(problemWithCauseMessage.getSource()).isEmpty();
         assertThat(problemWithCauseMessage.getLocation()).isEmpty();
         assertThat(problemWithCauseMessage.getMessage()).isEqualTo("message from cause");
-        assertThat(problemWithCauseMessage.toString()).isEqualTo("[ERROR] message from cause @ ");
+        assertThat(problemWithCauseMessage.toString()).isEqualTo("[ERROR] message from cause");
 
         Problem problemWithoutMessage = collector.getProblems().get(1);
         assertThat(problemWithoutMessage.getSeverity()).isEqualTo(Problem.Severity.ERROR);

--- a/tests/src/org.apache.maven/maven-builder-support/4.0.0-alpha-2/src/test/java/org_apache_maven/maven_builder_support/Maven_builder_supportTest.java
+++ b/tests/src/org.apache.maven/maven-builder-support/4.0.0-alpha-2/src/test/java/org_apache_maven/maven_builder_support/Maven_builder_supportTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven.maven_builder_support;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.maven.building.FileSource;
+import org.apache.maven.building.Problem;
+import org.apache.maven.building.ProblemCollector;
+import org.apache.maven.building.ProblemCollectorFactory;
+import org.apache.maven.building.Source;
+import org.apache.maven.building.StringSource;
+import org.apache.maven.building.UrlSource;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class Maven_builder_supportTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void stringSourcePreservesContentLocationAndUtf8Bytes() throws IOException {
+        StringBuilder content = new StringBuilder("<project>h\u00e9llo</project>\n");
+        StringSource source = new StringSource(content, "memory:pom.xml");
+
+        content.append("mutated after construction");
+
+        assertThat(source.getContent()).isEqualTo("<project>h\u00e9llo</project>\n");
+        assertThat(source.getLocation()).isEqualTo("memory:pom.xml");
+        assertThat(source.toString()).isEqualTo("memory:pom.xml");
+        assertThat(readUtf8(source)).isEqualTo("<project>h\u00e9llo</project>\n");
+    }
+
+    @Test
+    void stringSourceUsesDocumentedDefaultsForNullContentAndLocation() throws IOException {
+        StringSource source = new StringSource(null);
+
+        assertThat(source.getContent()).isEmpty();
+        assertThat(source.getLocation()).isEqualTo("(memory)");
+        assertThat(source.toString()).isEqualTo("(memory)");
+        assertThat(readUtf8(source)).isEmpty();
+    }
+
+    @Test
+    void fileSourceExposesAbsoluteFileAndCreatesFreshStreams() throws IOException {
+        Path file = tempDir.resolve("pom.xml");
+        Files.writeString(file, "<project>file-backed</project>", StandardCharsets.UTF_8);
+
+        FileSource source = new FileSource(file.toFile());
+        File expectedFile = file.toFile().getAbsoluteFile();
+
+        assertThat(source.getFile()).isEqualTo(expectedFile);
+        assertThat(source.getLocation()).isEqualTo(expectedFile.getPath());
+        assertThat(source.toString()).isEqualTo(expectedFile.getPath());
+        assertThat(readUtf8(source)).isEqualTo("<project>file-backed</project>");
+        assertThat(readUtf8(source)).isEqualTo("<project>file-backed</project>");
+    }
+
+    @Test
+    void fileSourceRejectsNullFile() {
+        assertThatThrownBy(() -> new FileSource(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("file cannot be null");
+    }
+
+    @Test
+    void fileSourceReportsMissingFileLocationBeforeOpeningStream() {
+        Path missingFile = tempDir.resolve("missing-pom.xml");
+        FileSource source = new FileSource(missingFile.toFile());
+        File expectedFile = missingFile.toFile().getAbsoluteFile();
+
+        assertThat(source.getFile()).isEqualTo(expectedFile);
+        assertThat(source.getLocation()).isEqualTo(expectedFile.getPath());
+        assertThatThrownBy(source::getInputStream)
+                .isInstanceOf(FileNotFoundException.class)
+                .hasMessageContaining("missing-pom.xml");
+    }
+
+    @Test
+    void urlSourceExposesUrlLocationAndReadableContent() throws IOException {
+        Path file = tempDir.resolve("settings.xml");
+        Files.writeString(file, "<settings>url-backed</settings>", StandardCharsets.UTF_8);
+        URL url = file.toUri().toURL();
+
+        UrlSource source = new UrlSource(url);
+
+        assertThat(source.getUrl()).isSameAs(url);
+        assertThat(source.getLocation()).isEqualTo(url.toString());
+        assertThat(source.toString()).isEqualTo(url.toString());
+        assertThat(readUtf8(source)).isEqualTo("<settings>url-backed</settings>");
+    }
+
+    @Test
+    void urlSourceRejectsNullUrl() {
+        assertThatThrownBy(() -> new UrlSource(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("url cannot be null");
+    }
+
+    @Test
+    void problemCollectorKeepsBackingListAndCapturesProblemDetails() {
+        List<Problem> backingProblems = new ArrayList<>();
+        ProblemCollector collector = ProblemCollectorFactory.newInstance(backingProblems);
+        IllegalArgumentException cause = new IllegalArgumentException("ignored when message is present");
+
+        collector.setSource("pom.xml");
+        collector.add(Problem.Severity.WARNING, "invalid dependency", 12, 34, cause);
+
+        assertThat(collector.getProblems()).isSameAs(backingProblems);
+        assertThat(backingProblems).hasSize(1);
+
+        Problem problem = backingProblems.get(0);
+        assertThat(problem.getSeverity()).isEqualTo(Problem.Severity.WARNING);
+        assertThat(problem.getMessage()).isEqualTo("invalid dependency");
+        assertThat(problem.getSource()).isEqualTo("pom.xml");
+        assertThat(problem.getLineNumber()).isEqualTo(12);
+        assertThat(problem.getColumnNumber()).isEqualTo(34);
+        assertThat(problem.getException()).isSameAs(cause);
+        assertThat(problem.getLocation()).isEqualTo("pom.xml, line 12, column 34");
+        assertThat(problem.toString()).isEqualTo("[WARNING] invalid dependency @ pom.xml, line 12, column 34");
+    }
+
+    @Test
+    void problemCollectorAppliesCurrentSourceOnlyToSubsequentProblems() {
+        ProblemCollector collector = ProblemCollectorFactory.newInstance(null);
+
+        collector.setSource("first.xml");
+        collector.add(Problem.Severity.ERROR, "first", 1, -1, null);
+        collector.setSource("second.xml");
+        collector.add(Problem.Severity.FATAL, "second", -1, 8, null);
+
+        assertThat(collector.getProblems()).hasSize(2);
+        assertThat(collector.getProblems().get(0).getLocation()).isEqualTo("first.xml, line 1");
+        assertThat(collector.getProblems().get(1).getLocation()).isEqualTo("second.xml, column 8");
+        assertThat(collector.getProblems().get(0).getSeverity()).isEqualTo(Problem.Severity.ERROR);
+        assertThat(collector.getProblems().get(1).getSeverity()).isEqualTo(Problem.Severity.FATAL);
+    }
+
+    @Test
+    void problemCollectorDefaultsSeveritySourceAndMessageWhenInputsAreAbsent() {
+        ProblemCollector collector = ProblemCollectorFactory.newInstance(null);
+        Exception cause = new Exception("message from cause");
+        Exception causeWithoutMessage = new Exception();
+
+        collector.add(null, null, 0, 0, cause);
+        collector.add(null, "", -1, -1, causeWithoutMessage);
+
+        Problem problemWithCauseMessage = collector.getProblems().get(0);
+        assertThat(problemWithCauseMessage.getSeverity()).isEqualTo(Problem.Severity.ERROR);
+        assertThat(problemWithCauseMessage.getSource()).isEmpty();
+        assertThat(problemWithCauseMessage.getLocation()).isEmpty();
+        assertThat(problemWithCauseMessage.getMessage()).isEqualTo("message from cause");
+        assertThat(problemWithCauseMessage.toString()).isEqualTo("[ERROR] message from cause @ ");
+
+        Problem problemWithoutMessage = collector.getProblems().get(1);
+        assertThat(problemWithoutMessage.getSeverity()).isEqualTo(Problem.Severity.ERROR);
+        assertThat(problemWithoutMessage.getMessage()).isEmpty();
+        assertThat(problemWithoutMessage.getLocation()).isEmpty();
+    }
+
+    @Test
+    void problemCollectorReportsLineAndColumnWithoutSource() {
+        ProblemCollector collector = ProblemCollectorFactory.newInstance(null);
+
+        collector.add(Problem.Severity.WARNING, "stream-backed descriptor warning", 7, 21, null);
+
+        Problem problem = collector.getProblems().get(0);
+        assertThat(problem.getSource()).isEmpty();
+        assertThat(problem.getLineNumber()).isEqualTo(7);
+        assertThat(problem.getColumnNumber()).isEqualTo(21);
+        assertThat(problem.getLocation()).isEqualTo("line 7, column 21");
+        assertThat(problem.toString()).isEqualTo("[WARNING] stream-backed descriptor warning @ line 7, column 21");
+    }
+
+    @Test
+    void severityEnumOrderMatchesDescendingSeverityContract() {
+        assertThat(Problem.Severity.values()).containsExactly(
+                Problem.Severity.FATAL,
+                Problem.Severity.ERROR,
+                Problem.Severity.WARNING);
+    }
+
+    private static String readUtf8(Source source) throws IOException {
+        try (InputStream inputStream = source.getInputStream()) {
+            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/tests/src/org.apache.maven/maven-builder-support/4.0.0-alpha-2/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.maven/maven-builder-support/4.0.0-alpha-2/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org_apache_maven.maven_builder_support.Maven_builder_supportTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_maven.maven_builder_support.Maven_builder_supportTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/tests/src/org.apache.maven/maven-builder-support/4.0.0-alpha-2/user-code-filter.json
+++ b/tests/src/org.apache.maven/maven-builder-support/4.0.0-alpha-2/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.maven.building.**"
+    },
+    {
+      "includeClasses" : "org_apache_maven.maven_builder_support.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7151

This PR provides test fixes and new metadata for org.apache.maven:maven-builder-support:4.0.0-alpha-2, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 13207
- Cached input tokens: 103424
- Output tokens: 736
- Metadata entries: 0
- Test-only metadata entries: 2
- Iterations: 1
- Library coverage percentage: 73.64
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 97.4

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `5cd2c9d2e7e605af98ad5ef84fef25cd09aa7264`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.maven:maven-builder-support:3.3.9: 0/0 covered calls (100.00%)
- org.apache.maven:maven-builder-support:4.0.0-alpha-2: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.maven:maven-builder-support:3.3.9: 316/323 (97.83%)
- org.apache.maven:maven-builder-support:4.0.0-alpha-2: 337/428 (78.74%)

**Line:**
- org.apache.maven:maven-builder-support:3.3.9: 75/77 (97.40%)
- org.apache.maven:maven-builder-support:4.0.0-alpha-2: 81/110 (73.64%)

**Method:**
- org.apache.maven:maven-builder-support:3.3.9: 31/32 (96.88%)
- org.apache.maven:maven-builder-support:4.0.0-alpha-2: 31/38 (81.58%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/org.apache.maven/maven-builder-support/3.3.9/src/test/java/org_apache_maven/maven_builder_support/Maven_builder_supportTest.java b/tests/src/org.apache.maven/maven-builder-support/4.0.0-alpha-2/src/test/java/org_apache_maven/maven_builder_support/Maven_builder_supportTest.java
index 7bc106daa9..e838a34dbd 100644
--- a/tests/src/org.apache.maven/maven-builder-support/3.3.9/src/test/java/org_apache_maven/maven_builder_support/Maven_builder_supportTest.java
+++ b/tests/src/org.apache.maven/maven-builder-support/4.0.0-alpha-2/src/test/java/org_apache_maven/maven_builder_support/Maven_builder_supportTest.java
@@ -166,7 +166,7 @@ public class Maven_builder_supportTest {
         assertThat(problemWithCauseMessage.getSource()).isEmpty();
         assertThat(problemWithCauseMessage.getLocation()).isEmpty();
         assertThat(problemWithCauseMessage.getMessage()).isEqualTo("message from cause");
-        assertThat(problemWithCauseMessage.toString()).isEqualTo("[ERROR] message from cause @ ");
+        assertThat(problemWithCauseMessage.toString()).isEqualTo("[ERROR] message from cause");
 
         Problem problemWithoutMessage = collector.getProblems().get(1);
         assertThat(problemWithoutMessage.getSeverity()).isEqualTo(Problem.Severity.ERROR);

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
