### PR TITLE
[Automation] Generated metadata for org.glassfish.hk2:hk2-api:2.6.0

### DIFF
--- a/metadata/org.glassfish.hk2/hk2-api/2.6.0/reachability-metadata.json
+++ b/metadata/org.glassfish.hk2/hk2-api/2.6.0/reachability-metadata.json
@@ -2,18 +2,6 @@
   "reflection" : [
     {
       "condition" : {
-        "typeReached" : "org.glassfish.hk2.utilities.AliasDescriptor"
-      },
-      "type" : "java.lang.Runnable"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.glassfish.hk2.api.AnnotationLiteral$1"
-      },
-      "type" : "java.lang.StackTraceElement[]"
-    },
-    {
-      "condition" : {
         "typeReached" : "org.glassfish.hk2.utilities.reflection.ReflectionHelper"
       },
       "type" : "java.lang.annotation.Annotation[]"
@@ -32,18 +20,6 @@
     },
     {
       "condition" : {
-        "typeReached" : "org.glassfish.hk2.utilities.BuilderHelper"
-      },
-      "type" : "java.util.HashMap",
-      "methods" : [
-        {
-          "name" : "clone",
-          "parameterTypes" : [ ]
-        }
-      ]
-    },
-    {
-      "condition" : {
         "typeReached" : "org.glassfish.hk2.api.AnnotationLiteral"
       },
       "type" : "javax.inject.Named",
@@ -59,38 +35,6 @@
         "typeReached" : "org.glassfish.hk2.api.AnnotationLiteral$1"
       },
       "type" : "javax.inject.Named"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.glassfish.hk2.utilities.binding.AbstractBinder$2"
-      },
-      "type" : "org.glassfish.hk2.utilities.DescriptorImpl"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.glassfish.hk2.utilities.HK2LoaderImpl"
-      },
-      "type" : "org.glassfish.hk2.utilities.HK2LoaderImpl"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.glassfish.hk2.utilities.reflection.ReflectionHelper"
-      },
-      "type" : {
-        "proxy" : [
-          "java.lang.FunctionalInterface"
-        ]
-      }
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.glassfish.hk2.utilities.reflection.ReflectionHelper"
-      },
-      "type" : {
-        "proxy" : [
-          "java.lang.annotation.Documented"
-        ]
-      }
     },
     {
       "condition" : {

--- a/tests/src/org.glassfish.hk2/hk2-api/2.6.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.glassfish.hk2/hk2-api/2.6.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,4 +1,12 @@
 {
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org_glassfish_hk2.hk2_api.HK2LoaderImplTest"
+      },
+      "type" : "org.glassfish.hk2.utilities.HK2LoaderImpl"
+    }
+  ],
   "resources" : [
     {
       "condition" : {


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7480

This PR provides new metadata needed for the org.glassfish.hk2:hk2-api:2.6.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.glassfish.hk2:hk2-api:2.6.0`): 10
- Test-only metadata entries (previous `org.glassfish.hk2:hk2-api:2.6.0`): 2
- Metadata entries (new `org.glassfish.hk2:hk2-api:2.6.0`): 10
- Test-only metadata entries (new `org.glassfish.hk2:hk2-api:2.6.0`): 2
- Library coverage (previous): 14.17%
- Library coverage (new): 14.17%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `404875454e3cdf7856c26fee01389fa653ac2673`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `org.glassfish.hk2:hk2-api:2.6.0` and `org.glassfish.hk2:hk2-api:2.6.0`.

### Local CI Verification

- Status: `success`
- Commands run: 0
- Fixup attempts: 0
