### PR TITLE
[Automation] Generated metadata for org.eclipse.jdt:ecj:3.32.0

### DIFF
--- a/metadata/org.eclipse.jdt/ecj/index.json
+++ b/metadata/org.eclipse.jdt/ecj/index.json
@@ -5,7 +5,7 @@
     "test-version" : "3.26.0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/eclipse/jdt/ecj/$version$/ecj-$version$-sources.jar",
     "repository-url" : "https://github.com/eclipse-jdt/eclipse.jdt.core",
-    "test-code-url" : "https://github.com/eclipse-jdt/eclipse.jdt.core/tree/R4_26/org.eclipse.jdt.core.tests.compiler",
+    "test-code-url" : "N/A",
     "documentation-url" : "https://repo1.maven.org/maven2/org/eclipse/jdt/ecj/$version$/ecj-$version$-javadoc.jar",
     "description" : "Eclipse Compiler for Java (ECJ) is the Java compiler implementation from the Eclipse JDT project, packaged for standalone use through Maven. It can compile Java source programmatically or from the command line and includes Eclipse's incremental compiler and batch compiler infrastructure.",
     "tested-versions" : [

--- a/stats/org.eclipse.jdt/ecj/3.32.0/stats.json
+++ b/stats/org.eclipse.jdt/ecj/3.32.0/stats.json
@@ -20,15 +20,15 @@
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 55577,
-        "missed" : 486947,
-        "ratio" : 0.102442,
+        "covered" : 55557,
+        "missed" : 486967,
+        "ratio" : 0.102405,
         "total" : 542524
       },
       "line" : {
-        "covered" : 12837,
-        "missed" : 110496,
-        "ratio" : 0.104084,
+        "covered" : 12835,
+        "missed" : 110498,
+        "ratio" : 0.104068,
         "total" : 123333
       },
       "method" : {


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7352

This PR provides new metadata needed for the org.eclipse.jdt:ecj:3.32.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.eclipse.jdt:ecj:3.26.0`): 1319
- Test-only metadata entries (previous `org.eclipse.jdt:ecj:3.26.0`): 17
- Metadata entries (new `org.eclipse.jdt:ecj:3.32.0`): 1363
- Test-only metadata entries (new `org.eclipse.jdt:ecj:3.32.0`): 17
- Library coverage (previous): 10.59%
- Library coverage (new): 10.41%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `b1781a513e2701312248807c2883fd09be9de214`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.eclipse.jdt:ecj:3.26.0: 55/55 covered calls (100.00%)
- org.eclipse.jdt:ecj:3.32.0: 56/56 covered calls (100.00%)

**Reflection:**
- org.eclipse.jdt:ecj:3.26.0: 29/29 covered calls (100.00%)
- org.eclipse.jdt:ecj:3.32.0: 30/30 covered calls (100.00%)

**Resources:**
- org.eclipse.jdt:ecj:3.26.0: 26/26 covered calls (100.00%)
- org.eclipse.jdt:ecj:3.32.0: 26/26 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.eclipse.jdt:ecj:3.26.0: 54997/528913 (10.40%)
- org.eclipse.jdt:ecj:3.32.0: 55557/542524 (10.24%)

**Line:**
- org.eclipse.jdt:ecj:3.26.0: 12705/119999 (10.59%)
- org.eclipse.jdt:ecj:3.32.0: 12835/123333 (10.41%)

**Method:**
- org.eclipse.jdt:ecj:3.26.0: 1630/10738 (15.18%)
- org.eclipse.jdt:ecj:3.32.0: 1682/11218 (14.99%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
