### PR TITLE
[Automation] Generated metadata for org.aesh:readline:3.1

### DIFF
--- a/stats/org.aesh/readline/3.1/stats.json
+++ b/stats/org.aesh/readline/3.1/stats.json
@@ -20,15 +20,15 @@
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 15941,
-        "missed" : 89365,
-        "ratio" : 0.151378,
+        "covered" : 15969,
+        "missed" : 89337,
+        "ratio" : 0.151644,
         "total" : 105306
       },
       "line" : {
-        "covered" : 2601,
-        "missed" : 17208,
-        "ratio" : 0.131304,
+        "covered" : 2603,
+        "missed" : 17206,
+        "ratio" : 0.131405,
         "total" : 19809
       },
       "method" : {


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7648

This PR provides new metadata needed for the org.aesh:readline:3.1, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.aesh:readline:3.1`): 21
- Metadata entries (new `org.aesh:readline:3.1`): 21
- Library coverage (previous): 13.14%
- Library coverage (new): 13.14%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `ba3bc3a41c511483fdc0c09ee76856a341047083`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `org.aesh:readline:3.1` and `org.aesh:readline:3.1`.

### Local CI Verification

- Status: `success`
- Commands run: 0
- Fixup attempts: 0
