### PR TITLE
[Automation] Generated metadata for org.jline:jline-terminal-jna:3.20.0

### DIFF
--- a/metadata/org.jline/jline-terminal-jna/3.20.0/reachability-metadata.json
+++ b/metadata/org.jline/jline-terminal-jna/3.20.0/reachability-metadata.json
@@ -1,38 +1,102 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org.jline.terminal.impl.jna.linux.LinuxNativePty"
-      },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "org.jline.terminal.impl.jna.linux.CLibrary"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jline.terminal.impl.jna.linux.LinuxNativePty$UtilLibrary"
-      },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "org.jline.terminal.impl.jna.linux.LinuxNativePty$UtilLibrary"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jline.terminal.impl.jna.linux.CLibrary$termios"
+      "condition" : {
+        "typeReached" : "org.jline.terminal.impl.jna.linux.CLibrary$termios"
       },
-      "type": "org.jline.terminal.impl.jna.linux.CLibrary$termios",
-      "allDeclaredFields": true
+      "type" : "org.jline.terminal.impl.jna.linux.CLibrary$termios",
+      "allDeclaredFields" : true
     },
     {
-      "condition": {
-        "typeReached": "org.jline.terminal.impl.jna.linux.CLibrary$winsize"
+      "condition" : {
+        "typeReached" : "org.jline.terminal.impl.jna.linux.CLibrary$winsize"
       },
-      "type": "org.jline.terminal.impl.jna.linux.CLibrary$winsize",
-      "allDeclaredFields": true
+      "type" : "org.jline.terminal.impl.jna.linux.CLibrary$winsize",
+      "allDeclaredFields" : true
+    },
+    {
+      "type" : {
+        "proxy" : [
+          "org.jline.terminal.impl.jna.freebsd.CLibrary"
+        ]
+      }
+    },
+    {
+      "type" : {
+        "proxy" : [
+          "org.jline.terminal.impl.jna.freebsd.FreeBsdNativePty$UtilLibrary"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jline.terminal.impl.jna.freebsd.CLibrary$termios"
+      },
+      "type" : "org.jline.terminal.impl.jna.freebsd.CLibrary$termios",
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jline.terminal.impl.jna.freebsd.CLibrary$winsize"
+      },
+      "type" : "org.jline.terminal.impl.jna.freebsd.CLibrary$winsize",
+      "allDeclaredFields" : true
+    },
+    {
+      "type" : {
+        "proxy" : [
+          "org.jline.terminal.impl.jna.osx.CLibrary"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jline.terminal.impl.jna.osx.CLibrary$termios"
+      },
+      "type" : "org.jline.terminal.impl.jna.osx.CLibrary$termios",
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jline.terminal.impl.jna.osx.CLibrary$winsize"
+      },
+      "type" : "org.jline.terminal.impl.jna.osx.CLibrary$winsize",
+      "allDeclaredFields" : true
+    },
+    {
+      "type" : {
+        "proxy" : [
+          "org.jline.terminal.impl.jna.solaris.CLibrary"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jline.terminal.impl.jna.solaris.CLibrary$termios"
+      },
+      "type" : "org.jline.terminal.impl.jna.solaris.CLibrary$termios",
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jline.terminal.impl.jna.solaris.CLibrary$winsize"
+      },
+      "type" : "org.jline.terminal.impl.jna.solaris.CLibrary$winsize",
+      "allDeclaredFields" : true
     }
   ]
 }

--- a/tests/src/org.jline/jline-terminal-jna/3.20.0/src/test/java/org/graalvm/jline/JnaMetadataCoverageTest.java
+++ b/tests/src/org.jline/jline-terminal-jna/3.20.0/src/test/java/org/graalvm/jline/JnaMetadataCoverageTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.jline;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import org.jline.terminal.impl.jna.freebsd.FreeBsdNativePty;
+import org.jline.terminal.impl.jna.linux.LinuxNativePty;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JnaMetadataCoverageTest {
+
+    private static final InvocationHandler NO_OP_HANDLER = JnaMetadataCoverageTest::defaultValue;
+
+    @Test
+    void posixProxyAndStructureMetadataRemainsUsable() {
+        assertProxy(org.jline.terminal.impl.jna.linux.CLibrary.class);
+        assertProxy(LinuxNativePty.UtilLibrary.class);
+        assertProxy(org.jline.terminal.impl.jna.freebsd.CLibrary.class);
+        assertProxy(FreeBsdNativePty.UtilLibrary.class);
+        assertProxy(org.jline.terminal.impl.jna.osx.CLibrary.class);
+        assertProxy(org.jline.terminal.impl.jna.solaris.CLibrary.class);
+
+        assertDeclaredFields(org.jline.terminal.impl.jna.linux.CLibrary.termios.class);
+        assertDeclaredFields(org.jline.terminal.impl.jna.linux.CLibrary.winsize.class);
+        assertDeclaredFields(org.jline.terminal.impl.jna.freebsd.CLibrary.termios.class);
+        assertDeclaredFields(org.jline.terminal.impl.jna.freebsd.CLibrary.winsize.class);
+        assertDeclaredFields(org.jline.terminal.impl.jna.osx.CLibrary.termios.class);
+        assertDeclaredFields(org.jline.terminal.impl.jna.osx.CLibrary.winsize.class);
+        assertDeclaredFields(org.jline.terminal.impl.jna.solaris.CLibrary.termios.class);
+        assertDeclaredFields(org.jline.terminal.impl.jna.solaris.CLibrary.winsize.class);
+    }
+
+    private static void assertProxy(Class<?> proxyInterface) {
+        Object proxy = Proxy.newProxyInstance(
+                proxyInterface.getClassLoader(),
+                new Class<?>[]{proxyInterface},
+                NO_OP_HANDLER
+        );
+        assertThat(Proxy.isProxyClass(proxy.getClass())).isTrue();
+    }
+
+    private static void assertDeclaredFields(Class<?> type) {
+        assertThat(type.getDeclaredFields()).isNotEmpty();
+    }
+
+    private static Object defaultValue(Object proxy, Method method, Object[] args) {
+        Class<?> returnType = method.getReturnType();
+        if (!returnType.isPrimitive()) {
+            return null;
+        }
+        if (returnType == Boolean.TYPE) {
+            return false;
+        }
+        if (returnType == Byte.TYPE) {
+            return (byte) 0;
+        }
+        if (returnType == Short.TYPE) {
+            return (short) 0;
+        }
+        if (returnType == Integer.TYPE) {
+            return 0;
+        }
+        if (returnType == Long.TYPE) {
+            return 0L;
+        }
+        if (returnType == Float.TYPE) {
+            return 0F;
+        }
+        if (returnType == Double.TYPE) {
+            return 0D;
+        }
+        if (returnType == Character.TYPE) {
+            return (char) 0;
+        }
+        return null;
+    }
+}

--- a/tests/src/org.jline/jline-terminal-jna/3.20.0/src/test/java/org/jline/terminal/impl/jna/win/JnaWinMetadataCoverageTest.java
+++ b/tests/src/org.jline/jline-terminal-jna/3.20.0/src/test/java/org/jline/terminal/impl/jna/win/JnaWinMetadataCoverageTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.jline.terminal.impl.jna.win;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JnaWinMetadataCoverageTest {
+
+    private static final InvocationHandler NO_OP_HANDLER = JnaWinMetadataCoverageTest::defaultValue;
+
+    @Test
+    void windowsProxyAndStructureMetadataRemainsUsable() {
+        assertThat(JnaWinSysTerminal.class).isNotNull();
+        Object proxy = Proxy.newProxyInstance(
+                Kernel32.class.getClassLoader(),
+                new Class<?>[]{Kernel32.class},
+                NO_OP_HANDLER
+        );
+        assertThat(Proxy.isProxyClass(proxy.getClass())).isTrue();
+
+        assertDeclaredFields(Kernel32.CHAR_INFO.class);
+        assertDeclaredFields(Kernel32.CONSOLE_CURSOR_INFO.class);
+        assertDeclaredFields(Kernel32.CONSOLE_SCREEN_BUFFER_INFO.class);
+        assertDeclaredFields(Kernel32.COORD.class);
+        assertDeclaredFields(Kernel32.FOCUS_EVENT_RECORD.class);
+        assertDeclaredFields(Kernel32.INPUT_RECORD.class);
+        assertDeclaredFields(Kernel32.INPUT_RECORD.EventUnion.class);
+        assertDeclaredFields(Kernel32.KEY_EVENT_RECORD.class);
+        assertDeclaredFields(Kernel32.MENU_EVENT_RECORD.class);
+        assertDeclaredFields(Kernel32.MOUSE_EVENT_RECORD.class);
+        assertDeclaredFields(Kernel32.SMALL_RECT.class);
+        assertDeclaredFields(Kernel32.UnionChar.class);
+        assertDeclaredFields(Kernel32.WINDOW_BUFFER_SIZE_RECORD.class);
+    }
+
+    private static void assertDeclaredFields(Class<?> type) {
+        assertThat(type.getDeclaredFields()).isNotEmpty();
+    }
+
+    private static Object defaultValue(Object proxy, Method method, Object[] args) {
+        Class<?> returnType = method.getReturnType();
+        if (!returnType.isPrimitive()) {
+            return null;
+        }
+        if (returnType == Boolean.TYPE) {
+            return false;
+        }
+        if (returnType == Byte.TYPE) {
+            return (byte) 0;
+        }
+        if (returnType == Short.TYPE) {
+            return (short) 0;
+        }
+        if (returnType == Integer.TYPE) {
+            return 0;
+        }
+        if (returnType == Long.TYPE) {
+            return 0L;
+        }
+        if (returnType == Float.TYPE) {
+            return 0F;
+        }
+        if (returnType == Double.TYPE) {
+            return 0D;
+        }
+        if (returnType == Character.TYPE) {
+            return (char) 0;
+        }
+        return null;
+    }
+}

--- a/tests/src/org.jline/jline-terminal-jna/3.20.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.jline/jline-terminal-jna/3.20.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,102 @@
+{
+  "reflection" : [
+    {
+      "type" : {
+        "proxy" : [
+          "org.jline.terminal.impl.jna.win.Kernel32"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jline.terminal.impl.jna.win.Kernel32$CHAR_INFO"
+      },
+      "type" : "org.jline.terminal.impl.jna.win.Kernel32$CHAR_INFO",
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jline.terminal.impl.jna.win.Kernel32$CONSOLE_CURSOR_INFO"
+      },
+      "type" : "org.jline.terminal.impl.jna.win.Kernel32$CONSOLE_CURSOR_INFO",
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jline.terminal.impl.jna.win.Kernel32$CONSOLE_SCREEN_BUFFER_INFO"
+      },
+      "type" : "org.jline.terminal.impl.jna.win.Kernel32$CONSOLE_SCREEN_BUFFER_INFO",
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jline.terminal.impl.jna.win.Kernel32$COORD"
+      },
+      "type" : "org.jline.terminal.impl.jna.win.Kernel32$COORD",
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jline.terminal.impl.jna.win.Kernel32$FOCUS_EVENT_RECORD"
+      },
+      "type" : "org.jline.terminal.impl.jna.win.Kernel32$FOCUS_EVENT_RECORD",
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jline.terminal.impl.jna.win.Kernel32$INPUT_RECORD"
+      },
+      "type" : "org.jline.terminal.impl.jna.win.Kernel32$INPUT_RECORD",
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jline.terminal.impl.jna.win.Kernel32$INPUT_RECORD$EventUnion"
+      },
+      "type" : "org.jline.terminal.impl.jna.win.Kernel32$INPUT_RECORD$EventUnion",
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jline.terminal.impl.jna.win.Kernel32$KEY_EVENT_RECORD"
+      },
+      "type" : "org.jline.terminal.impl.jna.win.Kernel32$KEY_EVENT_RECORD",
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jline.terminal.impl.jna.win.Kernel32$MENU_EVENT_RECORD"
+      },
+      "type" : "org.jline.terminal.impl.jna.win.Kernel32$MENU_EVENT_RECORD",
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jline.terminal.impl.jna.win.Kernel32$MOUSE_EVENT_RECORD"
+      },
+      "type" : "org.jline.terminal.impl.jna.win.Kernel32$MOUSE_EVENT_RECORD",
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jline.terminal.impl.jna.win.Kernel32$SMALL_RECT"
+      },
+      "type" : "org.jline.terminal.impl.jna.win.Kernel32$SMALL_RECT",
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jline.terminal.impl.jna.win.Kernel32$UnionChar"
+      },
+      "type" : "org.jline.terminal.impl.jna.win.Kernel32$UnionChar",
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jline.terminal.impl.jna.win.Kernel32$WINDOW_BUFFER_SIZE_RECORD"
+      },
+      "type" : "org.jline.terminal.impl.jna.win.Kernel32$WINDOW_BUFFER_SIZE_RECORD",
+      "allDeclaredFields" : true
+    }
+  ]
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7652

This PR provides new metadata needed for the org.jline:jline-terminal-jna:3.20.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.jline:jline-terminal-jna:3.20.0`): 22
- Test-only metadata entries (previous `org.jline:jline-terminal-jna:3.20.0`): 27
- Metadata entries (new `org.jline:jline-terminal-jna:3.20.0`): 22
- Test-only metadata entries (new `org.jline:jline-terminal-jna:3.20.0`): 27
- Library coverage (previous): 16.24%
- Library coverage (new): 16.24%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `404875454e3cdf7856c26fee01389fa653ac2673`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `org.jline:jline-terminal-jna:3.20.0` and `org.jline:jline-terminal-jna:3.20.0`.

### Local CI Verification

- Status: `success`
- Commands run: 0
- Fixup attempts: 0
