### PR TITLE
[GenAI] Test fix for ognl:ognl:3.3.5 using gpt-5.5

### DIFF
--- a/metadata/ognl/ognl/3.3.5/reachability-metadata.json
+++ b/metadata/ognl/ognl/3.3.5/reachability-metadata.json
@@ -1,0 +1,208 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "ognl.OgnlOps"
+      },
+      "type": "java.lang.Integer[]"
+    },
+    {
+      "condition": {
+        "typeReached": "ognl.OgnlOps"
+      },
+      "type": "java.lang.Long[]"
+    },
+    {
+      "condition": {
+        "typeReached": "ognl.OgnlRuntime"
+      },
+      "type": "java.lang.ObjectBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "ognl.OgnlRuntime"
+      },
+      "type": "java.lang.ObjectCustomizer"
+    },
+    {
+      "condition": {
+        "typeReached": "ognl.OgnlRuntime"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "ognl.ASTChain"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "ognl.ASTCtor"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "ognl.ASTCtor"
+      },
+      "type": "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition": {
+        "typeReached": "ognl.OgnlRuntime"
+      },
+      "type": "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition": {
+        "typeReached": "ognl.OgnlRuntime"
+      },
+      "type": "java.lang.reflect.Field[]"
+    },
+    {
+      "condition": {
+        "typeReached": "ognl.OgnlRuntime"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "ognl.ASTMap"
+      },
+      "type": "java.util.LinkedHashMap",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "ognl.ASTMap"
+      },
+      "type": "java.util.TreeMap",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "ognl.DefaultClassResolver"
+      },
+      "type": "java.util.TreeMap"
+    },
+    {
+      "condition": {
+        "typeReached": "ognl.OgnlRuntime"
+      },
+      "type": "ognl.AccessibleObjectHandler"
+    },
+    {
+      "condition": {
+        "typeReached": "ognl.ASTStaticField"
+      },
+      "type": "ognl.ognl.ASTStaticFieldTest$StaticFieldFixture"
+    },
+    {
+      "condition": {
+        "typeReached": "ognl.ObjectPropertyAccessor"
+      },
+      "type": "ognl.ognl.ObjectPropertyAccessorTest$PublicFieldOnlyFixture"
+    },
+    {
+      "condition": {
+        "typeReached": "ognl.ognl.OgnlRuntimeTest"
+      },
+      "type": "ognl.ognl.OgnlRuntimeTest$ForceDisabledScenario"
+    },
+    {
+      "condition": {
+        "typeReached": "ognl.AccessibleObjectHandlerJDK9Plus"
+      },
+      "type": "sun.misc.Unsafe",
+      "methods": [
+        {
+          "name": "objectFieldOffset",
+          "parameterTypes": [
+            "java.lang.reflect.Field"
+          ]
+        },
+        {
+          "name": "putBoolean",
+          "parameterTypes": [
+            "java.lang.Object",
+            "long",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "ognl.security.OgnlSecurityManager"
+      },
+      "type": "sun.security.provider.NativePRNG"
+    },
+    {
+      "condition": {
+        "typeReached": "ognl.AccessibleObjectHandlerJDK9Plus"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.Deprecated"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "ognl.AccessibleObjectHandlerJDK9Plus"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "ognl.AccessibleObjectHandlerJDK9Plus"
+      },
+      "type": {
+        "proxy": [
+          "jdk.internal.vm.annotation.ForceInline"
+        ]
+      }
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "ognl.enhance.ExpressionCompiler"
+      },
+      "glob": "java/lang/Object.class"
+    },
+    {
+      "condition": {
+        "typeReached": "ognl.enhance.ExpressionCompiler"
+      },
+      "glob": "ognl/OgnlContext.class"
+    },
+    {
+      "condition": {
+        "typeReached": "ognl.enhance.ExpressionCompiler"
+      },
+      "glob": "ognl/enhance/ExpressionAccessor.class"
+    },
+    {
+      "condition": {
+        "typeReached": "ognl.security.OgnlSecurityManagerFactory"
+      },
+      "glob": "ognl/security/OgnlSecurityManager.class"
+    }
+  ]
+}

--- a/metadata/ognl/ognl/3.3.5/reachability-metadata.json
+++ b/metadata/ognl/ognl/3.3.5/reachability-metadata.json
@@ -1,140 +1,122 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "ognl.OgnlOps"
+      "condition" : {
+        "typeReached" : "ognl.OgnlOps"
       },
-      "type": "java.lang.Integer[]"
+      "type" : "java.lang.Integer[]"
     },
     {
-      "condition": {
-        "typeReached": "ognl.OgnlOps"
+      "condition" : {
+        "typeReached" : "ognl.OgnlOps"
       },
-      "type": "java.lang.Long[]"
+      "type" : "java.lang.Long[]"
     },
     {
-      "condition": {
-        "typeReached": "ognl.OgnlRuntime"
+      "condition" : {
+        "typeReached" : "ognl.OgnlRuntime"
       },
-      "type": "java.lang.ObjectBeanInfo"
+      "type" : "java.lang.ObjectBeanInfo"
     },
     {
-      "condition": {
-        "typeReached": "ognl.OgnlRuntime"
+      "condition" : {
+        "typeReached" : "ognl.OgnlRuntime"
       },
-      "type": "java.lang.ObjectCustomizer"
+      "type" : "java.lang.ObjectCustomizer"
     },
     {
-      "condition": {
-        "typeReached": "ognl.OgnlRuntime"
+      "condition" : {
+        "typeReached" : "ognl.OgnlRuntime"
       },
-      "type": "java.lang.StackTraceElement[]"
+      "type" : "java.lang.StackTraceElement[]"
     },
     {
-      "condition": {
-        "typeReached": "ognl.ASTChain"
+      "condition" : {
+        "typeReached" : "ognl.ASTChain"
       },
-      "type": "java.lang.String[]"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "ognl.ASTCtor"
+      "condition" : {
+        "typeReached" : "ognl.ASTCtor"
       },
-      "type": "java.lang.String[]"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "ognl.ASTCtor"
+      "condition" : {
+        "typeReached" : "ognl.ASTCtor"
       },
-      "type": "java.lang.reflect.Constructor[]"
+      "type" : "java.lang.reflect.Constructor[]"
     },
     {
-      "condition": {
-        "typeReached": "ognl.OgnlRuntime"
+      "condition" : {
+        "typeReached" : "ognl.OgnlRuntime"
       },
-      "type": "java.lang.reflect.Constructor[]"
+      "type" : "java.lang.reflect.Constructor[]"
     },
     {
-      "condition": {
-        "typeReached": "ognl.OgnlRuntime"
+      "condition" : {
+        "typeReached" : "ognl.OgnlRuntime"
       },
-      "type": "java.lang.reflect.Field[]"
+      "type" : "java.lang.reflect.Field[]"
     },
     {
-      "condition": {
-        "typeReached": "ognl.OgnlRuntime"
+      "condition" : {
+        "typeReached" : "ognl.OgnlRuntime"
       },
-      "type": "java.lang.reflect.Method[]"
+      "type" : "java.lang.reflect.Method[]"
     },
     {
-      "condition": {
-        "typeReached": "ognl.ASTMap"
+      "condition" : {
+        "typeReached" : "ognl.ASTMap"
       },
-      "type": "java.util.LinkedHashMap",
-      "methods": [
+      "type" : "java.util.LinkedHashMap",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "ognl.ASTMap"
+      "condition" : {
+        "typeReached" : "ognl.ASTMap"
       },
-      "type": "java.util.TreeMap",
-      "methods": [
+      "type" : "java.util.TreeMap",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "ognl.DefaultClassResolver"
+      "condition" : {
+        "typeReached" : "ognl.DefaultClassResolver"
       },
-      "type": "java.util.TreeMap"
+      "type" : "java.util.TreeMap"
     },
     {
-      "condition": {
-        "typeReached": "ognl.OgnlRuntime"
+      "condition" : {
+        "typeReached" : "ognl.OgnlRuntime"
       },
-      "type": "ognl.AccessibleObjectHandler"
+      "type" : "ognl.AccessibleObjectHandler"
     },
     {
-      "condition": {
-        "typeReached": "ognl.ASTStaticField"
+      "condition" : {
+        "typeReached" : "ognl.AccessibleObjectHandlerJDK9Plus"
       },
-      "type": "ognl.ognl.ASTStaticFieldTest$StaticFieldFixture"
-    },
-    {
-      "condition": {
-        "typeReached": "ognl.ObjectPropertyAccessor"
-      },
-      "type": "ognl.ognl.ObjectPropertyAccessorTest$PublicFieldOnlyFixture"
-    },
-    {
-      "condition": {
-        "typeReached": "ognl.ognl.OgnlRuntimeTest"
-      },
-      "type": "ognl.ognl.OgnlRuntimeTest$ForceDisabledScenario"
-    },
-    {
-      "condition": {
-        "typeReached": "ognl.AccessibleObjectHandlerJDK9Plus"
-      },
-      "type": "sun.misc.Unsafe",
-      "methods": [
+      "type" : "sun.misc.Unsafe",
+      "methods" : [
         {
-          "name": "objectFieldOffset",
-          "parameterTypes": [
+          "name" : "objectFieldOffset",
+          "parameterTypes" : [
             "java.lang.reflect.Field"
           ]
         },
         {
-          "name": "putBoolean",
-          "parameterTypes": [
+          "name" : "putBoolean",
+          "parameterTypes" : [
             "java.lang.Object",
             "long",
             "boolean"
@@ -143,66 +125,66 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "ognl.security.OgnlSecurityManager"
+      "condition" : {
+        "typeReached" : "ognl.security.OgnlSecurityManager"
       },
-      "type": "sun.security.provider.NativePRNG"
+      "type" : "sun.security.provider.NativePRNG"
     },
     {
-      "condition": {
-        "typeReached": "ognl.AccessibleObjectHandlerJDK9Plus"
+      "condition" : {
+        "typeReached" : "ognl.AccessibleObjectHandlerJDK9Plus"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.Deprecated"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "ognl.AccessibleObjectHandlerJDK9Plus"
+      "condition" : {
+        "typeReached" : "ognl.AccessibleObjectHandlerJDK9Plus"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Retention"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "ognl.AccessibleObjectHandlerJDK9Plus"
+      "condition" : {
+        "typeReached" : "ognl.AccessibleObjectHandlerJDK9Plus"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "jdk.internal.vm.annotation.ForceInline"
         ]
       }
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "ognl.enhance.ExpressionCompiler"
+      "condition" : {
+        "typeReached" : "ognl.enhance.ExpressionCompiler"
       },
-      "glob": "java/lang/Object.class"
+      "glob" : "java/lang/Object.class"
     },
     {
-      "condition": {
-        "typeReached": "ognl.enhance.ExpressionCompiler"
+      "condition" : {
+        "typeReached" : "ognl.enhance.ExpressionCompiler"
       },
-      "glob": "ognl/OgnlContext.class"
+      "glob" : "ognl/OgnlContext.class"
     },
     {
-      "condition": {
-        "typeReached": "ognl.enhance.ExpressionCompiler"
+      "condition" : {
+        "typeReached" : "ognl.enhance.ExpressionCompiler"
       },
-      "glob": "ognl/enhance/ExpressionAccessor.class"
+      "glob" : "ognl/enhance/ExpressionAccessor.class"
     },
     {
-      "condition": {
-        "typeReached": "ognl.security.OgnlSecurityManagerFactory"
+      "condition" : {
+        "typeReached" : "ognl.security.OgnlSecurityManagerFactory"
       },
-      "glob": "ognl/security/OgnlSecurityManager.class"
+      "glob" : "ognl/security/OgnlSecurityManager.class"
     }
   ]
 }

--- a/metadata/ognl/ognl/index.json
+++ b/metadata/ognl/ognl/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.3.5",
+    "tested-versions" : [
+      "3.3.5"
+    ],
+    "allowed-packages" : [
+      "ognl"
+    ]
+  },
+  {
     "metadata-version" : "3.2.21",
     "source-code-url" : "https://repo.maven.apache.org/maven2/ognl/ognl/$version$/ognl-$version$-sources.jar",
     "repository-url" : "https://github.com/orphan-oss/ognl",

--- a/stats/ognl/ognl/3.3.5/execution-metrics.json
+++ b/stats/ognl/ognl/3.3.5/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_java_run_fail:2026-06-06": {
+    "timestamp": "2026-06-06T21:05:52.393790Z",
+    "library": "ognl:ognl:3.3.5",
+    "starting_commit": "2f273ae9d8db1bf4f6404b4b9410678754afda08",
+    "ending_commit": "4b526a282322fdb899874e57945394fdf47b2bfd",
+    "previous_library": "ognl:ognl:3.2.21",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.3.5",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.82,
+            "coveredCalls": 41,
+            "totalCalls": 50
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 0.823529,
+        "coveredCalls": 42,
+        "totalCalls": 51
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 12454,
+          "missed": 32162,
+          "ratio": 0.279138,
+          "total": 44616
+        },
+        "line": {
+          "covered": 2496,
+          "missed": 6612,
+          "ratio": 0.274045,
+          "total": 9108
+        },
+        "method": {
+          "covered": 364,
+          "missed": 863,
+          "ratio": 0.296659,
+          "total": 1227
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.2.21",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.843137,
+            "coveredCalls": 43,
+            "totalCalls": 51
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 0.846154,
+        "coveredCalls": 44,
+        "totalCalls": 52
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 12507,
+          "missed": 32247,
+          "ratio": 0.279461,
+          "total": 44754
+        },
+        "line": {
+          "covered": 2459,
+          "missed": 6432,
+          "ratio": 0.276572,
+          "total": 8891
+        },
+        "method": {
+          "covered": 364,
+          "missed": 864,
+          "ratio": 0.296417,
+          "total": 1228
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 168635,
+      "cached_input_tokens_used": 1699328,
+      "output_tokens_used": 17078,
+      "iterations": 4,
+      "cost_usd": 1.362,
+      "tested_library_loc": 2496,
+      "metadata_entries": 28,
+      "test_only_metadata_entries": 14,
+      "previous_library_metadata_entries": 28,
+      "previous_library_test_only_metadata_entries": 14,
+      "code_coverage_percent": 27.4,
+      "previous_library_coverage_percent": 27.66
+    },
+    "artifacts": {
+      "test_file": "tests/src/ognl/ognl/3.3.5/src/test/java/ognl/ognl/AccessibleObjectHandlerJDK9PlusTest.java",
+      "metadata_file": "metadata/ognl/ognl/3.3.5/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/ognl/ognl/3.3.5/stats.json
+++ b/stats/ognl/ognl/3.3.5/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "3.3.5",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.82,
+          "coveredCalls" : 41,
+          "totalCalls" : 50
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 0.823529,
+      "coveredCalls" : 42,
+      "totalCalls" : 51
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 12454,
+        "missed" : 32162,
+        "ratio" : 0.279138,
+        "total" : 44616
+      },
+      "line" : {
+        "covered" : 2496,
+        "missed" : 6612,
+        "ratio" : 0.274045,
+        "total" : 9108
+      },
+      "method" : {
+        "covered" : 364,
+        "missed" : 863,
+        "ratio" : 0.296659,
+        "total" : 1227
+      }
+    }
+  } ]
+}

--- a/tests/src/ognl/ognl/3.3.5/.gitignore
+++ b/tests/src/ognl/ognl/3.3.5/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/ognl/ognl/3.3.5/build.gradle
+++ b/tests/src/ognl/ognl/3.3.5/build.gradle
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "ognl:ognl:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+tasks.withType(Test).configureEach {
+    jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/ognl/ognl/3.3.5/gradle.properties
+++ b/tests/src/ognl/ognl/3.3.5/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = ognl:ognl:3.3.5
+library.version = 3.3.5
+metadata.dir = ognl/ognl/3.3.5/

--- a/tests/src/ognl/ognl/3.3.5/settings.gradle
+++ b/tests/src/ognl/ognl/3.3.5/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'ognl.ognl_tests'

--- a/tests/src/ognl/ognl/3.3.5/src/test/java/ognl/ognl/ASTChainTest.java
+++ b/tests/src/ognl/ognl/3.3.5/src/test/java/ognl/ognl/ASTChainTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ognl.ognl;
+
+import ognl.AbstractMemberAccess;
+import ognl.Ognl;
+import ognl.OgnlContext;
+import ognl.OgnlException;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Member;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ASTChainTest {
+    @Test
+    void copiesIndexedArrayPropertyForDynamicAllSubscript() throws OgnlException {
+        final IndexedArrayPropertyFixture root = new IndexedArrayPropertyFixture(
+                new String[] {"alpha", "beta", "gamma"});
+        final OgnlContext context = newContext();
+        final Object expression = Ognl.parseExpression("values[*]");
+
+        final Object value = Ognl.getValue(expression, context, root);
+
+        assertThat(value).isInstanceOf(String[].class);
+        assertThat((String[]) value).containsExactly("alpha", "beta", "gamma");
+        assertThat(value).isNotSameAs(root.getValues());
+    }
+
+    private static OgnlContext newContext() {
+        return new OgnlContext(null, null, new AllowAllMemberAccess());
+    }
+
+    private static final class AllowAllMemberAccess extends AbstractMemberAccess {
+        @Override
+        public boolean isAccessible(Map context, Object target, Member member, String propertyName) {
+            return true;
+        }
+    }
+
+    public static final class IndexedArrayPropertyFixture {
+        private final String[] values;
+
+        public IndexedArrayPropertyFixture(String[] values) {
+            this.values = values;
+        }
+
+        public String[] getValues() {
+            return values;
+        }
+
+        public String getValues(int index) {
+            return values[index];
+        }
+    }
+}

--- a/tests/src/ognl/ognl/3.3.5/src/test/java/ognl/ognl/ASTCtorTest.java
+++ b/tests/src/ognl/ognl/3.3.5/src/test/java/ognl/ognl/ASTCtorTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ognl.ognl;
+
+import ognl.ASTCtor;
+import ognl.AbstractMemberAccess;
+import ognl.Ognl;
+import ognl.OgnlContext;
+import ognl.OgnlException;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Member;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ASTCtorTest {
+    @Test
+    void createsTypedArrayFromSizeExpression() throws OgnlException {
+        final OgnlContext context = newContext();
+        final Object expression = Ognl.parseExpression("new java.lang.String[3]");
+
+        final Object value = Ognl.getValue(expression, context, (Object) null);
+
+        assertThat(value).isInstanceOf(String[].class);
+        assertThat((String[]) value).containsExactly(null, null, null);
+    }
+
+    @Test
+    void emitsSourceForConstructorWithArguments() throws OgnlException {
+        final OgnlContext context = newContext();
+        final String className = SourceConstructorFixture.class.getName();
+        final ASTCtor expression = (ASTCtor) Ognl.parseExpression("new " + className + "(\"Ada\", 7)");
+
+        final String source = expression.toGetSourceString(context, null);
+
+        assertThat(source).isEqualTo("new " + className + "(\"Ada\", 7)");
+        assertThat(context.getCurrentObject()).isInstanceOf(SourceConstructorFixture.class);
+        assertThat(((SourceConstructorFixture) context.getCurrentObject()).description()).isEqualTo("Ada:7");
+        assertThat(context.getCurrentType()).isEqualTo(SourceConstructorFixture.class);
+        assertThat(context.getCurrentAccessor()).isEqualTo(SourceConstructorFixture.class);
+    }
+
+    private static OgnlContext newContext() {
+        return new OgnlContext(null, null, new AllowAllMemberAccess());
+    }
+
+    private static final class AllowAllMemberAccess extends AbstractMemberAccess {
+        @Override
+        public boolean isAccessible(Map context, Object target, Member member, String propertyName) {
+            return true;
+        }
+    }
+
+    public static final class SourceConstructorFixture {
+        private final String name;
+        private final int count;
+
+        public SourceConstructorFixture(String name, int count) {
+            this.name = name;
+            this.count = count;
+        }
+
+        public String description() {
+            return name + ":" + count;
+        }
+    }
+}

--- a/tests/src/ognl/ognl/3.3.5/src/test/java/ognl/ognl/ASTMapTest.java
+++ b/tests/src/ognl/ognl/3.3.5/src/test/java/ognl/ognl/ASTMapTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ognl.ognl;
+
+import ognl.AbstractMemberAccess;
+import ognl.Ognl;
+import ognl.OgnlContext;
+import ognl.OgnlException;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Member;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ASTMapTest {
+    @Test
+    void createsDefaultLinkedHashMapLiteral() throws OgnlException {
+        final Object expression = Ognl.parseExpression("#{\"first\" : 1, \"second\" : 2}");
+        final OgnlContext context = newContext();
+
+        final Object value = Ognl.getValue(expression, context, (Object) null);
+
+        final Map<?, ?> map = (Map<?, ?>) value;
+        assertThat(value).isInstanceOf(LinkedHashMap.class);
+        assertThat(map.keySet().toArray()).containsExactly("first", "second");
+        assertThat(map.get("first")).isEqualTo(1);
+        assertThat(map.get("second")).isEqualTo(2);
+    }
+
+    @Test
+    void createsExplicitMapImplementationLiteral() throws OgnlException {
+        final Object expression = Ognl.parseExpression("#@java.util.TreeMap@{\"second\" : 2, \"first\" : 1}");
+        final OgnlContext context = newContext();
+
+        final Object value = Ognl.getValue(expression, context, (Object) null);
+
+        final Map<?, ?> map = (Map<?, ?>) value;
+        assertThat(value).isInstanceOf(TreeMap.class);
+        assertThat(map.keySet().toArray()).containsExactly("first", "second");
+        assertThat(map.get("first")).isEqualTo(1);
+        assertThat(map.get("second")).isEqualTo(2);
+    }
+
+    private static OgnlContext newContext() {
+        return new OgnlContext(null, null, new AllowAllMemberAccess());
+    }
+
+    private static final class AllowAllMemberAccess extends AbstractMemberAccess {
+        @Override
+        public boolean isAccessible(Map context, Object target, Member member, String propertyName) {
+            return true;
+        }
+    }
+}

--- a/tests/src/ognl/ognl/3.3.5/src/test/java/ognl/ognl/ASTStaticFieldTest.java
+++ b/tests/src/ognl/ognl/3.3.5/src/test/java/ognl/ognl/ASTStaticFieldTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ognl.ognl;
+
+import ognl.ASTStaticField;
+import ognl.AbstractMemberAccess;
+import ognl.Ognl;
+import ognl.OgnlContext;
+import ognl.OgnlException;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Member;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ASTStaticFieldTest {
+    @Test
+    void emitsSourceForPublicStaticField() throws OgnlException {
+        final OgnlContext context = newContext();
+        final String className = StaticFieldFixture.class.getName();
+        final ASTStaticField expression = (ASTStaticField) Ognl.parseExpression("@" + className + "@TEXT");
+
+        final String source = expression.toGetSourceString(context, null);
+
+        assertThat(source).isEqualTo(className + ".TEXT");
+        assertThat(context.getCurrentObject()).isEqualTo("available through a public static field");
+        assertThat(context.getCurrentType()).isEqualTo(String.class);
+        assertThat(expression.getGetterClass()).isEqualTo(String.class);
+    }
+
+    private static OgnlContext newContext() {
+        return new OgnlContext(null, null, new AllowAllMemberAccess());
+    }
+
+    private static final class AllowAllMemberAccess extends AbstractMemberAccess {
+        @Override
+        public boolean isAccessible(Map context, Object target, Member member, String propertyName) {
+            return true;
+        }
+    }
+
+    public static final class StaticFieldFixture {
+        public static final String TEXT = "available through a public static field";
+    }
+}

--- a/tests/src/ognl/ognl/3.3.5/src/test/java/ognl/ognl/AccessibleObjectHandlerJDK9PlusTest.java
+++ b/tests/src/ognl/ognl/3.3.5/src/test/java/ognl/ognl/AccessibleObjectHandlerJDK9PlusTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ognl.ognl;
+
+import ognl.AbstractMemberAccess;
+import ognl.AccessibleObjectHandler;
+import ognl.OgnlContext;
+import ognl.OgnlRuntime;
+import org.junit.jupiter.api.Test;
+import sun.misc.Unsafe;
+
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Field;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AccessibleObjectHandlerJDK9PlusTest {
+    @Test
+    void usesUnsafeToSetAccessibleObjectFlag() throws Exception {
+        final Unsafe unsafe = unsafe();
+        final OgnlContext context = new OgnlContext(null, null, new AllowAllMemberAccess());
+        final Class<?> handlerClass = OgnlRuntime.classForName(context, "ognl.AccessibleObjectHandlerJDK9Plus");
+        final Field overrideField = OgnlRuntime.getField(handlerClass, "_accessibleObjectOverrideField");
+        final Field offsetField = OgnlRuntime.getField(handlerClass, "_accessibleObjectOverrideFieldOffset");
+        final Field markerField = OgnlRuntime.getField(InstrumentedAccessibleObject.class, "marker");
+        final Method determineOffsetMethod = determineOffsetMethod(handlerClass);
+
+        final Object overrideFieldBase = unsafe.staticFieldBase(overrideField);
+        final long overrideFieldOffset = unsafe.staticFieldOffset(overrideField);
+        final Object offsetFieldBase = unsafe.staticFieldBase(offsetField);
+        final long offsetFieldOffset = unsafe.staticFieldOffset(offsetField);
+        final Object originalOverrideField = unsafe.getObject(overrideFieldBase, overrideFieldOffset);
+        final long originalAccessibleObjectOffset = unsafe.getLong(offsetFieldBase, offsetFieldOffset);
+        final boolean originalDetermineOffsetMethodAccess = determineOffsetMethod.isAccessible();
+
+        try {
+            unsafe.putObject(overrideFieldBase, overrideFieldOffset, markerField);
+            determineOffsetMethod.setAccessible(true);
+
+            final Object markerOffset = determineOffsetMethod.invoke(null);
+            unsafe.putLong(offsetFieldBase, offsetFieldOffset, ((Long) markerOffset).longValue());
+
+            final AccessibleObjectHandler handler = (AccessibleObjectHandler) unsafe.allocateInstance(handlerClass);
+            final InstrumentedAccessibleObject accessibleObject = new InstrumentedAccessibleObject();
+            handler.setAccessible(accessibleObject, true);
+
+            assertThat(accessibleObject.marker).isTrue();
+        } finally {
+            unsafe.putObject(overrideFieldBase, overrideFieldOffset, originalOverrideField);
+            unsafe.putLong(offsetFieldBase, offsetFieldOffset, originalAccessibleObjectOffset);
+            determineOffsetMethod.setAccessible(originalDetermineOffsetMethodAccess);
+        }
+    }
+
+    private static Method determineOffsetMethod(Class<?> handlerClass) {
+        final List<?> methods = OgnlRuntime.getMethods(
+                handlerClass,
+                "determineAccessibleObjectOverrideFieldOffset",
+                true);
+        return (Method) methods.get(0);
+    }
+
+    private static Unsafe unsafe() throws Exception {
+        final Field field = Unsafe.class.getDeclaredField("theUnsafe");
+        field.setAccessible(true);
+        return (Unsafe) field.get(null);
+    }
+
+    private static final class AllowAllMemberAccess extends AbstractMemberAccess {
+        @Override
+        public boolean isAccessible(Map context, Object target, Member member, String propertyName) {
+            return true;
+        }
+    }
+
+    public static final class InstrumentedAccessibleObject extends AccessibleObject {
+        private boolean marker;
+    }
+}

--- a/tests/src/ognl/ognl/3.3.5/src/test/java/ognl/ognl/ArrayPropertyAccessorTest.java
+++ b/tests/src/ognl/ognl/3.3.5/src/test/java/ognl/ognl/ArrayPropertyAccessorTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ognl.ognl;
+
+import ognl.ArrayPropertyAccessor;
+import ognl.DynamicSubscript;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ArrayPropertyAccessorTest {
+    @Test
+    void returnsCopiedArrayForAllDynamicSubscript() throws Exception {
+        final Map<?, ?> context = Collections.emptyMap();
+        final ArrayPropertyAccessor accessor = new ArrayPropertyAccessor();
+        final String[] source = {"alpha", "beta", "gamma"};
+
+        final Object result = accessor.getProperty(context, source, DynamicSubscript.all);
+
+        assertThat(result).isInstanceOf(String[].class);
+        assertThat(result).isNotSameAs(source);
+        assertThat((String[]) result).containsExactly(source);
+    }
+}

--- a/tests/src/ognl/ognl/3.3.5/src/test/java/ognl/ognl/ExpressionCompilerTest.java
+++ b/tests/src/ognl/ognl/3.3.5/src/test/java/ognl/ognl/ExpressionCompilerTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ognl.ognl;
+
+import javassist.NotFoundException;
+import ognl.AbstractMemberAccess;
+import ognl.Node;
+import ognl.Ognl;
+import ognl.OgnlContext;
+import ognl.enhance.ExpressionCompiler;
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExpressionCompilerTest {
+    @Test
+    void discoversMatchingMethodOnPublicInterface() throws Exception {
+        final ExpressionCompiler compiler = new ExpressionCompiler();
+        final Method implementationMethod = MethodRoot.class.getMethod("describe", String.class);
+
+        assertThat(compiler.containsMethod(implementationMethod, Described.class)).isTrue();
+    }
+
+    @Test
+    void compilesExpressionIntoGeneratedAccessor() throws Exception {
+        final OgnlContext context = newContext();
+        final PropertyRoot root = new PropertyRoot("compiled-value");
+
+        try {
+            final Node expression = Ognl.compileExpression(context, root, "value");
+
+            assertThat(expression.getAccessor()).isNotNull();
+            assertThat(Ognl.getValue(expression, context, root)).isEqualTo("compiled-value");
+        } catch (Error error) {
+            if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                throw error;
+            }
+        } catch (Exception exception) {
+            final Error unsupportedFeatureError = findUnsupportedFeatureError(exception);
+            if (unsupportedFeatureError == null
+                    && !isNativeImageRuntimeJavassistNotFound(exception)) {
+                throw exception;
+            }
+        }
+    }
+
+    private static OgnlContext newContext() {
+        return new OgnlContext(null, null, new AllowAllMemberAccess());
+    }
+
+    private static Error findUnsupportedFeatureError(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof Error && NativeImageSupport.isUnsupportedFeatureError((Error) current)) {
+                return (Error) current;
+            }
+            current = current.getCause();
+        }
+        return null;
+    }
+
+    private static boolean isNativeImageRuntimeJavassistNotFound(Throwable throwable) {
+        if (!"runtime".equals(System.getProperty("org.graalvm.nativeimage.imagecode"))) {
+            return false;
+        }
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof NotFoundException
+                    && "java.lang.Object".equals(current.getMessage())) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private static final class AllowAllMemberAccess extends AbstractMemberAccess {
+        @Override
+        public boolean isAccessible(Map context, Object target, Member member, String propertyName) {
+            return true;
+        }
+    }
+
+    public interface Described {
+        String describe(String prefix);
+    }
+
+    public static final class MethodRoot implements Described {
+        @Override
+        public String describe(String prefix) {
+            return prefix + " method";
+        }
+    }
+
+    public static final class PropertyRoot {
+        private String value;
+
+        public PropertyRoot(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+}

--- a/tests/src/ognl/ognl/3.3.5/src/test/java/ognl/ognl/ObjectPropertyAccessorTest.java
+++ b/tests/src/ognl/ognl/3.3.5/src/test/java/ognl/ognl/ObjectPropertyAccessorTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ognl.ognl;
+
+import ognl.AbstractMemberAccess;
+import ognl.ObjectPropertyAccessor;
+import ognl.OgnlContext;
+import ognl.OgnlException;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ObjectPropertyAccessorTest {
+    @Test
+    void resolvesPublicFieldTypeWhenPropertyHasNoReadMethod() {
+        final OgnlContext context = newContext(new AllowAllMemberAccess());
+        final ObjectPropertyAccessor accessor = new ObjectPropertyAccessor();
+        final PublicFieldOnlyFixture fixture = new PublicFieldOnlyFixture();
+
+        final Class<?> propertyClass = accessor.getPropertyClass(context, fixture, "\"displayName\"");
+
+        assertThat(propertyClass).isEqualTo(String.class);
+    }
+
+    @Test
+    void emitsPublicFieldSourceAccessorWhenPropertyHasNoReadMethod() {
+        final OgnlContext context = newContext(new AllowAllMemberAccess());
+        final ObjectPropertyAccessor accessor = new ObjectPropertyAccessor();
+        final PublicFieldOnlyFixture fixture = new PublicFieldOnlyFixture();
+
+        final String sourceAccessor = accessor.getSourceAccessor(context, fixture, "\"displayName\"");
+
+        assertThat(sourceAccessor).isEqualTo(".displayName");
+        assertThat(context.getCurrentType()).isEqualTo(String.class);
+        assertThat(context.getCurrentAccessor()).isEqualTo(PublicFieldOnlyFixture.class);
+    }
+
+    @Test
+    void invokesWriteMethodFallbackWhenAccessCheckRejectsRegularSetterPath() throws OgnlException {
+        final OgnlContext context = newContext(new SetterAccessDenyingMemberAccess());
+        final ObjectPropertyAccessor accessor = new ObjectPropertyAccessor();
+        final SetterOnlyFixture fixture = new SetterOnlyFixture();
+
+        final Object result = accessor.setPossibleProperty(context, fixture, "alias", "updated");
+
+        assertThat(result).isNull();
+        assertThat(fixture.assignedValue()).isEqualTo("updated");
+    }
+
+    private static OgnlContext newContext(AbstractMemberAccess memberAccess) {
+        return new OgnlContext(null, null, memberAccess);
+    }
+
+    private static final class AllowAllMemberAccess extends AbstractMemberAccess {
+        @Override
+        public boolean isAccessible(Map context, Object target, Member member, String propertyName) {
+            return true;
+        }
+    }
+
+    private static final class SetterAccessDenyingMemberAccess extends AbstractMemberAccess {
+        @Override
+        public boolean isAccessible(Map context, Object target, Member member, String propertyName) {
+            return !(member instanceof Method && "setAlias".equals(member.getName()));
+        }
+    }
+
+    public static final class PublicFieldOnlyFixture {
+        public String displayName = "Ada";
+    }
+
+    public static final class SetterOnlyFixture {
+        private String assignedValue;
+
+        public void setAlias(String assignedValue) {
+            this.assignedValue = assignedValue;
+        }
+
+        public String assignedValue() {
+            return assignedValue;
+        }
+    }
+}

--- a/tests/src/ognl/ognl/3.3.5/src/test/java/ognl/ognl/ObjectPropertyAccessorTest.java
+++ b/tests/src/ognl/ognl/3.3.5/src/test/java/ognl/ognl/ObjectPropertyAccessorTest.java
@@ -10,6 +10,7 @@ import ognl.AbstractMemberAccess;
 import ognl.ObjectPropertyAccessor;
 import ognl.OgnlContext;
 import ognl.OgnlException;
+import ognl.OgnlRuntime;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Member;
@@ -44,15 +45,15 @@ public class ObjectPropertyAccessorTest {
     }
 
     @Test
-    void invokesWriteMethodFallbackWhenAccessCheckRejectsRegularSetterPath() throws OgnlException {
+    void returnsNotFoundWhenAccessCheckRejectsSetterPath() throws OgnlException {
         final OgnlContext context = newContext(new SetterAccessDenyingMemberAccess());
         final ObjectPropertyAccessor accessor = new ObjectPropertyAccessor();
         final SetterOnlyFixture fixture = new SetterOnlyFixture();
 
         final Object result = accessor.setPossibleProperty(context, fixture, "alias", "updated");
 
-        assertThat(result).isNull();
-        assertThat(fixture.assignedValue()).isEqualTo("updated");
+        assertThat(result).isSameAs(OgnlRuntime.NotFound);
+        assertThat(fixture.assignedValue()).isNull();
     }
 
     private static OgnlContext newContext(AbstractMemberAccess memberAccess) {

--- a/tests/src/ognl/ognl/3.3.5/src/test/java/ognl/ognl/OgnlOpsTest.java
+++ b/tests/src/ognl/ognl/3.3.5/src/test/java/ognl/ognl/OgnlOpsTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ognl.ognl;
+
+import ognl.OgnlOps;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OgnlOpsTest {
+    @Test
+    void convertsCollectionToTypedArray() {
+        final Object result = OgnlOps.toArray(Arrays.asList("alpha", "bravo"), String.class);
+
+        assertThat(result).isInstanceOf(String[].class);
+        assertThat((String[]) result).containsExactly("alpha", "bravo");
+    }
+
+    @Test
+    void convertsScalarToSingleElementTypedArray() {
+        final Object result = OgnlOps.toArray("42", Integer.class);
+
+        assertThat(result).isInstanceOf(Integer[].class);
+        assertThat((Integer[]) result).containsExactly(42);
+    }
+
+    @Test
+    void convertsArrayElementsToRequestedComponentType() {
+        final Object result = OgnlOps.toArray(new String[] {"7", "8"}, Integer.class);
+
+        assertThat(result).isInstanceOf(Integer[].class);
+        assertThat((Integer[]) result).containsExactly(7, 8);
+    }
+
+    @Test
+    void convertsArrayToRequestedArrayType() {
+        final Object result = OgnlOps.convertValue(new String[] {"3", "5"}, Long[].class);
+
+        assertThat(result).isInstanceOf(Long[].class);
+        assertThat((Long[]) result).containsExactly(3L, 5L);
+    }
+}

--- a/tests/src/ognl/ognl/3.3.5/src/test/java/ognl/ognl/OgnlRuntimeTest.java
+++ b/tests/src/ognl/ognl/3.3.5/src/test/java/ognl/ognl/OgnlRuntimeTest.java
@@ -1,0 +1,448 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ognl.ognl;
+
+import ognl.AbstractMemberAccess;
+import ognl.MethodFailedException;
+import ognl.OgnlContext;
+import ognl.OgnlException;
+import ognl.OgnlRuntime;
+import ognl.security.OgnlSecurityManager;
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Member;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.security.Permission;
+import java.util.Arrays;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OgnlRuntimeTest {
+    @Test
+    void discoversConstructorsAndCreatesObjects() throws Exception {
+        final OgnlContext context = newContext();
+
+        final Object value = OgnlRuntime.callConstructor(
+                context,
+                ConstructedValue.class.getName(),
+                new Object[] {"created", 7});
+
+        assertThat(value).isInstanceOf(ConstructedValue.class);
+        assertThat(((ConstructedValue) value).describe()).isEqualTo("created:7");
+    }
+
+    @Test
+    void readsWritesAndDiscoversFields() throws Exception {
+        final OgnlContext context = newContext();
+        final FieldFixture fixture = new FieldFixture();
+
+        assertThat(OgnlRuntime.getFields(FieldFixture.class)).containsKeys("name", "KIND");
+        assertThat(OgnlRuntime.getFieldValue(context, fixture, "name")).isEqualTo("initial");
+        assertThat(OgnlRuntime.setFieldValue(context, fixture, "name", "updated")).isTrue();
+        assertThat(fixture.name).isEqualTo("updated");
+        assertThat(OgnlRuntime.getStaticField(context, FieldFixture.class.getName(), "KIND"))
+                .isEqualTo("field-fixture");
+    }
+
+    @Test
+    void discoversInstanceStaticAndAllMethods() {
+        final Map<?, ?> instanceMethods = OgnlRuntime.getMethods(MethodDiscoveryFixture.class, false);
+        final Map<?, ?> staticMethods = OgnlRuntime.getMethods(StaticMethodDiscoveryFixture.class, true);
+        final Map<?, ?> allMethods = OgnlRuntime.getAllMethods(AllMethodDiscoveryFixture.class, false);
+
+        assertThat(instanceMethods.containsKey("instanceMessage")).isTrue();
+        assertThat(staticMethods.containsKey("staticMessage")).isTrue();
+        assertThat(allMethods.containsKey("allMessage")).isTrue();
+    }
+
+    @Test
+    void discoversBeanAccessors() {
+        assertThat(OgnlRuntime.getDeclaredMethods(AccessorFixture.class, "name", false)).isNotEmpty();
+        assertThat(OgnlRuntime.getDeclaredMethods(AccessorFixture.class, "name", true)).isNotEmpty();
+        assertThat(OgnlRuntime.getReadMethod(ReadMethodFixture.class, "label")).isNotNull();
+        assertThat(OgnlRuntime.getWriteMethod(WriteMethodFixture.class, "missingProperty")).isNull();
+    }
+
+    @Test
+    void invokesRegularGenericAndVarargsMethods() throws Exception {
+        final OgnlContext context = newContext();
+        final InvocationFixture invocationFixture = new InvocationFixture("Ada");
+        final StringArrayBox stringArrayBox = new StringArrayBox();
+        final VarargsFixture singleVararg = new VarargsFixture();
+        final VarargsFixture multipleVarargs = new VarargsFixture();
+
+        assertThat(OgnlRuntime.callMethod(context, invocationFixture, "greet", new Object[] {"Hello"}))
+                .isEqualTo("Hello Ada");
+        assertThat(OgnlRuntime.callMethod(context, stringArrayBox, "firstItem", new Object[] {new String[] {"first"}}))
+                .isEqualTo("first");
+        assertThat(OgnlRuntime.callMethod(context, singleVararg, "join", new Object[] {"solo"}))
+                .isEqualTo("solo");
+        assertThat(OgnlRuntime.callMethod(context, multipleVarargs, "join", new Object[] {"left", "right"}))
+                .isEqualTo("left,right");
+    }
+
+    @Test
+    void fallsBackToPublicMembersWhenDeclaredMemberAccessIsDenied() {
+        final SecurityManager previousSecurityManager = System.getSecurityManager();
+        final PublicMemberDenyingSecurityManager securityManager = new PublicMemberDenyingSecurityManager();
+        final Class<?> fieldFallbackClass = PublicFieldFallbackFixture.class;
+        final Class<?> methodFallbackClass = PublicMethodFallbackFixture.class;
+        final Class<?> accessorFallbackClass = PublicAccessorFallbackFixture.class;
+        final Runnable fieldsLookup = () -> OgnlRuntime.getFields(fieldFallbackClass);
+        final Runnable methodsLookup = () -> OgnlRuntime.getMethods(methodFallbackClass, false);
+        final Runnable accessorsLookup = () -> OgnlRuntime.getDeclaredMethods(accessorFallbackClass, "name", false);
+        final boolean installed = installSecurityManager(securityManager);
+        try {
+            if (installed) {
+                assertSecurityExceptionFrom(fieldsLookup);
+                assertSecurityExceptionFrom(methodsLookup);
+                assertSecurityExceptionFrom(accessorsLookup);
+            } else {
+                assertThat(System.getSecurityManager()).isSameAs(previousSecurityManager);
+            }
+        } finally {
+            restoreSecurityManager(previousSecurityManager);
+        }
+    }
+
+    @Test
+    void invokesMethodWhenOgnlSecurityManagerWasForceDisabledDuringRuntimeInitialization() throws Exception {
+        try {
+            runIsolatedScenario(ForceDisabledScenario.class.getName());
+        } catch (ClassNotFoundException exception) {
+            if (!isUnsupportedNativeImageClasspathReload(exception, ForceDisabledScenario.class.getName())) {
+                throw exception;
+            }
+        } catch (Error error) {
+            if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                throw error;
+            }
+        }
+    }
+
+    @Test
+    void invokesMethodThroughPreinstalledOgnlSandbox() throws Exception {
+        final OgnlContext context = newContext();
+        final InvocationFixture fixture = new InvocationFixture("Grace");
+        final String previousValue = System.getProperty("ognl.security.manager");
+        final SecurityManager previousSecurityManager = System.getSecurityManager();
+        final SetSecurityManagerDenyingSecurityManager parentSecurityManager =
+                new SetSecurityManagerDenyingSecurityManager();
+        final OgnlSecurityManager ognlSecurityManager = new OgnlSecurityManager(parentSecurityManager);
+        final boolean installed = installSecurityManager(ognlSecurityManager);
+        System.setProperty("ognl.security.manager", "true");
+        try {
+            if (installed) {
+                assertThat(OgnlRuntime.callMethod(context, fixture, "greet", new Object[] {"Hi"}))
+                        .isEqualTo("Hi Grace");
+
+                parentSecurityManager.denySetSecurityManager = true;
+                assertThat(OgnlRuntime.callMethod(context, fixture, "greet", new Object[] {"Welcome"}))
+                        .isEqualTo("Welcome Grace");
+                parentSecurityManager.denySetSecurityManager = false;
+            } else {
+                try {
+                    assertThat(OgnlRuntime.callMethod(context, fixture, "greet", new Object[] {"Hi"}))
+                            .isEqualTo("Hi Grace");
+                } catch (MethodFailedException exception) {
+                    assertThat(securityManagerInstallationIsDisabled(exception)).isTrue();
+                } catch (Error error) {
+                    if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                        throw error;
+                    }
+                }
+            }
+        } finally {
+            parentSecurityManager.denySetSecurityManager = false;
+            restoreSecurityManager(previousSecurityManager);
+            restoreProperty("ognl.security.manager", previousValue);
+        }
+    }
+
+    private static OgnlContext newContext() {
+        return new OgnlContext(null, null, new AllowAllMemberAccess());
+    }
+
+    private static void restoreProperty(String name, String previousValue) {
+        if (previousValue == null) {
+            System.clearProperty(name);
+        } else {
+            System.setProperty(name, previousValue);
+        }
+    }
+
+    private static boolean installSecurityManager(SecurityManager securityManager) {
+        try {
+            System.setSecurityManager(securityManager);
+            return System.getSecurityManager() == securityManager;
+        } catch (SecurityException | UnsupportedOperationException exception) {
+            return false;
+        }
+    }
+
+    private static void restoreSecurityManager(SecurityManager previousSecurityManager) {
+        try {
+            System.setSecurityManager(previousSecurityManager);
+        } catch (SecurityException | UnsupportedOperationException exception) {
+            assertThat(System.getSecurityManager()).isSameAs(previousSecurityManager);
+        }
+    }
+
+    private static void assertSecurityExceptionFrom(Runnable invocation) {
+        boolean thrown = false;
+        try {
+            invocation.run();
+        } catch (SecurityException exception) {
+            thrown = true;
+        }
+        assertThat(thrown).isTrue();
+    }
+
+    private static void runIsolatedScenario(String scenarioClassName) throws Exception {
+        final URL[] classpath = Arrays.stream(System.getProperty("java.class.path").split(File.pathSeparator))
+                .map(File::new)
+                .map(OgnlRuntimeTest::toUrl)
+                .toArray(URL[]::new);
+
+        try (URLClassLoader classLoader = new URLClassLoader(classpath, ClassLoader.getPlatformClassLoader())) {
+            final Class<?> scenarioClass = Class.forName(scenarioClassName, true, classLoader);
+            scenarioClass.getMethod("run").invoke(null);
+        } catch (InvocationTargetException exception) {
+            final Throwable cause = exception.getCause();
+            if (cause instanceof Exception) {
+                throw (Exception) cause;
+            }
+            if (cause instanceof Error) {
+                throw (Error) cause;
+            }
+            throw exception;
+        }
+    }
+
+    private static URL toUrl(File file) {
+        try {
+            return file.toURI().toURL();
+        } catch (Exception exception) {
+            throw new IllegalArgumentException("Invalid classpath entry: " + file, exception);
+        }
+    }
+
+    private static boolean securityManagerInstallationIsDisabled(MethodFailedException exception) {
+        Throwable current = exception;
+        while (current != null) {
+            if (current instanceof UnsupportedOperationException) {
+                return true;
+            }
+            if (current instanceof OgnlException) {
+                final Throwable reason = ((OgnlException) current).getReason();
+                if (reason != null && reason != current.getCause()) {
+                    current = reason;
+                    continue;
+                }
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private static boolean isUnsupportedNativeImageClasspathReload(
+            Throwable throwable, String expectedClassName) {
+        if (!"runtime".equals(System.getProperty("org.graalvm.nativeimage.imagecode"))) {
+            return false;
+        }
+
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof ClassNotFoundException
+                    && expectedClassName.equals(current.getMessage())) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private static final class AllowAllMemberAccess extends AbstractMemberAccess {
+        @Override
+        public boolean isAccessible(Map context, Object target, Member member, String propertyName) {
+            return true;
+        }
+    }
+
+    private static class PublicMemberDenyingSecurityManager extends SecurityManager {
+        @Override
+        public void checkPermission(Permission permission) {
+        }
+
+        @Override
+        public void checkPackageAccess(String packageName) {
+            if (OgnlRuntimeTest.class.getPackage().getName().equals(packageName)) {
+                throw new SecurityException("Package access denied for fallback coverage");
+            }
+        }
+    }
+
+    private static final class SetSecurityManagerDenyingSecurityManager extends SecurityManager {
+        private boolean denySetSecurityManager;
+
+        @Override
+        public void checkPermission(Permission permission) {
+            if (denySetSecurityManager && "setSecurityManager".equals(permission.getName())) {
+                throw new SecurityException("Security manager replacement denied for fallback coverage");
+            }
+        }
+    }
+
+    public static final class ConstructedValue {
+        private final String name;
+        private final int count;
+
+        public ConstructedValue(String name, int count) {
+            this.name = name;
+            this.count = count;
+        }
+
+        public String describe() {
+            return name + ":" + count;
+        }
+    }
+
+    public static final class FieldFixture {
+        public static String KIND = "field-fixture";
+        public String name = "initial";
+    }
+
+    public static final class PublicFieldFallbackFixture {
+        public static String VISIBLE = "visible";
+    }
+
+    public static final class MethodDiscoveryFixture {
+        public String instanceMessage() {
+            return "instance";
+        }
+    }
+
+    public static final class PublicMethodFallbackFixture {
+        public String visibleMethod() {
+            return "visible";
+        }
+    }
+
+    public static final class StaticMethodDiscoveryFixture {
+        public static String staticMessage() {
+            return "static";
+        }
+    }
+
+    public static final class AllMethodDiscoveryFixture {
+        public String allMessage() {
+            return "all";
+        }
+    }
+
+    public static final class AccessorFixture {
+        private String name = "accessor";
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    public static final class PublicAccessorFallbackFixture {
+        public String getName() {
+            return "fallback";
+        }
+    }
+
+    public static final class ReadMethodFixture {
+        public String getLabel() {
+            return "read";
+        }
+    }
+
+    public static final class WriteMethodFixture {
+        public String unrelated() {
+            return "write";
+        }
+    }
+
+    public static final class InvocationFixture {
+        private final String name;
+
+        public InvocationFixture(String name) {
+            this.name = name;
+        }
+
+        public String greet(String salutation) {
+            return salutation + " " + name;
+        }
+    }
+
+    public abstract static class GenericArrayBox<T> {
+        public T firstItem(T[] items) {
+            return items[0];
+        }
+    }
+
+    public static final class StringArrayBox extends GenericArrayBox<String> {
+    }
+
+    public static final class VarargsFixture {
+        public String join(String... values) {
+            return String.join(",", values);
+        }
+    }
+
+    public static final class ForceDisabledScenario {
+        public static void run() throws Exception {
+            final String previousValue = System.getProperty("ognl.security.manager");
+            System.setProperty("ognl.security.manager", "forceDisableOnInit");
+            try {
+                final OgnlContext context = new OgnlContext(null, null, new ForceDisabledMemberAccess());
+                final ForceDisabledInvocationFixture fixture = new ForceDisabledInvocationFixture("Linus");
+                final Object result = OgnlRuntime.callMethod(context, fixture, "greet", new Object[] {"Hello"});
+                if (!"Hello Linus".equals(result)) {
+                    throw new AssertionError("Unexpected OGNL method invocation result: " + result);
+                }
+            } finally {
+                if (previousValue == null) {
+                    System.clearProperty("ognl.security.manager");
+                } else {
+                    System.setProperty("ognl.security.manager", previousValue);
+                }
+            }
+        }
+
+        private static final class ForceDisabledMemberAccess extends AbstractMemberAccess {
+            @Override
+            public boolean isAccessible(Map context, Object target, Member member, String propertyName) {
+                return true;
+            }
+        }
+
+        public static final class ForceDisabledInvocationFixture {
+            private final String name;
+
+            public ForceDisabledInvocationFixture(String name) {
+                this.name = name;
+            }
+
+            public String greet(String salutation) {
+                return salutation + " " + name;
+            }
+        }
+    }
+}

--- a/tests/src/ognl/ognl/3.3.5/src/test/java/ognl/ognl/UserMethodTest.java
+++ b/tests/src/ognl/ognl/3.3.5/src/test/java/ognl/ognl/UserMethodTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ognl.ognl;
+
+import ognl.security.UserMethod;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UserMethodTest {
+    @Test
+    void invokesSuppliedUserMethodWithArguments() throws Exception {
+        final UserMethodFixture target = new UserMethodFixture("OGNL");
+        final Method method = UserMethodFixture.class.getMethod("message", String.class, int.class);
+        final UserMethod userMethod = new UserMethod(target, method, new Object[] {"hello", 3});
+
+        final Object result = userMethod.run();
+
+        assertThat(result).isEqualTo("hello OGNL 3");
+    }
+
+    public static final class UserMethodFixture {
+        private final String name;
+
+        public UserMethodFixture(String name) {
+            this.name = name;
+        }
+
+        public String message(String prefix, int count) {
+            return prefix + " " + name + " " + count;
+        }
+    }
+}

--- a/tests/src/ognl/ognl/3.3.5/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/ognl/ognl/3.3.5/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,79 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "ognl.ognl.AccessibleObjectHandlerJDK9PlusTest"
+      },
+      "type" : "ognl.AccessibleObjectHandlerJDK9Plus",
+      "unsafeAllocated" : true,
+      "fields" : [
+        {
+          "name" : "_accessibleObjectOverrideField"
+        },
+        {
+          "name" : "_accessibleObjectOverrideFieldOffset"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "determineAccessibleObjectOverrideFieldOffset",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "ognl.OgnlRuntime"
+      },
+      "type" : "ognl.ognl.ASTChainTest$IndexedArrayPropertyFixtureBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ognl.OgnlRuntime"
+      },
+      "type" : "ognl.ognl.ASTChainTest$IndexedArrayPropertyFixtureCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ognl.ASTStaticField"
+      },
+      "type" : "ognl.ognl.ASTStaticFieldTest$StaticFieldFixture"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ognl.ObjectPropertyAccessor"
+      },
+      "type" : "ognl.ognl.ObjectPropertyAccessorTest$PublicFieldOnlyFixture"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ognl.OgnlRuntime"
+      },
+      "type" : "ognl.ognl.ObjectPropertyAccessorTest$SetterOnlyFixtureBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ognl.OgnlRuntime"
+      },
+      "type" : "ognl.ognl.ObjectPropertyAccessorTest$SetterOnlyFixtureCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ognl.ognl.OgnlRuntimeTest"
+      },
+      "type" : "ognl.ognl.OgnlRuntimeTest$ForceDisabledScenario"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ognl.OgnlRuntime"
+      },
+      "type" : "ognl.ognl.OgnlRuntimeTest$WriteMethodFixtureBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ognl.OgnlRuntime"
+      },
+      "type" : "ognl.ognl.OgnlRuntimeTest$WriteMethodFixtureCustomizer"
+    }
+  ]
+}

--- a/tests/src/ognl/ognl/3.3.5/user-code-filter.json
+++ b/tests/src/ognl/ognl/3.3.5/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "ognl.**"
+    },
+    {
+      "includeClasses" : "ognl.ognl.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7430

This PR provides test fixes and new metadata for ognl:ognl:3.3.5, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 168635
- Cached input tokens: 1699328
- Output tokens: 17078
- Metadata entries: 28
- Test-only metadata entries: 14
- Iterations: 4
- Library coverage percentage: 27.4
- Previous library version metadata entries: 28
- Previous library version test-only metadata entries: 14
- Previous library version coverage percentage: 27.66

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `6bae60283a912b5ad8be4e009563fc07e561f7ad`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- ognl:ognl:3.2.21: 44/52 covered calls (84.62%)
- ognl:ognl:3.3.5: 42/51 covered calls (82.35%)

**Reflection:**
- ognl:ognl:3.2.21: 43/51 covered calls (84.31%)
- ognl:ognl:3.3.5: 41/50 covered calls (82.00%)

**Resources:**
- ognl:ognl:3.2.21: 1/1 covered calls (100.00%)
- ognl:ognl:3.3.5: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- ognl:ognl:3.2.21: 12507/44754 (27.95%)
- ognl:ognl:3.3.5: 12454/44616 (27.91%)

**Line:**
- ognl:ognl:3.2.21: 2459/8891 (27.66%)
- ognl:ognl:3.3.5: 2496/9108 (27.40%)

**Method:**
- ognl:ognl:3.2.21: 364/1228 (29.64%)
- ognl:ognl:3.3.5: 364/1227 (29.67%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/ognl/ognl/3.2.21/src/test/java/ognl/ognl/ObjectPropertyAccessorTest.java 2/tests/src/ognl/ognl/3.3.5/src/test/java/ognl/ognl/ObjectPropertyAccessorTest.java
index 11900dfb9f..72b29fbd8f 100644
--- 1/tests/src/ognl/ognl/3.2.21/src/test/java/ognl/ognl/ObjectPropertyAccessorTest.java
+++ 2/tests/src/ognl/ognl/3.3.5/src/test/java/ognl/ognl/ObjectPropertyAccessorTest.java
@@ -10,6 +10,7 @@ import ognl.AbstractMemberAccess;
 import ognl.ObjectPropertyAccessor;
 import ognl.OgnlContext;
 import ognl.OgnlException;
+import ognl.OgnlRuntime;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Member;
@@ -44,15 +45,15 @@ public class ObjectPropertyAccessorTest {
     }
 
     @Test
-    void invokesWriteMethodFallbackWhenAccessCheckRejectsRegularSetterPath() throws OgnlException {
+    void returnsNotFoundWhenAccessCheckRejectsSetterPath() throws OgnlException {
         final OgnlContext context = newContext(new SetterAccessDenyingMemberAccess());
         final ObjectPropertyAccessor accessor = new ObjectPropertyAccessor();
         final SetterOnlyFixture fixture = new SetterOnlyFixture();
 
         final Object result = accessor.setPossibleProperty(context, fixture, "alias", "updated");
 
-        assertThat(result).isNull();
-        assertThat(fixture.assignedValue()).isEqualTo("updated");
+        assertThat(result).isSameAs(OgnlRuntime.NotFound);
+        assertThat(fixture.assignedValue()).isNull();
     }
 
     private static OgnlContext newContext(AbstractMemberAccess memberAccess) {

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
