### PR TITLE
[Automation] Generated metadata for org.xerial:sqlite-jdbc:3.40.0.0

### DIFF
--- a/metadata/org.xerial/sqlite-jdbc/3.40.0.0/reachability-metadata.json
+++ b/metadata/org.xerial/sqlite-jdbc/3.40.0.0/reachability-metadata.json
@@ -254,7 +254,7 @@
       "condition" : {
         "typeReached" : "org.sqlite.SQLiteJDBCLoader"
       },
-      "glob" : "org/sqlite/native/Linux/x86_64/libsqlitejdbc.so"
+      "glob" : "org/sqlite/native/**"
     },
     {
       "condition" : {

--- a/metadata/org.xerial/sqlite-jdbc/index.json
+++ b/metadata/org.xerial/sqlite-jdbc/index.json
@@ -5,7 +5,7 @@
     "test-version" : "3.36.0.3",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/xerial/sqlite-jdbc/$version$/sqlite-jdbc-$version$-sources.jar",
     "repository-url" : "https://github.com/xerial/sqlite-jdbc",
-    "test-code-url" : "https://github.com/xerial/sqlite-jdbc/tree/$version$/src/test",
+    "test-code-url" : "N/A",
     "documentation-url" : "https://repo.maven.apache.org/maven2/org/xerial/sqlite-jdbc/$version$/sqlite-jdbc-$version$-javadoc.jar",
     "description" : "SQLite JDBC is a JDBC driver for accessing and creating SQLite database files from Java applications. It packages native SQLite libraries for major operating systems into a single JAR so applications can use SQLite without separate native setup.",
     "tested-versions" : [

--- a/tests/src/org.xerial/sqlite-jdbc/3.36.0.3/src/test/java/org_xerial/sqlite_jdbc/SQLiteJDBCLoaderTest.java
+++ b/tests/src/org.xerial/sqlite-jdbc/3.36.0.3/src/test/java/org_xerial/sqlite_jdbc/SQLiteJDBCLoaderTest.java
@@ -6,6 +6,7 @@
  */
 package org_xerial.sqlite_jdbc;
 
+import java.net.URL;
 import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
@@ -32,6 +33,17 @@ public class SQLiteJDBCLoaderTest {
             restoreProperty("org.sqlite.lib.path", previousLibPath);
             restoreProperty("org.sqlite.lib.name", previousLibName);
         }
+    }
+
+    @Test
+    public void packagedNativeLibrariesRemainReachableForOtherSupportedPlatforms() {
+        URL windowsResource = SQLiteJDBCLoader.class.getResource("/org/sqlite/native/Windows/x86_64/sqlitejdbc.dll");
+        URL linuxMuslResource = SQLiteJDBCLoader.class.getResource("/org/sqlite/native/Linux-Musl/x86_64/libsqlitejdbc.so");
+        URL macResource = SQLiteJDBCLoader.class.getResource("/org/sqlite/native/Mac/aarch64/libsqlitejdbc.jnilib");
+
+        assertThat(windowsResource).isNotNull();
+        assertThat(linuxMuslResource).isNotNull();
+        assertThat(macResource).isNotNull();
     }
 
     private static void restoreProperty(String name, String value) {


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7659

This PR provides new metadata needed for the org.xerial:sqlite-jdbc:3.40.0.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.xerial:sqlite-jdbc:3.36.0.3`): 32
- Test-only metadata entries (previous `org.xerial:sqlite-jdbc:3.36.0.3`): 1
- Metadata entries (new `org.xerial:sqlite-jdbc:3.40.0.0`): 54
- Test-only metadata entries (new `org.xerial:sqlite-jdbc:3.40.0.0`): 1
- Library coverage (previous): 26.55%
- Library coverage (new): 26.18%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `404875454e3cdf7856c26fee01389fa653ac2673`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.xerial:sqlite-jdbc:3.36.0.3: 8/8 covered calls (100.00%)
- org.xerial:sqlite-jdbc:3.40.0.0: 8/8 covered calls (100.00%)

**Reflection:**
- org.xerial:sqlite-jdbc:3.36.0.3: 3/3 covered calls (100.00%)
- org.xerial:sqlite-jdbc:3.40.0.0: 3/3 covered calls (100.00%)

**Resources:**
- org.xerial:sqlite-jdbc:3.36.0.3: 5/5 covered calls (100.00%)
- org.xerial:sqlite-jdbc:3.40.0.0: 5/5 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.xerial:sqlite-jdbc:3.36.0.3: 5428/19427 (27.94%)
- org.xerial:sqlite-jdbc:3.40.0.0: 5746/21381 (26.87%)

**Line:**
- org.xerial:sqlite-jdbc:3.36.0.3: 1132/4264 (26.55%)
- org.xerial:sqlite-jdbc:3.40.0.0: 1262/4821 (26.18%)

**Method:**
- org.xerial:sqlite-jdbc:3.36.0.3: 236/1277 (18.48%)
- org.xerial:sqlite-jdbc:3.40.0.0: 264/1370 (19.27%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
