### PR TITLE
[GenAI] Add support for io.awspring.cloud:spring-cloud-aws-core:4.0.2 using gpt-5.5

### DIFF
--- a/metadata/io.awspring.cloud/spring-cloud-aws-core/4.0.2/reachability-metadata.json
+++ b/metadata/io.awspring.cloud/spring-cloud-aws-core/4.0.2/reachability-metadata.json
@@ -1,0 +1,90 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "io.awspring.cloud.core.support.JacksonPresent"
+      },
+      "type" : "com.fasterxml.jackson.databind.ObjectMapper"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.awspring.cloud.core.config.AwsPropertySource"
+      },
+      "type" : "org.apache.commons.logging.LogFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.awspring.cloud.core.config.AwsPropertySource"
+      },
+      "type" : "org.apache.commons.logging.impl.Log4jApiLogFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.awspring.cloud.core.config.AwsPropertySource"
+      },
+      "type" : "org.apache.commons.logging.impl.Slf4jLogFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.awspring.cloud.core.config.AwsPropertySource"
+      },
+      "type" : "org.apache.commons.logging.impl.WeakHashtable",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.awspring.cloud.core.config.AwsPropertySource"
+      },
+      "type" : "org.apache.logging.slf4j.SLF4JProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.awspring.cloud.core.support.JacksonPresent"
+      },
+      "type" : "tools.jackson.databind.ObjectMapper"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "io.awspring.cloud.core.config.AwsPropertySource"
+      },
+      "glob" : "META-INF/services/org.apache.commons.logging.LogFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.awspring.cloud.core.config.AwsPropertySource"
+      },
+      "glob" : "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.awspring.cloud.core.config.AwsPropertySource"
+      },
+      "glob" : "commons-logging.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.awspring.cloud.core.SpringCloudClientConfiguration"
+      },
+      "glob" : "io/awspring/cloud/core/SpringCloudClientConfiguration.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.awspring.cloud.core.config.AwsPropertySource"
+      },
+      "glob" : "org/slf4j/impl/StaticLoggerBinder.class"
+    }
+  ]
+}

--- a/metadata/io.awspring.cloud/spring-cloud-aws-core/index.json
+++ b/metadata/io.awspring.cloud/spring-cloud-aws-core/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.0.2",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/awspring/cloud/spring-cloud-aws-core/$version$/spring-cloud-aws-core-$version$-sources.jar",
+    "repository-url" : "https://github.com/awspring/spring-cloud-aws",
+    "test-code-url" : "https://github.com/awspring/spring-cloud-aws/tree/v$version$/spring-cloud-aws-core/src/test/java",
+    "documentation-url" : "https://docs.awspring.io/spring-cloud-aws/docs/$version$/reference/html/index.html",
+    "description" : "Spring Cloud AWS Core provides foundational Spring integration for AWS services, including shared credential and region provider support used by the Spring Cloud AWS modules. It supplies the common configuration classes and runtime hints that let Spring and Spring Boot applications create AWS SDK clients using Spring idioms.",
+    "tested-versions" : [
+      "4.0.2"
+    ],
+    "allowed-packages" : [
+      "io.awspring.cloud.core"
+    ]
+  }
+]

--- a/stats/io.awspring.cloud/spring-cloud-aws-core/4.0.2/execution-metrics.json
+++ b/stats/io.awspring.cloud/spring-cloud-aws-core/4.0.2/execution-metrics.json
@@ -1,0 +1,57 @@
+{
+  "add_new_library_support:2026-06-07": {
+    "timestamp": "2026-06-07T03:06:43.177442Z",
+    "library": "io.awspring.cloud:spring-cloud-aws-core:4.0.2",
+    "starting_commit": "117dc1f901cf5ec586b911683b794db28efc8221",
+    "ending_commit": "ffb8a326b9485f10e073722aa280fb76f2668f44",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.0.2",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 83,
+          "missed": 27,
+          "ratio": 0.754545,
+          "total": 110
+        },
+        "line": {
+          "covered": 30,
+          "missed": 4,
+          "ratio": 0.882353,
+          "total": 34
+        },
+        "method": {
+          "covered": 13,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 13
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 94897,
+      "cached_input_tokens_used": 1822720,
+      "output_tokens_used": 16033,
+      "iterations": 3,
+      "cost_usd": 1.3924,
+      "generated_loc": 131,
+      "tested_library_loc": 30,
+      "metadata_entries": 14,
+      "test_only_metadata_entries": 20,
+      "code_coverage_percent": 88.24
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/src/test/java/io_awspring_cloud/spring_cloud_aws_core/Spring_cloud_aws_coreTest.java",
+      "metadata_file": "metadata/io.awspring.cloud/spring-cloud-aws-core/4.0.2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.awspring.cloud/spring-cloud-aws-core/4.0.2/stats.json
+++ b/stats/io.awspring.cloud/spring-cloud-aws-core/4.0.2/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.0.2",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 83,
+        "missed" : 27,
+        "ratio" : 0.754545,
+        "total" : 110
+      },
+      "line" : {
+        "covered" : 30,
+        "missed" : 4,
+        "ratio" : 0.882353,
+        "total" : 34
+      },
+      "method" : {
+        "covered" : 13,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 13
+      }
+    }
+  } ]
+}

--- a/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/.gitignore
+++ b/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/build.gradle
+++ b/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.awspring.cloud:spring-cloud-aws-core:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/gradle.properties
+++ b/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.awspring.cloud:spring-cloud-aws-core:4.0.2
+library.version = 4.0.2
+metadata.dir = io.awspring.cloud/spring-cloud-aws-core/4.0.2/

--- a/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/settings.gradle
+++ b/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.awspring.cloud.spring-cloud-aws-core_tests'

--- a/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/src/test/java/io_awspring_cloud/spring_cloud_aws_core/Spring_cloud_aws_coreTest.java
+++ b/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/src/test/java/io_awspring_cloud/spring_cloud_aws_core/Spring_cloud_aws_coreTest.java
@@ -15,10 +15,13 @@ import io.awspring.cloud.core.config.AwsPropertySource;
 import io.awspring.cloud.core.region.StaticRegionProvider;
 import io.awspring.cloud.core.support.JacksonPresent;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.aot.hint.ResourcePatternHint;
 import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.core.io.support.SpringFactoriesLoader;
 import org.springframework.util.ClassUtils;
 import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.regions.Region;
@@ -92,6 +95,16 @@ public class Spring_cloud_aws_coreTest {
                 .flatMap(resourcePatternHints -> resourcePatternHints.getIncludes().stream())
                 .map(ResourcePatternHint::getPattern))
                 .contains("io/awspring/cloud/core/SpringCloudClientConfiguration.properties");
+    }
+
+    @Test
+    void runtimeHintsRegistrarIsDiscoverableFromSpringAotFactories() {
+        List<RuntimeHintsRegistrar> registrars = SpringFactoriesLoader
+                .forResourceLocation("META-INF/spring/aot.factories", getClass().getClassLoader())
+                .load(RuntimeHintsRegistrar.class);
+
+        assertThat(registrars)
+                .anySatisfy(registrar -> assertThat(registrar).isInstanceOf(AWSCoreRuntimeHints.class));
     }
 
     @Test

--- a/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/src/test/java/io_awspring_cloud/spring_cloud_aws_core/Spring_cloud_aws_coreTest.java
+++ b/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/src/test/java/io_awspring_cloud/spring_cloud_aws_core/Spring_cloud_aws_coreTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_awspring_cloud.spring_cloud_aws_core;
+
+import org.junit.jupiter.api.Test;
+
+class Spring_cloud_aws_coreTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/src/test/java/io_awspring_cloud/spring_cloud_aws_core/Spring_cloud_aws_coreTest.java
+++ b/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/src/test/java/io_awspring_cloud/spring_cloud_aws_core/Spring_cloud_aws_coreTest.java
@@ -59,6 +59,15 @@ public class Spring_cloud_aws_coreTest {
     }
 
     @Test
+    void staticRegionProviderSupportsCustomRegionIdentifiers() {
+        StaticRegionProvider provider = new StaticRegionProvider("local-test-1");
+
+        Region region = provider.getRegion();
+
+        assertThat(region.id()).isEqualTo("local-test-1");
+    }
+
+    @Test
     void staticRegionProviderRequiresRegionIdentifier() {
         assertThatThrownBy(() -> new StaticRegionProvider(null))
                 .isInstanceOf(IllegalArgumentException.class)

--- a/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/src/test/java/io_awspring_cloud/spring_cloud_aws_core/Spring_cloud_aws_coreTest.java
+++ b/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/src/test/java/io_awspring_cloud/spring_cloud_aws_core/Spring_cloud_aws_coreTest.java
@@ -6,11 +6,136 @@
  */
 package io_awspring_cloud.spring_cloud_aws_core;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class Spring_cloud_aws_coreTest {
+import io.awspring.cloud.core.AWSCoreRuntimeHints;
+import io.awspring.cloud.core.SpringCloudClientConfiguration;
+import io.awspring.cloud.core.config.AwsPropertySource;
+import io.awspring.cloud.core.region.StaticRegionProvider;
+import io.awspring.cloud.core.support.JacksonPresent;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.aot.hint.ResourcePatternHint;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.util.ClassUtils;
+import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
+import software.amazon.awssdk.regions.Region;
+
+public class Spring_cloud_aws_coreTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void springCloudClientConfigurationAddsSpringCloudAwsUserAgentSuffix() {
+        SpringCloudClientConfiguration configuration = new SpringCloudClientConfiguration("test-version");
+
+        String userAgentSuffix = configuration.clientOverrideConfiguration()
+                .advancedOption(SdkAdvancedClientOption.USER_AGENT_SUFFIX)
+                .orElseThrow();
+
+        assertThat(userAgentSuffix).isEqualTo("spring-cloud-aws/test-version");
+    }
+
+    @Test
+    void defaultSpringCloudClientConfigurationLoadsPackagedVersionResource() {
+        SpringCloudClientConfiguration configuration = new SpringCloudClientConfiguration();
+
+        String userAgentSuffix = configuration.clientOverrideConfiguration()
+                .advancedOption(SdkAdvancedClientOption.USER_AGENT_SUFFIX)
+                .orElseThrow();
+
+        assertThat(userAgentSuffix).startsWith("spring-cloud-aws/");
+        assertThat(userAgentSuffix).doesNotEndWith("/");
+    }
+
+    @Test
+    void staticRegionProviderAlwaysReturnsConfiguredRegion() {
+        StaticRegionProvider provider = new StaticRegionProvider("eu-central-1");
+
+        assertThat(provider.getRegion()).isEqualTo(Region.EU_CENTRAL_1);
+        assertThat(provider.getRegion()).isSameAs(provider.getRegion());
+    }
+
+    @Test
+    void staticRegionProviderRequiresRegionIdentifier() {
+        assertThatThrownBy(() -> new StaticRegionProvider(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("region is required");
+    }
+
+    @Test
+    void awsPropertySourceCanBeImplementedAsLazyCopyablePropertySource() {
+        Map<String, Object> source = new LinkedHashMap<>();
+        source.put("cloud.aws.region.static", "us-east-1");
+        source.put("cloud.aws.stack.auto", false);
+        InMemoryAwsPropertySource propertySource = new InMemoryAwsPropertySource("aws", source);
+
+        assertThat(propertySource.getName()).isEqualTo("aws");
+        assertThat(propertySource.getSource()).isSameAs(source);
+        assertThat(propertySource.getPropertyNames()).isEmpty();
+
+        propertySource.init();
+
+        assertThat(propertySource.getPropertyNames())
+                .containsExactly("cloud.aws.region.static", "cloud.aws.stack.auto");
+        assertThat(propertySource.getProperty("cloud.aws.region.static")).isEqualTo("us-east-1");
+        assertThat(propertySource.getProperty("cloud.aws.stack.auto")).isEqualTo(false);
+        assertThat(propertySource.copy().getPropertyNames()).isEmpty();
+    }
+
+    @Test
+    void runtimeHintsRegisterClientConfigurationVersionResource() {
+        RuntimeHints hints = new RuntimeHints();
+
+        new AWSCoreRuntimeHints().registerHints(hints, getClass().getClassLoader());
+
+        assertThat(hints.resources().resourcePatternHints()
+                .flatMap(resourcePatternHints -> resourcePatternHints.getIncludes().stream())
+                .map(ResourcePatternHint::getPattern))
+                .contains("io/awspring/cloud/core/SpringCloudClientConfiguration.properties");
+    }
+
+    @Test
+    void jacksonPresenceReportsClasspathAvailability() {
+        boolean jackson2Present = isClassPresent("com.fasterxml.jackson.databind.ObjectMapper")
+                && isClassPresent("com.fasterxml.jackson.core.JsonGenerator");
+        boolean jackson3Present = isClassPresent("tools.jackson.databind.ObjectMapper")
+                && isClassPresent("tools.jackson.core.JsonGenerator");
+
+        assertThat(JacksonPresent.isJackson2Present()).isEqualTo(jackson2Present);
+        assertThat(JacksonPresent.isJackson3Present()).isEqualTo(jackson3Present);
+    }
+
+    private static boolean isClassPresent(String className) {
+        return ClassUtils.isPresent(className, ClassUtils.getDefaultClassLoader());
+    }
+
+    private static final class InMemoryAwsPropertySource
+            extends AwsPropertySource<InMemoryAwsPropertySource, Map<String, Object>> {
+        private final Map<String, Object> initializedProperties = new LinkedHashMap<>();
+
+        private InMemoryAwsPropertySource(String name, Map<String, Object> source) {
+            super(name, source);
+        }
+
+        @Override
+        public void init() {
+            initializedProperties.clear();
+            initializedProperties.putAll(getSource());
+        }
+
+        @Override
+        public InMemoryAwsPropertySource copy() {
+            return new InMemoryAwsPropertySource(getName(), getSource());
+        }
+
+        @Override
+        public String[] getPropertyNames() {
+            return initializedProperties.keySet().toArray(String[]::new);
+        }
+
+        @Override
+        public Object getProperty(String name) {
+            return initializedProperties.get(name);
+        }
     }
 }

--- a/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,126 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "io_awspring_cloud.spring_cloud_aws_core.Spring_cloud_aws_coreTest"
+      },
+      "type" : "com.fasterxml.jackson.databind.ObjectMapper"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_awspring_cloud.spring_cloud_aws_core.Spring_cloud_aws_coreTest"
+      },
+      "type" : "io.awspring.cloud.core.AWSCoreRuntimeHints",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_awspring_cloud.spring_cloud_aws_core.Spring_cloud_aws_coreTest"
+      },
+      "type" : "kotlin.Metadata"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_awspring_cloud.spring_cloud_aws_core.Spring_cloud_aws_coreTest"
+      },
+      "type" : "kotlin.reflect.full.KClasses"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_awspring_cloud.spring_cloud_aws_core.Spring_cloud_aws_coreTest"
+      },
+      "type" : "org.springframework.aot.hint.support.KotlinDetectorRuntimeHints",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_awspring_cloud.spring_cloud_aws_core.Spring_cloud_aws_coreTest"
+      },
+      "type" : "org.springframework.aot.hint.support.ObjectToObjectConverterRuntimeHints",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_awspring_cloud.spring_cloud_aws_core.Spring_cloud_aws_coreTest"
+      },
+      "type" : "org.springframework.aot.hint.support.PathMatchingResourcePatternResolverRuntimeHints",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_awspring_cloud.spring_cloud_aws_core.Spring_cloud_aws_coreTest"
+      },
+      "type" : "org.springframework.aot.hint.support.SpringFactoriesLoaderRuntimeHints",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_awspring_cloud.spring_cloud_aws_core.Spring_cloud_aws_coreTest"
+      },
+      "type" : "org.springframework.aot.hint.support.SpringPropertiesRuntimeHints",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_awspring_cloud.spring_cloud_aws_core.Spring_cloud_aws_coreTest"
+      },
+      "type" : "org.springframework.util.ConcurrentReferenceHashMap$Segment[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_awspring_cloud.spring_cloud_aws_core.Spring_cloud_aws_coreTest"
+      },
+      "type" : "tools.jackson.databind.ObjectMapper"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "io_awspring_cloud.spring_cloud_aws_core.Spring_cloud_aws_coreTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_awspring_cloud.spring_cloud_aws_core.Spring_cloud_aws_coreTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_awspring_cloud.spring_cloud_aws_core.Spring_cloud_aws_coreTest"
+      },
+      "glob" : "META-INF/spring/aot.factories"
+    }
+  ]
+}

--- a/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/user-code-filter.json
+++ b/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.awspring.cloud.core.**"
+    }
+  ]
+}

--- a/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/user-code-filter.json
+++ b/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.awspring.cloud.core.**"
+      "includeClasses" : "io.awspring.cloud.core.**"
+    },
+    {
+      "includeClasses" : "io_awspring_cloud.spring_cloud_aws_core.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #7696

This PR introduces tests and metadata for io.awspring.cloud:spring-cloud-aws-core:4.0.2, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 94897
- Cached input tokens: 1822720
- Output tokens: 16033
- Metadata entries: 14
- Test-only metadata entries: 20
- Iterations: 3
- Library coverage percentage: 88.24
- Generated lines of code: 131
- Tested library lines of code: 30

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `da08d7a48fce53f6c6266e822538b41d7f3ced4e`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 83/110 (75.45%)
- Line: 30/34 (88.24%)
- Method: 13/13 (100.00%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
