### PR TITLE
[Automation] Generated metadata for io.netty:netty-transport-udt:4.1.74.Final

### DIFF
--- a/metadata/io.netty/netty-transport-udt/index.json
+++ b/metadata/io.netty/netty-transport-udt/index.json
@@ -2,10 +2,10 @@
   {
     "latest" : true,
     "metadata-version" : "4.1.74.Final",
-    "source-code-url" : "https://repo1.maven.org/maven2/io/netty/netty-transport-udt/4.1.74.Final/netty-transport-udt-4.1.74.Final-sources.jar",
+    "source-code-url" : "https://repo1.maven.org/maven2/io/netty/netty-transport-udt/$version$/netty-transport-udt-$version$-sources.jar",
     "repository-url" : "https://github.com/netty/netty",
-    "test-code-url" : "https://repo1.maven.org/maven2/io/netty/netty-transport-udt/4.1.74.Final/netty-transport-udt-4.1.74.Final-test-sources.jar",
-    "documentation-url" : "https://repo1.maven.org/maven2/io/netty/netty-transport-udt/4.1.74.Final/netty-transport-udt-4.1.74.Final-javadoc.jar",
+    "test-code-url" : "https://repo1.maven.org/maven2/io/netty/netty-transport-udt/$version$/netty-transport-udt-$version$-test-sources.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/io/netty/netty-transport-udt/$version$/netty-transport-udt-$version$-javadoc.jar",
     "description" : "Netty Transport UDT provides Netty channel implementations and configuration types for the UDT transport over NIO. It integrates Netty's asynchronous event-driven networking model with the Barchart UDT bundle, although the UDT transport was deprecated as no longer maintained in this release.",
     "tested-versions" : [
       "4.1.74.Final",


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7645

This PR provides new metadata needed for the io.netty:netty-transport-udt:4.1.74.Final, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `io.netty:netty-transport-udt:4.1.74.Final`): 36
- Metadata entries (new `io.netty:netty-transport-udt:4.1.74.Final`): 36
- Library coverage (previous): 68.64%
- Library coverage (new): 68.64%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `dc0678041c17d86b81989ac05a5e0bfd226deae3`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `io.netty:netty-transport-udt:4.1.74.Final` and `io.netty:netty-transport-udt:4.1.74.Final`.

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
