### PR TITLE
[GenAI] Add support for io.sundr:resourcecify-annotations:0.230.1 using gpt-5.5

### DIFF
--- a/metadata/io.sundr/resourcecify-annotations/0.230.1/reachability-metadata.json
+++ b/metadata/io.sundr/resourcecify-annotations/0.230.1/reachability-metadata.json
@@ -1,0 +1,39 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.sundr.resourcecify.internal.processor.ResourcecifyProcessor"
+      },
+      "type": "jdk.internal.jrtfs.JrtFileSystemProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.sundr.resourcecify.internal.processor.ResourcecifyProcessor"
+      },
+      "module": "java.base",
+      "glob": "META-INF/services/java.nio.file.spi.FileSystemProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.sundr.resourcecify.internal.processor.ResourcecifyProcessor"
+      },
+      "module": "jdk.compiler",
+      "bundle": "com.sun.tools.javac.resources.compiler"
+    },
+    {
+      "condition": {
+        "typeReached": "io.sundr.resourcecify.internal.processor.ResourcecifyProcessor"
+      },
+      "module": "jdk.compiler",
+      "bundle": "com.sun.tools.javac.resources.javac"
+    }
+  ]
+}

--- a/metadata/io.sundr/resourcecify-annotations/index.json
+++ b/metadata/io.sundr/resourcecify-annotations/index.json
@@ -1,0 +1,18 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "0.230.1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/sundr/resourcecify-annotations/$version$/resourcecify-annotations-$version$-sources.jar",
+    "repository-url" : "https://github.com/sundrio/sundrio",
+    "test-code-url" : "https://github.com/sundrio/sundrio/tree/$version$/tests/shapes",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/sundr/resourcecify-annotations/$version$/resourcecify-annotations-$version$-javadoc.jar",
+    "description" : "Resourcecify provides the @Resourcecify source-retention annotation and annotation processor for copying annotated Java source files into the generated JAR resources. It is intended for tooling scenarios where a source file should remain compiled normally while also being packaged as a resource.",
+    "tested-versions" : [
+      "0.230.1"
+    ],
+    "allowed-packages" : [
+      "io.sundr.resourcecify.annotations",
+      "io.sundr.resourcecify.internal.processor"
+    ]
+  }
+]

--- a/stats/io.sundr/resourcecify-annotations/0.230.1/execution-metrics.json
+++ b/stats/io.sundr/resourcecify-annotations/0.230.1/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-06-06": {
+    "timestamp": "2026-06-06T17:43:58.033532Z",
+    "library": "io.sundr:resourcecify-annotations:0.230.1",
+    "starting_commit": "e019652e471036f0754c10caea9fd5667c57ab1f",
+    "ending_commit": "4ce0142da239d58779d9676cd03615b32e81bccc",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "0.230.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 134,
+          "missed": 4,
+          "ratio": 0.971014,
+          "total": 138
+        },
+        "line": {
+          "covered": 34,
+          "missed": 3,
+          "ratio": 0.918919,
+          "total": 37
+        },
+        "method": {
+          "covered": 6,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 6
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 128353,
+      "cached_input_tokens_used": 1287680,
+      "output_tokens_used": 22734,
+      "iterations": 3,
+      "cost_usd": 1.3258,
+      "generated_loc": 367,
+      "tested_library_loc": 34,
+      "metadata_entries": 8,
+      "code_coverage_percent": 91.89
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.sundr/resourcecify-annotations/0.230.1/src/test/java/io_sundr/resourcecify_annotations/Resourcecify_annotationsTest.java",
+      "metadata_file": "metadata/io.sundr/resourcecify-annotations/0.230.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.sundr/resourcecify-annotations/0.230.1/stats.json
+++ b/stats/io.sundr/resourcecify-annotations/0.230.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "0.230.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 134,
+        "missed" : 4,
+        "ratio" : 0.971014,
+        "total" : 138
+      },
+      "line" : {
+        "covered" : 34,
+        "missed" : 3,
+        "ratio" : 0.918919,
+        "total" : 37
+      },
+      "method" : {
+        "covered" : 6,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 6
+      }
+    }
+  } ]
+}

--- a/tests/src/io.sundr/resourcecify-annotations/0.230.1/.gitignore
+++ b/tests/src/io.sundr/resourcecify-annotations/0.230.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.sundr/resourcecify-annotations/0.230.1/build.gradle
+++ b/tests/src/io.sundr/resourcecify-annotations/0.230.1/build.gradle
@@ -4,11 +4,18 @@
  * You should have received a copy of the CC0 legalcode along with this
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
+import org.graalvm.buildtools.gradle.tasks.NativeRunTask
+
 plugins {
     id "org.graalvm.internal.tck"
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+String javaHome = System.getenv('JAVA_HOME') ?: System.getenv('GRAALVM_HOME')
+List<String> javacRuntimeArgs = [
+        "-Djava.home=${javaHome}",
+        "-Djava.class.path=${-> sourceSets.test.runtimeClasspath.asPath}"
+]
 
 dependencies {
     testImplementation "io.sundr:resourcecify-annotations:$libraryVersion"
@@ -16,6 +23,11 @@ dependencies {
 }
 
 graalvmNative {
+    binaries {
+        test {
+            runtimeArgs.addAll(javacRuntimeArgs)
+        }
+    }
     agent {
         defaultMode = "conditional"
         modes {
@@ -24,4 +36,8 @@ graalvmNative {
             }
         }
     }
+}
+
+tasks.named("nativeTest", NativeRunTask) {
+    runtimeArgs.addAll(javacRuntimeArgs)
 }

--- a/tests/src/io.sundr/resourcecify-annotations/0.230.1/build.gradle
+++ b/tests/src/io.sundr/resourcecify-annotations/0.230.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.sundr:resourcecify-annotations:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.sundr/resourcecify-annotations/0.230.1/gradle.properties
+++ b/tests/src/io.sundr/resourcecify-annotations/0.230.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.sundr:resourcecify-annotations:0.230.1
+library.version = 0.230.1
+metadata.dir = io.sundr/resourcecify-annotations/0.230.1/

--- a/tests/src/io.sundr/resourcecify-annotations/0.230.1/settings.gradle
+++ b/tests/src/io.sundr/resourcecify-annotations/0.230.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.sundr.resourcecify-annotations_tests'

--- a/tests/src/io.sundr/resourcecify-annotations/0.230.1/src/test/java/io_sundr/resourcecify_annotations/Resourcecify_annotationsTest.java
+++ b/tests/src/io.sundr/resourcecify-annotations/0.230.1/src/test/java/io_sundr/resourcecify_annotations/Resourcecify_annotationsTest.java
@@ -106,6 +106,28 @@ public class Resourcecify_annotationsTest {
     }
 
     @Test
+    void resourcecifyProcessorCopiesAnnotatedDefaultPackageSource(@TempDir Path sourceDirectory)
+            throws IOException {
+        String annotatedSource = """
+                import io.sundr.resourcecify.annotations.Resourcecify;
+
+                @Resourcecify
+                public class DefaultPackageResource {
+                    public String value() {
+                        return "default-package";
+                    }
+                }
+                """;
+        writeSource(sourceDirectory, "DefaultPackageResource", annotatedSource);
+
+        CompilationResult result = compileWithDiscoveredProcessor(sourceDirectory);
+
+        assertThat(result.successful()).as(result.diagnosticText()).isTrue();
+        assertThat(result.generatedResources())
+                .containsEntry("DefaultPackageResource.java", annotatedSource);
+    }
+
+    @Test
     void resourcecifyProcessorCopiesAnnotatedInterfaceAndEnumSources(@TempDir Path sourceDirectory)
             throws IOException {
         String interfaceSource = """

--- a/tests/src/io.sundr/resourcecify-annotations/0.230.1/src/test/java/io_sundr/resourcecify_annotations/Resourcecify_annotationsTest.java
+++ b/tests/src/io.sundr/resourcecify-annotations/0.230.1/src/test/java/io_sundr/resourcecify_annotations/Resourcecify_annotationsTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_sundr.resourcecify_annotations;
+
+import org.junit.jupiter.api.Test;
+
+class Resourcecify_annotationsTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.sundr/resourcecify-annotations/0.230.1/src/test/java/io_sundr/resourcecify_annotations/Resourcecify_annotationsTest.java
+++ b/tests/src/io.sundr/resourcecify-annotations/0.230.1/src/test/java/io_sundr/resourcecify_annotations/Resourcecify_annotationsTest.java
@@ -105,6 +105,41 @@ public class Resourcecify_annotationsTest {
                 .doesNotContainKey("sample/resourcecify/PlainSource.java");
     }
 
+    @Test
+    void resourcecifyProcessorCopiesAnnotatedInterfaceAndEnumSources(@TempDir Path sourceDirectory)
+            throws IOException {
+        String interfaceSource = """
+                package sample.resourcecify.types;
+
+                import io.sundr.resourcecify.annotations.Resourcecify;
+
+                @Resourcecify
+                public interface AnnotatedContract {
+                    String value();
+                }
+                """;
+        String enumSource = """
+                package sample.resourcecify.types;
+
+                import io.sundr.resourcecify.annotations.Resourcecify;
+
+                @Resourcecify
+                public enum AnnotatedKind {
+                    FIRST,
+                    SECOND
+                }
+                """;
+        writeSource(sourceDirectory, "sample.resourcecify.types.AnnotatedContract", interfaceSource);
+        writeSource(sourceDirectory, "sample.resourcecify.types.AnnotatedKind", enumSource);
+
+        CompilationResult result = compileWithDiscoveredProcessor(sourceDirectory);
+
+        assertThat(result.successful()).as(result.diagnosticText()).isTrue();
+        assertThat(result.generatedResources())
+                .containsEntry("sample/resourcecify/types/AnnotatedContract.java", interfaceSource)
+                .containsEntry("sample/resourcecify/types/AnnotatedKind.java", enumSource);
+    }
+
     private static Processor findResourcecifyProcessor() {
         for (Processor processor : ServiceLoader.load(Processor.class)) {
             if (PROCESSOR_CLASS_NAME.equals(processor.getClass().getName())) {

--- a/tests/src/io.sundr/resourcecify-annotations/0.230.1/src/test/java/io_sundr/resourcecify_annotations/Resourcecify_annotationsTest.java
+++ b/tests/src/io.sundr/resourcecify-annotations/0.230.1/src/test/java/io_sundr/resourcecify_annotations/Resourcecify_annotationsTest.java
@@ -6,11 +6,359 @@
  */
 package io_sundr.resourcecify_annotations;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
-class Resourcecify_annotationsTest {
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.ServiceLoader;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.processing.Processor;
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.StandardLocation;
+import javax.tools.ToolProvider;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class Resourcecify_annotationsTest {
+    private static final String PROCESSOR_CLASS_NAME =
+            "io.sundr.resourcecify.internal.processor.ResourcecifyProcessor";
+    private static final long EXTERNAL_COMPILER_TIMEOUT_SECONDS = 30;
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void resourcecifyAnnotationIsRejectedOutsideTypes(@TempDir Path sourceDirectory) throws IOException {
+        String invalidSource = """
+                package sample.resourcecify;
+
+                import io.sundr.resourcecify.annotations.Resourcecify;
+
+                public class InvalidResourcecifyTarget {
+                    @Resourcecify
+                    public String value() {
+                        return "not-a-type";
+                    }
+                }
+                """;
+        writeSource(sourceDirectory, "sample.resourcecify.InvalidResourcecifyTarget", invalidSource);
+
+        CompilationResult result = compileWithDiscoveredProcessor(sourceDirectory);
+
+        assertThat(result.successful()).isFalse();
+        assertThat(result.diagnosticText()).contains("not applicable to this kind of declaration");
+    }
+
+    @Test
+    void annotationProcessorIsRegisteredAsAJavaService() {
+        Processor processor = findResourcecifyProcessor();
+
+        assertThat(processor.getClass().getName()).isEqualTo(PROCESSOR_CLASS_NAME);
+        assertThat(processor.getSupportedAnnotationTypes())
+                .containsExactly("io.sundr.resourcecify.annotations.Resourcecify");
+    }
+
+    @Test
+    void resourcecifyProcessorCopiesAnnotatedSourcesToClassOutput(@TempDir Path sourceDirectory) throws IOException {
+        String annotatedSource = """
+                package sample.resourcecify;
+
+                import io.sundr.resourcecify.annotations.Resourcecify;
+
+                @Resourcecify
+                public class AnnotatedSource {
+                    public String value() {
+                        return "copied";
+                    }
+                }
+                """;
+        String plainSource = """
+                package sample.resourcecify;
+
+                public class PlainSource {
+                    public String value() {
+                        return "not-copied";
+                    }
+                }
+                """;
+        writeSource(sourceDirectory, "sample.resourcecify.AnnotatedSource", annotatedSource);
+        writeSource(sourceDirectory, "sample.resourcecify.PlainSource", plainSource);
+
+        CompilationResult result = compileWithDiscoveredProcessor(sourceDirectory);
+
+        assertThat(result.successful()).as(result.diagnosticText()).isTrue();
+        assertThat(result.generatedResources())
+                .containsEntry("sample/resourcecify/AnnotatedSource.java", annotatedSource)
+                .doesNotContainKey("sample/resourcecify/PlainSource.java");
+    }
+
+    private static Processor findResourcecifyProcessor() {
+        for (Processor processor : ServiceLoader.load(Processor.class)) {
+            if (PROCESSOR_CLASS_NAME.equals(processor.getClass().getName())) {
+                return processor;
+            }
+        }
+        throw new AssertionError("Resourcecify annotation processor service was not discovered");
+    }
+
+    private static CompilationResult compileWithDiscoveredProcessor(Path sourceDirectory) {
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        if (compiler == null) {
+            return compileInExternalJvm(sourceDirectory);
+        }
+
+        CompilationResult result = compileInProcess(sourceDirectory, System.getProperty("java.class.path", ""));
+        if (needsExternalCompiler(result)) {
+            return compileInExternalJvm(sourceDirectory);
+        }
+        return result;
+    }
+
+    private static CompilationResult compileInProcess(Path sourceDirectory, String classpath) {
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        assertThat(compiler).as("system Java compiler").isNotNull();
+
+        DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
+        List<String> options = new ArrayList<>();
+        options.add("-proc:only");
+        options.add("-implicit:none");
+        if (!classpath.isBlank()) {
+            options.add("-classpath");
+            options.add(classpath);
+        }
+
+        try (StandardJavaFileManager fileManager = compiler.getStandardFileManager(
+                diagnostics, Locale.ROOT, StandardCharsets.UTF_8)) {
+            Path classOutputDirectory = Files.createTempDirectory("resourcecify-class-output");
+            fileManager.setLocationFromPaths(StandardLocation.SOURCE_PATH, List.of(sourceDirectory));
+            fileManager.setLocationFromPaths(StandardLocation.CLASS_OUTPUT, List.of(classOutputDirectory));
+            JavaCompiler.CompilationTask task = compiler.getTask(
+                    null,
+                    fileManager,
+                    diagnostics,
+                    options,
+                    null,
+                    fileManager.getJavaFileObjectsFromPaths(sourceFiles(sourceDirectory)));
+            task.setProcessors(List.of(findResourcecifyProcessor()));
+            Boolean successful = task.call();
+            return new CompilationResult(
+                    Boolean.TRUE.equals(successful),
+                    diagnosticText(diagnostics.getDiagnostics()),
+                    generatedResources(classOutputDirectory));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static CompilationResult compileInExternalJvm(Path sourceDirectory) {
+        try {
+            Path outputFile = Files.createTempFile("resourcecify-compiler-result", ".properties");
+            Path logFile = Files.createTempFile("resourcecify-compiler", ".log");
+
+            List<String> command = new ArrayList<>();
+            command.add(javaExecutable());
+            command.add("-cp");
+            command.add(externalClasspath());
+            command.add(Resourcecify_annotationsTest.class.getName());
+            command.add("compile-helper");
+            command.add(sourceDirectory.toString());
+            command.add(outputFile.toString());
+
+            Process process = new ProcessBuilder(command)
+                    .redirectErrorStream(true)
+                    .redirectOutput(logFile.toFile())
+                    .start();
+            boolean completed = process.waitFor(EXTERNAL_COMPILER_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            if (!completed) {
+                process.destroyForcibly();
+                return new CompilationResult(false, "External javac process timed out", Map.of());
+            }
+            String processOutput = Files.readString(logFile, StandardCharsets.UTF_8);
+            if (process.exitValue() != 0) {
+                return new CompilationResult(false, processOutput, Map.of());
+            }
+
+            Properties properties = new Properties();
+            try (var inputStream = Files.newInputStream(outputFile)) {
+                properties.load(inputStream);
+            }
+            return new CompilationResult(
+                    Boolean.parseBoolean(properties.getProperty("successful")),
+                    properties.getProperty("diagnostics", ""),
+                    generatedResources(properties));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("External javac process was interrupted", e);
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        if (args.length == 0 || !"compile-helper".equals(args[0])) {
+            return;
+        }
+
+        CompilationResult result = compileInProcess(Path.of(args[1]), externalClasspath());
+        Properties properties = new Properties();
+        properties.setProperty("successful", Boolean.toString(result.successful()));
+        properties.setProperty("diagnostics", result.diagnosticText());
+        int index = 0;
+        for (Map.Entry<String, String> resource : result.generatedResources().entrySet()) {
+            properties.setProperty("resource.path." + index, resource.getKey());
+            properties.setProperty("resource.content." + index, resource.getValue());
+            index++;
+        }
+        properties.setProperty("resource.count", Integer.toString(index));
+        try (OutputStream outputStream = Files.newOutputStream(Path.of(args[2]))) {
+            properties.store(outputStream, null);
+        }
+    }
+
+    private static void writeSource(Path sourceDirectory, String className, String source) throws IOException {
+        Path sourceFile = sourceDirectory.resolve(className.replace('.', '/') + ".java");
+        Files.createDirectories(sourceFile.getParent());
+        Files.writeString(sourceFile, source, StandardCharsets.UTF_8);
+    }
+
+    private static List<Path> sourceFiles(Path sourceDirectory) throws IOException {
+        try (var paths = Files.walk(sourceDirectory)) {
+            return paths.filter(path -> path.getFileName().toString().endsWith(".java")).toList();
+        }
+    }
+
+    private static Map<String, String> generatedResources(Path classOutputDirectory) throws IOException {
+        Map<String, String> resources = new HashMap<>();
+        if (!Files.isDirectory(classOutputDirectory)) {
+            return resources;
+        }
+        try (var paths = Files.walk(classOutputDirectory)) {
+            for (Path resource : paths.filter(path -> path.getFileName().toString().endsWith(".java")).toList()) {
+                String relativePath = classOutputDirectory.relativize(resource).toString()
+                        .replace(resource.getFileSystem().getSeparator(), "/");
+                resources.put(relativePath, Files.readString(resource, StandardCharsets.UTF_8));
+            }
+        }
+        return resources;
+    }
+
+    private static Map<String, String> generatedResources(Properties properties) {
+        int count = Integer.parseInt(properties.getProperty("resource.count", "0"));
+        Map<String, String> resources = new HashMap<>();
+        for (int index = 0; index < count; index++) {
+            resources.put(
+                    properties.getProperty("resource.path." + index),
+                    properties.getProperty("resource.content." + index));
+        }
+        return resources;
+    }
+
+    private static String diagnosticText(List<Diagnostic<? extends JavaFileObject>> diagnostics) {
+        StringBuilder builder = new StringBuilder();
+        for (Diagnostic<? extends JavaFileObject> diagnostic : diagnostics) {
+            builder.append(diagnostic.getKind())
+                    .append(':')
+                    .append(diagnostic.getMessage(Locale.ROOT))
+                    .append(System.lineSeparator());
+        }
+        return builder.toString();
+    }
+
+    private static boolean needsExternalCompiler(CompilationResult result) {
+        return result.diagnosticText().contains("Unable to find package java.lang in platform classes");
+    }
+
+    private static String externalClasspath() throws IOException {
+        List<String> entries = new ArrayList<>();
+        entries.add(Path.of("build", "classes", "java", "test").toAbsolutePath().toString());
+        entries.add(Path.of("build", "resources", "test").toAbsolutePath().toString());
+        Path libs = Path.of("build", "libs");
+        if (Files.isDirectory(libs)) {
+            try (var paths = Files.list(libs)) {
+                paths.filter(path -> path.getFileName().toString().endsWith(".jar"))
+                        .map(path -> path.toAbsolutePath().toString())
+                        .forEach(entries::add);
+            }
+        }
+        addCachedArtifacts(entries, "io.sundr", "resourcecify-annotations");
+        addCachedArtifacts(entries, "org.assertj", "assertj-core");
+        addCachedArtifacts(entries, "org.junit.jupiter", "junit-jupiter-api");
+        addCachedArtifacts(entries, "org.junit.platform", "junit-platform-commons");
+        addCachedArtifacts(entries, "org.opentest4j", "opentest4j");
+        addCachedArtifacts(entries, "org.apiguardian", "apiguardian-api");
+        String currentClasspath = System.getProperty("java.class.path", "");
+        if (!currentClasspath.isBlank()) {
+            entries.add(currentClasspath);
+        }
+        return String.join(System.getProperty("path.separator"), entries);
+    }
+
+    private static void addCachedArtifacts(List<String> entries, String group, String artifact) throws IOException {
+        String userHome = System.getProperty("user.home");
+        if (userHome != null && !userHome.isBlank()) {
+            addCachedArtifacts(entries, Path.of(userHome, ".gradle"), group, artifact);
+        }
+        String gradleUserHome = System.getenv("GRADLE_USER_HOME");
+        if (gradleUserHome != null && !gradleUserHome.isBlank()) {
+            addCachedArtifacts(entries, Path.of(gradleUserHome), group, artifact);
+        }
+
+        Path forgeGradleCaches = Path.of(System.getProperty("java.io.tmpdir"), "metadata-forge-gradle");
+        if (Files.isDirectory(forgeGradleCaches)) {
+            Path expectedSuffix = Path.of("caches", "modules-2", "files-2.1", group, artifact);
+            try (var paths = Files.walk(forgeGradleCaches, 8)) {
+                for (Path artifactCache : paths.filter(path -> path.endsWith(expectedSuffix)).toList()) {
+                    addJarPaths(entries, artifactCache);
+                }
+            }
+        }
+    }
+
+    private static void addCachedArtifacts(
+            List<String> entries, Path gradleUserHome, String group, String artifact) throws IOException {
+        Path artifactCache = gradleUserHome.resolve(Path.of("caches", "modules-2", "files-2.1", group, artifact));
+        addJarPaths(entries, artifactCache);
+    }
+
+    private static void addJarPaths(List<String> entries, Path artifactCache) throws IOException {
+        if (!Files.isDirectory(artifactCache)) {
+            return;
+        }
+        try (var paths = Files.walk(artifactCache, 3)) {
+            paths.filter(path -> path.getFileName().toString().endsWith(".jar"))
+                    .map(path -> path.toAbsolutePath().toString())
+                    .forEach(entries::add);
+        }
+    }
+
+    private static String javaExecutable() {
+        String javaHome = System.getenv("JAVA_HOME");
+        if (javaHome == null || javaHome.isBlank()) {
+            javaHome = System.getenv("GRAALVM_HOME");
+        }
+        if (javaHome != null && !javaHome.isBlank()) {
+            Path java = Path.of(javaHome, "bin", "java");
+            if (Files.isRegularFile(java)) {
+                return java.toString();
+            }
+        }
+        return "java";
+    }
+
+    private record CompilationResult(
+            boolean successful, String diagnosticText, Map<String, String> generatedResources) {
     }
 }

--- a/tests/src/io.sundr/resourcecify-annotations/0.230.1/user-code-filter.json
+++ b/tests/src/io.sundr/resourcecify-annotations/0.230.1/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.sundr.resourcecify.annotations.**"
+    },
+    {
+      "includeClasses": "io.sundr.resourcecify.internal.processor.**"
+    }
+  ]
+}

--- a/tests/src/io.sundr/resourcecify-annotations/0.230.1/user-code-filter.json
+++ b/tests/src/io.sundr/resourcecify-annotations/0.230.1/user-code-filter.json
@@ -1,13 +1,16 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.sundr.resourcecify.annotations.**"
+      "includeClasses" : "io.sundr.resourcecify.annotations.**"
     },
     {
-      "includeClasses": "io.sundr.resourcecify.internal.processor.**"
+      "includeClasses" : "io.sundr.resourcecify.internal.processor.**"
+    },
+    {
+      "includeClasses" : "io_sundr.resourcecify_annotations.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #7779

This PR introduces tests and metadata for io.sundr:resourcecify-annotations:0.230.1, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 128353
- Cached input tokens: 1287680
- Output tokens: 22734
- Metadata entries: 8
- Iterations: 3
- Library coverage percentage: 91.89
- Generated lines of code: 367
- Tested library lines of code: 34

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `9098be2d37195574e77c5e9e4664c95b69ffc58b`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 134/138 (97.10%)
- Line: 34/37 (91.89%)
- Method: 6/6 (100.00%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
