### PR TITLE
[Automation] Generated metadata for net.java.dev.jna:jna:5.8.0

### DIFF
--- a/metadata/net.java.dev.jna/jna/5.8.0/reachability-metadata.json
+++ b/metadata/net.java.dev.jna/jna/5.8.0/reachability-metadata.json
@@ -1,58 +1,58 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "com.sun.jna.Callback",
-      "jniAccessible": true
+      "type" : "com.sun.jna.Callback",
+      "jniAccessible" : true
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.CallbackReference"
+      "condition" : {
+        "typeReached" : "com.sun.jna.CallbackReference"
       },
-      "type": "com.sun.jna.CallbackProxy",
-      "methods": [
+      "type" : "com.sun.jna.CallbackProxy",
+      "methods" : [
         {
-          "name": "callback",
-          "parameterTypes": [
+          "name" : "callback",
+          "parameterTypes" : [
             "java.lang.Object[]"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "com.sun.jna.CallbackReference",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "com.sun.jna.CallbackReference",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "getCallback",
-          "parameterTypes": [
+          "name" : "getCallback",
+          "parameterTypes" : [
             "java.lang.Class",
             "com.sun.jna.Pointer",
             "boolean"
           ]
         },
         {
-          "name": "getFunctionPointer",
-          "parameterTypes": [
+          "name" : "getFunctionPointer",
+          "parameterTypes" : [
             "com.sun.jna.Callback",
             "boolean"
           ]
         },
         {
-          "name": "getNativeString",
-          "parameterTypes": [
+          "name" : "getNativeString",
+          "parameterTypes" : [
             "java.lang.Object",
             "boolean"
           ]
         },
         {
-          "name": "initializeThread",
-          "parameterTypes": [
+          "name" : "initializeThread",
+          "parameterTypes" : [
             "com.sun.jna.Callback",
             "com.sun.jna.CallbackReference$AttachOptions"
           ]
@@ -60,86 +60,86 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "com.sun.jna.CallbackReference$AttachOptions",
-      "jniAccessible": true
+      "type" : "com.sun.jna.CallbackReference$AttachOptions",
+      "jniAccessible" : true
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "com.sun.jna.FromNativeConverter",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "com.sun.jna.FromNativeConverter",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "nativeType",
-          "parameterTypes": []
+          "name" : "nativeType",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "com.sun.jna.IntegerType",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "com.sun.jna.IntegerType",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "value"
+          "name" : "value"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "com.sun.jna.JNIEnv",
-      "jniAccessible": true
+      "type" : "com.sun.jna.JNIEnv",
+      "jniAccessible" : true
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "com.sun.jna.Native",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "com.sun.jna.Native",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "dispose",
-          "parameterTypes": []
+          "name" : "dispose",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "fromNative",
-          "parameterTypes": [
+          "name" : "fromNative",
+          "parameterTypes" : [
             "com.sun.jna.FromNativeConverter",
             "java.lang.Object",
             "java.lang.reflect.Method"
           ]
         },
         {
-          "name": "fromNative",
-          "parameterTypes": [
+          "name" : "fromNative",
+          "parameterTypes" : [
             "java.lang.Class",
             "java.lang.Object"
           ]
         },
         {
-          "name": "fromNative",
-          "parameterTypes": [
+          "name" : "fromNative",
+          "parameterTypes" : [
             "java.lang.reflect.Method",
             "java.lang.Object"
           ]
         },
         {
-          "name": "nativeType",
-          "parameterTypes": [
+          "name" : "nativeType",
+          "parameterTypes" : [
             "java.lang.Class"
           ]
         },
         {
-          "name": "toNative",
-          "parameterTypes": [
+          "name" : "toNative",
+          "parameterTypes" : [
             "com.sun.jna.ToNativeConverter",
             "java.lang.Object"
           ]
@@ -147,15 +147,15 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "com.sun.jna.Native$ffi_callback",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "com.sun.jna.Native$ffi_callback",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "invoke",
-          "parameterTypes": [
+          "name" : "invoke",
+          "parameterTypes" : [
             "long",
             "long",
             "long"
@@ -164,80 +164,80 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "com.sun.jna.NativeMapped",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "com.sun.jna.NativeMapped",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "toNative",
-          "parameterTypes": []
+          "name" : "toNative",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "com.sun.jna.Pointer",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "com.sun.jna.Pointer",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "peer"
+          "name" : "peer"
         }
       ],
-      "methods": [
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "long"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "com.sun.jna.PointerType",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "com.sun.jna.PointerType",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "pointer"
+          "name" : "pointer"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "com.sun.jna.Structure",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "com.sun.jna.Structure",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "memory"
+          "name" : "memory"
         },
         {
-          "name": "typeInfo"
+          "name" : "typeInfo"
         }
       ],
-      "methods": [
+      "methods" : [
         {
-          "name": "autoRead",
-          "parameterTypes": []
+          "name" : "autoRead",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "autoWrite",
-          "parameterTypes": []
+          "name" : "autoWrite",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "getTypeInfo",
-          "parameterTypes": []
+          "name" : "getTypeInfo",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "newInstance",
-          "parameterTypes": [
+          "name" : "newInstance",
+          "parameterTypes" : [
             "java.lang.Class",
             "long"
           ]
@@ -245,417 +245,417 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "com.sun.jna.Structure$ByValue",
-      "jniAccessible": true
+      "type" : "com.sun.jna.Structure$ByValue",
+      "jniAccessible" : true
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "com.sun.jna.Structure$FFIType$FFITypes",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "com.sun.jna.Structure$FFIType$FFITypes",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "ffi_type_double"
+          "name" : "ffi_type_double"
         },
         {
-          "name": "ffi_type_float"
+          "name" : "ffi_type_float"
         },
         {
-          "name": "ffi_type_longdouble"
+          "name" : "ffi_type_longdouble"
         },
         {
-          "name": "ffi_type_pointer"
+          "name" : "ffi_type_pointer"
         },
         {
-          "name": "ffi_type_sint16"
+          "name" : "ffi_type_sint16"
         },
         {
-          "name": "ffi_type_sint32"
+          "name" : "ffi_type_sint32"
         },
         {
-          "name": "ffi_type_sint64"
+          "name" : "ffi_type_sint64"
         },
         {
-          "name": "ffi_type_sint8"
+          "name" : "ffi_type_sint8"
         },
         {
-          "name": "ffi_type_uint16"
+          "name" : "ffi_type_uint16"
         },
         {
-          "name": "ffi_type_uint32"
+          "name" : "ffi_type_uint32"
         },
         {
-          "name": "ffi_type_uint64"
+          "name" : "ffi_type_uint64"
         },
         {
-          "name": "ffi_type_uint8"
+          "name" : "ffi_type_uint8"
         },
         {
-          "name": "ffi_type_void"
+          "name" : "ffi_type_void"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "com.sun.jna.WString",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "com.sun.jna.WString",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.String"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.lang.Boolean",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "java.lang.Boolean",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "TYPE"
+          "name" : "TYPE"
         },
         {
-          "name": "value"
+          "name" : "value"
         }
       ],
-      "methods": [
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "boolean"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.lang.Byte",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "java.lang.Byte",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "TYPE"
+          "name" : "TYPE"
         },
         {
-          "name": "value"
+          "name" : "value"
         }
       ],
-      "methods": [
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "byte"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.lang.Character",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "java.lang.Character",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "TYPE"
+          "name" : "TYPE"
         },
         {
-          "name": "value"
+          "name" : "value"
         }
       ],
-      "methods": [
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "char"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.lang.Class",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "java.lang.Class",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "getComponentType",
-          "parameterTypes": []
+          "name" : "getComponentType",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.lang.Double",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "java.lang.Double",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "TYPE"
+          "name" : "TYPE"
         },
         {
-          "name": "value"
+          "name" : "value"
         }
       ],
-      "methods": [
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "double"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.lang.Float",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "java.lang.Float",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "TYPE"
+          "name" : "TYPE"
         },
         {
-          "name": "value"
+          "name" : "value"
         }
       ],
-      "methods": [
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "float"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.lang.Integer",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "java.lang.Integer",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "TYPE"
+          "name" : "TYPE"
         },
         {
-          "name": "value"
+          "name" : "value"
         }
       ],
-      "methods": [
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "int"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.lang.Long",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "java.lang.Long",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "TYPE"
+          "name" : "TYPE"
         },
         {
-          "name": "value"
+          "name" : "value"
         }
       ],
-      "methods": [
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "long"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Library$Handler"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Library$Handler"
       },
-      "type": "java.lang.Object",
-      "methods": [
+      "type" : "java.lang.Object",
+      "methods" : [
         {
-          "name": "equals",
-          "parameterTypes": [
+          "name" : "equals",
+          "parameterTypes" : [
             "java.lang.Object"
           ]
         },
         {
-          "name": "hashCode",
-          "parameterTypes": []
+          "name" : "hashCode",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "toString",
-          "parameterTypes": []
+          "name" : "toString",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.lang.Object",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "java.lang.Object",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "toString",
-          "parameterTypes": []
+          "name" : "toString",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.lang.Short",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "java.lang.Short",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "TYPE"
+          "name" : "TYPE"
         },
         {
-          "name": "value"
+          "name" : "value"
         }
       ],
-      "methods": [
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "short"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.lang.String",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "java.lang.String",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "byte[]"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "byte[]",
             "java.lang.String"
           ]
         },
         {
-          "name": "getBytes",
-          "parameterTypes": []
+          "name" : "getBytes",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "getBytes",
-          "parameterTypes": [
+          "name" : "getBytes",
+          "parameterTypes" : [
             "java.lang.String"
           ]
         },
         {
-          "name": "toCharArray",
-          "parameterTypes": []
+          "name" : "toCharArray",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.lang.System",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "java.lang.System",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "getProperty",
-          "parameterTypes": [
+          "name" : "getProperty",
+          "parameterTypes" : [
             "java.lang.String"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.NativeLibrary"
+      "condition" : {
+        "typeReached" : "com.sun.jna.NativeLibrary"
       },
-      "type": "java.lang.Throwable",
-      "methods": [
+      "type" : "java.lang.Throwable",
+      "methods" : [
         {
-          "name": "addSuppressed",
-          "parameterTypes": [
+          "name" : "addSuppressed",
+          "parameterTypes" : [
             "java.lang.Throwable"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.lang.Void",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "java.lang.Void",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "TYPE"
+          "name" : "TYPE"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.internal.ReflectionUtils"
+      "condition" : {
+        "typeReached" : "com.sun.jna.internal.ReflectionUtils"
       },
-      "type": "java.lang.invoke.MethodHandle",
-      "methods": [
+      "type" : "java.lang.invoke.MethodHandle",
+      "methods" : [
         {
-          "name": "bindTo",
-          "parameterTypes": [
+          "name" : "bindTo",
+          "parameterTypes" : [
             "java.lang.Object"
           ]
         },
         {
-          "name": "invokeWithArguments",
-          "parameterTypes": [
+          "name" : "invokeWithArguments",
+          "parameterTypes" : [
             "java.lang.Object[]"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.internal.ReflectionUtils"
+      "condition" : {
+        "typeReached" : "com.sun.jna.internal.ReflectionUtils"
       },
-      "type": "java.lang.invoke.MethodHandles",
-      "methods": [
+      "type" : "java.lang.invoke.MethodHandles",
+      "methods" : [
         {
-          "name": "lookup",
-          "parameterTypes": []
+          "name" : "lookup",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "privateLookupIn",
-          "parameterTypes": [
+          "name" : "privateLookupIn",
+          "parameterTypes" : [
             "java.lang.Class",
             "java.lang.invoke.MethodHandles$Lookup"
           ]
@@ -663,14 +663,14 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.internal.ReflectionUtils"
+      "condition" : {
+        "typeReached" : "com.sun.jna.internal.ReflectionUtils"
       },
-      "type": "java.lang.invoke.MethodHandles$Lookup",
-      "methods": [
+      "type" : "java.lang.invoke.MethodHandles$Lookup",
+      "methods" : [
         {
-          "name": "findSpecial",
-          "parameterTypes": [
+          "name" : "findSpecial",
+          "parameterTypes" : [
             "java.lang.Class",
             "java.lang.String",
             "java.lang.invoke.MethodType",
@@ -678,14 +678,14 @@
           ]
         },
         {
-          "name": "in",
-          "parameterTypes": [
+          "name" : "in",
+          "parameterTypes" : [
             "java.lang.Class"
           ]
         },
         {
-          "name": "unreflectSpecial",
-          "parameterTypes": [
+          "name" : "unreflectSpecial",
+          "parameterTypes" : [
             "java.lang.reflect.Method",
             "java.lang.Class"
           ]
@@ -693,14 +693,14 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.internal.ReflectionUtils"
+      "condition" : {
+        "typeReached" : "com.sun.jna.internal.ReflectionUtils"
       },
-      "type": "java.lang.invoke.MethodType",
-      "methods": [
+      "type" : "java.lang.invoke.MethodType",
+      "methods" : [
         {
-          "name": "methodType",
-          "parameterTypes": [
+          "name" : "methodType",
+          "parameterTypes" : [
             "java.lang.Class",
             "java.lang.Class[]"
           ]
@@ -708,245 +708,245 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.lang.reflect.Method",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "java.lang.reflect.Method",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "getParameterTypes",
-          "parameterTypes": []
+          "name" : "getParameterTypes",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "getReturnType",
-          "parameterTypes": []
+          "name" : "getReturnType",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.VarArgsChecker"
+      "condition" : {
+        "typeReached" : "com.sun.jna.VarArgsChecker"
       },
-      "type": "java.lang.reflect.Method",
-      "methods": [
+      "type" : "java.lang.reflect.Method",
+      "methods" : [
         {
-          "name": "isVarArgs",
-          "parameterTypes": []
+          "name" : "isVarArgs",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.internal.ReflectionUtils"
+      "condition" : {
+        "typeReached" : "com.sun.jna.internal.ReflectionUtils"
       },
-      "type": "java.lang.reflect.Method",
-      "methods": [
+      "type" : "java.lang.reflect.Method",
+      "methods" : [
         {
-          "name": "isDefault",
-          "parameterTypes": []
+          "name" : "isDefault",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.nio.Buffer",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "java.nio.Buffer",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "position",
-          "parameterTypes": []
+          "name" : "position",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Platform"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Platform"
       },
-      "type": "java.nio.Buffer"
+      "type" : "java.nio.Buffer"
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.nio.ByteBuffer",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "java.nio.ByteBuffer",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "array",
-          "parameterTypes": []
+          "name" : "array",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "arrayOffset",
-          "parameterTypes": []
+          "name" : "arrayOffset",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.nio.CharBuffer",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "java.nio.CharBuffer",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "array",
-          "parameterTypes": []
+          "name" : "array",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "arrayOffset",
-          "parameterTypes": []
+          "name" : "arrayOffset",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.nio.DoubleBuffer",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "java.nio.DoubleBuffer",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "array",
-          "parameterTypes": []
+          "name" : "array",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "arrayOffset",
-          "parameterTypes": []
+          "name" : "arrayOffset",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.nio.FloatBuffer",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "java.nio.FloatBuffer",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "array",
-          "parameterTypes": []
+          "name" : "array",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "arrayOffset",
-          "parameterTypes": []
+          "name" : "arrayOffset",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.nio.IntBuffer",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "java.nio.IntBuffer",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "array",
-          "parameterTypes": []
+          "name" : "array",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "arrayOffset",
-          "parameterTypes": []
+          "name" : "arrayOffset",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.nio.LongBuffer",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "java.nio.LongBuffer",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "array",
-          "parameterTypes": []
+          "name" : "array",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "arrayOffset",
-          "parameterTypes": []
+          "name" : "arrayOffset",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.nio.ShortBuffer",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "java.nio.ShortBuffer",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "array",
-          "parameterTypes": []
+          "name" : "array",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "arrayOffset",
-          "parameterTypes": []
+          "name" : "arrayOffset",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.security.SecureRandomParameters"
+      "type" : "java.security.SecureRandomParameters"
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "sun.security.provider.NativePRNG",
-      "methods": [
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "sun.security.provider.SHA",
-      "methods": [
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "glob": "com/sun/jna/darwin-aarch64/libjnidispatch.jnilib"
+      "glob" : "com/sun/jna/darwin-aarch64/libjnidispatch.jnilib"
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "glob": "com/sun/jna/darwin-x86-64/libjnidispatch.jnilib"
+      "glob" : "com/sun/jna/darwin-x86-64/libjnidispatch.jnilib"
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "glob": "com/sun/jna/linux-aarch64/libjnidispatch.so"
+      "glob" : "com/sun/jna/linux-aarch64/libjnidispatch.so"
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "glob": "com/sun/jna/linux-x86-64/libjnidispatch.so"
+      "glob" : "com/sun/jna/linux-x86-64/libjnidispatch.so"
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "glob": "com/sun/jna/win32-x86-64/jnidispatch.dll"
+      "glob" : "com/sun/jna/win32-x86-64/jnidispatch.dll"
     }
   ]
 }

--- a/tests/src/net.java.dev.jna/jna/5.8.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/net.java.dev.jna/jna/5.8.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,8 +1,8 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "net_java_dev_jna.jna.CLibrary"
         ]
       }


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7646

This PR provides new metadata needed for the net.java.dev.jna:jna:5.8.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `net.java.dev.jna:jna:5.8.0`): 196
- Test-only metadata entries (previous `net.java.dev.jna:jna:5.8.0`): 1
- Metadata entries (new `net.java.dev.jna:jna:5.8.0`): 196
- Test-only metadata entries (new `net.java.dev.jna:jna:5.8.0`): 1
- Library coverage (previous): 12.51%
- Library coverage (new): 12.51%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `dc0678041c17d86b81989ac05a5e0bfd226deae3`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `net.java.dev.jna:jna:5.8.0` and `net.java.dev.jna:jna:5.8.0`.

### Local CI Verification

- Status: `success`
- Commands run: 0
- Fixup attempts: 0
