### PR TITLE
[GenAI] Test fix for jakarta.xml.bind:jakarta.xml.bind-api:4.1.0-M1 using gpt-5.5

### DIFF
--- a/metadata/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/reachability-metadata.json
+++ b/metadata/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/reachability-metadata.json
@@ -1,0 +1,125 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.ContextFinder"
+      },
+      "type": "DefaultPackageContextFactory",
+      "methods": [
+        {
+          "name": "createContext",
+          "parameterTypes": [
+            "java.lang.String",
+            "java.lang.ClassLoader",
+            "java.util.Map"
+          ]
+        },
+        {
+          "name": "createContext",
+          "parameterTypes": [
+            "java.lang.Class[]",
+            "java.util.Map"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.ServiceLoaderUtil"
+      },
+      "type": "DefaultPackageContextFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.ServiceLoaderUtil"
+      },
+      "type": "jakarta.xml.bind.JAXBContextFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.ContextFinder"
+      },
+      "type": "jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.ServiceLoaderUtil"
+      },
+      "type": "jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.ContextFinder"
+      },
+      "type": "jakarta_xml_bind.jakarta_xml_bind_api.support.LegacyContextFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.ContextFinder"
+      },
+      "type": "jakarta_xml_bind.jakarta_xml_bind_api.support.PropertiesContextFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.ServiceLoaderUtil"
+      },
+      "type": "jakarta_xml_bind.jakarta_xml_bind_api.support.ServiceContextFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.ContextFinder"
+      },
+      "type": "jakarta_xml_bind.jakarta_xml_bind_api.support.WrongTypeContextFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.ModuleUtil"
+      },
+      "type": "java.lang.Class[]"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.ContextFinder"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.ContextFinder"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.ContextFinder"
+      },
+      "type": "java.lang.reflect.Method[]"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.ContextFinder"
+      },
+      "glob": "jakarta/xml/bind/JAXBContext.class"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.Messages"
+      },
+      "bundle": "jakarta.xml.bind.Messages"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.helpers.Messages"
+      },
+      "bundle": "jakarta.xml.bind.helpers.Messages"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.util.Messages"
+      },
+      "bundle": "jakarta.xml.bind.util.Messages"
+    }
+  ]
+}

--- a/metadata/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/reachability-metadata.json
+++ b/metadata/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/reachability-metadata.json
@@ -1,22 +1,22 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.ContextFinder"
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder"
       },
-      "type": "DefaultPackageContextFactory",
-      "methods": [
+      "type" : "DefaultPackageContextFactory",
+      "methods" : [
         {
-          "name": "createContext",
-          "parameterTypes": [
+          "name" : "createContext",
+          "parameterTypes" : [
             "java.lang.String",
             "java.lang.ClassLoader",
             "java.util.Map"
           ]
         },
         {
-          "name": "createContext",
-          "parameterTypes": [
+          "name" : "createContext",
+          "parameterTypes" : [
             "java.lang.Class[]",
             "java.util.Map"
           ]
@@ -24,102 +24,66 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.ServiceLoaderUtil"
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ServiceLoaderUtil"
       },
-      "type": "DefaultPackageContextFactory"
+      "type" : "DefaultPackageContextFactory"
     },
     {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.ServiceLoaderUtil"
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ServiceLoaderUtil"
       },
-      "type": "jakarta.xml.bind.JAXBContextFactory"
+      "type" : "jakarta.xml.bind.JAXBContextFactory"
     },
     {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.ContextFinder"
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ModuleUtil"
       },
-      "type": "jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory"
+      "type" : "java.lang.Class[]"
     },
     {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.ServiceLoaderUtil"
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder"
       },
-      "type": "jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory"
+      "type" : "java.lang.StackTraceElement[]"
     },
     {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.ContextFinder"
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder"
       },
-      "type": "jakarta_xml_bind.jakarta_xml_bind_api.support.LegacyContextFactory"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.ContextFinder"
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder"
       },
-      "type": "jakarta_xml_bind.jakarta_xml_bind_api.support.PropertiesContextFactory"
-    },
-    {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.ServiceLoaderUtil"
-      },
-      "type": "jakarta_xml_bind.jakarta_xml_bind_api.support.ServiceContextFactory"
-    },
-    {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.ContextFinder"
-      },
-      "type": "jakarta_xml_bind.jakarta_xml_bind_api.support.WrongTypeContextFactory"
-    },
-    {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.ModuleUtil"
-      },
-      "type": "java.lang.Class[]"
-    },
-    {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.ContextFinder"
-      },
-      "type": "java.lang.StackTraceElement[]"
-    },
-    {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.ContextFinder"
-      },
-      "type": "java.lang.String[]"
-    },
-    {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.ContextFinder"
-      },
-      "type": "java.lang.reflect.Method[]"
+      "type" : "java.lang.reflect.Method[]"
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.ContextFinder"
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder"
       },
-      "glob": "jakarta/xml/bind/JAXBContext.class"
+      "glob" : "jakarta/xml/bind/JAXBContext.class"
     },
     {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.Messages"
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.Messages"
       },
-      "bundle": "jakarta.xml.bind.Messages"
+      "bundle" : "jakarta.xml.bind.Messages"
     },
     {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.helpers.Messages"
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.helpers.Messages"
       },
-      "bundle": "jakarta.xml.bind.helpers.Messages"
+      "bundle" : "jakarta.xml.bind.helpers.Messages"
     },
     {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.util.Messages"
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.util.Messages"
       },
-      "bundle": "jakarta.xml.bind.util.Messages"
+      "bundle" : "jakarta.xml.bind.util.Messages"
     }
   ]
 }

--- a/metadata/jakarta.xml.bind/jakarta.xml.bind-api/index.json
+++ b/metadata/jakarta.xml.bind/jakarta.xml.bind-api/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "4.1.0-M1",
+    "tested-versions" : [
+      "4.1.0-M1"
+    ],
+    "allowed-packages" : [
+      "jakarta.xml.bind"
+    ]
+  },
+  {
     "metadata-version" : "4.0.0",
     "tested-versions" : [
       "4.0.0",

--- a/metadata/jakarta.xml.bind/jakarta.xml.bind-api/index.json
+++ b/metadata/jakarta.xml.bind/jakarta.xml.bind-api/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "4.1.0-M1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/jakarta/xml/bind/jakarta.xml.bind-api/$version$/jakarta.xml.bind-api-$version$-sources.jar",
+    "repository-url" : "https://github.com/jakartaee/jaxb-api",
+    "test-code-url" : "https://github.com/jakartaee/jaxb-api/tree/$version$/jaxb-api-test/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/jakarta/xml/bind/jakarta.xml.bind-api/$version$/jakarta.xml.bind-api-$version$-javadoc.jar",
+    "description" : "Jakarta XML Binding API defines the standard Jakarta API for binding Java classes to XML representations. It provides annotations and runtime interfaces for marshalling, unmarshalling, and validating XML content in Java applications.",
     "tested-versions" : [
       "4.1.0-M1"
     ],

--- a/stats/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/execution-metrics.json
+++ b/stats/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_java_run_fail:2026-06-06": {
+    "timestamp": "2026-06-06T18:58:47.372143Z",
+    "library": "jakarta.xml.bind:jakarta.xml.bind-api:4.1.0-M1",
+    "starting_commit": "d1c717d46f39761bfd020e304bf4e2af87d2819e",
+    "ending_commit": "5d13ece108e1f32f84890cbe157dfc2c5c81f141",
+    "previous_library": "jakarta.xml.bind:jakarta.xml.bind-api:4.0.0",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.1.0-M1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 19,
+            "totalCalls": 19
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 6,
+            "totalCalls": 6
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 25,
+        "totalCalls": 25
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 835,
+          "missed": 6000,
+          "ratio": 0.122165,
+          "total": 6835
+        },
+        "line": {
+          "covered": 197,
+          "missed": 1519,
+          "ratio": 0.114802,
+          "total": 1716
+        },
+        "method": {
+          "covered": 45,
+          "missed": 409,
+          "ratio": 0.099119,
+          "total": 454
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "4.0.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.947368,
+            "coveredCalls": 18,
+            "totalCalls": 19
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 6,
+            "totalCalls": 6
+          }
+        },
+        "coverageRatio": 0.96,
+        "coveredCalls": 24,
+        "totalCalls": 25
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 822,
+          "missed": 6066,
+          "ratio": 0.119338,
+          "total": 6888
+        },
+        "line": {
+          "covered": 196,
+          "missed": 1489,
+          "ratio": 0.11632,
+          "total": 1685
+        },
+        "method": {
+          "covered": 49,
+          "missed": 417,
+          "ratio": 0.10515,
+          "total": 466
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 162546,
+      "cached_input_tokens_used": 2117632,
+      "output_tokens_used": 32524,
+      "iterations": 4,
+      "cost_usd": 2.0345,
+      "tested_library_loc": 197,
+      "metadata_entries": 13,
+      "test_only_metadata_entries": 34,
+      "previous_library_metadata_entries": 20,
+      "previous_library_test_only_metadata_entries": 29,
+      "code_coverage_percent": 11.48,
+      "previous_library_coverage_percent": 11.63
+    },
+    "artifacts": {
+      "test_file": "tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/DefaultPackageContextFactory.java",
+      "metadata_file": "metadata/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/stats.json
+++ b/stats/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "4.1.0-M1",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 19,
+          "totalCalls" : 19
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 6,
+          "totalCalls" : 6
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 25,
+      "totalCalls" : 25
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 835,
+        "missed" : 6000,
+        "ratio" : 0.122165,
+        "total" : 6835
+      },
+      "line" : {
+        "covered" : 197,
+        "missed" : 1519,
+        "ratio" : 0.114802,
+        "total" : 1716
+      },
+      "method" : {
+        "covered" : 45,
+        "missed" : 409,
+        "ratio" : 0.099119,
+        "total" : 454
+      }
+    }
+  } ]
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/.gitignore
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/build.gradle
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/build.gradle
@@ -1,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "jakarta.xml.bind:jakarta.xml.bind-api:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}
+
+tasks.named("test") {
+    if ((JavaVersion.current().majorVersion as int) < 24) {
+        jvmArgs += ["-Djava.security.manager=allow"]
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/gradle.properties
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = jakarta.xml.bind:jakarta.xml.bind-api:4.1.0-M1
+library.version = 4.1.0-M1
+metadata.dir = jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/settings.gradle
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'jakarta.xml.bind.jakarta.xml.bind-api_tests'

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/DefaultPackageContextFactory.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/DefaultPackageContextFactory.java
@@ -4,7 +4,6 @@
  * You should have received a copy of the CC0 legalcode along with this
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
-
 import java.util.Map;
 
 import jakarta.xml.bind.JAXBContext;

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/DefaultPackageContextFactory.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/DefaultPackageContextFactory.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+import java.util.Map;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta_xml_bind.jakarta_xml_bind_api.support.StubJaxbContext;
+
+public class DefaultPackageContextFactory {
+    public static JAXBContext createContext(Class<?>[] classesToBeBound, Map<String, ?> properties) {
+        return new StubJaxbContext("default-package-classes-factory");
+    }
+
+    public static JAXBContext createContext(
+            String contextPath,
+            ClassLoader classLoader,
+            Map<String, ?> properties) {
+        return new StubJaxbContext("default-package-context-path-factory");
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta/xml/bind/ServiceLoaderUtilInvoker.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta/xml/bind/ServiceLoaderUtilInvoker.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta.xml.bind;
+
+import jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory;
+
+public final class ServiceLoaderUtilInvoker {
+    private static final ServiceLoaderUtil.ExceptionHandler<JAXBException> EXCEPTION_HANDLER =
+            new ServiceLoaderUtil.ExceptionHandler<>() {
+                @Override
+                public JAXBException createException(Throwable throwable, String message) {
+                    return new JAXBException(message, throwable);
+                }
+            };
+
+    private ServiceLoaderUtilInvoker() {
+    }
+
+    public static FactoryBackedContextFactory instantiateFactoryBackedContextFactory() throws JAXBException {
+        return (FactoryBackedContextFactory) ServiceLoaderUtil.newInstance(
+                FactoryBackedContextFactory.class.getName(),
+                FactoryBackedContextFactory.class.getName(),
+                EXCEPTION_HANDLER);
+    }
+
+    public static Class<?> loadFactoryBackedContextFactory(ClassLoader classLoader) throws ClassNotFoundException {
+        return ServiceLoaderUtil.safeLoadClass(
+                FactoryBackedContextFactory.class.getName(),
+                FactoryBackedContextFactory.class.getName(),
+                classLoader);
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta/xml/bind/ServiceLoaderUtilInvoker.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta/xml/bind/ServiceLoaderUtilInvoker.java
@@ -6,7 +6,12 @@
  */
 package jakarta.xml.bind;
 
+import java.util.Map;
+
 import jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory;
+import jakarta_xml_bind.jakarta_xml_bind_api.support.LegacyContextFactory;
+import jakarta_xml_bind.jakarta_xml_bind_api.support.PropertiesContextFactory;
+import jakarta_xml_bind.jakarta_xml_bind_api.support.WrongTypeContextFactory;
 
 public final class ServiceLoaderUtilInvoker {
     private static final ServiceLoaderUtil.ExceptionHandler<JAXBException> EXCEPTION_HANDLER =
@@ -32,5 +37,47 @@ public final class ServiceLoaderUtilInvoker {
                 FactoryBackedContextFactory.class.getName(),
                 FactoryBackedContextFactory.class.getName(),
                 classLoader);
+    }
+
+    public static JAXBContext createContextWithPropertiesFactory(
+            String contextPath,
+            ClassLoader classLoader,
+            Map<String, ?> properties) throws JAXBException {
+        return ContextFinder.newInstance(
+                contextPath,
+                ModuleUtil.getClassesFromContextPath(contextPath, classLoader),
+                PropertiesContextFactory.class,
+                classLoader,
+                properties);
+    }
+
+    public static JAXBContext createContextWithPropertiesFactory(
+            Class<?>[] classes,
+            Map<String, ?> properties) throws JAXBException {
+        return ContextFinder.newInstance(classes, properties, PropertiesContextFactory.class);
+    }
+
+    public static JAXBContext createContextWithLegacyFactory(
+            String contextPath,
+            ClassLoader classLoader,
+            Map<String, ?> properties) throws JAXBException {
+        return ContextFinder.newInstance(
+                contextPath,
+                ModuleUtil.getClassesFromContextPath(contextPath, classLoader),
+                LegacyContextFactory.class,
+                classLoader,
+                properties);
+    }
+
+    public static JAXBContext createContextWithFactoryBackedFactory(
+            Class<?>[] classes,
+            Map<String, ?> properties) throws JAXBException {
+        return ContextFinder.newInstance(classes, properties, FactoryBackedContextFactory.class);
+    }
+
+    public static JAXBContext createContextWithWrongTypeFactory(
+            Class<?>[] classes,
+            Map<String, ?> properties) throws JAXBException {
+        return ContextFinder.newInstance(classes, properties, WrongTypeContextFactory.class);
     }
 }

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ContextFinderTest.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ContextFinderTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api;
+
+import java.util.Map;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta_xml_bind.jakarta_xml_bind_api.classproperties.PropertiesBoundType;
+import jakarta_xml_bind.jakarta_xml_bind_api.factorybacked.FactoryBackedBoundType;
+import jakarta_xml_bind.jakarta_xml_bind_api.servicebound.ServiceBoundType;
+import jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory;
+import jakarta_xml_bind.jakarta_xml_bind_api.support.LegacyContextFactory;
+import jakarta_xml_bind.jakarta_xml_bind_api.support.PropertiesContextFactory;
+import jakarta_xml_bind.jakarta_xml_bind_api.support.StubJaxbContext;
+import jakarta_xml_bind.jakarta_xml_bind_api.support.WrongTypeContextFactory;
+import jakarta_xml_bind.jakarta_xml_bind_api.wrongtype.WrongTypeBoundType;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ContextFinderTest {
+    private static final String PROPERTIES_CONTEXT_PATH =
+            "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.properties";
+    private static final String SERVICE_CONTEXT_PATH =
+            "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.service";
+
+    @Test
+    public void loadsThreeArgumentFactoryFromPropertiesMapForContextPath() throws Exception {
+        JAXBContext context = JAXBContext.newInstance(
+                PROPERTIES_CONTEXT_PATH,
+                getClass().getClassLoader(),
+                Map.of(
+                        JAXBContext.JAXB_CONTEXT_FACTORY,
+                        PropertiesContextFactory.class.getName(),
+                        "trigger",
+                        "jaxb-properties"));
+
+        assertContextSource(context, "properties-context-path-factory");
+    }
+
+    @Test
+    public void loadsFactoryFromPropertiesMapForBoundClasses() throws Exception {
+        JAXBContext context = JAXBContext.newInstance(
+                new Class<?>[] {PropertiesBoundType.class},
+                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, PropertiesContextFactory.class.getName()));
+
+        assertContextSource(context, "properties-classes-factory");
+    }
+
+    @Test
+    public void loadsServiceProviderForContextPath() throws Exception {
+        JAXBContext context = JAXBContext.newInstance(
+                SERVICE_CONTEXT_PATH,
+                getClass().getClassLoader(),
+                Map.of());
+
+        assertContextSource(context, "service-context-factory-string");
+    }
+
+    @Test
+    public void loadsLegacyTwoArgumentFactoryFromPropertiesMapForContextPath() throws Exception {
+        JAXBContext context = JAXBContext.newInstance(
+                PROPERTIES_CONTEXT_PATH,
+                getClass().getClassLoader(),
+                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, LegacyContextFactory.class.getName()));
+
+        assertContextSource(context, "legacy-context-path-factory");
+    }
+
+    @Test
+    public void instantiatesJaxbContextFactoryImplementations() throws Exception {
+        JAXBContext context = JAXBContext.newInstance(
+                new Class<?>[] {FactoryBackedBoundType.class},
+                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, FactoryBackedContextFactory.class.getName()));
+
+        assertContextSource(context, "factory-backed-classes-factory");
+    }
+
+    @Test
+    public void loadsServiceProviderForBoundClassesWithoutContextClassLoader() throws Exception {
+        JAXBContext context = withContextClassLoader(null, () -> JAXBContext.newInstance(ServiceBoundType.class));
+
+        assertContextSource(context, "service-context-factory-classes");
+    }
+
+    @Test
+    public void throwsHelpfulExceptionWhenProviderReturnsWrongType() {
+        assertThatThrownBy(() -> JAXBContext.newInstance(
+                new Class<?>[] {WrongTypeBoundType.class},
+                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, WrongTypeContextFactory.class.getName())))
+                .isInstanceOf(JAXBException.class)
+                .hasMessageContaining("ClassCastException");
+    }
+
+    private static void assertContextSource(JAXBContext context, String expectedSource) {
+        assertThat(context).isInstanceOf(StubJaxbContext.class);
+        assertThat(((StubJaxbContext) context).getSource()).isEqualTo(expectedSource);
+    }
+
+    private static <T> T withContextClassLoader(
+            ClassLoader classLoader,
+            ThrowingSupplier<T> supplier) throws Exception {
+        Thread currentThread = Thread.currentThread();
+        ClassLoader previousClassLoader = currentThread.getContextClassLoader();
+        currentThread.setContextClassLoader(classLoader);
+        try {
+            return supplier.get();
+        } finally {
+            currentThread.setContextClassLoader(previousClassLoader);
+        }
+    }
+
+    @FunctionalInterface
+    private interface ThrowingSupplier<T> {
+        T get() throws Exception;
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ContextFinderTest.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ContextFinderTest.java
@@ -10,14 +10,11 @@ import java.util.Map;
 
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.ServiceLoaderUtilInvoker;
 import jakarta_xml_bind.jakarta_xml_bind_api.classproperties.PropertiesBoundType;
 import jakarta_xml_bind.jakarta_xml_bind_api.factorybacked.FactoryBackedBoundType;
 import jakarta_xml_bind.jakarta_xml_bind_api.servicebound.ServiceBoundType;
-import jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory;
-import jakarta_xml_bind.jakarta_xml_bind_api.support.LegacyContextFactory;
-import jakarta_xml_bind.jakarta_xml_bind_api.support.PropertiesContextFactory;
 import jakarta_xml_bind.jakarta_xml_bind_api.support.StubJaxbContext;
-import jakarta_xml_bind.jakarta_xml_bind_api.support.WrongTypeContextFactory;
 import jakarta_xml_bind.jakarta_xml_bind_api.wrongtype.WrongTypeBoundType;
 import org.junit.jupiter.api.Test;
 
@@ -31,24 +28,20 @@ public class ContextFinderTest {
             "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.service";
 
     @Test
-    public void loadsThreeArgumentFactoryFromPropertiesMapForContextPath() throws Exception {
-        JAXBContext context = JAXBContext.newInstance(
+    public void invokesThreeArgumentFactoryClassForContextPath() throws Exception {
+        JAXBContext context = ServiceLoaderUtilInvoker.createContextWithPropertiesFactory(
                 PROPERTIES_CONTEXT_PATH,
                 getClass().getClassLoader(),
-                Map.of(
-                        JAXBContext.JAXB_CONTEXT_FACTORY,
-                        PropertiesContextFactory.class.getName(),
-                        "trigger",
-                        "jaxb-properties"));
+                Map.of("trigger", "jaxb-properties"));
 
         assertContextSource(context, "properties-context-path-factory");
     }
 
     @Test
-    public void loadsFactoryFromPropertiesMapForBoundClasses() throws Exception {
-        JAXBContext context = JAXBContext.newInstance(
+    public void invokesFactoryClassForBoundClasses() throws Exception {
+        JAXBContext context = ServiceLoaderUtilInvoker.createContextWithPropertiesFactory(
                 new Class<?>[] {PropertiesBoundType.class},
-                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, PropertiesContextFactory.class.getName()));
+                Map.of());
 
         assertContextSource(context, "properties-classes-factory");
     }
@@ -64,20 +57,20 @@ public class ContextFinderTest {
     }
 
     @Test
-    public void loadsLegacyTwoArgumentFactoryFromPropertiesMapForContextPath() throws Exception {
-        JAXBContext context = JAXBContext.newInstance(
+    public void invokesLegacyTwoArgumentFactoryClassForContextPath() throws Exception {
+        JAXBContext context = ServiceLoaderUtilInvoker.createContextWithLegacyFactory(
                 PROPERTIES_CONTEXT_PATH,
                 getClass().getClassLoader(),
-                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, LegacyContextFactory.class.getName()));
+                Map.of());
 
         assertContextSource(context, "legacy-context-path-factory");
     }
 
     @Test
     public void instantiatesJaxbContextFactoryImplementations() throws Exception {
-        JAXBContext context = JAXBContext.newInstance(
+        JAXBContext context = ServiceLoaderUtilInvoker.createContextWithFactoryBackedFactory(
                 new Class<?>[] {FactoryBackedBoundType.class},
-                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, FactoryBackedContextFactory.class.getName()));
+                Map.of());
 
         assertContextSource(context, "factory-backed-classes-factory");
     }
@@ -91,9 +84,9 @@ public class ContextFinderTest {
 
     @Test
     public void throwsHelpfulExceptionWhenProviderReturnsWrongType() {
-        assertThatThrownBy(() -> JAXBContext.newInstance(
+        assertThatThrownBy(() -> ServiceLoaderUtilInvoker.createContextWithWrongTypeFactory(
                 new Class<?>[] {WrongTypeBoundType.class},
-                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, WrongTypeContextFactory.class.getName())))
+                Map.of()))
                 .isInstanceOf(JAXBException.class)
                 .hasMessageContaining("ClassCastException");
     }

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/HelpersMessagesTest.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/HelpersMessagesTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api;
+
+import jakarta.xml.bind.helpers.ValidationEventLocatorImpl;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.Locator;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class HelpersMessagesTest {
+    @Test
+    public void formatsHelperMessagesFromTheResourceBundle() {
+        assertThatThrownBy(() -> new ValidationEventLocatorImpl((Locator) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("loc");
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/MessagesTest.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/MessagesTest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api;
+
+import jakarta.xml.bind.PropertyException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MessagesTest {
+    @Test
+    public void formatsPropertyExceptionMessagesFromTheResourceBundle() {
+        PropertyException exception = new PropertyException("example.property", 7);
+
+        assertThat(exception.getMessage()).contains("example.property").contains("7");
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ModuleUtilTest.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ModuleUtilTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api;
+
+import java.util.Map;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta_xml_bind.jakarta_xml_bind_api.support.PropertiesContextFactory;
+import jakarta_xml_bind.jakarta_xml_bind_api.support.StubJaxbContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ModuleUtilTest {
+    private static final String CONTEXT_PATH =
+            "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.properties"
+                    + ":jakarta_xml_bind.jakarta_xml_bind_api.contextpath.indexed";
+
+    @Test
+    public void resolvesObjectFactoryAndJaxbIndexEntriesFromTheContextPath() throws Exception {
+        JAXBContext context = JAXBContext.newInstance(
+                CONTEXT_PATH,
+                getClass().getClassLoader(),
+                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, PropertiesContextFactory.class.getName()));
+
+        assertThat(context).isInstanceOf(StubJaxbContext.class);
+        assertThat(((StubJaxbContext) context).getSource()).isEqualTo("properties-context-path-factory");
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ModuleUtilTest.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ModuleUtilTest.java
@@ -9,7 +9,7 @@ package jakarta_xml_bind.jakarta_xml_bind_api;
 import java.util.Map;
 
 import jakarta.xml.bind.JAXBContext;
-import jakarta_xml_bind.jakarta_xml_bind_api.support.PropertiesContextFactory;
+import jakarta.xml.bind.ServiceLoaderUtilInvoker;
 import jakarta_xml_bind.jakarta_xml_bind_api.support.StubJaxbContext;
 import org.junit.jupiter.api.Test;
 
@@ -22,10 +22,10 @@ public class ModuleUtilTest {
 
     @Test
     public void resolvesObjectFactoryAndJaxbIndexEntriesFromTheContextPath() throws Exception {
-        JAXBContext context = JAXBContext.newInstance(
+        JAXBContext context = ServiceLoaderUtilInvoker.createContextWithPropertiesFactory(
                 CONTEXT_PATH,
                 getClass().getClassLoader(),
-                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, PropertiesContextFactory.class.getName()));
+                Map.of());
 
         assertThat(context).isInstanceOf(StubJaxbContext.class);
         assertThat(((StubJaxbContext) context).getSource()).isEqualTo("properties-context-path-factory");

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ServiceLoaderUtilTest.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ServiceLoaderUtilTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.security.Permission;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Map;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.ServiceLoaderUtilInvoker;
+import jakarta_xml_bind.jakarta_xml_bind_api.servicebound.ServiceBoundType;
+import jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory;
+import jakarta_xml_bind.jakarta_xml_bind_api.support.StubJaxbContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ServiceLoaderUtilTest {
+    private static final String OSGI_CONTEXT_PATH =
+            "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.osgi";
+    private static final String JAXB_CONTEXT_FACTORY_SERVICE_RESOURCE =
+            "META-INF/services/jakarta.xml.bind.JAXBContextFactory";
+
+    @Test
+    public void loadsProviderClassUsingContextClassLoader() throws Exception {
+        JAXBContext context = withContextClassLoader(
+                getClass().getClassLoader(),
+                () -> JAXBContext.newInstance(ServiceBoundType.class));
+
+        assertThat(context).isInstanceOf(StubJaxbContext.class);
+        assertThat(((StubJaxbContext) context).getSource()).isEqualTo("service-context-factory-classes");
+    }
+
+    @Test
+    public void loadsProviderClassWithoutContextClassLoader() throws Exception {
+        JAXBContext context = withContextClassLoader(null, () -> JAXBContext.newInstance(ServiceBoundType.class));
+
+        assertThat(context).isInstanceOf(StubJaxbContext.class);
+        assertThat(((StubJaxbContext) context).getSource()).isEqualTo("service-context-factory-classes");
+    }
+
+    @Test
+    public void instantiatesProviderClassByName() throws Exception {
+        Object provider = withContextClassLoader(
+                null,
+                ServiceLoaderUtilInvoker::instantiateFactoryBackedContextFactory);
+
+        assertThat(provider).isInstanceOf(FactoryBackedContextFactory.class);
+    }
+
+    @Test
+    @SuppressWarnings("removal")
+    public void fallsBackToClassForNameWhenDefaultImplementationPackageAccessIsDenied() throws Exception {
+        SecurityManager previousSecurityManager = System.getSecurityManager();
+        PackageAccessDenyingSecurityManager securityManager =
+                new PackageAccessDenyingSecurityManager(FactoryBackedContextFactory.class.getPackage().getName());
+        boolean securityManagerInstalled = installSecurityManagerIfSupported(securityManager);
+
+        try {
+            Class<?> providerClass = ServiceLoaderUtilInvoker.loadFactoryBackedContextFactory(
+                    getClass().getClassLoader());
+
+            assertThat(providerClass).isEqualTo(FactoryBackedContextFactory.class);
+            if (securityManagerInstalled) {
+                assertThat(securityManager.wasCheckPackageAccessCalled()).isTrue();
+            }
+        } finally {
+            if (securityManagerInstalled) {
+                System.setSecurityManager(previousSecurityManager);
+            }
+        }
+    }
+
+    @Test
+    public void loadsContextPathProviderFromOsgiLocatorWhenServiceResourceIsAbsent() throws Exception {
+        ClassLoader classLoader = new ServiceResourceHidingClassLoader(getClass().getClassLoader());
+
+        JAXBContext context = withContextClassLoader(
+                classLoader,
+                () -> JAXBContext.newInstance(OSGI_CONTEXT_PATH, classLoader, Map.of()));
+
+        assertThat(context).isInstanceOf(StubJaxbContext.class);
+        assertThat(((StubJaxbContext) context).getSource()).isEqualTo("factory-backed-context-path-factory");
+    }
+
+    @Test
+    public void loadsClassProviderFromOsgiLocatorWhenServiceResourceIsAbsent() throws Exception {
+        ClassLoader classLoader = new ServiceResourceHidingClassLoader(getClass().getClassLoader());
+
+        JAXBContext context = withContextClassLoader(
+                classLoader,
+                () -> JAXBContext.newInstance(ServiceBoundType.class));
+
+        assertThat(context).isInstanceOf(StubJaxbContext.class);
+        assertThat(((StubJaxbContext) context).getSource()).isEqualTo("factory-backed-classes-factory");
+    }
+
+    @SuppressWarnings("removal")
+    private static boolean installSecurityManagerIfSupported(SecurityManager securityManager) {
+        try {
+            System.setSecurityManager(securityManager);
+            return System.getSecurityManager() == securityManager;
+        } catch (UnsupportedOperationException unsupportedOperationException) {
+            return false;
+        }
+    }
+
+    private static <T> T withContextClassLoader(
+            ClassLoader classLoader,
+            ThrowingSupplier<T> supplier) throws Exception {
+        Thread currentThread = Thread.currentThread();
+        ClassLoader previousClassLoader = currentThread.getContextClassLoader();
+        currentThread.setContextClassLoader(classLoader);
+        try {
+            return supplier.get();
+        } finally {
+            currentThread.setContextClassLoader(previousClassLoader);
+        }
+    }
+
+    @FunctionalInterface
+    private interface ThrowingSupplier<T> {
+        T get() throws Exception;
+    }
+
+    @SuppressWarnings("removal")
+    private static final class PackageAccessDenyingSecurityManager extends SecurityManager {
+        private final String deniedPackageName;
+        private boolean checkPackageAccessCalled;
+
+        private PackageAccessDenyingSecurityManager(String deniedPackageName) {
+            this.deniedPackageName = deniedPackageName;
+        }
+
+        @Override
+        public void checkPermission(Permission permission) {
+        }
+
+        @Override
+        public void checkPackageAccess(String packageName) {
+            if (deniedPackageName.equals(packageName)) {
+                checkPackageAccessCalled = true;
+                throw new SecurityException(packageName);
+            }
+        }
+
+        private boolean wasCheckPackageAccessCalled() {
+            return checkPackageAccessCalled;
+        }
+    }
+
+    private static final class ServiceResourceHidingClassLoader extends ClassLoader {
+        private ServiceResourceHidingClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        @Override
+        public URL getResource(String name) {
+            if (JAXB_CONTEXT_FACTORY_SERVICE_RESOURCE.equals(name)) {
+                return null;
+            }
+            return super.getResource(name);
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            if (JAXB_CONTEXT_FACTORY_SERVICE_RESOURCE.equals(name)) {
+                return Collections.emptyEnumeration();
+            }
+            return super.getResources(name);
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            if (JAXB_CONTEXT_FACTORY_SERVICE_RESOURCE.equals(name)) {
+                return null;
+            }
+            return super.getResourceAsStream(name);
+        }
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ServiceLoaderUtilTest.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ServiceLoaderUtilTest.java
@@ -28,6 +28,7 @@ public class ServiceLoaderUtilTest {
             "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.osgi";
     private static final String JAXB_CONTEXT_FACTORY_SERVICE_RESOURCE =
             "META-INF/services/jakarta.xml.bind.JAXBContextFactory";
+    private static final String DEFAULT_PACKAGE_CONTEXT_FACTORY = "DefaultPackageContextFactory";
 
     @Test
     public void loadsProviderClassUsingContextClassLoader() throws Exception {
@@ -54,6 +55,31 @@ public class ServiceLoaderUtilTest {
                 ServiceLoaderUtilInvoker::instantiateFactoryBackedContextFactory);
 
         assertThat(provider).isInstanceOf(FactoryBackedContextFactory.class);
+    }
+
+    @Test
+    public void loadsPackageLessProviderClassWithoutContextClassLoader() throws Exception {
+        JAXBContext context = withContextClassLoader(null, () -> JAXBContext.newInstance(
+                new Class<?>[] {ServiceBoundType.class},
+                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, DEFAULT_PACKAGE_CONTEXT_FACTORY)));
+
+        assertThat(context).isInstanceOf(StubJaxbContext.class);
+        assertThat(((StubJaxbContext) context).getSource())
+                .isEqualTo("default-package-classes-factory");
+    }
+
+    @Test
+    public void loadsPackageLessProviderClassWithSuppliedClassLoader() throws Exception {
+        ClassLoader classLoader = getClass().getClassLoader();
+
+        JAXBContext context = JAXBContext.newInstance(
+                OSGI_CONTEXT_PATH,
+                classLoader,
+                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, DEFAULT_PACKAGE_CONTEXT_FACTORY));
+
+        assertThat(context).isInstanceOf(StubJaxbContext.class);
+        assertThat(((StubJaxbContext) context).getSource())
+                .isEqualTo("default-package-context-path-factory");
     }
 
     @Test

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/UtilMessagesTest.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/UtilMessagesTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.util.JAXBResult;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class UtilMessagesTest {
+    @Test
+    public void formatsUtilMessagesFromTheResourceBundle() {
+        assertThatThrownBy(() -> new JAXBResult((JAXBContext) null))
+                .isInstanceOf(JAXBException.class);
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/classproperties/PropertiesBoundType.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/classproperties/PropertiesBoundType.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api.classproperties;
+
+public final class PropertiesBoundType {
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/contextpath/indexed/IndexedBoundType.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/contextpath/indexed/IndexedBoundType.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api.contextpath.indexed;
+
+public final class IndexedBoundType {
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/contextpath/osgi/ObjectFactory.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/contextpath/osgi/ObjectFactory.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api.contextpath.osgi;
+
+public class ObjectFactory {
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/contextpath/properties/ObjectFactory.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/contextpath/properties/ObjectFactory.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api.contextpath.properties;
+
+public class ObjectFactory {
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/contextpath/service/ObjectFactory.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/contextpath/service/ObjectFactory.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api.contextpath.service;
+
+public class ObjectFactory {
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/factorybacked/FactoryBackedBoundType.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/factorybacked/FactoryBackedBoundType.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api.factorybacked;
+
+public final class FactoryBackedBoundType {
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/servicebound/ServiceBoundType.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/servicebound/ServiceBoundType.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api.servicebound;
+
+public final class ServiceBoundType {
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/support/FactoryBackedContextFactory.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/support/FactoryBackedContextFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api.support;
+
+import java.util.Map;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBContextFactory;
+import jakarta.xml.bind.JAXBException;
+
+public class FactoryBackedContextFactory implements JAXBContextFactory {
+    @Override
+    public JAXBContext createContext(Class<?>[] classesToBeBound, Map<String, ?> properties) throws JAXBException {
+        return new StubJaxbContext("factory-backed-classes-factory");
+    }
+
+    @Override
+    public JAXBContext createContext(String contextPath, ClassLoader classLoader, Map<String, ?> properties)
+            throws JAXBException {
+        return new StubJaxbContext("factory-backed-context-path-factory");
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/support/LegacyContextFactory.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/support/LegacyContextFactory.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api.support;
+
+import jakarta.xml.bind.JAXBContext;
+
+public final class LegacyContextFactory {
+    private LegacyContextFactory() {
+    }
+
+    public static JAXBContext createContext(String contextPath, ClassLoader classLoader) {
+        return new StubJaxbContext("legacy-context-path-factory");
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/support/PropertiesContextFactory.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/support/PropertiesContextFactory.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api.support;
+
+import java.util.Map;
+
+import jakarta.xml.bind.JAXBContext;
+
+public final class PropertiesContextFactory {
+    private PropertiesContextFactory() {
+    }
+
+    public static JAXBContext createContext(String contextPath, ClassLoader classLoader, Map<?, ?> properties) {
+        return new StubJaxbContext("properties-context-path-factory");
+    }
+
+    public static JAXBContext createContext(Class<?>[] classes, Map<?, ?> properties) {
+        return new StubJaxbContext("properties-classes-factory");
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/support/ServiceContextFactory.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/support/ServiceContextFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api.support;
+
+import java.util.Map;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBContextFactory;
+import jakarta.xml.bind.JAXBException;
+
+public final class ServiceContextFactory implements JAXBContextFactory {
+    @Override
+    public JAXBContext createContext(String contextPath, ClassLoader classLoader, Map<String, ?> properties)
+            throws JAXBException {
+        return new StubJaxbContext("service-context-factory-string");
+    }
+
+    @Override
+    public JAXBContext createContext(Class<?>[] classes, Map<String, ?> properties) throws JAXBException {
+        return new StubJaxbContext("service-context-factory-classes");
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/support/StubJaxbContext.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/support/StubJaxbContext.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api.support;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
+
+public class StubJaxbContext extends JAXBContext {
+    private final String source;
+
+    public StubJaxbContext(String source) {
+        this.source = source;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    @Override
+    public Unmarshaller createUnmarshaller() throws JAXBException {
+        throw new UnsupportedOperationException("Unmarshaller is not needed for this test");
+    }
+
+    @Override
+    public Marshaller createMarshaller() throws JAXBException {
+        throw new UnsupportedOperationException("Marshaller is not needed for this test");
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/support/WrongTypeContextFactory.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/support/WrongTypeContextFactory.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api.support;
+
+import java.util.Map;
+
+public final class WrongTypeContextFactory {
+    private WrongTypeContextFactory() {
+    }
+
+    public static Object createContext(Class<?>[] classes, Map<?, ?> properties) {
+        return new WrongTypeReturnValue();
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/support/WrongTypeReturnValue.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/support/WrongTypeReturnValue.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api.support;
+
+public final class WrongTypeReturnValue {
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/wrongtype/WrongTypeBoundType.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/wrongtype/WrongTypeBoundType.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api.wrongtype;
+
+public final class WrongTypeBoundType {
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/org/glassfish/hk2/osgiresourcelocator/ServiceLoader.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/org/glassfish/hk2/osgiresourcelocator/ServiceLoader.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.glassfish.hk2.osgiresourcelocator;
+
+import java.util.Collections;
+
+import jakarta.xml.bind.JAXBContextFactory;
+import jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory;
+
+public final class ServiceLoader {
+    private ServiceLoader() {
+    }
+
+    public static <T> Iterable<Class<? extends T>> lookupProviderClasses(Class<T> serviceClass) {
+        if (serviceClass != JAXBContextFactory.class) {
+            return Collections.emptyList();
+        }
+        return Collections.singletonList(FactoryBackedContextFactory.class.asSubclass(serviceClass));
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,197 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.support.ServiceContextFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.support.PropertiesContextFactory",
+      "methods" : [
+        {
+          "name" : "createContext",
+          "parameterTypes" : [
+            "java.lang.String",
+            "java.lang.ClassLoader",
+            "java.util.Map"
+          ]
+        },
+        {
+          "name" : "createContext",
+          "parameterTypes" : [
+            "java.lang.Class[]",
+            "java.util.Map"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.support.LegacyContextFactory",
+      "methods" : [
+        {
+          "name" : "createContext",
+          "parameterTypes" : [
+            "java.lang.String",
+            "java.lang.ClassLoader"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "createContext",
+          "parameterTypes" : [
+            "java.lang.Class[]",
+            "java.util.Map"
+          ]
+        },
+        {
+          "name" : "createContext",
+          "parameterTypes" : [
+            "java.lang.String",
+            "java.lang.ClassLoader",
+            "java.util.Map"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.support.WrongTypeContextFactory",
+      "methods" : [
+        {
+          "name" : "createContext",
+          "parameterTypes" : [
+            "java.lang.Class[]",
+            "java.util.Map"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ModuleUtil"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.indexed.IndexedBoundType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ModuleUtil"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.indexed.ObjectFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ModuleUtil"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.osgi.ObjectFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ModuleUtil"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.properties.ObjectFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ModuleUtil"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.service.ObjectFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory",
+      "methods" : [
+        {
+          "name" : "createContext",
+          "parameterTypes" : [
+            "java.lang.Class[]",
+            "java.util.Map"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder$2"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ServiceLoaderUtil"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ServiceLoaderUtilInvoker"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ServiceLoaderUtil"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.support.ServiceContextFactory"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder"
+      },
+      "glob" : "META-INF/services/jakarta.xml.bind.JAXBContextFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ModuleUtil"
+      },
+      "glob" : "jakarta_xml_bind/jakarta_xml_bind_api/contextpath/indexed/jaxb.index"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ServiceLoaderUtil"
+      },
+      "glob" : "META-INF/services/jakarta.xml.bind.JAXBContextFactory"
+    }
+  ]
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -172,6 +172,36 @@
         "typeReached" : "jakarta.xml.bind.ServiceLoaderUtil"
       },
       "type" : "jakarta_xml_bind.jakarta_xml_bind_api.support.ServiceContextFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ServiceLoaderUtil"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.support.LegacyContextFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.support.PropertiesContextFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.support.WrongTypeContextFactory"
     }
   ],
   "resources" : [

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/resources/META-INF/services/jakarta.xml.bind.JAXBContextFactory
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/resources/META-INF/services/jakarta.xml.bind.JAXBContextFactory
@@ -1,0 +1,1 @@
+jakarta_xml_bind.jakarta_xml_bind_api.support.ServiceContextFactory

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/resources/jakarta_xml_bind/jakarta_xml_bind_api/contextpath/indexed/jaxb.index
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/resources/jakarta_xml_bind/jakarta_xml_bind_api/contextpath/indexed/jaxb.index
@@ -1,0 +1,1 @@
+IndexedBoundType

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/user-code-filter.json
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "jakarta.xml.bind.**"
+    }
+  ]
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/user-code-filter.json
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/user-code-filter.json
@@ -5,6 +5,39 @@
     },
     {
       "includeClasses" : "jakarta.xml.bind.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.servicebound.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.classproperties.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.osgi.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.properties.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.service.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.indexed.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.factorybacked.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.wrongtype.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.support.**"
+    },
+    {
+      "includeClasses" : "org.glassfish.hk2.osgiresourcelocator.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #4422

This PR provides test fixes and new metadata for jakarta.xml.bind:jakarta.xml.bind-api:4.1.0-M1, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 162546
- Cached input tokens: 2117632
- Output tokens: 32524
- Metadata entries: 13
- Test-only metadata entries: 34
- Iterations: 4
- Library coverage percentage: 11.48
- Previous library version metadata entries: 20
- Previous library version test-only metadata entries: 29
- Previous library version coverage percentage: 11.63

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `e73f0e0ac0a6d704adee550917c7e88dd4de2645`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- jakarta.xml.bind:jakarta.xml.bind-api:4.0.0: 24/25 covered calls (96.00%)
- jakarta.xml.bind:jakarta.xml.bind-api:4.1.0-M1: 25/25 covered calls (100.00%)

**Reflection:**
- jakarta.xml.bind:jakarta.xml.bind-api:4.0.0: 18/19 covered calls (94.74%)
- jakarta.xml.bind:jakarta.xml.bind-api:4.1.0-M1: 19/19 covered calls (100.00%)

**Resources:**
- jakarta.xml.bind:jakarta.xml.bind-api:4.0.0: 6/6 covered calls (100.00%)
- jakarta.xml.bind:jakarta.xml.bind-api:4.1.0-M1: 6/6 covered calls (100.00%)

#### Library coverage

**Instruction:**
- jakarta.xml.bind:jakarta.xml.bind-api:4.0.0: 822/6888 (11.93%)
- jakarta.xml.bind:jakarta.xml.bind-api:4.1.0-M1: 835/6835 (12.22%)

**Line:**
- jakarta.xml.bind:jakarta.xml.bind-api:4.0.0: 196/1685 (11.63%)
- jakarta.xml.bind:jakarta.xml.bind-api:4.1.0-M1: 197/1716 (11.48%)

**Method:**
- jakarta.xml.bind:jakarta.xml.bind-api:4.0.0: 49/466 (10.51%)
- jakarta.xml.bind:jakarta.xml.bind-api:4.1.0-M1: 45/454 (9.91%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/DefaultPackageContextFactory.java 2/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/DefaultPackageContextFactory.java
new file mode 100644
index 0000000000..c00c75d135
--- /dev/null
+++ 2/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/DefaultPackageContextFactory.java
@@ -0,0 +1,23 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+import java.util.Map;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta_xml_bind.jakarta_xml_bind_api.support.StubJaxbContext;
+
+public class DefaultPackageContextFactory {
+    public static JAXBContext createContext(Class<?>[] classesToBeBound, Map<String, ?> properties) {
+        return new StubJaxbContext("default-package-classes-factory");
+    }
+
+    public static JAXBContext createContext(
+            String contextPath,
+            ClassLoader classLoader,
+            Map<String, ?> properties) {
+        return new StubJaxbContext("default-package-context-path-factory");
+    }
+}
diff --git 1/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0/src/test/java/jakarta/xml/bind/ServiceLoaderUtilInvoker.java 2/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta/xml/bind/ServiceLoaderUtilInvoker.java
index d60c837eee..47e4c6693a 100644
--- 1/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0/src/test/java/jakarta/xml/bind/ServiceLoaderUtilInvoker.java
+++ 2/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta/xml/bind/ServiceLoaderUtilInvoker.java
@@ -6,7 +6,12 @@
  */
 package jakarta.xml.bind;
 
+import java.util.Map;
+
 import jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory;
+import jakarta_xml_bind.jakarta_xml_bind_api.support.LegacyContextFactory;
+import jakarta_xml_bind.jakarta_xml_bind_api.support.PropertiesContextFactory;
+import jakarta_xml_bind.jakarta_xml_bind_api.support.WrongTypeContextFactory;
 
 public final class ServiceLoaderUtilInvoker {
     private static final ServiceLoaderUtil.ExceptionHandler<JAXBException> EXCEPTION_HANDLER =
@@ -33,4 +38,46 @@ public final class ServiceLoaderUtilInvoker {
                 FactoryBackedContextFactory.class.getName(),
                 classLoader);
     }
+
+    public static JAXBContext createContextWithPropertiesFactory(
+            String contextPath,
+            ClassLoader classLoader,
+            Map<String, ?> properties) throws JAXBException {
+        return ContextFinder.newInstance(
+                contextPath,
+                ModuleUtil.getClassesFromContextPath(contextPath, classLoader),
+                PropertiesContextFactory.class,
+                classLoader,
+                properties);
+    }
+
+    public static JAXBContext createContextWithPropertiesFactory(
+            Class<?>[] classes,
+            Map<String, ?> properties) throws JAXBException {
+        return ContextFinder.newInstance(classes, properties, PropertiesContextFactory.class);
+    }
+
+    public static JAXBContext createContextWithLegacyFactory(
+            String contextPath,
+            ClassLoader classLoader,
+            Map<String, ?> properties) throws JAXBException {
+        return ContextFinder.newInstance(
+                contextPath,
+                ModuleUtil.getClassesFromContextPath(contextPath, classLoader),
+                LegacyContextFactory.class,
+                classLoader,
+                properties);
+    }
+
+    public static JAXBContext createContextWithFactoryBackedFactory(
+            Class<?>[] classes,
+            Map<String, ?> properties) throws JAXBException {
+        return ContextFinder.newInstance(classes, properties, FactoryBackedContextFactory.class);
+    }
+
+    public static JAXBContext createContextWithWrongTypeFactory(
+            Class<?>[] classes,
+            Map<String, ?> properties) throws JAXBException {
+        return ContextFinder.newInstance(classes, properties, WrongTypeContextFactory.class);
+    }
 }
diff --git 1/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ContextFinderTest.java 2/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ContextFinderTest.java
index 34f5daa1a3..32b6a277be 100644
--- 1/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ContextFinderTest.java
+++ 2/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ContextFinderTest.java
@@ -10,14 +10,11 @@ import java.util.Map;
 
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.ServiceLoaderUtilInvoker;
 import jakarta_xml_bind.jakarta_xml_bind_api.classproperties.PropertiesBoundType;
 import jakarta_xml_bind.jakarta_xml_bind_api.factorybacked.FactoryBackedBoundType;
 import jakarta_xml_bind.jakarta_xml_bind_api.servicebound.ServiceBoundType;
-import jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory;
-import jakarta_xml_bind.jakarta_xml_bind_api.support.LegacyContextFactory;
-import jakarta_xml_bind.jakarta_xml_bind_api.support.PropertiesContextFactory;
 import jakarta_xml_bind.jakarta_xml_bind_api.support.StubJaxbContext;
-import jakarta_xml_bind.jakarta_xml_bind_api.support.WrongTypeContextFactory;
 import jakarta_xml_bind.jakarta_xml_bind_api.wrongtype.WrongTypeBoundType;
 import org.junit.jupiter.api.Test;
 
@@ -31,24 +28,20 @@ public class ContextFinderTest {
             "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.service";
 
     @Test
-    public void loadsThreeArgumentFactoryFromPropertiesMapForContextPath() throws Exception {
-        JAXBContext context = JAXBContext.newInstance(
+    public void invokesThreeArgumentFactoryClassForContextPath() throws Exception {
+        JAXBContext context = ServiceLoaderUtilInvoker.createContextWithPropertiesFactory(
                 PROPERTIES_CONTEXT_PATH,
                 getClass().getClassLoader(),
-                Map.of(
-                        JAXBContext.JAXB_CONTEXT_FACTORY,
-                        PropertiesContextFactory.class.getName(),
-                        "trigger",
-                        "jaxb-properties"));
+                Map.of("trigger", "jaxb-properties"));
 
         assertContextSource(context, "properties-context-path-factory");
     }
 
     @Test
-    public void loadsFactoryFromPropertiesMapForBoundClasses() throws Exception {
-        JAXBContext context = JAXBContext.newInstance(
+    public void invokesFactoryClassForBoundClasses() throws Exception {
+        JAXBContext context = ServiceLoaderUtilInvoker.createContextWithPropertiesFactory(
                 new Class<?>[] {PropertiesBoundType.class},
-                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, PropertiesContextFactory.class.getName()));
+                Map.of());
 
         assertContextSource(context, "properties-classes-factory");
     }
@@ -64,20 +57,20 @@ public class ContextFinderTest {
     }
 
     @Test
-    public void loadsLegacyTwoArgumentFactoryFromPropertiesMapForContextPath() throws Exception {
-        JAXBContext context = JAXBContext.newInstance(
+    public void invokesLegacyTwoArgumentFactoryClassForContextPath() throws Exception {
+        JAXBContext context = ServiceLoaderUtilInvoker.createContextWithLegacyFactory(
                 PROPERTIES_CONTEXT_PATH,
                 getClass().getClassLoader(),
-                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, LegacyContextFactory.class.getName()));
+                Map.of());
 
         assertContextSource(context, "legacy-context-path-factory");
     }
 
     @Test
     public void instantiatesJaxbContextFactoryImplementations() throws Exception {
-        JAXBContext context = JAXBContext.newInstance(
+        JAXBContext context = ServiceLoaderUtilInvoker.createContextWithFactoryBackedFactory(
                 new Class<?>[] {FactoryBackedBoundType.class},
-                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, FactoryBackedContextFactory.class.getName()));
+                Map.of());
 
         assertContextSource(context, "factory-backed-classes-factory");
     }
@@ -91,9 +84,9 @@ public class ContextFinderTest {
 
     @Test
     public void throwsHelpfulExceptionWhenProviderReturnsWrongType() {
-        assertThatThrownBy(() -> JAXBContext.newInstance(
+        assertThatThrownBy(() -> ServiceLoaderUtilInvoker.createContextWithWrongTypeFactory(
                 new Class<?>[] {WrongTypeBoundType.class},
-                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, WrongTypeContextFactory.class.getName())))
+                Map.of()))
                 .isInstanceOf(JAXBException.class)
                 .hasMessageContaining("ClassCastException");
     }
diff --git 1/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ModuleUtilTest.java 2/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ModuleUtilTest.java
index 4074763a76..82b031b83b 100644
--- 1/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ModuleUtilTest.java
+++ 2/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ModuleUtilTest.java
@@ -9,7 +9,7 @@ package jakarta_xml_bind.jakarta_xml_bind_api;
 import java.util.Map;
 
 import jakarta.xml.bind.JAXBContext;
-import jakarta_xml_bind.jakarta_xml_bind_api.support.PropertiesContextFactory;
+import jakarta.xml.bind.ServiceLoaderUtilInvoker;
 import jakarta_xml_bind.jakarta_xml_bind_api.support.StubJaxbContext;
 import org.junit.jupiter.api.Test;
 
@@ -22,10 +22,10 @@ public class ModuleUtilTest {
 
     @Test
     public void resolvesObjectFactoryAndJaxbIndexEntriesFromTheContextPath() throws Exception {
-        JAXBContext context = JAXBContext.newInstance(
+        JAXBContext context = ServiceLoaderUtilInvoker.createContextWithPropertiesFactory(
                 CONTEXT_PATH,
                 getClass().getClassLoader(),
-                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, PropertiesContextFactory.class.getName()));
+                Map.of());
 
         assertThat(context).isInstanceOf(StubJaxbContext.class);
         assertThat(((StubJaxbContext) context).getSource()).isEqualTo("properties-context-path-factory");
diff --git 1/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ServiceLoaderUtilTest.java 2/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ServiceLoaderUtilTest.java
index d2a43cd4ba..0ec20559e2 100644
--- 1/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ServiceLoaderUtilTest.java
+++ 2/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ServiceLoaderUtilTest.java
@@ -28,6 +28,7 @@ public class ServiceLoaderUtilTest {
             "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.osgi";
     private static final String JAXB_CONTEXT_FACTORY_SERVICE_RESOURCE =
             "META-INF/services/jakarta.xml.bind.JAXBContextFactory";
+    private static final String DEFAULT_PACKAGE_CONTEXT_FACTORY = "DefaultPackageContextFactory";
 
     @Test
     public void loadsProviderClassUsingContextClassLoader() throws Exception {
@@ -56,6 +57,31 @@ public class ServiceLoaderUtilTest {
         assertThat(provider).isInstanceOf(FactoryBackedContextFactory.class);
     }
 
+    @Test
+    public void loadsPackageLessProviderClassWithoutContextClassLoader() throws Exception {
+        JAXBContext context = withContextClassLoader(null, () -> JAXBContext.newInstance(
+                new Class<?>[] {ServiceBoundType.class},
+                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, DEFAULT_PACKAGE_CONTEXT_FACTORY)));
+
+        assertThat(context).isInstanceOf(StubJaxbContext.class);
+        assertThat(((StubJaxbContext) context).getSource())
+                .isEqualTo("default-package-classes-factory");
+    }
+
+    @Test
+    public void loadsPackageLessProviderClassWithSuppliedClassLoader() throws Exception {
+        ClassLoader classLoader = getClass().getClassLoader();
+
+        JAXBContext context = JAXBContext.newInstance(
+                OSGI_CONTEXT_PATH,
+                classLoader,
+                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, DEFAULT_PACKAGE_CONTEXT_FACTORY));
+
+        assertThat(context).isInstanceOf(StubJaxbContext.class);
+        assertThat(((StubJaxbContext) context).getSource())
+                .isEqualTo("default-package-context-path-factory");
+    }
+
     @Test
     @SuppressWarnings("removal")
     public void fallsBackToClassForNameWhenDefaultImplementationPackageAccessIsDenied() throws Exception {
diff --git 1/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0/user-code-filter.json 2/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/user-code-filter.json
index d2d90d9f1a..5100f6f133 100644
--- 1/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0/user-code-filter.json
+++ 2/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/user-code-filter.json
@@ -5,6 +5,39 @@
     },
     {
       "includeClasses" : "jakarta.xml.bind.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.servicebound.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.classproperties.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.osgi.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.properties.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.service.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.indexed.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.factorybacked.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.wrongtype.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.support.**"
+    },
+    {
+      "includeClasses" : "org.glassfish.hk2.osgiresourcelocator.**"
     }
   ]
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
