### PR TITLE
[Automation] Generated metadata for org.apache-extras.beanshell:bsh:2.0b6

### DIFF
--- a/metadata/org.apache-extras.beanshell/bsh/2.0b6/reachability-metadata.json
+++ b/metadata/org.apache-extras.beanshell/bsh/2.0b6/reachability-metadata.json
@@ -2,63 +2,6 @@
   "reflection" : [
     {
       "condition" : {
-        "typeReached" : "bsh.ClassGeneratorImpl"
-      },
-      "type" : "ClassGeneratorUtilScriptedException",
-      "fields" : [
-        {
-          "name" : "_bshStaticClassGeneratorUtilScriptedException"
-        }
-      ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "bsh.ClassGeneratorUtil"
-      },
-      "type" : "ClassGeneratorUtilScriptedException",
-      "fields" : [
-        {
-          "name" : "_bshThisClassGeneratorUtilScriptedException"
-        }
-      ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "bsh.NameSpace"
-      },
-      "type" : "ClassGeneratorUtilScriptedException"
-    },
-    {
-      "condition" : {
-        "typeReached" : "bsh.Reflect"
-      },
-      "type" : "ClassGeneratorUtilScriptedException",
-      "fields" : [
-        {
-          "name" : "_bshStaticClassGeneratorUtilScriptedException"
-        }
-      ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "bsh.BSHUnaryExpression"
-      },
-      "type" : "Primitive"
-    },
-    {
-      "condition" : {
-        "typeReached" : "bsh.BSHArguments"
-      },
-      "type" : "String"
-    },
-    {
-      "condition" : {
-        "typeReached" : "bsh.BSHReturnType"
-      },
-      "type" : "String"
-    },
-    {
-      "condition" : {
         "typeReached" : "bsh.Reflect"
       },
       "type" : "java.lang.String",
@@ -70,18 +13,6 @@
           ]
         }
       ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "bsh.BSHType"
-      },
-      "type" : "String"
-    },
-    {
-      "condition" : {
-        "typeReached" : "bsh.NameSpace"
-      },
-      "type" : "bsh"
     },
     {
       "condition" : {
@@ -368,12 +299,6 @@
     },
     {
       "condition" : {
-        "typeReached" : "bsh.NameSpace"
-      },
-      "type" : "java.awt.bsh"
-    },
-    {
-      "condition" : {
         "typeReached" : "bsh.util.ClassBrowser"
       },
       "type" : "java.awt.event.KeyEvent",
@@ -505,12 +430,6 @@
         "typeReached" : "bsh.util.ClassBrowser"
       },
       "type" : "java.awt.event.MouseMotionListener[]"
-    },
-    {
-      "condition" : {
-        "typeReached" : "bsh.NameSpace"
-      },
-      "type" : "java.awt.event.bsh"
     },
     {
       "condition" : {
@@ -895,12 +814,6 @@
     },
     {
       "condition" : {
-        "typeReached" : "bsh.NameSpace"
-      },
-      "type" : "java.io.bsh"
-    },
-    {
-      "condition" : {
         "typeReached" : "bsh.util.ClassBrowser"
       },
       "type" : "java.lang.System",
@@ -1110,12 +1023,6 @@
     },
     {
       "condition" : {
-        "typeReached" : "bsh.NameSpace"
-      },
-      "type" : "java.lang.bsh"
-    },
-    {
-      "condition" : {
         "typeReached" : "bsh.BSHIfStatement"
       },
       "type" : "java.lang.constant.Constable"
@@ -1188,12 +1095,6 @@
     },
     {
       "condition" : {
-        "typeReached" : "bsh.NameSpace"
-      },
-      "type" : "java.net.bsh"
-    },
-    {
-      "condition" : {
         "typeReached" : "bsh.CollectionManager"
       },
       "type" : "java.util.Collection"
@@ -1203,24 +1104,6 @@
         "typeReached" : "bsh.BshClassManager"
       },
       "type" : "java.util.HashMap"
-    },
-    {
-      "condition" : {
-        "typeReached" : "bsh.NameSpace"
-      },
-      "type" : "java.util.bsh"
-    },
-    {
-      "condition" : {
-        "typeReached" : "bsh.NameSpace"
-      },
-      "type" : "javax.swing.bsh"
-    },
-    {
-      "condition" : {
-        "typeReached" : "bsh.NameSpace"
-      },
-      "type" : "javax.swing.event.bsh"
     },
     {
       "condition" : {
@@ -2649,36 +2532,6 @@
   "resources" : [
     {
       "condition" : {
-        "typeReached" : "bsh.BSHUnaryExpression"
-      },
-      "glob" : "Primitive.java"
-    },
-    {
-      "condition" : {
-        "typeReached" : "bsh.BSHArguments"
-      },
-      "glob" : "String.java"
-    },
-    {
-      "condition" : {
-        "typeReached" : "bsh.BSHReturnType"
-      },
-      "glob" : "String.java"
-    },
-    {
-      "condition" : {
-        "typeReached" : "bsh.BSHType"
-      },
-      "glob" : "String.java"
-    },
-    {
-      "condition" : {
-        "typeReached" : "bsh.NameSpace"
-      },
-      "glob" : "bsh.java"
-    },
-    {
-      "condition" : {
         "typeReached" : "bsh.NameSpace"
       },
       "glob" : "bsh/commands/print.bsh"
@@ -2688,82 +2541,6 @@
         "typeReached" : "bsh.util.HttpdConnection"
       },
       "glob" : "bsh/util/lib/remote.html"
-    },
-    {
-      "condition" : {
-        "typeReached" : "bsh.NameSpace"
-      },
-      "glob" : "java/awt/bsh.java"
-    },
-    {
-      "condition" : {
-        "typeReached" : "bsh.NameSpace"
-      },
-      "glob" : "java/awt/event/bsh.java"
-    },
-    {
-      "condition" : {
-        "typeReached" : "bsh.NameSpace"
-      },
-      "glob" : "java/io/bsh.java"
-    },
-    {
-      "condition" : {
-        "typeReached" : "bsh.NameSpace"
-      },
-      "glob" : "java/lang/bsh.java"
-    },
-    {
-      "condition" : {
-        "typeReached" : "bsh.NameSpace"
-      },
-      "glob" : "java/net/bsh.java"
-    },
-    {
-      "condition" : {
-        "typeReached" : "bsh.NameSpace"
-      },
-      "glob" : "java/util/bsh.java"
-    },
-    {
-      "condition" : {
-        "typeReached" : "bsh.NameSpace"
-      },
-      "glob" : "javax/swing/bsh.java"
-    },
-    {
-      "condition" : {
-        "typeReached" : "bsh.NameSpace"
-      },
-      "glob" : "javax/swing/event/bsh.java"
-    },
-    {
-      "condition" : {
-        "typeReached" : "bsh.NameSpace"
-      },
-      "module" : "java.base",
-      "glob" : "java/io/bsh.java"
-    },
-    {
-      "condition" : {
-        "typeReached" : "bsh.NameSpace"
-      },
-      "module" : "java.base",
-      "glob" : "java/lang/bsh.java"
-    },
-    {
-      "condition" : {
-        "typeReached" : "bsh.NameSpace"
-      },
-      "module" : "java.base",
-      "glob" : "java/net/bsh.java"
-    },
-    {
-      "condition" : {
-        "typeReached" : "bsh.NameSpace"
-      },
-      "module" : "java.base",
-      "glob" : "java/util/bsh.java"
     },
     {
       "condition" : {
@@ -2792,34 +2569,6 @@
       },
       "module" : "java.desktop",
       "glob" : "com/sun/swing/internal/plaf/metal/resources/metal_en_US.properties"
-    },
-    {
-      "condition" : {
-        "typeReached" : "bsh.NameSpace"
-      },
-      "module" : "java.desktop",
-      "glob" : "java/awt/bsh.java"
-    },
-    {
-      "condition" : {
-        "typeReached" : "bsh.NameSpace"
-      },
-      "module" : "java.desktop",
-      "glob" : "java/awt/event/bsh.java"
-    },
-    {
-      "condition" : {
-        "typeReached" : "bsh.NameSpace"
-      },
-      "module" : "java.desktop",
-      "glob" : "javax/swing/bsh.java"
-    },
-    {
-      "condition" : {
-        "typeReached" : "bsh.NameSpace"
-      },
-      "module" : "java.desktop",
-      "glob" : "javax/swing/event/bsh.java"
     },
     {
       "condition" : {


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7649

This PR provides new metadata needed for the org.apache-extras.beanshell:bsh:2.0b6, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.apache-extras.beanshell:bsh:2.0b6`): 550
- Test-only metadata entries (previous `org.apache-extras.beanshell:bsh:2.0b6`): 18
- Metadata entries (new `org.apache-extras.beanshell:bsh:2.0b6`): 550
- Test-only metadata entries (new `org.apache-extras.beanshell:bsh:2.0b6`): 18
- Library coverage (previous): 41.70%
- Library coverage (new): 41.70%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3c4fe2d725e2e0e710ab438dc7b3a1d36a853e96`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `org.apache-extras.beanshell:bsh:2.0b6` and `org.apache-extras.beanshell:bsh:2.0b6`.

### Local CI Verification

- Status: `success`
- Commands run: 0
- Fixup attempts: 0
