### PR TITLE
[GenAI] Test fix for com.typesafe.slick:slick_2.13:4.0.0-RC1 using gpt-5.5

### DIFF
--- a/metadata/com.typesafe.slick/slick_2.13/4.0.0-RC1/reachability-metadata.json
+++ b/metadata/com.typesafe.slick/slick_2.13/4.0.0-RC1/reachability-metadata.json
@@ -1,0 +1,95 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "slick.util.BeanConfigurator$"
+      },
+      "type" : "java.lang.ObjectBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "slick.util.BeanConfigurator$"
+      },
+      "type" : "java.lang.ObjectCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "slick.jdbc.DataSourceJdbcDataSource$"
+      },
+      "type" : "slick.jdbc.DriverDataSource",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "slick.jdbc.JdbcDataSource$"
+      },
+      "type" : "slick.jdbc.DataSourceJdbcDataSource$",
+      "fields" : [
+        {
+          "name" : "MODULE$"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "slick.basic.DatabaseConfig$"
+      },
+      "type" : "slick.memory.MemoryProfile$",
+      "fields" : [
+        {
+          "name" : "MODULE$"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "slick.jdbc.PGUtils$"
+      },
+      "type" : "org.postgresql.util.PGobject",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setType",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setValue",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "slick.util.ClassLoaderUtil$$anon$1"
+      },
+      "type" : "slick.util.ClassLoaderUtil$"
+    },
+    {
+      "condition" : {
+        "typeReached" : "slick.jdbc.JdbcTypesComponent$"
+      },
+      "type" : "java.sql.Types",
+      "allPublicFields" : true
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "slick.util.Logging"
+      },
+      "glob" : "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
+    }
+  ]
+}

--- a/metadata/com.typesafe.slick/slick_2.13/4.0.0-RC1/reachability-metadata.json
+++ b/metadata/com.typesafe.slick/slick_2.13/4.0.0-RC1/reachability-metadata.json
@@ -16,6 +16,18 @@
       "condition" : {
         "typeReached" : "slick.jdbc.DataSourceJdbcDataSource$"
       },
+      "type" : "org.postgresql.ds.PGSimpleDataSource",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "slick.jdbc.DataSourceJdbcDataSource$"
+      },
       "type" : "slick.jdbc.DriverDataSource",
       "methods" : [
         {

--- a/metadata/com.typesafe.slick/slick_2.13/index.json
+++ b/metadata/com.typesafe.slick/slick_2.13/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "4.0.0-RC1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/typesafe/slick/slick_2.13/$version$/slick_2.13-$version$-sources.jar",
+    "repository-url" : "https://github.com/slick/slick",
+    "test-code-url" : "https://github.com/slick/slick/tree/v$version$/slick-testkit/src/test/scala",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/typesafe/slick/slick_2.13/$version$/slick_2.13-$version$-javadoc.jar",
+    "description" : "Slick is a Scala database access library that provides strongly typed, composable APIs for working with relational databases. It lets applications express queries in Scala, generate SQL for multiple database engines, and use asynchronous or reactive-streaming database actions.",
     "language" : {
       "name" : "scala",
       "version" : "2"

--- a/metadata/com.typesafe.slick/slick_2.13/index.json
+++ b/metadata/com.typesafe.slick/slick_2.13/index.json
@@ -1,6 +1,20 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "4.0.0-RC1",
+    "language" : {
+      "name" : "scala",
+      "version" : "2"
+    },
+    "tested-versions" : [
+      "4.0.0-RC1"
+    ],
+    "allowed-packages" : [
+      "scala.reflect",
+      "slick"
+    ]
+  },
+  {
     "metadata-version" : "3.6.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/com/typesafe/slick/slick_2.13/$version$/slick_2.13-$version$-sources.jar",
     "repository-url" : "https://github.com/slick/slick",

--- a/stats/com.typesafe.slick/slick_2.13/4.0.0-RC1/execution-metrics.json
+++ b/stats/com.typesafe.slick/slick_2.13/4.0.0-RC1/execution-metrics.json
@@ -1,0 +1,101 @@
+{
+  "fix_java_run_fail:2026-06-06": {
+    "timestamp": "2026-06-06T22:01:20.321976Z",
+    "library": "com.typesafe.slick:slick_2.13:4.0.0-RC1",
+    "starting_commit": "5cdb845fee6ab207f562f2fde2792e7cebd941e0",
+    "ending_commit": "914281fbeccb92a8e1f94a345ee4249639de5328",
+    "previous_library": "com.typesafe.slick:slick_2.13:3.6.1",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.0.0-RC1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.925,
+            "coveredCalls": 37,
+            "totalCalls": 40
+          }
+        },
+        "coverageRatio": 0.925,
+        "coveredCalls": 37,
+        "totalCalls": 40
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4155,
+          "missed": 251730,
+          "ratio": 0.016238,
+          "total": 255885
+        },
+        "line": {
+          "covered": 512,
+          "missed": 10699,
+          "ratio": 0.045669,
+          "total": 11211
+        },
+        "method": {
+          "covered": 355,
+          "missed": 21452,
+          "ratio": 0.016279,
+          "total": 21807
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.6.1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.925,
+            "coveredCalls": 37,
+            "totalCalls": 40
+          }
+        },
+        "coverageRatio": 0.925,
+        "coveredCalls": 37,
+        "totalCalls": 40
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3995,
+          "missed": 251560,
+          "ratio": 0.015633,
+          "total": 255555
+        },
+        "line": {
+          "covered": 474,
+          "missed": 10931,
+          "ratio": 0.041561,
+          "total": 11405
+        },
+        "method": {
+          "covered": 346,
+          "missed": 21269,
+          "ratio": 0.016007,
+          "total": 21615
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 112936,
+      "cached_input_tokens_used": 1583104,
+      "output_tokens_used": 16530,
+      "iterations": 3,
+      "cost_usd": 1.2875,
+      "tested_library_loc": 512,
+      "metadata_entries": 18,
+      "test_only_metadata_entries": 15,
+      "previous_library_metadata_entries": 16,
+      "previous_library_test_only_metadata_entries": 20,
+      "code_coverage_percent": 4.57,
+      "previous_library_coverage_percent": 4.16
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/scala/com_typesafe_slick/slick_2_13/DatabaseConfigTest.scala",
+      "metadata_file": "metadata/com.typesafe.slick/slick_2.13/4.0.0-RC1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.typesafe.slick/slick_2.13/4.0.0-RC1/stats.json
+++ b/stats/com.typesafe.slick/slick_2.13/4.0.0-RC1/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "4.0.0-RC1",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.925,
+          "coveredCalls" : 37,
+          "totalCalls" : 40
+        }
+      },
+      "coverageRatio" : 0.925,
+      "coveredCalls" : 37,
+      "totalCalls" : 40
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 4155,
+        "missed" : 251730,
+        "ratio" : 0.016238,
+        "total" : 255885
+      },
+      "line" : {
+        "covered" : 512,
+        "missed" : 10699,
+        "ratio" : 0.045669,
+        "total" : 11211
+      },
+      "method" : {
+        "covered" : 355,
+        "missed" : 21452,
+        "ratio" : 0.016279,
+        "total" : 21807
+      }
+    }
+  } ]
+}

--- a/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/.gitignore
+++ b/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/build.gradle
+++ b/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/build.gradle
@@ -1,0 +1,37 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.typesafe.slick:slick_2.13:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.postgresql:postgresql:42.7.7'
+    testImplementation 'org.scala-lang:scala-library:2.13.16'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/gradle.properties
+++ b/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.typesafe.slick:slick_2.13:4.0.0-RC1
+library.version = 4.0.0-RC1
+metadata.dir = com.typesafe.slick/slick_2.13/4.0.0-RC1/

--- a/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/settings.gradle
+++ b/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.typesafe.slick.slick_2.13_tests'

--- a/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/java/oracle/sql/TIMESTAMPTZ.java
+++ b/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/java/oracle/sql/TIMESTAMPTZ.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package oracle.sql;
+
+import java.util.Arrays;
+
+public final class TIMESTAMPTZ {
+    private final byte[] bytes;
+
+    public TIMESTAMPTZ(byte[] bytes) {
+        this.bytes = Arrays.copyOf(bytes, bytes.length);
+    }
+
+    public byte[] toBytes() {
+        return Arrays.copyOf(bytes, bytes.length);
+    }
+}

--- a/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/java/oracle/sql/ZONEIDMAP.java
+++ b/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/java/oracle/sql/ZONEIDMAP.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package oracle.sql;
+
+public final class ZONEIDMAP {
+    private ZONEIDMAP() {
+    }
+
+    public static String getRegion(int regionCode) {
+        if (regionCode == 1) {
+            return "Europe/Paris";
+        }
+        throw new IllegalArgumentException("Unsupported test region code: " + regionCode);
+    }
+}

--- a/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,126 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "slick.util.BeanConfigurator$"
+      },
+      "type" : "com_typesafe_slick.slick_2_13.BeanConfiguratorTargetBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "slick.util.BeanConfigurator$"
+      },
+      "type" : "com_typesafe_slick.slick_2_13.BeanConfiguratorTargetCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "slick.util.BeanConfigurator$"
+      },
+      "type" : "com_typesafe_slick.slick_2_13.BeanConfiguratorTarget",
+      "methods" : [
+        {
+          "name" : "setBooleanValue",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        },
+        {
+          "name" : "setIntValue",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "setLongValue",
+          "parameterTypes" : [
+            "long"
+          ]
+        },
+        {
+          "name" : "setObjectValue",
+          "parameterTypes" : [
+            "java.lang.Object"
+          ]
+        },
+        {
+          "name" : "setStringValue",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "slick.jdbc.DriverDataSource"
+      },
+      "type" : "com_typesafe_slick.slick_2_13.DriverDataSourceTestDriver",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "slick.basic.DatabaseConfig$"
+      },
+      "type" : "com_typesafe_slick.slick_2_13.ConfiguredMemoryProfile",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "slick.lifted.AbstractTable"
+      },
+      "type" : "com_typesafe_slick.slick_2_13.AbstractTableFixture",
+      "methods" : [
+        {
+          "name" : "tablePrimaryKey",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "tableNameIndex",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "slick.jdbc.TimestamptzConverter$"
+      },
+      "type" : "oracle.sql.TIMESTAMPTZ",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "byte[]"
+          ]
+        },
+        {
+          "name" : "toBytes",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "slick.jdbc.TimestamptzConverter$"
+      },
+      "type" : "oracle.sql.ZONEIDMAP",
+      "methods" : [
+        {
+          "name" : "getRegion",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -89,38 +89,6 @@
           "parameterTypes" : [ ]
         }
       ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "slick.jdbc.TimestamptzConverter$"
-      },
-      "type" : "oracle.sql.TIMESTAMPTZ",
-      "methods" : [
-        {
-          "name" : "<init>",
-          "parameterTypes" : [
-            "byte[]"
-          ]
-        },
-        {
-          "name" : "toBytes",
-          "parameterTypes" : [ ]
-        }
-      ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "slick.jdbc.TimestamptzConverter$"
-      },
-      "type" : "oracle.sql.ZONEIDMAP",
-      "methods" : [
-        {
-          "name" : "getRegion",
-          "parameterTypes" : [
-            "int"
-          ]
-        }
-      ]
     }
   ]
 }

--- a/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/scala/com_typesafe_slick/slick_2_13/AbstractTableTest.scala
+++ b/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/scala/com_typesafe_slick/slick_2_13/AbstractTableTest.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_slick.slick_2_13
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import slick.lifted.{Index, PrimaryKey, ProvenShape, Tag}
+import slick.memory.MemoryProfile.api._
+
+import scala.jdk.CollectionConverters._
+
+class AbstractTableFixture(tag: Tag) extends Table[(Int, String)](tag, "abstract_table_fixture") {
+  def id: Rep[Int] = column[Int]("id")
+
+  def name: Rep[String] = column[String]("name")
+
+  def tablePrimaryKey: PrimaryKey = primaryKey("pk_abstract_table_fixture", id)
+
+  def tableNameIndex: Index = index("idx_abstract_table_fixture_name", name, unique = true)
+
+  override def * : ProvenShape[(Int, String)] = (id, name)
+}
+
+class AbstractTableTest {
+  @Test
+  def discoversPrimaryKeysAndIndexesDeclaredOnTable(): Unit = {
+    val tables: TableQuery[AbstractTableFixture] = TableQuery[AbstractTableFixture]
+    val table: AbstractTableFixture = tables.shaped.value
+
+    val primaryKeys: IndexedSeq[PrimaryKey] = table.primaryKeys.toIndexedSeq
+    val indexes: IndexedSeq[Index] = table.indexes.toIndexedSeq
+
+    assertThat(primaryKeys.map(_.name).asJava).containsExactly("pk_abstract_table_fixture")
+    assertThat(primaryKeys.head.columns.asJava).hasSize(1)
+
+    assertThat(indexes.map(_.name).asJava).containsExactly("idx_abstract_table_fixture_name")
+    assertThat(indexes.head.unique).isTrue
+    assertThat(indexes.head.on.asJava).hasSize(1)
+    assertThat(indexes.head.table).isSameAs(table)
+  }
+}

--- a/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/scala/com_typesafe_slick/slick_2_13/BeanConfiguratorTest.scala
+++ b/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/scala/com_typesafe_slick/slick_2_13/BeanConfiguratorTest.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_slick.slick_2_13
+
+import java.util.Properties
+
+import scala.beans.BeanProperty
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import slick.util.BeanConfigurator
+
+class BeanConfiguratorTarget {
+  @BeanProperty var intValue: Int = 0
+  @BeanProperty var longValue: Long = 0L
+  @BeanProperty var booleanValue: Boolean = false
+  @BeanProperty var stringValue: String = ""
+  @BeanProperty var objectValue: AnyRef = _
+}
+
+class BeanConfiguratorTest {
+  @Test
+  def configuresJavaBeanPropertiesWithSupportedTypes(): Unit = {
+    val target = new BeanConfiguratorTarget
+    val objectValue = new Object
+    val properties = new Properties
+    properties.setProperty("intValue", "42")
+    properties.setProperty("longValue", "9223372036854775806")
+    properties.setProperty("booleanValue", "true")
+    properties.setProperty("stringValue", "configured")
+    properties.put("objectValue", objectValue)
+
+    BeanConfigurator.configure(target, properties)
+
+    assertThat(target.intValue).isEqualTo(42)
+    assertThat(target.longValue).isEqualTo(9223372036854775806L)
+    assertThat(target.booleanValue).isTrue
+    assertThat(target.stringValue).isEqualTo("configured")
+    assertThat(target.objectValue).isSameAs(objectValue)
+  }
+}

--- a/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/scala/com_typesafe_slick/slick_2_13/ClassLoaderUtilAnonymous1Test.scala
+++ b/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/scala/com_typesafe_slick/slick_2_13/ClassLoaderUtilAnonymous1Test.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_slick.slick_2_13
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import slick.util.ClassLoaderUtil
+
+class ClassLoaderUtilAnonymous1Test {
+  @Test
+  def defaultClassLoaderFallsBackWhenThreadContextClassLoaderCannotFindClass(): Unit = {
+    val originalClassLoader: ClassLoader = Thread.currentThread().getContextClassLoader
+    val rejectingClassLoader: ClassLoader = new ClassLoader(null) {
+      override def loadClass(name: String): Class[?] =
+        throw new ClassNotFoundException(name)
+    }
+
+    Thread.currentThread().setContextClassLoader(rejectingClassLoader)
+    try {
+      val loadedClass: Class[?] = ClassLoaderUtil.defaultClassLoader.loadClass(ClassLoaderUtil.getClass.getName)
+
+      assertThat(loadedClass).isSameAs(ClassLoaderUtil.getClass)
+    } finally {
+      Thread.currentThread().setContextClassLoader(originalClassLoader)
+    }
+  }
+}

--- a/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/scala/com_typesafe_slick/slick_2_13/DataSourceJdbcDataSourceTest.scala
+++ b/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/scala/com_typesafe_slick/slick_2_13/DataSourceJdbcDataSourceTest.scala
@@ -6,6 +6,7 @@
  */
 package com_typesafe_slick.slick_2_13
 
+import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -15,22 +16,40 @@ import slick.jdbc.JdbcDataSource
 class DataSourceJdbcDataSourceTest {
   @Test
   def createsDataSourceFromConfiguredClassName(): Unit = {
-    val dataSourceClassName = "slick.jdbc.DriverDataSource"
-    val config = ConfigFactory.parseString(s"""
+    val dataSourceClassName: String = "slick.jdbc.DriverDataSource"
+    val config: Config = ConfigFactory.parseString(s"""
       connectionPool = "disabled"
       dataSourceClassName = "$dataSourceClassName"
       maxConnections = 7
       """)
 
-    val jdbcDataSource = JdbcDataSource.forConfig(
+    val jdbcDataSource: JdbcDataSource = JdbcDataSource.forConfig(
       config,
       driver = null,
       name = "configured-data-source",
       classLoader = getClass.getClassLoader)
 
     assertThat(jdbcDataSource).isInstanceOf(classOf[DataSourceJdbcDataSource])
-    val dataSource = jdbcDataSource.asInstanceOf[DataSourceJdbcDataSource]
+    val dataSource: DataSourceJdbcDataSource = jdbcDataSource.asInstanceOf[DataSourceJdbcDataSource]
     assertThat(dataSource.ds.getClass.getName).isEqualTo(dataSourceClassName)
     assertThat(dataSource.maxConnections).isEqualTo(Some(7))
+  }
+
+  @Test
+  def factoryInstantiatesConfiguredDataSourceClass(): Unit = {
+    val dataSourceClassName: String = "org.postgresql.ds.PGSimpleDataSource"
+    val config: Config = ConfigFactory.parseString(s"""
+      dataSourceClassName = "$dataSourceClassName"
+      maxConnections = 3
+      """)
+
+    val dataSource: DataSourceJdbcDataSource = DataSourceJdbcDataSource.forConfig(
+      config,
+      driver = null,
+      name = "direct-configured-data-source",
+      classLoader = getClass.getClassLoader)
+
+    assertThat(dataSource.ds.getClass.getName).isEqualTo(dataSourceClassName)
+    assertThat(dataSource.maxConnections).isEqualTo(Some(3))
   }
 }

--- a/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/scala/com_typesafe_slick/slick_2_13/DataSourceJdbcDataSourceTest.scala
+++ b/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/scala/com_typesafe_slick/slick_2_13/DataSourceJdbcDataSourceTest.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_slick.slick_2_13
+
+import com.typesafe.config.ConfigFactory
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import slick.jdbc.DataSourceJdbcDataSource
+import slick.jdbc.JdbcDataSource
+
+class DataSourceJdbcDataSourceTest {
+  @Test
+  def createsDataSourceFromConfiguredClassName(): Unit = {
+    val dataSourceClassName = "slick.jdbc.DriverDataSource"
+    val config = ConfigFactory.parseString(s"""
+      connectionPool = "disabled"
+      dataSourceClassName = "$dataSourceClassName"
+      maxConnections = 7
+      """)
+
+    val jdbcDataSource = JdbcDataSource.forConfig(
+      config,
+      driver = null,
+      name = "configured-data-source",
+      classLoader = getClass.getClassLoader)
+
+    assertThat(jdbcDataSource).isInstanceOf(classOf[DataSourceJdbcDataSource])
+    val dataSource = jdbcDataSource.asInstanceOf[DataSourceJdbcDataSource]
+    assertThat(dataSource.ds.getClass.getName).isEqualTo(dataSourceClassName)
+    assertThat(dataSource.maxConnections).isEqualTo(Some(7))
+  }
+}

--- a/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/scala/com_typesafe_slick/slick_2_13/DatabaseConfigTest.scala
+++ b/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/scala/com_typesafe_slick/slick_2_13/DatabaseConfigTest.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_slick.slick_2_13
+
+import com.typesafe.config.ConfigFactory
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import slick.basic.DatabaseConfig
+import slick.memory.MemoryProfile
+
+class ConfiguredMemoryProfile extends MemoryProfile
+
+class DatabaseConfigTest {
+  @Test
+  def loadsProfileObjectFromConfig(): Unit = {
+    val config = ConfigFactory.parseString("""
+      slick.profile = "slick.memory.MemoryProfile$"
+      """)
+
+    val databaseConfig = DatabaseConfig.forConfig[MemoryProfile]("slick", config)
+
+    assertThat(databaseConfig.profile).isSameAs(MemoryProfile)
+    assertThat(databaseConfig.profileName).isEqualTo("slick.memory.MemoryProfile")
+    assertThat(databaseConfig.profileIsObject).isTrue
+    assertThat(databaseConfig.config.getString("profile")).isEqualTo("slick.memory.MemoryProfile$")
+  }
+
+  @Test
+  def instantiatesProfileClassFromConfig(): Unit = {
+    val profileClassName = classOf[ConfiguredMemoryProfile].getName
+    val config = ConfigFactory.parseString(s"""
+      slick.profile = "$profileClassName"
+      """)
+
+    val databaseConfig = DatabaseConfig.forConfig[MemoryProfile]("slick", config)
+
+    assertThat(databaseConfig.profile).isInstanceOf(classOf[ConfiguredMemoryProfile])
+    assertThat(databaseConfig.profileName).isEqualTo(profileClassName)
+    assertThat(databaseConfig.profileIsObject).isFalse
+    assertThat(databaseConfig.config.getString("profile")).isEqualTo(profileClassName)
+  }
+}

--- a/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/scala/com_typesafe_slick/slick_2_13/DriverDataSourceTest.scala
+++ b/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/scala/com_typesafe_slick/slick_2_13/DriverDataSourceTest.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_slick.slick_2_13
+
+import java.sql.{Connection, Driver, DriverPropertyInfo}
+import java.util.Properties
+import java.util.logging.Logger
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import slick.jdbc.DriverDataSource
+
+class DriverDataSourceTestDriver extends Driver {
+  override def acceptsURL(url: String): Boolean =
+    url != null && url.startsWith("jdbc:slick-driver-data-source-test:")
+
+  override def connect(url: String, info: Properties): Connection = null
+
+  override def getMajorVersion: Int = 1
+
+  override def getMinorVersion: Int = 0
+
+  override def getParentLogger: Logger =
+    Logger.getLogger("com_typesafe_slick.slick_2_13.DriverDataSourceTestDriver")
+
+  override def getPropertyInfo(url: String, info: Properties): Array[DriverPropertyInfo] =
+    Array.empty[DriverPropertyInfo]
+
+  override def jdbcCompliant: Boolean = false
+}
+
+class DriverDataSourceTest {
+  @Test
+  def loadsAndInstantiatesUnregisteredDriverClass(): Unit = {
+    val dataSource = new DriverDataSource(
+      url = "jdbc:slick-driver-data-source-test:database",
+      driverClassName = classOf[DriverDataSourceTestDriver].getName,
+      classLoader = getClass.getClassLoader)
+
+    try {
+      dataSource.init()
+
+      assertThat(dataSource.getParentLogger.getName)
+        .isEqualTo("com_typesafe_slick.slick_2_13.DriverDataSourceTestDriver")
+    } finally {
+      dataSource.close()
+    }
+  }
+}

--- a/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/scala/com_typesafe_slick/slick_2_13/JdbcDataSourceTest.scala
+++ b/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/scala/com_typesafe_slick/slick_2_13/JdbcDataSourceTest.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_slick.slick_2_13
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import slick.jdbc.DataSourceJdbcDataSource
+import slick.jdbc.JdbcDataSource
+
+class JdbcDataSourceTest {
+  @Test
+  def loadsConfiguredJdbcDataSourceFactoryObject(): Unit = {
+    val config: Config = ConfigFactory.parseString("""
+      connectionPool = "slick.jdbc.DataSourceJdbcDataSource$"
+      dataSourceClassName = "slick.jdbc.DriverDataSource"
+      maxConnections = 1
+      """)
+
+    val jdbcDataSource: JdbcDataSource = JdbcDataSource.forConfig(
+      config,
+      driver = null,
+      name = "configured-factory",
+      classLoader = getClass.getClassLoader)
+
+    assertThat(jdbcDataSource).isInstanceOf(classOf[DataSourceJdbcDataSource])
+    val configuredDataSource: DataSourceJdbcDataSource = jdbcDataSource.asInstanceOf[DataSourceJdbcDataSource]
+    assertThat(configuredDataSource.ds.getClass.getName).isEqualTo("slick.jdbc.DriverDataSource")
+    assertThat(configuredDataSource.maxConnections).isEqualTo(Some(1))
+  }
+}

--- a/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/scala/com_typesafe_slick/slick_2_13/JdbcTypesComponentTest.scala
+++ b/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/scala/com_typesafe_slick/slick_2_13/JdbcTypesComponentTest.scala
@@ -32,7 +32,8 @@ class JdbcTypesComponentTest {
       isNullable = Some(false),
       scope = None,
       sourceDataType = None,
-      isAutoInc = Some(true))
+      isAutoInc = Some(true),
+      isGenerated = Some(false))
 
     assertThat(column.sqlTypeName).isEqualTo(Some("INTEGER"))
   }

--- a/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/scala/com_typesafe_slick/slick_2_13/JdbcTypesComponentTest.scala
+++ b/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/scala/com_typesafe_slick/slick_2_13/JdbcTypesComponentTest.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_slick.slick_2_13
+
+import java.sql.Types
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import slick.jdbc.meta.{MColumn, MQName}
+
+class JdbcTypesComponentTest {
+  @Test
+  def resolvesJdbcTypeNamesFromMetadataWrapper(): Unit = {
+    val tableName: MQName = MQName(None, None, "users")
+    val column: MColumn = MColumn(
+      table = tableName,
+      name = "id",
+      sqlType = Types.INTEGER,
+      typeName = "INTEGER",
+      size = Some(10),
+      decimalDigits = Some(0),
+      numPrecRadix = 10,
+      nullable = Some(false),
+      remarks = Some("primary key"),
+      columnDef = None,
+      charOctetLength = 0,
+      ordinalPosition = 1,
+      isNullable = Some(false),
+      scope = None,
+      sourceDataType = None,
+      isAutoInc = Some(true))
+
+    assertThat(column.sqlTypeName).isEqualTo(Some("INTEGER"))
+  }
+}

--- a/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/scala/com_typesafe_slick/slick_2_13/PGUtilsTest.scala
+++ b/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/scala/com_typesafe_slick/slick_2_13/PGUtilsTest.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_slick.slick_2_13
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.postgresql.util.PGobject
+import slick.jdbc.PGUtils
+
+class PGUtilsTest {
+  @Test
+  def createsPostgresObjectWithTypeAndValue(): Unit = {
+    val dbType: String = "timestamp"
+    val value: String = "2026-05-06 12:34:56"
+
+    val pgObject: AnyRef = PGUtils.createPGObject(value, dbType)
+
+    assertThat(pgObject).isInstanceOf(classOf[PGobject])
+    val typedPgObject: PGobject = pgObject.asInstanceOf[PGobject]
+    assertThat(typedPgObject.getType).isEqualTo(dbType)
+    assertThat(typedPgObject.getValue).isEqualTo(value)
+  }
+}

--- a/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/scala/com_typesafe_slick/slick_2_13/TimestamptzConverterTest.scala
+++ b/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/src/test/scala/com_typesafe_slick/slick_2_13/TimestamptzConverterTest.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_slick.slick_2_13
+
+import java.time.OffsetDateTime
+import java.time.OffsetTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+
+import oracle.sql.TIMESTAMPTZ
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import slick.jdbc.TimestamptzConverter
+
+class TimestamptzConverterTest {
+  @Test
+  def convertsOffsetTimeToTimestamptzAndBack(): Unit = {
+    val offsetTime: OffsetTime = OffsetTime.of(23, 45, 7, 123456789, ZoneOffset.ofHoursMinutes(5, 30))
+
+    val timestamptz: Object = TimestamptzConverter.offsetTimeToTimestamptz(offsetTime).asInstanceOf[Object]
+    val converted: OffsetTime = TimestamptzConverter.timestamptzToOffsetTime(timestamptz)
+
+    assertThat(timestamptz).isInstanceOf(classOf[TIMESTAMPTZ])
+    assertThat(converted).isEqualTo(offsetTime)
+  }
+
+  @Test
+  def convertsRegionBasedTimestamptzToOffsetTime(): Unit = {
+    val utcDateTime: OffsetDateTime = OffsetDateTime
+      .of(2001, 1, 1, 11, 30, 15, 987654321, ZoneOffset.UTC)
+    val timestamptz: TIMESTAMPTZ = new TIMESTAMPTZ(regionBasedBytes(utcDateTime, regionCode = 1))
+
+    val converted: OffsetTime = TimestamptzConverter.timestamptzToOffsetTime(timestamptz)
+
+    val expected: OffsetTime = utcDateTime
+      .atZoneSameInstant(ZoneId.of("Europe/Paris"))
+      .toOffsetDateTime
+      .toOffsetTime
+    assertThat(converted).isEqualTo(expected)
+  }
+
+  private def regionBasedBytes(utcDateTime: OffsetDateTime, regionCode: Int): Array[Byte] = {
+    val bytes: Array[Byte] = new Array[Byte](13)
+    val year: Int = utcDateTime.getYear
+    bytes(0) = (year / 100 + 100).toByte
+    bytes(1) = (year % 100 + 100).toByte
+    bytes(2) = utcDateTime.getMonthValue.toByte
+    bytes(3) = utcDateTime.getDayOfMonth.toByte
+    bytes(4) = (utcDateTime.getHour + 1).toByte
+    bytes(5) = (utcDateTime.getMinute + 1).toByte
+    bytes(6) = (utcDateTime.getSecond + 1).toByte
+    writeNanos(bytes, utcDateTime.getNano)
+    writeRegionCode(bytes, regionCode)
+    bytes
+  }
+
+  private def writeNanos(bytes: Array[Byte], nano: Int): Unit = {
+    bytes(7) = ((nano >>> 24) & 0xff).toByte
+    bytes(8) = ((nano >>> 16) & 0xff).toByte
+    bytes(9) = ((nano >>> 8) & 0xff).toByte
+    bytes(10) = (nano & 0xff).toByte
+  }
+
+  private def writeRegionCode(bytes: Array[Byte], regionCode: Int): Unit = {
+    bytes(11) = (0x80 | ((regionCode >>> 6) & 0x7f)).toByte
+    bytes(12) = ((regionCode & 0x3f) << 2).toByte
+  }
+}

--- a/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/user-code-filter.json
+++ b/tests/src/com.typesafe.slick/slick_2.13/4.0.0-RC1/user-code-filter.json
@@ -1,0 +1,19 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "scala.reflect.**"
+    },
+    {
+      "includeClasses" : "slick.**"
+    },
+    {
+      "includeClasses" : "oracle.sql.**"
+    },
+    {
+      "includeClasses" : "com_typesafe_slick.slick_2_13.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7664

This PR provides test fixes and new metadata for com.typesafe.slick:slick_2.13:4.0.0-RC1, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 112936
- Cached input tokens: 1583104
- Output tokens: 16530
- Metadata entries: 18
- Test-only metadata entries: 15
- Iterations: 3
- Library coverage percentage: 4.57
- Previous library version metadata entries: 16
- Previous library version test-only metadata entries: 20
- Previous library version coverage percentage: 4.16

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `79800c5736364481f14f4341613f9dedc03d2256`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.typesafe.slick:slick_2.13:3.6.1: 37/40 covered calls (92.50%)
- com.typesafe.slick:slick_2.13:4.0.0-RC1: 37/40 covered calls (92.50%)

**Reflection:**
- com.typesafe.slick:slick_2.13:3.6.1: 37/40 covered calls (92.50%)
- com.typesafe.slick:slick_2.13:4.0.0-RC1: 37/40 covered calls (92.50%)

#### Library coverage

**Instruction:**
- com.typesafe.slick:slick_2.13:3.6.1: 3995/255555 (1.56%)
- com.typesafe.slick:slick_2.13:4.0.0-RC1: 4155/255885 (1.62%)

**Line:**
- com.typesafe.slick:slick_2.13:3.6.1: 474/11405 (4.16%)
- com.typesafe.slick:slick_2.13:4.0.0-RC1: 512/11211 (4.57%)

**Method:**
- com.typesafe.slick:slick_2.13:3.6.1: 346/21615 (1.60%)
- com.typesafe.slick:slick_2.13:4.0.0-RC1: 355/21807 (1.63%)

**Comparison between existing test version and AI-Generated update**

```diff

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
