### PR TITLE
[Automation] Generated metadata for org.apache.kafka:kafka-streams:3.6.0

### DIFF
--- a/metadata/org.apache.kafka/kafka-streams/3.6.0/reachability-metadata.json
+++ b/metadata/org.apache.kafka/kafka-streams/3.6.0/reachability-metadata.json
@@ -26,17 +26,6 @@
     },
     {
       "condition" : {
-        "typeReached" : "org.apache.kafka.streams.integration.TaskAssignorIntegrationTest"
-      },
-      "type" : "org.apache.kafka.clients.consumer.KafkaConsumer",
-      "fields" : [
-        {
-          "name" : "assignors"
-        }
-      ]
-    },
-    {
-      "condition" : {
         "typeReached" : "org.apache.kafka.clients.consumer.KafkaConsumer"
       },
       "type" : "org.apache.kafka.clients.consumer.RangeAssignor",
@@ -58,12 +47,6 @@
           "parameterTypes" : [ ]
         }
       ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.apache.kafka.streams.integration.IQv2IntegrationTest"
-      },
-      "type" : "org.apache.kafka.common.resource.PatternType[]"
     },
     {
       "condition" : {
@@ -145,51 +128,6 @@
     },
     {
       "condition" : {
-        "typeReached" : "org.apache.kafka.common.config.AbstractConfig"
-      },
-      "type" : "org.apache.kafka.coordinator.group.assignor.RangeAssignor",
-      "methods" : [
-        {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
-        }
-      ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.apache.kafka.streams.integration.IQv2IntegrationTest"
-      },
-      "type" : "org.apache.kafka.streams.KafkaStreams",
-      "fields" : [
-        {
-          "name" : "threads"
-        }
-      ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.apache.kafka.streams.integration.TaskAssignorIntegrationTest"
-      },
-      "type" : "org.apache.kafka.streams.KafkaStreams",
-      "fields" : [
-        {
-          "name" : "threads"
-        }
-      ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.apache.kafka.streams.integration.utils.IntegrationTestUtils"
-      },
-      "type" : "org.apache.kafka.streams.KafkaStreams",
-      "fields" : [
-        {
-          "name" : "stateListener"
-        }
-      ]
-    },
-    {
-      "condition" : {
         "typeReached" : "org.apache.kafka.common.config.ConfigDef"
       },
       "type" : "org.apache.kafka.streams.errors.DefaultProductionExceptionHandler"
@@ -234,18 +172,6 @@
     },
     {
       "condition" : {
-        "typeReached" : "org.apache.kafka.streams.integration.TaskAssignorIntegrationTest"
-      },
-      "type" : "org.apache.kafka.streams.integration.TaskAssignorIntegrationTest$MyTaskAssignor",
-      "methods" : [
-        {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
-        }
-      ]
-    },
-    {
-      "condition" : {
         "typeReached" : "org.apache.kafka.streams.kstream.internals.KStreamImpl"
       },
       "type" : "org.apache.kafka.streams.kstream.KStream[]"
@@ -270,12 +196,6 @@
     },
     {
       "condition" : {
-        "typeReached" : "org.apache.kafka.test.StreamsTestUtils$TaskBuilder"
-      },
-      "type" : "org.apache.kafka.streams.processor.internals.AbstractTask"
-    },
-    {
-      "condition" : {
         "typeReached" : "org.apache.kafka.common.config.ConfigDef"
       },
       "type" : "org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier"
@@ -289,178 +209,6 @@
         {
           "name" : "<init>",
           "parameterTypes" : [ ]
-        }
-      ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.apache.kafka.test.StreamsTestUtils$TaskBuilder"
-      },
-      "type" : "org.apache.kafka.streams.processor.internals.ProcessorNodePunctuator"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.apache.kafka.streams.state.KeyValueStoreTestDriver"
-      },
-      "type" : "org.apache.kafka.streams.processor.internals.ProcessorTopology"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.apache.kafka.streams.processor.internals.ReadOnlyTaskTest"
-      },
-      "type" : "org.apache.kafka.streams.processor.internals.ReadOnlyTask",
-      "methods" : [
-        {
-          "name" : "addPartitionsForOffsetReset",
-          "parameterTypes" : [
-            "java.util.Set"
-          ]
-        },
-        {
-          "name" : "addRecords",
-          "parameterTypes" : [
-            "org.apache.kafka.common.TopicPartition",
-            "java.lang.Iterable"
-          ]
-        },
-        {
-          "name" : "clearTaskTimeout",
-          "parameterTypes" : [ ]
-        },
-        {
-          "name" : "closeClean",
-          "parameterTypes" : [ ]
-        },
-        {
-          "name" : "closeDirty",
-          "parameterTypes" : [ ]
-        },
-        {
-          "name" : "commitNeeded",
-          "parameterTypes" : [ ]
-        },
-        {
-          "name" : "committedOffsets",
-          "parameterTypes" : [ ]
-        },
-        {
-          "name" : "completeRestoration",
-          "parameterTypes" : [
-            "java.util.function.Consumer"
-          ]
-        },
-        {
-          "name" : "getStore",
-          "parameterTypes" : [
-            "java.lang.String"
-          ]
-        },
-        {
-          "name" : "highWaterMark",
-          "parameterTypes" : [ ]
-        },
-        {
-          "name" : "initializeIfNeeded",
-          "parameterTypes" : [ ]
-        },
-        {
-          "name" : "markChangelogAsCorrupted",
-          "parameterTypes" : [
-            "java.util.Collection"
-          ]
-        },
-        {
-          "name" : "maybeCheckpoint",
-          "parameterTypes" : [
-            "boolean"
-          ]
-        },
-        {
-          "name" : "maybeInitTaskTimeoutOrThrow",
-          "parameterTypes" : [
-            "long",
-            "java.lang.Exception"
-          ]
-        },
-        {
-          "name" : "maybePunctuateStreamTime",
-          "parameterTypes" : [ ]
-        },
-        {
-          "name" : "maybePunctuateSystemTime",
-          "parameterTypes" : [ ]
-        },
-        {
-          "name" : "postCommit",
-          "parameterTypes" : [
-            "boolean"
-          ]
-        },
-        {
-          "name" : "prepareCommit",
-          "parameterTypes" : [ ]
-        },
-        {
-          "name" : "prepareRecycle",
-          "parameterTypes" : [ ]
-        },
-        {
-          "name" : "process",
-          "parameterTypes" : [
-            "long"
-          ]
-        },
-        {
-          "name" : "purgeableOffsets",
-          "parameterTypes" : [ ]
-        },
-        {
-          "name" : "recordProcessBatchTime",
-          "parameterTypes" : [
-            "long"
-          ]
-        },
-        {
-          "name" : "recordProcessTimeRatioAndBufferSize",
-          "parameterTypes" : [
-            "long",
-            "long"
-          ]
-        },
-        {
-          "name" : "recordRestoration",
-          "parameterTypes" : [
-            "org.apache.kafka.common.utils.Time",
-            "long",
-            "boolean"
-          ]
-        },
-        {
-          "name" : "resume",
-          "parameterTypes" : [ ]
-        },
-        {
-          "name" : "revive",
-          "parameterTypes" : [ ]
-        },
-        {
-          "name" : "stateManager",
-          "parameterTypes" : [ ]
-        },
-        {
-          "name" : "suspend",
-          "parameterTypes" : [ ]
-        },
-        {
-          "name" : "timeCurrentIdlingStarted",
-          "parameterTypes" : [ ]
-        },
-        {
-          "name" : "updateInputPartitions",
-          "parameterTypes" : [
-            "java.util.Set",
-            "java.util.Map"
-          ]
         }
       ]
     },
@@ -483,54 +231,6 @@
     },
     {
       "condition" : {
-        "typeReached" : "org.apache.kafka.test.StreamsTestUtils$TaskBuilder"
-      },
-      "type" : "org.apache.kafka.streams.processor.internals.StreamTask"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.apache.kafka.streams.integration.IQv2IntegrationTest"
-      },
-      "type" : "org.apache.kafka.streams.processor.internals.StreamThread",
-      "fields" : [
-        {
-          "name" : "state"
-        },
-        {
-          "name" : "stateLock"
-        }
-      ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.apache.kafka.streams.integration.TaskAssignorIntegrationTest"
-      },
-      "type" : "org.apache.kafka.streams.processor.internals.StreamThread",
-      "fields" : [
-        {
-          "name" : "mainConsumer"
-        }
-      ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.apache.kafka.streams.integration.TaskAssignorIntegrationTest"
-      },
-      "type" : "org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor",
-      "fields" : [
-        {
-          "name" : "assignmentConfigs"
-        },
-        {
-          "name" : "assignmentListener"
-        },
-        {
-          "name" : "taskAssignorSupplier"
-        }
-      ]
-    },
-    {
-      "condition" : {
         "typeReached" : "org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier"
       },
       "type" : "org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor",
@@ -540,12 +240,6 @@
           "parameterTypes" : [ ]
         }
       ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.apache.kafka.test.StreamsTestUtils$TaskBuilder"
-      },
-      "type" : "org.apache.kafka.streams.processor.internals.Task"
     },
     {
       "condition" : {
@@ -606,93 +300,9 @@
       "allDeclaredMethods" : true,
       "allDeclaredConstructors" : true,
       "jniAccessible" : true
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.apache.kafka.streams.state.internals.RocksDBStoreTest"
-      },
-      "type" : "org.apache.kafka.streams.state.internals.RocksDBStore",
-      "fields" : [
-        {
-          "name" : "statistics"
-        }
-      ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.apache.kafka.streams.state.internals.RocksDBStoreTest"
-      },
-      "type" : "org.apache.kafka.test.MockRocksDbConfigSetter",
-      "methods" : [
-        {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
-        }
-      ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.mockito.internal.configuration.plugins.PluginLoader"
-      },
-      "type" : {
-        "proxy" : [
-          "org.mockito.plugins.MockMaker"
-        ]
-      }
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.mockito.internal.configuration.plugins.DefaultMockitoPlugins"
-      },
-      "type" : "org.mockito.internal.creation.bytebuddy.ByteBuddyMockMaker",
-      "methods" : [
-        {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
-        }
-      ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.mockito.internal.runners.util.RunnerProvider"
-      },
-      "type" : "org.mockito.internal.runners.DefaultInternalRunner",
-      "methods" : [
-        {
-          "name" : "<init>",
-          "parameterTypes" : [
-            "java.lang.Class",
-            "org.mockito.internal.util.Supplier"
-          ]
-        }
-      ]
     }
   ],
   "resources" : [
-    {
-      "condition" : {
-        "typeReached" : "org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster"
-      },
-      "glob" : "META-INF/services/ch.qos.logback.classic.spi.Configurator"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster"
-      },
-      "glob" : "META-INF/services/java.time.zone.ZoneRulesProvider"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster"
-      },
-      "glob" : "META-INF/services/javax.xml.parsers.SAXParserFactory"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster"
-      },
-      "glob" : "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
-    },
     {
       "condition" : {
         "typeReached" : "org.apache.kafka.streams.internals.metrics.ClientMetrics"
@@ -716,73 +326,6 @@
         "typeReached" : "org.apache.kafka.streams.state.internals.CachingKeyValueStore"
       },
       "glob" : "librocksdbjni-linux64.so"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster"
-      },
-      "glob" : "logback-test.xml"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.apache.kafka.test.StreamsTestUtils$TaskBuilder"
-      },
-      "glob" : "mockito-extensions/org.mockito.plugins.AnnotationEngine"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.apache.kafka.test.StreamsTestUtils$TaskBuilder"
-      },
-      "glob" : "mockito-extensions/org.mockito.plugins.DoNotMockEnforcer"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.apache.kafka.test.StreamsTestUtils$TaskBuilder"
-      },
-      "glob" : "mockito-extensions/org.mockito.plugins.InstantiatorProvider2"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.apache.kafka.test.StreamsTestUtils$TaskBuilder"
-      },
-      "glob" : "mockito-extensions/org.mockito.plugins.MemberAccessor"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.apache.kafka.test.StreamsTestUtils$TaskBuilder"
-      },
-      "glob" : "mockito-extensions/org.mockito.plugins.MockMaker"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.apache.kafka.test.StreamsTestUtils$TaskBuilder"
-      },
-      "glob" : "mockito-extensions/org.mockito.plugins.MockResolver"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.apache.kafka.test.StreamsTestUtils$TaskBuilder"
-      },
-      "glob" : "mockito-extensions/org.mockito.plugins.MockitoLogger"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.apache.kafka.test.StreamsTestUtils$TaskBuilder"
-      },
-      "glob" : "mockito-extensions/org.mockito.plugins.PluginSwitch"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.apache.kafka.test.StreamsTestUtils$TaskBuilder"
-      },
-      "glob" : "mockito-extensions/org.mockito.plugins.StackTraceCleanerProvider"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.apache.kafka.streams.integration.IQv2IntegrationTest"
-      },
-      "module" : "jdk.jfr",
-      "glob" : "jdk/jfr/internal/query/view.ini"
     }
   ]
 }

--- a/metadata/org.apache.kafka/kafka-streams/index.json
+++ b/metadata/org.apache.kafka/kafka-streams/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "3.6.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/apache/kafka/kafka-streams/$version$/kafka-streams-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/kafka",
+    "test-code-url" : "https://repo1.maven.org/maven2/org/apache/kafka/kafka-streams/$version$/kafka-streams-$version$-test-sources.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/apache/kafka/kafka-streams/$version$/kafka-streams-$version$-javadoc.jar",
+    "description" : "Apache Kafka Streams is a client library for building applications and microservices that process data stored in Kafka clusters. It lets Java applications define stream-processing topologies to transform, join, aggregate, and materialize event streams and tables.",
     "tested-versions" : [
       "3.6.0",
       "3.6.1",

--- a/stats/org.apache.kafka/kafka-streams/3.6.0/stats.json
+++ b/stats/org.apache.kafka/kafka-streams/3.6.0/stats.json
@@ -20,21 +20,21 @@
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 38652,
-        "missed" : 612788,
-        "ratio" : 0.059333,
+        "covered" : 38827,
+        "missed" : 612613,
+        "ratio" : 0.059602,
         "total" : 651440
       },
       "line" : {
-        "covered" : 8571,
-        "missed" : 103824,
-        "ratio" : 0.076258,
+        "covered" : 8611,
+        "missed" : 103784,
+        "ratio" : 0.076614,
         "total" : 112395
       },
       "method" : {
-        "covered" : 1855,
-        "missed" : 17428,
-        "ratio" : 0.096199,
+        "covered" : 1864,
+        "missed" : 17419,
+        "ratio" : 0.096665,
         "total" : 19283
       }
     }

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,82 +1,22 @@
 {
-  "reflection": [
+  "resources" : [
     {
-      "fields": [
-        {
-          "name": "stateListener"
-        }
-      ],
-      "type": "org.apache.kafka.streams.KafkaStreams"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.zookeeper.ZooKeeper"
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.integration.QueryableStateIntegrationTest"
       },
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "org.apache.zookeeper.client.ZKClientConfig"
-          ]
-        }
-      ],
-      "type": "org.apache.zookeeper.ClientCnxnSocketNIO"
+      "glob" : "QueryableStateIntegrationTest/inputValues.txt"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.zookeeper.server.watch.WatchManagerFactory"
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster"
       },
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ],
-      "type": "org.apache.zookeeper.server.watch.WatchManager"
+      "glob" : "logback.xml"
     },
     {
-      "condition": {
-        "typeReached": "javax.security.auth.login.Configuration"
-      },
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ],
-      "type": "sun.security.provider.ConfigFile"
+      "glob" : "logback.xml"
     },
     {
-      "condition": {
-        "typeReached": "kafka.server.KafkaConfig"
-      },
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ],
-      "type": "org.apache.kafka.coordinator.group.assignor.RangeAssignor"
-    }
-  ],
-  "resources": [
-    {
-      "condition": {
-        "typeReached": "org.apache.kafka.streams.integration.QueryableStateIntegrationTest"
-      },
-      "glob": "QueryableStateIntegrationTest/inputValues.txt"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster"
-      },
-      "glob": "logback.xml"
-    },
-    {
-      "glob": "logback.xml"
-    },
-    {
-      "glob": "QueryableStateIntegrationTest/inputValues.txt"
+      "glob" : "QueryableStateIntegrationTest/inputValues.txt"
     }
   ]
 }


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7651

This PR provides new metadata needed for the org.apache.kafka:kafka-streams:3.6.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.apache.kafka:kafka-streams:3.6.0`): 64
- Test-only metadata entries (previous `org.apache.kafka:kafka-streams:3.6.0`): 4
- Metadata entries (new `org.apache.kafka:kafka-streams:3.6.0`): 64
- Test-only metadata entries (new `org.apache.kafka:kafka-streams:3.6.0`): 4
- Library coverage (previous): 7.66%
- Library coverage (new): 7.66%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `404875454e3cdf7856c26fee01389fa653ac2673`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `org.apache.kafka:kafka-streams:3.6.0` and `org.apache.kafka:kafka-streams:3.6.0`.

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
