### PR TITLE
[GenAI] Test fix for com.graphql-java:graphql-java:2018-07-28T00-19-13-5ea18ff using gpt-5.5

### DIFF
--- a/metadata/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/reachability-metadata.json
+++ b/metadata/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "resources" : [
+    {
+      "bundle" : "i18n.General"
+    },
+    {
+      "bundle" : "i18n.Parsing"
+    },
+    {
+      "bundle" : "i18n.Scalars"
+    },
+    {
+      "bundle" : "i18n.Validation"
+    }
+  ]
+}

--- a/metadata/com.graphql-java/graphql-java/index.json
+++ b/metadata/com.graphql-java/graphql-java/index.json
@@ -62,6 +62,15 @@
     ]
   },
   {
+    "metadata-version" : "2018-07-28T00-19-13-5ea18ff",
+    "tested-versions" : [
+      "2018-07-28T00-19-13-5ea18ff"
+    ],
+    "allowed-packages" : [
+      "graphql"
+    ]
+  },
+  {
     "metadata-version" : "19.2",
     "source-code-url" : "https://repo1.maven.org/maven2/com/graphql-java/graphql-java/$version$/graphql-java-$version$-sources.jar",
     "repository-url" : "https://github.com/graphql-java/graphql-java",

--- a/metadata/com.graphql-java/graphql-java/index.json
+++ b/metadata/com.graphql-java/graphql-java/index.json
@@ -63,6 +63,11 @@
   },
   {
     "metadata-version" : "2018-07-28T00-19-13-5ea18ff",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/graphql-java/graphql-java/$version$/graphql-java-$version$-sources.jar",
+    "repository-url" : "https://github.com/graphql-java/graphql-java",
+    "test-code-url" : "https://github.com/graphql-java/graphql-java/tree/5ea18ffd2cc456cec4463b403dc8a1e1ab486c78/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/graphql-java/graphql-java/$version$/graphql-java-$version$-javadoc.jar",
+    "description" : "GraphQL Java is a Java implementation of the GraphQL specification for building and executing GraphQL schemas. It provides APIs for schema definition, validation, parsing, and query execution against application data.",
     "tested-versions" : [
       "2018-07-28T00-19-13-5ea18ff"
     ],

--- a/stats/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/execution-metrics.json
+++ b/stats/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/execution-metrics.json
@@ -1,0 +1,106 @@
+{
+  "fix_javac_fail:2026-06-06": {
+    "timestamp": "2026-06-06T11:37:03.956202Z",
+    "library": "com.graphql-java:graphql-java:2018-07-28T00-19-13-5ea18ff",
+    "starting_commit": "89bac5aad7c04380363334ea5c78ce8ca28357c0",
+    "ending_commit": "d37f26e60fdbafd4f205742681d89adfe51ccc0b",
+    "previous_library": "com.graphql-java:graphql-java:19.7",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2018-07-28T00-19-13-5ea18ff",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 10,
+            "totalCalls": 10
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 10,
+        "totalCalls": 10
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 24452,
+          "missed": 49345,
+          "ratio": 0.331341,
+          "total": 73797
+        },
+        "line": {
+          "covered": 5771,
+          "missed": 10639,
+          "ratio": 0.351676,
+          "total": 16410
+        },
+        "method": {
+          "covered": 1595,
+          "missed": 3235,
+          "ratio": 0.330228,
+          "total": 4830
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "19.7",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.909091,
+            "coveredCalls": 10,
+            "totalCalls": 11
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 0.916667,
+        "coveredCalls": 11,
+        "totalCalls": 12
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 42419,
+          "missed": 107078,
+          "ratio": 0.283745,
+          "total": 149497
+        },
+        "line": {
+          "covered": 10223,
+          "missed": 22881,
+          "ratio": 0.308815,
+          "total": 33104
+        },
+        "method": {
+          "covered": 2959,
+          "missed": 6763,
+          "ratio": 0.304361,
+          "total": 9722
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 189682,
+      "cached_input_tokens_used": 2080256,
+      "output_tokens_used": 25245,
+      "iterations": 5,
+      "cost_usd": 1.7974,
+      "tested_library_loc": 5771,
+      "metadata_entries": 4,
+      "test_only_metadata_entries": 47,
+      "previous_library_metadata_entries": 4,
+      "previous_library_test_only_metadata_entries": 26,
+      "code_coverage_percent": 35.17,
+      "previous_library_coverage_percent": 30.88
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/com_graphql_java/graphql_java/AstValueHelperTest.java",
+      "metadata_file": "metadata/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/stats.json
+++ b/stats/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "2018-07-28T00-19-13-5ea18ff",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 10,
+          "totalCalls" : 10
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 10,
+      "totalCalls" : 10
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 24452,
+        "missed" : 49345,
+        "ratio" : 0.331341,
+        "total" : 73797
+      },
+      "line" : {
+        "covered" : 5771,
+        "missed" : 10639,
+        "ratio" : 0.351676,
+        "total" : 16410
+      },
+      "method" : {
+        "covered" : 1595,
+        "missed" : 3235,
+        "ratio" : 0.330228,
+        "total" : 4830
+      }
+    }
+  } ]
+}

--- a/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/.gitignore
+++ b/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/build.gradle
+++ b/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/build.gradle
@@ -1,0 +1,45 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.gradle.api.tasks.TaskProvider
+
+plugins {
+    id "org.graalvm.internal.tck"
+    id "com.gradleup.shadow" version "9.4.1"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+configurations {
+    relocatedGuava
+}
+
+// graphql-java 19.7 bytecode references relocated Guava classes that are not present in the published jar.
+TaskProvider relocatedGuavaJar = tasks.register("relocatedGuavaJar", ShadowJar) {
+    archiveClassifier = "relocated-guava"
+    configurations = [project.configurations.relocatedGuava]
+    relocate "com.google.common", "graphql.com.google.common"
+}
+
+dependencies {
+    testImplementation "com.graphql-java:graphql-java:$libraryVersion"
+    testRuntimeOnly files(relocatedGuavaJar).builtBy(relocatedGuavaJar)
+    relocatedGuava 'com.google.guava:guava:32.0.0-jre'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.awaitility:awaitility:4.2.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/gradle.properties
+++ b/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 2018-07-28T00-19-13-5ea18ff
+metadata.dir = com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/

--- a/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/settings.gradle
+++ b/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'graphql-java-tests'

--- a/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/com_graphql_java/graphql_java/AstValueHelperTest.java
+++ b/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/com_graphql_java/graphql_java/AstValueHelperTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_graphql_java.graphql_java;
+
+import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.idl.SchemaPrinter;
+import org.junit.jupiter.api.Test;
+
+import static graphql.Scalars.GraphQLString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AstValueHelperTest {
+
+  @Test
+  void printsInputObjectDefaultValueFromJavaBeanProperties() {
+    GraphQLInputObjectType addressInput = GraphQLInputObjectType.newInputObject()
+        .name("AddressInput")
+        .field(field -> field.name("city").type(GraphQLString))
+        .field(field -> field.name("street").type(GraphQLString))
+        .build();
+    GraphQLInputObjectType personInput = GraphQLInputObjectType.newInputObject()
+        .name("PersonInput")
+        .field(field -> field.name("home").type(addressInput).defaultValue(new AddressInput("London", "Baker Street")))
+        .build();
+
+    String schema = new SchemaPrinter().print(personInput);
+
+    assertThat(schema).contains("home: AddressInput = {city : \"London\", street : \"Baker Street\"}");
+  }
+
+  public static class AddressInput {
+
+    private final String city;
+    private final String street;
+
+    public AddressInput(String city, String street) {
+      this.city = city;
+      this.street = street;
+    }
+
+    public String getCity() {
+      return city;
+    }
+
+    public String getStreet() {
+      return street;
+    }
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/com_graphql_java/graphql_java/BatchedDataFetcherFactoryTest.java
+++ b/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/com_graphql_java/graphql_java/BatchedDataFetcherFactoryTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_graphql_java.graphql_java;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import graphql.execution.ExecutionContext;
+import graphql.execution.ExecutionId;
+import graphql.execution.batched.BatchedDataFetcher;
+import graphql.execution.batched.BatchedDataFetcherFactory;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.StaticDataFetcher;
+import org.junit.jupiter.api.Test;
+
+import static graphql.schema.DataFetchingEnvironmentBuilder.newDataFetchingEnvironment;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BatchedDataFetcherFactoryTest {
+
+  @Test
+  void wrapsOrdinaryDataFetcherForBatchedExecution() throws Exception {
+    StaticDataFetcher suppliedFetcher = new StaticDataFetcher("constant value");
+    DataFetchingEnvironment environment = newDataFetchingEnvironment()
+        .source(List.of("Leia", "Luke"))
+        .executionContext(newExecutionContext())
+        .build();
+
+    BatchedDataFetcher batchedFetcher = new BatchedDataFetcherFactory().create(suppliedFetcher);
+    CompletableFuture<?> result = (CompletableFuture<?>) batchedFetcher.get(environment);
+
+    assertThat(result.get(5, TimeUnit.SECONDS)).isEqualTo(List.of("constant value", "constant value"));
+  }
+
+  private ExecutionContext newExecutionContext() {
+    return new ExecutionContext(
+        null,
+        ExecutionId.from("batched-data-fetcher-factory-test"),
+        null,
+        null,
+        null,
+        null,
+        null,
+        Collections.emptyMap(),
+        null,
+        null,
+        Collections.emptyMap(),
+        null,
+        null);
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/com_graphql_java/graphql_java/PropertyDataFetcherTest.java
+++ b/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/com_graphql_java/graphql_java/PropertyDataFetcherTest.java
@@ -6,6 +6,10 @@
  */
 package com_graphql_java.graphql_java;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -28,7 +32,7 @@ import org.junit.jupiter.api.Test;
 import static graphql.Scalars.GraphQLString;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class PropertyFetchingImplTest {
+public class PropertyDataFetcherTest {
 
   @BeforeEach
   void resetPropertyFetcher() {
@@ -80,6 +84,21 @@ public class PropertyFetchingImplTest {
     assertThat(fetcher.get(environmentFor(source))).isEqualTo("private field value");
   }
 
+  @Test
+  void findsPublicMethodOnRootInterfaceWhenNoSuperclassExists() throws Throwable {
+    PropertyDataFetcher<String> fetcher = PropertyDataFetcher.fetching("name");
+    MethodHandle finder = MethodHandles.privateLookupIn(PropertyDataFetcher.class, MethodHandles.lookup())
+        .findVirtual(
+            PropertyDataFetcher.class,
+            "findPubliclyAccessibleMethod",
+            MethodType.methodType(Method.class, Class.class, String.class));
+
+    Method method = (Method) finder.invoke(fetcher, NonPublicNameSource.class, "getName");
+
+    assertThat(method.getDeclaringClass()).isEqualTo(NonPublicNameSource.class);
+    assertThat(method.getName()).isEqualTo("getName");
+  }
+
   private DataFetchingEnvironment environmentFor(Object source) {
     return new TestDataFetchingEnvironment(source, GraphQLString);
   }
@@ -95,6 +114,7 @@ public class PropertyFetchingImplTest {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> T getSource() {
       return (T) source;
     }
@@ -202,5 +222,10 @@ public class PropertyFetchingImplTest {
   public static class PrivateFieldSource {
 
     private final String privateField = "private field value";
+  }
+
+  interface NonPublicNameSource {
+
+    String getName();
   }
 }

--- a/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/com_graphql_java/graphql_java/PropertyFetchingImplTest.java
+++ b/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/com_graphql_java/graphql_java/PropertyFetchingImplTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_graphql_java.graphql_java;
+
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingEnvironmentImpl;
+import graphql.schema.PropertyDataFetcher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static graphql.Scalars.GraphQLString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PropertyFetchingImplTest {
+
+  @BeforeEach
+  void resetPropertyFetcher() {
+    PropertyDataFetcher.clearReflectionCache();
+    PropertyDataFetcher.setUseSetAccessible(true);
+    PropertyDataFetcher.setUseNegativeCache(true);
+  }
+
+  @Test
+  void invokesPublicGetterWithDataFetchingEnvironmentArgument() throws Exception {
+    EnvironmentAwareSource source = new EnvironmentAwareSource();
+    DataFetchingEnvironment environment = environmentFor(source);
+
+    String value = PropertyDataFetcher.<String>fetching("value").get(environment);
+
+    assertThat(value).isEqualTo("value from " + EnvironmentAwareSource.class.getSimpleName());
+    assertThat(source.seenEnvironment).isSameAs(environment);
+  }
+
+  @Test
+  void invokesPublicZeroArgumentGetter() throws Exception {
+    ZeroArgumentGetterSource source = new ZeroArgumentGetterSource();
+
+    String value = PropertyDataFetcher.<String>fetching("name").get(environmentFor(source));
+
+    assertThat(value).isEqualTo("zero argument getter value");
+  }
+
+  @Test
+  void invokesPrivateGetterViaSetAccessibleLookup() throws Exception {
+    PrivateGetterSource source = new PrivateGetterSource();
+
+    String value = PropertyDataFetcher.<String>fetching("secret").get(environmentFor(source));
+
+    assertThat(value).isEqualTo("private getter value");
+  }
+
+  @Test
+  void readsAndCachesPublicField() throws Exception {
+    PublicFieldSource source = new PublicFieldSource();
+    PropertyDataFetcher<String> fetcher = PropertyDataFetcher.fetching("publicField");
+
+    assertThat(fetcher.get(environmentFor(source))).isEqualTo("public field value");
+    assertThat(fetcher.get(environmentFor(source))).isEqualTo("public field value");
+  }
+
+  @Test
+  void readsAndCachesPrivateFieldViaSetAccessibleLookup() throws Exception {
+    PrivateFieldSource source = new PrivateFieldSource();
+    PropertyDataFetcher<String> fetcher = PropertyDataFetcher.fetching("privateField");
+
+    assertThat(fetcher.get(environmentFor(source))).isEqualTo("private field value");
+    assertThat(fetcher.get(environmentFor(source))).isEqualTo("private field value");
+  }
+
+  private DataFetchingEnvironment environmentFor(Object source) {
+    return DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
+        .source(source)
+        .fieldType(GraphQLString)
+        .build();
+  }
+
+  public static class EnvironmentAwareSource {
+
+    private DataFetchingEnvironment seenEnvironment;
+
+    public String getValue(DataFetchingEnvironment environment) {
+      this.seenEnvironment = environment;
+      return "value from " + getClass().getSimpleName();
+    }
+  }
+
+  public static class ZeroArgumentGetterSource {
+
+    public String getName() {
+      return "zero argument getter value";
+    }
+  }
+
+  public static class PrivateGetterSource {
+
+    private String getSecret() {
+      return "private getter value";
+    }
+  }
+
+  public static class PublicFieldSource {
+
+    public final String publicField = "public field value";
+  }
+
+  public static class PrivateFieldSource {
+
+    private final String privateField = "private field value";
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/com_graphql_java/graphql_java/PropertyFetchingImplTest.java
+++ b/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/com_graphql_java/graphql_java/PropertyFetchingImplTest.java
@@ -6,8 +6,21 @@
  */
 package com_graphql_java.graphql_java;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import graphql.execution.ExecutionContext;
+import graphql.execution.ExecutionId;
+import graphql.execution.ExecutionTypeInfo;
+import graphql.language.Field;
+import graphql.language.FragmentDefinition;
 import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.DataFetchingEnvironmentImpl;
+import graphql.schema.DataFetchingFieldSelectionSet;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLOutputType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLType;
 import graphql.schema.PropertyDataFetcher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,19 +33,15 @@ public class PropertyFetchingImplTest {
   @BeforeEach
   void resetPropertyFetcher() {
     PropertyDataFetcher.clearReflectionCache();
-    PropertyDataFetcher.setUseSetAccessible(true);
-    PropertyDataFetcher.setUseNegativeCache(true);
   }
 
   @Test
-  void invokesPublicGetterWithDataFetchingEnvironmentArgument() throws Exception {
-    EnvironmentAwareSource source = new EnvironmentAwareSource();
-    DataFetchingEnvironment environment = environmentFor(source);
+  void invokesSuppliedFunction() throws Exception {
+    ZeroArgumentGetterSource source = new ZeroArgumentGetterSource();
 
-    String value = PropertyDataFetcher.<String>fetching("value").get(environment);
+    PropertyDataFetcher<String> fetcher = PropertyDataFetcher.fetching(ZeroArgumentGetterSource::getName);
 
-    assertThat(value).isEqualTo("value from " + EnvironmentAwareSource.class.getSimpleName());
-    assertThat(source.seenEnvironment).isSameAs(environment);
+    assertThat(fetcher.get(environmentFor(source))).isEqualTo("zero argument getter value");
   }
 
   @Test
@@ -72,19 +81,102 @@ public class PropertyFetchingImplTest {
   }
 
   private DataFetchingEnvironment environmentFor(Object source) {
-    return DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
-        .source(source)
-        .fieldType(GraphQLString)
-        .build();
+    return new TestDataFetchingEnvironment(source, GraphQLString);
   }
 
-  public static class EnvironmentAwareSource {
+  private static final class TestDataFetchingEnvironment implements DataFetchingEnvironment {
 
-    private DataFetchingEnvironment seenEnvironment;
+    private final Object source;
+    private final GraphQLOutputType fieldType;
 
-    public String getValue(DataFetchingEnvironment environment) {
-      this.seenEnvironment = environment;
-      return "value from " + getClass().getSimpleName();
+    private TestDataFetchingEnvironment(Object source, GraphQLOutputType fieldType) {
+      this.source = source;
+      this.fieldType = fieldType;
+    }
+
+    @Override
+    public <T> T getSource() {
+      return (T) source;
+    }
+
+    @Override
+    public Map<String, Object> getArguments() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public boolean containsArgument(String name) {
+      return false;
+    }
+
+    @Override
+    public <T> T getArgument(String name) {
+      return null;
+    }
+
+    @Override
+    public <T> T getContext() {
+      return null;
+    }
+
+    @Override
+    public <T> T getRoot() {
+      return null;
+    }
+
+    @Override
+    public GraphQLFieldDefinition getFieldDefinition() {
+      return null;
+    }
+
+    @Override
+    public List<Field> getFields() {
+      return Collections.emptyList();
+    }
+
+    @Override
+    public Field getField() {
+      return null;
+    }
+
+    @Override
+    public GraphQLOutputType getFieldType() {
+      return fieldType;
+    }
+
+    @Override
+    public GraphQLType getParentType() {
+      return null;
+    }
+
+    @Override
+    public GraphQLSchema getGraphQLSchema() {
+      return null;
+    }
+
+    @Override
+    public Map<String, FragmentDefinition> getFragmentsByName() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public ExecutionId getExecutionId() {
+      return null;
+    }
+
+    @Override
+    public DataFetchingFieldSelectionSet getSelectionSet() {
+      return null;
+    }
+
+    @Override
+    public ExecutionTypeInfo getFieldTypeInfo() {
+      return null;
+    }
+
+    @Override
+    public ExecutionContext getExecutionContext() {
+      return null;
     }
   }
 

--- a/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/graphql/GraphQlTests.java
+++ b/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/graphql/GraphQlTests.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.function.Consumer;
+
+import graphql.introspection.IntrospectionQuery;
+import graphql.relay.Connection;
+import graphql.relay.DefaultConnection;
+import graphql.relay.DefaultConnectionCursor;
+import graphql.relay.DefaultEdge;
+import graphql.relay.DefaultPageInfo;
+import graphql.relay.Edge;
+import graphql.relay.PageInfo;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.StaticDataFetcher;
+import graphql.schema.TypeResolver;
+import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.SchemaGenerator;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import graphql.starwars.Droid;
+import graphql.starwars.Human;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Brian Clozel
+ */
+public class GraphQlTests {
+
+
+  @Test
+  void greetingQuery() throws Exception {
+    GraphQLSchema graphQLSchema = parseSchema("greeting", runtimeWiringBuilder ->
+        runtimeWiringBuilder.type("Query", builder ->
+            builder.dataFetcher("greeting", new StaticDataFetcher("Hello GraphQL"))));
+    GraphQL graphQl = GraphQL.newGraphQL(graphQLSchema).build();
+    ExecutionResult result = graphQl.execute("{ greeting }");
+    assertThat(result.getErrors()).isEmpty();
+    assertThat(result.getData().toString()).isEqualTo("{greeting=Hello GraphQL}");
+  }
+
+  @Test
+  void introspectionQuery() throws Exception {
+    GraphQLSchema graphQLSchema = parseSchema("starwars", runtimeWiringBuilder -> {
+      runtimeWiringBuilder.type("Query", builder -> builder.typeName("Character").typeResolver(characterTypeResolver()));
+    });
+    GraphQL graphQl = GraphQL.newGraphQL(graphQLSchema).build();
+    ExecutionResult result = graphQl.execute(IntrospectionQuery.INTROSPECTION_QUERY);
+    assertThat(result.getErrors()).isEmpty();
+    assertThat(result.getData().toString()).contains("{__schema={queryType={name=QueryType}");
+  }
+
+  @Test
+  void paginatedQuery() throws Exception {
+    PageInfo pageInfo = new DefaultPageInfo(new DefaultConnectionCursor("start"),
+            new DefaultConnectionCursor("end"), true, true);
+    Edge<Human> edge = new DefaultEdge<>(new Human(), new DefaultConnectionCursor("current"));
+    Connection<Human> connection = new DefaultConnection<>(List.of(edge), pageInfo);
+    GraphQLSchema graphQLSchema = parseSchema("starwars", runtimeWiringBuilder ->
+            runtimeWiringBuilder.type("QueryType", builder ->
+                    builder.dataFetcher("humans", new StaticDataFetcher(connection)))
+                    .type("Character", typeBuilder -> typeBuilder.typeResolver(characterTypeResolver())));
+    GraphQL graphQl = GraphQL.newGraphQL(graphQLSchema).build();
+    ExecutionResult result = graphQl.execute("{ humans { edges { node { id name } } pageInfo { startCursor } } }");
+    assertThat(result.getErrors()).isEmpty();
+    assertThat(result.getData().toString()).isEqualTo("{humans={edges=[{node={id=42, name=GraalVM}}], pageInfo={startCursor=start}}}");
+  }
+
+  private GraphQLSchema parseSchema(String schemaFileName, Consumer<RuntimeWiring.Builder> consumer) throws IOException {
+    try (InputStream inputStream = GraphQlTests.class.getResourceAsStream(schemaFileName + ".graphqls")) {
+      TypeDefinitionRegistry registry = new SchemaParser().parse(inputStream);
+      RuntimeWiring.Builder runtimeWiringBuilder = RuntimeWiring.newRuntimeWiring();
+      consumer.accept(runtimeWiringBuilder);
+      return new SchemaGenerator().makeExecutableSchema(registry, runtimeWiringBuilder.build());
+    }
+  }
+
+  private TypeResolver characterTypeResolver() {
+    return env -> {
+      Object javaObject = env.getObject();
+      if (javaObject instanceof Droid) {
+        return env.getSchema().getObjectType("Droid");
+      } else if (javaObject instanceof Human) {
+        return env.getSchema().getObjectType("Human");
+      } else {
+        throw new IllegalStateException("Unknown Character type");
+      }
+    };
+  }
+
+}

--- a/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/graphql/GraphQlTests.java
+++ b/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/graphql/GraphQlTests.java
@@ -8,6 +8,8 @@ package graphql;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -77,8 +79,9 @@ public class GraphQlTests {
   }
 
   private GraphQLSchema parseSchema(String schemaFileName, Consumer<RuntimeWiring.Builder> consumer) throws IOException {
-    try (InputStream inputStream = GraphQlTests.class.getResourceAsStream(schemaFileName + ".graphqls")) {
-      TypeDefinitionRegistry registry = new SchemaParser().parse(inputStream);
+    try (InputStream inputStream = GraphQlTests.class.getResourceAsStream(schemaFileName + ".graphqls");
+        InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8)) {
+      TypeDefinitionRegistry registry = new SchemaParser().parse(reader);
       RuntimeWiring.Builder runtimeWiringBuilder = RuntimeWiring.newRuntimeWiring();
       consumer.accept(runtimeWiringBuilder);
       return new SchemaGenerator().makeExecutableSchema(registry, runtimeWiringBuilder.build());

--- a/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/graphql/starwars/Character.java
+++ b/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/graphql/starwars/Character.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.starwars;
+
+import java.util.List;
+
+/**
+ * @author Brian Clozel
+ */
+public interface Character {
+
+  Long getId();
+
+  String getName();
+
+  Character getFriends();
+
+  List<Episode> getAppearsIn();
+
+}

--- a/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/graphql/starwars/Droid.java
+++ b/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/graphql/starwars/Droid.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.starwars;
+
+import java.util.List;
+
+/**
+ * @author Brian Clozel
+ */
+public class Droid implements Character {
+
+  @Override
+  public Long getId() {
+    return null;
+  }
+
+  @Override
+  public String getName() {
+    return null;
+  }
+
+  @Override
+  public Character getFriends() {
+    return null;
+  }
+
+  @Override
+  public List<Episode> getAppearsIn() {
+    return null;
+  }
+
+  public String getPrimaryFunction() {
+    return null;
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/graphql/starwars/Episode.java
+++ b/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/graphql/starwars/Episode.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.starwars;
+
+/**
+ * @author Brian Clozel
+ */
+public enum Episode {
+  NEWHOPE,
+  EMPIRE,
+  JEDI
+}

--- a/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/graphql/starwars/Human.java
+++ b/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/graphql/starwars/Human.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.starwars;
+
+import java.util.List;
+
+/**
+ * @author Brian Clozel
+ */
+public class Human implements Character {
+
+  @Override
+  public Long getId() {
+    return 42L;
+  }
+
+  @Override
+  public String getName() {
+    return "GraalVM";
+  }
+
+  @Override
+  public Character getFriends() {
+    return null;
+  }
+
+  @Override
+  public List<Episode> getAppearsIn() {
+    return null;
+  }
+
+  public String getHomePlanet() {
+    return null;
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,104 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "graphql.relay.Connection"
+      },
+      "type" : "graphql.relay.DefaultConnection",
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.relay.Connection"
+      },
+      "type" : "graphql.relay.DefaultConnectionCursor",
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.relay.Connection"
+      },
+      "type" : "graphql.relay.DefaultEdge",
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.relay.Connection"
+      },
+      "type" : "graphql.relay.DefaultPageInfo",
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "type" : "graphql.schema.GraphQLArgument",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "type" : "graphql.schema.GraphQLDirective",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "type" : "graphql.schema.GraphQLEnumValueDefinition",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "type" : "graphql.schema.GraphQLFieldDefinition",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "type" : "graphql.schema.GraphQLInputObjectField",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "type" : "graphql.schema.GraphQLOutputType",
+      "allPublicMethods" : true
+    },
+    {
+      "type" : "graphql.starwars.Human",
+      "allPublicMethods" : true
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQlTests"
+      },
+      "glob" : "graphql/greeting.graphqls"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQlTests"
+      },
+      "glob" : "graphql/starwars.graphqls"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.reporting.legacy.xml.XmlReportWriter"
+      },
+      "glob" : "META-INF/services/javax.xml.stream.XMLOutputFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.reporting.legacy.xml.XmlReportWriter"
+      },
+      "glob" : "META-INF/services/java.net.spi.InetAddressResolverProvider"
+    }
+  ]
+}

--- a/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -71,7 +71,97 @@
       "allPublicMethods" : true
     },
     {
+      "condition" : {
+        "typeReached" : "graphql.execution.batched.BatchedDataFetcherFactory"
+      },
+      "type" : "graphql.schema.StaticDataFetcher",
+      "methods" : [
+        {
+          "name" : "get",
+          "parameterTypes" : [
+            "graphql.schema.DataFetchingEnvironment"
+          ]
+        }
+      ]
+    },
+    {
       "type" : "graphql.starwars.Human",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.introspection.Introspection"
+      },
+      "type" : "graphql.schema.GraphQLObjectType",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.introspection.Introspection"
+      },
+      "type" : "graphql.schema.GraphQLInterfaceType",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.introspection.Introspection"
+      },
+      "type" : "graphql.schema.GraphQLEnumType",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.introspection.Introspection"
+      },
+      "type" : "graphql.schema.GraphQLInputObjectType",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.introspection.Introspection"
+      },
+      "type" : "graphql.schema.GraphQLScalarType",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.introspection.Introspection"
+      },
+      "type" : "graphql.schema.GraphQLUnionType",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.introspection.Introspection"
+      },
+      "type" : "graphql.schema.GraphQLTypeReference",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.introspection.Introspection"
+      },
+      "type" : "graphql.schema.GraphQLList",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.introspection.Introspection"
+      },
+      "type" : "graphql.schema.GraphQLNonNull",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.language.AstValueHelper"
+      },
+      "type" : "com_graphql_java.graphql_java.AstValueHelperTest$AddressInputBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.language.AstValueHelper"
+      },
+      "type" : "com_graphql_java.graphql_java.AstValueHelperTest$AddressInput",
       "allPublicMethods" : true
     }
   ],

--- a/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -177,18 +177,6 @@
         "typeReached" : "graphql.GraphQlTests"
       },
       "glob" : "graphql/starwars.graphqls"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.junit.platform.reporting.legacy.xml.XmlReportWriter"
-      },
-      "glob" : "META-INF/services/javax.xml.stream.XMLOutputFactory"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.junit.platform.reporting.legacy.xml.XmlReportWriter"
-      },
-      "glob" : "META-INF/services/java.net.spi.InetAddressResolverProvider"
     }
   ]
 }

--- a/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/resources/graphql/greeting.graphqls
+++ b/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/resources/graphql/greeting.graphqls
@@ -1,0 +1,3 @@
+type Query {
+    greeting: String
+}

--- a/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/resources/graphql/starwars.graphqls
+++ b/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/resources/graphql/starwars.graphqls
@@ -1,0 +1,63 @@
+schema {
+    query: QueryType
+    mutation: Mutation
+}
+
+type Mutation {
+    addFriend(characterId: ID!, newFriend: NewCharacter!) : Character!
+}
+
+type QueryType {
+    hero(episode: Episode): Character!
+    human(id : String) : Human
+    droid(id: ID!): Droid
+    humans: HumanConnection
+}
+
+enum Episode {
+    NEWHOPE
+    EMPIRE
+    JEDI
+}
+
+type Human implements Character {
+    id: ID!
+    name: String!
+    friends: [Character]
+    appearsIn: [Episode]
+    homePlanet: String
+}
+
+type Droid implements Character {
+    id: ID!
+    name: String!
+    friends: [Character]
+    appearsIn: [Episode]!
+    primaryFunction: String
+}
+
+interface Character {
+    id: ID!
+    name: String!
+}
+
+input NewCharacter {
+    name: String
+}
+
+type HumanConnection {
+    edges: [HumanEdge]
+    pageInfo: PageInfo!
+}
+
+type HumanEdge {
+    cursor: String!
+    node: Human
+}
+
+type PageInfo {
+    hasNextPage: Boolean!
+    hasPreviousPage: Boolean!
+    startCursor: String
+    endCursor: String
+}

--- a/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/user-code-filter.json
+++ b/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "graphql.**"
+    }
+  ]
+}

--- a/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/user-code-filter.json
+++ b/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/user-code-filter.json
@@ -5,6 +5,12 @@
     },
     {
       "includeClasses" : "graphql.**"
+    },
+    {
+      "includeClasses" : "com_graphql_java.graphql_java.**"
+    },
+    {
+      "includeClasses" : "graphql.starwars.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #5845

This PR provides test fixes and new metadata for com.graphql-java:graphql-java:2018-07-28T00-19-13-5ea18ff, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 189682
- Cached input tokens: 2080256
- Output tokens: 25245
- Metadata entries: 4
- Test-only metadata entries: 47
- Iterations: 5
- Library coverage percentage: 35.17
- Previous library version metadata entries: 4
- Previous library version test-only metadata entries: 26
- Previous library version coverage percentage: 30.88

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `011d5fa3bb8eb1b58c27644e36962c43bd1244d5`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.graphql-java:graphql-java:19.7: 11/12 covered calls (91.67%)
- com.graphql-java:graphql-java:2018-07-28T00-19-13-5ea18ff: 10/10 covered calls (100.00%)

**Reflection:**
- com.graphql-java:graphql-java:19.7: 10/11 covered calls (90.91%)
- com.graphql-java:graphql-java:2018-07-28T00-19-13-5ea18ff: 10/10 covered calls (100.00%)

**Resources:**
- com.graphql-java:graphql-java:19.7: 1/1 covered calls (100.00%)
- com.graphql-java:graphql-java:2018-07-28T00-19-13-5ea18ff: N/A

#### Library coverage

**Instruction:**
- com.graphql-java:graphql-java:19.7: 42419/149497 (28.37%)
- com.graphql-java:graphql-java:2018-07-28T00-19-13-5ea18ff: 24452/73797 (33.13%)

**Line:**
- com.graphql-java:graphql-java:19.7: 10223/33104 (30.88%)
- com.graphql-java:graphql-java:2018-07-28T00-19-13-5ea18ff: 5771/16410 (35.17%)

**Method:**
- com.graphql-java:graphql-java:19.7: 2959/9722 (30.44%)
- com.graphql-java:graphql-java:2018-07-28T00-19-13-5ea18ff: 1595/4830 (33.02%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/com_graphql_java/graphql_java/AstValueHelperTest.java 2/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/com_graphql_java/graphql_java/AstValueHelperTest.java
new file mode 100644
index 0000000000..e2a9008a88
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/com_graphql_java/graphql_java/AstValueHelperTest.java
@@ -0,0 +1,53 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_graphql_java.graphql_java;
+
+import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.idl.SchemaPrinter;
+import org.junit.jupiter.api.Test;
+
+import static graphql.Scalars.GraphQLString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AstValueHelperTest {
+
+  @Test
+  void printsInputObjectDefaultValueFromJavaBeanProperties() {
+    GraphQLInputObjectType addressInput = GraphQLInputObjectType.newInputObject()
+        .name("AddressInput")
+        .field(field -> field.name("city").type(GraphQLString))
+        .field(field -> field.name("street").type(GraphQLString))
+        .build();
+    GraphQLInputObjectType personInput = GraphQLInputObjectType.newInputObject()
+        .name("PersonInput")
+        .field(field -> field.name("home").type(addressInput).defaultValue(new AddressInput("London", "Baker Street")))
+        .build();
+
+    String schema = new SchemaPrinter().print(personInput);
+
+    assertThat(schema).contains("home: AddressInput = {city : \"London\", street : \"Baker Street\"}");
+  }
+
+  public static class AddressInput {
+
+    private final String city;
+    private final String street;
+
+    public AddressInput(String city, String street) {
+      this.city = city;
+      this.street = street;
+    }
+
+    public String getCity() {
+      return city;
+    }
+
+    public String getStreet() {
+      return street;
+    }
+  }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/com_graphql_java/graphql_java/BatchedDataFetcherFactoryTest.java 2/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/com_graphql_java/graphql_java/BatchedDataFetcherFactoryTest.java
new file mode 100644
index 0000000000..9db3d82fd2
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/com_graphql_java/graphql_java/BatchedDataFetcherFactoryTest.java
@@ -0,0 +1,57 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_graphql_java.graphql_java;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import graphql.execution.ExecutionContext;
+import graphql.execution.ExecutionId;
+import graphql.execution.batched.BatchedDataFetcher;
+import graphql.execution.batched.BatchedDataFetcherFactory;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.StaticDataFetcher;
+import org.junit.jupiter.api.Test;
+
+import static graphql.schema.DataFetchingEnvironmentBuilder.newDataFetchingEnvironment;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BatchedDataFetcherFactoryTest {
+
+  @Test
+  void wrapsOrdinaryDataFetcherForBatchedExecution() throws Exception {
+    StaticDataFetcher suppliedFetcher = new StaticDataFetcher("constant value");
+    DataFetchingEnvironment environment = newDataFetchingEnvironment()
+        .source(List.of("Leia", "Luke"))
+        .executionContext(newExecutionContext())
+        .build();
+
+    BatchedDataFetcher batchedFetcher = new BatchedDataFetcherFactory().create(suppliedFetcher);
+    CompletableFuture<?> result = (CompletableFuture<?>) batchedFetcher.get(environment);
+
+    assertThat(result.get(5, TimeUnit.SECONDS)).isEqualTo(List.of("constant value", "constant value"));
+  }
+
+  private ExecutionContext newExecutionContext() {
+    return new ExecutionContext(
+        null,
+        ExecutionId.from("batched-data-fetcher-factory-test"),
+        null,
+        null,
+        null,
+        null,
+        null,
+        Collections.emptyMap(),
+        null,
+        null,
+        Collections.emptyMap(),
+        null,
+        null);
+  }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/com_graphql_java/graphql_java/PropertyDataFetcherTest.java 2/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/com_graphql_java/graphql_java/PropertyDataFetcherTest.java
new file mode 100644
index 0000000000..20df4c9949
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/com_graphql_java/graphql_java/PropertyDataFetcherTest.java
@@ -0,0 +1,231 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_graphql_java.graphql_java;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import graphql.execution.ExecutionContext;
+import graphql.execution.ExecutionId;
+import graphql.execution.ExecutionTypeInfo;
+import graphql.language.Field;
+import graphql.language.FragmentDefinition;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingFieldSelectionSet;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLOutputType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLType;
+import graphql.schema.PropertyDataFetcher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static graphql.Scalars.GraphQLString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PropertyDataFetcherTest {
+
+  @BeforeEach
+  void resetPropertyFetcher() {
+    PropertyDataFetcher.clearReflectionCache();
+  }
+
+  @Test
+  void invokesSuppliedFunction() throws Exception {
+    ZeroArgumentGetterSource source = new ZeroArgumentGetterSource();
+
+    PropertyDataFetcher<String> fetcher = PropertyDataFetcher.fetching(ZeroArgumentGetterSource::getName);
+
+    assertThat(fetcher.get(environmentFor(source))).isEqualTo("zero argument getter value");
+  }
+
+  @Test
+  void invokesPublicZeroArgumentGetter() throws Exception {
+    ZeroArgumentGetterSource source = new ZeroArgumentGetterSource();
+
+    String value = PropertyDataFetcher.<String>fetching("name").get(environmentFor(source));
+
+    assertThat(value).isEqualTo("zero argument getter value");
+  }
+
+  @Test
+  void invokesPrivateGetterViaSetAccessibleLookup() throws Exception {
+    PrivateGetterSource source = new PrivateGetterSource();
+
+    String value = PropertyDataFetcher.<String>fetching("secret").get(environmentFor(source));
+
+    assertThat(value).isEqualTo("private getter value");
+  }
+
+  @Test
+  void readsAndCachesPublicField() throws Exception {
+    PublicFieldSource source = new PublicFieldSource();
+    PropertyDataFetcher<String> fetcher = PropertyDataFetcher.fetching("publicField");
+
+    assertThat(fetcher.get(environmentFor(source))).isEqualTo("public field value");
+    assertThat(fetcher.get(environmentFor(source))).isEqualTo("public field value");
+  }
+
+  @Test
+  void readsAndCachesPrivateFieldViaSetAccessibleLookup() throws Exception {
+    PrivateFieldSource source = new PrivateFieldSource();
+    PropertyDataFetcher<String> fetcher = PropertyDataFetcher.fetching("privateField");
+
+    assertThat(fetcher.get(environmentFor(source))).isEqualTo("private field value");
+    assertThat(fetcher.get(environmentFor(source))).isEqualTo("private field value");
+  }
+
+  @Test
+  void findsPublicMethodOnRootInterfaceWhenNoSuperclassExists() throws Throwable {
+    PropertyDataFetcher<String> fetcher = PropertyDataFetcher.fetching("name");
+    MethodHandle finder = MethodHandles.privateLookupIn(PropertyDataFetcher.class, MethodHandles.lookup())
+        .findVirtual(
+            PropertyDataFetcher.class,
+            "findPubliclyAccessibleMethod",
+            MethodType.methodType(Method.class, Class.class, String.class));
+
+    Method method = (Method) finder.invoke(fetcher, NonPublicNameSource.class, "getName");
+
+    assertThat(method.getDeclaringClass()).isEqualTo(NonPublicNameSource.class);
+    assertThat(method.getName()).isEqualTo("getName");
+  }
+
+  private DataFetchingEnvironment environmentFor(Object source) {
+    return new TestDataFetchingEnvironment(source, GraphQLString);
+  }
+
+  private static final class TestDataFetchingEnvironment implements DataFetchingEnvironment {
+
+    private final Object source;
+    private final GraphQLOutputType fieldType;
+
+    private TestDataFetchingEnvironment(Object source, GraphQLOutputType fieldType) {
+      this.source = source;
+      this.fieldType = fieldType;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T getSource() {
+      return (T) source;
+    }
+
+    @Override
+    public Map<String, Object> getArguments() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public boolean containsArgument(String name) {
+      return false;
+    }
+
+    @Override
+    public <T> T getArgument(String name) {
+      return null;
+    }
+
+    @Override
+    public <T> T getContext() {
+      return null;
+    }
+
+    @Override
+    public <T> T getRoot() {
+      return null;
+    }
+
+    @Override
+    public GraphQLFieldDefinition getFieldDefinition() {
+      return null;
+    }
+
+    @Override
+    public List<Field> getFields() {
+      return Collections.emptyList();
+    }
+
+    @Override
+    public Field getField() {
+      return null;
+    }
+
+    @Override
+    public GraphQLOutputType getFieldType() {
+      return fieldType;
+    }
+
+    @Override
+    public GraphQLType getParentType() {
+      return null;
+    }
+
+    @Override
+    public GraphQLSchema getGraphQLSchema() {
+      return null;
+    }
+
+    @Override
+    public Map<String, FragmentDefinition> getFragmentsByName() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public ExecutionId getExecutionId() {
+      return null;
+    }
+
+    @Override
+    public DataFetchingFieldSelectionSet getSelectionSet() {
+      return null;
+    }
+
+    @Override
+    public ExecutionTypeInfo getFieldTypeInfo() {
+      return null;
+    }
+
+    @Override
+    public ExecutionContext getExecutionContext() {
+      return null;
+    }
+  }
+
+  public static class ZeroArgumentGetterSource {
+
+    public String getName() {
+      return "zero argument getter value";
+    }
+  }
+
+  public static class PrivateGetterSource {
+
+    private String getSecret() {
+      return "private getter value";
+    }
+  }
+
+  public static class PublicFieldSource {
+
+    public final String publicField = "public field value";
+  }
+
+  public static class PrivateFieldSource {
+
+    private final String privateField = "private field value";
+  }
+
+  interface NonPublicNameSource {
+
+    String getName();
+  }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/com_graphql_java/graphql_java/PropertyFetchingImplTest.java 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/com_graphql_java/graphql_java/PropertyFetchingImplTest.java
deleted file mode 100644
index e36e5f0ffe..0000000000
--- 1/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/com_graphql_java/graphql_java/PropertyFetchingImplTest.java
+++ /dev/null
@@ -1,114 +0,0 @@
-/*
- * Copyright and related rights waived via CC0
- *
- * You should have received a copy of the CC0 legalcode along with this
- * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
- */
-package com_graphql_java.graphql_java;
-
-import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.DataFetchingEnvironmentImpl;
-import graphql.schema.PropertyDataFetcher;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import static graphql.Scalars.GraphQLString;
-import static org.assertj.core.api.Assertions.assertThat;
-
-public class PropertyFetchingImplTest {
-
-  @BeforeEach
-  void resetPropertyFetcher() {
-    PropertyDataFetcher.clearReflectionCache();
-    PropertyDataFetcher.setUseSetAccessible(true);
-    PropertyDataFetcher.setUseNegativeCache(true);
-  }
-
-  @Test
-  void invokesPublicGetterWithDataFetchingEnvironmentArgument() throws Exception {
-    EnvironmentAwareSource source = new EnvironmentAwareSource();
-    DataFetchingEnvironment environment = environmentFor(source);
-
-    String value = PropertyDataFetcher.<String>fetching("value").get(environment);
-
-    assertThat(value).isEqualTo("value from " + EnvironmentAwareSource.class.getSimpleName());
-    assertThat(source.seenEnvironment).isSameAs(environment);
-  }
-
-  @Test
-  void invokesPublicZeroArgumentGetter() throws Exception {
-    ZeroArgumentGetterSource source = new ZeroArgumentGetterSource();
-
-    String value = PropertyDataFetcher.<String>fetching("name").get(environmentFor(source));
-
-    assertThat(value).isEqualTo("zero argument getter value");
-  }
-
-  @Test
-  void invokesPrivateGetterViaSetAccessibleLookup() throws Exception {
-    PrivateGetterSource source = new PrivateGetterSource();
-
-    String value = PropertyDataFetcher.<String>fetching("secret").get(environmentFor(source));
-
-    assertThat(value).isEqualTo("private getter value");
-  }
-
-  @Test
-  void readsAndCachesPublicField() throws Exception {
-    PublicFieldSource source = new PublicFieldSource();
-    PropertyDataFetcher<String> fetcher = PropertyDataFetcher.fetching("publicField");
-
-    assertThat(fetcher.get(environmentFor(source))).isEqualTo("public field value");
-    assertThat(fetcher.get(environmentFor(source))).isEqualTo("public field value");
-  }
-
-  @Test
-  void readsAndCachesPrivateFieldViaSetAccessibleLookup() throws Exception {
-    PrivateFieldSource source = new PrivateFieldSource();
-    PropertyDataFetcher<String> fetcher = PropertyDataFetcher.fetching("privateField");
-
-    assertThat(fetcher.get(environmentFor(source))).isEqualTo("private field value");
-    assertThat(fetcher.get(environmentFor(source))).isEqualTo("private field value");
-  }
-
-  private DataFetchingEnvironment environmentFor(Object source) {
-    return DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
-        .source(source)
-        .fieldType(GraphQLString)
-        .build();
-  }
-
-  public static class EnvironmentAwareSource {
-
-    private DataFetchingEnvironment seenEnvironment;
-
-    public String getValue(DataFetchingEnvironment environment) {
-      this.seenEnvironment = environment;
-      return "value from " + getClass().getSimpleName();
-    }
-  }
-
-  public static class ZeroArgumentGetterSource {
-
-    public String getName() {
-      return "zero argument getter value";
-    }
-  }
-
-  public static class PrivateGetterSource {
-
-    private String getSecret() {
-      return "private getter value";
-    }
-  }
-
-  public static class PublicFieldSource {
-
-    public final String publicField = "public field value";
-  }
-
-  public static class PrivateFieldSource {
-
-    private final String privateField = "private field value";
-  }
-}
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/GraphQlTests.java 2/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/graphql/GraphQlTests.java
index bc57b070ff..7608bdf551 100644
--- 1/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/GraphQlTests.java
+++ 2/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/src/test/java/graphql/GraphQlTests.java
@@ -8,6 +8,8 @@ package graphql;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -77,8 +79,9 @@ public class GraphQlTests {
   }
 
   private GraphQLSchema parseSchema(String schemaFileName, Consumer<RuntimeWiring.Builder> consumer) throws IOException {
-    try (InputStream inputStream = GraphQlTests.class.getResourceAsStream(schemaFileName + ".graphqls")) {
-      TypeDefinitionRegistry registry = new SchemaParser().parse(inputStream);
+    try (InputStream inputStream = GraphQlTests.class.getResourceAsStream(schemaFileName + ".graphqls");
+        InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8)) {
+      TypeDefinitionRegistry registry = new SchemaParser().parse(reader);
       RuntimeWiring.Builder runtimeWiringBuilder = RuntimeWiring.newRuntimeWiring();
       consumer.accept(runtimeWiringBuilder);
       return new SchemaGenerator().makeExecutableSchema(registry, runtimeWiringBuilder.build());
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/user-code-filter.json 2/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/user-code-filter.json
index b154f38b11..3d996b1625 100644
--- 1/tests/src/com.graphql-java/graphql-java/19.7/user-code-filter.json
+++ 2/tests/src/com.graphql-java/graphql-java/2018-07-28T00-19-13-5ea18ff/user-code-filter.json
@@ -5,6 +5,12 @@
     },
     {
       "includeClasses" : "graphql.**"
+    },
+    {
+      "includeClasses" : "com_graphql_java.graphql_java.**"
+    },
+    {
+      "includeClasses" : "graphql.starwars.**"
     }
   ]
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
