### PR TITLE
[GenAI] Mark org.springframework.boot:spring-boot-starter-micrometer-metrics as not for Native Image

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-starter-micrometer-metrics/index.json
+++ b/metadata/org.springframework.boot/spring-boot-starter-micrometer-metrics/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published spring-boot-starter-micrometer-metrics-4.0.6 JAR contains only META-INF/MANIFEST.MF, LICENSE.txt, and NOTICE.txt and no JVM class files; it is a dependency starter whose runtime classes are supplied by dependencies.",
+    "replacement": "Use class-bearing dependencies such as org.springframework.boot:spring-boot-micrometer-metrics:4.0.6 for reachability metadata."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #7695

This PR records `org.springframework.boot:spring-boot-starter-micrometer-metrics` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published spring-boot-starter-micrometer-metrics-4.0.6 JAR contains only META-INF/MANIFEST.MF, LICENSE.txt, and NOTICE.txt and no JVM class files; it is a dependency starter whose runtime classes are supplied by dependencies.

Replacement guidance:
- Use class-bearing dependencies such as org.springframework.boot:spring-boot-micrometer-metrics:4.0.6 for reachability metadata.

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `ba3bc3a41c511483fdc0c09ee76856a341047083`

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
