### PR TITLE
[Automation] Generated metadata for org.eclipse.jdt:ecj:3.29.0

### DIFF
--- a/metadata/org.eclipse.jdt/ecj/3.29.0/reachability-metadata.json
+++ b/metadata/org.eclipse.jdt/ecj/3.29.0/reachability-metadata.json
@@ -4174,6 +4174,12 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.eclipse.jdt.internal.compiler.tool.JrtFileSystem"
+      },
+      "glob" : "META-INF/services/java.nio.file.spi.FileSystemProvider"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.eclipse.jdt.internal.compiler.batch.Main$ResourceBundleFactory"
       },
       "glob" : "META-INF/services/java.util.spi.ResourceBundleControlProvider"

--- a/stats/org.eclipse.jdt/ecj/3.29.0/stats.json
+++ b/stats/org.eclipse.jdt/ecj/3.29.0/stats.json
@@ -20,15 +20,15 @@
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 55373,
-        "missed" : 478134,
-        "ratio" : 0.103791,
+        "covered" : 55332,
+        "missed" : 478175,
+        "ratio" : 0.103714,
         "total" : 533507
       },
       "line" : {
-        "covered" : 12778,
-        "missed" : 108253,
-        "ratio" : 0.105576,
+        "covered" : 12770,
+        "missed" : 108261,
+        "ratio" : 0.10551,
         "total" : 121031
       },
       "method" : {


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7350

This PR provides new metadata needed for the org.eclipse.jdt:ecj:3.29.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.eclipse.jdt:ecj:3.26.0`): 1319
- Test-only metadata entries (previous `org.eclipse.jdt:ecj:3.26.0`): 17
- Metadata entries (new `org.eclipse.jdt:ecj:3.29.0`): 1349
- Test-only metadata entries (new `org.eclipse.jdt:ecj:3.29.0`): 17
- Library coverage (previous): 10.59%
- Library coverage (new): 10.55%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `18cf6df6216c15ddd57866924db5d8f8dabc4aca`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.eclipse.jdt:ecj:3.26.0: 55/55 covered calls (100.00%)
- org.eclipse.jdt:ecj:3.29.0: 56/56 covered calls (100.00%)

**Reflection:**
- org.eclipse.jdt:ecj:3.26.0: 29/29 covered calls (100.00%)
- org.eclipse.jdt:ecj:3.29.0: 30/30 covered calls (100.00%)

**Resources:**
- org.eclipse.jdt:ecj:3.26.0: 26/26 covered calls (100.00%)
- org.eclipse.jdt:ecj:3.29.0: 26/26 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.eclipse.jdt:ecj:3.26.0: 54997/528913 (10.40%)
- org.eclipse.jdt:ecj:3.29.0: 55332/533507 (10.37%)

**Line:**
- org.eclipse.jdt:ecj:3.26.0: 12705/119999 (10.59%)
- org.eclipse.jdt:ecj:3.29.0: 12770/121031 (10.55%)

**Method:**
- org.eclipse.jdt:ecj:3.26.0: 1630/10738 (15.18%)
- org.eclipse.jdt:ecj:3.29.0: 1670/11050 (15.11%)

### Local CI Verification

- Status: `success`
- Commands run: 0
- Fixup attempts: 0
