### PR TITLE
[GenAI] Add support for io.sundr:sundr-model:0.230.1 using gpt-5.5

### DIFF
--- a/metadata/io.sundr/sundr-model/0.230.1/reachability-metadata.json
+++ b/metadata/io.sundr/sundr-model/0.230.1/reachability-metadata.json
@@ -1,0 +1,940 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.AnnotationRef"
+      },
+      "type" : "io.sundr.model.AnnotationRefBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.AnnotationRef" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Assign"
+      },
+      "type" : "io.sundr.model.AssignBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Assign" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.AttributeSupport"
+      },
+      "type" : "io.sundr.model.AttributeSupportBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.AttributeSupport" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.BinaryExpression"
+      },
+      "type" : "io.sundr.model.BinaryExpressionBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.BinaryExpression" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.BitwiseAnd"
+      },
+      "type" : "io.sundr.model.BitwiseAndBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.BitwiseAnd" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.BitwiseOr"
+      },
+      "type" : "io.sundr.model.BitwiseOrBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.BitwiseOr" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Block"
+      },
+      "type" : "io.sundr.model.BlockBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Block" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Break"
+      },
+      "type" : "io.sundr.model.BreakBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Break" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Cast"
+      },
+      "type" : "io.sundr.model.CastBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Cast" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.ClassRef"
+      },
+      "type" : "io.sundr.model.ClassRefBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.ClassRef" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Construct"
+      },
+      "type" : "io.sundr.model.ConstructBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Construct" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.ContextRef"
+      },
+      "type" : "io.sundr.model.ContextRefBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.ContextRef" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Continue"
+      },
+      "type" : "io.sundr.model.ContinueBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Continue" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Declare"
+      },
+      "type" : "io.sundr.model.DeclareBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Declare" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Divide"
+      },
+      "type" : "io.sundr.model.DivideBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Divide" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Do"
+      },
+      "type" : "io.sundr.model.DoBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Do" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.DotClass"
+      },
+      "type" : "io.sundr.model.DotClassBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.DotClass" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Empty"
+      },
+      "type" : "io.sundr.model.EmptyBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Empty" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Enclosed"
+      },
+      "type" : "io.sundr.model.EnclosedBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Enclosed" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Equals"
+      },
+      "type" : "io.sundr.model.EqualsBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Equals" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.For"
+      },
+      "type" : "io.sundr.model.ForBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.For" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Foreach"
+      },
+      "type" : "io.sundr.model.ForeachBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Foreach" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.GreaterThan"
+      },
+      "type" : "io.sundr.model.GreaterThanBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.GreaterThan" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.GreaterThanOrEqual"
+      },
+      "type" : "io.sundr.model.GreaterThanOrEqualBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.GreaterThanOrEqual" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.If"
+      },
+      "type" : "io.sundr.model.IfBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.If" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.IfDslConditionStep"
+      },
+      "type" : "io.sundr.model.IfDslConditionStepBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.IfDslConditionStep" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.IfDslThenStep"
+      },
+      "type" : "io.sundr.model.IfDslThenStepBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.IfDslThenStep" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Index"
+      },
+      "type" : "io.sundr.model.IndexBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Index" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.InstanceOf"
+      },
+      "type" : "io.sundr.model.InstanceOfBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.InstanceOf" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Inverse"
+      },
+      "type" : "io.sundr.model.InverseBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Inverse" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Lambda"
+      },
+      "type" : "io.sundr.model.LambdaBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Lambda" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.LeftShift"
+      },
+      "type" : "io.sundr.model.LeftShiftBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.LeftShift" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.LessThan"
+      },
+      "type" : "io.sundr.model.LessThanBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.LessThan" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.LessThanOrEqual"
+      },
+      "type" : "io.sundr.model.LessThanOrEqualBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.LessThanOrEqual" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.LogicalAnd"
+      },
+      "type" : "io.sundr.model.LogicalAndBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.LogicalAnd" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.LogicalOr"
+      },
+      "type" : "io.sundr.model.LogicalOrBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.LogicalOr" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Method"
+      },
+      "type" : "io.sundr.model.MethodBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Method" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.MethodCall"
+      },
+      "type" : "io.sundr.model.MethodCallBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.MethodCall" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Minus"
+      },
+      "type" : "io.sundr.model.MinusBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Minus" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.ModifierSupport"
+      },
+      "type" : "io.sundr.model.ModifierSupportBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.ModifierSupport" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Modifiers"
+      },
+      "type" : "io.sundr.model.ModifiersBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Modifiers" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Modulo"
+      },
+      "type" : "io.sundr.model.ModuloBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Modulo" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Multiply"
+      },
+      "type" : "io.sundr.model.MultiplyBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Multiply" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Negative"
+      },
+      "type" : "io.sundr.model.NegativeBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Negative" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.NewArray"
+      },
+      "type" : "io.sundr.model.NewArrayBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.NewArray" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Not"
+      },
+      "type" : "io.sundr.model.NotBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Not" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.NotEquals"
+      },
+      "type" : "io.sundr.model.NotEqualsBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.NotEquals" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Plus"
+      },
+      "type" : "io.sundr.model.PlusBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Plus" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Positive"
+      },
+      "type" : "io.sundr.model.PositiveBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Positive" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.PostDecrement"
+      },
+      "type" : "io.sundr.model.PostDecrementBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.PostDecrement" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.PostIncrement"
+      },
+      "type" : "io.sundr.model.PostIncrementBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.PostIncrement" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.PreDecrement"
+      },
+      "type" : "io.sundr.model.PreDecrementBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.PreDecrement" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.PreIncrement"
+      },
+      "type" : "io.sundr.model.PreIncrementBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.PreIncrement" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.PrimitiveRef"
+      },
+      "type" : "io.sundr.model.PrimitiveRefBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.PrimitiveRef" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Property"
+      },
+      "type" : "io.sundr.model.PropertyBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Property" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.PropertyRef"
+      },
+      "type" : "io.sundr.model.PropertyRefBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.PropertyRef" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Return"
+      },
+      "type" : "io.sundr.model.ReturnBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Return" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.ReturnDslThisStep"
+      },
+      "type" : "io.sundr.model.ReturnDslThisStepBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.ReturnDslThisStep" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.ReturnDslVariableStep"
+      },
+      "type" : "io.sundr.model.ReturnDslVariableStepBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.ReturnDslVariableStep" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.RightShift"
+      },
+      "type" : "io.sundr.model.RightShiftBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.RightShift" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.RightUnsignedShift"
+      },
+      "type" : "io.sundr.model.RightUnsignedShiftBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.RightUnsignedShift" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Source"
+      },
+      "type" : "io.sundr.model.SourceBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Source" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.StringStatement"
+      },
+      "type" : "io.sundr.model.StringStatementBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.StringStatement" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Super"
+      },
+      "type" : "io.sundr.model.SuperBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Super" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Switch"
+      },
+      "type" : "io.sundr.model.SwitchBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Switch" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Synchronized"
+      },
+      "type" : "io.sundr.model.SynchronizedBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Synchronized" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Ternary"
+      },
+      "type" : "io.sundr.model.TernaryBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Ternary" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.This"
+      },
+      "type" : "io.sundr.model.ThisBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.This" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Throw"
+      },
+      "type" : "io.sundr.model.ThrowBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Throw" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Try"
+      },
+      "type" : "io.sundr.model.TryBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Try" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.TypeDef"
+      },
+      "type" : "io.sundr.model.TypeDefBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.TypeDef" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.TypeParamDef"
+      },
+      "type" : "io.sundr.model.TypeParamDefBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.TypeParamDef" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.TypeParamRef"
+      },
+      "type" : "io.sundr.model.TypeParamRefBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.TypeParamRef" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.ValueRef"
+      },
+      "type" : "io.sundr.model.ValueRefBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.ValueRef" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.VoidRef"
+      },
+      "type" : "io.sundr.model.VoidRefBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.VoidRef" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.While"
+      },
+      "type" : "io.sundr.model.WhileBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.While" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.WildcardRef"
+      },
+      "type" : "io.sundr.model.WildcardRefBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.WildcardRef" ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.Xor"
+      },
+      "type" : "io.sundr.model.XorBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ "io.sundr.model.Xor" ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/io.sundr/sundr-model/index.json
+++ b/metadata/io.sundr/sundr-model/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "0.230.1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/sundr/sundr-model/$version$/sundr-model-$version$-sources.jar",
+    "repository-url" : "https://github.com/sundrio/sundrio",
+    "test-code-url" : "https://github.com/sundrio/sundrio/tree/$version$/model/builder/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/sundr/sundr-model/$version$/sundr-model-$version$-javadoc.jar",
+    "description" : "Sundr is a Java code generation toolkit for builders, fluent APIs, domain-specific languages, and other boilerplate-heavy code. The sundr-model artifact provides the builder and fluent API layer for Sundr's Java code model, including generated model builders for representing source types, members, statements, and expressions.",
+    "tested-versions" : [
+      "0.230.1"
+    ],
+    "allowed-packages" : [
+      "io.sundr.model"
+    ]
+  }
+]

--- a/stats/io.sundr/sundr-model/0.230.1/execution-metrics.json
+++ b/stats/io.sundr/sundr-model/0.230.1/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-06-06": {
+    "timestamp": "2026-06-06T14:25:51.246259Z",
+    "library": "io.sundr:sundr-model:0.230.1",
+    "starting_commit": "bb58d70070648bd8134b59762fbbd2d936ee3024",
+    "ending_commit": "72534aba593ab2e8f30b612bef4db9d341335134",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "0.230.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3975,
+          "missed": 138385,
+          "ratio": 0.027922,
+          "total": 142360
+        },
+        "line": {
+          "covered": 922,
+          "missed": 27250,
+          "ratio": 0.032728,
+          "total": 28172
+        },
+        "method": {
+          "covered": 264,
+          "missed": 14981,
+          "ratio": 0.017317,
+          "total": 15245
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 348697,
+      "cached_input_tokens_used": 5934592,
+      "output_tokens_used": 33507,
+      "iterations": 7,
+      "cost_usd": 3.9725,
+      "generated_loc": 415,
+      "tested_library_loc": 922,
+      "metadata_entries": 156,
+      "code_coverage_percent": 3.27
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.sundr/sundr-model/0.230.1/src/test/java/io_sundr/sundr_model/Sundr_modelTest.java",
+      "metadata_file": "metadata/io.sundr/sundr-model/0.230.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.sundr/sundr-model/0.230.1/stats.json
+++ b/stats/io.sundr/sundr-model/0.230.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "0.230.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3975,
+        "missed" : 138385,
+        "ratio" : 0.027922,
+        "total" : 142360
+      },
+      "line" : {
+        "covered" : 922,
+        "missed" : 27250,
+        "ratio" : 0.032728,
+        "total" : 28172
+      },
+      "method" : {
+        "covered" : 264,
+        "missed" : 14981,
+        "ratio" : 0.017317,
+        "total" : 15245
+      }
+    }
+  } ]
+}

--- a/tests/src/io.sundr/sundr-model/0.230.1/.gitignore
+++ b/tests/src/io.sundr/sundr-model/0.230.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.sundr/sundr-model/0.230.1/build.gradle
+++ b/tests/src/io.sundr/sundr-model/0.230.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.sundr:sundr-model:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.sundr/sundr-model/0.230.1/gradle.properties
+++ b/tests/src/io.sundr/sundr-model/0.230.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.sundr:sundr-model:0.230.1
+library.version = 0.230.1
+metadata.dir = io.sundr/sundr-model/0.230.1/

--- a/tests/src/io.sundr/sundr-model/0.230.1/settings.gradle
+++ b/tests/src/io.sundr/sundr-model/0.230.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.sundr.sundr-model_tests'

--- a/tests/src/io.sundr/sundr-model/0.230.1/src/test/java/io_sundr/sundr_model/Sundr_modelTest.java
+++ b/tests/src/io.sundr/sundr-model/0.230.1/src/test/java/io_sundr/sundr_model/Sundr_modelTest.java
@@ -6,11 +6,335 @@
  */
 package io_sundr.sundr_model;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.sundr.model.AnnotationRef;
+import io.sundr.model.AnnotationRefBuilder;
+import io.sundr.model.Assign;
+import io.sundr.model.AttributeKey;
+import io.sundr.model.Block;
+import io.sundr.model.ClassRef;
+import io.sundr.model.ClassRefBuilder;
+import io.sundr.model.Construct;
+import io.sundr.model.Declare;
+import io.sundr.model.Empty;
+import io.sundr.model.Expression;
+import io.sundr.model.For;
+import io.sundr.model.GreaterThan;
+import io.sundr.model.If;
+import io.sundr.model.Kind;
+import io.sundr.model.Lambda;
+import io.sundr.model.Method;
+import io.sundr.model.MethodBuilder;
+import io.sundr.model.MethodCall;
+import io.sundr.model.Modifiers;
+import io.sundr.model.NewArray;
+import io.sundr.model.PostIncrement;
+import io.sundr.model.PrimitiveRef;
+import io.sundr.model.Property;
+import io.sundr.model.PropertyBuilder;
+import io.sundr.model.PropertyRef;
+import io.sundr.model.Return;
+import io.sundr.model.StringStatement;
+import io.sundr.model.Ternary;
+import io.sundr.model.Throw;
+import io.sundr.model.Try;
+import io.sundr.model.TypeDef;
+import io.sundr.model.TypeDefBuilder;
+import io.sundr.model.TypeParamDef;
+import io.sundr.model.TypeParamDefBuilder;
+import io.sundr.model.ValueRef;
+import io.sundr.model.While;
+import io.sundr.model.WildcardRef;
+import io.sundr.model.WildcardRefBuilder;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
-class Sundr_modelTest {
+public class Sundr_modelTest {
+
+    private static final PrimitiveRef INT = new PrimitiveRef("int", 0, Map.of());
+    private static final ClassRef STRING = ClassRef.forName("java.lang.String");
+    private static final ClassRef NUMBER = ClassRef.forName("java.lang.Number");
+    private static final ClassRef SERIALIZABLE = ClassRef.forName("java.io.Serializable");
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void buildsTypeDefinitionsWithNestedMembersAttributesAndAnnotations() {
+        AttributeKey<String> sourceAttribute = new AttributeKey<>("source", String.class);
+        TypeParamDef typeParameter = new TypeParamDefBuilder()
+                .withName("T")
+                .addToBounds(NUMBER)
+                .addToAttributes(sourceAttribute, "type-parameter")
+                .build();
+        AnnotationRef generated = new AnnotationRefBuilder()
+                .withClassRef(ClassRef.forName("example.Generated"))
+                .addToParameters("value", "sundr-model-test")
+                .build();
+        Property value = new PropertyBuilder()
+                .withModifiers(privateFinalModifiers())
+                .withTypeRef(typeParameter.toReference())
+                .withName("value")
+                .withInitialValue(new ValueRef(42))
+                .addToComments("stored constructor value")
+                .addToAttributes(sourceAttribute, "property")
+                .build();
+        Method getter = new MethodBuilder()
+                .withModifiers(publicModifiers())
+                .withName("getValue")
+                .withReturnType(typeParameter.toReference())
+                .withBlock(new Block(Return.variable(value)))
+                .addToComments("Returns the stored value.")
+                .build();
+        TypeDef nested = TypeDef.forName("example.model.Box.Metadata");
+
+        TypeDef box = new TypeDefBuilder()
+                .withKind(Kind.CLASS)
+                .withPackageName("example.model")
+                .withName("Box")
+                .withModifiers(publicModifiers())
+                .addToComments("A small generic value object.")
+                .addToAnnotations(generated)
+                .addToImplementsList(SERIALIZABLE)
+                .addToParameters(typeParameter)
+                .addToProperties(value)
+                .addToMethods(getter)
+                .addToInnerTypes(nested)
+                .addToAttributes(sourceAttribute, "type")
+                .build();
+
+        assertThat(box.getFullyQualifiedName()).isEqualTo("example.model.Box");
+        assertThat(box.isClass()).isTrue();
+        assertThat(box.getAttribute(sourceAttribute)).isEqualTo("type");
+        assertThat(box.getParameters()).containsExactly(typeParameter);
+        assertThat(box.getProperties()).containsExactly(value);
+        assertThat(box.getMethods()).containsExactly(getter);
+        assertThat(box.getInnerTypes()).containsExactly(nested);
+        assertThat(box.getAnnotations()).containsExactly(generated);
+        assertThat(box.getImports()).contains("java.io.Serializable");
+        assertThat(box.getReferences()).extracting(ClassRef::getFullyQualifiedName)
+                .contains("java.io.Serializable");
+        assertThat(typeParameter.getBounds()).containsExactly(NUMBER);
+
+        String definition = box.renderDefinition();
+
+        assertThat(definition)
+                .contains("class Box")
+                .contains("Serializable")
+                .contains("T extends")
+                .contains("Number");
+    }
+
+    @Test
+    void fluentBuildersCanCopyEditMatchAndRemoveGeneratedModelParts() {
+        Property first = Property.newProperty(STRING, "firstName");
+        Property last = Property.newProperty(STRING, "lastName");
+        Method fullName = Method.newMethod("fullName", STRING);
+        TypeDef person = new TypeDefBuilder()
+                .withKind(Kind.CLASS)
+                .withPackageName("example.people")
+                .withName("Person")
+                .withProperties(first, last)
+                .withMethods(fullName)
+                .build();
+
+        TypeDef edited = new TypeDefBuilder(person)
+                .editMatchingProperty(property -> "firstName".equals(property.getName()))
+                .withName("givenName")
+                .endProperty()
+                .editMatchingMethod(method -> "fullName".equals(method.getName()))
+                .withName("displayName")
+                .endMethod()
+                .removeMatchingFromProperties(property -> "lastName".equals(property.getName()))
+                .addNewPropertyLike(Property.newProperty(STRING, "familyName"))
+                .addToComments("created through copy-edit fluent API")
+                .endProperty()
+                .build();
+
+        assertThat(edited).isNotSameAs(person);
+        assertThat(edited.getFullyQualifiedName()).isEqualTo("example.people.Person");
+        assertThat(edited.getProperties()).extracting(Property::getName)
+                .containsExactly("givenName", "familyName");
+        assertThat(edited.getMethods()).extracting(Method::getName).containsExactly("displayName");
+        assertThat(new TypeDefBuilder(edited)
+                .hasMatchingProperty(property -> "givenName".equals(property.getName())))
+                .isTrue();
+        assertThat(new TypeDefBuilder(edited)
+                .buildMatchingProperty(property -> "familyName".equals(property.getName())))
+                .satisfies(property -> {
+                    assertThat(property.getName()).isEqualTo("familyName");
+                    assertThat(property.getTypeRef()).isEqualTo(STRING);
+                });
+    }
+
+    @Test
+    void rendersClassPrimitiveTypeParameterAndWildcardReferences() {
+        TypeParamDef key = new TypeParamDefBuilder()
+                .withName("K")
+                .withBounds(ClassRef.forName("java.lang.Comparable"))
+                .build();
+        TypeParamDef value = new TypeParamDefBuilder().withName("V").build();
+        TypeParamDef arrayItem = new TypeParamDefBuilder().withName("A").build();
+        WildcardRef superString = new WildcardRefBuilder()
+                .withBoundKind(WildcardRef.BoundKind.SUPER)
+                .withBounds(STRING)
+                .build();
+        WildcardRef extendsNumber = new WildcardRefBuilder()
+                .withBoundKind(WildcardRef.BoundKind.EXTENDS)
+                .withBounds(NUMBER)
+                .build();
+        TypeDef holder = new TypeDefBuilder()
+                .withKind(Kind.INTERFACE)
+                .withPackageName("example.generics")
+                .withName("Holder")
+                .withParameters(key, value, arrayItem)
+                .build();
+        PrimitiveRef intArray = INT.withDimensions(2);
+        ClassRef holderReference = holder
+                .toReference(key.toReference(), superString, intArray)
+                .withDimensions(1);
+        ClassRef rebuiltReference = new ClassRefBuilder(holderReference)
+                .setToArguments(1, extendsNumber)
+                .withDimensions(0)
+                .build();
+
+        assertThat(key.render()).contains("K").contains("Comparable");
+        assertThat(superString.render()).contains("? super").contains("String");
+        assertThat(extendsNumber.render()).contains("? extends").contains("Number");
+        assertThat(intArray.toString()).isEqualTo("int[][]");
+        assertThat(holderReference.getName()).contains("Holder");
+        assertThat(holderReference.getArguments()).extracting(Object::toString)
+                .containsExactly("K", "? super java.lang.String", "int[][]");
+        assertThat(rebuiltReference.getFullyQualifiedName()).isEqualTo("example.generics.Holder");
+        assertThat(rebuiltReference.getArguments()).extracting(Object::toString)
+                .containsExactly("K", "? extends java.lang.Number", "int[][]");
+        assertThat(rebuiltReference.render())
+                .contains("Holder")
+                .contains("? extends")
+                .contains("Number")
+                .contains("int[][]");
+    }
+
+    @Test
+    void rendersComposedExpressionsStatementsAndControlFlow() {
+        Property counter = Property.newProperty(INT, "counter");
+        PropertyRef counterRef = counter.toReference();
+        Expression increment = counterRef.plus(new ValueRef(1));
+        Assign assignment = counterRef.assign(increment);
+        If conditional = If.gt(counterRef, new ValueRef(0))
+                .then(Return.value("positive"))
+                .orElse(Return.Null());
+        While loop = While.lt(counterRef, new ValueRef(3))
+                .body(new PostIncrement(counterRef));
+        For forLoop = For.init(new Declare(counter, new ValueRef(0)))
+                .lt(counterRef, new ValueRef(2))
+                .update(new PostIncrement(counterRef))
+                .body(new StringStatement("visited(counter);"));
+        MethodCall appendCall = new Construct(ClassRef.forName("java.lang.StringBuilder"))
+                .call("append", new ValueRef("value"));
+        Ternary ternary = new Ternary(
+                new GreaterThan(counterRef, new ValueRef(1)),
+                new ValueRef("many"),
+                new ValueRef("one"));
+        Expression trimCall = Property.newProperty("item").toReference().call("trim");
+        Lambda lambda = new Lambda("item", trimCall);
+        NewArray array = new NewArray(STRING, 2);
+        Try guarded = new Try(
+                new Block(Throw.illegalArgument("bad input")),
+                List.of(new Try.Catch(
+                        Property.newProperty(
+                                ClassRef.forName("java.lang.IllegalArgumentException"),
+                                "exception"),
+                        new Block(Return.value("handled")))),
+                Optional.of(new Block(new Empty())));
+        Block block = new Block(
+                new Declare(counter, new ValueRef(0)),
+                assignment,
+                conditional,
+                loop,
+                forLoop,
+                new Return(appendCall),
+                new Return(ternary),
+                new Return(lambda),
+                new Return(array),
+                guarded);
+
+        String rendered = block.render();
+
+        assertThat(assignment.render()).contains("counter").contains("=").contains("+ 1");
+        assertThat(appendCall.render())
+                .contains("StringBuilder")
+                .contains("append")
+                .contains("value");
+        assertThat(ternary.render()).contains("?").contains(":");
+        assertThat(lambda.render()).contains("item").contains("->").contains("trim");
+        assertThat(array.render()).contains("String").contains("[2]");
+        assertThat(rendered)
+                .contains("if")
+                .contains("while")
+                .contains("for")
+                .contains("throw")
+                .contains("IllegalArgumentException")
+                .contains("catch")
+                .contains("finally")
+                .contains("handled");
+        assertThat(block.getReferences()).extracting(ClassRef::getFullyQualifiedName)
+                .contains(
+                        "java.lang.StringBuilder",
+                        "java.lang.IllegalArgumentException",
+                        "java.lang.String");
+    }
+
+    @Test
+    void propertiesMethodsModifiersValuesAndReferencesExposeConvenienceBehavior() {
+        AttributeKey<String> ownerAttribute = new AttributeKey<>("owner", String.class);
+        Property name = new PropertyBuilder()
+                .withModifiers(privateFinalModifiers())
+                .withTypeRef(STRING)
+                .withName("name")
+                .withInitialValue(new ValueRef("unknown"))
+                .addToAttributes(ownerAttribute, "model-test")
+                .build();
+        Method withVarArg = new MethodBuilder()
+                .withName("format")
+                .withReturnType(STRING)
+                .withArguments(Property.newProperty(STRING.withDimensions(1), "parts"))
+                .withVarArgPreferred()
+                .withExceptions(ClassRef.forName("java.io.IOException"))
+                .withBlock(new Block(new Return(new MethodCall(
+                        "join",
+                        STRING,
+                        new ValueRef(","),
+                        name.toReference()))))
+                .build();
+        Property erasedName = name.withErasure();
+        Property initializedName = name.withoutInitialValue().withInitialValue("created");
+        Modifiers modifiersFromInt = Modifiers.from(publicModifiers().toInt());
+
+        assertThat(name.hasAttribute(ownerAttribute)).isTrue();
+        assertThat(name.getAttribute(ownerAttribute)).isEqualTo("model-test");
+        assertThat(name.getInitialValue())
+                .hasValueSatisfying(value -> assertThat(value.render()).contains("unknown"));
+        assertThat(erasedName.getErasure()).isEqualTo(name.getErasure());
+        assertThat(initializedName.getInitialValue())
+                .hasValueSatisfying(value -> assertThat(value.render()).contains("created"));
+        assertThat(name.toReference().render()).isEqualTo("name");
+        assertThat(withVarArg.isVarArgPreferred()).isTrue();
+        assertThat(withVarArg.getSignature()).contains("format").contains("String");
+        assertThat(withVarArg.getReferences()).extracting(ClassRef::getFullyQualifiedName)
+                .contains("java.lang.String", "java.io.IOException");
+        assertThat(modifiersFromInt).isEqualTo(publicModifiers());
+        assertThat(modifiersFromInt.isPublic()).isTrue();
+        assertThat(Modifiers.create()).isEqualTo(new Modifiers());
+        assertThat(ValueRef.from("a", "b").render()).contains("a").contains("b");
+        assertThat(ValueRef.NULL.render()).isEqualTo("null");
+    }
+
+    private static Modifiers publicModifiers() {
+        return new Modifiers(false, false, true, false, false, false, false, false, false);
+    }
+
+    private static Modifiers privateFinalModifiers() {
+        return new Modifiers(true, false, false, false, true, false, false, false, false);
     }
 }

--- a/tests/src/io.sundr/sundr-model/0.230.1/src/test/java/io_sundr/sundr_model/Sundr_modelTest.java
+++ b/tests/src/io.sundr/sundr-model/0.230.1/src/test/java/io_sundr/sundr_model/Sundr_modelTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_sundr.sundr_model;
+
+import org.junit.jupiter.api.Test;
+
+class Sundr_modelTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.sundr/sundr-model/0.230.1/src/test/java/io_sundr/sundr_model/Sundr_modelTest.java
+++ b/tests/src/io.sundr/sundr-model/0.230.1/src/test/java/io_sundr/sundr_model/Sundr_modelTest.java
@@ -117,7 +117,7 @@ public class Sundr_modelTest {
         assertThat(box.getProperties()).containsExactly(value);
         assertThat(box.getMethods()).containsExactly(getter);
         assertThat(box.getInnerTypes()).containsExactly(nested);
-        assertThat(box.getAnnotations()).containsExactly(generated);
+        assertThat(box).extracting(TypeDef::getAnnotations).isEqualTo(List.of(generated));
         assertThat(box.getImports()).contains("java.io.Serializable");
         assertThat(box.getReferences()).extracting(ClassRef::getFullyQualifiedName)
                 .contains("java.io.Serializable");

--- a/tests/src/io.sundr/sundr-model/0.230.1/src/test/java/io_sundr/sundr_model/Sundr_modelTest.java
+++ b/tests/src/io.sundr/sundr-model/0.230.1/src/test/java/io_sundr/sundr_model/Sundr_modelTest.java
@@ -13,13 +13,17 @@ import io.sundr.model.AnnotationRefBuilder;
 import io.sundr.model.Assign;
 import io.sundr.model.AttributeKey;
 import io.sundr.model.Block;
+import io.sundr.model.Break;
 import io.sundr.model.ClassRef;
 import io.sundr.model.ClassRefBuilder;
 import io.sundr.model.Construct;
+import io.sundr.model.Continue;
 import io.sundr.model.Declare;
+import io.sundr.model.Do;
 import io.sundr.model.Empty;
 import io.sundr.model.Expression;
 import io.sundr.model.For;
+import io.sundr.model.Foreach;
 import io.sundr.model.GreaterThan;
 import io.sundr.model.If;
 import io.sundr.model.Kind;
@@ -36,6 +40,8 @@ import io.sundr.model.PropertyBuilder;
 import io.sundr.model.PropertyRef;
 import io.sundr.model.Return;
 import io.sundr.model.StringStatement;
+import io.sundr.model.Switch;
+import io.sundr.model.Synchronized;
 import io.sundr.model.Ternary;
 import io.sundr.model.Throw;
 import io.sundr.model.Try;
@@ -47,6 +53,7 @@ import io.sundr.model.ValueRef;
 import io.sundr.model.While;
 import io.sundr.model.WildcardRef;
 import io.sundr.model.WildcardRefBuilder;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -283,6 +290,66 @@ public class Sundr_modelTest {
                         "java.lang.StringBuilder",
                         "java.lang.IllegalArgumentException",
                         "java.lang.String");
+    }
+
+    @Test
+    void rendersAdditionalStructuredStatements() {
+        Property state = Property.newProperty(STRING, "state");
+        Property name = Property.newProperty(STRING, "name");
+        Property names = Property.newProperty(ClassRef.forName("java.util.List"), "names");
+        Block startBlock = new Block(new Return(new ValueRef("ready")));
+        Block stopBlock = new Block(new Break());
+        Block defaultBlock = new Block(new Return(new ValueRef("unknown")));
+        ValueRef startCase = new ValueRef("start");
+        ValueRef stopCase = new ValueRef("stop");
+        Map<ValueRef, Block> cases = new LinkedHashMap<>();
+        cases.put(startCase, startBlock);
+        cases.put(stopCase, stopBlock);
+        ValueRef keepRunning = new ValueRef(false);
+
+        Switch switchStatement = new Switch(state.toReference(), cases, Optional.of(defaultBlock));
+        Foreach foreach = new Foreach(name, names, new Continue());
+        Synchronized synchronizedStatement = Synchronized.on(Property.newProperty("lock").toReference())
+                .body(foreach, switchStatement);
+        Do doStatement = new Do(keepRunning, synchronizedStatement);
+
+        String switchRender = switchStatement.render();
+        String foreachRender = foreach.render();
+        String synchronizedRender = synchronizedStatement.render();
+        String doRender = doStatement.render();
+
+        assertThat(switchStatement.getExpression().render()).isEqualTo("state");
+        assertThat(switchStatement.getCases()).containsEntry(startCase, startBlock);
+        assertThat(switchStatement.getDefaultCase()).hasValue(defaultBlock);
+        assertThat(switchRender)
+                .contains("switch")
+                .contains("case")
+                .contains("default")
+                .contains("break;")
+                .contains("ready")
+                .contains("unknown");
+        assertThat(foreach.getDeclare().getProperties()).containsExactly(name);
+        assertThat(foreach.getExpression()).isEqualTo(names);
+        assertThat(foreachRender)
+                .contains("for")
+                .contains("String")
+                .contains("name")
+                .contains("names")
+                .contains("continue;");
+        assertThat(synchronizedStatement.getLockExpression().render()).isEqualTo("lock");
+        assertThat(synchronizedRender)
+                .contains("synchronized")
+                .contains("lock")
+                .contains("switch")
+                .contains("continue;");
+        assertThat(doStatement.getCondition()).isEqualTo(keepRunning);
+        assertThat(doRender)
+                .contains("do")
+                .contains("synchronized")
+                .contains("while")
+                .contains("false");
+        assertThat(doStatement.getReferences()).extracting(ClassRef::getFullyQualifiedName)
+                .contains("java.lang.String", "java.util.List");
     }
 
     @Test

--- a/tests/src/io.sundr/sundr-model/0.230.1/src/test/java/io_sundr/sundr_model/Sundr_modelTest.java
+++ b/tests/src/io.sundr/sundr-model/0.230.1/src/test/java/io_sundr/sundr_model/Sundr_modelTest.java
@@ -397,6 +397,42 @@ public class Sundr_modelTest {
         assertThat(ValueRef.NULL.render()).isEqualTo("null");
     }
 
+    @Test
+    void rendersDefaultInterfaceMethodsWithExecutableBlocks() {
+        Method displayName = new MethodBuilder()
+                .withDefaultMethod()
+                .withName("displayName")
+                .withReturnType(STRING)
+                .withBlock(new Block(Return.value("anonymous")))
+                .build();
+        TypeDef named = new TypeDefBuilder()
+                .withKind(Kind.INTERFACE)
+                .withPackageName("example.api")
+                .withName("Named")
+                .withMethods(displayName)
+                .build();
+
+        String methodRender = displayName.render(named);
+        String typeRender = named.render();
+
+        assertThat(displayName.isDefaultMethod()).isTrue();
+        assertThat(methodRender)
+                .contains("default")
+                .contains("String")
+                .contains("displayName()")
+                .contains("return")
+                .contains("anonymous")
+                .contains("{")
+                .contains("}");
+        assertThat(typeRender)
+                .contains("interface Named")
+                .contains("default String displayName()")
+                .contains("anonymous")
+                .doesNotContain("class Named");
+        assertThat(displayName.getReferences()).extracting(ClassRef::getFullyQualifiedName)
+                .containsExactly("java.lang.String");
+    }
+
     private static Modifiers publicModifiers() {
         return new Modifiers(false, false, true, false, false, false, false, false, false);
     }

--- a/tests/src/io.sundr/sundr-model/0.230.1/user-code-filter.json
+++ b/tests/src/io.sundr/sundr-model/0.230.1/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.sundr.model.**"
+      "includeClasses" : "io.sundr.model.**"
+    },
+    {
+      "includeClasses" : "io_sundr.sundr_model.**"
     }
   ]
 }

--- a/tests/src/io.sundr/sundr-model/0.230.1/user-code-filter.json
+++ b/tests/src/io.sundr/sundr-model/0.230.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.sundr.model.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #7788

This PR introduces tests and metadata for io.sundr:sundr-model:0.230.1, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 348697
- Cached input tokens: 5934592
- Output tokens: 33507
- Metadata entries: 156
- Iterations: 7
- Library coverage percentage: 3.27
- Generated lines of code: 415
- Tested library lines of code: 922

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `215d4ea178a80532278dc617669eb345d769f9cb`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 3975/142360 (2.79%)
- Line: 922/28172 (3.27%)
- Method: 264/15245 (1.73%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
