### PR TITLE
[Automation] Generated metadata for org.apache.lucene:lucene-core:5.5.0

### DIFF
--- a/stats/org.apache.lucene/lucene-core/5.5.0/stats.json
+++ b/stats/org.apache.lucene/lucene-core/5.5.0/stats.json
@@ -20,21 +20,21 @@
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 4097,
-        "missed" : 269593,
-        "ratio" : 0.014969,
+        "covered" : 4120,
+        "missed" : 269570,
+        "ratio" : 0.015054,
         "total" : 273690
       },
       "line" : {
-        "covered" : 670,
-        "missed" : 49099,
-        "ratio" : 0.013462,
+        "covered" : 676,
+        "missed" : 49093,
+        "ratio" : 0.013583,
         "total" : 49769
       },
       "method" : {
-        "covered" : 166,
-        "missed" : 8913,
-        "ratio" : 0.018284,
+        "covered" : 167,
+        "missed" : 8912,
+        "ratio" : 0.018394,
         "total" : 9079
       }
     }


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7346

This PR provides new metadata needed for the org.apache.lucene:lucene-core:5.5.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.apache.lucene:lucene-core:5.5.0`): 60
- Test-only metadata entries (previous `org.apache.lucene:lucene-core:5.5.0`): 11
- Metadata entries (new `org.apache.lucene:lucene-core:5.5.0`): 60
- Test-only metadata entries (new `org.apache.lucene:lucene-core:5.5.0`): 11
- Library coverage (previous): 1.36%
- Library coverage (new): 1.36%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `0db76886ea08654469b86c0748be36de8f73ca30`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `org.apache.lucene:lucene-core:5.5.0` and `org.apache.lucene:lucene-core:5.5.0`.

### Local CI Verification

- Status: `success`
- Commands run: 0
- Fixup attempts: 0
