### PR TITLE
[GenAI] Mark io.awspring.cloud:spring-cloud-aws-starter as not for Native Image

### DIFF
--- a/metadata/io.awspring.cloud/spring-cloud-aws-starter/index.json
+++ b/metadata/io.awspring.cloud/spring-cloud-aws-starter/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published spring-cloud-aws-starter-4.0.2 JAR contains only Maven metadata under META-INF and no JVM class files; it is a dependency starter whose runtime classes are supplied by dependencies.",
+    "replacement": "io.awspring.cloud:spring-cloud-aws-autoconfigure:4.0.2 and io.awspring.cloud:spring-cloud-aws-core:4.0.2"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #7705

This PR records `io.awspring.cloud:spring-cloud-aws-starter` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published spring-cloud-aws-starter-4.0.2 JAR contains only Maven metadata under META-INF and no JVM class files; it is a dependency starter whose runtime classes are supplied by dependencies.

Replacement guidance:
- io.awspring.cloud:spring-cloud-aws-autoconfigure:4.0.2 and io.awspring.cloud:spring-cloud-aws-core:4.0.2

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `404875454e3cdf7856c26fee01389fa653ac2673`

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
