### PR TITLE
[Automation] Generated metadata for org.junit.jupiter:junit-jupiter-engine:6.1.0

### DIFF
--- a/metadata/com.alibaba/fastjson/1.2.83_noneautotype/reachability-metadata.json
+++ b/metadata/com.alibaba/fastjson/1.2.83_noneautotype/reachability-metadata.json
@@ -1,0 +1,2442 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.ASMClassLoader"
+      },
+      "type": "com.alibaba.fastjson.JSON"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.JSONObject"
+      },
+      "type": "com.alibaba.fastjson.JSONObject",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JSONObjectInnerSecureObjectInputStreamTest"
+      },
+      "type": "com.alibaba.fastjson.JSONObject",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.TypeReference"
+      },
+      "type": "com.alibaba.fastjson.TypeReference"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "com.alibaba.fastjson.parser.Feature[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.parser.deserializer.ASMDeserializerFactory"
+      },
+      "type": "com.alibaba.fastjson.parser.deserializer.FastjsonASMDeserializer_1_AsmBackedBean",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.alibaba.fastjson.parser.ParserConfig",
+            "com.alibaba.fastjson.util.JavaBeanInfo"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.serializer.ASMSerializerFactory"
+      },
+      "type": "com.alibaba.fastjson.serializer.ASMSerializer_1_AsmSerializedBean",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.alibaba.fastjson.serializer.SerializeBeanInfo"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "com.alibaba.fastjson.serializer.SerializerFeature[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.AntiCollisionHashMap"
+      },
+      "type": "com.alibaba.fastjson.util.AntiCollisionHashMap",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.AntiCollisionHashMapTest"
+      },
+      "type": "com.alibaba.fastjson.util.AntiCollisionHashMap",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "com.fasterxml.jackson.annotation.JsonCreator"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.parser.ParserConfig"
+      },
+      "type": "com.google.common.collect.HashMultimap"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.serializer.SerializeConfig"
+      },
+      "type": "com.google.common.collect.HashMultimap"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.ParserConfigTest"
+      },
+      "type": "com.google.common.collect.HashMultimap"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.SerializeConfigTest"
+      },
+      "type": "com.google.common.collect.HashMultimap"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.parser.deserializer.JavaBeanDeserializer"
+      },
+      "type": "com_alibaba.fastjson.ASMDeserializerFactoryTest$AsmBackedBean",
+      "fields": [
+        {
+          "name": "enabled"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.ASMDeserializerFactoryTest"
+      },
+      "type": "com_alibaba.fastjson.ASMDeserializerFactoryTest$AsmBackedBean"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "com_alibaba.fastjson.ASMSerializerFactoryTest$AsmSerializedBean"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.ASMUtils"
+      },
+      "type": "com_alibaba.fastjson.ASMUtilsTest$GenericValueProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.serializer.AnnotationSerializer"
+      },
+      "type": "com_alibaba.fastjson.AnnotationSerializerTest$SerializedAnnotation",
+      "methods": [
+        {
+          "name": "name",
+          "parameterTypes": []
+        },
+        {
+          "name": "priority",
+          "parameterTypes": []
+        },
+        {
+          "name": "status",
+          "parameterTypes": []
+        },
+        {
+          "name": "tags",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.DefaultFieldDeserializerTest"
+      },
+      "type": "com_alibaba.fastjson.DefaultFieldDeserializerTest$BeanWithCustomFieldDeserializer",
+      "fields": [
+        {
+          "name": "value"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.DefaultFieldDeserializerTest"
+      },
+      "type": "com_alibaba.fastjson.DefaultFieldDeserializerTest$PrefixingDeserializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.parser.deserializer.EnumDeserializer"
+      },
+      "type": "com_alibaba.fastjson.EnumDeserializerTest$WireStatus"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.EnumDeserializerTest"
+      },
+      "type": "com_alibaba.fastjson.EnumDeserializerTest$WireStatus"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.parser.deserializer.ArrayListTypeFieldDeserializer"
+      },
+      "type": "com_alibaba.fastjson.FieldDeserializerTest$FinalFieldPropertiesBean",
+      "fields": [
+        {
+          "name": "tags"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.FieldDeserializerTest"
+      },
+      "type": "com_alibaba.fastjson.FieldDeserializerTest$FinalFieldPropertiesBean",
+      "fields": [
+        {
+          "name": "attributes"
+        },
+        {
+          "name": "enabled"
+        },
+        {
+          "name": "intValue"
+        },
+        {
+          "name": "longValue"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.FieldDeserializerTest"
+      },
+      "type": "com_alibaba.fastjson.FieldDeserializerTest$GetterOnlyPropertiesBean",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "getAttributes",
+          "parameterTypes": []
+        },
+        {
+          "name": "getEnabled",
+          "parameterTypes": []
+        },
+        {
+          "name": "getIntValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "getLongValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "getTags",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.parser.deserializer.FieldDeserializer"
+      },
+      "type": "com_alibaba.fastjson.FieldDeserializerTest$NullMapGetterBean",
+      "fields": [
+        {
+          "name": "settings"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.FieldDeserializerTest"
+      },
+      "type": "com_alibaba.fastjson.FieldDeserializerTest$NullMapGetterBean",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "getSettings",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.FieldDeserializerTest"
+      },
+      "type": "com_alibaba.fastjson.FieldDeserializerTest$SetterFallbackBean",
+      "methods": [
+        {
+          "name": "getCounter",
+          "parameterTypes": []
+        },
+        {
+          "name": "setCounter",
+          "parameterTypes": [
+            "java.util.concurrent.atomic.AtomicInteger"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.FieldInfoTest"
+      },
+      "type": "com_alibaba.fastjson.FieldInfoTest$FieldBackedBean",
+      "fields": [
+        {
+          "name": "name"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.FieldInfoTest"
+      },
+      "type": "com_alibaba.fastjson.FieldInfoTest$GenericArrayBean",
+      "fields": [
+        {
+          "name": "values"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.FieldInfoTest"
+      },
+      "type": "com_alibaba.fastjson.FieldInfoTest$GetterBackedBean",
+      "methods": [
+        {
+          "name": "getName",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.FieldInfoTest"
+      },
+      "type": "com_alibaba.fastjson.FieldInfoTest$SetterBackedBean",
+      "methods": [
+        {
+          "name": "setName",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.FieldSerializerTest"
+      },
+      "type": "com_alibaba.fastjson.FieldSerializerTest$BeanWithCustomFieldSerializer",
+      "fields": [
+        {
+          "name": "value"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.serializer.FieldSerializer"
+      },
+      "type": "com_alibaba.fastjson.FieldSerializerTest$PrefixingStringSerializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JSONObjectInnerSecureObjectInputStreamTest"
+      },
+      "type": "com_alibaba.fastjson.JSONObjectInnerSecureObjectInputStreamTest$EmptyMapInvocationHandler",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanDeserializerTest"
+      },
+      "type": "com_alibaba.fastjson.JavaBeanDeserializerTest$AutoTypeCheckedBean",
+      "fields": [
+        {
+          "name": "name"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanDeserializerTest"
+      },
+      "type": "com_alibaba.fastjson.JavaBeanDeserializerTest$BuilderBackedBean"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanDeserializerTest"
+      },
+      "type": "com_alibaba.fastjson.JavaBeanDeserializerTest$BuilderBackedBean$Builder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "withName",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanDeserializerTest"
+      },
+      "type": "com_alibaba.fastjson.JavaBeanDeserializerTest$CreatorConstructorBean",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanDeserializerTest"
+      },
+      "type": "com_alibaba.fastjson.JavaBeanDeserializerTest$CreatorFactoryBean",
+      "methods": [
+        {
+          "name": "create",
+          "parameterTypes": [
+            "java.lang.String",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanDeserializerTest"
+      },
+      "type": "com_alibaba.fastjson.JavaBeanDeserializerTest$FactoryDefaultBean",
+      "methods": [
+        {
+          "name": "create",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanDeserializerTest"
+      },
+      "type": "com_alibaba.fastjson.JavaBeanDeserializerTest$KotlinLikeBean",
+      "fields": [
+        {
+          "name": "number"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanDeserializerTest"
+      },
+      "type": "com_alibaba.fastjson.JavaBeanDeserializerTest$MapBackedFieldsBean",
+      "fields": [
+        {
+          "name": "name"
+        },
+        {
+          "name": "reference"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanDeserializerTest"
+      },
+      "type": "com_alibaba.fastjson.JavaBeanDeserializerTest$NestedValueBean",
+      "fields": [
+        {
+          "name": "nestedName"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanDeserializerTest"
+      },
+      "type": "com_alibaba.fastjson.JavaBeanDeserializerTest$OuterBean",
+      "fields": [
+        {
+          "name": "inner"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanDeserializerTest"
+      },
+      "type": "com_alibaba.fastjson.JavaBeanDeserializerTest$OuterBean$InnerBean",
+      "fields": [
+        {
+          "name": "value"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com_alibaba.fastjson.JavaBeanDeserializerTest$OuterBean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanDeserializerTest"
+      },
+      "type": "com_alibaba.fastjson.JavaBeanDeserializerTest$PrimitiveDirectFieldsBean",
+      "fields": [
+        {
+          "name": "doubleNumber"
+        },
+        {
+          "name": "doubleString"
+        },
+        {
+          "name": "falseValue"
+        },
+        {
+          "name": "floatNumber"
+        },
+        {
+          "name": "floatString"
+        },
+        {
+          "name": "intValue"
+        },
+        {
+          "name": "longValue"
+        },
+        {
+          "name": "trueValue"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanDeserializerTest"
+      },
+      "type": "com_alibaba.fastjson.JavaBeanDeserializerTest$PrivateFieldBean",
+      "fields": [
+        {
+          "name": "hidden"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanDeserializerTest"
+      },
+      "type": "com_alibaba.fastjson.JavaBeanDeserializerTest$ProxyView"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.parser.deserializer.JavaBeanDeserializer"
+      },
+      "type": "com_alibaba.fastjson.JavaBeanDeserializerTest$RecordingAutoTypeCheckHandler",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.parser.deserializer.JavaBeanDeserializer"
+      },
+      "type": "com_alibaba.fastjson.JavaBeanDeserializerTest$SingleValueFactoryBean",
+      "methods": [
+        {
+          "name": "create",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanDeserializerTest"
+      },
+      "type": "com_alibaba.fastjson.JavaBeanDeserializerTest$SingleValueFactoryBean"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanDeserializerTest"
+      },
+      "type": "com_alibaba.fastjson.JavaBeanDeserializerTest$UnwrappedMapContainer",
+      "fields": [
+        {
+          "name": "values"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanDeserializerTest"
+      },
+      "type": "com_alibaba.fastjson.JavaBeanDeserializerTest$UnwrappedMethodContainer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "put",
+          "parameterTypes": [
+            "java.lang.String",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanDeserializerTest"
+      },
+      "type": "com_alibaba.fastjson.JavaBeanDeserializerTest$UnwrappedNestedContainer",
+      "fields": [
+        {
+          "name": "nested"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanInfoTest"
+      },
+      "type": "com_alibaba.fastjson.JavaBeanInfoTest$CreateOnlyBuilderBean"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanInfoTest"
+      },
+      "type": "com_alibaba.fastjson.JavaBeanInfoTest$CreateOnlyBuilderBean$Builder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "create",
+          "parameterTypes": []
+        },
+        {
+          "name": "withName",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanInfoTest"
+      },
+      "type": "com_alibaba.fastjson.JavaBeanInfoTest$FieldBasedBaseBean",
+      "fields": [
+        {
+          "name": "baseName"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanInfoTest"
+      },
+      "type": "com_alibaba.fastjson.JavaBeanInfoTest$FieldBasedChildBean",
+      "fields": [
+        {
+          "name": "childValue"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanInfoTest"
+      },
+      "type": "com_alibaba.fastjson.JavaBeanInfoTest$MixinConstructedBean",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.FieldInfo"
+      },
+      "type": "com_alibaba.fastjson.JavaBeanInfoTest$MixinConstructedBeanMixin"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanInfoTest"
+      },
+      "type": "com_alibaba.fastjson.JavaBeanInfoTest$MixinConstructedBeanMixin"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanSerializerTest"
+      },
+      "type": "com_alibaba.fastjson.JavaBeanSerializerTest$BeanWithJsonTypeFilter",
+      "fields": [
+        {
+          "name": "value"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanSerializerTest"
+      },
+      "type": "com_alibaba.fastjson.JavaBeanSerializerTest$PrefixValueFilter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.parser.deserializer.MapDeserializer"
+      },
+      "type": "com_alibaba.fastjson.MapDeserializerTest$CustomMap",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.parser.deserializer.EnumCreatorDeserializer"
+      },
+      "type": "com_alibaba.fastjson.ParserConfigTest$CreatorEnum",
+      "methods": [
+        {
+          "name": "fromJson",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.ParserConfigTest"
+      },
+      "type": "com_alibaba.fastjson.ParserConfigTest$CreatorEnum"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.ParserConfigTest"
+      },
+      "type": "com_alibaba.fastjson.ParserConfigTest$CustomBeanDeserializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.ParserConfigTest"
+      },
+      "type": "com_alibaba.fastjson.ParserConfigTest$CustomEnumDeserializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.parser.deserializer.EnumCreatorDeserializer"
+      },
+      "type": "com_alibaba.fastjson.ParserConfigTest$MixInCreatorEnum",
+      "methods": [
+        {
+          "name": "fromJson",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.ParserConfigTest"
+      },
+      "type": "com_alibaba.fastjson.ParserConfigTest$MixInCreatorEnum"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.ParserConfigTest"
+      },
+      "type": "com_alibaba.fastjson.ParserConfigTest$MixInCreatorEnumMixin"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.parser.deserializer.PropertyProcessableDeserializer"
+      },
+      "type": "com_alibaba.fastjson.PropertyProcessableDeserializerTest$PropertyProcessableBean",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.serializer.EnumSerializer"
+      },
+      "type": "com_alibaba.fastjson.SerializeConfigTest$AnnotatedFieldEnum",
+      "fields": [
+        {
+          "name": "code"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.serializer.SerializeConfig"
+      },
+      "type": "com_alibaba.fastjson.SerializeConfigTest$AnnotatedFieldEnum"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.SerializeConfigTest"
+      },
+      "type": "com_alibaba.fastjson.SerializeConfigTest$BeanWithCustomSerializer"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.SerializeConfigTest"
+      },
+      "type": "com_alibaba.fastjson.SerializeConfigTest$CustomObjectSerializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.serializer.EnumSerializer"
+      },
+      "type": "com_alibaba.fastjson.SerializeConfigTest$MixInEnum",
+      "methods": [
+        {
+          "name": "getCode",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.SerializeConfigTest"
+      },
+      "type": "com_alibaba.fastjson.SerializeConfigTest$MixInEnum"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.serializer.SerializeConfig"
+      },
+      "type": "com_alibaba.fastjson.SerializeConfigTest$MixInEnumMixin"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.ServiceLoaderTest"
+      },
+      "type": "com_alibaba.fastjson.ServiceLoaderTest$DiscoveredService",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.ThrowableDeserializerTest"
+      },
+      "type": "com_alibaba.fastjson.ThrowableDeserializerTest$CauseOnlyException",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String",
+            "java.lang.Throwable"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.ThrowableDeserializerTest"
+      },
+      "type": "com_alibaba.fastjson.ThrowableDeserializerTest$DefaultOnlyException",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.ThrowableDeserializerTest"
+      },
+      "type": "com_alibaba.fastjson.ThrowableDeserializerTest$MessageOnlyException",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.TypeUtilsTest"
+      },
+      "type": "com_alibaba.fastjson.TopLevelConstructorAnnotationMixin"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "com_alibaba.fastjson.TypeUtilsTest$AbstractAnnotatedProperty"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "com_alibaba.fastjson.TypeUtilsTest$AnnotatedPropertyInterface"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.TypeUtilsTest"
+      },
+      "type": "com_alibaba.fastjson.TypeUtilsTest$BaseFieldBean"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.TypeUtilsTest"
+      },
+      "type": "com_alibaba.fastjson.TypeUtilsTest$ChildFieldBean"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "com_alibaba.fastjson.TypeUtilsTest$ConcreteAnnotatedBean"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.TypeUtilsTest"
+      },
+      "type": "com_alibaba.fastjson.TypeUtilsTest$ConstructorAnnotationTarget"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "com_alibaba.fastjson.TypeUtilsTest$CustomCalendar",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "com_alibaba.fastjson.TypeUtilsTest$CustomCollection",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "com_alibaba.fastjson.TypeUtilsTest$CustomSet",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.TypeUtilsTest"
+      },
+      "type": "com_alibaba.fastjson.TypeUtilsTest$FieldAnnotationMixin"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.TypeUtilsTest"
+      },
+      "type": "com_alibaba.fastjson.TypeUtilsTest$FieldAnnotationTarget"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "com_alibaba.fastjson.TypeUtilsTest$FieldBasedBean"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.TypeUtilsTest"
+      },
+      "type": "com_alibaba.fastjson.TypeUtilsTest$InnerConstructorAnnotationMixin"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.TypeUtilsTest"
+      },
+      "type": "com_alibaba.fastjson.TypeUtilsTest$InnerConstructorAnnotationTarget"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.TypeUtilsTest"
+      },
+      "type": "com_alibaba.fastjson.TypeUtilsTest$MethodAnnotationMixin"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.TypeUtilsTest"
+      },
+      "type": "com_alibaba.fastjson.TypeUtilsTest$MethodAnnotationTarget"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.TypeUtilsTest"
+      },
+      "type": "com_alibaba.fastjson.TypeUtilsTest$MethodParameterMixin"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.TypeUtilsTest"
+      },
+      "type": "com_alibaba.fastjson.TypeUtilsTest$MethodParameterTarget"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.TypeUtilsTest$ResolvingClassLoader"
+      },
+      "type": "example.Year"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "int[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.parser.ParserConfig"
+      },
+      "type": "java.awt.Point"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.serializer.SerializeConfig"
+      },
+      "type": "java.awt.Point"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.ParserConfigTest"
+      },
+      "type": "java.awt.Point"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.SerializeConfigTest"
+      },
+      "type": "java.awt.Point"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "java.beans.Transient"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "java.io.Serializable"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "java.lang.AutoCloseable"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanInfoTest"
+      },
+      "type": "java.lang.ClassValue"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.parser.deserializer.ThrowableDeserializer"
+      },
+      "type": "java.lang.Exception"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.AntiCollisionHashMap"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanInfoTest"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.IOUtils$1"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.AntiCollisionHashMap"
+      },
+      "type": "java.lang.String",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.JSONPath"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.serializer.ObjectArrayCodec"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.FieldInfoTest"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.parser.deserializer.ThrowableDeserializer"
+      },
+      "type": "java.lang.Throwable"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "java.lang.annotation.Annotation[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "java.lang.annotation.Annotation[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "java.lang.annotation.ElementType[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.JavaBeanInfo"
+      },
+      "type": "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.JavaBeanInfo"
+      },
+      "type": "java.lang.reflect.Field[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.JavaBeanInfo"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.JSONObject"
+      },
+      "type": "java.lang.reflect.Proxy",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JSONObjectInnerSecureObjectInputStreamTest"
+      },
+      "type": "java.lang.reflect.Proxy",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "java.nio.file.Path"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.serializer.MiscCodec"
+      },
+      "type": "java.nio.file.Paths",
+      "methods": [
+        {
+          "name": "get",
+          "parameterTypes": [
+            "java.lang.String",
+            "java.lang.String[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "java.nio.file.Paths"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.ModuleUtil"
+      },
+      "type": "java.sql.Time"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.parser.ParserConfig"
+      },
+      "type": "java.time.LocalDate"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.serializer.SerializeConfig"
+      },
+      "type": "java.time.LocalDate"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.ParserConfigTest"
+      },
+      "type": "java.time.LocalDate"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.SerializeConfigTest"
+      },
+      "type": "java.time.LocalDate"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "java.time.LocalTime"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.TypeUtilsTest"
+      },
+      "type": "java.time.LocalTime"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "java.time.LocalTime[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.TypeUtilsTest"
+      },
+      "type": "java.time.LocalTime[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.TypeUtilsTest$ResolvingClassLoader"
+      },
+      "type": "java.time.MonthDay"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "java.time.YearMonth"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.TypeUtilsTest"
+      },
+      "type": "java.time.YearMonth"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.parser.deserializer.Jdk8DateCodec"
+      },
+      "type": "java.time.format.DateTimeFormatterBuilder$DateTimePrinterParser[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.FieldInfo"
+      },
+      "type": "java.util.Collection"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "java.util.Deque"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.parser.DefaultJSONParser"
+      },
+      "type": "java.util.HashMap",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.parser.deserializer.JavaObjectDeserializer"
+      },
+      "type": "java.util.List[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.FieldInfo"
+      },
+      "type": "java.util.Map"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "java.util.Optional",
+      "methods": [
+        {
+          "name": "empty",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.parser.ParserConfig"
+      },
+      "type": "java.util.OptionalInt"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.serializer.SerializeConfig"
+      },
+      "type": "java.util.OptionalInt"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.ParserConfigTest"
+      },
+      "type": "java.util.OptionalInt"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.SerializeConfigTest"
+      },
+      "type": "java.util.OptionalInt"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "java.util.SequencedCollection"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.parser.JSONLexerBase"
+      },
+      "type": "java.util.TreeSet",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.serializer.SerializeConfig"
+      },
+      "type": "java.util.concurrent.atomic.LongAdder"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.SerializeConfigTest"
+      },
+      "type": "java.util.concurrent.atomic.LongAdder"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "javax.persistence.ManyToMany"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "javax.persistence.OneToMany"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "javax.xml.bind.annotation.XmlAccessType",
+      "fields": [
+        {
+          "name": "FIELD"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.TypeUtilsTest"
+      },
+      "type": "javax.xml.bind.annotation.XmlAccessType",
+      "fields": [
+        {
+          "name": "FIELD"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "javax.xml.bind.annotation.XmlAccessorType"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.TypeUtilsTest"
+      },
+      "type": "javax.xml.bind.annotation.XmlAccessorType",
+      "methods": [
+        {
+          "name": "value",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.JavaBeanInfo"
+      },
+      "type": "kotlin.KotlinNullPointerException"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "kotlin.KotlinNullPointerException"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanInfoTest"
+      },
+      "type": "kotlin.KotlinNullPointerException"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "kotlin.Metadata",
+      "methods": [
+        {
+          "name": "bv",
+          "parameterTypes": []
+        },
+        {
+          "name": "d1",
+          "parameterTypes": []
+        },
+        {
+          "name": "d2",
+          "parameterTypes": []
+        },
+        {
+          "name": "k",
+          "parameterTypes": []
+        },
+        {
+          "name": "mv",
+          "parameterTypes": []
+        },
+        {
+          "name": "pn",
+          "parameterTypes": []
+        },
+        {
+          "name": "xi",
+          "parameterTypes": []
+        },
+        {
+          "name": "xs",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanInfoTest"
+      },
+      "type": "kotlin.Metadata",
+      "methods": [
+        {
+          "name": "bv",
+          "parameterTypes": []
+        },
+        {
+          "name": "d1",
+          "parameterTypes": []
+        },
+        {
+          "name": "d2",
+          "parameterTypes": []
+        },
+        {
+          "name": "k",
+          "parameterTypes": []
+        },
+        {
+          "name": "mv",
+          "parameterTypes": []
+        },
+        {
+          "name": "pn",
+          "parameterTypes": []
+        },
+        {
+          "name": "xi",
+          "parameterTypes": []
+        },
+        {
+          "name": "xs",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.parser.ParserConfig"
+      },
+      "type": "kotlin.Pair"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.JavaBeanInfo"
+      },
+      "type": "kotlin.Pair"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "kotlin.Pair"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanInfoTest"
+      },
+      "type": "kotlin.Pair"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "kotlin.SafePublicationLazyImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanInfoTest"
+      },
+      "type": "kotlin.SafePublicationLazyImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "kotlin.String"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanInfoTest"
+      },
+      "type": "kotlin.String"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "kotlin.annotation.AnnotationTarget[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanInfoTest"
+      },
+      "type": "kotlin.jvm.internal.DefaultConstructorMarker"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "kotlin.ranges.CharRange"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "kotlin.ranges.ClosedDoubleRange"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "kotlin.ranges.ClosedFloatRange"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "kotlin.ranges.IntRange"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "kotlin.ranges.LongRange"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "kotlin.reflect.KCallable",
+      "methods": [
+        {
+          "name": "getParameters",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanInfoTest"
+      },
+      "type": "kotlin.reflect.KFunction"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "kotlin.reflect.KParameter",
+      "methods": [
+        {
+          "name": "getName",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "kotlin.reflect.jvm.internal.KClassImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name": "getConstructors",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "kotlin.reflect.jvm.internal.ReflectionFactoryImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanInfoTest"
+      },
+      "type": "kotlin.reflect.jvm.internal.ReflectionFactoryImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "kotlin.reflect.jvm.internal.impl.load.java.ErasedOverridabilityCondition"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanInfoTest"
+      },
+      "type": "kotlin.reflect.jvm.internal.impl.load.java.ErasedOverridabilityCondition"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "kotlin.reflect.jvm.internal.impl.load.java.FieldOverridabilityCondition"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanInfoTest"
+      },
+      "type": "kotlin.reflect.jvm.internal.impl.load.java.FieldOverridabilityCondition"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "kotlin.reflect.jvm.internal.impl.load.java.JavaIncompatibilityRulesOverridabilityCondition"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanInfoTest"
+      },
+      "type": "kotlin.reflect.jvm.internal.impl.load.java.JavaIncompatibilityRulesOverridabilityCondition"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "kotlin.reflect.jvm.internal.impl.resolve.scopes.MemberScope[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.serializer.SerializeConfig"
+      },
+      "type": "oracle.sql.DATE"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "oracle.sql.DATE",
+      "methods": [
+        {
+          "name": "toJdbc",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.SerializeConfigTest"
+      },
+      "type": "oracle.sql.DATE"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "oracle.sql.TIMESTAMP",
+      "methods": [
+        {
+          "name": "toJdbc",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": "org.hibernate.Hibernate",
+      "methods": [
+        {
+          "name": "isInitialized",
+          "parameterTypes": [
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.parser.ParserConfig"
+      },
+      "type": "org.joda.time.DateTime"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.serializer.SerializeConfig"
+      },
+      "type": "org.joda.time.DateTime"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.ParserConfigTest"
+      },
+      "type": "org.joda.time.DateTime"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.SerializeConfigTest"
+      },
+      "type": "org.joda.time.DateTime"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.serializer.JSONObjectCodec"
+      },
+      "type": "org.json.JSONObject",
+      "fields": [
+        {
+          "name": "map"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.serializer.SerializeConfig"
+      },
+      "type": "springfox.documentation.spring.web.json.Json"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.SerializeConfigTest"
+      },
+      "type": "springfox.documentation.spring.web.json.Json"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.serializer.AnnotationSerializer"
+      },
+      "type": "sun.reflect.annotation.AnnotationType",
+      "methods": [
+        {
+          "name": "getInstance",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name": "members",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.parser.ParserConfig"
+      },
+      "type": {
+        "proxy": [
+          "com.alibaba.fastjson.annotation.JSONCreator"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.JavaBeanInfo"
+      },
+      "type": {
+        "proxy": [
+          "com.alibaba.fastjson.annotation.JSONCreator"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": {
+        "proxy": [
+          "com.alibaba.fastjson.annotation.JSONCreator"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.serializer.SerializeConfig"
+      },
+      "type": {
+        "proxy": [
+          "com.alibaba.fastjson.annotation.JSONField"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": {
+        "proxy": [
+          "com.alibaba.fastjson.annotation.JSONField"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": {
+        "proxy": [
+          "com.alibaba.fastjson.annotation.JSONPOJOBuilder"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": {
+        "proxy": [
+          "com.alibaba.fastjson.annotation.JSONType"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": {
+        "proxy": [
+          "com.google.common.collect.ElementTypesAreNonnullByDefault"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.serializer.SerializeConfig"
+      },
+      "type": {
+        "proxy": [
+          "com.oracle.svm.shared.Uninterruptible"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanDeserializerTest"
+      },
+      "type": {
+        "proxy": [
+          "com_alibaba.fastjson.JavaBeanDeserializerTest$ProxyView"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.TypeUtilsTest"
+      },
+      "type": {
+        "proxy": [
+          "com_alibaba.fastjson.TypeUtilsTest$NamedView"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.SafeVarargs"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Inherited"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.serializer.SerializeConfig"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Target"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.JSONObject"
+      },
+      "type": {
+        "proxy": [
+          "java.util.Map",
+          "java.io.Serializable"
+        ]
+      },
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.JSONObject$SecureObjectInputStream"
+      },
+      "type": {
+        "proxy": [
+          "java.util.Map",
+          "java.io.Serializable"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JSONObjectInnerSecureObjectInputStreamTest"
+      },
+      "type": {
+        "proxy": [
+          "java.util.Map",
+          "java.io.Serializable"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": {
+        "proxy": [
+          "javax.annotation.Nonnull"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": {
+        "proxy": [
+          "javax.annotation.meta.TypeQualifierDefault"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": {
+        "proxy": [
+          "javax.xml.bind.annotation.XmlAccessorType"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": {
+        "proxy": [
+          "jdk.internal.ValueBased"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": {
+        "proxy": [
+          "kotlin.Metadata"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": {
+        "proxy": [
+          "kotlin.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type": {
+        "proxy": [
+          "kotlin.annotation.Target"
+        ]
+      }
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.JSON"
+      },
+      "glob": "META-INF/services/com.alibaba.fastjson.parser.deserializer.AutowiredObjectDeserializer"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.ServiceLoader"
+      },
+      "glob": "META-INF/services/com.alibaba.fastjson.parser.deserializer.AutowiredObjectDeserializer"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanDeserializerTest"
+      },
+      "glob": "META-INF/services/com.alibaba.fastjson.parser.deserializer.AutowiredObjectDeserializer"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.PropertyProcessableDeserializerTest"
+      },
+      "glob": "META-INF/services/com.alibaba.fastjson.parser.deserializer.AutowiredObjectDeserializer"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.serializer.SerializeConfig"
+      },
+      "glob": "META-INF/services/com.alibaba.fastjson.serializer.AutowiredObjectSerializer"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.ServiceLoader"
+      },
+      "glob": "META-INF/services/com.alibaba.fastjson.serializer.AutowiredObjectSerializer"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.parser.deserializer.Jdk8DateCodec"
+      },
+      "glob": "META-INF/services/java.time.zone.ZoneRulesProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanInfoTest"
+      },
+      "glob": "META-INF/services/kotlin.reflect.jvm.internal.impl.resolve.ExternalOverridabilityCondition"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "glob": "META-INF/services/kotlin.reflect.jvm.internal.impl.util.ModuleVisibilityHelper"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanInfoTest"
+      },
+      "glob": "META-INF/services/kotlin.reflect.jvm.internal.impl.util.ModuleVisibilityHelper"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.ASMDeserializerFactoryTest"
+      },
+      "glob": "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.ASMDeserializerFactoryTest"
+      },
+      "glob": "META-INF/services/org.assertj.core.presentation.Representation"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.parser.ParserConfig"
+      },
+      "glob": "com_alibaba/fastjson/JSONObjectInnerSecureObjectInputStreamTest$EmptyMapInvocationHandler.class"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.parser.ParserConfig"
+      },
+      "glob": "com_alibaba/fastjson/ParserConfigTest$ConfiguredLoaderAutoTypeBean.class"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.parser.ParserConfig"
+      },
+      "glob": "com_alibaba/fastjson/ParserConfigTest$DefaultLoaderAutoTypeBean.class"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.ASMUtils"
+      },
+      "glob": "com_alibaba/fastjson/ThrowableDeserializerTest$CauseOnlyException.class"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.ThrowableDeserializerTest"
+      },
+      "glob": "com_alibaba/fastjson/ThrowableDeserializerTest$CauseOnlyException.class"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.ASMUtils"
+      },
+      "glob": "com_alibaba/fastjson/ThrowableDeserializerTest$DefaultOnlyException.class"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.ASMUtils"
+      },
+      "glob": "com_alibaba/fastjson/ThrowableDeserializerTest$MessageOnlyException.class"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.ThrowableDeserializerTest"
+      },
+      "glob": "com_alibaba/fastjson/ThrowableDeserializerTest$MessageOnlyException.class"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.IOUtils$1"
+      },
+      "glob": "fastjson.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.parser.ParserConfig"
+      },
+      "glob": "java/lang/reflect/Proxy.class"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.parser.ParserConfig"
+      },
+      "glob": "java/util/Map.class"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "glob": "kotlin/kotlin.kotlin_builtins"
+    },
+    {
+      "condition": {
+        "typeReached": "com_alibaba.fastjson.JavaBeanInfoTest"
+      },
+      "glob": "kotlin/kotlin.kotlin_builtins"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.serializer.JodaCodec"
+      },
+      "glob": "org/joda/time/tz/data/Europe/Belgrade"
+    },
+    {
+      "condition": {
+        "typeReached": "com.alibaba.fastjson.serializer.JodaCodec"
+      },
+      "glob": "org/joda/time/tz/data/ZoneInfoMap"
+    }
+  ]
+}

--- a/metadata/com.alibaba/fastjson/index.json
+++ b/metadata/com.alibaba/fastjson/index.json
@@ -13,5 +13,14 @@
     "allowed-packages" : [
       "com.alibaba.fastjson"
     ]
+  },
+  {
+    "metadata-version" : "1.2.83_noneautotype",
+    "tested-versions" : [
+      "1.2.83_noneautotype"
+    ],
+    "allowed-packages" : [
+      "com.alibaba.fastjson"
+    ]
   }
 ]

--- a/metadata/com.alibaba/fastjson/index.json
+++ b/metadata/com.alibaba/fastjson/index.json
@@ -16,6 +16,11 @@
   },
   {
     "metadata-version" : "1.2.83_noneautotype",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/alibaba/fastjson/$version$/fastjson-$version$-sources.jar",
+    "repository-url" : "https://github.com/alibaba/fastjson",
+    "test-code-url" : "https://github.com/alibaba/fastjson/tree/1.2.83/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/alibaba/fastjson/$version$/fastjson-$version$-javadoc.jar",
+    "description" : "Fastjson is a Java JSON library that parses JSON text into Java objects and serializes Java objects back to JSON. It supports arbitrary Java object graphs, generics, custom representations, JSONPath, and integrations with common Java frameworks.",
     "tested-versions" : [
       "1.2.83_noneautotype"
     ],

--- a/metadata/org.junit.jupiter/junit-jupiter-engine/6.1.0/reachability-metadata.json
+++ b/metadata/org.junit.jupiter/junit-jupiter-engine/6.1.0/reachability-metadata.json
@@ -1,0 +1,50 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.junit.jupiter.engine.discovery.ClassSelectorResolver"
+      },
+      "type" : "kotlin.Metadata"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.jupiter.engine.discovery.ClassSelectorResolver"
+      },
+      "type" : "kotlin.jvm.JvmInline"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.jupiter.engine.extension.TempDirectory$CloseablePath"
+      },
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.jupiter.engine.extension.TempDirectory$CloseablePath"
+      },
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.junit.jupiter.engine.discovery.ClassSelectorResolver"
+      },
+      "glob" : "META-INF/services/org.junit.platform.commons.support.scanning.ClasspathScanner"
+    }
+  ]
+}

--- a/metadata/org.junit.jupiter/junit-jupiter-engine/index.json
+++ b/metadata/org.junit.jupiter/junit-jupiter-engine/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "6.1.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-engine/$version$/junit-jupiter-engine-$version$-sources.jar",
+    "repository-url" : "https://github.com/junit-team/junit-framework",
+    "test-code-url" : "https://github.com/junit-team/junit-framework/tree/r$version$/jupiter-tests/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-engine/$version$/junit-jupiter-engine-$version$-javadoc.jar",
+    "description" : "JUnit Jupiter Engine is the test engine that discovers and executes tests written with the JUnit Jupiter programming model on the JUnit Platform. It bridges Jupiter's APIs to the platform engine SPI so build tools, IDEs, and launchers can run those tests.",
+    "test-version" : "5.8.2",
+    "tested-versions" : [
+      "6.1.0"
+    ],
+    "allowed-packages" : [
+      "org.junit.jupiter.engine"
+    ]
+  },
+  {
     "metadata-version" : "5.8.2",
     "source-code-url" : "https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-engine/$version$/junit-jupiter-engine-$version$-sources.jar",
     "repository-url" : "https://github.com/junit-team/junit-framework",

--- a/stats/org.junit.jupiter/junit-jupiter-engine/6.1.0/stats.json
+++ b/stats/org.junit.jupiter/junit-jupiter-engine/6.1.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "6.1.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 1,
+      "totalCalls" : 1
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 5873,
+        "missed" : 8906,
+        "ratio" : 0.397388,
+        "total" : 14779
+      },
+      "line" : {
+        "covered" : 1338,
+        "missed" : 1852,
+        "ratio" : 0.419436,
+        "total" : 3190
+      },
+      "method" : {
+        "covered" : 550,
+        "missed" : 719,
+        "ratio" : 0.433412,
+        "total" : 1269
+      }
+    }
+  } ]
+}

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/.gitignore
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/build.gradle
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/build.gradle
@@ -1,0 +1,48 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.alibaba:fastjson:$libraryVersion"
+    testImplementation 'com.oracle.database.jdbc:ojdbc11:23.3.0.23.09'
+    testImplementation 'javax.xml.bind:jaxb-api:2.3.1'
+    testImplementation 'org.hibernate:hibernate-core:5.6.15.Final'
+    testImplementation 'org.json:json:20220320'
+    testImplementation 'io.springfox:springfox-spring-web:2.6.1'
+    testImplementation 'joda-time:joda-time:2.12.7'
+    testImplementation 'com.google.guava:guava:32.1.3-jre'
+    testImplementation 'org.jetbrains.kotlin:kotlin-reflect:1.9.23'
+    testImplementation 'org.jetbrains.kotlin:kotlin-stdlib:1.9.23'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+tasks.withType(Test).configureEach {
+    jvmArgs "--add-opens=java.base/java.io=ALL-UNNAMED"
+    jvmArgs "--add-exports=java.base/sun.reflect.annotation=ALL-UNNAMED"
+}
+
+graalvmNative {
+    binaries {
+        test {
+            buildArgs.add("--add-opens=java.base/java.io=ALL-UNNAMED")
+            buildArgs.add("--add-exports=java.base/sun.reflect.annotation=ALL-UNNAMED")
+        }
+    }
+
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/gradle.properties
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.alibaba:fastjson:1.2.83_noneautotype
+library.version = 1.2.83_noneautotype
+metadata.dir = com.alibaba/fastjson/1.2.83_noneautotype/

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/settings.gradle
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.alibaba.fastjson_tests'

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/ASMDeserializerFactoryTest.java
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/ASMDeserializerFactoryTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_alibaba.fastjson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.parser.ParserConfig;
+import com.alibaba.fastjson.parser.deserializer.JavaBeanDeserializer;
+import com.alibaba.fastjson.parser.deserializer.ObjectDeserializer;
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+
+public class ASMDeserializerFactoryTest {
+    @Test
+    void parseObjectUsesGeneratedJavaBeanDeserializerWhenAsmIsEnabled() {
+        ParserConfig config = new ParserConfig(ASMDeserializerFactoryTest.class.getClassLoader());
+        config.setAsmEnable(true);
+
+        try {
+            AsmBackedBean bean = JSON.parseObject(
+                    "{\"id\":7,\"name\":\"generated\",\"enabled\":true}", AsmBackedBean.class, config);
+            ObjectDeserializer deserializer = config.getDeserializer(AsmBackedBean.class);
+
+            assertThat(bean.id).isEqualTo(7);
+            assertThat(bean.name).isEqualTo("generated");
+            assertThat(bean.enabled).isTrue();
+            assertThat(deserializer).isInstanceOf(JavaBeanDeserializer.class);
+            assertThat(deserializer.getClass()).isNotEqualTo(JavaBeanDeserializer.class);
+            assertThat(deserializer.getClass().getName()).contains("FastjsonASMDeserializer");
+        } catch (Error error) {
+            if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                throw error;
+            }
+        }
+    }
+
+    public static class AsmBackedBean {
+        public int id;
+        public String name;
+        public boolean enabled;
+    }
+}

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/ASMSerializerFactoryTest.java
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/ASMSerializerFactoryTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_alibaba.fastjson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.serializer.ASMSerializerFactory;
+import com.alibaba.fastjson.serializer.JavaBeanSerializer;
+import com.alibaba.fastjson.serializer.SerializeBeanInfo;
+import com.alibaba.fastjson.serializer.SerializeConfig;
+import com.alibaba.fastjson.util.TypeUtils;
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+
+public class ASMSerializerFactoryTest {
+    @Test
+    void createJavaBeanSerializerDefinesAndInstantiatesGeneratedSerializer() throws Exception {
+        try {
+            SerializeBeanInfo beanInfo = TypeUtils.buildBeanInfo(AsmSerializedBean.class, null, null);
+            ASMSerializerFactory factory = new ASMSerializerFactory();
+
+            JavaBeanSerializer serializer = factory.createJavaBeanSerializer(beanInfo);
+
+            SerializeConfig config = new SerializeConfig();
+            config.put(AsmSerializedBean.class, serializer);
+            String json = JSON.toJSONString(new AsmSerializedBean(7, "generated", true), config);
+
+            assertThat(serializer.getClass()).isNotEqualTo(JavaBeanSerializer.class);
+            assertThat(serializer.getClass().getName()).contains("ASMSerializer_");
+            assertThat(json).contains("\"enabled\":true", "\"id\":7", "\"name\":\"generated\"");
+        } catch (Error error) {
+            if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                throw error;
+            }
+        }
+    }
+
+    public static class AsmSerializedBean {
+        public int id;
+        public String name;
+        public boolean enabled;
+
+        public AsmSerializedBean(int id, String name, boolean enabled) {
+            this.id = id;
+            this.name = name;
+            this.enabled = enabled;
+        }
+    }
+}

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/ASMUtilsTest.java
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/ASMUtilsTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_alibaba.fastjson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.alibaba.fastjson.util.ASMUtils;
+
+import java.lang.reflect.Type;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class ASMUtilsTest {
+    @Test
+    void getMethodTypeReturnsGenericReturnTypeForPublicNoArgumentMethod() {
+        Type valuesType = ASMUtils.getMethodType(GenericValueProvider.class, "getValues");
+        Type numberType = ASMUtils.getMethodType(GenericValueProvider.class, "getNumber");
+
+        assertThat(valuesType).hasToString("java.util.List<java.lang.String>");
+        assertThat(numberType).isEqualTo(int.class);
+    }
+
+    public interface GenericValueProvider {
+        List<String> getValues();
+
+        int getNumber();
+    }
+}

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/AnnotationSerializerTest.java
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/AnnotationSerializerTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_alibaba.fastjson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.junit.jupiter.api.Test;
+
+public class AnnotationSerializerTest {
+    @Test
+    void runtimeAnnotationProxySerializesDeclaredMembers() {
+        Class<AnnotatedTarget> annotatedTargetAnnotationAccess = AnnotatedTarget.class;
+        SerializedAnnotation annotation = annotatedTargetAnnotationAccess.getAnnotation(SerializedAnnotation.class);
+
+        String json = JSON.toJSONString(annotation);
+        JSONObject object = JSON.parseObject(json);
+
+        assertThat(object.getString("name")).isEqualTo("fastjson");
+        assertThat(object.getInteger("priority")).isEqualTo(83);
+        assertThat(object.getString("status")).isEqualTo("ACTIVE");
+        assertThat(object.getJSONArray("tags")).containsExactly("annotation", "serializer");
+    }
+
+    @SerializedAnnotation(
+            name = "fastjson",
+            priority = 83,
+            status = Status.ACTIVE,
+            tags = {"annotation", "serializer"})
+    private static class AnnotatedTarget {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface SerializedAnnotation {
+        String name();
+
+        int priority();
+
+        Status status();
+
+        String[] tags();
+    }
+
+    public enum Status {
+        ACTIVE,
+        INACTIVE
+    }
+}

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/AntiCollisionHashMapTest.java
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/AntiCollisionHashMapTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_alibaba.fastjson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.alibaba.fastjson.util.AntiCollisionHashMap;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.jupiter.api.Test;
+
+public class AntiCollisionHashMapTest {
+    @Test
+    @SuppressWarnings("deprecation")
+    void javaSerializationRoundTripPreservesEntries() throws Exception {
+        AntiCollisionHashMap<String, String> source = new AntiCollisionHashMap<>();
+        source.put("name", "fastjson");
+
+        AntiCollisionHashMap<String, String> restored = deserialize(serialize(source));
+
+        assertThat(restored).isNotSameAs(source);
+        assertThat(restored).containsEntry("name", "fastjson");
+        assertThat(restored).hasSize(1);
+    }
+
+    private static byte[] serialize(Object value) throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
+            out.writeObject(value);
+        }
+        return bytes.toByteArray();
+    }
+
+    @SuppressWarnings({"deprecation", "unchecked"})
+    private static AntiCollisionHashMap<String, String> deserialize(byte[] bytes)
+            throws IOException, ClassNotFoundException {
+        try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+            Object value = in.readObject();
+            assertThat(value).isInstanceOf(AntiCollisionHashMap.class);
+            return (AntiCollisionHashMap<String, String>) value;
+        }
+    }
+}

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/DefaultFieldDeserializerTest.java
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/DefaultFieldDeserializerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_alibaba.fastjson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.annotation.JSONField;
+import com.alibaba.fastjson.parser.DefaultJSONParser;
+import com.alibaba.fastjson.parser.JSONToken;
+import com.alibaba.fastjson.parser.ParserConfig;
+import com.alibaba.fastjson.parser.deserializer.ObjectDeserializer;
+
+import java.lang.reflect.Type;
+import org.junit.jupiter.api.Test;
+
+public class DefaultFieldDeserializerTest {
+    @Test
+    void parseObjectInstantiatesJsonFieldCustomDeserializer() {
+        PrefixingDeserializer.constructed = false;
+
+        BeanWithCustomFieldDeserializer bean = JSON.parseObject("{\"value\":\"fastjson\"}",
+                BeanWithCustomFieldDeserializer.class, noAsmConfig());
+
+        assertThat(PrefixingDeserializer.constructed).isTrue();
+        assertThat(bean.value).isEqualTo("custom:fastjson");
+    }
+
+    private static ParserConfig noAsmConfig() {
+        ParserConfig config = new ParserConfig();
+        config.setAsmEnable(false);
+        return config;
+    }
+
+    public static class BeanWithCustomFieldDeserializer {
+        @JSONField(deserializeUsing = PrefixingDeserializer.class)
+        public String value;
+    }
+
+    public static class PrefixingDeserializer implements ObjectDeserializer {
+        static boolean constructed;
+
+        public PrefixingDeserializer() {
+            constructed = true;
+        }
+
+        @Override
+        public <T> T deserialze(DefaultJSONParser parser, Type type, Object fieldName) {
+            String value = parser.parseObject(String.class);
+            return (T) ("custom:" + value);
+        }
+
+        @Override
+        public int getFastMatchToken() {
+            return JSONToken.LITERAL_STRING;
+        }
+    }
+}

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/DefaultJSONParserTest.java
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/DefaultJSONParserTest.java
@@ -11,18 +11,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.parser.ParserConfig;
 
-import java.util.ArrayList;
+import java.util.HashMap;
 import org.junit.jupiter.api.Test;
 
 public class DefaultJSONParserTest {
     @Test
-    void parseInstantiatesEmptyAutoTypedCollection() {
+    void parseInstantiatesEmptyAutoTypedHashMap() {
         ParserConfig config = new ParserConfig();
-        config.setAutoTypeSupport(true);
 
-        Object value = JSON.parse("{\"@type\":\"java.util.ArrayList\"}", config, JSON.DEFAULT_PARSER_FEATURE);
+        Object value = JSON.parse("{\"@type\":\"java.util.HashMap\"}", config, JSON.DEFAULT_PARSER_FEATURE);
 
-        assertThat(value).isInstanceOf(ArrayList.class);
-        assertThat((ArrayList<?>) value).isEmpty();
+        assertThat(value).isInstanceOf(HashMap.class);
+        assertThat((HashMap<?, ?>) value).isEmpty();
     }
 }

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/DefaultJSONParserTest.java
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/DefaultJSONParserTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_alibaba.fastjson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.parser.ParserConfig;
+
+import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+
+public class DefaultJSONParserTest {
+    @Test
+    void parseInstantiatesEmptyAutoTypedCollection() {
+        ParserConfig config = new ParserConfig();
+        config.setAutoTypeSupport(true);
+
+        Object value = JSON.parse("{\"@type\":\"java.util.ArrayList\"}", config, JSON.DEFAULT_PARSER_FEATURE);
+
+        assertThat(value).isInstanceOf(ArrayList.class);
+        assertThat((ArrayList<?>) value).isEmpty();
+    }
+}

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/EnumDeserializerTest.java
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/EnumDeserializerTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_alibaba.fastjson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.annotation.JSONField;
+
+import org.junit.jupiter.api.Test;
+
+public class EnumDeserializerTest {
+    @Test
+    void parseObjectUsesJsonFieldNamesAndAlternateNamesForEnums() {
+        assertThat(JSON.parseObject("\"wire-name\"", WireStatus.class)).isEqualTo(WireStatus.READY);
+        assertThat(JSON.parseObject("\"legacy-ready\"", WireStatus.class)).isEqualTo(WireStatus.READY);
+        assertThat(JSON.parseObject("\"DONE\"", WireStatus.class)).isEqualTo(WireStatus.DONE);
+    }
+
+    public enum WireStatus {
+        @JSONField(name = "wire-name", alternateNames = "legacy-ready")
+        READY,
+        DONE
+    }
+}

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/FieldDeserializerTest.java
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/FieldDeserializerTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_alibaba.fastjson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.parser.ParserConfig;
+import com.alibaba.fastjson.parser.deserializer.DefaultFieldDeserializer;
+import com.alibaba.fastjson.util.FieldInfo;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.Test;
+
+public class FieldDeserializerTest {
+    @Test
+    void parseObjectUpdatesGetterOnlyAtomicMapAndCollectionProperties() {
+        GetterOnlyPropertiesBean bean = JSON.parseObject("""
+                {
+                  "intValue": 7,
+                  "longValue": 9,
+                  "enabled": true,
+                  "attributes": {"answer": 42},
+                  "tags": ["new"]
+                }
+                """, GetterOnlyPropertiesBean.class, noAsmConfig());
+
+        assertThat(bean.getIntValue().get()).isEqualTo(7);
+        assertThat(bean.getLongValue().get()).isEqualTo(9L);
+        assertThat(bean.getEnabled().get()).isTrue();
+        assertThat(bean.getAttributes()).containsEntry("answer", 42);
+        assertThat(bean.getTags()).containsExactly("new");
+    }
+
+    @Test
+    void parseObjectUpdatesFinalAtomicMapAndCollectionFields() {
+        FinalFieldPropertiesBean bean = JSON.parseObject("""
+                {
+                  "intValue": 11,
+                  "longValue": 13,
+                  "enabled": true,
+                  "attributes": {"size": 5},
+                  "tags": ["final"]
+                }
+                """, FinalFieldPropertiesBean.class, noAsmConfig());
+
+        assertThat(bean.intValue.get()).isEqualTo(11);
+        assertThat(bean.longValue.get()).isEqualTo(13L);
+        assertThat(bean.enabled.get()).isTrue();
+        assertThat(bean.attributes).containsEntry("size", 5);
+        assertThat(bean.tags).containsExactly("final");
+    }
+
+    @Test
+    void parseObjectFallsBackToFieldAssignmentWhenGetterReturnsNull() {
+        NullMapGetterBean bean = JSON.parseObject("""
+                {
+                  "settings": {"retries": 3}
+                }
+                """, NullMapGetterBean.class, noAsmConfig());
+
+        assertThat(bean.getSettings()).containsEntry("retries", 3);
+    }
+
+    @Test
+    void setValueFallsBackToMatchingSetterWhenGetterReturnsNullAndNoFieldIsAvailable() throws Exception {
+        Method getter = SetterFallbackBean.class.getMethod("getCounter");
+        FieldInfo fieldInfo = new FieldInfo("counter", getter, null, SetterFallbackBean.class,
+                SetterFallbackBean.class, 0, 0, 0, null, null, null);
+        DefaultFieldDeserializer fieldDeserializer = new DefaultFieldDeserializer(
+                noAsmConfig(), SetterFallbackBean.class, fieldInfo);
+        SetterFallbackBean bean = new SetterFallbackBean();
+
+        fieldDeserializer.setValue(bean, new AtomicInteger(17));
+
+        assertThat(bean.getCounter().get()).isEqualTo(17);
+    }
+
+    private static ParserConfig noAsmConfig() {
+        ParserConfig config = new ParserConfig();
+        config.setAsmEnable(false);
+        return config;
+    }
+
+    public static class GetterOnlyPropertiesBean {
+        private final AtomicInteger intValue = new AtomicInteger(1);
+        private final AtomicLong longValue = new AtomicLong(2L);
+        private final AtomicBoolean enabled = new AtomicBoolean(false);
+        private final Map<String, Integer> attributes = new LinkedHashMap<>();
+        private final List<String> tags = new ArrayList<>();
+
+        public GetterOnlyPropertiesBean() {
+            attributes.put("old", -1);
+            tags.add("old");
+        }
+
+        public AtomicInteger getIntValue() {
+            return intValue;
+        }
+
+        public AtomicLong getLongValue() {
+            return longValue;
+        }
+
+        public AtomicBoolean getEnabled() {
+            return enabled;
+        }
+
+        public Map<String, Integer> getAttributes() {
+            return attributes;
+        }
+
+        public Collection<String> getTags() {
+            return tags;
+        }
+    }
+
+    public static class FinalFieldPropertiesBean {
+        public final AtomicInteger intValue = new AtomicInteger(1);
+        public final AtomicLong longValue = new AtomicLong(2L);
+        public final AtomicBoolean enabled = new AtomicBoolean(false);
+        public final Map<String, Integer> attributes = new LinkedHashMap<>();
+        public final List<String> tags = new ArrayList<>();
+    }
+
+    public static class NullMapGetterBean {
+        private Map<String, Integer> settings;
+
+        public Map<String, Integer> getSettings() {
+            return settings;
+        }
+    }
+
+    public static class SetterFallbackBean {
+        private AtomicInteger counter;
+
+        public AtomicInteger getCounter() {
+            return counter;
+        }
+
+        public void setCounter(AtomicInteger counter) {
+            this.counter = counter;
+        }
+    }
+}

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/FieldInfoTest.java
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/FieldInfoTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_alibaba.fastjson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.TypeReference;
+import com.alibaba.fastjson.parser.ParserConfig;
+import com.alibaba.fastjson.serializer.SerializeConfig;
+import com.alibaba.fastjson.util.FieldInfo;
+import com.alibaba.fastjson.util.JavaBeanInfo;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+public class FieldInfoTest {
+    @Test
+    void genericArrayFieldTypeIsResolvedWhenParsingParameterizedBeans() {
+        ParserConfig config = noAsmParserConfig();
+        Type beanType = new TypeReference<GenericArrayBean<String>>() {
+        }.getType();
+
+        GenericArrayBean<String> bean = JSON.parseObject("{\"values\":[\"one\",\"two\"]}", beanType, config);
+
+        assertThat(bean.values).isInstanceOf(String[].class);
+        assertThat(Arrays.asList(bean.values)).containsExactly("one", "two");
+    }
+
+    @Test
+    void serializationReadsGetterAndFieldValuesThroughFieldInfo() {
+        SerializeConfig config = noAsmSerializeConfig();
+
+        String getterJson = JSON.toJSONString(new GetterBackedBean("getter"), config);
+        String fieldJson = JSON.toJSONString(new FieldBackedBean("field"), config);
+
+        assertThat(getterJson).isEqualTo("{\"name\":\"getter\"}");
+        assertThat(fieldJson).isEqualTo("{\"name\":\"field\"}");
+    }
+
+    @Test
+    void setAssignsValuesThroughBeanInfoSetterFieldInfo() throws InvocationTargetException, IllegalAccessException {
+        JavaBeanInfo beanInfo = JavaBeanInfo.build(SetterBackedBean.class, SetterBackedBean.class, null);
+        FieldInfo fieldInfo = Arrays.stream(beanInfo.fields)
+                .filter(field -> "name".equals(field.name))
+                .findFirst()
+                .orElseThrow(AssertionError::new);
+        SetterBackedBean bean = new SetterBackedBean();
+
+        fieldInfo.set(bean, "setter");
+
+        assertThat(bean.getName()).isEqualTo("setter");
+    }
+
+    private static ParserConfig noAsmParserConfig() {
+        ParserConfig config = new ParserConfig();
+        config.setAsmEnable(false);
+        return config;
+    }
+
+    private static SerializeConfig noAsmSerializeConfig() {
+        SerializeConfig config = new SerializeConfig();
+        config.setAsmEnable(false);
+        return config;
+    }
+
+    public static class GenericArrayBean<T> {
+        public T[] values;
+    }
+
+    public static class GetterBackedBean {
+        private final String name;
+
+        GetterBackedBean(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+    public static class FieldBackedBean {
+        public String name;
+
+        FieldBackedBean(String name) {
+            this.name = name;
+        }
+    }
+
+    public static class SetterBackedBean {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/FieldSerializerTest.java
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/FieldSerializerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_alibaba.fastjson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.annotation.JSONField;
+import com.alibaba.fastjson.serializer.JSONSerializer;
+import com.alibaba.fastjson.serializer.ObjectSerializer;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import org.junit.jupiter.api.Test;
+
+public class FieldSerializerTest {
+    @Test
+    void jsonFieldSerializeUsingInstantiatesCustomFieldSerializer() {
+        PrefixingStringSerializer.constructed = false;
+
+        String json = JSON.toJSONString(new BeanWithCustomFieldSerializer("field-value"));
+
+        assertThat(PrefixingStringSerializer.constructed).isTrue();
+        assertThat(json).isEqualTo("{\"value\":\"custom-field-value\"}");
+    }
+
+    public static class BeanWithCustomFieldSerializer {
+        @JSONField(serializeUsing = PrefixingStringSerializer.class)
+        public final String value;
+
+        public BeanWithCustomFieldSerializer(String value) {
+            this.value = value;
+        }
+    }
+
+    public static class PrefixingStringSerializer implements ObjectSerializer {
+        static boolean constructed;
+
+        public PrefixingStringSerializer() {
+            constructed = true;
+        }
+
+        @Override
+        public void write(JSONSerializer serializer, Object object, Object fieldName, Type fieldType, int features)
+                throws IOException {
+            serializer.write("custom-" + object);
+        }
+    }
+}

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/IOUtilsAnonymous1Test.java
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/IOUtilsAnonymous1Test.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_alibaba.fastjson;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.alibaba.fastjson.util.IOUtils;
+
+import org.junit.jupiter.api.Test;
+
+public class IOUtilsAnonymous1Test {
+    @Test
+    void loadPropertiesFromFileUsesSystemClassLoaderWhenContextClassLoaderIsAbsent() {
+        ClassLoader originalContextClassLoader = Thread.currentThread().getContextClassLoader();
+
+        try {
+            Thread.currentThread().setContextClassLoader(null);
+
+            assertThatCode(IOUtils::loadPropertiesFromFile).doesNotThrowAnyException();
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalContextClassLoader);
+        }
+    }
+}

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/JSONLexerBaseTest.java
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/JSONLexerBaseTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_alibaba.fastjson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.alibaba.fastjson.parser.JSONLexerBase;
+import com.alibaba.fastjson.parser.JSONScanner;
+
+import java.util.Collection;
+import java.util.TreeSet;
+import org.junit.jupiter.api.Test;
+
+public class JSONLexerBaseTest {
+    @Test
+    void scanFieldStringArrayInstantiatesRequestedCollectionType() {
+        JSONLexerBase lexer = new JSONScanner("\"names\":[\"Bob\",\"Ada\"]}");
+        try {
+            Collection<String> names = lexer.scanFieldStringArray("\"names\":".toCharArray(), TreeSet.class);
+
+            assertThat(names).isInstanceOf(TreeSet.class);
+            assertThat(names).containsExactly("Ada", "Bob");
+        } finally {
+            lexer.close();
+        }
+    }
+}

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/JSONObjectCodecTest.java
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/JSONObjectCodecTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_alibaba.fastjson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.alibaba.fastjson.JSON;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+public class JSONObjectCodecTest {
+    @Test
+    void serializesOrgJsonObjectThroughFastjsonPublicApi() {
+        JSONObject object = new JSONObject();
+        object.put("name", "fastjson");
+        object.put("count", 2);
+
+        String json = JSON.toJSONString(object);
+
+        assertThat(json).contains("\"name\":\"fastjson\"");
+        assertThat(json).contains("\"count\":2");
+    }
+}

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/JSONObjectInnerSecureObjectInputStreamTest.java
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/JSONObjectInnerSecureObjectInputStreamTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_alibaba.fastjson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson.parser.ParserConfig;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class JSONObjectInnerSecureObjectInputStreamTest {
+    @Test
+    void javaSerializationRestoresJSONObjectWithSerializableProxyMap() throws Exception {
+        boolean originalAutoTypeSupport = ParserConfig.global.isAutoTypeSupport();
+        ParserConfig.global.setAutoTypeSupport(true);
+        try {
+            JSONObject source = new JSONObject(emptySerializableProxyMap());
+
+            JSONObject restored = deserialize(serialize(source));
+
+            assertThat(restored).isNotSameAs(source);
+            assertThat(restored.isEmpty()).isTrue();
+            assertThat(restored.size()).isZero();
+        } finally {
+            ParserConfig.global.setAutoTypeSupport(originalAutoTypeSupport);
+        }
+    }
+
+    private static byte[] serialize(JSONObject value) throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
+            out.writeObject(value);
+        }
+        return bytes.toByteArray();
+    }
+
+    private static JSONObject deserialize(byte[] bytes) throws IOException, ClassNotFoundException {
+        try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+            Object value = in.readObject();
+            assertThat(value).isInstanceOf(JSONObject.class);
+            return (JSONObject) value;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> emptySerializableProxyMap() {
+        Object proxy = Proxy.newProxyInstance(
+                JSONObjectInnerSecureObjectInputStreamTest.class.getClassLoader(),
+                new Class<?>[]{Map.class, Serializable.class},
+                new EmptyMapInvocationHandler());
+        return (Map<String, Object>) proxy;
+    }
+
+    private static final class EmptyMapInvocationHandler implements InvocationHandler, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) {
+            switch (method.getName()) {
+                case "entrySet":
+                    return Collections.emptySet();
+                case "keySet":
+                    return Collections.emptySet();
+                case "values":
+                    return Collections.emptyList();
+                case "size":
+                    return 0;
+                case "isEmpty":
+                    return true;
+                case "containsKey":
+                    return false;
+                case "containsValue":
+                    return false;
+                case "get":
+                    return null;
+                case "hashCode":
+                    return 0;
+                case "equals":
+                    return proxy == args[0];
+                case "toString":
+                    return "{}";
+                default:
+                    throw new UnsupportedOperationException(method.toGenericString());
+            }
+        }
+    }
+}

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/JSONPathTest.java
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/JSONPathTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_alibaba.fastjson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.alibaba.fastjson.JSONPath;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class JSONPathTest {
+    @Test
+    void arrayAddAppendsValuesToArrayProperty() {
+        Map<String, Object> root = new HashMap<>();
+        root.put("names", new String[] {"fast", "json" });
+
+        JSONPath.arrayAdd(root, "$.names", "native", "image");
+
+        assertThat((String[]) root.get("names")).containsExactly("fast", "json", "native", "image");
+    }
+
+    @Test
+    void patchAddAppendsValueToArrayProperty() {
+        Map<String, Object> root = new HashMap<>();
+        root.put("names", new String[] {"fast", "json" });
+
+        JSONPath.compile("$.names").patchAdd(root, "native", false);
+
+        assertThat((String[]) root.get("names")).containsExactly("fast", "json", "native");
+    }
+}

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/JavaBeanDeserializerTest.java
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/JavaBeanDeserializerTest.java
@@ -195,7 +195,7 @@ public class JavaBeanDeserializerTest {
         fields.add(kotlinLikeFieldInfo("name", String.class));
         fields.add(kotlinLikeFieldInfo("number", int.class));
         JavaBeanInfo beanInfo = new JavaBeanInfo(
-                KotlinLikeBean.class, null, defaultConstructor, creatorConstructor, null, null, null, fields);
+                KotlinLikeBean.class, null, null, creatorConstructor, null, null, null, fields);
         beanInfo.kotlin = true;
         beanInfo.creatorConstructorParameters = new String[] {"name", "number"};
         beanInfo.kotlinDefaultConstructor = defaultConstructor;

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/JavaBeanDeserializerTest.java
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/JavaBeanDeserializerTest.java
@@ -1,0 +1,397 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_alibaba.fastjson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.annotation.JSONCreator;
+import com.alibaba.fastjson.annotation.JSONField;
+import com.alibaba.fastjson.annotation.JSONPOJOBuilder;
+import com.alibaba.fastjson.annotation.JSONType;
+import com.alibaba.fastjson.parser.DefaultJSONParser;
+import com.alibaba.fastjson.parser.Feature;
+import com.alibaba.fastjson.parser.ParserConfig;
+import com.alibaba.fastjson.parser.deserializer.JavaBeanDeserializer;
+import com.alibaba.fastjson.parser.deserializer.ObjectDeserializer;
+import com.alibaba.fastjson.util.FieldInfo;
+import com.alibaba.fastjson.util.JavaBeanInfo;
+import com.alibaba.fastjson.util.TypeUtils;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class JavaBeanDeserializerTest {
+    @Test
+    void parseObjectCreatesDefaultFactoryProxyInnerAndAutoTypeHandlerInstances() {
+        ParserConfig config = noAsmConfig();
+        RecordingAutoTypeCheckHandler.constructed = false;
+
+        AutoTypeCheckedBean autoTypeChecked = JSON.parseObject(
+                "{\"name\":\"handler\"}", AutoTypeCheckedBean.class, config);
+        FactoryDefaultBean factoryDefault = JSON.parseObject("{}", FactoryDefaultBean.class, config);
+        ProxyView proxyView = JSON.parseObject("{}", ProxyView.class, config);
+        OuterBean outerBean = JSON.parseObject("{\"inner\":{\"value\":7}}", OuterBean.class, config);
+
+        assertThat(autoTypeChecked.name).isEqualTo("handler");
+        assertThat(RecordingAutoTypeCheckHandler.constructed).isTrue();
+        assertThat(factoryDefault.source).isEqualTo("factory");
+        assertThat(proxyView).isNotNull();
+        assertThat(outerBean.inner.value).isEqualTo(7);
+    }
+
+    @Test
+    void parseObjectUsesCreatorConstructorFactoryMethodBuilderAndSingleValueFactory() {
+        ParserConfig config = noAsmConfig();
+
+        CreatorConstructorBean creatorConstructor = JSON.parseObject(
+                "{\"name\":\"constructor\",\"number\":3}", CreatorConstructorBean.class, config);
+        CreatorFactoryBean creatorFactory = JSON.parseObject(
+                "{\"name\":\"factory\",\"number\":4}", CreatorFactoryBean.class, config);
+        BuilderBackedBean builderBacked = JSON.parseObject("{\"name\":\"built\"}", BuilderBackedBean.class, config);
+        SingleValueFactoryBean singleValue = parseWithDeserializer("\"scalar\"", SingleValueFactoryBean.class, config);
+
+        assertThat(creatorConstructor.name).isEqualTo("constructor");
+        assertThat(creatorConstructor.number).isEqualTo(3);
+        assertThat(creatorFactory.name).isEqualTo("factory");
+        assertThat(creatorFactory.number).isEqualTo(4);
+        assertThat(builderBacked.name).isEqualTo("built");
+        assertThat(singleValue.value).isEqualTo("scalar");
+    }
+
+    @Test
+    void castToJavaBeanCreatesBeansFromMapsWithFieldsCreatorsFactoriesAndBuilders() {
+        ParserConfig config = noAsmConfig();
+        Map<String, Object> fieldValues = new LinkedHashMap<>();
+        fieldValues.put("name", "field");
+        fieldValues.put("reference", new ReferencedValue("direct"));
+
+        MapBackedFieldsBean fieldsBean = TypeUtils.castToJavaBean(fieldValues, MapBackedFieldsBean.class, config);
+        CreatorConstructorBean creatorConstructor = TypeUtils.castToJavaBean(
+                mapOf("name", "constructor", "number", 5), CreatorConstructorBean.class, config);
+        CreatorFactoryBean creatorFactory = TypeUtils.castToJavaBean(
+                mapOf("name", "factory", "number", 6), CreatorFactoryBean.class, config);
+        BuilderBackedBean builderBacked = TypeUtils.castToJavaBean(
+                mapOf("name", "builtFromMap"), BuilderBackedBean.class, config);
+
+        assertThat(fieldsBean.name).isEqualTo("field");
+        assertThat(fieldsBean.reference.label).isEqualTo("direct");
+        assertThat(creatorConstructor.name).isEqualTo("constructor");
+        assertThat(creatorConstructor.number).isEqualTo(5);
+        assertThat(creatorFactory.name).isEqualTo("factory");
+        assertThat(creatorFactory.number).isEqualTo(6);
+        assertThat(builderBacked.name).isEqualTo("builtFromMap");
+    }
+
+    @Test
+    void parseFieldSupportsNonPublicFieldsAndUnwrappedFieldMapAndMethodProperties() {
+        ParserConfig config = noAsmConfig();
+
+        PrivateFieldBean privateField = JSON.parseObject(
+                "{\"hidden\":\"visible\"}", PrivateFieldBean.class, config, Feature.SupportNonPublicField);
+        UnwrappedNestedContainer nested = JSON.parseObject("{\"nestedName\":\"inner\"}",
+                UnwrappedNestedContainer.class, config);
+        UnwrappedMapContainer map = JSON.parseObject("{\"dynamic\":12}", UnwrappedMapContainer.class, config);
+        UnwrappedMethodContainer method = JSON.parseObject("{\"methodValue\":true}",
+                UnwrappedMethodContainer.class, config);
+
+        assertThat(privateField.getHidden()).isEqualTo("visible");
+        assertThat(nested.nested.nestedName).isEqualTo("inner");
+        assertThat(map.values).containsEntry("dynamic", 12);
+        assertThat(method.values).containsEntry("methodValue", true);
+    }
+
+    @Test
+    void customBeanInfoMapCreationSetsPrimitiveFieldsDirectly() throws Exception {
+        ParserConfig config = noAsmConfig();
+        JavaBeanDeserializer deserializer = customFieldDeserializer(PrimitiveDirectFieldsBean.class,
+                "falseValue", "trueValue", "intValue", "longValue", "floatNumber", "floatString",
+                "doubleNumber", "doubleString");
+        Map<String, Object> values = new LinkedHashMap<>();
+        values.put("falseValue", Boolean.FALSE);
+        values.put("trueValue", Boolean.TRUE);
+        values.put("intValue", 11);
+        values.put("longValue", 12L);
+        values.put("floatNumber", 1.25F);
+        values.put("floatString", "2.5");
+        values.put("doubleNumber", 3.75D);
+        values.put("doubleString", "4.5");
+
+        PrimitiveDirectFieldsBean bean = (PrimitiveDirectFieldsBean) deserializer.createInstance(values, config);
+
+        assertThat(bean.falseValue).isFalse();
+        assertThat(bean.trueValue).isTrue();
+        assertThat(bean.intValue).isEqualTo(11);
+        assertThat(bean.longValue).isEqualTo(12L);
+        assertThat(bean.floatNumber).isEqualTo(1.25F);
+        assertThat(bean.floatString).isEqualTo(2.5F);
+        assertThat(bean.doubleNumber).isEqualTo(3.75D);
+        assertThat(bean.doubleString).isEqualTo(4.5D);
+    }
+
+    @Test
+    void customBeanInfoUsesDefaultConstructorWhenKotlinCreatorStringArgumentIsMissing() throws Exception {
+        ParserConfig config = noAsmConfig();
+        JavaBeanDeserializer deserializer = customKotlinLikeDeserializer();
+        Map<String, Object> values = mapOf("number", 8);
+
+        KotlinLikeBean fromMap = (KotlinLikeBean) deserializer.createInstance(values, config);
+        KotlinLikeBean fromJson = parseWithDeserializer("{\"number\":9}", KotlinLikeBean.class, deserializer, config);
+
+        assertThat(fromMap.name).isEqualTo("default");
+        assertThat(fromMap.number).isEqualTo(8);
+        assertThat(fromJson.name).isEqualTo("default");
+        assertThat(fromJson.number).isEqualTo(9);
+    }
+
+    private static ParserConfig noAsmConfig() {
+        ParserConfig config = new ParserConfig();
+        config.setAsmEnable(false);
+        return config;
+    }
+
+    private static <T> T parseWithDeserializer(String json, Class<T> beanClass, ParserConfig config) {
+        ObjectDeserializer deserializer = config.getDeserializer(beanClass);
+        return parseWithDeserializer(json, beanClass, deserializer, config);
+    }
+
+    private static <T> T parseWithDeserializer(
+            String json, Class<T> beanClass, ObjectDeserializer deserializer, ParserConfig config) {
+        DefaultJSONParser parser = new DefaultJSONParser(json, config);
+        try {
+            return deserializer.deserialze(parser, beanClass, null);
+        } finally {
+            parser.close();
+        }
+    }
+
+    private static JavaBeanDeserializer customFieldDeserializer(Class<?> beanClass, String... fieldNames)
+            throws NoSuchFieldException, NoSuchMethodException {
+        Constructor<?> defaultConstructor = beanClass.getConstructor();
+        List<FieldInfo> fields = new ArrayList<>();
+        for (String fieldName : fieldNames) {
+            Field field = beanClass.getField(fieldName);
+            fields.add(new FieldInfo(fieldName, null, field.getType(), field.getGenericType(), field, 0, 0, 0));
+        }
+        JavaBeanInfo beanInfo = new JavaBeanInfo(beanClass, null, defaultConstructor, null, null, null, null, fields);
+        return new JavaBeanDeserializer(noAsmConfig(), beanInfo);
+    }
+
+    private static JavaBeanDeserializer customKotlinLikeDeserializer()
+            throws NoSuchFieldException, NoSuchMethodException {
+        Constructor<KotlinLikeBean> defaultConstructor = KotlinLikeBean.class.getConstructor();
+        Constructor<KotlinLikeBean> creatorConstructor = KotlinLikeBean.class.getConstructor(String.class, int.class);
+        List<FieldInfo> fields = new ArrayList<>();
+        fields.add(kotlinLikeFieldInfo("name", String.class));
+        fields.add(kotlinLikeFieldInfo("number", int.class));
+        JavaBeanInfo beanInfo = new JavaBeanInfo(
+                KotlinLikeBean.class, null, defaultConstructor, creatorConstructor, null, null, null, fields);
+        beanInfo.kotlin = true;
+        beanInfo.creatorConstructorParameters = new String[] {"name", "number"};
+        beanInfo.kotlinDefaultConstructor = defaultConstructor;
+        return new JavaBeanDeserializer(noAsmConfig(), beanInfo);
+    }
+
+    private static FieldInfo kotlinLikeFieldInfo(String name, Class<?> fieldClass) throws NoSuchFieldException {
+        Field field = KotlinLikeBean.class.getField(name);
+        return new FieldInfo(name, KotlinLikeBean.class, fieldClass, field.getGenericType(), field, 0, 0, 0);
+    }
+
+    private static Map<String, Object> mapOf(String firstKey, Object firstValue, String secondKey, Object secondValue) {
+        Map<String, Object> values = new HashMap<>();
+        values.put(firstKey, firstValue);
+        values.put(secondKey, secondValue);
+        return values;
+    }
+
+    private static Map<String, Object> mapOf(String key, Object value) {
+        Map<String, Object> values = new HashMap<>();
+        values.put(key, value);
+        return values;
+    }
+
+    @JSONType(autoTypeCheckHandler = RecordingAutoTypeCheckHandler.class)
+    public static class AutoTypeCheckedBean {
+        public String name;
+    }
+
+    public static class RecordingAutoTypeCheckHandler implements ParserConfig.AutoTypeCheckHandler {
+        static boolean constructed;
+
+        public RecordingAutoTypeCheckHandler() {
+            constructed = true;
+        }
+
+        @Override
+        public Class<?> handler(String typeName, Class<?> expectClass, int features) {
+            return null;
+        }
+    }
+
+    public interface ProxyView {
+        String getName();
+    }
+
+    public static class FactoryDefaultBean {
+        public final String source;
+
+        private FactoryDefaultBean(String source) {
+            this.source = source;
+        }
+
+        @JSONCreator
+        public static FactoryDefaultBean create() {
+            return new FactoryDefaultBean("factory");
+        }
+    }
+
+    public static class OuterBean {
+        public InnerBean inner;
+
+        public class InnerBean {
+            public int value;
+        }
+    }
+
+    public static class CreatorConstructorBean {
+        public final String name;
+        public final int number;
+
+        @JSONCreator
+        public CreatorConstructorBean(@JSONField(name = "name") String name, @JSONField(name = "number") int number) {
+            this.name = name;
+            this.number = number;
+        }
+    }
+
+    public static class CreatorFactoryBean {
+        public final String name;
+        public final int number;
+
+        private CreatorFactoryBean(String name, int number) {
+            this.name = name;
+            this.number = number;
+        }
+
+        @JSONCreator
+        public static CreatorFactoryBean create(
+                @JSONField(name = "name") String name, @JSONField(name = "number") int number) {
+            return new CreatorFactoryBean(name, number);
+        }
+    }
+
+    public static class SingleValueFactoryBean {
+        public final String value;
+
+        private SingleValueFactoryBean(String value) {
+            this.value = value;
+        }
+
+        @JSONCreator
+        public static SingleValueFactoryBean create(@JSONField(name = "value") String value) {
+            return new SingleValueFactoryBean(value);
+        }
+    }
+
+    @JSONType(builder = BuilderBackedBean.Builder.class)
+    public static class BuilderBackedBean {
+        public final String name;
+
+        private BuilderBackedBean(String name) {
+            this.name = name;
+        }
+
+        @JSONPOJOBuilder
+        public static class Builder {
+            private String name;
+
+            public Builder withName(String name) {
+                this.name = name;
+                return this;
+            }
+
+            public BuilderBackedBean build() {
+                return new BuilderBackedBean(name);
+            }
+        }
+    }
+
+    public static class ReferencedValue {
+        public final String label;
+
+        public ReferencedValue(String label) {
+            this.label = label;
+        }
+    }
+
+    public static class MapBackedFieldsBean {
+        public String name;
+        public ReferencedValue reference;
+    }
+
+    public static class PrivateFieldBean {
+        private String hidden;
+
+        public String getHidden() {
+            return hidden;
+        }
+    }
+
+    public static class PrimitiveDirectFieldsBean {
+        public boolean falseValue = true;
+        public boolean trueValue;
+        public int intValue;
+        public long longValue;
+        public float floatNumber;
+        public float floatString;
+        public double doubleNumber;
+        public double doubleString;
+    }
+
+    public static class KotlinLikeBean {
+        public String name;
+        public int number;
+
+        public KotlinLikeBean() {
+            this.name = "default";
+        }
+
+        public KotlinLikeBean(String name, int number) {
+            this.name = name;
+            this.number = number;
+        }
+    }
+
+    public static class NestedValueBean {
+        public String nestedName;
+    }
+
+    public static class UnwrappedNestedContainer {
+        @JSONField(unwrapped = true)
+        public NestedValueBean nested = new NestedValueBean();
+    }
+
+    public static class UnwrappedMapContainer {
+        @JSONField(unwrapped = true)
+        public Map<String, Object> values = new LinkedHashMap<>();
+    }
+
+    public static class UnwrappedMethodContainer {
+        public Map<String, Object> values = new LinkedHashMap<>();
+
+        @JSONField(unwrapped = true)
+        public void put(String key, Object value) {
+            values.put(key, value);
+        }
+    }
+}

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/JavaBeanInfoTest.java
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/JavaBeanInfoTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_alibaba.fastjson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.annotation.JSONCreator;
+import com.alibaba.fastjson.annotation.JSONField;
+import com.alibaba.fastjson.annotation.JSONPOJOBuilder;
+import com.alibaba.fastjson.annotation.JSONType;
+import com.alibaba.fastjson.parser.ParserConfig;
+import com.alibaba.fastjson.util.JavaBeanInfo;
+import java.lang.reflect.Constructor;
+import java.util.Collections;
+import kotlin.KotlinNullPointerException;
+import kotlin.Pair;
+import org.junit.jupiter.api.Test;
+
+public class JavaBeanInfoTest {
+    @Test
+    void buildUsesMixinCreatorConstructorWhenTargetHasNoDefaultConstructor() {
+        ParserConfig config = noAsmConfig();
+        JSON.addMixInAnnotations(MixinConstructedBean.class, MixinConstructedBeanMixin.class);
+        try {
+            MixinConstructedBean bean = JSON.parseObject("{\"name\":\"mixed\"}", MixinConstructedBean.class, config);
+
+            assertThat(bean.name).isEqualTo("mixed");
+        } finally {
+            JSON.removeMixInAnnotations(MixinConstructedBean.class);
+        }
+    }
+
+    @Test
+    void parseObjectWithFieldBasedConfigCollectsDeclaredFieldsFromClassHierarchy() {
+        ParserConfig config = new ParserConfig(true);
+
+        FieldBasedChildBean bean = JSON.parseObject(
+                "{\"baseName\":\"base\",\"childValue\":42}", FieldBasedChildBean.class, config);
+
+        assertThat(bean.baseName).isEqualTo("base");
+        assertThat(bean.childValue).isEqualTo(42);
+    }
+
+    @Test
+    void builderDeserializationFallsBackToCreateBuildMethod() {
+        ParserConfig config = noAsmConfig();
+
+        CreateOnlyBuilderBean bean = JSON.parseObject("{\"name\":\"created\"}", CreateOnlyBuilderBean.class, config);
+
+        assertThat(bean.name).isEqualTo("created");
+    }
+
+    @Test
+    void buildRecognizesKotlinConstructorMetadata() {
+        JavaBeanInfo beanInfo = JavaBeanInfo.build(Pair.class, Pair.class, null);
+
+        assertThat(beanInfo.kotlin).isTrue();
+        assertThat(beanInfo.creatorConstructor).isNotNull();
+        assertThat(beanInfo.creatorConstructorParameters).contains("first", "second");
+    }
+
+    @Test
+    void constructorStoresKotlinDefaultConstructorWhenCreatorConstructorIsPresent() throws NoSuchMethodException {
+        Constructor<KotlinNullPointerException> defaultConstructor = KotlinNullPointerException.class.getConstructor();
+        Constructor<KotlinNullPointerException> creatorConstructor = KotlinNullPointerException.class.getConstructor(
+                String.class);
+
+        JavaBeanInfo beanInfo = new JavaBeanInfo(KotlinNullPointerException.class, null, defaultConstructor,
+                creatorConstructor, null, null, null, Collections.emptyList());
+
+        assertThat(beanInfo.kotlin).isTrue();
+        assertThat(beanInfo.kotlinDefaultConstructor).isEqualTo(defaultConstructor);
+    }
+
+    private static ParserConfig noAsmConfig() {
+        ParserConfig config = new ParserConfig();
+        config.setAsmEnable(false);
+        return config;
+    }
+
+    public static class MixinConstructedBean {
+        public final String name;
+
+        public MixinConstructedBean(@JSONField(name = "name") String name) {
+            this.name = name;
+        }
+    }
+
+    public static class MixinConstructedBeanMixin {
+        @JSONCreator
+        public MixinConstructedBeanMixin(String name) {
+        }
+    }
+
+    public static class FieldBasedBaseBean {
+        public String baseName;
+    }
+
+    public static class FieldBasedChildBean extends FieldBasedBaseBean {
+        public int childValue;
+    }
+
+    @JSONType(builder = CreateOnlyBuilderBean.Builder.class)
+    public static class CreateOnlyBuilderBean {
+        public final String name;
+
+        private CreateOnlyBuilderBean(String name) {
+            this.name = name;
+        }
+
+        @JSONPOJOBuilder
+        public static class Builder {
+            private String name;
+
+            public Builder withName(String name) {
+                this.name = name;
+                return this;
+            }
+
+            public CreateOnlyBuilderBean create() {
+                return new CreateOnlyBuilderBean(name);
+            }
+        }
+    }
+}

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/JavaBeanSerializerTest.java
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/JavaBeanSerializerTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_alibaba.fastjson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.annotation.JSONType;
+import com.alibaba.fastjson.serializer.ValueFilter;
+import org.junit.jupiter.api.Test;
+
+public class JavaBeanSerializerTest {
+    @Test
+    void jsonTypeSerializeFilterIsConstructedAndApplied() {
+        PrefixValueFilter.constructed = false;
+
+        String json = JSON.toJSONString(new BeanWithJsonTypeFilter("fastjson"));
+
+        assertThat(PrefixValueFilter.constructed).isTrue();
+        assertThat(json).isEqualTo("{\"value\":\"filtered-fastjson\"}");
+    }
+
+    @JSONType(serialzeFilters = PrefixValueFilter.class)
+    public static class BeanWithJsonTypeFilter {
+        public final String value;
+
+        public BeanWithJsonTypeFilter(String value) {
+            this.value = value;
+        }
+    }
+
+    public static class PrefixValueFilter implements ValueFilter {
+        static boolean constructed;
+
+        public PrefixValueFilter() {
+            constructed = true;
+        }
+
+        @Override
+        public Object process(Object object, String name, Object value) {
+            if ("value".equals(name)) {
+                return "filtered-" + value;
+            }
+            return value;
+        }
+    }
+}

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/JavaObjectDeserializerTest.java
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/JavaObjectDeserializerTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_alibaba.fastjson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.TypeReference;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class JavaObjectDeserializerTest {
+    @Test
+    void parseObjectDeserializesGenericArrayTypes() {
+        List<String>[] values = JSON.parseObject("[[\"alpha\",\"beta\"],[\"gamma\"]]",
+                new TypeReference<List<String>[]>() { });
+
+        assertThat(values).hasSize(2);
+        assertThat(values[0]).containsExactly("alpha", "beta");
+        assertThat(values[1]).containsExactly("gamma");
+    }
+}

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/MapDeserializerTest.java
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/MapDeserializerTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_alibaba.fastjson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.alibaba.fastjson.JSON;
+
+import java.util.LinkedHashMap;
+import org.junit.jupiter.api.Test;
+
+public class MapDeserializerTest {
+    @Test
+    void parseObjectInstantiatesCustomMapType() {
+        CustomMap value = JSON.parseObject("{\"first\":1,\"second\":2}", CustomMap.class);
+
+        assertThat(value).isInstanceOf(CustomMap.class);
+        assertThat(value).containsEntry("first", 1).containsEntry("second", 2);
+    }
+
+    public static class CustomMap extends LinkedHashMap<String, Integer> {
+    }
+}

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/MiscCodecTest.java
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/MiscCodecTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_alibaba.fastjson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.alibaba.fastjson.JSON;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Test;
+
+public class MiscCodecTest {
+    @Test
+    void parseObjectDeserializesPathFromJsonString() {
+        Path path = JSON.parseObject("\"native-image-path\"", Path.class);
+
+        assertThat(path).isEqualTo(Paths.get("native-image-path"));
+    }
+}

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/ParserConfigTest.java
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/ParserConfigTest.java
@@ -80,19 +80,18 @@ public class ParserConfigTest {
     }
 
     @Test
-    void checkAutoTypeScansClassResourcesWithDefaultAndConfiguredClassLoaders() {
-        ParserConfig defaultLoaderConfig = new ParserConfig();
-        defaultLoaderConfig.setAutoTypeSupport(true);
-        ParserConfig configuredLoaderConfig = new ParserConfig();
-        configuredLoaderConfig.setAutoTypeSupport(true);
-        configuredLoaderConfig.setDefaultClassLoader(ParserConfigTest.class.getClassLoader());
+    void checkAutoTypeUsesRegisteredHandlers() {
+        ParserConfig config = new ParserConfig();
+        RecordingAutoTypeCheckHandler handler = new RecordingAutoTypeCheckHandler(DefaultLoaderAutoTypeBean.class);
+        config.addAutoTypeCheckHandler(handler);
 
-        Class<?> defaultLoaderClass = defaultLoaderConfig.checkAutoType(DefaultLoaderAutoTypeBean.class.getName(), null);
-        Class<?> configuredLoaderClass = configuredLoaderConfig.checkAutoType(
-                ConfiguredLoaderAutoTypeBean.class.getName(), null);
+        Class<?> resolvedClass = config.checkAutoType(
+                DefaultLoaderAutoTypeBean.class.getName(), ConfiguredLoaderAutoTypeBean.class, 123);
 
-        assertThat(defaultLoaderClass).isEqualTo(DefaultLoaderAutoTypeBean.class);
-        assertThat(configuredLoaderClass).isEqualTo(ConfiguredLoaderAutoTypeBean.class);
+        assertThat(resolvedClass).isEqualTo(DefaultLoaderAutoTypeBean.class);
+        assertThat(handler.typeName).isEqualTo(DefaultLoaderAutoTypeBean.class.getName());
+        assertThat(handler.expectClass).isEqualTo(ConfiguredLoaderAutoTypeBean.class);
+        assertThat(handler.features).isEqualTo(123);
     }
 
     private static <T> T parseWithDeserializer(
@@ -185,6 +184,25 @@ public class ParserConfigTest {
         @Override
         public int getFastMatchToken() {
             return 0;
+        }
+    }
+
+    public static class RecordingAutoTypeCheckHandler implements ParserConfig.AutoTypeCheckHandler {
+        private final Class<?> supportedClass;
+        String typeName;
+        Class<?> expectClass;
+        int features;
+
+        RecordingAutoTypeCheckHandler(Class<?> supportedClass) {
+            this.supportedClass = supportedClass;
+        }
+
+        @Override
+        public Class<?> handler(String typeName, Class<?> expectClass, int features) {
+            this.typeName = typeName;
+            this.expectClass = expectClass;
+            this.features = features;
+            return supportedClass.getName().equals(typeName) ? supportedClass : null;
         }
     }
 

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/ParserConfigTest.java
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/ParserConfigTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_alibaba.fastjson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.annotation.JSONCreator;
+import com.alibaba.fastjson.annotation.JSONType;
+import com.alibaba.fastjson.parser.DefaultJSONParser;
+import com.alibaba.fastjson.parser.ParserConfig;
+import com.alibaba.fastjson.parser.deserializer.ObjectDeserializer;
+import com.google.common.collect.HashMultimap;
+
+import java.awt.Point;
+import java.lang.reflect.Type;
+import java.time.LocalDate;
+import java.util.OptionalInt;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.Test;
+
+public class ParserConfigTest {
+    @Test
+    void getDeserializerRegistersBuiltInOptionalAwtJodaAndGuavaCodecs() {
+        ParserConfig config = new ParserConfig();
+
+        ObjectDeserializer pointDeserializer = config.getDeserializer(Point.class);
+        ObjectDeserializer localDateDeserializer = config.getDeserializer(LocalDate.class);
+        ObjectDeserializer optionalIntDeserializer = config.getDeserializer(OptionalInt.class);
+        ObjectDeserializer dateTimeDeserializer = config.getDeserializer(DateTime.class);
+        ObjectDeserializer multimapDeserializer = config.getDeserializer(HashMultimap.class);
+
+        assertThat(pointDeserializer).isNotNull();
+        assertThat(localDateDeserializer).isNotNull();
+        assertThat(optionalIntDeserializer).isNotNull();
+        assertThat(dateTimeDeserializer).isNotNull();
+        assertThat(multimapDeserializer).isNotNull();
+    }
+
+    @Test
+    void getDeserializerSupportsEnumJsonTypeDeserializerCreatorAndMixinCreator() {
+        ParserConfig enumDeserializerConfig = new ParserConfig();
+        CustomEnumDeserializer.constructed = false;
+
+        CustomEnum customEnum = JSON.parseObject("1", CustomEnum.class, enumDeserializerConfig);
+
+        ParserConfig creatorConfig = new ParserConfig();
+        creatorConfig.setJacksonCompatible(true);
+        CreatorEnum creatorEnum = JSON.parseObject("\"created\"", CreatorEnum.class, creatorConfig);
+
+        ParserConfig mixInConfig = new ParserConfig();
+        JSON.addMixInAnnotations(MixInCreatorEnum.class, MixInCreatorEnumMixin.class);
+        try {
+            MixInCreatorEnum mixInCreatorEnum = JSON.parseObject("\"mixed\"", MixInCreatorEnum.class, mixInConfig);
+            assertThat(mixInCreatorEnum).isEqualTo(MixInCreatorEnum.MIXED);
+        } finally {
+            JSON.removeMixInAnnotations(MixInCreatorEnum.class);
+        }
+
+        assertThat(CustomEnumDeserializer.constructed).isTrue();
+        assertThat(customEnum).isEqualTo(CustomEnum.SECOND);
+        assertThat(creatorEnum).isEqualTo(CreatorEnum.CREATED);
+    }
+
+    @Test
+    void createJavaBeanDeserializerUsesJsonTypeCustomDeserializer() {
+        ParserConfig config = new ParserConfig();
+        config.setAsmEnable(true);
+        CustomBeanDeserializer.constructed = false;
+
+        ObjectDeserializer deserializer = config.createJavaBeanDeserializer(CustomBean.class, CustomBean.class);
+        CustomBean bean = parseWithDeserializer("{}", CustomBean.class, deserializer, config);
+
+        assertThat(CustomBeanDeserializer.constructed).isTrue();
+        assertThat(bean.source).isEqualTo("custom");
+    }
+
+    @Test
+    void checkAutoTypeScansClassResourcesWithDefaultAndConfiguredClassLoaders() {
+        ParserConfig defaultLoaderConfig = new ParserConfig();
+        defaultLoaderConfig.setAutoTypeSupport(true);
+        ParserConfig configuredLoaderConfig = new ParserConfig();
+        configuredLoaderConfig.setAutoTypeSupport(true);
+        configuredLoaderConfig.setDefaultClassLoader(ParserConfigTest.class.getClassLoader());
+
+        Class<?> defaultLoaderClass = defaultLoaderConfig.checkAutoType(DefaultLoaderAutoTypeBean.class.getName(), null);
+        Class<?> configuredLoaderClass = configuredLoaderConfig.checkAutoType(
+                ConfiguredLoaderAutoTypeBean.class.getName(), null);
+
+        assertThat(defaultLoaderClass).isEqualTo(DefaultLoaderAutoTypeBean.class);
+        assertThat(configuredLoaderClass).isEqualTo(ConfiguredLoaderAutoTypeBean.class);
+    }
+
+    private static <T> T parseWithDeserializer(
+            String json, Class<T> beanClass, ObjectDeserializer deserializer, ParserConfig config) {
+        DefaultJSONParser parser = new DefaultJSONParser(json, config);
+        try {
+            return deserializer.deserialze(parser, beanClass, null);
+        } finally {
+            parser.close();
+        }
+    }
+
+    public enum CreatorEnum {
+        CREATED,
+        OTHER;
+
+        @JSONCreator
+        public static CreatorEnum fromJson(String value) {
+            return "created".equals(value) ? CREATED : OTHER;
+        }
+    }
+
+    public enum MixInCreatorEnum {
+        MIXED,
+        OTHER;
+
+        public static MixInCreatorEnum fromJson(String value) {
+            return "mixed".equals(value) ? MIXED : OTHER;
+        }
+    }
+
+    public static class MixInCreatorEnumMixin {
+        @JSONCreator
+        public static MixInCreatorEnum fromJson(String value) {
+            return null;
+        }
+    }
+
+    @JSONType(deserializer = CustomEnumDeserializer.class)
+    public enum CustomEnum {
+        FIRST,
+        SECOND
+    }
+
+    public static class CustomEnumDeserializer implements ObjectDeserializer {
+        static boolean constructed;
+
+        public CustomEnumDeserializer() {
+            constructed = true;
+        }
+
+        @Override
+        public <T> T deserialze(DefaultJSONParser parser, Type type, Object fieldName) {
+            Integer value = parser.parseObject(Integer.class);
+            return (T) (Integer.valueOf(1).equals(value) ? CustomEnum.SECOND : CustomEnum.FIRST);
+        }
+
+        @Override
+        public int getFastMatchToken() {
+            return 0;
+        }
+    }
+
+    @JSONType(deserializer = CustomBeanDeserializer.class)
+    public static class CustomBean {
+        public final String source;
+
+        public CustomBean() {
+            this("default");
+        }
+
+        CustomBean(String source) {
+            this.source = source;
+        }
+    }
+
+    public static class CustomBeanDeserializer implements ObjectDeserializer {
+        static boolean constructed;
+
+        public CustomBeanDeserializer() {
+            constructed = true;
+        }
+
+        @Override
+        public <T> T deserialze(DefaultJSONParser parser, Type type, Object fieldName) {
+            parser.parseObject();
+            return (T) new CustomBean("custom");
+        }
+
+        @Override
+        public int getFastMatchToken() {
+            return 0;
+        }
+    }
+
+    @JSONType
+    public static class DefaultLoaderAutoTypeBean {
+    }
+
+    @JSONType
+    public static class ConfiguredLoaderAutoTypeBean {
+    }
+}

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/PropertyProcessableDeserializerTest.java
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/PropertyProcessableDeserializerTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_alibaba.fastjson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.parser.ParserConfig;
+import com.alibaba.fastjson.parser.deserializer.ObjectDeserializer;
+import com.alibaba.fastjson.parser.deserializer.PropertyProcessable;
+import com.alibaba.fastjson.parser.deserializer.PropertyProcessableDeserializer;
+
+import java.lang.reflect.Type;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class PropertyProcessableDeserializerTest {
+    @Test
+    void parseObjectInstantiatesAndPopulatesPropertyProcessableType() {
+        PropertyProcessableBean bean = JSON.parseObject(
+                "{\"name\":\"fastjson\",\"count\":83,\"enabled\":true}", PropertyProcessableBean.class);
+
+        assertThat(bean.values)
+                .containsEntry("name", "fastjson")
+                .containsEntry("count", 83)
+                .containsEntry("enabled", true);
+    }
+
+    @Test
+    void parserConfigCreatesPropertyProcessableDeserializer() {
+        ParserConfig config = new ParserConfig();
+
+        ObjectDeserializer deserializer = config.getDeserializer(PropertyProcessableBean.class);
+
+        assertThat(deserializer).isInstanceOf(PropertyProcessableDeserializer.class);
+    }
+
+    public static class PropertyProcessableBean implements PropertyProcessable {
+        private final Map<String, Object> values = new LinkedHashMap<>();
+
+        public PropertyProcessableBean() {
+        }
+
+        @Override
+        public Type getType(String name) {
+            if ("count".equals(name)) {
+                return Integer.class;
+            }
+            if ("enabled".equals(name)) {
+                return Boolean.class;
+            }
+            return String.class;
+        }
+
+        @Override
+        public void apply(String name, Object value) {
+            values.put(name, value);
+        }
+    }
+}

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/SerializeConfigTest.java
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/SerializeConfigTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_alibaba.fastjson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.annotation.JSONField;
+import com.alibaba.fastjson.annotation.JSONType;
+import com.alibaba.fastjson.serializer.JSONSerializer;
+import com.alibaba.fastjson.serializer.ObjectSerializer;
+import com.alibaba.fastjson.serializer.SerializeConfig;
+import com.alibaba.fastjson.serializer.SerializeWriter;
+import com.alibaba.fastjson.serializer.SerializerFeature;
+import com.google.common.collect.HashMultimap;
+
+import java.awt.Point;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.time.LocalDate;
+import java.util.OptionalInt;
+import java.util.concurrent.atomic.LongAdder;
+import oracle.sql.DATE;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.Test;
+import springfox.documentation.spring.web.json.Json;
+
+public class SerializeConfigTest {
+    @Test
+    void getObjectWriterRegistersBuiltInAwtJdk8OracleSpringfoxGuavaAndJodaSerializers() {
+        SerializeConfig config = new SerializeConfig();
+
+        assertThat(config.getObjectWriter(Point.class)).isNotNull();
+        assertThat(config.getObjectWriter(LocalDate.class)).isNotNull();
+        assertThat(config.getObjectWriter(OptionalInt.class)).isNotNull();
+        assertThat(config.getObjectWriter(LongAdder.class)).isNotNull();
+        assertThat(config.getObjectWriter(DATE.class)).isNotNull();
+        assertThat(config.getObjectWriter(Json.class)).isNotNull();
+        assertThat(config.getObjectWriter(HashMultimap.class)).isNotNull();
+        assertThat(config.getObjectWriter(DateTime.class)).isNotNull();
+    }
+
+    @Test
+    void jsonTypeCustomSerializerIsInstantiatedForJavaBeans() {
+        CustomObjectSerializer.constructed = false;
+        SerializeConfig config = new SerializeConfig();
+        config.setAsmEnable(false);
+
+        String json = JSON.toJSONString(new BeanWithCustomSerializer("fastjson"), config);
+
+        assertThat(CustomObjectSerializer.constructed).isTrue();
+        assertThat(json).isEqualTo("\"custom-fastjson\"");
+    }
+
+    @Test
+    void enumJsonFieldMethodAndMixinMethodAreUsedAsSerializedValues() {
+        SerializeConfig fieldConfig = new SerializeConfig();
+        SerializeConfig mixInConfig = new SerializeConfig();
+
+        String fieldValue = JSON.toJSONString(AnnotatedFieldEnum.ACTIVE, fieldConfig);
+        JSON.addMixInAnnotations(MixInEnum.class, MixInEnumMixin.class);
+        try {
+            String mixInValue = JSON.toJSONString(MixInEnum.ACTIVE, mixInConfig);
+            assertThat(mixInValue).isEqualTo("7");
+        } finally {
+            JSON.removeMixInAnnotations(MixInEnum.class);
+        }
+
+        assertThat(fieldValue).isEqualTo("5");
+    }
+
+    @JSONType(serializer = CustomObjectSerializer.class)
+    public static class BeanWithCustomSerializer {
+        private final String name;
+
+        public BeanWithCustomSerializer(String name) {
+            this.name = name;
+        }
+    }
+
+    public static class CustomObjectSerializer implements ObjectSerializer {
+        static boolean constructed;
+
+        public CustomObjectSerializer() {
+            constructed = true;
+        }
+
+        @Override
+        public void write(JSONSerializer serializer, Object object, Object fieldName, Type fieldType, int features)
+                throws IOException {
+            BeanWithCustomSerializer bean = (BeanWithCustomSerializer) object;
+            SerializeWriter writer = serializer.getWriter();
+            writer.writeString("custom-" + bean.name);
+        }
+    }
+
+    public enum AnnotatedFieldEnum {
+        ACTIVE(5),
+        INACTIVE(0);
+
+        @JSONField
+        public final int code;
+
+        AnnotatedFieldEnum(int code) {
+            this.code = code;
+        }
+    }
+
+    public enum MixInEnum {
+        ACTIVE(7),
+        INACTIVE(0);
+
+        private final int code;
+
+        MixInEnum(int code) {
+            this.code = code;
+        }
+
+        public int getCode() {
+            return code;
+        }
+    }
+
+    public static class MixInEnumMixin {
+        @JSONField(serialzeFeatures = SerializerFeature.WriteNonStringValueAsString)
+        public int getCode() {
+            return 0;
+        }
+    }
+}

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/ServiceLoaderTest.java
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/ServiceLoaderTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_alibaba.fastjson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.alibaba.fastjson.util.ServiceLoader;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class ServiceLoaderTest {
+    private static final String SERVICES_PREFIX = "META-INF/services/";
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void loadInstantiatesImplementationListedByServiceResource() throws IOException {
+        DiscoveredService.constructedCount = 0;
+        Path serviceFile = temporaryDirectory.resolve("service-provider.txt");
+        Files.writeString(serviceFile, DiscoveredService.class.getName() + "\n", StandardCharsets.UTF_8);
+        ClassLoader classLoader = new SingleServiceResourceClassLoader(
+                ServiceContract.class.getClassLoader(),
+                SERVICES_PREFIX + ServiceContract.class.getName(),
+                serviceFile.toUri().toURL());
+
+        Set<ServiceContract> services = ServiceLoader.load(ServiceContract.class, classLoader);
+
+        assertThat(services).hasSize(1);
+        assertThat(services.iterator().next()).isInstanceOf(DiscoveredService.class);
+        assertThat(DiscoveredService.constructedCount).isEqualTo(1);
+    }
+
+    public interface ServiceContract {
+    }
+
+    public static class DiscoveredService implements ServiceContract {
+        static int constructedCount;
+
+        public DiscoveredService() {
+            constructedCount++;
+        }
+    }
+
+    private static final class SingleServiceResourceClassLoader extends ClassLoader {
+        private final String resourceName;
+        private final URL serviceResource;
+
+        SingleServiceResourceClassLoader(ClassLoader parent, String resourceName, URL serviceResource) {
+            super(parent);
+            this.resourceName = resourceName;
+            this.serviceResource = serviceResource;
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            if (resourceName.equals(name)) {
+                return Collections.enumeration(List.of(serviceResource));
+            }
+            return super.getResources(name);
+        }
+    }
+}

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/ThrowableDeserializerTest.java
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/ThrowableDeserializerTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_alibaba.fastjson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.parser.ParserConfig;
+import org.junit.jupiter.api.Test;
+
+public class ThrowableDeserializerTest {
+    @Test
+    void parseThrowableUsesStringAndCauseConstructorWhenAvailable() {
+        ParserConfig config = noAsmConfig();
+        String json = """
+                {
+                  "message": "outer message",
+                  "cause": {
+                    "message": "root cause"
+                  }
+                }
+                """;
+
+        CauseOnlyException exception = JSON.parseObject(json, CauseOnlyException.class, config);
+
+        assertThat(exception).isInstanceOf(CauseOnlyException.class);
+        assertThat(exception.getMessage()).isEqualTo("outer message");
+        assertThat(exception.getCause()).isInstanceOf(Exception.class);
+        assertThat(exception.getCause()).hasMessage("root cause");
+    }
+
+    @Test
+    void parseThrowableUsesStringConstructorWhenCauseConstructorIsUnavailable() {
+        ParserConfig config = noAsmConfig();
+
+        MessageOnlyException exception = JSON.parseObject(
+                "{\"message\":\"message constructor\"}", MessageOnlyException.class, config);
+
+        assertThat(exception).isInstanceOf(MessageOnlyException.class);
+        assertThat(exception.getMessage()).isEqualTo("message constructor");
+        assertThat(exception.getCause()).isNull();
+    }
+
+    @Test
+    void parseThrowableUsesDefaultConstructorWhenOnlyDefaultConstructorIsAvailable() {
+        ParserConfig config = noAsmConfig();
+
+        DefaultOnlyException exception = JSON.parseObject(
+                "{\"message\":\"default constructor\"}", DefaultOnlyException.class, config);
+
+        assertThat(exception).isInstanceOf(DefaultOnlyException.class);
+        assertThat(exception.getMessage()).isNull();
+        assertThat(exception.getCause()).isNull();
+    }
+
+    private static ParserConfig noAsmConfig() {
+        ParserConfig config = new ParserConfig();
+        config.setAsmEnable(false);
+        return config;
+    }
+
+    public static class CauseOnlyException extends Exception {
+        private static final long serialVersionUID = 1L;
+
+        public CauseOnlyException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    public static class MessageOnlyException extends Exception {
+        private static final long serialVersionUID = 1L;
+
+        public MessageOnlyException(String message) {
+            super(message);
+        }
+    }
+
+    public static class DefaultOnlyException extends Exception {
+        private static final long serialVersionUID = 1L;
+
+        public DefaultOnlyException() {
+            super();
+        }
+    }
+}

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/TypeUtilsTest.java
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/TypeUtilsTest.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_alibaba.fastjson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.annotation.JSONField;
+import com.alibaba.fastjson.parser.ParserConfig;
+import com.alibaba.fastjson.util.FieldInfo;
+import com.alibaba.fastjson.util.TypeUtils;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.sql.Timestamp;
+import java.time.LocalTime;
+import java.time.MonthDay;
+import java.time.Year;
+import java.time.YearMonth;
+import java.util.AbstractCollection;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import kotlin.Pair;
+import oracle.sql.DATE;
+import oracle.sql.TIMESTAMP;
+import org.junit.jupiter.api.Test;
+
+public class TypeUtilsTest {
+    @Test
+    void loadClassResolvesArraysAndFallbackClassLoaders() {
+        Class<?> classLoaderResult = TypeUtils.loadClass("example.Year", new ResolvingClassLoader("example.Year", Year.class));
+        assertThat(classLoaderResult).isEqualTo(Year.class);
+
+        Class<?> contextLoaderResult;
+        Class<?> classForNameResult;
+        ClassLoader previousClassLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(new ResolvingClassLoader("java.time.MonthDay", MonthDay.class));
+            contextLoaderResult = TypeUtils.loadClass("java.time.MonthDay", null);
+
+            Thread.currentThread().setContextClassLoader(null);
+            classForNameResult = TypeUtils.loadClass("java.time.YearMonth", null);
+        } finally {
+            Thread.currentThread().setContextClassLoader(previousClassLoader);
+        }
+        assertThat(contextLoaderResult).isEqualTo(MonthDay.class);
+        assertThat(classForNameResult).isEqualTo(YearMonth.class);
+        assertThat(TypeUtils.loadClass("[java.time.LocalTime", null)).isEqualTo(LocalTime[].class);
+    }
+
+    @Test
+    void castAndFactoryMethodsCreateArraysCalendarsAndCustomCollections() {
+        int[] numbers = TypeUtils.cast(Arrays.asList("1", "2", "3"), int[].class, ParserConfig.getGlobalInstance());
+        assertThat(numbers).containsExactly(1, 2, 3);
+
+        CustomCalendar calendar = TypeUtils.cast(new Date(0L), CustomCalendar.class, ParserConfig.getGlobalInstance());
+        assertThat(calendar.getTime()).isEqualTo(new Date(0L));
+
+        Set customSet = TypeUtils.createSet(CustomSet.class);
+        Collection customCollection = TypeUtils.createCollection(CustomCollection.class);
+        assertThat(customSet).isInstanceOf(CustomSet.class);
+        assertThat(customCollection).isInstanceOf(CustomCollection.class);
+    }
+
+    @Test
+    void castToDateSupportsOracleJdbcTemporalTypes() throws Exception {
+        Timestamp timestamp = new Timestamp(1_000L);
+        Date oracleTimestamp = TypeUtils.castToDate(new TIMESTAMP(timestamp));
+        Date oracleDate = TypeUtils.castToDate(new DATE(timestamp));
+
+        assertThat(oracleTimestamp).isEqualTo(timestamp);
+        assertThat(oracleDate.getTime()).isEqualTo(timestamp.getTime());
+    }
+
+    @Test
+    void castToJavaBeanCreatesProxyForInterfaces() {
+        Map<String, Object> values = Collections.singletonMap("name", "fastjson");
+        NamedView proxy = TypeUtils.castToJavaBean(values, NamedView.class, ParserConfig.getGlobalInstance());
+        assertThat(proxy.getName()).isEqualTo("fastjson");
+    }
+
+    @Test
+    void optionalEmptyUsesOptionalFactoryMethod() {
+        Object optional = TypeUtils.optionalEmpty(Optional.class);
+        assertThat(optional).isEqualTo(Optional.empty());
+    }
+
+    @Test
+    void checkPrimitiveArrayResolvesPrimitiveGenericArrays() {
+        Type resolvedType = TypeUtils.checkPrimitiveArray(new PrimitiveGenericArrayType(int.class));
+        assertThat(resolvedType).isEqualTo(int[].class);
+    }
+
+    @Test
+    void xmlAccessorTypeAnnotationsAreReadThroughPublicUtility() {
+        assertThat(TypeUtils.isXmlField(XmlFieldBean.class)).isTrue();
+    }
+
+    @Test
+    void computeGettersCoversMethodsFieldsSuperTypesAndKotlinConstructorDiscovery() {
+        List<FieldInfo> fieldBased = TypeUtils.computeGettersWithFieldBase(FieldBasedBean.class, null, true, null);
+        assertThat(fieldBased).extracting(fieldInfo -> fieldInfo.name).contains("publicValue", "privateValue");
+
+        List<FieldInfo> getters = TypeUtils.computeGetters(ConcreteAnnotatedBean.class, null, true);
+        assertThat(getters).extracting(fieldInfo -> fieldInfo.name).contains("ifaceName", "abstractName", "publicValue");
+
+        List<FieldInfo> kotlinGetters = TypeUtils.computeGetters(Pair.class, null, true);
+        assertThat(kotlinGetters).extracting(fieldInfo -> fieldInfo.name).contains("first", "second");
+    }
+
+    @Test
+    void kotlinConstructorParametersAreResolvedWithKotlinReflect() {
+        String[] parameterNames = TypeUtils.getKoltinConstructorParameters(Pair.class);
+        assertThat(parameterNames).contains("first", "second");
+    }
+
+    @Test
+    void hibernateInitializationDelegatesToHibernateUtility() {
+        assertThat(TypeUtils.isHibernateInitialized(new Object())).isTrue();
+    }
+
+    @Test
+    void getFieldSearchesDeclaredFieldsOnSuperclasses() {
+        Field field = TypeUtils.getField(ChildFieldBean.class, "baseValue", ChildFieldBean.class.getDeclaredFields());
+        assertThat(field).isNotNull();
+        assertThat(field.getDeclaringClass()).isEqualTo(BaseFieldBean.class);
+    }
+
+    @Test
+    void mixInAnnotationsAreReadFromFieldsMethodsAndParameters() throws NoSuchMethodException, NoSuchFieldException {
+        JSON.addMixInAnnotations(FieldAnnotationTarget.class, FieldAnnotationMixin.class);
+        JSON.addMixInAnnotations(MethodAnnotationTarget.class, MethodAnnotationMixin.class);
+        JSON.addMixInAnnotations(MethodParameterTarget.class, MethodParameterMixin.class);
+        try {
+            TypeUtils typeUtilsAnnotationAccess = null;
+            Field field = FieldAnnotationTarget.class.getField("name");
+            JSONField fieldAnnotation = typeUtilsAnnotationAccess.getAnnotation(field, JSONField.class);
+            assertThat(fieldAnnotation.name()).isEqualTo("mixedField");
+
+            Method method = MethodAnnotationTarget.class.getMethod("getName");
+            JSONField methodAnnotation = typeUtilsAnnotationAccess.getAnnotation(method, JSONField.class);
+            assertThat(methodAnnotation.name()).isEqualTo("mixedMethod");
+
+            Method parameterMethod = MethodParameterTarget.class.getMethod("setName", String.class);
+            Annotation[][] parameterAnnotations = TypeUtils.getParameterAnnotations(parameterMethod);
+            assertThat(Arrays.stream(parameterAnnotations[0]).map(Annotation::annotationType)).contains(JSONField.class);
+        } finally {
+            JSON.removeMixInAnnotations(FieldAnnotationTarget.class);
+            JSON.removeMixInAnnotations(MethodAnnotationTarget.class);
+            JSON.removeMixInAnnotations(MethodParameterTarget.class);
+        }
+    }
+
+    @Test
+    void mixInConstructorParameterAnnotationsAreReadForTopLevelAndInnerMixIns() throws NoSuchMethodException {
+        JSON.addMixInAnnotations(ConstructorAnnotationTarget.class, TopLevelConstructorAnnotationMixin.class);
+        JSON.addMixInAnnotations(InnerConstructorAnnotationTarget.class, InnerConstructorAnnotationMixin.class);
+        try {
+            Constructor<ConstructorAnnotationTarget> constructor = ConstructorAnnotationTarget.class.getConstructor(String.class);
+            Annotation[][] parameterAnnotations = TypeUtils.getParameterAnnotations(constructor);
+            assertThat(Arrays.stream(parameterAnnotations[0]).map(Annotation::annotationType)).contains(JSONField.class);
+
+            Constructor<InnerConstructorAnnotationTarget> innerConstructor = InnerConstructorAnnotationTarget.class.getConstructor(String.class);
+            Annotation[][] innerParameterAnnotations = TypeUtils.getParameterAnnotations(innerConstructor);
+            assertThat(Arrays.stream(innerParameterAnnotations).flatMap(Arrays::stream).map(Annotation::annotationType))
+                    .contains(JSONField.class);
+        } finally {
+            JSON.removeMixInAnnotations(ConstructorAnnotationTarget.class);
+            JSON.removeMixInAnnotations(InnerConstructorAnnotationTarget.class);
+        }
+    }
+
+    public interface NamedView {
+        String getName();
+    }
+
+    public static class CustomCalendar extends GregorianCalendar {
+    }
+
+    public static class CustomSet extends HashSet<String> {
+    }
+
+    public static class CustomCollection extends AbstractCollection<String> {
+        @Override
+        public Iterator<String> iterator() {
+            return Collections.emptyIterator();
+        }
+
+        @Override
+        public int size() {
+            return 0;
+        }
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    public static class XmlFieldBean {
+        public String value;
+    }
+
+    public static class FieldBasedBean {
+        public String publicValue;
+        private String privateValue;
+    }
+
+    public interface AnnotatedPropertyInterface {
+        @JSONField(name = "ifaceName")
+        String getInterfaceName();
+    }
+
+    public abstract static class AbstractAnnotatedProperty {
+        @JSONField(name = "abstractName")
+        public abstract String getAbstractName();
+    }
+
+    public static class ConcreteAnnotatedBean extends AbstractAnnotatedProperty implements AnnotatedPropertyInterface {
+        public String publicValue;
+
+        @Override
+        public String getInterfaceName() {
+            return "iface";
+        }
+
+        @Override
+        public String getAbstractName() {
+            return "abstract";
+        }
+    }
+
+    public static class BaseFieldBean {
+        public String baseValue;
+    }
+
+    public static class ChildFieldBean extends BaseFieldBean {
+        public String childValue;
+    }
+
+    public static class FieldAnnotationTarget {
+        public String name;
+    }
+
+    public static class FieldAnnotationMixin {
+        @JSONField(name = "mixedField")
+        public String name;
+    }
+
+    public static class MethodAnnotationTarget {
+        public String getName() {
+            return "target";
+        }
+    }
+
+    public static class MethodAnnotationMixin {
+        @JSONField(name = "mixedMethod")
+        public String getName() {
+            return "mixin";
+        }
+    }
+
+    public static class MethodParameterTarget {
+        public void setName(String name) {
+        }
+    }
+
+    public static class MethodParameterMixin {
+        public void setName(@JSONField(name = "mixedParameter") String name) {
+        }
+    }
+
+    public static class ConstructorAnnotationTarget {
+        public ConstructorAnnotationTarget(String name) {
+        }
+    }
+
+    public static class InnerConstructorAnnotationTarget {
+        public InnerConstructorAnnotationTarget(String name) {
+        }
+    }
+
+    public class InnerConstructorAnnotationMixin {
+        public InnerConstructorAnnotationMixin(@JSONField(name = "mixedInnerConstructorParameter") String name) {
+        }
+    }
+
+    private static class PrimitiveGenericArrayType implements GenericArrayType {
+        private final Type componentType;
+
+        PrimitiveGenericArrayType(Type componentType) {
+            this.componentType = componentType;
+        }
+
+        @Override
+        public Type getGenericComponentType() {
+            return componentType;
+        }
+    }
+
+    private static class ResolvingClassLoader extends ClassLoader {
+        private final String supportedName;
+        private final Class<?> resolvedClass;
+
+        ResolvingClassLoader(String supportedName, Class<?> resolvedClass) {
+            super(null);
+            this.supportedName = supportedName;
+            this.resolvedClass = resolvedClass;
+        }
+
+        @Override
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            if (supportedName.equals(name)) {
+                return resolvedClass;
+            }
+            throw new ClassNotFoundException(name);
+        }
+    }
+}
+
+class TopLevelConstructorAnnotationMixin {
+    TopLevelConstructorAnnotationMixin(@JSONField(name = "mixedConstructorParameter") String name) {
+    }
+}

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,193 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson.util.ASMUtils"
+      },
+      "type" : "com_alibaba.fastjson.ASMUtilsTest$GenericValueProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson.parser.deserializer.DefaultFieldDeserializer"
+      },
+      "type" : "com_alibaba.fastjson.DefaultFieldDeserializerTest$PrefixingDeserializer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson.parser.deserializer.EnumDeserializer"
+      },
+      "type" : "com_alibaba.fastjson.EnumDeserializerTest$WireStatus"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson.parser.deserializer.FieldDeserializer"
+      },
+      "type" : "com_alibaba.fastjson.FieldDeserializerTest$SetterFallbackBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson.serializer.FieldSerializer"
+      },
+      "type" : "com_alibaba.fastjson.FieldSerializerTest$PrefixingStringSerializer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson.JSONObject"
+      },
+      "type" : "com_alibaba.fastjson.JSONObjectInnerSecureObjectInputStreamTest$EmptyMapInvocationHandler",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson.util.JavaBeanInfo"
+      },
+      "type" : "com_alibaba.fastjson.JavaBeanDeserializerTest$BuilderBackedBean$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson.parser.deserializer.JavaBeanDeserializer"
+      },
+      "type" : "com_alibaba.fastjson.JavaBeanDeserializerTest$RecordingAutoTypeCheckHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson.util.JavaBeanInfo"
+      },
+      "type" : "com_alibaba.fastjson.JavaBeanInfoTest$CreateOnlyBuilderBean$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson.util.JavaBeanInfo"
+      },
+      "type" : "com_alibaba.fastjson.JavaBeanInfoTest$MixinConstructedBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type" : "com_alibaba.fastjson.JavaBeanInfoTest$MixinConstructedBeanMixin"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson.serializer.JavaBeanSerializer"
+      },
+      "type" : "com_alibaba.fastjson.JavaBeanSerializerTest$PrefixValueFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson.parser.deserializer.MapDeserializer"
+      },
+      "type" : "com_alibaba.fastjson.MapDeserializerTest$CustomMap"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson.parser.ParserConfig"
+      },
+      "type" : "com_alibaba.fastjson.ParserConfigTest$CustomBeanDeserializer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson.parser.ParserConfig"
+      },
+      "type" : "com_alibaba.fastjson.ParserConfigTest$CustomEnumDeserializer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson.parser.ParserConfig"
+      },
+      "type" : "com_alibaba.fastjson.ParserConfigTest$MixInCreatorEnum"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson.parser.deserializer.PropertyProcessableDeserializer"
+      },
+      "type" : "com_alibaba.fastjson.PropertyProcessableDeserializerTest$PropertyProcessableBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson.serializer.SerializeConfig"
+      },
+      "type" : "com_alibaba.fastjson.SerializeConfigTest$CustomObjectSerializer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson.serializer.SerializeConfig"
+      },
+      "type" : "com_alibaba.fastjson.SerializeConfigTest$MixInEnum"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson.util.ServiceLoader"
+      },
+      "type" : "com_alibaba.fastjson.ServiceLoaderTest$DiscoveredService"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type" : "com_alibaba.fastjson.TopLevelConstructorAnnotationMixin"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type" : "com_alibaba.fastjson.TypeUtilsTest$CustomCalendar"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type" : "com_alibaba.fastjson.TypeUtilsTest$CustomCollection"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type" : "com_alibaba.fastjson.TypeUtilsTest$CustomSet"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type" : "com_alibaba.fastjson.TypeUtilsTest$FieldAnnotationMixin"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type" : "com_alibaba.fastjson.TypeUtilsTest$InnerConstructorAnnotationMixin"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type" : "com_alibaba.fastjson.TypeUtilsTest$MethodAnnotationMixin"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type" : "com_alibaba.fastjson.TypeUtilsTest$MethodParameterMixin"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson.parser.deserializer.JavaBeanDeserializer"
+      },
+      "type" : {
+        "proxy" : [
+          "com_alibaba.fastjson.JavaBeanDeserializerTest$ProxyView"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson.util.TypeUtils"
+      },
+      "type" : {
+        "proxy" : [
+          "com_alibaba.fastjson.TypeUtilsTest$NamedView"
+        ]
+      }
+    }
+  ]
+}

--- a/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/user-code-filter.json
+++ b/tests/src/com.alibaba/fastjson/1.2.83_noneautotype/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.alibaba.fastjson.**"
+    },
+    {
+      "includeClasses" : "com_alibaba.fastjson.**"
+    }
+  ]
+}

--- a/tests/src/org.junit.jupiter/junit-jupiter-engine/5.8.2/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.junit.jupiter/junit-jupiter-engine/5.8.2/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -67,6 +67,30 @@
           "name" : "pathTempDirectory"
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.jupiter.engine.discovery.predicates.TestClassPredicates"
+      },
+      "type" : "org_junit_jupiter.junit_jupiter_engine.TempDirectoryTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.jupiter.engine.extension.AutoCloseExtension"
+      },
+      "type" : "org_junit_jupiter.junit_jupiter_engine.TempDirectoryTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.jupiter.engine.support.MethodReflectionUtils"
+      },
+      "type" : "org_junit_jupiter.junit_jupiter_engine.TempDirectoryTest",
+      "methods" : [
+        {
+          "name" : "injectsTempDirAnnotatedFields",
+          "parameterTypes" : [ ]
+        }
+      ]
     }
   ],
   "resources" : [


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7251

This PR provides new metadata needed for the org.junit.jupiter:junit-jupiter-engine:6.1.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.junit.jupiter:junit-jupiter-engine:5.8.2`): 4
- Test-only metadata entries (previous `org.junit.jupiter:junit-jupiter-engine:5.8.2`): 18
- Metadata entries (new `org.junit.jupiter:junit-jupiter-engine:6.1.0`): 7
- Test-only metadata entries (new `org.junit.jupiter:junit-jupiter-engine:6.1.0`): 18
- Library coverage (previous): 48.44%
- Library coverage (new): 41.94%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `da08d7a48fce53f6c6266e822538b41d7f3ced4e`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.junit.jupiter:junit-jupiter-engine:5.8.2: 1/1 covered calls (100.00%)
- org.junit.jupiter:junit-jupiter-engine:6.1.0: 1/1 covered calls (100.00%)

**Reflection:**
- org.junit.jupiter:junit-jupiter-engine:5.8.2: 1/1 covered calls (100.00%)
- org.junit.jupiter:junit-jupiter-engine:6.1.0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.junit.jupiter:junit-jupiter-engine:5.8.2: 4630/10464 (44.25%)
- org.junit.jupiter:junit-jupiter-engine:6.1.0: 5873/14779 (39.74%)

**Line:**
- org.junit.jupiter:junit-jupiter-engine:5.8.2: 1103/2277 (48.44%)
- org.junit.jupiter:junit-jupiter-engine:6.1.0: 1338/3190 (41.94%)

**Method:**
- org.junit.jupiter:junit-jupiter-engine:5.8.2: 427/878 (48.63%)
- org.junit.jupiter:junit-jupiter-engine:6.1.0: 550/1269 (43.34%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
- Human intervention: required because repository-level files changed during verification.
- Repository-level fix paths:
  - `metadata/com.alibaba/fastjson/1.2.83_noneautotype/reachability-metadata.json`
  - `metadata/com.alibaba/fastjson/index.json`
  - `tests/src/com.alibaba/fastjson/1.2.83_noneautotype/.gitignore`
  - `tests/src/com.alibaba/fastjson/1.2.83_noneautotype/build.gradle`
  - `tests/src/com.alibaba/fastjson/1.2.83_noneautotype/gradle.properties`
  - `tests/src/com.alibaba/fastjson/1.2.83_noneautotype/settings.gradle`
  - `tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/ASMDeserializerFactoryTest.java`
  - `tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/ASMSerializerFactoryTest.java`
  - `tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/ASMUtilsTest.java`
  - `tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/AnnotationSerializerTest.java`
  - `tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/AntiCollisionHashMapTest.java`
  - `tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/DefaultFieldDeserializerTest.java`
  - `tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/DefaultJSONParserTest.java`
  - `tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/EnumDeserializerTest.java`
  - `tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/FieldDeserializerTest.java`
  - `tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/FieldInfoTest.java`
  - `tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/FieldSerializerTest.java`
  - `tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/IOUtilsAnonymous1Test.java`
  - `tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/JSONLexerBaseTest.java`
  - `tests/src/com.alibaba/fastjson/1.2.83_noneautotype/src/test/java/com_alibaba/fastjson/JSONObjectCodecTest.java`
