### PR TITLE
[GenAI] Test fix for io.sundr:sundr-model-utils:0.240.1 using gpt-5.5

### DIFF
--- a/metadata/io.sundr/sundr-model-utils/0.240.1/reachability-metadata.json
+++ b/metadata/io.sundr/sundr-model-utils/0.240.1/reachability-metadata.json
@@ -1,0 +1,988 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.AnnotationRef"
+      },
+      "type" : "io.sundr.model.AnnotationRefBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.AnnotationRef" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Argument"
+      },
+      "type" : "io.sundr.model.ArgumentBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Argument" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Assign"
+      },
+      "type" : "io.sundr.model.AssignBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Assign" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.AttributeSupport"
+      },
+      "type" : "io.sundr.model.AttributeSupportBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.AttributeSupport" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.BinaryExpression"
+      },
+      "type" : "io.sundr.model.BinaryExpressionBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.BinaryExpression" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.BitwiseAnd"
+      },
+      "type" : "io.sundr.model.BitwiseAndBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.BitwiseAnd" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.BitwiseOr"
+      },
+      "type" : "io.sundr.model.BitwiseOrBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.BitwiseOr" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Block"
+      },
+      "type" : "io.sundr.model.BlockBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Block" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Break"
+      },
+      "type" : "io.sundr.model.BreakBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Break" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Cast"
+      },
+      "type" : "io.sundr.model.CastBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Cast" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.ClassRef"
+      },
+      "type" : "io.sundr.model.ClassRefBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.ClassRef" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Construct"
+      },
+      "type" : "io.sundr.model.ConstructBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Construct" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.ContextRef"
+      },
+      "type" : "io.sundr.model.ContextRefBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.ContextRef" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Continue"
+      },
+      "type" : "io.sundr.model.ContinueBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Continue" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Declare"
+      },
+      "type" : "io.sundr.model.DeclareBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Declare" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Divide"
+      },
+      "type" : "io.sundr.model.DivideBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Divide" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Do"
+      },
+      "type" : "io.sundr.model.DoBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Do" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.DotClass"
+      },
+      "type" : "io.sundr.model.DotClassBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.DotClass" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Empty"
+      },
+      "type" : "io.sundr.model.EmptyBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Empty" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Enclosed"
+      },
+      "type" : "io.sundr.model.EnclosedBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Enclosed" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Equals"
+      },
+      "type" : "io.sundr.model.EqualsBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Equals" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Field"
+      },
+      "type" : "io.sundr.model.FieldBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Field" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.FieldRef"
+      },
+      "type" : "io.sundr.model.FieldRefBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.FieldRef" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.For"
+      },
+      "type" : "io.sundr.model.ForBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.For" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Foreach"
+      },
+      "type" : "io.sundr.model.ForeachBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Foreach" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.GreaterThan"
+      },
+      "type" : "io.sundr.model.GreaterThanBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.GreaterThan" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.GreaterThanOrEqual"
+      },
+      "type" : "io.sundr.model.GreaterThanOrEqualBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.GreaterThanOrEqual" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.If"
+      },
+      "type" : "io.sundr.model.IfBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.If" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.IfDslConditionStep"
+      },
+      "type" : "io.sundr.model.IfDslConditionStepBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.IfDslConditionStep" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.IfDslThenStep"
+      },
+      "type" : "io.sundr.model.IfDslThenStepBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.IfDslThenStep" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Index"
+      },
+      "type" : "io.sundr.model.IndexBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Index" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.InstanceOf"
+      },
+      "type" : "io.sundr.model.InstanceOfBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.InstanceOf" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Inverse"
+      },
+      "type" : "io.sundr.model.InverseBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Inverse" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Lambda"
+      },
+      "type" : "io.sundr.model.LambdaBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Lambda" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.LeftShift"
+      },
+      "type" : "io.sundr.model.LeftShiftBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.LeftShift" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.LessThan"
+      },
+      "type" : "io.sundr.model.LessThanBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.LessThan" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.LessThanOrEqual"
+      },
+      "type" : "io.sundr.model.LessThanOrEqualBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.LessThanOrEqual" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.LocalVariable"
+      },
+      "type" : "io.sundr.model.LocalVariableBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.LocalVariable" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.LogicalAnd"
+      },
+      "type" : "io.sundr.model.LogicalAndBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.LogicalAnd" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.LogicalOr"
+      },
+      "type" : "io.sundr.model.LogicalOrBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.LogicalOr" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Method"
+      },
+      "type" : "io.sundr.model.MethodBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Method" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.MethodCall"
+      },
+      "type" : "io.sundr.model.MethodCallBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.MethodCall" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Minus"
+      },
+      "type" : "io.sundr.model.MinusBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Minus" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.ModifierSupport"
+      },
+      "type" : "io.sundr.model.ModifierSupportBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.ModifierSupport" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Modifiers"
+      },
+      "type" : "io.sundr.model.ModifiersBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Modifiers" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Modulo"
+      },
+      "type" : "io.sundr.model.ModuloBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Modulo" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Multiply"
+      },
+      "type" : "io.sundr.model.MultiplyBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Multiply" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Negative"
+      },
+      "type" : "io.sundr.model.NegativeBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Negative" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.NewArray"
+      },
+      "type" : "io.sundr.model.NewArrayBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.NewArray" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Not"
+      },
+      "type" : "io.sundr.model.NotBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Not" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.NotEquals"
+      },
+      "type" : "io.sundr.model.NotEqualsBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.NotEquals" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Plus"
+      },
+      "type" : "io.sundr.model.PlusBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Plus" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Positive"
+      },
+      "type" : "io.sundr.model.PositiveBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Positive" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.PostDecrement"
+      },
+      "type" : "io.sundr.model.PostDecrementBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.PostDecrement" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.PostIncrement"
+      },
+      "type" : "io.sundr.model.PostIncrementBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.PostIncrement" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.PreDecrement"
+      },
+      "type" : "io.sundr.model.PreDecrementBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.PreDecrement" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.PreIncrement"
+      },
+      "type" : "io.sundr.model.PreIncrementBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.PreIncrement" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.PrimitiveRef"
+      },
+      "type" : "io.sundr.model.PrimitiveRefBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.PrimitiveRef" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Property"
+      },
+      "type" : "io.sundr.model.PropertyBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Property" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.PropertyRef"
+      },
+      "type" : "io.sundr.model.PropertyRefBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.PropertyRef" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Return"
+      },
+      "type" : "io.sundr.model.ReturnBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Return" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.ReturnDslThisStep"
+      },
+      "type" : "io.sundr.model.ReturnDslThisStepBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.ReturnDslThisStep" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.ReturnDslVariableStep"
+      },
+      "type" : "io.sundr.model.ReturnDslVariableStepBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.ReturnDslVariableStep" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.RightShift"
+      },
+      "type" : "io.sundr.model.RightShiftBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.RightShift" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.RightUnsignedShift"
+      },
+      "type" : "io.sundr.model.RightUnsignedShiftBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.RightUnsignedShift" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Source"
+      },
+      "type" : "io.sundr.model.SourceBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Source" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.StringStatement"
+      },
+      "type" : "io.sundr.model.StringStatementBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.StringStatement" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Super"
+      },
+      "type" : "io.sundr.model.SuperBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Super" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Switch"
+      },
+      "type" : "io.sundr.model.SwitchBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Switch" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Synchronized"
+      },
+      "type" : "io.sundr.model.SynchronizedBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Synchronized" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Ternary"
+      },
+      "type" : "io.sundr.model.TernaryBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Ternary" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.This"
+      },
+      "type" : "io.sundr.model.ThisBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.This" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Throw"
+      },
+      "type" : "io.sundr.model.ThrowBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Throw" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Try"
+      },
+      "type" : "io.sundr.model.TryBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Try" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.TypeDef"
+      },
+      "type" : "io.sundr.model.TypeDefBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.TypeDef" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.TypeParamDef"
+      },
+      "type" : "io.sundr.model.TypeParamDefBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.TypeParamDef" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.TypeParamRef"
+      },
+      "type" : "io.sundr.model.TypeParamRefBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.TypeParamRef" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.ValueRef"
+      },
+      "type" : "io.sundr.model.ValueRefBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.ValueRef" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.VoidRef"
+      },
+      "type" : "io.sundr.model.VoidRefBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.VoidRef" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.While"
+      },
+      "type" : "io.sundr.model.WhileBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.While" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.WildcardRef"
+      },
+      "type" : "io.sundr.model.WildcardRefBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.WildcardRef" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Xor"
+      },
+      "type" : "io.sundr.model.XorBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Xor" ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/io.sundr/sundr-model-utils/index.json
+++ b/metadata/io.sundr/sundr-model-utils/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "0.240.1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/sundr/sundr-model-utils/$version$/sundr-model-utils-$version$-sources.jar",
+    "repository-url" : "https://github.com/sundrio/sundrio",
+    "test-code-url" : "https://github.com/sundrio/sundrio/tree/$version$/model/utils/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/sundr/sundr-model-utils/$version$/sundr-model-utils-$version$-javadoc.jar",
+    "description" : "Sundr Model Utils provides utility APIs for Sundrio's Java code model, including helpers for type references, properties, parsing, assignability, and model visitors. It supports code generation and manipulation workflows built around Sundrio TypeDef and TypeRef model objects.",
     "tested-versions" : [
       "0.240.1"
     ],

--- a/metadata/io.sundr/sundr-model-utils/index.json
+++ b/metadata/io.sundr/sundr-model-utils/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "0.240.1",
+    "tested-versions" : [
+      "0.240.1"
+    ],
+    "allowed-packages" : [
+      "io.sundr.model"
+    ]
+  },
+  {
     "metadata-version" : "0.230.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/sundr/sundr-model-utils/$version$/sundr-model-utils-$version$-sources.jar",
     "repository-url" : "https://github.com/sundrio/sundrio",

--- a/stats/io.sundr/sundr-model-utils/0.240.1/execution-metrics.json
+++ b/stats/io.sundr/sundr-model-utils/0.240.1/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_javac_fail:2026-06-06": {
+    "timestamp": "2026-06-06T14:03:56.562133Z",
+    "library": "io.sundr:sundr-model-utils:0.240.1",
+    "starting_commit": "8af4e9515941680352974ee96276f42293840932",
+    "ending_commit": "f3de9492d11aaca06e604c8d327afe10851219ad",
+    "previous_library": "io.sundr:sundr-model-utils:0.230.1",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "0.240.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3167,
+          "missed": 3079,
+          "ratio": 0.507045,
+          "total": 6246
+        },
+        "line": {
+          "covered": 656,
+          "missed": 633,
+          "ratio": 0.508922,
+          "total": 1289
+        },
+        "method": {
+          "covered": 150,
+          "missed": 126,
+          "ratio": 0.543478,
+          "total": 276
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "0.230.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3264,
+          "missed": 2708,
+          "ratio": 0.546551,
+          "total": 5972
+        },
+        "line": {
+          "covered": 669,
+          "missed": 561,
+          "ratio": 0.543902,
+          "total": 1230
+        },
+        "method": {
+          "covered": 154,
+          "missed": 104,
+          "ratio": 0.596899,
+          "total": 258
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 99110,
+      "cached_input_tokens_used": 959488,
+      "output_tokens_used": 8485,
+      "iterations": 1,
+      "cost_usd": 0.7342,
+      "tested_library_loc": 656,
+      "metadata_entries": 164,
+      "previous_library_metadata_entries": 156,
+      "code_coverage_percent": 50.89,
+      "previous_library_coverage_percent": 54.39
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.sundr/sundr-model-utils/0.240.1/src/test/java/io_sundr/sundr_model_utils/Sundr_model_utilsTest.java",
+      "metadata_file": "metadata/io.sundr/sundr-model-utils/0.240.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.sundr/sundr-model-utils/0.240.1/stats.json
+++ b/stats/io.sundr/sundr-model-utils/0.240.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "0.240.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3167,
+        "missed" : 3079,
+        "ratio" : 0.507045,
+        "total" : 6246
+      },
+      "line" : {
+        "covered" : 656,
+        "missed" : 633,
+        "ratio" : 0.508922,
+        "total" : 1289
+      },
+      "method" : {
+        "covered" : 150,
+        "missed" : 126,
+        "ratio" : 0.543478,
+        "total" : 276
+      }
+    }
+  } ]
+}

--- a/tests/src/io.sundr/sundr-model-utils/0.240.1/.gitignore
+++ b/tests/src/io.sundr/sundr-model-utils/0.240.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.sundr/sundr-model-utils/0.240.1/build.gradle
+++ b/tests/src/io.sundr/sundr-model-utils/0.240.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.sundr:sundr-model-utils:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.sundr/sundr-model-utils/0.240.1/gradle.properties
+++ b/tests/src/io.sundr/sundr-model-utils/0.240.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.sundr:sundr-model-utils:0.240.1
+library.version = 0.240.1
+metadata.dir = io.sundr/sundr-model-utils/0.240.1/

--- a/tests/src/io.sundr/sundr-model-utils/0.240.1/settings.gradle
+++ b/tests/src/io.sundr/sundr-model-utils/0.240.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.sundr.sundr-model-utils_tests'

--- a/tests/src/io.sundr/sundr-model-utils/0.240.1/src/test/java/io_sundr/sundr_model_utils/Sundr_model_utilsTest.java
+++ b/tests/src/io.sundr/sundr-model-utils/0.240.1/src/test/java/io_sundr/sundr_model_utils/Sundr_model_utilsTest.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_sundr.sundr_model_utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.sundr.model.ClassRef;
+import io.sundr.model.Kind;
+import io.sundr.model.Method;
+import io.sundr.model.Property;
+import io.sundr.model.RichTypeDef;
+import io.sundr.model.TypeDef;
+import io.sundr.model.TypeDefBuilder;
+import io.sundr.model.TypeParamDef;
+import io.sundr.model.TypeRef;
+import io.sundr.model.functions.Assignable;
+import io.sundr.model.functions.GetDefinition;
+import io.sundr.model.functions.TypeCast;
+import io.sundr.model.repo.DefinitionRepository;
+import io.sundr.model.utils.Collections;
+import io.sundr.model.utils.Getter;
+import io.sundr.model.utils.Optionals;
+import io.sundr.model.utils.Parsers;
+import io.sundr.model.utils.Record;
+import io.sundr.model.utils.Setter;
+import io.sundr.model.utils.TypeArguments;
+import io.sundr.model.utils.Types;
+import io.sundr.model.visitors.ReplacePackage;
+import io.sundr.model.visitors.ReplaceType;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class Sundr_model_utilsTest {
+    @Test
+    void recognizesPrimitiveCollectionMapAndOptionalReferences() {
+        TypeRef boxedInteger = Types.box(Types.PRIMITIVE_INT_REF);
+        ClassRef listOfStrings = Collections.LIST.toReference(Types.STRING_REF);
+        ClassRef mapOfStringToInteger = Collections.MAP.toReference(Types.STRING_REF, boxedInteger);
+        DefinitionRepository repository = DefinitionRepository.getRepository();
+        repository.register(Collections.COLLECTION);
+        repository.register(Collections.LIST);
+        repository.register(Collections.MAP);
+        ClassRef optionalString = Optionals.OPTIONAL.toReference(Types.STRING_REF);
+
+        assertThat(boxedInteger).isEqualTo(Types.INT_REF);
+        assertThat(Types.isPrimitive(Types.PRIMITIVE_INT_REF)).isTrue();
+        assertThat(Types.isPrimitive(boxedInteger)).isFalse();
+
+        assertThat(Types.isList(listOfStrings)).isTrue();
+        assertThat(Collections.isCollection(listOfStrings)).isTrue();
+        assertThat(Collections.getCollectionElementType(listOfStrings)).contains(Types.STRING_REF);
+
+        assertThat(Types.isMap(mapOfStringToInteger)).isTrue();
+        assertThat(Collections.getMapKeyType(mapOfStringToInteger)).contains(Types.STRING_REF);
+        assertThat(Collections.getMapValueType(mapOfStringToInteger)).contains(boxedInteger);
+
+        assertThat(Types.isOptional(optionalString)).isTrue();
+        assertThat(Optionals.isOptional(optionalString)).isTrue();
+        assertThat(Optionals.isOptionalInt(Optionals.OPTIONAL_INT.toReference())).isTrue();
+        assertThat(Optionals.isOptionalDouble(Optionals.OPTIONAL_DOUBLE.toReference())).isTrue();
+        assertThat(Optionals.isOptionalLong(Optionals.OPTIONAL_LONG.toReference())).isTrue();
+    }
+
+    @Test
+    void parsesImportsNamesAndMethodBodiesFromJavaSourceText() {
+        String source = """
+                package example.parser;
+
+                import java.util.List;
+                import java.util.Map;
+
+                public class Greeter {
+                    public String greet(String name) {
+                        String prefix = "Hello, ";
+                        return prefix + name;
+                    }
+
+                    public int size(List values) {
+                        return values.size();
+                    }
+                }
+                """;
+        Method greet = Method.newMethod(
+                "greet",
+                Types.STRING_REF,
+                Property.newProperty(Types.STRING_REF, "name"));
+
+        List<ClassRef> imports = Parsers.parseImports(source);
+        String greetBody = Parsers.parseMethodBody(source, greet);
+        String sizeBody = Parsers.parseMethodBody(
+                source,
+                "size",
+                List.of(Property.newProperty(Collections.LIST.toReference(Types.STRING_REF), "values")));
+
+        assertThat(imports)
+                .extracting(ClassRef::getFullyQualifiedName)
+                .containsExactly("java.util.List", "java.util.Map");
+        assertThat(greetBody).contains("String prefix = \"Hello, \";").contains("return prefix + name;");
+        assertThat(sizeBody).contains("return values.size();");
+        assertThat(Types.parsePackage(source)).contains("example.parser");
+        assertThat(Types.parseName(source)).contains("Greeter");
+        assertThat(Types.parseFullyQualifiedName(source)).isEqualTo("example.parser.Greeter");
+    }
+
+    @Test
+    void resolvesDefinitionsHierarchyPropertiesAndAssignability() {
+        TypeDef identifiable = new TypeDefBuilder()
+                .withKind(Kind.INTERFACE)
+                .withPackageName("example.model")
+                .withName("Identifiable")
+                .addToMethods(Method.newMethod("id", Types.STRING_REF))
+                .build();
+        TypeDef base = new TypeDefBuilder()
+                .withKind(Kind.CLASS)
+                .withPackageName("example.model")
+                .withName("Base")
+                .addToProperties(Property.newProperty(Types.STRING_REF, "name"))
+                .build();
+        TypeDef child = new TypeDefBuilder()
+                .withKind(Kind.CLASS)
+                .withPackageName("example.model")
+                .withName("Child")
+                .addToExtendsList(base.toReference())
+                .addToImplementsList(identifiable.toReference())
+                .addToProperties(Property.newProperty(Types.INT_REF, "count"))
+                .addToMethods(Method.newMethod("count", Types.INT_REF))
+                .build();
+
+        DefinitionRepository repository = DefinitionRepository.getRepository();
+        repository.register(identifiable);
+        repository.register(base);
+        repository.register(child);
+
+        assertThat(GetDefinition.of(child.toReference())).isEqualTo(child);
+        assertThat(Assignable.isAssignable(base).from(child)).isTrue();
+        assertThat(Assignable.isAssignable(identifiable).from(child)).isTrue();
+        assertThat(Assignable.isAssignable(Types.PRIMITIVE_INT_REF).from(Types.INT_REF)).isTrue();
+        assertThat(Types.hasProperty(child, "count")).isTrue();
+        assertThat(Types.hasMethod(child, "count")).isTrue();
+        assertThat(Types.allProperties(child)).extracting(Property::getName).contains("name", "count");
+        assertThat(Types.unrollHierarchy(child)).extracting(TypeDef::getFullyQualifiedName)
+                .contains("example.model.Base", "example.model.Child");
+    }
+
+    @Test
+    void mapsGenericTypeArgumentsToConcreteReferences() {
+        TypeParamDef key = Types.newTypeParamDef("K");
+        TypeParamDef value = Types.newTypeParamDef("V");
+        TypeDef pair = new TypeDefBuilder()
+                .withKind(Kind.CLASS)
+                .withPackageName("example.generics")
+                .withName("Pair")
+                .withParameters(key, value)
+                .addToProperties(Property.newProperty(key.toReference(), "key"))
+                .addToProperties(Property.newProperty(value.toReference(), "value"))
+                .build();
+        ClassRef pairOfStringAndInteger = pair.toReference(Types.STRING_REF, Types.INT_REF);
+        DefinitionRepository.getRepository().register(pair);
+
+        Map<String, TypeRef> mappings = TypeArguments.getGenericArgumentsMappings(pairOfStringAndInteger, pair);
+        RichTypeDef richTypeDef = TypeArguments.apply(pairOfStringAndInteger);
+
+        assertThat(mappings).containsEntry("K", Types.STRING_REF).containsEntry("V", Types.INT_REF);
+        assertThat(richTypeDef.getFullyQualifiedName()).isEqualTo("example.generics.Pair");
+        assertThat(richTypeDef.getAllProperties()).extracting(Property::getName).containsExactly("key", "value");
+        assertThat(richTypeDef.getProperties()).extracting(Property::getTypeRef)
+                .containsExactly(Types.STRING_REF, Types.INT_REF);
+    }
+
+    @Test
+    void castsReferencesToInheritedGenericTypes() {
+        TypeParamDef item = Types.newTypeParamDef("T");
+        TypeDef source = new TypeDefBuilder()
+                .withKind(Kind.INTERFACE)
+                .withPackageName("example.cast")
+                .withName("Source")
+                .withParameters(item)
+                .build();
+        TypeDef stringSource = new TypeDefBuilder()
+                .withKind(Kind.CLASS)
+                .withPackageName("example.cast")
+                .withName("StringSource")
+                .addToImplementsList(source.toReference(Types.STRING_REF))
+                .build();
+
+        DefinitionRepository repository = DefinitionRepository.getRepository();
+        repository.register(source);
+        repository.register(stringSource);
+
+        ClassRef castReference = TypeCast.to(source.toReference())
+                .apply(stringSource.toReference())
+                .orElseThrow();
+
+        assertThat(castReference.getFullyQualifiedName()).isEqualTo("example.cast.Source");
+        assertThat(castReference.getArguments()).containsExactly(Types.STRING_REF);
+        assertThat(TypeCast.to(source.toReference()).apply(Types.PRIMITIVE_INT_REF)).isEmpty();
+    }
+
+    @Test
+    void discoversPropertyAccessorsIncludingRecordComponents() {
+        Property name = Property.newProperty(Types.STRING_REF, "name");
+        Property enabled = Property.newProperty(Types.PRIMITIVE_BOOLEAN_REF, "enabled");
+        Method getName = Method.newMethod("getName", Types.STRING_REF);
+        Method setName = Method.newMethod("setName", Types.VOID, name);
+        TypeDef bean = new TypeDefBuilder()
+                .withKind(Kind.CLASS)
+                .withPackageName("example.accessors")
+                .withName("Bean")
+                .addToProperties(name)
+                .addToProperties(enabled)
+                .addToMethods(getName)
+                .addToMethods(setName)
+                .build();
+        TypeDef record = new TypeDefBuilder()
+                .withKind(Kind.CLASS)
+                .withPackageName("example.accessors")
+                .withName("PersonRecord")
+                .addToExtendsList(ClassRef.forName("java.lang.Record"))
+                .addToProperties(name)
+                .addToMethods(Method.newMethod("name", Types.STRING_REF))
+                .build();
+
+        Method generatedBooleanGetter = Getter.forProperty(enabled);
+
+        assertThat(Getter.name(name)).isEqualTo("getName");
+        assertThat(Getter.name(enabled)).isEqualTo("isEnabled");
+        assertThat(generatedBooleanGetter.getName()).isEqualTo("isEnabled");
+        assertThat(generatedBooleanGetter.getReturnType()).isEqualTo(Types.PRIMITIVE_BOOLEAN_REF);
+        assertThat(Getter.is(generatedBooleanGetter)).isTrue();
+        assertThat(Getter.propertyName(getName)).isEqualTo("name");
+        assertThat(Getter.find(bean, name)).isEqualTo(getName);
+        assertThat(Getter.findOptional(bean, Property.newProperty(Types.STRING_REF, "missing"))).isEmpty();
+
+        assertThat(Setter.has(bean, name)).isTrue();
+        assertThat(Setter.find(bean, name).getSignature()).isEqualTo(setName.getSignature());
+        assertThat(Setter.isApplicable(setName, name)).isTrue();
+
+        assertThat(Record.is(record)).isTrue();
+        assertThat(Getter.find(record, name)).isEqualTo(record.getMethods().get(0));
+    }
+
+    @Test
+    void visitorsRewritePackagesAndClassReferencesAcrossBuilders() {
+        ClassRef oldWidgetRef = ClassRef.forName("example.old.Widget");
+        ClassRef newWidgetRef = ClassRef.forName("example.new.Widget");
+        TypeDef original = new TypeDefBuilder()
+                .withKind(Kind.CLASS)
+                .withPackageName("example.old")
+                .withName("Container")
+                .addToProperties(Property.newProperty(oldWidgetRef, "widget"))
+                .addToMethods(Method.newMethod("widget", oldWidgetRef))
+                .build();
+
+        TypeDef moved = new TypeDefBuilder(original)
+                .accept(new ReplacePackage("example.old", "example.new"))
+                .build();
+        TypeDef retargeted = new TypeDefBuilder(moved)
+                .accept(new ReplaceType(newWidgetRef, Types.STRING_REF))
+                .build();
+
+        assertThat(moved.getPackageName()).isEqualTo("example.new");
+        assertThat(moved.getProperties()).extracting(property -> property.getTypeRef().toString())
+                .containsExactly("example.new.Widget");
+        assertThat(moved.getMethods()).extracting(method -> method.getReturnType().toString())
+                .containsExactly("example.new.Widget");
+
+        assertThat(retargeted.getProperties()).extracting(property -> property.getTypeRef().toString())
+                .containsExactly("java.lang.String");
+        assertThat(retargeted.getMethods()).extracting(method -> method.getReturnType().toString())
+                .containsExactly("java.lang.String");
+    }
+}

--- a/tests/src/io.sundr/sundr-model-utils/0.240.1/src/test/java/io_sundr/sundr_model_utils/Sundr_model_utilsTest.java
+++ b/tests/src/io.sundr/sundr-model-utils/0.240.1/src/test/java/io_sundr/sundr_model_utils/Sundr_model_utilsTest.java
@@ -8,10 +8,11 @@ package io_sundr.sundr_model_utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.sundr.model.Argument;
 import io.sundr.model.ClassRef;
+import io.sundr.model.Field;
 import io.sundr.model.Kind;
 import io.sundr.model.Method;
-import io.sundr.model.Property;
 import io.sundr.model.RichTypeDef;
 import io.sundr.model.TypeDef;
 import io.sundr.model.TypeDefBuilder;
@@ -88,14 +89,14 @@ public class Sundr_model_utilsTest {
         Method greet = Method.newMethod(
                 "greet",
                 Types.STRING_REF,
-                Property.newProperty(Types.STRING_REF, "name"));
+                Argument.newArgument(Types.STRING_REF, "name"));
 
         List<ClassRef> imports = Parsers.parseImports(source);
         String greetBody = Parsers.parseMethodBody(source, greet);
         String sizeBody = Parsers.parseMethodBody(
                 source,
                 "size",
-                List.of(Property.newProperty(Collections.LIST.toReference(Types.STRING_REF), "values")));
+                List.of(Argument.newArgument(Collections.LIST.toReference(Types.STRING_REF), "values")));
 
         assertThat(imports)
                 .extracting(ClassRef::getFullyQualifiedName)
@@ -119,7 +120,7 @@ public class Sundr_model_utilsTest {
                 .withKind(Kind.CLASS)
                 .withPackageName("example.model")
                 .withName("Base")
-                .addToProperties(Property.newProperty(Types.STRING_REF, "name"))
+                .addToFields(Field.newField(Types.STRING_REF, "name"))
                 .build();
         TypeDef child = new TypeDefBuilder()
                 .withKind(Kind.CLASS)
@@ -127,7 +128,7 @@ public class Sundr_model_utilsTest {
                 .withName("Child")
                 .addToExtendsList(base.toReference())
                 .addToImplementsList(identifiable.toReference())
-                .addToProperties(Property.newProperty(Types.INT_REF, "count"))
+                .addToFields(Field.newField(Types.INT_REF, "count"))
                 .addToMethods(Method.newMethod("count", Types.INT_REF))
                 .build();
 
@@ -140,9 +141,9 @@ public class Sundr_model_utilsTest {
         assertThat(Assignable.isAssignable(base).from(child)).isTrue();
         assertThat(Assignable.isAssignable(identifiable).from(child)).isTrue();
         assertThat(Assignable.isAssignable(Types.PRIMITIVE_INT_REF).from(Types.INT_REF)).isTrue();
-        assertThat(Types.hasProperty(child, "count")).isTrue();
+        assertThat(Types.hasField(child, "count")).isTrue();
         assertThat(Types.hasMethod(child, "count")).isTrue();
-        assertThat(Types.allProperties(child)).extracting(Property::getName).contains("name", "count");
+        assertThat(Types.allFields(child)).extracting(Field::getName).contains("name", "count");
         assertThat(Types.unrollHierarchy(child)).extracting(TypeDef::getFullyQualifiedName)
                 .contains("example.model.Base", "example.model.Child");
     }
@@ -156,8 +157,8 @@ public class Sundr_model_utilsTest {
                 .withPackageName("example.generics")
                 .withName("Pair")
                 .withParameters(key, value)
-                .addToProperties(Property.newProperty(key.toReference(), "key"))
-                .addToProperties(Property.newProperty(value.toReference(), "value"))
+                .addToFields(Field.newField(key.toReference(), "key"))
+                .addToFields(Field.newField(value.toReference(), "value"))
                 .build();
         ClassRef pairOfStringAndInteger = pair.toReference(Types.STRING_REF, Types.INT_REF);
         DefinitionRepository.getRepository().register(pair);
@@ -167,8 +168,8 @@ public class Sundr_model_utilsTest {
 
         assertThat(mappings).containsEntry("K", Types.STRING_REF).containsEntry("V", Types.INT_REF);
         assertThat(richTypeDef.getFullyQualifiedName()).isEqualTo("example.generics.Pair");
-        assertThat(richTypeDef.getAllProperties()).extracting(Property::getName).containsExactly("key", "value");
-        assertThat(richTypeDef.getProperties()).extracting(Property::getTypeRef)
+        assertThat(richTypeDef.getAllFields()).extracting(Field::getName).containsExactly("key", "value");
+        assertThat(richTypeDef.getFields()).extracting(Field::getTypeRef)
                 .containsExactly(Types.STRING_REF, Types.INT_REF);
     }
 
@@ -203,16 +204,16 @@ public class Sundr_model_utilsTest {
 
     @Test
     void discoversPropertyAccessorsIncludingRecordComponents() {
-        Property name = Property.newProperty(Types.STRING_REF, "name");
-        Property enabled = Property.newProperty(Types.PRIMITIVE_BOOLEAN_REF, "enabled");
+        Field name = Field.newField(Types.STRING_REF, "name");
+        Field enabled = Field.newField(Types.PRIMITIVE_BOOLEAN_REF, "enabled");
         Method getName = Method.newMethod("getName", Types.STRING_REF);
-        Method setName = Method.newMethod("setName", Types.VOID, name);
+        Method setName = Method.newMethod("setName", Types.VOID, Argument.newArgument(Types.STRING_REF, "name"));
         TypeDef bean = new TypeDefBuilder()
                 .withKind(Kind.CLASS)
                 .withPackageName("example.accessors")
                 .withName("Bean")
-                .addToProperties(name)
-                .addToProperties(enabled)
+                .addToFields(name)
+                .addToFields(enabled)
                 .addToMethods(getName)
                 .addToMethods(setName)
                 .build();
@@ -221,20 +222,20 @@ public class Sundr_model_utilsTest {
                 .withPackageName("example.accessors")
                 .withName("PersonRecord")
                 .addToExtendsList(ClassRef.forName("java.lang.Record"))
-                .addToProperties(name)
+                .addToFields(name)
                 .addToMethods(Method.newMethod("name", Types.STRING_REF))
                 .build();
 
-        Method generatedBooleanGetter = Getter.forProperty(enabled);
+        Method generatedBooleanGetter = Getter.forField(enabled);
 
         assertThat(Getter.name(name)).isEqualTo("getName");
         assertThat(Getter.name(enabled)).isEqualTo("isEnabled");
         assertThat(generatedBooleanGetter.getName()).isEqualTo("isEnabled");
         assertThat(generatedBooleanGetter.getReturnType()).isEqualTo(Types.PRIMITIVE_BOOLEAN_REF);
         assertThat(Getter.is(generatedBooleanGetter)).isTrue();
-        assertThat(Getter.propertyName(getName)).isEqualTo("name");
+        assertThat(Getter.fieldName(getName)).isEqualTo("name");
         assertThat(Getter.find(bean, name)).isEqualTo(getName);
-        assertThat(Getter.findOptional(bean, Property.newProperty(Types.STRING_REF, "missing"))).isEmpty();
+        assertThat(Getter.findOptional(bean, Field.newField(Types.STRING_REF, "missing"))).isEmpty();
 
         assertThat(Setter.has(bean, name)).isTrue();
         assertThat(Setter.find(bean, name).getSignature()).isEqualTo(setName.getSignature());
@@ -252,7 +253,7 @@ public class Sundr_model_utilsTest {
                 .withKind(Kind.CLASS)
                 .withPackageName("example.old")
                 .withName("Container")
-                .addToProperties(Property.newProperty(oldWidgetRef, "widget"))
+                .addToFields(Field.newField(oldWidgetRef, "widget"))
                 .addToMethods(Method.newMethod("widget", oldWidgetRef))
                 .build();
 
@@ -264,12 +265,12 @@ public class Sundr_model_utilsTest {
                 .build();
 
         assertThat(moved.getPackageName()).isEqualTo("example.new");
-        assertThat(moved.getProperties()).extracting(property -> property.getTypeRef().toString())
+        assertThat(moved.getFields()).extracting(field -> field.getTypeRef().toString())
                 .containsExactly("example.new.Widget");
         assertThat(moved.getMethods()).extracting(method -> method.getReturnType().toString())
                 .containsExactly("example.new.Widget");
 
-        assertThat(retargeted.getProperties()).extracting(property -> property.getTypeRef().toString())
+        assertThat(retargeted.getFields()).extracting(field -> field.getTypeRef().toString())
                 .containsExactly("java.lang.String");
         assertThat(retargeted.getMethods()).extracting(method -> method.getReturnType().toString())
                 .containsExactly("java.lang.String");

--- a/tests/src/io.sundr/sundr-model-utils/0.240.1/user-code-filter.json
+++ b/tests/src/io.sundr/sundr-model-utils/0.240.1/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "io.sundr.model.**"
+    },
+    {
+      "includeClasses" : "io_sundr.sundr_model_utils.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7997

This PR provides test fixes and new metadata for io.sundr:sundr-model-utils:0.240.1, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 99110
- Cached input tokens: 959488
- Output tokens: 8485
- Metadata entries: 164
- Iterations: 1
- Library coverage percentage: 50.89
- Previous library version metadata entries: 156
- Previous library version coverage percentage: 54.39

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `b1781a513e2701312248807c2883fd09be9de214`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.sundr:sundr-model-utils:0.230.1: 0/0 covered calls (100.00%)
- io.sundr:sundr-model-utils:0.240.1: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.sundr:sundr-model-utils:0.230.1: 3264/5972 (54.66%)
- io.sundr:sundr-model-utils:0.240.1: 3167/6246 (50.70%)

**Line:**
- io.sundr:sundr-model-utils:0.230.1: 669/1230 (54.39%)
- io.sundr:sundr-model-utils:0.240.1: 656/1289 (50.89%)

**Method:**
- io.sundr:sundr-model-utils:0.230.1: 154/258 (59.69%)
- io.sundr:sundr-model-utils:0.240.1: 150/276 (54.35%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/io.sundr/sundr-model-utils/0.230.1/src/test/java/io_sundr/sundr_model_utils/Sundr_model_utilsTest.java 2/tests/src/io.sundr/sundr-model-utils/0.240.1/src/test/java/io_sundr/sundr_model_utils/Sundr_model_utilsTest.java
index 8e7c901388..75609d01f9 100644
--- 1/tests/src/io.sundr/sundr-model-utils/0.230.1/src/test/java/io_sundr/sundr_model_utils/Sundr_model_utilsTest.java
+++ 2/tests/src/io.sundr/sundr-model-utils/0.240.1/src/test/java/io_sundr/sundr_model_utils/Sundr_model_utilsTest.java
@@ -8,10 +8,11 @@ package io_sundr.sundr_model_utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.sundr.model.Argument;
 import io.sundr.model.ClassRef;
+import io.sundr.model.Field;
 import io.sundr.model.Kind;
 import io.sundr.model.Method;
-import io.sundr.model.Property;
 import io.sundr.model.RichTypeDef;
 import io.sundr.model.TypeDef;
 import io.sundr.model.TypeDefBuilder;
@@ -88,14 +89,14 @@ public class Sundr_model_utilsTest {
         Method greet = Method.newMethod(
                 "greet",
                 Types.STRING_REF,
-                Property.newProperty(Types.STRING_REF, "name"));
+                Argument.newArgument(Types.STRING_REF, "name"));
 
         List<ClassRef> imports = Parsers.parseImports(source);
         String greetBody = Parsers.parseMethodBody(source, greet);
         String sizeBody = Parsers.parseMethodBody(
                 source,
                 "size",
-                List.of(Property.newProperty(Collections.LIST.toReference(Types.STRING_REF), "values")));
+                List.of(Argument.newArgument(Collections.LIST.toReference(Types.STRING_REF), "values")));
 
         assertThat(imports)
                 .extracting(ClassRef::getFullyQualifiedName)
@@ -119,7 +120,7 @@ public class Sundr_model_utilsTest {
                 .withKind(Kind.CLASS)
                 .withPackageName("example.model")
                 .withName("Base")
-                .addToProperties(Property.newProperty(Types.STRING_REF, "name"))
+                .addToFields(Field.newField(Types.STRING_REF, "name"))
                 .build();
         TypeDef child = new TypeDefBuilder()
                 .withKind(Kind.CLASS)
@@ -127,7 +128,7 @@ public class Sundr_model_utilsTest {
                 .withName("Child")
                 .addToExtendsList(base.toReference())
                 .addToImplementsList(identifiable.toReference())
-                .addToProperties(Property.newProperty(Types.INT_REF, "count"))
+                .addToFields(Field.newField(Types.INT_REF, "count"))
                 .addToMethods(Method.newMethod("count", Types.INT_REF))
                 .build();
 
@@ -140,9 +141,9 @@ public class Sundr_model_utilsTest {
         assertThat(Assignable.isAssignable(base).from(child)).isTrue();
         assertThat(Assignable.isAssignable(identifiable).from(child)).isTrue();
         assertThat(Assignable.isAssignable(Types.PRIMITIVE_INT_REF).from(Types.INT_REF)).isTrue();
-        assertThat(Types.hasProperty(child, "count")).isTrue();
+        assertThat(Types.hasField(child, "count")).isTrue();
         assertThat(Types.hasMethod(child, "count")).isTrue();
-        assertThat(Types.allProperties(child)).extracting(Property::getName).contains("name", "count");
+        assertThat(Types.allFields(child)).extracting(Field::getName).contains("name", "count");
         assertThat(Types.unrollHierarchy(child)).extracting(TypeDef::getFullyQualifiedName)
                 .contains("example.model.Base", "example.model.Child");
     }
@@ -156,8 +157,8 @@ public class Sundr_model_utilsTest {
                 .withPackageName("example.generics")
                 .withName("Pair")
                 .withParameters(key, value)
-                .addToProperties(Property.newProperty(key.toReference(), "key"))
-                .addToProperties(Property.newProperty(value.toReference(), "value"))
+                .addToFields(Field.newField(key.toReference(), "key"))
+                .addToFields(Field.newField(value.toReference(), "value"))
                 .build();
         ClassRef pairOfStringAndInteger = pair.toReference(Types.STRING_REF, Types.INT_REF);
         DefinitionRepository.getRepository().register(pair);
@@ -167,8 +168,8 @@ public class Sundr_model_utilsTest {
 
         assertThat(mappings).containsEntry("K", Types.STRING_REF).containsEntry("V", Types.INT_REF);
         assertThat(richTypeDef.getFullyQualifiedName()).isEqualTo("example.generics.Pair");
-        assertThat(richTypeDef.getAllProperties()).extracting(Property::getName).containsExactly("key", "value");
-        assertThat(richTypeDef.getProperties()).extracting(Property::getTypeRef)
+        assertThat(richTypeDef.getAllFields()).extracting(Field::getName).containsExactly("key", "value");
+        assertThat(richTypeDef.getFields()).extracting(Field::getTypeRef)
                 .containsExactly(Types.STRING_REF, Types.INT_REF);
     }
 
@@ -203,16 +204,16 @@ public class Sundr_model_utilsTest {
 
     @Test
     void discoversPropertyAccessorsIncludingRecordComponents() {
-        Property name = Property.newProperty(Types.STRING_REF, "name");
-        Property enabled = Property.newProperty(Types.PRIMITIVE_BOOLEAN_REF, "enabled");
+        Field name = Field.newField(Types.STRING_REF, "name");
+        Field enabled = Field.newField(Types.PRIMITIVE_BOOLEAN_REF, "enabled");
         Method getName = Method.newMethod("getName", Types.STRING_REF);
-        Method setName = Method.newMethod("setName", Types.VOID, name);
+        Method setName = Method.newMethod("setName", Types.VOID, Argument.newArgument(Types.STRING_REF, "name"));
         TypeDef bean = new TypeDefBuilder()
                 .withKind(Kind.CLASS)
                 .withPackageName("example.accessors")
                 .withName("Bean")
-                .addToProperties(name)
-                .addToProperties(enabled)
+                .addToFields(name)
+                .addToFields(enabled)
                 .addToMethods(getName)
                 .addToMethods(setName)
                 .build();
@@ -221,20 +222,20 @@ public class Sundr_model_utilsTest {
                 .withPackageName("example.accessors")
                 .withName("PersonRecord")
                 .addToExtendsList(ClassRef.forName("java.lang.Record"))
-                .addToProperties(name)
+                .addToFields(name)
                 .addToMethods(Method.newMethod("name", Types.STRING_REF))
                 .build();
 
-        Method generatedBooleanGetter = Getter.forProperty(enabled);
+        Method generatedBooleanGetter = Getter.forField(enabled);
 
         assertThat(Getter.name(name)).isEqualTo("getName");
         assertThat(Getter.name(enabled)).isEqualTo("isEnabled");
         assertThat(generatedBooleanGetter.getName()).isEqualTo("isEnabled");
         assertThat(generatedBooleanGetter.getReturnType()).isEqualTo(Types.PRIMITIVE_BOOLEAN_REF);
         assertThat(Getter.is(generatedBooleanGetter)).isTrue();
-        assertThat(Getter.propertyName(getName)).isEqualTo("name");
+        assertThat(Getter.fieldName(getName)).isEqualTo("name");
         assertThat(Getter.find(bean, name)).isEqualTo(getName);
-        assertThat(Getter.findOptional(bean, Property.newProperty(Types.STRING_REF, "missing"))).isEmpty();
+        assertThat(Getter.findOptional(bean, Field.newField(Types.STRING_REF, "missing"))).isEmpty();
 
         assertThat(Setter.has(bean, name)).isTrue();
         assertThat(Setter.find(bean, name).getSignature()).isEqualTo(setName.getSignature());
@@ -252,7 +253,7 @@ public class Sundr_model_utilsTest {
                 .withKind(Kind.CLASS)
                 .withPackageName("example.old")
                 .withName("Container")
-                .addToProperties(Property.newProperty(oldWidgetRef, "widget"))
+                .addToFields(Field.newField(oldWidgetRef, "widget"))
                 .addToMethods(Method.newMethod("widget", oldWidgetRef))
                 .build();
 
@@ -264,12 +265,12 @@ public class Sundr_model_utilsTest {
                 .build();
 
         assertThat(moved.getPackageName()).isEqualTo("example.new");
-        assertThat(moved.getProperties()).extracting(property -> property.getTypeRef().toString())
+        assertThat(moved.getFields()).extracting(field -> field.getTypeRef().toString())
                 .containsExactly("example.new.Widget");
         assertThat(moved.getMethods()).extracting(method -> method.getReturnType().toString())
                 .containsExactly("example.new.Widget");
 
-        assertThat(retargeted.getProperties()).extracting(property -> property.getTypeRef().toString())
+        assertThat(retargeted.getFields()).extracting(field -> field.getTypeRef().toString())
                 .containsExactly("java.lang.String");
         assertThat(retargeted.getMethods()).extracting(method -> method.getReturnType().toString())
                 .containsExactly("java.lang.String");

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
