### PR TITLE
[Automation] Generated metadata for org.apache.lucene:lucene-core:5.3.0

### DIFF
--- a/stats/org.apache.lucene/lucene-core/5.3.0/stats.json
+++ b/stats/org.apache.lucene/lucene-core/5.3.0/stats.json
@@ -20,21 +20,21 @@
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 4056,
-        "missed" : 267456,
-        "ratio" : 0.014939,
+        "covered" : 4033,
+        "missed" : 267479,
+        "ratio" : 0.014854,
         "total" : 271512
       },
       "line" : {
-        "covered" : 664,
-        "missed" : 48746,
-        "ratio" : 0.013439,
+        "covered" : 658,
+        "missed" : 48752,
+        "ratio" : 0.013317,
         "total" : 49410
       },
       "method" : {
-        "covered" : 164,
-        "missed" : 8834,
-        "ratio" : 0.018226,
+        "covered" : 163,
+        "missed" : 8835,
+        "ratio" : 0.018115,
         "total" : 8998
       }
     }


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7345

This PR provides new metadata needed for the org.apache.lucene:lucene-core:5.3.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.apache.lucene:lucene-core:5.5.0`): 60
- Test-only metadata entries (previous `org.apache.lucene:lucene-core:5.5.0`): 11
- Metadata entries (new `org.apache.lucene:lucene-core:5.3.0`): 60
- Test-only metadata entries (new `org.apache.lucene:lucene-core:5.3.0`): 11
- Library coverage (previous): 1.35%
- Library coverage (new): 1.33%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `ff881e9089913a176fa1884939790b8ac78023ec`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.lucene:lucene-core:5.5.0: 31/31 covered calls (100.00%)
- org.apache.lucene:lucene-core:5.3.0: 32/32 covered calls (100.00%)

**Reflection:**
- org.apache.lucene:lucene-core:5.5.0: 29/29 covered calls (100.00%)
- org.apache.lucene:lucene-core:5.3.0: 29/29 covered calls (100.00%)

**Resources:**
- org.apache.lucene:lucene-core:5.5.0: 2/2 covered calls (100.00%)
- org.apache.lucene:lucene-core:5.3.0: 3/3 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.lucene:lucene-core:5.5.0: 4097/273690 (1.50%)
- org.apache.lucene:lucene-core:5.3.0: 4033/271512 (1.49%)

**Line:**
- org.apache.lucene:lucene-core:5.5.0: 670/49769 (1.35%)
- org.apache.lucene:lucene-core:5.3.0: 658/49410 (1.33%)

**Method:**
- org.apache.lucene:lucene-core:5.5.0: 166/9079 (1.83%)
- org.apache.lucene:lucene-core:5.3.0: 163/8998 (1.81%)

### Local CI Verification

- Status: `success`
- Commands run: 0
- Fixup attempts: 0
