### PR TITLE
[Automation] Generated metadata for org.xerial:sqlite-jdbc:3.36.0.3

### DIFF
--- a/metadata/org.xerial/sqlite-jdbc/3.36.0.3/reachability-metadata.json
+++ b/metadata/org.xerial/sqlite-jdbc/3.36.0.3/reachability-metadata.json
@@ -25,49 +25,147 @@
         "typeReached" : "org.sqlite.SQLiteJDBCLoader"
       },
       "type" : "org.sqlite.Collation",
-      "jniAccessible" : true
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "xCompare",
+          "parameterTypes" : [
+            "java.lang.String",
+            "java.lang.String"
+          ]
+        }
+      ]
     },
     {
       "condition" : {
         "typeReached" : "org.sqlite.SQLiteJDBCLoader"
       },
       "type" : "org.sqlite.Function",
-      "jniAccessible" : true
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "args"
+        },
+        {
+          "name" : "context"
+        },
+        {
+          "name" : "value"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "xFunc",
+          "parameterTypes" : [ ]
+        }
+      ]
     },
     {
       "condition" : {
         "typeReached" : "org.sqlite.SQLiteJDBCLoader"
       },
       "type" : "org.sqlite.Function$Aggregate",
-      "jniAccessible" : true
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "clone",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "xFinal",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "xStep",
+          "parameterTypes" : [ ]
+        }
+      ]
     },
     {
       "condition" : {
         "typeReached" : "org.sqlite.SQLiteJDBCLoader"
       },
       "type" : "org.sqlite.Function$Window",
-      "jniAccessible" : true
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "xInverse",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "xValue",
+          "parameterTypes" : [ ]
+        }
+      ]
     },
     {
       "condition" : {
         "typeReached" : "org.sqlite.SQLiteJDBCLoader"
       },
       "type" : "org.sqlite.ProgressHandler",
-      "jniAccessible" : true
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "progress",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.sqlite.SQLiteJDBCLoader"
+      },
+      "type" : "org.sqlite.core.DB",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "throwex",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "throwex",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
     },
     {
       "condition" : {
         "typeReached" : "org.sqlite.SQLiteJDBCLoader"
       },
       "type" : "org.sqlite.core.DB$ProgressObserver",
-      "jniAccessible" : true
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "progress",
+          "parameterTypes" : [
+            "int",
+            "int"
+          ]
+        }
+      ]
     },
     {
       "condition" : {
         "typeReached" : "org.sqlite.SQLiteJDBCLoader"
       },
       "type" : "org.sqlite.core.NativeDB",
-      "jniAccessible" : true
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "stringToUtf8ByteArray",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "throwex",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
     },
     {
       "condition" : {

--- a/stats/org.xerial/sqlite-jdbc/3.36.0.3/stats.json
+++ b/stats/org.xerial/sqlite-jdbc/3.36.0.3/stats.json
@@ -20,21 +20,21 @@
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 5428,
-        "missed" : 13999,
-        "ratio" : 0.279405,
+        "covered" : 5693,
+        "missed" : 13734,
+        "ratio" : 0.293046,
         "total" : 19427
       },
       "line" : {
-        "covered" : 1132,
-        "missed" : 3132,
-        "ratio" : 0.265478,
+        "covered" : 1187,
+        "missed" : 3077,
+        "ratio" : 0.278377,
         "total" : 4264
       },
       "method" : {
-        "covered" : 236,
-        "missed" : 1041,
-        "ratio" : 0.184808,
+        "covered" : 259,
+        "missed" : 1018,
+        "ratio" : 0.202819,
         "total" : 1277
       }
     }

--- a/tests/src/org.xerial/sqlite-jdbc/3.36.0.3/src/test/java/org_xerial/sqlite_jdbc/SQLiteCallbackMetadataTest.java
+++ b/tests/src/org.xerial/sqlite-jdbc/3.36.0.3/src/test/java/org_xerial/sqlite_jdbc/SQLiteCallbackMetadataTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_xerial.sqlite_jdbc;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.sqlite.Collation;
+import org.sqlite.Function;
+import org.sqlite.ProgressHandler;
+import org.sqlite.SQLiteDataSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SQLiteCallbackMetadataTest {
+    @Test
+    public void customScalarAndAggregateFunctionsExecuteThroughNativeCallbacks() throws Exception {
+        SQLiteDataSource dataSource = new SQLiteDataSource();
+        dataSource.setUrl("jdbc:sqlite::memory:");
+
+        try (Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement()) {
+            Function.create(connection, "echo_with_arg_count", new Function() {
+                @Override
+                protected void xFunc() throws SQLException {
+                    result(value_text(0) + ":" + args());
+                }
+            });
+            Function.create(connection, "sum_window", new Function.Aggregate() {
+                private int total;
+
+                @Override
+                protected void xStep() throws SQLException {
+                    total += value_int(0);
+                }
+
+                @Override
+                protected void xFinal() throws SQLException {
+                    result(total);
+                }
+            });
+
+            try (ResultSet scalarResultSet = statement.executeQuery("SELECT echo_with_arg_count('sqlite')")) {
+                assertThat(scalarResultSet.next()).isTrue();
+                assertThat(scalarResultSet.getString(1)).isEqualTo("sqlite:1");
+                assertThat(scalarResultSet.next()).isFalse();
+            }
+
+            statement.executeUpdate("CREATE TABLE callback_values (value INTEGER NOT NULL)");
+            statement.executeUpdate("INSERT INTO callback_values(value) VALUES (3), (7), (11)");
+
+            try (ResultSet aggregateResultSet = statement.executeQuery("SELECT sum_window(value) FROM callback_values")) {
+                assertThat(aggregateResultSet.next()).isTrue();
+                assertThat(aggregateResultSet.getInt(1)).isEqualTo(21);
+                assertThat(aggregateResultSet.next()).isFalse();
+            }
+        }
+    }
+
+    @Test
+    public void customWindowFunctionAndCollationExecuteThroughNativeCallbacks() throws Exception {
+        SQLiteDataSource dataSource = new SQLiteDataSource();
+        dataSource.setUrl("jdbc:sqlite::memory:");
+
+        try (Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement()) {
+            Function.create(connection, "sliding_sum", new Function.Window() {
+                private int total;
+
+                @Override
+                protected void xStep() throws SQLException {
+                    total += value_int(0);
+                }
+
+                @Override
+                protected void xInverse() throws SQLException {
+                    total -= value_int(0);
+                }
+
+                @Override
+                protected void xValue() throws SQLException {
+                    result(total);
+                }
+
+                @Override
+                protected void xFinal() throws SQLException {
+                    result(total);
+                }
+            });
+            Collation.create(connection, "REVERSE_TEXT", new Collation() {
+                @Override
+                protected int xCompare(String first, String second) {
+                    return second.compareTo(first);
+                }
+            });
+
+            statement.executeUpdate("CREATE TABLE window_values (id INTEGER PRIMARY KEY, label TEXT NOT NULL, value INTEGER NOT NULL)");
+            statement.executeUpdate("""
+                    INSERT INTO window_values(id, label, value)
+                    VALUES (1, 'alpha', 2), (2, 'charlie', 5), (3, 'bravo', 7)
+                    """);
+
+            try (ResultSet windowResultSet = statement.executeQuery("""
+                    SELECT sliding_sum(value) OVER (
+                        ORDER BY id
+                        ROWS BETWEEN 1 PRECEDING AND CURRENT ROW
+                    )
+                    FROM window_values
+                    ORDER BY id
+                    """)) {
+                assertThat(windowResultSet.next()).isTrue();
+                assertThat(windowResultSet.getInt(1)).isEqualTo(2);
+                assertThat(windowResultSet.next()).isTrue();
+                assertThat(windowResultSet.getInt(1)).isEqualTo(7);
+                assertThat(windowResultSet.next()).isTrue();
+                assertThat(windowResultSet.getInt(1)).isEqualTo(12);
+                assertThat(windowResultSet.next()).isFalse();
+            }
+
+            try (ResultSet collationResultSet = statement.executeQuery("""
+                    SELECT label
+                    FROM window_values
+                    ORDER BY label COLLATE REVERSE_TEXT
+                    """)) {
+                assertThat(collationResultSet.next()).isTrue();
+                assertThat(collationResultSet.getString(1)).isEqualTo("charlie");
+                assertThat(collationResultSet.next()).isTrue();
+                assertThat(collationResultSet.getString(1)).isEqualTo("bravo");
+                assertThat(collationResultSet.next()).isTrue();
+                assertThat(collationResultSet.getString(1)).isEqualTo("alpha");
+                assertThat(collationResultSet.next()).isFalse();
+            }
+        }
+    }
+
+    @Test
+    public void progressHandlerExecutesThroughNativeCallback() throws Exception {
+        SQLiteDataSource dataSource = new SQLiteDataSource();
+        dataSource.setUrl("jdbc:sqlite::memory:");
+        AtomicInteger progressInvocations = new AtomicInteger();
+
+        try (Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement()) {
+            ProgressHandler.setHandler(connection, 1, new ProgressHandler() {
+                @Override
+                protected int progress() {
+                    progressInvocations.incrementAndGet();
+                    return 0;
+                }
+            });
+
+            try (ResultSet resultSet = statement.executeQuery("""
+                    WITH RECURSIVE counter(value) AS (
+                        VALUES (1)
+                        UNION ALL
+                        SELECT value + 1 FROM counter WHERE value < 200
+                    )
+                    SELECT SUM(value) FROM counter
+                    """)) {
+                assertThat(resultSet.next()).isTrue();
+                assertThat(resultSet.getInt(1)).isEqualTo(20100);
+                assertThat(resultSet.next()).isFalse();
+            } finally {
+                ProgressHandler.clearHandler(connection);
+            }
+        }
+
+        assertThat(progressInvocations.get()).isGreaterThan(0);
+    }
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7657

This PR provides new metadata needed for the org.xerial:sqlite-jdbc:3.36.0.3, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.xerial:sqlite-jdbc:3.36.0.3`): 50
- Test-only metadata entries (previous `org.xerial:sqlite-jdbc:3.36.0.3`): 1
- Metadata entries (new `org.xerial:sqlite-jdbc:3.36.0.3`): 50
- Test-only metadata entries (new `org.xerial:sqlite-jdbc:3.36.0.3`): 1
- Library coverage (previous): 27.84%
- Library coverage (new): 27.84%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `404875454e3cdf7856c26fee01389fa653ac2673`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `org.xerial:sqlite-jdbc:3.36.0.3` and `org.xerial:sqlite-jdbc:3.36.0.3`.

### Local CI Verification

- Status: `success`
- Commands run: 0
- Fixup attempts: 0
