### PR TITLE
[Automation] Generated metadata for org.jline:jline-terminal-jni:3.30.7

### DIFF
--- a/metadata/org.jline/jline-terminal-jni/3.30.7/reachability-metadata.json
+++ b/metadata/org.jline/jline-terminal-jni/3.30.7/reachability-metadata.json
@@ -2,7 +2,7 @@
   "reflection": [
     {
       "condition": {
-        "typeReached": "org.jline.terminal.impl.jni.linux.LinuxNativePty"
+        "typeReached": "org.jline.terminal.impl.jni.JniNativePty"
       },
       "type": "java.io.FileDescriptor",
       "jniAccessible": true,
@@ -74,7 +74,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.jline.terminal.impl.jni.linux.LinuxNativePty"
+        "typeReached": "org.jline.terminal.impl.jni.JniNativePty"
       },
       "type": "org.jline.nativ.CLibrary$Termios",
       "jniAccessible": true,
@@ -120,7 +120,7 @@
       "condition": {
         "typeReached": "org.jline.terminal.impl.jni.JniNativePty"
       },
-      "glob": "org/jline/nativ/Linux/x86_64/libjlinenative.so"
+      "glob": "org/jline/nativ/**/libjlinenative.so"
     },
     {
       "condition": {

--- a/metadata/org.jline/jline-terminal-jni/index.json
+++ b/metadata/org.jline/jline-terminal-jni/index.json
@@ -4,7 +4,7 @@
     "metadata-version" : "3.30.7",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/jline/jline-terminal-jni/$version$/jline-terminal-jni-$version$-sources.jar",
     "repository-url" : "https://github.com/jline/jline3",
-    "test-code-url" : "https://github.com/jline/jline3/tree/jline-$version$/terminal-jni/src/test/java",
+    "test-code-url" : "N/A",
     "documentation-url" : "https://repo.maven.apache.org/maven2/org/jline/jline-terminal-jni/$version$/jline-terminal-jni-$version$-javadoc.jar",
     "description" : "JLine JNI Terminal provides the JLine terminal provider implementation that uses JLine's JNI native library for low-level terminal and pseudoterminal access. It plugs into the JLine terminal API to support native console operations across supported platforms without relying on JNA or external process execution.",
     "tested-versions" : [


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7654

This PR provides new metadata needed for the org.jline:jline-terminal-jni:3.30.7, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.jline:jline-terminal-jni:3.30.7`): 34
- Metadata entries (new `org.jline:jline-terminal-jni:3.30.7`): 34
- Library coverage (previous): 20.18%
- Library coverage (new): 20.18%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `404875454e3cdf7856c26fee01389fa653ac2673`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `org.jline:jline-terminal-jni:3.30.7` and `org.jline:jline-terminal-jni:3.30.7`.

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
