### PR TITLE
[Automation] Generated metadata for org.glassfish.hk2:hk2-api:2.5.0

### DIFF
--- a/stats/org.glassfish.hk2/hk2-api/2.5.0/stats.json
+++ b/stats/org.glassfish.hk2/hk2-api/2.5.0/stats.json
@@ -20,21 +20,21 @@
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 1309,
-        "missed" : 9828,
-        "ratio" : 0.117536,
+        "covered" : 1883,
+        "missed" : 9254,
+        "ratio" : 0.169076,
         "total" : 11137
       },
       "line" : {
-        "covered" : 356,
-        "missed" : 2154,
-        "ratio" : 0.141833,
+        "covered" : 498,
+        "missed" : 2012,
+        "ratio" : 0.198406,
         "total" : 2510
       },
       "method" : {
-        "covered" : 85,
-        "missed" : 499,
-        "ratio" : 0.145548,
+        "covered" : 116,
+        "missed" : 468,
+        "ratio" : 0.19863,
         "total" : 584
       }
     }


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7353

This PR provides new metadata needed for the org.glassfish.hk2:hk2-api:2.5.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.glassfish.hk2:hk2-api:2.6.0`): 18
- Test-only metadata entries (previous `org.glassfish.hk2:hk2-api:2.6.0`): 1
- Metadata entries (new `org.glassfish.hk2:hk2-api:2.5.0`): 18
- Test-only metadata entries (new `org.glassfish.hk2:hk2-api:2.5.0`): 1
- Library coverage (previous): 14.17%
- Library coverage (new): 19.84%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `ff881e9089913a176fa1884939790b8ac78023ec`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.glassfish.hk2:hk2-api:2.6.0: 7/7 covered calls (100.00%)
- org.glassfish.hk2:hk2-api:2.5.0: 7/7 covered calls (100.00%)

**Reflection:**
- org.glassfish.hk2:hk2-api:2.6.0: 6/6 covered calls (100.00%)
- org.glassfish.hk2:hk2-api:2.5.0: 6/6 covered calls (100.00%)

**Resources:**
- org.glassfish.hk2:hk2-api:2.6.0: 1/1 covered calls (100.00%)
- org.glassfish.hk2:hk2-api:2.5.0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.glassfish.hk2:hk2-api:2.6.0: 1309/11143 (11.75%)
- org.glassfish.hk2:hk2-api:2.5.0: 1883/11137 (16.91%)

**Line:**
- org.glassfish.hk2:hk2-api:2.6.0: 356/2513 (14.17%)
- org.glassfish.hk2:hk2-api:2.5.0: 498/2510 (19.84%)

**Method:**
- org.glassfish.hk2:hk2-api:2.6.0: 85/586 (14.51%)
- org.glassfish.hk2:hk2-api:2.5.0: 116/584 (19.86%)

### Local CI Verification

- Status: `success`
- Commands run: 0
- Fixup attempts: 0
