### PR TITLE
[GenAI] Test fix for io.projectreactor.netty:reactor-netty-core:1.1.0 using gpt-5.5

### DIFF
--- a/metadata/io.projectreactor.netty/reactor-netty-core/1.1.0/reachability-metadata.json
+++ b/metadata/io.projectreactor.netty/reactor-netty-core/1.1.0/reachability-metadata.json
@@ -1,0 +1,784 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.transport.ProxyProvider"
+      },
+      "type" : "io.netty.buffer.AbstractByteBufAllocator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.transport.ProxyProvider"
+      },
+      "type" : "io.netty.buffer.AbstractReferenceCountedByteBuf",
+      "fields" : [
+        {
+          "name" : "refCnt"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultLoopEpoll"
+      },
+      "type" : "io.netty.channel.ChannelException",
+      "jniAccessible" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.transport.NameResolverProvider"
+      },
+      "type" : "io.netty.channel.DefaultChannelPipeline$HeadContext"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.transport.ServerTransport"
+      },
+      "type" : "io.netty.channel.DefaultChannelPipeline$HeadContext"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.udp.UdpServerConfig"
+      },
+      "type" : "io.netty.channel.DefaultChannelPipeline$HeadContext"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.transport.NameResolverProvider"
+      },
+      "type" : "io.netty.channel.DefaultChannelPipeline$TailContext"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.transport.ServerTransport"
+      },
+      "type" : "io.netty.channel.DefaultChannelPipeline$TailContext"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.udp.UdpServerConfig"
+      },
+      "type" : "io.netty.channel.DefaultChannelPipeline$TailContext"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultLoopEpoll"
+      },
+      "type" : "io.netty.channel.DefaultFileRegion",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "file"
+        },
+        {
+          "name" : "transferred"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultLoopEpoll"
+      },
+      "type" : "io.netty.channel.epoll.Epoll"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultLoopEpoll"
+      },
+      "type" : "io.netty.channel.epoll.LinuxSocket",
+      "jniAccessible" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultLoopEpoll"
+      },
+      "type" : "io.netty.channel.epoll.Native",
+      "jniAccessible" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultLoopEpoll"
+      },
+      "type" : "io.netty.channel.epoll.NativeDatagramPacketArray$NativeDatagramPacket",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "count"
+        },
+        {
+          "name" : "memoryAddress"
+        },
+        {
+          "name" : "recipientAddr"
+        },
+        {
+          "name" : "recipientAddrLen"
+        },
+        {
+          "name" : "recipientPort"
+        },
+        {
+          "name" : "recipientScopeId"
+        },
+        {
+          "name" : "segmentSize"
+        },
+        {
+          "name" : "senderAddr"
+        },
+        {
+          "name" : "senderAddrLen"
+        },
+        {
+          "name" : "senderPort"
+        },
+        {
+          "name" : "senderScopeId"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultLoopEpoll"
+      },
+      "type" : "io.netty.channel.epoll.NativeStaticallyReferencedJniMethods",
+      "jniAccessible" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultLoopEpoll"
+      },
+      "type" : "io.netty.channel.unix.Buffer",
+      "jniAccessible" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultLoopEpoll"
+      },
+      "type" : "io.netty.channel.unix.DatagramSocketAddress",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "byte[]",
+            "int",
+            "int",
+            "int",
+            "io.netty.channel.unix.DatagramSocketAddress"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultLoopEpoll"
+      },
+      "type" : "io.netty.channel.unix.DomainDatagramSocketAddress",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "byte[]",
+            "int",
+            "io.netty.channel.unix.DomainDatagramSocketAddress"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultLoopEpoll"
+      },
+      "type" : "io.netty.channel.unix.ErrorsStaticallyReferencedJniMethods",
+      "jniAccessible" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultLoopEpoll"
+      },
+      "type" : "io.netty.channel.unix.FileDescriptor",
+      "jniAccessible" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultLoopEpoll"
+      },
+      "type" : "io.netty.channel.unix.LimitsStaticallyReferencedJniMethods",
+      "jniAccessible" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultLoopEpoll"
+      },
+      "type" : "io.netty.channel.unix.PeerCredentials",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "int",
+            "int",
+            "int[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultLoopEpoll"
+      },
+      "type" : "io.netty.channel.unix.Socket",
+      "jniAccessible" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.Connection"
+      },
+      "type" : "io.netty.handler.codec.LineBasedFrameDecoder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.transport.TransportConnector"
+      },
+      "type" : "io.netty.handler.codec.dns.DatagramDnsQueryEncoder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultLoopIOUring"
+      },
+      "type" : "io.netty.incubator.channel.uring.IOUring"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.transport.TransportConnector"
+      },
+      "type" : "io.netty.resolver.dns.Cache$Entries"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.transport.TransportConnector"
+      },
+      "type" : "io.netty.resolver.dns.DnsNameResolver$1"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.transport.TransportConnector"
+      },
+      "type" : "io.netty.resolver.dns.DnsNameResolver$3"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.transport.TransportConnector"
+      },
+      "type" : "io.netty.resolver.dns.DnsNameResolver$DnsResponseHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultLoopEpoll"
+      },
+      "type" : "io.netty.util.AbstractReferenceCounted",
+      "fields" : [
+        {
+          "name" : "refCnt"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultPooledConnectionProvider$PooledConnectionAllocator$PooledConnectionInitializer"
+      },
+      "type" : "io.netty.util.DefaultAttributeMap$DefaultAttribute"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.NettyOutbound"
+      },
+      "type" : "io.netty.util.Recycler$DefaultHandle"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.transport.ProxyProvider"
+      },
+      "type" : "io.netty.util.concurrent.DefaultPromise"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultLoopEpoll"
+      },
+      "type" : "io.netty.util.internal.NativeLibraryUtil",
+      "methods" : [
+        {
+          "name" : "loadLibrary",
+          "parameterTypes" : [
+            "java.lang.String",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultLoopEpoll"
+      },
+      "type" : "java.io.FileDescriptor",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "fd"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultLoopEpoll"
+      },
+      "type" : "java.io.IOException",
+      "jniAccessible" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultLoopEpoll"
+      },
+      "type" : "java.lang.OutOfMemoryError",
+      "jniAccessible" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultLoopEpoll"
+      },
+      "type" : "java.lang.RuntimeException",
+      "jniAccessible" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.transport.AddressUtils"
+      },
+      "type" : "java.lang.management.ManagementFactory",
+      "methods" : [
+        {
+          "name" : "getRuntimeMXBean",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.transport.AddressUtils"
+      },
+      "type" : "java.lang.management.RuntimeMXBean",
+      "methods" : [
+        {
+          "name" : "getInputArguments",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultLoopEpoll"
+      },
+      "type" : "java.net.InetSocketAddress",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultLoopEpoll"
+      },
+      "type" : "java.net.PortUnreachableException",
+      "jniAccessible" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.transport.NameResolverProvider"
+      },
+      "type" : "java.net.SocketOption"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.transport.NameResolverProvider"
+      },
+      "type" : "java.net.StandardSocketOptions",
+      "fields" : [
+        {
+          "name" : "IP_MULTICAST_IF"
+        },
+        {
+          "name" : "IP_MULTICAST_LOOP"
+        },
+        {
+          "name" : "IP_MULTICAST_TTL"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.transport.AddressUtils"
+      },
+      "type" : "java.nio.Bits"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultLoopEpoll"
+      },
+      "type" : "java.nio.Buffer",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "limit"
+        },
+        {
+          "name" : "position"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "limit",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "position",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.transport.AddressUtils"
+      },
+      "type" : "java.nio.Buffer",
+      "fields" : [
+        {
+          "name" : "address"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.transport.AddressUtils"
+      },
+      "type" : "java.nio.ByteBuffer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultLoopEpoll"
+      },
+      "type" : "java.nio.DirectByteBuffer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.transport.AddressUtils"
+      },
+      "type" : "java.nio.DirectByteBuffer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultLoopEpoll"
+      },
+      "type" : "java.nio.channels.ClosedChannelException",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultLoopEpoll"
+      },
+      "type" : "java.nio.channels.FileChannel"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.transport.NameResolverProvider"
+      },
+      "type" : "java.nio.channels.NetworkChannel"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.transport.AddressUtils"
+      },
+      "type" : "jdk.internal.misc.Unsafe",
+      "methods" : [
+        {
+          "name" : "getUnsafe",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultPooledConnectionProvider$DisposableAcquire"
+      },
+      "type" : "reactor.core.publisher.FluxDoFinally$DoFinallySubscriber"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.Connection"
+      },
+      "type" : "reactor.core.publisher.FluxFirstWithSignal$RaceCoordinator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.ByteBufMono"
+      },
+      "type" : "reactor.core.publisher.MonoCallable$MonoCallableSubscription"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.transport.ServerTransport$DisposableBind"
+      },
+      "type" : "reactor.core.publisher.MonoIgnoreThen$ThenIgnoreMain"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.Connection"
+      },
+      "type" : "reactor.core.publisher.Operators$DeferredSubscription"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.transport.TransportConnector$MonoChannelPromise"
+      },
+      "type" : "reactor.core.publisher.Operators$MultiSubscriptionSubscriber"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultPooledConnectionProvider$PooledConnection"
+      },
+      "type" : "reactor.core.publisher.SinkEmptyMulticast"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.ByteBufMono$ReleasingInputStream"
+      },
+      "type" : "reactor.netty.ByteBufMono$ReleasingInputStream"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.Connection"
+      },
+      "type" : "reactor.netty.ReactorNetty$InboundIdleStateHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.Connection"
+      },
+      "type" : "reactor.netty.ReactorNetty$OutboundIdleStateHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.channel.ChannelOperations"
+      },
+      "type" : "reactor.netty.channel.ChannelOperations"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.channel.ChannelOperations"
+      },
+      "type" : "reactor.netty.channel.ChannelOperationsHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.channel.FluxReceive"
+      },
+      "type" : "reactor.netty.channel.FluxReceive"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.channel.MonoSendMany$SendManyInner"
+      },
+      "type" : "reactor.netty.channel.MonoSendMany$SendManyInner"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.internal.shaded.reactor.pool.AbstractPool$AbstractPooledRef"
+      },
+      "type" : "reactor.netty.internal.shaded.reactor.pool.AbstractPool$AbstractPooledRef"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.internal.shaded.reactor.pool.AllocationStrategies$SizeBasedAllocationStrategy"
+      },
+      "type" : "reactor.netty.internal.shaded.reactor.pool.AllocationStrategies$SizeBasedAllocationStrategy"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.internal.shaded.reactor.pool.SimpleDequePool"
+      },
+      "type" : "reactor.netty.internal.shaded.reactor.pool.SimpleDequePool"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultPooledConnectionProvider$PooledConnectionAllocator"
+      },
+      "type" : "reactor.netty.resources.DefaultPooledConnectionProvider$PooledConnectionAllocator$PooledConnectionInitializer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.transport.ServerTransport$AcceptorInitializer"
+      },
+      "type" : "reactor.netty.transport.ServerTransport$Acceptor"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.transport.ServerTransport"
+      },
+      "type" : "reactor.netty.transport.ServerTransport$AcceptorInitializer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultPooledConnectionProvider$PooledConnectionAllocator$PooledConnectionInitializer"
+      },
+      "type" : "reactor.netty.transport.TransportConfig$TransportChannelInitializer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.transport.TransportConnector$MonoChannelPromise"
+      },
+      "type" : "reactor.netty.transport.TransportConnector$MonoChannelPromise"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.channel.MonoSendMany$SendManyInner"
+      },
+      "type" : "reactor.util.concurrent.SpscArrayQueueConsumer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.channel.MonoSendMany$SendManyInner"
+      },
+      "type" : "reactor.util.concurrent.SpscArrayQueueProducer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultPooledConnectionProvider$PendingConnectionObserver"
+      },
+      "type" : "reactor.util.concurrent.SpscLinkedArrayQueue"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.transport.AddressUtils"
+      },
+      "type" : "sun.management.VMManagementImpl",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "compTimeMonitoringSupport"
+        },
+        {
+          "name" : "currentThreadCpuTimeSupport"
+        },
+        {
+          "name" : "objectMonitorUsageSupport"
+        },
+        {
+          "name" : "otherThreadCpuTimeSupport"
+        },
+        {
+          "name" : "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name" : "synchronizerUsageSupport"
+        },
+        {
+          "name" : "threadAllocatedMemorySupport"
+        },
+        {
+          "name" : "threadContentionMonitoringSupport"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.transport.AddressUtils"
+      },
+      "type" : "sun.misc.Unsafe",
+      "fields" : [
+        {
+          "name" : "theUnsafe"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "invokeCleaner",
+          "parameterTypes" : [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.transport.ProxyProvider"
+      },
+      "type" : "sun.misc.Unsafe",
+      "methods" : [
+        {
+          "name" : "invokeCleaner",
+          "parameterTypes" : [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.transport.AddressUtils"
+      },
+      "type" : "sun.misc.VM"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultLoopEpoll"
+      },
+      "type" : "sun.nio.ch.FileChannelImpl",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "fd"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultLoopResources"
+      },
+      "type" : "sun.nio.ch.SelectorImpl",
+      "fields" : [
+        {
+          "name" : "publicSelectedKeys"
+        },
+        {
+          "name" : "selectedKeys"
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.resources.DefaultLoopEpoll"
+      },
+      "glob" : "META-INF/native/libnetty_transport_native_epoll_x86_64.so"
+    },
+    {
+      "condition" : {
+        "typeReached" : "reactor.netty.ReactorNetty"
+      },
+      "glob" : "META-INF/services/java.time.zone.ZoneRulesProvider"
+    }
+  ]
+}

--- a/metadata/io.projectreactor.netty/reactor-netty-core/index.json
+++ b/metadata/io.projectreactor.netty/reactor-netty-core/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.1.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/projectreactor/netty/reactor-netty-core/$version$/reactor-netty-core-$version$-sources.jar",
+    "repository-url" : "https://github.com/reactor/reactor-netty",
+    "test-code-url" : "https://github.com/reactor/reactor-netty/tree/v$version$/reactor-netty-core/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/projectreactor/netty/reactor-netty-core/$version$/reactor-netty-core-$version$-javadoc.jar",
+    "description" : "Reactor Netty Core provides the shared reactive networking foundation used by Reactor Netty clients and servers. It builds on Netty and Reactor Core to offer non-blocking connection management, transport support, DNS/proxy handling, and common infrastructure for higher-level HTTP, TCP, and UDP components.",
     "tested-versions" : [
       "1.1.0"
     ],

--- a/metadata/io.projectreactor.netty/reactor-netty-core/index.json
+++ b/metadata/io.projectreactor.netty/reactor-netty-core/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.1.0",
+    "tested-versions" : [
+      "1.1.0"
+    ],
+    "allowed-packages" : [
+      "reactor.netty"
+    ]
+  },
+  {
     "metadata-version" : "1.0.39",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/projectreactor/netty/reactor-netty-core/$version$/reactor-netty-core-$version$-sources.jar",
     "repository-url" : "https://github.com/reactor/reactor-netty",

--- a/stats/io.projectreactor.netty/reactor-netty-core/1.1.0/execution-metrics.json
+++ b/stats/io.projectreactor.netty/reactor-netty-core/1.1.0/execution-metrics.json
@@ -1,0 +1,88 @@
+{
+  "fix_javac_fail:2026-06-06": {
+    "timestamp": "2026-06-06T12:22:49.711569Z",
+    "library": "io.projectreactor.netty:reactor-netty-core:1.1.0",
+    "starting_commit": "7234e361761e7de82a079f657f246299c8c86e2f",
+    "ending_commit": "f78cca563ed4969dfcae2ae77292e127b6d9f25c",
+    "previous_library": "io.projectreactor.netty:reactor-netty-core:1.0.39",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.1.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 8963,
+          "missed": 20029,
+          "ratio": 0.309154,
+          "total": 28992
+        },
+        "line": {
+          "covered": 2352,
+          "missed": 4447,
+          "ratio": 0.345933,
+          "total": 6799
+        },
+        "method": {
+          "covered": 706,
+          "missed": 1390,
+          "ratio": 0.336832,
+          "total": 2096
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.0.39",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 9127,
+          "missed": 18275,
+          "ratio": 0.333078,
+          "total": 27402
+        },
+        "line": {
+          "covered": 2408,
+          "missed": 4198,
+          "ratio": 0.364517,
+          "total": 6606
+        },
+        "method": {
+          "covered": 708,
+          "missed": 1130,
+          "ratio": 0.385201,
+          "total": 1838
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 12431,
+      "cached_input_tokens_used": 84480,
+      "output_tokens_used": 880,
+      "iterations": 1,
+      "cost_usd": 0.0686,
+      "tested_library_loc": 2352,
+      "metadata_entries": 159,
+      "test_only_metadata_entries": 8,
+      "previous_library_metadata_entries": 0,
+      "code_coverage_percent": 34.59,
+      "previous_library_coverage_percent": 36.45
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.projectreactor.netty/reactor-netty-core/1.1.0/src/test/java/io_projectreactor_netty/reactor_netty_core/Reactor_netty_coreTest.java",
+      "metadata_file": "metadata/io.projectreactor.netty/reactor-netty-core/1.1.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.projectreactor.netty/reactor-netty-core/1.1.0/stats.json
+++ b/stats/io.projectreactor.netty/reactor-netty-core/1.1.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.1.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 8963,
+        "missed" : 20029,
+        "ratio" : 0.309154,
+        "total" : 28992
+      },
+      "line" : {
+        "covered" : 2352,
+        "missed" : 4447,
+        "ratio" : 0.345933,
+        "total" : 6799
+      },
+      "method" : {
+        "covered" : 706,
+        "missed" : 1390,
+        "ratio" : 0.336832,
+        "total" : 2096
+      }
+    }
+  } ]
+}

--- a/tests/src/io.projectreactor.netty/reactor-netty-core/1.1.0/.gitignore
+++ b/tests/src/io.projectreactor.netty/reactor-netty-core/1.1.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.projectreactor.netty/reactor-netty-core/1.1.0/build.gradle
+++ b/tests/src/io.projectreactor.netty/reactor-netty-core/1.1.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.projectreactor.netty:reactor-netty-core:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.projectreactor.netty/reactor-netty-core/1.1.0/gradle.properties
+++ b/tests/src/io.projectreactor.netty/reactor-netty-core/1.1.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.projectreactor.netty:reactor-netty-core:1.1.0
+library.version = 1.1.0
+metadata.dir = io.projectreactor.netty/reactor-netty-core/1.1.0/

--- a/tests/src/io.projectreactor.netty/reactor-netty-core/1.1.0/settings.gradle
+++ b/tests/src/io.projectreactor.netty/reactor-netty-core/1.1.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.projectreactor.netty.reactor-netty-core_tests'

--- a/tests/src/io.projectreactor.netty/reactor-netty-core/1.1.0/src/test/java/io_projectreactor_netty/reactor_netty_core/Reactor_netty_coreTest.java
+++ b/tests/src/io.projectreactor.netty/reactor-netty-core/1.1.0/src/test/java/io_projectreactor_netty/reactor_netty_core/Reactor_netty_coreTest.java
@@ -1,0 +1,384 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_projectreactor_netty.reactor_netty_core;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.handler.codec.LineBasedFrameDecoder;
+import io.netty.handler.proxy.HttpProxyHandler;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.netty.ByteBufFlux;
+import reactor.netty.ByteBufMono;
+import reactor.netty.Connection;
+import reactor.netty.ConnectionObserver;
+import reactor.netty.DisposableServer;
+import reactor.netty.FutureMono;
+import reactor.netty.resources.ConnectionProvider;
+import reactor.netty.resources.LoopResources;
+import reactor.netty.tcp.TcpClient;
+import reactor.netty.tcp.TcpServer;
+import reactor.netty.transport.NameResolverProvider;
+import reactor.netty.transport.ProxyProvider;
+import reactor.netty.udp.UdpClient;
+import reactor.netty.udp.UdpServer;
+
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Reactor_netty_coreTest {
+    private static final Duration TIMEOUT = Duration.ofSeconds(10);
+    private static final String LOOPBACK = "127.0.0.1";
+
+    @TempDir
+    private Path tempDir;
+
+    @Test
+    void tcpServerAndClientExchangeDataAndInvokeConnectionCallbacks() {
+        AtomicInteger acceptedConnections = new AtomicInteger();
+        AtomicBoolean clientConnected = new AtomicBoolean();
+        CountDownLatch clientDisposed = new CountDownLatch(1);
+        Queue<ConnectionObserver.State> observedStates = new ConcurrentLinkedQueue<>();
+        ChannelHandler customHandler = new ChannelInboundHandlerAdapter();
+        ConnectionProvider provider = ConnectionProvider.builder("reactor-netty-core-test")
+                .maxConnections(1)
+                .pendingAcquireTimeout(Duration.ofSeconds(2))
+                .build();
+        LoopResources loops = LoopResources.create("reactor-netty-tcp-test", 1, true);
+        DisposableServer server = null;
+        Connection client = null;
+
+        try {
+            server = TcpServer.create()
+                    .host(LOOPBACK)
+                    .runOn(loops, false)
+                    .port(0)
+                    .doOnConnection(connection -> {
+                        acceptedConnections.incrementAndGet();
+                        connection.addHandlerLast(new LineBasedFrameDecoder(128));
+                    })
+                    .handle((inbound, outbound) -> outbound.sendString(
+                            inbound.receive()
+                                    .asString(StandardCharsets.UTF_8)
+                                    .map(value -> value.toUpperCase(Locale.ROOT) + "\n"),
+                            StandardCharsets.UTF_8))
+                    .bindNow(TIMEOUT);
+
+            client = TcpClient.create(provider)
+                    .host(LOOPBACK)
+                    .runOn(loops, false)
+                    .port(server.port())
+                    .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) TIMEOUT.toMillis())
+                    .observe((connection, newState) -> observedStates.add(newState))
+                    .doOnConnected(connection -> {
+                        clientConnected.set(true);
+                        connection.markPersistent(false);
+                        connection.addHandlerLast(new LineBasedFrameDecoder(128));
+                        connection.addHandlerLast("customTestHandler", customHandler);
+                        connection.onDispose(clientDisposed::countDown);
+                    })
+                    .connectNow(TIMEOUT);
+
+            client.outbound()
+                    .sendString(Mono.just("reactor-netty\n"), StandardCharsets.UTF_8)
+                    .then()
+                    .block(TIMEOUT);
+            String response = client.inbound()
+                    .receive()
+                    .asString(StandardCharsets.UTF_8)
+                    .next()
+                    .block(TIMEOUT);
+
+            assertThat(response).isEqualTo("REACTOR-NETTY");
+            assertThat(acceptedConnections).hasValue(1);
+            assertThat(clientConnected).isTrue();
+            assertThat(client.isPersistent()).isFalse();
+            assertThat(client.channel().pipeline().get("customTestHandler")).isSameAs(customHandler);
+            assertThat(observedStates)
+                    .contains(ConnectionObserver.State.CONNECTED, ConnectionObserver.State.CONFIGURED);
+        } finally {
+            if (client != null) {
+                client.disposeNow(TIMEOUT);
+            }
+            if (server != null) {
+                server.disposeNow(TIMEOUT);
+            }
+            provider.disposeLater().block(TIMEOUT);
+            loops.disposeLater(Duration.ofMillis(100), Duration.ofSeconds(2)).block(TIMEOUT);
+        }
+
+        assertThat(clientDisposed.getCount()).isZero();
+    }
+
+    @Test
+    void connectionInvokesIdleCallbacksWhenNoTrafficOccurs() throws Exception {
+        CountDownLatch readIdle = new CountDownLatch(1);
+        CountDownLatch writeIdle = new CountDownLatch(1);
+        LoopResources loops = LoopResources.create("reactor-netty-idle-test", 1, true);
+        DisposableServer server = null;
+        Connection client = null;
+
+        try {
+            server = TcpServer.create()
+                    .host(LOOPBACK)
+                    .runOn(loops, false)
+                    .port(0)
+                    .doOnConnection(connection -> {
+                        connection.onReadIdle(100, readIdle::countDown);
+                        connection.onWriteIdle(100, writeIdle::countDown);
+                    })
+                    .handle((inbound, outbound) -> inbound.receive().then())
+                    .bindNow(TIMEOUT);
+
+            client = TcpClient.create()
+                    .host(LOOPBACK)
+                    .runOn(loops, false)
+                    .port(server.port())
+                    .connectNow(TIMEOUT);
+
+            assertThat(readIdle.await(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)).isTrue();
+            assertThat(writeIdle.await(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)).isTrue();
+        } finally {
+            if (client != null) {
+                client.disposeNow(TIMEOUT);
+            }
+            if (server != null) {
+                server.disposeNow(TIMEOUT);
+            }
+            loops.disposeLater(Duration.ofMillis(100), Duration.ofSeconds(2)).block(TIMEOUT);
+        }
+    }
+
+    @Test
+    void udpServerReceivesDatagramsFromClient() throws Exception {
+        CountDownLatch receivedDatagram = new CountDownLatch(1);
+        Queue<String> receivedMessages = new ConcurrentLinkedQueue<>();
+        LoopResources loops = LoopResources.create("reactor-netty-udp-test", 1, true);
+        Connection server = null;
+        Connection client = null;
+
+        try {
+            server = UdpServer.create()
+                    .host(LOOPBACK)
+                    .runOn(loops, false)
+                    .port(0)
+                    .handle((inbound, outbound) -> inbound.receive()
+                            .asString(StandardCharsets.UTF_8)
+                            .doOnNext(message -> {
+                                receivedMessages.add(message);
+                                receivedDatagram.countDown();
+                            })
+                            .then())
+                    .bindNow(TIMEOUT);
+
+            int serverPort = ((InetSocketAddress) server.address()).getPort();
+            client = UdpClient.create()
+                    .host(LOOPBACK)
+                    .runOn(loops, false)
+                    .port(serverPort)
+                    .connectNow(TIMEOUT);
+
+            client.outbound()
+                    .sendString(Mono.just("udp-payload"), StandardCharsets.UTF_8)
+                    .then()
+                    .block(TIMEOUT);
+
+            assertThat(receivedDatagram.await(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)).isTrue();
+            assertThat(receivedMessages).containsExactly("udp-payload");
+        } finally {
+            if (client != null) {
+                client.disposeNow(TIMEOUT);
+            }
+            if (server != null) {
+                server.disposeNow(TIMEOUT);
+            }
+            loops.disposeLater(Duration.ofMillis(100), Duration.ofSeconds(2)).block(TIMEOUT);
+        }
+    }
+
+    @Test
+    void byteBufPublishersConvertStringsFilesByteArraysAndInputStreams() throws Exception {
+        String fileContent = "alpha\nbeta\ngamma";
+        Path file = tempDir.resolve("reactor-netty-payload.txt");
+        Files.writeString(file, fileContent, StandardCharsets.UTF_8);
+
+        String fromPath = ByteBufFlux.fromPath(file, 5, ByteBufAllocator.DEFAULT)
+                .asString(StandardCharsets.UTF_8)
+                .collectList()
+                .map(parts -> String.join("", parts))
+                .block(TIMEOUT);
+        String aggregated = ByteBufFlux.fromString(
+                        Flux.just("reactor", "-", "netty"),
+                        StandardCharsets.UTF_8,
+                        ByteBufAllocator.DEFAULT)
+                .aggregate()
+                .asString(StandardCharsets.UTF_8)
+                .block(TIMEOUT);
+        List<byte[]> byteArrays = ByteBufFlux.fromString(
+                        Flux.just("ab", "cd"),
+                        StandardCharsets.UTF_8,
+                        ByteBufAllocator.DEFAULT)
+                .asByteArray()
+                .collectList()
+                .block(TIMEOUT);
+        ByteBuffer byteBuffer = ByteBufMono.fromString(
+                        Mono.just("buffer"),
+                        StandardCharsets.UTF_8,
+                        ByteBufAllocator.DEFAULT)
+                .asByteBuffer()
+                .block(TIMEOUT);
+
+        byte[] inputStreamBytes;
+        try (InputStream inputStream = ByteBufMono.fromString(
+                        Mono.just("stream"),
+                        StandardCharsets.UTF_8,
+                        ByteBufAllocator.DEFAULT)
+                .asInputStream()
+                .block(TIMEOUT)) {
+            inputStreamBytes = inputStream.readAllBytes();
+        }
+
+        assertThat(fromPath).isEqualTo(fileContent);
+        assertThat(aggregated).isEqualTo("reactor-netty");
+        assertThat(byteArrays).extracting(bytes -> new String(bytes, StandardCharsets.UTF_8))
+                .containsExactly("ab", "cd");
+        assertThat(StandardCharsets.UTF_8.decode(byteBuffer).toString()).isEqualTo("buffer");
+        assertThat(new String(inputStreamBytes, StandardCharsets.UTF_8)).isEqualTo("stream");
+    }
+
+    @Test
+    void connectionProviderBuilderConfiguresGlobalAndHostSpecificPools() {
+        SocketAddress remoteHost = InetSocketAddress.createUnresolved("example.org", 443);
+        ConnectionProvider provider = ConnectionProvider.builder("configured-provider")
+                .maxConnections(3)
+                .pendingAcquireMaxCount(4)
+                .pendingAcquireTimeout(Duration.ofSeconds(3))
+                .maxIdleTime(Duration.ofSeconds(20))
+                .maxLifeTime(Duration.ofSeconds(30))
+                .lifo()
+                .forRemoteHost(remoteHost, hostSpec -> hostSpec.maxConnections(1)
+                        .pendingAcquireMaxCount(2))
+                .build();
+
+        try {
+            assertThat(provider.name()).isEqualTo("configured-provider");
+            assertThat(provider.maxConnections()).isEqualTo(3);
+            assertThat(provider.maxConnectionsPerHost()).containsEntry(remoteHost, 1);
+
+            ConnectionProvider mutated = provider.mutate()
+                    .name("mutated-provider")
+                    .maxConnections(2)
+                    .build();
+            try {
+                assertThat(mutated.name()).isEqualTo("mutated-provider");
+                assertThat(mutated.maxConnections()).isEqualTo(2);
+                assertThat(mutated.maxConnectionsPerHost()).containsEntry(remoteHost, 1);
+            } finally {
+                mutated.disposeLater().block(TIMEOUT);
+            }
+        } finally {
+            provider.disposeLater().block(TIMEOUT);
+        }
+    }
+
+    @Test
+    void loopResourcesCreateEventLoopGroupsAndDisposeGracefully() {
+        LoopResources loops = LoopResources.create("reactor-netty-loop-test", 1, 1, true, true);
+
+        try {
+            EventLoopGroup clientGroup = loops.onClient(false);
+            EventLoopGroup serverGroup = loops.onServer(false);
+            EventLoopGroup selectGroup = loops.onServerSelect(false);
+
+            assertThat(clientGroup).isNotNull();
+            assertThat(serverGroup).isNotNull();
+            assertThat(selectGroup).isNotNull();
+        } finally {
+            loops.disposeLater(Duration.ofMillis(100), Duration.ofSeconds(2)).block(TIMEOUT);
+        }
+    }
+
+    @Test
+    void proxyAndNameResolverProvidersExposeConfiguredPublicOptions() {
+        ProxyProvider proxy = ProxyProvider.builder()
+                .type(ProxyProvider.Proxy.HTTP)
+                .host("192.0.2.1")
+                .port(8080)
+                .username("user")
+                .password(username -> username + "-password")
+                .nonProxyHosts("localhost|127\\..*")
+                .connectTimeoutMillis(750)
+                .build();
+        NameResolverProvider resolver = NameResolverProvider.builder()
+                .cacheMaxTimeToLive(Duration.ofSeconds(30))
+                .cacheMinTimeToLive(Duration.ofSeconds(1))
+                .cacheNegativeTimeToLive(Duration.ZERO)
+                .completeOncePreferredResolved(true)
+                .disableOptionalRecord(true)
+                .disableRecursionDesired(true)
+                .maxPayloadSize(2048)
+                .maxQueriesPerResolve(2)
+                .ndots(1)
+                .queryTimeout(Duration.ofSeconds(2))
+                .roundRobinSelection(true)
+                .searchDomains(Arrays.asList("example.org", "internal.example.org"))
+                .build();
+
+        InetSocketAddress proxyAddress = proxy.getAddress().get();
+
+        assertThat(proxy.getType()).isEqualTo(ProxyProvider.Proxy.HTTP);
+        assertThat(proxyAddress.getHostString()).isEqualTo("192.0.2.1");
+        assertThat(proxyAddress.getPort()).isEqualTo(8080);
+        assertThat(proxy.shouldProxy(InetSocketAddress.createUnresolved("service.example.org", 443)))
+                .isTrue();
+        assertThat(proxy.shouldProxy(InetSocketAddress.createUnresolved("localhost", 8080)))
+                .isFalse();
+        assertThat(proxy.newProxyHandler()).isInstanceOf(HttpProxyHandler.class);
+
+        assertThat(resolver.cacheMaxTimeToLive()).isEqualTo(Duration.ofSeconds(30));
+        assertThat(resolver.cacheMinTimeToLive()).isEqualTo(Duration.ofSeconds(1));
+        assertThat(resolver.cacheNegativeTimeToLive()).isEqualTo(Duration.ZERO);
+        assertThat(resolver.isCompleteOncePreferredResolved()).isTrue();
+        assertThat(resolver.isDisableOptionalRecord()).isTrue();
+        assertThat(resolver.isDisableRecursionDesired()).isTrue();
+        assertThat(resolver.maxPayloadSize()).isEqualTo(2048);
+        assertThat(resolver.maxQueriesPerResolve()).isEqualTo(2);
+        assertThat(resolver.ndots()).isEqualTo(1);
+        assertThat(resolver.queryTimeout()).isEqualTo(Duration.ofSeconds(2));
+        assertThat(resolver.isRoundRobinSelection()).isTrue();
+        assertThat(resolver.searchDomains()).containsExactly("example.org", "internal.example.org");
+    }
+
+    @Test
+    void futureMonoAdaptsSucceededAndDeferredNettyFutures() {
+        FutureMono.from(ImmediateEventExecutor.INSTANCE.newSucceededFuture(null)).block(TIMEOUT);
+        FutureMono.deferFuture(() -> ImmediateEventExecutor.INSTANCE.newSucceededFuture(null)).block(TIMEOUT);
+    }
+}

--- a/tests/src/io.projectreactor.netty/reactor-netty-core/1.1.0/src/test/java/io_projectreactor_netty/reactor_netty_core/Reactor_netty_coreTest.java
+++ b/tests/src/io.projectreactor.netty/reactor-netty-core/1.1.0/src/test/java/io_projectreactor_netty/reactor_netty_core/Reactor_netty_coreTest.java
@@ -310,7 +310,7 @@ public class Reactor_netty_coreTest {
 
     @Test
     void loopResourcesCreateEventLoopGroupsAndDisposeGracefully() {
-        LoopResources loops = LoopResources.create("reactor-netty-loop-test", 1, 1, true, true);
+        LoopResources loops = LoopResources.create("reactor-netty-loop-test", 1, 1, true);
 
         try {
             EventLoopGroup clientGroup = loops.onClient(false);

--- a/tests/src/io.projectreactor.netty/reactor-netty-core/1.1.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/io.projectreactor.netty/reactor-netty-core/1.1.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,54 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "io_projectreactor_netty.reactor_netty_core.Reactor_netty_coreTest"
+      },
+      "type" : "io.netty.channel.ChannelInboundHandlerAdapter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_projectreactor_netty.reactor_netty_core.Reactor_netty_coreTest"
+      },
+      "type" : "reactor.core.publisher.MonoCreate$DefaultMonoSink"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_projectreactor_netty.reactor_netty_core.Reactor_netty_coreTest"
+      },
+      "type" : "reactor.core.publisher.MonoNext$NextSubscriber"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_projectreactor_netty.reactor_netty_core.Reactor_netty_coreTest"
+      },
+      "type" : "reactor.core.publisher.MonoWhen$WhenCoordinator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_projectreactor_netty.reactor_netty_core.Reactor_netty_coreTest"
+      },
+      "type" : "reactor.core.publisher.MonoWhen$WhenInner"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_projectreactor_netty.reactor_netty_core.Reactor_netty_coreTest"
+      },
+      "type" : "reactor.core.publisher.Operators$BaseFluxToMonoOperator"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "io_projectreactor_netty.reactor_netty_core.Reactor_netty_coreTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_projectreactor_netty.reactor_netty_core.Reactor_netty_coreTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/tests/src/io.projectreactor.netty/reactor-netty-core/1.1.0/user-code-filter.json
+++ b/tests/src/io.projectreactor.netty/reactor-netty-core/1.1.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "reactor.netty.**"
+    },
+    {
+      "includeClasses" : "io_projectreactor_netty.reactor_netty_core.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #5849

This PR provides test fixes and new metadata for io.projectreactor.netty:reactor-netty-core:1.1.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 12431
- Cached input tokens: 84480
- Output tokens: 880
- Metadata entries: 159
- Test-only metadata entries: 8
- Iterations: 1
- Library coverage percentage: 34.59
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 36.45

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `8ab24cfed67b4903e4e2ea72b53e53a4b03170af`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.projectreactor.netty:reactor-netty-core:1.0.39: 0/0 covered calls (100.00%)
- io.projectreactor.netty:reactor-netty-core:1.1.0: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.projectreactor.netty:reactor-netty-core:1.0.39: 9127/27402 (33.31%)
- io.projectreactor.netty:reactor-netty-core:1.1.0: 8963/28992 (30.92%)

**Line:**
- io.projectreactor.netty:reactor-netty-core:1.0.39: 2408/6606 (36.45%)
- io.projectreactor.netty:reactor-netty-core:1.1.0: 2352/6799 (34.59%)

**Method:**
- io.projectreactor.netty:reactor-netty-core:1.0.39: 708/1838 (38.52%)
- io.projectreactor.netty:reactor-netty-core:1.1.0: 706/2096 (33.68%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/io.projectreactor.netty/reactor-netty-core/1.0.39/src/test/java/io_projectreactor_netty/reactor_netty_core/Reactor_netty_coreTest.java b/tests/src/io.projectreactor.netty/reactor-netty-core/1.1.0/src/test/java/io_projectreactor_netty/reactor_netty_core/Reactor_netty_coreTest.java
index a670bff123..79f2169553 100644
--- a/tests/src/io.projectreactor.netty/reactor-netty-core/1.0.39/src/test/java/io_projectreactor_netty/reactor_netty_core/Reactor_netty_coreTest.java
+++ b/tests/src/io.projectreactor.netty/reactor-netty-core/1.1.0/src/test/java/io_projectreactor_netty/reactor_netty_core/Reactor_netty_coreTest.java
@@ -310,7 +310,7 @@ public class Reactor_netty_coreTest {
 
     @Test
     void loopResourcesCreateEventLoopGroupsAndDisposeGracefully() {
-        LoopResources loops = LoopResources.create("reactor-netty-loop-test", 1, 1, true, true);
+        LoopResources loops = LoopResources.create("reactor-netty-loop-test", 1, 1, true);
 
         try {
             EventLoopGroup clientGroup = loops.onClient(false);

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
