### PR TITLE
[Automation] Generated metadata for org.rocksdb:rocksdbjni:7.9.2

### DIFF
--- a/metadata/org.rocksdb/rocksdbjni/7.9.2/reachability-metadata.json
+++ b/metadata/org.rocksdb/rocksdbjni/7.9.2/reachability-metadata.json
@@ -9,6 +9,12 @@
     },
     {
       "condition": {
+        "typeReached": "org.rocksdb.RocksDB"
+      },
+      "type": "byte[][]"
+    },
+    {
+      "condition": {
         "typeReached": "org.rocksdb.NativeLibraryLoader"
       },
       "type": "java.security.SecureRandomParameters"

--- a/metadata/org.rocksdb/rocksdbjni/index.json
+++ b/metadata/org.rocksdb/rocksdbjni/index.json
@@ -42,7 +42,7 @@
     "metadata-version" : "7.9.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/rocksdb/rocksdbjni/$version$/rocksdbjni-$version$-sources.jar",
     "repository-url" : "https://github.com/facebook/rocksdb",
-    "test-code-url" : "https://github.com/facebook/rocksdb/tree/v$version$/java/src/test",
+    "test-code-url" : "https://github.com/facebook/rocksdb/tree/v7.9.2/java/src/test",
     "documentation-url" : "https://repo.maven.apache.org/maven2/org/rocksdb/rocksdbjni/$version$/rocksdbjni-$version$-javadoc.jar",
     "description" : "RocksDB JNI provides Java bindings for RocksDB, an embeddable persistent key-value store optimized for fast storage on flash and RAM. The rocksdbjni artifact packages the native RocksDB libraries for supported platforms so Java applications can use RocksDB without building them separately.",
     "tested-versions" : [


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7656

This PR provides new metadata needed for the org.rocksdb:rocksdbjni:7.9.2, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.rocksdb:rocksdbjni:10.4.2`): 8
- Test-only metadata entries (previous `org.rocksdb:rocksdbjni:10.4.2`): 5
- Metadata entries (new `org.rocksdb:rocksdbjni:7.9.2`): 11
- Library coverage (previous): 5.43%
- Library coverage (new): 5.21%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `404875454e3cdf7856c26fee01389fa653ac2673`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.rocksdb:rocksdbjni:10.4.2: 2/2 covered calls (100.00%)
- org.rocksdb:rocksdbjni:7.9.2: 1/2 covered calls (50.00%)

**Resources:**
- org.rocksdb:rocksdbjni:10.4.2: 2/2 covered calls (100.00%)
- org.rocksdb:rocksdbjni:7.9.2: 1/2 covered calls (50.00%)

#### Library coverage

**Instruction:**
- org.rocksdb:rocksdbjni:10.4.2: 1471/37532 (3.92%)
- org.rocksdb:rocksdbjni:7.9.2: 1308/34206 (3.82%)

**Line:**
- org.rocksdb:rocksdbjni:10.4.2: 402/7410 (5.43%)
- org.rocksdb:rocksdbjni:7.9.2: 340/6522 (5.21%)

**Method:**
- org.rocksdb:rocksdbjni:10.4.2: 132/2784 (4.74%)
- org.rocksdb:rocksdbjni:7.9.2: 109/2447 (4.45%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
