### PR TITLE
[Automation] Generated metadata for software.amazon.awssdk:sdk-core:2.42.0

### DIFF
--- a/metadata/software.amazon.awssdk/sdk-core/2.42.0/reachability-metadata.json
+++ b/metadata/software.amazon.awssdk/sdk-core/2.42.0/reachability-metadata.json
@@ -1,0 +1,48 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "software.amazon.awssdk.core.checksums.Crc32CChecksum"
+      },
+      "type" : "java.util.zip.CRC32C",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory"
+      },
+      "type" : "software.amazon.awssdk.core.internal.interceptor.HttpChecksumValidationInterceptor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "software.amazon.awssdk.core.internal.util.ClassLoaderHelper"
+      },
+      "type" : "software.amazon.awssdk.core.internal.interceptor.HttpChecksumValidationInterceptor"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "software.amazon.awssdk.core.checksums.Crc32CChecksum"
+      },
+      "glob" : "org/slf4j/impl/StaticLoggerBinder.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "software.amazon.awssdk.core.internal.util.Mimetype"
+      },
+      "glob" : "software/amazon/awssdk/core/util/mime.types"
+    }
+  ]
+}

--- a/metadata/software.amazon.awssdk/sdk-core/index.json
+++ b/metadata/software.amazon.awssdk/sdk-core/index.json
@@ -1,6 +1,22 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.42.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/software/amazon/awssdk/sdk-core/$version$/sdk-core-$version$-sources.jar",
+    "repository-url" : "https://github.com/aws/aws-sdk-java-v2",
+    "test-code-url" : "https://github.com/aws/aws-sdk-java-v2/tree/$version$/core/sdk-core/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/software/amazon/awssdk/sdk-core/$version$/sdk-core-$version$-javadoc.jar",
+    "description" : "AWS SDK for Java v2 SDK Core provides runtime classes and shared infrastructure used by AWS service clients to make requests, configure clients, transform payloads, handle responses, retries, pagination, checksums, and exceptions. It is a foundational JVM module for AWS SDK service artifacts rather than a standalone service client.",
+    "test-version" : "2.37.0",
+    "tested-versions" : [
+      "2.42.0"
+    ],
+    "allowed-packages" : [
+      "software.amazon.awssdk.core",
+      "software.amazon.awssdk.checksums.internal"
+    ]
+  },
+  {
     "metadata-version" : "2.37.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/software/amazon/awssdk/sdk-core/$version$/sdk-core-$version$-sources.jar",
     "repository-url" : "https://github.com/aws/aws-sdk-java-v2",

--- a/stats/software.amazon.awssdk/sdk-core/2.42.0/stats.json
+++ b/stats/software.amazon.awssdk/sdk-core/2.42.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "2.42.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 6,
+          "totalCalls" : 6
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 8,
+      "totalCalls" : 8
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1102,
+        "missed" : 44510,
+        "ratio" : 0.02416,
+        "total" : 45612
+      },
+      "line" : {
+        "covered" : 209,
+        "missed" : 10857,
+        "ratio" : 0.018887,
+        "total" : 11066
+      },
+      "method" : {
+        "covered" : 55,
+        "missed" : 3672,
+        "ratio" : 0.014757,
+        "total" : 3727
+      }
+    }
+  } ]
+}

--- a/tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/software.amazon.awssdk/sdk-core/2.37.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -5,6 +5,36 @@
         "typeReached" : "software.amazon.awssdk.core.internal.http.loader.SystemPropertyHttpServiceProvider"
       },
       "type" : "software_amazon_awssdk.sdk_core.SystemPropertyHttpServiceProviderTest$TestSdkHttpService"
+    },
+    {
+      "condition" : {
+        "typeReached" : "software_amazon_awssdk.sdk_core.ClassLoaderHelperTest"
+      },
+      "type" : "example.missing.ClassLoaderHelperTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "software_amazon_awssdk.sdk_core.ClassLoaderHelperTest"
+      },
+      "type" : "java.lang.Integer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "software_amazon_awssdk.sdk_core.ClassLoaderHelperTest"
+      },
+      "type" : "java.lang.String"
+    },
+    {
+      "condition" : {
+        "typeReached" : "software.amazon.awssdk.core.internal.http.loader.SystemPropertyHttpServiceProvider"
+      },
+      "type" : "software_amazon_awssdk.sdk_core.SystemPropertyHttpServiceProviderTest$TestSdkHttpService",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
     }
   ],
   "resources" : [
@@ -13,6 +43,18 @@
         "typeReached" : "software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory"
       },
       "glob" : "sdk-core-test/execution.interceptors"
+    },
+    {
+      "condition" : {
+        "typeReached" : "software_amazon_awssdk.sdk_core.ClassLoaderHelperTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "software_amazon_awssdk.sdk_core.ClassLoaderHelperTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
     }
   ]
 }


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7190

This PR provides new metadata needed for the software.amazon.awssdk:sdk-core:2.42.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `software.amazon.awssdk:sdk-core:2.37.0`): 7
- Test-only metadata entries (previous `software.amazon.awssdk:sdk-core:2.37.0`): 9
- Metadata entries (new `software.amazon.awssdk:sdk-core:2.42.0`): 7
- Test-only metadata entries (new `software.amazon.awssdk:sdk-core:2.42.0`): 9
- Library coverage (previous): 1.94%
- Library coverage (new): 1.89%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `5cd2c9d2e7e605af98ad5ef84fef25cd09aa7264`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- software.amazon.awssdk:sdk-core:2.37.0: 8/8 covered calls (100.00%)
- software.amazon.awssdk:sdk-core:2.42.0: 8/8 covered calls (100.00%)

**Reflection:**
- software.amazon.awssdk:sdk-core:2.37.0: 6/6 covered calls (100.00%)
- software.amazon.awssdk:sdk-core:2.42.0: 6/6 covered calls (100.00%)

**Resources:**
- software.amazon.awssdk:sdk-core:2.37.0: 2/2 covered calls (100.00%)
- software.amazon.awssdk:sdk-core:2.42.0: 2/2 covered calls (100.00%)

#### Library coverage

**Instruction:**
- software.amazon.awssdk:sdk-core:2.37.0: 1098/44288 (2.48%)
- software.amazon.awssdk:sdk-core:2.42.0: 1102/45612 (2.42%)

**Line:**
- software.amazon.awssdk:sdk-core:2.37.0: 208/10735 (1.94%)
- software.amazon.awssdk:sdk-core:2.42.0: 209/11066 (1.89%)

**Method:**
- software.amazon.awssdk:sdk-core:2.37.0: 55/3657 (1.50%)
- software.amazon.awssdk:sdk-core:2.42.0: 55/3727 (1.48%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
