### PR TITLE
[GenAI] Test fix for com.google.code.gson:gson:2.3 using gpt-5.5

### DIFF
--- a/metadata/com.google.code.gson/gson/2.3/reachability-metadata.json
+++ b/metadata/com.google.code.gson/gson/2.3/reachability-metadata.json
@@ -1,0 +1,29 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.google.gson.internal.UnsafeAllocator"
+      },
+      "type" : "sun.misc.Unsafe",
+      "fields" : [
+        {
+          "name" : "theUnsafe"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.gson.internal.UnsafeAllocator$1"
+      },
+      "type" : "sun.misc.Unsafe",
+      "methods" : [
+        {
+          "name" : "allocateInstance",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/com.google.code.gson/gson/index.json
+++ b/metadata/com.google.code.gson/gson/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.3",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/google/code/gson/gson/$version$/gson-$version$-sources.jar",
+    "repository-url" : "https://github.com/google/gson",
+    "test-code-url" : "https://github.com/google/gson/tree/gson-$version$/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/google/code/gson/gson/$version$/gson-$version$-javadoc.jar",
+    "description" : "Gson is a Java library for converting Java objects to and from JSON. It provides object mapping, tree, and streaming APIs for JSON serialization and deserialization.",
     "tested-versions" : [
       "2.3"
     ],

--- a/metadata/com.google.code.gson/gson/index.json
+++ b/metadata/com.google.code.gson/gson/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.3",
+    "tested-versions" : [
+      "2.3"
+    ],
+    "allowed-packages" : [
+      "com.google.gson"
+    ]
+  },
+  {
     "metadata-version" : "2.2.4",
     "source-code-url" : "https://repo1.maven.org/maven2/com/google/code/gson/gson/$version$/gson-$version$-sources.jar",
     "repository-url" : "https://github.com/google/gson",

--- a/stats/com.google.code.gson/gson/2.3/execution-metrics.json
+++ b/stats/com.google.code.gson/gson/2.3/execution-metrics.json
@@ -1,0 +1,101 @@
+{
+  "fix_java_run_fail:2026-06-06": {
+    "timestamp": "2026-06-06T18:56:26.092590Z",
+    "library": "com.google.code.gson:gson:2.3",
+    "starting_commit": "c8f60e3d19d441a0bad9f73b9916b549b102f0e6",
+    "ending_commit": "ce67e4ee78c6ce607ddd97a4123b64406f3afea3",
+    "previous_library": "com.google.code.gson:gson:2.2.4",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.3",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 13,
+            "totalCalls": 13
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 13,
+        "totalCalls": 13
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4027,
+          "missed": 13364,
+          "ratio": 0.231557,
+          "total": 17391
+        },
+        "line": {
+          "covered": 953,
+          "missed": 2976,
+          "ratio": 0.242555,
+          "total": 3929
+        },
+        "method": {
+          "covered": 233,
+          "missed": 573,
+          "ratio": 0.289082,
+          "total": 806
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.2.4",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 13,
+            "totalCalls": 13
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 13,
+        "totalCalls": 13
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3910,
+          "missed": 11376,
+          "ratio": 0.25579,
+          "total": 15286
+        },
+        "line": {
+          "covered": 906,
+          "missed": 2481,
+          "ratio": 0.267493,
+          "total": 3387
+        },
+        "method": {
+          "covered": 230,
+          "missed": 503,
+          "ratio": 0.313779,
+          "total": 733
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 23548,
+      "cached_input_tokens_used": 126976,
+      "output_tokens_used": 2714,
+      "iterations": 1,
+      "cost_usd": 0.1449,
+      "tested_library_loc": 953,
+      "metadata_entries": 4,
+      "test_only_metadata_entries": 22,
+      "previous_library_metadata_entries": 4,
+      "previous_library_test_only_metadata_entries": 20,
+      "code_coverage_percent": 24.26,
+      "previous_library_coverage_percent": 26.75
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.google.code.gson/gson/2.3/src/test/java/com_google_code_gson/gson/ArrayTypeAdapterTest.java",
+      "metadata_file": "metadata/com.google.code.gson/gson/2.3/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.google.code.gson/gson/2.3/stats.json
+++ b/stats/com.google.code.gson/gson/2.3/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "2.3",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 13,
+          "totalCalls" : 13
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 13,
+      "totalCalls" : 13
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 4027,
+        "missed" : 13364,
+        "ratio" : 0.231557,
+        "total" : 17391
+      },
+      "line" : {
+        "covered" : 953,
+        "missed" : 2976,
+        "ratio" : 0.242555,
+        "total" : 3929
+      },
+      "method" : {
+        "covered" : 233,
+        "missed" : 573,
+        "ratio" : 0.289082,
+        "total" : 806
+      }
+    }
+  } ]
+}

--- a/tests/src/com.google.code.gson/gson/2.3/.gitignore
+++ b/tests/src/com.google.code.gson/gson/2.3/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.google.code.gson/gson/2.3/build.gradle
+++ b/tests/src/com.google.code.gson/gson/2.3/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.google.code.gson:gson:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.google.code.gson/gson/2.3/gradle.properties
+++ b/tests/src/com.google.code.gson/gson/2.3/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.google.code.gson:gson:2.3
+library.version = 2.3
+metadata.dir = com.google.code.gson/gson/2.3/

--- a/tests/src/com.google.code.gson/gson/2.3/settings.gradle
+++ b/tests/src/com.google.code.gson/gson/2.3/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.google.code.gson.gson_tests'

--- a/tests/src/com.google.code.gson/gson/2.3/src/test/java/com_google_code_gson/gson/ArrayTypeAdapterTest.java
+++ b/tests/src/com.google.code.gson/gson/2.3/src/test/java/com_google_code_gson/gson/ArrayTypeAdapterTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_code_gson.gson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.gson.Gson;
+import org.junit.jupiter.api.Test;
+
+public class ArrayTypeAdapterTest {
+    private final Gson gson = new Gson();
+
+    @Test
+    void deserializesObjectArrayThroughReflectiveArrayAllocation() {
+        String json = """
+                [
+                  {"name":"paperclips","quantity":3,"available":true},
+                  {"name":"folders","quantity":9,"available":false}
+                ]
+                """;
+
+        InventoryItem[] items = gson.fromJson(json, InventoryItem[].class);
+
+        assertThat(items).hasSize(2);
+        assertThat(items[0].name).isEqualTo("paperclips");
+        assertThat(items[0].quantity).isEqualTo(3);
+        assertThat(items[0].available).isTrue();
+        assertThat(items[1].name).isEqualTo("folders");
+        assertThat(items[1].quantity).isEqualTo(9);
+        assertThat(items[1].available).isFalse();
+    }
+
+    public static final class InventoryItem {
+        private String name;
+        private int quantity;
+        private boolean available;
+
+        public InventoryItem() {
+        }
+    }
+}

--- a/tests/src/com.google.code.gson/gson/2.3/src/test/java/com_google_code_gson/gson/EnumTypeAdapterTest.java
+++ b/tests/src/com.google.code.gson/gson/2.3/src/test/java/com_google_code_gson/gson/EnumTypeAdapterTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_code_gson.gson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
+import org.junit.jupiter.api.Test;
+
+public class EnumTypeAdapterTest {
+    private final Gson gson = new Gson();
+
+    @Test
+    void resolvesEnumConstantsThroughReflectedPublicFields() {
+        ShipmentState state = gson.fromJson("\"shipped\"", ShipmentState.class);
+
+        assertThat(state).isEqualTo(ShipmentState.IN_TRANSIT);
+        assertThat(gson.toJson(ShipmentState.READY)).isEqualTo("\"ready\"");
+    }
+
+    public enum ShipmentState {
+        @SerializedName("ready")
+        READY,
+        @SerializedName("shipped")
+        IN_TRANSIT
+    }
+}

--- a/tests/src/com.google.code.gson/gson/2.3/src/test/java/com_google_code_gson/gson/FieldAttributesTest.java
+++ b/tests/src/com.google.code.gson/gson/2.3/src/test/java/com_google_code_gson/gson/FieldAttributesTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_code_gson.gson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.gson.FieldAttributes;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+
+public class FieldAttributesTest {
+    @Test
+    void readsValueFromWrappedPublicField() throws Exception {
+        Field field = FieldCarrier.class.getField("title");
+        FieldAttributes attributes = new FieldAttributes(field);
+        FieldCarrier carrier = new FieldCarrier("integration-guide");
+
+        Method getMethod = FieldAttributes.class.getDeclaredMethod("get", Object.class);
+        getMethod.setAccessible(true);
+        Object value = getMethod.invoke(attributes, carrier);
+
+        assertThat(value).isEqualTo("integration-guide");
+        assertThat(attributes.getName()).isEqualTo("title");
+        assertThat(attributes.getDeclaredClass()).isEqualTo(String.class);
+        assertThat(attributes.getDeclaringClass()).isEqualTo(FieldCarrier.class);
+    }
+
+    public static final class FieldCarrier {
+        public String title;
+
+        public FieldCarrier(String title) {
+            this.title = title;
+        }
+    }
+}

--- a/tests/src/com.google.code.gson/gson/2.3/src/test/java/com_google_code_gson/gson/InnerGsonInnerTypesTest.java
+++ b/tests/src/com.google.code.gson/gson/2.3/src/test/java/com_google_code_gson/gson/InnerGsonInnerTypesTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_code_gson.gson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.gson.internal.$Gson$Types;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.ParameterizedType;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class InnerGsonInnerTypesTest {
+    @Test
+    void resolvesRawClassForGenericArrayType() {
+        ParameterizedType listOfStrings = $Gson$Types.newParameterizedTypeWithOwner(
+                null,
+                List.class,
+                String.class);
+        GenericArrayType arrayOfLists = $Gson$Types.arrayOf(listOfStrings);
+
+        Class<?> rawType = $Gson$Types.getRawType(arrayOfLists);
+
+        assertThat(rawType).isEqualTo(List[].class);
+        assertThat(rawType.isArray()).isTrue();
+        assertThat(rawType.getComponentType()).isEqualTo(List.class);
+    }
+}

--- a/tests/src/com.google.code.gson/gson/2.3/src/test/java/com_google_code_gson/gson/ReflectiveTypeAdapterFactoryAnonymous1Test.java
+++ b/tests/src/com.google.code.gson/gson/2.3/src/test/java/com_google_code_gson/gson/ReflectiveTypeAdapterFactoryAnonymous1Test.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_code_gson.gson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.gson.Gson;
+import org.junit.jupiter.api.Test;
+
+public class ReflectiveTypeAdapterFactoryAnonymous1Test {
+    private final Gson gson = new Gson();
+
+    @Test
+    void serializesObjectFieldsThroughReflectiveBoundFields() {
+        InventoryItem item = new InventoryItem("desk-lamp", 12, true);
+
+        String json = gson.toJson(item);
+
+        assertThat(json).contains("\"name\":\"desk-lamp\"");
+        assertThat(json).contains("\"quantity\":12");
+        assertThat(json).contains("\"available\":true");
+    }
+
+    @Test
+    void deserializesObjectFieldsThroughReflectiveBoundFields() {
+        String json = "{\"name\":\"notebook\",\"quantity\":5,\"available\":false}";
+
+        InventoryItem item = gson.fromJson(json, InventoryItem.class);
+
+        assertThat(item.name).isEqualTo("notebook");
+        assertThat(item.quantity).isEqualTo(5);
+        assertThat(item.available).isFalse();
+    }
+
+    public static final class InventoryItem {
+        private String name;
+        private int quantity;
+        private boolean available;
+
+        public InventoryItem() {
+        }
+
+        InventoryItem(String name, int quantity, boolean available) {
+            this.name = name;
+            this.quantity = quantity;
+            this.available = available;
+        }
+    }
+}

--- a/tests/src/com.google.code.gson/gson/2.3/src/test/java/com_google_code_gson/gson/UnsafeAllocatorAnonymous2Test.java
+++ b/tests/src/com.google.code.gson/gson/2.3/src/test/java/com_google_code_gson/gson/UnsafeAllocatorAnonymous2Test.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_code_gson.gson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.gson.internal.UnsafeAllocator;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+
+public class UnsafeAllocatorAnonymous2Test {
+    @Test
+    void invokesConfiguredLegacyObjectInputStreamAllocationMethod() throws Exception {
+        Method fallbackMethod = UnsafeAllocatorAnonymous2Test.class.getDeclaredMethod(
+                "legacyObjectInputStreamNewInstance", Class.class, Class.class);
+        UnsafeAllocator allocator = newLegacyObjectInputStreamAllocator(fallbackMethod);
+
+        FallbackAllocatedMessage message = allocator.newInstance(FallbackAllocatedMessage.class);
+
+        assertThat(message.instantiationClass).isEqualTo(FallbackAllocatedMessage.class);
+        assertThat(message.constructorClass).isEqualTo(Object.class);
+    }
+
+    private static UnsafeAllocator newLegacyObjectInputStreamAllocator(Method fallbackMethod) throws Exception {
+        Class<?> allocatorClass = Class.forName("com.google.gson.internal.UnsafeAllocator$2");
+        Constructor<?> constructor = allocatorClass.getDeclaredConstructor(Method.class);
+        constructor.setAccessible(true);
+        return (UnsafeAllocator) constructor.newInstance(fallbackMethod);
+    }
+
+    public static Object legacyObjectInputStreamNewInstance(Class<?> instantiationClass, Class<?> constructorClass) {
+        return new FallbackAllocatedMessage(instantiationClass, constructorClass);
+    }
+
+    public static final class FallbackAllocatedMessage {
+        private final Class<?> instantiationClass;
+        private final Class<?> constructorClass;
+
+        FallbackAllocatedMessage(Class<?> instantiationClass, Class<?> constructorClass) {
+            this.instantiationClass = instantiationClass;
+            this.constructorClass = constructorClass;
+        }
+    }
+}

--- a/tests/src/com.google.code.gson/gson/2.3/src/test/java/com_google_code_gson/gson/UnsafeAllocatorAnonymous2Test.java
+++ b/tests/src/com.google.code.gson/gson/2.3/src/test/java/com_google_code_gson/gson/UnsafeAllocatorAnonymous2Test.java
@@ -15,35 +15,36 @@ import org.junit.jupiter.api.Test;
 
 public class UnsafeAllocatorAnonymous2Test {
     @Test
-    void invokesConfiguredLegacyObjectInputStreamAllocationMethod() throws Exception {
+    void invokesConfiguredLegacyObjectStreamClassAllocationMethod() throws Exception {
         Method fallbackMethod = UnsafeAllocatorAnonymous2Test.class.getDeclaredMethod(
-                "legacyObjectInputStreamNewInstance", Class.class, Class.class);
-        UnsafeAllocator allocator = newLegacyObjectInputStreamAllocator(fallbackMethod);
+                "legacyObjectStreamClassNewInstance", Class.class, int.class);
+        UnsafeAllocator allocator = newLegacyObjectStreamClassAllocator(fallbackMethod, 41);
 
         FallbackAllocatedMessage message = allocator.newInstance(FallbackAllocatedMessage.class);
 
         assertThat(message.instantiationClass).isEqualTo(FallbackAllocatedMessage.class);
-        assertThat(message.constructorClass).isEqualTo(Object.class);
+        assertThat(message.constructorId).isEqualTo(41);
     }
 
-    private static UnsafeAllocator newLegacyObjectInputStreamAllocator(Method fallbackMethod) throws Exception {
+    private static UnsafeAllocator newLegacyObjectStreamClassAllocator(Method fallbackMethod, int constructorId)
+            throws Exception {
         Class<?> allocatorClass = Class.forName("com.google.gson.internal.UnsafeAllocator$2");
-        Constructor<?> constructor = allocatorClass.getDeclaredConstructor(Method.class);
+        Constructor<?> constructor = allocatorClass.getDeclaredConstructor(Method.class, int.class);
         constructor.setAccessible(true);
-        return (UnsafeAllocator) constructor.newInstance(fallbackMethod);
+        return (UnsafeAllocator) constructor.newInstance(fallbackMethod, constructorId);
     }
 
-    public static Object legacyObjectInputStreamNewInstance(Class<?> instantiationClass, Class<?> constructorClass) {
-        return new FallbackAllocatedMessage(instantiationClass, constructorClass);
+    public static Object legacyObjectStreamClassNewInstance(Class<?> instantiationClass, int constructorId) {
+        return new FallbackAllocatedMessage(instantiationClass, constructorId);
     }
 
     public static final class FallbackAllocatedMessage {
         private final Class<?> instantiationClass;
-        private final Class<?> constructorClass;
+        private final int constructorId;
 
-        FallbackAllocatedMessage(Class<?> instantiationClass, Class<?> constructorClass) {
+        FallbackAllocatedMessage(Class<?> instantiationClass, int constructorId) {
             this.instantiationClass = instantiationClass;
-            this.constructorClass = constructorClass;
+            this.constructorId = constructorId;
         }
     }
 }

--- a/tests/src/com.google.code.gson/gson/2.3/src/test/java/com_google_code_gson/gson/UnsafeAllocatorAnonymous3Test.java
+++ b/tests/src/com.google.code.gson/gson/2.3/src/test/java/com_google_code_gson/gson/UnsafeAllocatorAnonymous3Test.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_code_gson.gson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.gson.internal.UnsafeAllocator;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+
+public class UnsafeAllocatorAnonymous3Test {
+    @Test
+    void invokesConfiguredLegacyObjectStreamClassAllocationMethod() throws Exception {
+        Method fallbackMethod = UnsafeAllocatorAnonymous3Test.class.getDeclaredMethod(
+                "legacyObjectStreamClassNewInstance", Class.class, int.class);
+        UnsafeAllocator allocator = newLegacyObjectStreamClassAllocator(fallbackMethod, 41);
+
+        FallbackAllocatedMessage message = allocator.newInstance(FallbackAllocatedMessage.class);
+
+        assertThat(message.instantiationClass).isEqualTo(FallbackAllocatedMessage.class);
+        assertThat(message.constructorId).isEqualTo(41);
+    }
+
+    private static UnsafeAllocator newLegacyObjectStreamClassAllocator(Method fallbackMethod, int constructorId)
+            throws Exception {
+        Class<?> allocatorClass = Class.forName("com.google.gson.internal.UnsafeAllocator$3");
+        Constructor<?> constructor = allocatorClass.getDeclaredConstructor(Method.class, int.class);
+        constructor.setAccessible(true);
+        return (UnsafeAllocator) constructor.newInstance(fallbackMethod, constructorId);
+    }
+
+    public static Object legacyObjectStreamClassNewInstance(Class<?> instantiationClass, int constructorId) {
+        return new FallbackAllocatedMessage(instantiationClass, constructorId);
+    }
+
+    public static final class FallbackAllocatedMessage {
+        private final Class<?> instantiationClass;
+        private final int constructorId;
+
+        FallbackAllocatedMessage(Class<?> instantiationClass, int constructorId) {
+            this.instantiationClass = instantiationClass;
+            this.constructorId = constructorId;
+        }
+    }
+}

--- a/tests/src/com.google.code.gson/gson/2.3/src/test/java/com_google_code_gson/gson/UnsafeAllocatorAnonymous3Test.java
+++ b/tests/src/com.google.code.gson/gson/2.3/src/test/java/com_google_code_gson/gson/UnsafeAllocatorAnonymous3Test.java
@@ -15,36 +15,35 @@ import org.junit.jupiter.api.Test;
 
 public class UnsafeAllocatorAnonymous3Test {
     @Test
-    void invokesConfiguredLegacyObjectStreamClassAllocationMethod() throws Exception {
+    void invokesConfiguredLegacyObjectInputStreamAllocationMethod() throws Exception {
         Method fallbackMethod = UnsafeAllocatorAnonymous3Test.class.getDeclaredMethod(
-                "legacyObjectStreamClassNewInstance", Class.class, int.class);
-        UnsafeAllocator allocator = newLegacyObjectStreamClassAllocator(fallbackMethod, 41);
+                "legacyObjectInputStreamNewInstance", Class.class, Class.class);
+        UnsafeAllocator allocator = newLegacyObjectInputStreamAllocator(fallbackMethod);
 
         FallbackAllocatedMessage message = allocator.newInstance(FallbackAllocatedMessage.class);
 
         assertThat(message.instantiationClass).isEqualTo(FallbackAllocatedMessage.class);
-        assertThat(message.constructorId).isEqualTo(41);
+        assertThat(message.constructorClass).isEqualTo(Object.class);
     }
 
-    private static UnsafeAllocator newLegacyObjectStreamClassAllocator(Method fallbackMethod, int constructorId)
-            throws Exception {
+    private static UnsafeAllocator newLegacyObjectInputStreamAllocator(Method fallbackMethod) throws Exception {
         Class<?> allocatorClass = Class.forName("com.google.gson.internal.UnsafeAllocator$3");
-        Constructor<?> constructor = allocatorClass.getDeclaredConstructor(Method.class, int.class);
+        Constructor<?> constructor = allocatorClass.getDeclaredConstructor(Method.class);
         constructor.setAccessible(true);
-        return (UnsafeAllocator) constructor.newInstance(fallbackMethod, constructorId);
+        return (UnsafeAllocator) constructor.newInstance(fallbackMethod);
     }
 
-    public static Object legacyObjectStreamClassNewInstance(Class<?> instantiationClass, int constructorId) {
-        return new FallbackAllocatedMessage(instantiationClass, constructorId);
+    public static Object legacyObjectInputStreamNewInstance(Class<?> instantiationClass, Class<?> constructorClass) {
+        return new FallbackAllocatedMessage(instantiationClass, constructorClass);
     }
 
     public static final class FallbackAllocatedMessage {
         private final Class<?> instantiationClass;
-        private final int constructorId;
+        private final Class<?> constructorClass;
 
-        FallbackAllocatedMessage(Class<?> instantiationClass, int constructorId) {
+        FallbackAllocatedMessage(Class<?> instantiationClass, Class<?> constructorClass) {
             this.instantiationClass = instantiationClass;
-            this.constructorId = constructorId;
+            this.constructorClass = constructorClass;
         }
     }
 }

--- a/tests/src/com.google.code.gson/gson/2.3/src/test/java/com_google_code_gson/gson/UnsafeAllocatorTest.java
+++ b/tests/src/com.google.code.gson/gson/2.3/src/test/java/com_google_code_gson/gson/UnsafeAllocatorTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_code_gson.gson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.gson.Gson;
+import org.junit.jupiter.api.Test;
+
+public class UnsafeAllocatorTest {
+    private final Gson gson = new Gson();
+
+    @Test
+    void deserializesTypeWithoutNoArgsConstructorUsingUnsafeAllocation() {
+        ConstructorOnlyMessage message = gson.fromJson(
+                "{\"label\":\"created-from-json\",\"priority\":7}",
+                ConstructorOnlyMessage.class);
+
+        assertThat(message.label).isEqualTo("created-from-json");
+        assertThat(message.priority).isEqualTo(7);
+        assertThat(message.wasConstructorInvoked()).isFalse();
+    }
+
+    public static final class ConstructorOnlyMessage {
+        private final transient boolean constructorInvoked;
+        private String label;
+        private int priority;
+
+        public ConstructorOnlyMessage(String label, int priority) {
+            this.constructorInvoked = true;
+            this.label = label;
+            this.priority = priority;
+        }
+
+        boolean wasConstructorInvoked() {
+            return constructorInvoked;
+        }
+    }
+}

--- a/tests/src/com.google.code.gson/gson/2.3/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.google.code.gson/gson/2.3/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,115 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.google.gson.internal.bind.ArrayTypeAdapter$1"
+      },
+      "type" : "com_google_code_gson.gson.ArrayTypeAdapterTest$InventoryItem"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper"
+      },
+      "type" : "com_google_code_gson.gson.ArrayTypeAdapterTest$InventoryItem",
+      "fields" : [
+        {
+          "name" : "available"
+        },
+        {
+          "name" : "name"
+        },
+        {
+          "name" : "quantity"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.gson.internal.bind.ArrayTypeAdapter"
+      },
+      "type" : "com_google_code_gson.gson.ArrayTypeAdapterTest$InventoryItem[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.gson.reflect.TypeToken"
+      },
+      "type" : "com_google_code_gson.gson.ArrayTypeAdapterTest$InventoryItem[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.gson.internal.bind.TypeAdapters$EnumTypeAdapter"
+      },
+      "type" : "com_google_code_gson.gson.EnumTypeAdapterTest$ShipmentState"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.gson.FieldAttributes"
+      },
+      "type" : "com_google_code_gson.gson.FieldAttributesTest$FieldCarrier",
+      "fields" : [
+        {
+          "name" : "title"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.gson.Gson"
+      },
+      "type" : "com_google_code_gson.gson.ReflectiveTypeAdapterFactoryAnonymous1Test$InventoryItem"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1"
+      },
+      "type" : "com_google_code_gson.gson.ReflectiveTypeAdapterFactoryAnonymous1Test$InventoryItem",
+      "fields" : [
+        {
+          "name" : "available"
+        },
+        {
+          "name" : "name"
+        },
+        {
+          "name" : "quantity"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.gson.internal.UnsafeAllocator$2"
+      },
+      "type" : "com_google_code_gson.gson.UnsafeAllocatorAnonymous2Test",
+      "methods" : [
+        {
+          "name" : "legacyObjectInputStreamNewInstance",
+          "parameterTypes" : [
+            "java.lang.Class",
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.gson.internal.UnsafeAllocator$3"
+      },
+      "type" : "com_google_code_gson.gson.UnsafeAllocatorAnonymous3Test",
+      "methods" : [
+        {
+          "name" : "legacyObjectStreamClassNewInstance",
+          "parameterTypes" : [
+            "java.lang.Class",
+            "int"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/com.google.code.gson/gson/2.3/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.google.code.gson/gson/2.3/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -83,15 +83,22 @@
     },
     {
       "condition" : {
+        "typeReached" : "com.google.gson.internal.UnsafeAllocator$1"
+      },
+      "type" : "com_google_code_gson.gson.UnsafeAllocatorTest$ConstructorOnlyMessage",
+      "unsafeAllocated" : true
+    },
+    {
+      "condition" : {
         "typeReached" : "com.google.gson.internal.UnsafeAllocator$2"
       },
       "type" : "com_google_code_gson.gson.UnsafeAllocatorAnonymous2Test",
       "methods" : [
         {
-          "name" : "legacyObjectInputStreamNewInstance",
+          "name" : "legacyObjectStreamClassNewInstance",
           "parameterTypes" : [
             "java.lang.Class",
-            "java.lang.Class"
+            "int"
           ]
         }
       ]
@@ -103,10 +110,10 @@
       "type" : "com_google_code_gson.gson.UnsafeAllocatorAnonymous3Test",
       "methods" : [
         {
-          "name" : "legacyObjectStreamClassNewInstance",
+          "name" : "legacyObjectInputStreamNewInstance",
           "parameterTypes" : [
             "java.lang.Class",
-            "int"
+            "java.lang.Class"
           ]
         }
       ]

--- a/tests/src/com.google.code.gson/gson/2.3/user-code-filter.json
+++ b/tests/src/com.google.code.gson/gson/2.3/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.google.gson.**"
+    }
+  ]
+}

--- a/tests/src/com.google.code.gson/gson/2.3/user-code-filter.json
+++ b/tests/src/com.google.code.gson/gson/2.3/user-code-filter.json
@@ -5,6 +5,9 @@
     },
     {
       "includeClasses" : "com.google.gson.**"
+    },
+    {
+      "includeClasses" : "com_google_code_gson.gson.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #4832

This PR provides test fixes and new metadata for com.google.code.gson:gson:2.3, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 23548
- Cached input tokens: 126976
- Output tokens: 2714
- Metadata entries: 4
- Test-only metadata entries: 22
- Iterations: 1
- Library coverage percentage: 24.26
- Previous library version metadata entries: 4
- Previous library version test-only metadata entries: 20
- Previous library version coverage percentage: 26.75

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `e73f0e0ac0a6d704adee550917c7e88dd4de2645`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.google.code.gson:gson:2.2.4: 13/13 covered calls (100.00%)
- com.google.code.gson:gson:2.3: 13/13 covered calls (100.00%)

**Reflection:**
- com.google.code.gson:gson:2.2.4: 13/13 covered calls (100.00%)
- com.google.code.gson:gson:2.3: 13/13 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.google.code.gson:gson:2.2.4: 3910/15286 (25.58%)
- com.google.code.gson:gson:2.3: 4027/17391 (23.16%)

**Line:**
- com.google.code.gson:gson:2.2.4: 906/3387 (26.75%)
- com.google.code.gson:gson:2.3: 953/3929 (24.26%)

**Method:**
- com.google.code.gson:gson:2.2.4: 230/733 (31.38%)
- com.google.code.gson:gson:2.3: 233/806 (28.91%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/com.google.code.gson/gson/2.2.4/src/test/java/com_google_code_gson/gson/UnsafeAllocatorAnonymous2Test.java 2/tests/src/com.google.code.gson/gson/2.3/src/test/java/com_google_code_gson/gson/UnsafeAllocatorAnonymous2Test.java
index 417ee02e90..b60564d155 100644
--- 1/tests/src/com.google.code.gson/gson/2.2.4/src/test/java/com_google_code_gson/gson/UnsafeAllocatorAnonymous2Test.java
+++ 2/tests/src/com.google.code.gson/gson/2.3/src/test/java/com_google_code_gson/gson/UnsafeAllocatorAnonymous2Test.java
@@ -15,35 +15,36 @@ import org.junit.jupiter.api.Test;
 
 public class UnsafeAllocatorAnonymous2Test {
     @Test
-    void invokesConfiguredLegacyObjectInputStreamAllocationMethod() throws Exception {
+    void invokesConfiguredLegacyObjectStreamClassAllocationMethod() throws Exception {
         Method fallbackMethod = UnsafeAllocatorAnonymous2Test.class.getDeclaredMethod(
-                "legacyObjectInputStreamNewInstance", Class.class, Class.class);
-        UnsafeAllocator allocator = newLegacyObjectInputStreamAllocator(fallbackMethod);
+                "legacyObjectStreamClassNewInstance", Class.class, int.class);
+        UnsafeAllocator allocator = newLegacyObjectStreamClassAllocator(fallbackMethod, 41);
 
         FallbackAllocatedMessage message = allocator.newInstance(FallbackAllocatedMessage.class);
 
         assertThat(message.instantiationClass).isEqualTo(FallbackAllocatedMessage.class);
-        assertThat(message.constructorClass).isEqualTo(Object.class);
+        assertThat(message.constructorId).isEqualTo(41);
     }
 
-    private static UnsafeAllocator newLegacyObjectInputStreamAllocator(Method fallbackMethod) throws Exception {
+    private static UnsafeAllocator newLegacyObjectStreamClassAllocator(Method fallbackMethod, int constructorId)
+            throws Exception {
         Class<?> allocatorClass = Class.forName("com.google.gson.internal.UnsafeAllocator$2");
-        Constructor<?> constructor = allocatorClass.getDeclaredConstructor(Method.class);
+        Constructor<?> constructor = allocatorClass.getDeclaredConstructor(Method.class, int.class);
         constructor.setAccessible(true);
-        return (UnsafeAllocator) constructor.newInstance(fallbackMethod);
+        return (UnsafeAllocator) constructor.newInstance(fallbackMethod, constructorId);
     }
 
-    public static Object legacyObjectInputStreamNewInstance(Class<?> instantiationClass, Class<?> constructorClass) {
-        return new FallbackAllocatedMessage(instantiationClass, constructorClass);
+    public static Object legacyObjectStreamClassNewInstance(Class<?> instantiationClass, int constructorId) {
+        return new FallbackAllocatedMessage(instantiationClass, constructorId);
     }
 
     public static final class FallbackAllocatedMessage {
         private final Class<?> instantiationClass;
-        private final Class<?> constructorClass;
+        private final int constructorId;
 
-        FallbackAllocatedMessage(Class<?> instantiationClass, Class<?> constructorClass) {
+        FallbackAllocatedMessage(Class<?> instantiationClass, int constructorId) {
             this.instantiationClass = instantiationClass;
-            this.constructorClass = constructorClass;
+            this.constructorId = constructorId;
         }
     }
 }
diff --git 1/tests/src/com.google.code.gson/gson/2.2.4/src/test/java/com_google_code_gson/gson/UnsafeAllocatorAnonymous3Test.java 2/tests/src/com.google.code.gson/gson/2.3/src/test/java/com_google_code_gson/gson/UnsafeAllocatorAnonymous3Test.java
index 6fb7c9c5c6..defb1c89d3 100644
--- 1/tests/src/com.google.code.gson/gson/2.2.4/src/test/java/com_google_code_gson/gson/UnsafeAllocatorAnonymous3Test.java
+++ 2/tests/src/com.google.code.gson/gson/2.3/src/test/java/com_google_code_gson/gson/UnsafeAllocatorAnonymous3Test.java
@@ -15,36 +15,35 @@ import org.junit.jupiter.api.Test;
 
 public class UnsafeAllocatorAnonymous3Test {
     @Test
-    void invokesConfiguredLegacyObjectStreamClassAllocationMethod() throws Exception {
+    void invokesConfiguredLegacyObjectInputStreamAllocationMethod() throws Exception {
         Method fallbackMethod = UnsafeAllocatorAnonymous3Test.class.getDeclaredMethod(
-                "legacyObjectStreamClassNewInstance", Class.class, int.class);
-        UnsafeAllocator allocator = newLegacyObjectStreamClassAllocator(fallbackMethod, 41);
+                "legacyObjectInputStreamNewInstance", Class.class, Class.class);
+        UnsafeAllocator allocator = newLegacyObjectInputStreamAllocator(fallbackMethod);
 
         FallbackAllocatedMessage message = allocator.newInstance(FallbackAllocatedMessage.class);
 
         assertThat(message.instantiationClass).isEqualTo(FallbackAllocatedMessage.class);
-        assertThat(message.constructorId).isEqualTo(41);
+        assertThat(message.constructorClass).isEqualTo(Object.class);
     }
 
-    private static UnsafeAllocator newLegacyObjectStreamClassAllocator(Method fallbackMethod, int constructorId)
-            throws Exception {
+    private static UnsafeAllocator newLegacyObjectInputStreamAllocator(Method fallbackMethod) throws Exception {
         Class<?> allocatorClass = Class.forName("com.google.gson.internal.UnsafeAllocator$3");
-        Constructor<?> constructor = allocatorClass.getDeclaredConstructor(Method.class, int.class);
+        Constructor<?> constructor = allocatorClass.getDeclaredConstructor(Method.class);
         constructor.setAccessible(true);
-        return (UnsafeAllocator) constructor.newInstance(fallbackMethod, constructorId);
+        return (UnsafeAllocator) constructor.newInstance(fallbackMethod);
     }
 
-    public static Object legacyObjectStreamClassNewInstance(Class<?> instantiationClass, int constructorId) {
-        return new FallbackAllocatedMessage(instantiationClass, constructorId);
+    public static Object legacyObjectInputStreamNewInstance(Class<?> instantiationClass, Class<?> constructorClass) {
+        return new FallbackAllocatedMessage(instantiationClass, constructorClass);
     }
 
     public static final class FallbackAllocatedMessage {
         private final Class<?> instantiationClass;
-        private final int constructorId;
+        private final Class<?> constructorClass;
 
-        FallbackAllocatedMessage(Class<?> instantiationClass, int constructorId) {
+        FallbackAllocatedMessage(Class<?> instantiationClass, Class<?> constructorClass) {
             this.instantiationClass = instantiationClass;
-            this.constructorId = constructorId;
+            this.constructorClass = constructorClass;
         }
     }
 }
diff --git 1/tests/src/com.google.code.gson/gson/2.2.4/user-code-filter.json 2/tests/src/com.google.code.gson/gson/2.3/user-code-filter.json
index dfe1ab75a1..a8574c5fa0 100644
--- 1/tests/src/com.google.code.gson/gson/2.2.4/user-code-filter.json
+++ 2/tests/src/com.google.code.gson/gson/2.3/user-code-filter.json
@@ -5,6 +5,9 @@
     },
     {
       "includeClasses" : "com.google.gson.**"
+    },
+    {
+      "includeClasses" : "com_google_code_gson.gson.**"
     }
   ]
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
