### PR TITLE
[GenAI] Test fix for org.apache.thrift:libthrift:0.17.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.thrift/libthrift/0.17.0/reachability-metadata.json
+++ b/metadata/org.apache.thrift/libthrift/0.17.0/reachability-metadata.json
@@ -1,248 +1,218 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
       },
-      "type": "com.sun.crypto.provider.AESCipher$General",
-      "methods": [
+      "type" : "com.sun.crypto.provider.AESCipher$General",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
       },
-      "type": "com.sun.crypto.provider.ARCFOURCipher",
-      "methods": [
+      "type" : "com.sun.crypto.provider.ARCFOURCipher",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
       },
-      "type": "com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Poly1305",
-      "methods": [
+      "type" : "com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Poly1305",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
       },
-      "type": "com.sun.crypto.provider.DESCipher",
-      "methods": [
+      "type" : "com.sun.crypto.provider.DESCipher",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
       },
-      "type": "com.sun.crypto.provider.DESedeCipher",
-      "methods": [
+      "type" : "com.sun.crypto.provider.DESedeCipher",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
       },
-      "type": "com.sun.crypto.provider.DHParameters",
-      "methods": [
+      "type" : "com.sun.crypto.provider.DHParameters",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
       },
-      "type": "com.sun.crypto.provider.GaloisCounterMode$AESGCM",
-      "methods": [
+      "type" : "com.sun.crypto.provider.GaloisCounterMode$AESGCM",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
       },
-      "type": "com.sun.crypto.provider.TlsMasterSecretGenerator",
-      "methods": [
+      "type" : "com.sun.crypto.provider.TlsMasterSecretGenerator",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.thrift.TEnumHelper"
+      "condition" : {
+        "typeReached" : "org.apache.thrift.TEnumHelper"
       },
-      "type": "java.lang.reflect.Method[]"
+      "type" : "java.lang.reflect.Method[]"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.thrift.partial.EnumCache"
+      "condition" : {
+        "typeReached" : "org.apache.thrift.partial.EnumCache"
       },
-      "type": "java.lang.reflect.Method[]"
+      "type" : "java.lang.reflect.Method[]"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
       },
-      "type": "java.security.AlgorithmParametersSpi"
+      "type" : "java.security.AlgorithmParametersSpi"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
       },
-      "type": "javax.net.ssl.SSLContext"
+      "type" : "javax.net.ssl.SSLContext"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
       },
-      "type": "jdk.net.LinuxSocketOptions"
+      "type" : "jdk.net.LinuxSocketOptions"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.thrift.partial.EnumCache"
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
       },
-      "type": "org_apache_thrift.libthrift.EnumCacheTest$ExampleCachedEnum"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.thrift.meta_data.FieldMetaData"
-      },
-      "type": "org_apache_thrift.libthrift.FieldMetaDataTest$GeneratedStruct"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.thrift.TEnumHelper"
-      },
-      "type": "org_apache_thrift.libthrift.TEnumHelperTest$ExampleThriftEnum"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.thrift.meta_data.FieldMetaData"
-      },
-      "type": "org_apache_thrift.libthrift.ThriftMetadataInnerThriftStructTest$GeneratedStruct"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.thrift.partial.ThriftMetadata$ThriftStruct"
-      },
-      "type": "org_apache_thrift.libthrift.ThriftMetadataInnerThriftStructTest$GeneratedStruct"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
-      },
-      "type": "sun.security.provider.JavaKeyStore$DualFormatJKS",
-      "methods": [
+      "type" : "sun.security.provider.JavaKeyStore$DualFormatJKS",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
       },
-      "type": "sun.security.provider.JavaKeyStore$JKS",
-      "methods": [
+      "type" : "sun.security.provider.JavaKeyStore$JKS",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
       },
-      "type": "sun.security.provider.NativePRNG",
-      "methods": [
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.security.SecureRandomParameters"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
       },
-      "type": "sun.security.provider.SHA",
-      "methods": [
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
       },
-      "type": "sun.security.ssl.SSLContextImpl$TLSContext",
-      "methods": [
+      "type" : "sun.security.ssl.SSLContextImpl$TLSContext",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
       },
-      "type": "sun.security.ssl.TrustManagerFactoryImpl$PKIXFactory",
-      "methods": [
+      "type" : "sun.security.ssl.TrustManagerFactoryImpl$PKIXFactory",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition" : {
+        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
       },
-      "glob": "META-INF/services/java.net.spi.URLStreamHandlerProvider"
+      "glob" : "META-INF/services/java.net.spi.URLStreamHandlerProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.thrift.partial.EnumCache"
+      "condition" : {
+        "typeReached" : "org.apache.thrift.partial.EnumCache"
       },
-      "glob": "org/slf4j/impl/StaticLoggerBinder.class"
+      "glob" : "org/slf4j/impl/StaticLoggerBinder.class"
     }
   ]
 }

--- a/metadata/org.apache.thrift/libthrift/0.17.0/reachability-metadata.json
+++ b/metadata/org.apache.thrift/libthrift/0.17.0/reachability-metadata.json
@@ -1,194 +1,248 @@
 {
-  "reflection" : [
+  "reflection": [
     {
-      "condition" : {
-        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition": {
+        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
       },
-      "type" : "com.sun.crypto.provider.AESCipher$General",
-      "methods" : [
+      "type": "com.sun.crypto.provider.AESCipher$General",
+      "methods": [
         {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
+          "name": "<init>",
+          "parameterTypes": []
         }
       ]
     },
     {
-      "condition" : {
-        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition": {
+        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
       },
-      "type" : "com.sun.crypto.provider.ARCFOURCipher",
-      "methods" : [
+      "type": "com.sun.crypto.provider.ARCFOURCipher",
+      "methods": [
         {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
+          "name": "<init>",
+          "parameterTypes": []
         }
       ]
     },
     {
-      "condition" : {
-        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition": {
+        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
       },
-      "type" : "com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Poly1305",
-      "methods" : [
+      "type": "com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Poly1305",
+      "methods": [
         {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
+          "name": "<init>",
+          "parameterTypes": []
         }
       ]
     },
     {
-      "condition" : {
-        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition": {
+        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
       },
-      "type" : "com.sun.crypto.provider.DESCipher",
-      "methods" : [
+      "type": "com.sun.crypto.provider.DESCipher",
+      "methods": [
         {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
+          "name": "<init>",
+          "parameterTypes": []
         }
       ]
     },
     {
-      "condition" : {
-        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition": {
+        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
       },
-      "type" : "com.sun.crypto.provider.DESedeCipher",
-      "methods" : [
+      "type": "com.sun.crypto.provider.DESedeCipher",
+      "methods": [
         {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
+          "name": "<init>",
+          "parameterTypes": []
         }
       ]
     },
     {
-      "condition" : {
-        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition": {
+        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
       },
-      "type" : "com.sun.crypto.provider.DHParameters",
-      "methods" : [
+      "type": "com.sun.crypto.provider.DHParameters",
+      "methods": [
         {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
+          "name": "<init>",
+          "parameterTypes": []
         }
       ]
     },
     {
-      "condition" : {
-        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition": {
+        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
       },
-      "type" : "com.sun.crypto.provider.GaloisCounterMode$AESGCM",
-      "methods" : [
+      "type": "com.sun.crypto.provider.GaloisCounterMode$AESGCM",
+      "methods": [
         {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
+          "name": "<init>",
+          "parameterTypes": []
         }
       ]
     },
     {
-      "condition" : {
-        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition": {
+        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
       },
-      "type" : "com.sun.crypto.provider.TlsMasterSecretGenerator",
-      "methods" : [
+      "type": "com.sun.crypto.provider.TlsMasterSecretGenerator",
+      "methods": [
         {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
+          "name": "<init>",
+          "parameterTypes": []
         }
       ]
     },
     {
-      "condition" : {
-        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition": {
+        "typeReached": "org.apache.thrift.TEnumHelper"
       },
-      "type" : "java.security.AlgorithmParametersSpi"
+      "type": "java.lang.reflect.Method[]"
     },
     {
-      "condition" : {
-        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition": {
+        "typeReached": "org.apache.thrift.partial.EnumCache"
       },
-      "type" : "sun.security.provider.JavaKeyStore$DualFormatJKS",
-      "methods" : [
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
+      },
+      "type": "java.security.AlgorithmParametersSpi"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
+      },
+      "type": "javax.net.ssl.SSLContext"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
+      },
+      "type": "jdk.net.LinuxSocketOptions"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.thrift.partial.EnumCache"
+      },
+      "type": "org_apache_thrift.libthrift.EnumCacheTest$ExampleCachedEnum"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.thrift.meta_data.FieldMetaData"
+      },
+      "type": "org_apache_thrift.libthrift.FieldMetaDataTest$GeneratedStruct"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.thrift.TEnumHelper"
+      },
+      "type": "org_apache_thrift.libthrift.TEnumHelperTest$ExampleThriftEnum"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.thrift.meta_data.FieldMetaData"
+      },
+      "type": "org_apache_thrift.libthrift.ThriftMetadataInnerThriftStructTest$GeneratedStruct"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.thrift.partial.ThriftMetadata$ThriftStruct"
+      },
+      "type": "org_apache_thrift.libthrift.ThriftMetadataInnerThriftStructTest$GeneratedStruct"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
+      },
+      "type": "sun.security.provider.JavaKeyStore$DualFormatJKS",
+      "methods": [
         {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
+          "name": "<init>",
+          "parameterTypes": []
         }
       ]
     },
     {
-      "condition" : {
-        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition": {
+        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
       },
-      "type" : "sun.security.provider.JavaKeyStore$JKS",
-      "methods" : [
+      "type": "sun.security.provider.JavaKeyStore$JKS",
+      "methods": [
         {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
+          "name": "<init>",
+          "parameterTypes": []
         }
       ]
     },
     {
-      "condition" : {
-        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition": {
+        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
       },
-      "type" : "sun.security.provider.NativePRNG",
-      "methods" : [
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
         {
-          "name" : "<init>",
-          "parameterTypes" : [
+          "name": "<init>",
+          "parameterTypes": [
             "java.security.SecureRandomParameters"
           ]
         }
       ]
     },
     {
-      "condition" : {
-        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition": {
+        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
       },
-      "type" : "sun.security.provider.SHA",
-      "methods" : [
+      "type": "sun.security.provider.SHA",
+      "methods": [
         {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
+          "name": "<init>",
+          "parameterTypes": []
         }
       ]
     },
     {
-      "condition" : {
-        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition": {
+        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
       },
-      "type" : "sun.security.ssl.SSLContextImpl$TLSContext",
-      "methods" : [
+      "type": "sun.security.ssl.SSLContextImpl$TLSContext",
+      "methods": [
         {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
+          "name": "<init>",
+          "parameterTypes": []
         }
       ]
     },
     {
-      "condition" : {
-        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition": {
+        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
       },
-      "type" : "sun.security.ssl.TrustManagerFactoryImpl$PKIXFactory",
-      "methods" : [
+      "type": "sun.security.ssl.TrustManagerFactoryImpl$PKIXFactory",
+      "methods": [
         {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
+          "name": "<init>",
+          "parameterTypes": []
         }
       ]
     }
   ],
-  "resources" : [
+  "resources": [
     {
-      "condition" : {
-        "typeReached" : "org.apache.thrift.transport.TSSLTransportFactory"
+      "condition": {
+        "typeReached": "org.apache.thrift.transport.TSSLTransportFactory"
       },
-      "glob" : "META-INF/services/java.net.spi.URLStreamHandlerProvider"
+      "glob": "META-INF/services/java.net.spi.URLStreamHandlerProvider"
     },
     {
-      "condition" : {
-        "typeReached" : "org.apache.thrift.partial.EnumCache"
+      "condition": {
+        "typeReached": "org.apache.thrift.partial.EnumCache"
       },
-      "glob" : "org/slf4j/impl/StaticLoggerBinder.class"
+      "glob": "org/slf4j/impl/StaticLoggerBinder.class"
     }
   ]
 }

--- a/stats/org.apache.thrift/libthrift/0.17.0/execution-metrics.json
+++ b/stats/org.apache.thrift/libthrift/0.17.0/execution-metrics.json
@@ -107,5 +107,114 @@
       "test_file": "tests/src/org.apache.thrift/libthrift/0.17.0/src/test/java/org_apache_thrift/libthrift/TSSLTransportFactoryTest.java",
       "metadata_file": "metadata/org.apache.thrift/libthrift/0.17.0/reachability-metadata.json"
     }
+  },
+  "fix_java_run_fail:2026-06-06": {
+    "timestamp": "2026-06-06T18:08:59.592021Z",
+    "library": "org.apache.thrift:libthrift:0.17.0",
+    "starting_commit": "0db76886ea08654469b86c0748be36de8f73ca30",
+    "ending_commit": "4a11ec6ae9668de4a01c3092e71fa67e59a6a56f",
+    "previous_library": "org.apache.thrift:libthrift:0.17.0",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "0.17.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 8,
+            "totalCalls": 8
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 9,
+        "totalCalls": 9
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 696,
+          "missed": 28584,
+          "ratio": 0.02377,
+          "total": 29280
+        },
+        "line": {
+          "covered": 182,
+          "missed": 6729,
+          "ratio": 0.026335,
+          "total": 6911
+        },
+        "method": {
+          "covered": 45,
+          "missed": 1590,
+          "ratio": 0.027523,
+          "total": 1635
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "0.17.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 8,
+            "totalCalls": 8
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 9,
+        "totalCalls": 9
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 696,
+          "missed": 28584,
+          "ratio": 0.02377,
+          "total": 29280
+        },
+        "line": {
+          "covered": 182,
+          "missed": 6729,
+          "ratio": 0.026335,
+          "total": 6911
+        },
+        "method": {
+          "covered": 45,
+          "missed": 1590,
+          "ratio": 0.027523,
+          "total": 1635
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 25059,
+      "cached_input_tokens_used": 104448,
+      "output_tokens_used": 1474,
+      "iterations": 1,
+      "cost_usd": 0.0964,
+      "tested_library_loc": 182,
+      "metadata_entries": 35,
+      "test_only_metadata_entries": 13,
+      "previous_library_metadata_entries": 35,
+      "previous_library_test_only_metadata_entries": 13,
+      "code_coverage_percent": 2.63,
+      "previous_library_coverage_percent": 2.63
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.thrift/libthrift/0.17.0/src/test/java/org_apache_thrift/libthrift/TSSLTransportFactoryTest.java",
+      "metadata_file": "metadata/org.apache.thrift/libthrift/0.17.0/reachability-metadata.json"
+    }
   }
 }

--- a/tests/src/org.apache.thrift/libthrift/0.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.thrift/libthrift/0.17.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -49,6 +49,36 @@
           "parameterTypes" : [ ]
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.thrift.partial.EnumCache"
+      },
+      "type" : "org_apache_thrift.libthrift.EnumCacheTest$ExampleCachedEnum"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.thrift.meta_data.FieldMetaData"
+      },
+      "type" : "org_apache_thrift.libthrift.FieldMetaDataTest$GeneratedStruct"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.thrift.TEnumHelper"
+      },
+      "type" : "org_apache_thrift.libthrift.TEnumHelperTest$ExampleThriftEnum"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.thrift.meta_data.FieldMetaData"
+      },
+      "type" : "org_apache_thrift.libthrift.ThriftMetadataInnerThriftStructTest$GeneratedStruct"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.thrift.partial.ThriftMetadata$ThriftStruct"
+      },
+      "type" : "org_apache_thrift.libthrift.ThriftMetadataInnerThriftStructTest$GeneratedStruct"
     }
   ]
 }

--- a/tests/src/org.apache.thrift/libthrift/0.17.0/user-code-filter.json
+++ b/tests/src/org.apache.thrift/libthrift/0.17.0/user-code-filter.json
@@ -5,6 +5,9 @@
     },
     {
       "includeClasses" : "org.apache.thrift.**"
+    },
+    {
+      "includeClasses" : "org_apache_thrift.libthrift.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #4262

This PR provides test fixes and new metadata for org.apache.thrift:libthrift:0.17.0, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 25059
- Cached input tokens: 104448
- Output tokens: 1474
- Metadata entries: 35
- Test-only metadata entries: 13
- Iterations: 1
- Library coverage percentage: 2.63
- Previous library version metadata entries: 35
- Previous library version test-only metadata entries: 13
- Previous library version coverage percentage: 2.63

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `0db76886ea08654469b86c0748be36de8f73ca30`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `org.apache.thrift:libthrift:0.17.0` and `org.apache.thrift:libthrift:0.17.0`.

**Comparison between existing test version and AI-Generated update**

```diff

```

### Local CI Verification

- Status: `success`
- Commands run: 0
- Fixup attempts: 0
