### PR TITLE
[GenAI] Test fix for org.apache.directory.server:apacheds-kerberos-codec:2.0.0.AM27 using gpt-5.5

### DIFF
--- a/metadata/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/reachability-metadata.json
+++ b/metadata/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/reachability-metadata.json
@@ -1,0 +1,80 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.directory.server.kerberos.shared.crypto.encryption.RandomKeyFactory"
+      },
+      "type" : "com.sun.crypto.provider.AESKeyGenerator",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.directory.server.kerberos.shared.crypto.encryption.RandomKeyFactory"
+      },
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.directory.server.kerberos.shared.crypto.encryption.RandomKeyFactory"
+      },
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.directory.server.kerberos.shared.crypto.encryption.RandomKeyFactory"
+      },
+      "glob" : "META-INF/services/java.net.spi.URLStreamHandlerProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.directory.shared.kerberos.codec.KerberosDecoder"
+      },
+      "glob" : "META-INF/services/java.util.spi.ResourceBundleControlProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.directory.shared.kerberos.codec.KerberosDecoder"
+      },
+      "glob" : "org/apache/directory/api/i18n/errors.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.directory.shared.kerberos.codec.KerberosDecoder"
+      },
+      "glob" : "org/apache/directory/api/i18n/messages.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.directory.shared.kerberos.components.EncryptionKey"
+      },
+      "glob" : "org/slf4j/impl/StaticLoggerBinder.class"
+    },
+    {
+      "bundle" : "org/apache/directory/api/i18n/errors"
+    },
+    {
+      "bundle" : "org/apache/directory/api/i18n/messages"
+    }
+  ]
+}

--- a/metadata/org.apache.directory.server/apacheds-kerberos-codec/index.json
+++ b/metadata/org.apache.directory.server/apacheds-kerberos-codec/index.json
@@ -38,7 +38,9 @@
     ],
     "allowed-packages" : [
       "org.apache.directory.server.kerberos",
-      "org.apache.directory.shared.kerberos"
+      "org.apache.directory.shared.kerberos",
+      "org.apache.directory.server.kerberos.shared.crypto.encryption",
+      "org.apache.directory.server.kerberos.shared.store"
     ]
   }
 ]

--- a/metadata/org.apache.directory.server/apacheds-kerberos-codec/index.json
+++ b/metadata/org.apache.directory.server/apacheds-kerberos-codec/index.json
@@ -28,6 +28,11 @@
   },
   {
     "metadata-version" : "2.0.0.AM27",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/directory/server/apacheds-kerberos-codec/$version$/apacheds-kerberos-codec-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/directory-server",
+    "test-code-url" : "https://github.com/apache/directory-server/tree/$version$/kerberos-codec/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/directory/server/apacheds-kerberos-codec/$version$/apacheds-kerberos-codec-$version$-javadoc.jar",
+    "description" : "ApacheDS Protocol Kerberos Codec implements Kerberos and Change Password protocol encoding and decoding classes used by Apache Directory Server. It provides Java classes for ASN1 Kerberos message structures, cryptography helpers, keytab handling, replay cache support, and client/server protocol codecs.",
     "tested-versions" : [
       "2.0.0.AM27"
     ],

--- a/metadata/org.apache.directory.server/apacheds-kerberos-codec/index.json
+++ b/metadata/org.apache.directory.server/apacheds-kerberos-codec/index.json
@@ -25,5 +25,15 @@
       "org.apache.directory.server.kerberos",
       "org.apache.directory.shared.kerberos"
     ]
+  },
+  {
+    "metadata-version" : "2.0.0.AM27",
+    "tested-versions" : [
+      "2.0.0.AM27"
+    ],
+    "allowed-packages" : [
+      "org.apache.directory.server.kerberos",
+      "org.apache.directory.shared.kerberos"
+    ]
   }
 ]

--- a/stats/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/execution-metrics.json
+++ b/stats/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/execution-metrics.json
@@ -1,0 +1,94 @@
+{
+  "fix_javac_fail:2026-06-07": {
+    "timestamp": "2026-06-07T03:40:45.928012Z",
+    "library": "org.apache.directory.server:apacheds-kerberos-codec:2.0.0.AM27",
+    "starting_commit": "642dd1d3d9a8b669d18b171467ce2e32b880e65b",
+    "ending_commit": "eb2b4229498671bb95971082eb8575e9b75f3253",
+    "previous_library": "org.apache.directory.server:apacheds-kerberos-codec:2.0.0-M15",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.0.0.AM27",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1694,
+          "missed": 2148,
+          "ratio": 0.440916,
+          "total": 3842
+        },
+        "line": {
+          "covered": 250,
+          "missed": 443,
+          "ratio": 0.36075,
+          "total": 693
+        },
+        "method": {
+          "covered": 41,
+          "missed": 101,
+          "ratio": 0.288732,
+          "total": 142
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.0.0-M15",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 2,
+        "totalCalls": 2
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1862,
+          "missed": 48883,
+          "ratio": 0.036693,
+          "total": 50745
+        },
+        "line": {
+          "covered": 247,
+          "missed": 9535,
+          "ratio": 0.02525,
+          "total": 9782
+        },
+        "method": {
+          "covered": 45,
+          "missed": 2135,
+          "ratio": 0.020642,
+          "total": 2180
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 70711,
+      "cached_input_tokens_used": 588800,
+      "output_tokens_used": 9175,
+      "iterations": 2,
+      "cost_usd": 0.5697,
+      "tested_library_loc": 250,
+      "metadata_entries": 13,
+      "test_only_metadata_entries": 2,
+      "previous_library_metadata_entries": 7,
+      "code_coverage_percent": 36.08,
+      "previous_library_coverage_percent": 2.53
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/src/test/java/org_apache_directory_server/apacheds_kerberos_codec/ChecksumHandlerTest.java",
+      "metadata_file": "metadata/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/stats.json
+++ b/stats/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.0.0.AM27",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1694,
+        "missed" : 2148,
+        "ratio" : 0.440916,
+        "total" : 3842
+      },
+      "line" : {
+        "covered" : 250,
+        "missed" : 443,
+        "ratio" : 0.36075,
+        "total" : 693
+      },
+      "method" : {
+        "covered" : 41,
+        "missed" : 101,
+        "ratio" : 0.288732,
+        "total" : 142
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/.gitignore
+++ b/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/build.gradle
+++ b/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.directory.server:apacheds-kerberos-codec:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/gradle.properties
+++ b/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.directory.server:apacheds-kerberos-codec:2.0.0.AM27
+library.version = 2.0.0.AM27
+metadata.dir = org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/

--- a/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/settings.gradle
+++ b/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.directory.server.apacheds-kerberos-codec_tests'

--- a/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/src/test/java/org_apache_directory_server/apacheds_kerberos_codec/ChecksumHandlerTest.java
+++ b/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/src/test/java/org_apache_directory_server/apacheds_kerberos_codec/ChecksumHandlerTest.java
@@ -7,41 +7,42 @@
 package org_apache_directory_server.apacheds_kerberos_codec;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.apache.directory.server.kerberos.shared.crypto.checksum.ChecksumHandler;
-import org.apache.directory.shared.kerberos.components.Checksum;
-import org.apache.directory.shared.kerberos.crypto.checksum.ChecksumType;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.directory.shared.kerberos.codec.KerberosDecoder;
+import org.apache.directory.shared.kerberos.codec.types.EncryptionType;
+import org.apache.directory.shared.kerberos.components.EncryptionKey;
 import org.apache.directory.shared.kerberos.exceptions.KerberosException;
 import org.junit.jupiter.api.Test;
 
 public class ChecksumHandlerTest {
     @Test
-    void calculatesAndVerifiesRsaMd5Checksum() throws Exception {
-        ChecksumHandler handler = new ChecksumHandler();
-        byte[] data = "Apache Directory Kerberos checksum".getBytes("UTF-8");
+    void encodesAndDecodesEncryptionKey() throws Exception {
+        byte[] keyValue = "Apache Directory Kerberos key".getBytes(StandardCharsets.UTF_8);
+        EncryptionKey originalKey = new EncryptionKey(EncryptionType.AES128_CTS_HMAC_SHA1_96, keyValue, 5);
+        ByteBuffer encodedKey = ByteBuffer.allocate(originalKey.computeLength());
 
-        Checksum checksum = handler.calculateChecksum(ChecksumType.RSA_MD5, data, null, null);
+        originalKey.encode(encodedKey);
+        EncryptionKey decodedKey = KerberosDecoder.decodeEncryptionKey(encodedKey.array());
 
-        assertThat(checksum.getChecksumType()).isEqualTo(ChecksumType.RSA_MD5);
-        assertThat(checksum.getChecksumValue()).containsExactly(
-                (byte) 0x30, (byte) 0x1e, (byte) 0x33, (byte) 0xbc,
-                (byte) 0xe2, (byte) 0xdb, (byte) 0xc3, (byte) 0x2f,
-                (byte) 0x05, (byte) 0x85, (byte) 0x98, (byte) 0x92,
-                (byte) 0x49, (byte) 0x02, (byte) 0x72, (byte) 0x2e);
-        assertThatCode(() -> handler.verifyChecksum(checksum, data, null, null)).doesNotThrowAnyException();
+        assertThat(decodedKey.getKeyType()).isEqualTo(EncryptionType.AES128_CTS_HMAC_SHA1_96);
+        assertThat(decodedKey.getKeyValue()).containsExactly(keyValue);
+        assertThat(decodedKey).isEqualTo(new EncryptionKey(EncryptionType.AES128_CTS_HMAC_SHA1_96, keyValue));
     }
 
     @Test
-    void rejectsMismatchedRsaMd5Checksum() throws Exception {
-        ChecksumHandler handler = new ChecksumHandler();
-        byte[] data = "Apache Directory Kerberos checksum".getBytes("UTF-8");
-        Checksum checksum = handler.calculateChecksum(ChecksumType.RSA_MD5, data, null, null);
-        byte[] alteredChecksum = checksum.getChecksumValue().clone();
-        alteredChecksum[0] ^= 0x01;
+    void rejectsInvalidEncryptionKeyEncoding() throws Exception {
+        byte[] keyValue = "Apache Directory Kerberos key".getBytes(StandardCharsets.UTF_8);
+        EncryptionKey originalKey = new EncryptionKey(EncryptionType.AES128_CTS_HMAC_SHA1_96, keyValue);
+        ByteBuffer encodedKey = ByteBuffer.allocate(originalKey.computeLength());
+        originalKey.encode(encodedKey);
+        byte[] invalidEncoding = encodedKey.array().clone();
+        invalidEncoding[0] = 0x31;
 
-        assertThatThrownBy(() -> handler.verifyChecksum(new Checksum(ChecksumType.RSA_MD5, alteredChecksum), data, null, null))
+        assertThatThrownBy(() -> KerberosDecoder.decodeEncryptionKey(invalidEncoding))
                 .isInstanceOf(KerberosException.class);
     }
 }

--- a/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/src/test/java/org_apache_directory_server/apacheds_kerberos_codec/ChecksumHandlerTest.java
+++ b/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/src/test/java/org_apache_directory_server/apacheds_kerberos_codec/ChecksumHandlerTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_directory_server.apacheds_kerberos_codec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.apache.directory.server.kerberos.shared.crypto.checksum.ChecksumHandler;
+import org.apache.directory.shared.kerberos.components.Checksum;
+import org.apache.directory.shared.kerberos.crypto.checksum.ChecksumType;
+import org.apache.directory.shared.kerberos.exceptions.KerberosException;
+import org.junit.jupiter.api.Test;
+
+public class ChecksumHandlerTest {
+    @Test
+    void calculatesAndVerifiesRsaMd5Checksum() throws Exception {
+        ChecksumHandler handler = new ChecksumHandler();
+        byte[] data = "Apache Directory Kerberos checksum".getBytes("UTF-8");
+
+        Checksum checksum = handler.calculateChecksum(ChecksumType.RSA_MD5, data, null, null);
+
+        assertThat(checksum.getChecksumType()).isEqualTo(ChecksumType.RSA_MD5);
+        assertThat(checksum.getChecksumValue()).containsExactly(
+                (byte) 0x30, (byte) 0x1e, (byte) 0x33, (byte) 0xbc,
+                (byte) 0xe2, (byte) 0xdb, (byte) 0xc3, (byte) 0x2f,
+                (byte) 0x05, (byte) 0x85, (byte) 0x98, (byte) 0x92,
+                (byte) 0x49, (byte) 0x02, (byte) 0x72, (byte) 0x2e);
+        assertThatCode(() -> handler.verifyChecksum(checksum, data, null, null)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void rejectsMismatchedRsaMd5Checksum() throws Exception {
+        ChecksumHandler handler = new ChecksumHandler();
+        byte[] data = "Apache Directory Kerberos checksum".getBytes("UTF-8");
+        Checksum checksum = handler.calculateChecksum(ChecksumType.RSA_MD5, data, null, null);
+        byte[] alteredChecksum = checksum.getChecksumValue().clone();
+        alteredChecksum[0] ^= 0x01;
+
+        assertThatThrownBy(() -> handler.verifyChecksum(new Checksum(ChecksumType.RSA_MD5, alteredChecksum), data, null, null))
+                .isInstanceOf(KerberosException.class);
+    }
+}

--- a/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/src/test/java/org_apache_directory_server/apacheds_kerberos_codec/CipherTextHandlerTest.java
+++ b/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/src/test/java/org_apache_directory_server/apacheds_kerberos_codec/CipherTextHandlerTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_directory_server.apacheds_kerberos_codec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+
+import org.apache.directory.server.kerberos.shared.crypto.encryption.CipherTextHandler;
+import org.apache.directory.server.kerberos.shared.crypto.encryption.KeyUsage;
+import org.apache.directory.shared.kerberos.codec.types.EncryptionType;
+import org.apache.directory.shared.kerberos.components.EncryptedData;
+import org.apache.directory.shared.kerberos.components.EncryptionKey;
+import org.junit.jupiter.api.Test;
+
+public class CipherTextHandlerTest {
+    @Test
+    void encryptsAndDecryptsRc4HmacData() throws Exception {
+        CipherTextHandler handler = new CipherTextHandler();
+        byte[] keyBytes = "deterministic-key".getBytes(StandardCharsets.UTF_8);
+        EncryptionKey key = new EncryptionKey(EncryptionType.RC4_HMAC, keyBytes, 3);
+        byte[] plainText = "Apache Directory Kerberos cipher text".getBytes(StandardCharsets.UTF_8);
+
+        EncryptedData encryptedData = handler.encrypt(key, plainText, KeyUsage.AP_REQ_AUTHNT_SESS_KEY);
+        byte[] decryptedData = handler.decrypt(key, encryptedData, KeyUsage.AP_REQ_AUTHNT_SESS_KEY);
+
+        assertThat(encryptedData.getEType()).isEqualTo(EncryptionType.RC4_HMAC);
+        assertThat(encryptedData.getKvno()).isEqualTo(3);
+        assertThat(encryptedData.getCipher()).containsExactly(plainText);
+        assertThat(decryptedData).containsExactly(plainText);
+    }
+}

--- a/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/src/test/java/org_apache_directory_server/apacheds_kerberos_codec/CipherTextHandlerTest.java
+++ b/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/src/test/java/org_apache_directory_server/apacheds_kerberos_codec/CipherTextHandlerTest.java
@@ -8,29 +8,24 @@ package org_apache_directory_server.apacheds_kerberos_codec;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.nio.charset.StandardCharsets;
-
-import org.apache.directory.server.kerberos.shared.crypto.encryption.CipherTextHandler;
-import org.apache.directory.server.kerberos.shared.crypto.encryption.KeyUsage;
+import org.apache.directory.server.kerberos.shared.crypto.encryption.RandomKeyFactory;
 import org.apache.directory.shared.kerberos.codec.types.EncryptionType;
-import org.apache.directory.shared.kerberos.components.EncryptedData;
 import org.apache.directory.shared.kerberos.components.EncryptionKey;
 import org.junit.jupiter.api.Test;
 
 public class CipherTextHandlerTest {
     @Test
-    void encryptsAndDecryptsRc4HmacData() throws Exception {
-        CipherTextHandler handler = new CipherTextHandler();
-        byte[] keyBytes = "deterministic-key".getBytes(StandardCharsets.UTF_8);
-        EncryptionKey key = new EncryptionKey(EncryptionType.RC4_HMAC, keyBytes, 3);
-        byte[] plainText = "Apache Directory Kerberos cipher text".getBytes(StandardCharsets.UTF_8);
+    void createsAndDestroysAesSessionKey() throws Exception {
+        EncryptionKey sessionKey = RandomKeyFactory.getRandomKey(EncryptionType.AES128_CTS_HMAC_SHA1_96);
+        byte[] keyValue = sessionKey.getKeyValue();
 
-        EncryptedData encryptedData = handler.encrypt(key, plainText, KeyUsage.AP_REQ_AUTHNT_SESS_KEY);
-        byte[] decryptedData = handler.decrypt(key, encryptedData, KeyUsage.AP_REQ_AUTHNT_SESS_KEY);
+        assertThat(sessionKey.getKeyType()).isEqualTo(EncryptionType.AES128_CTS_HMAC_SHA1_96);
+        assertThat(sessionKey.getKeyVersion()).isZero();
+        assertThat(keyValue).hasSize(16);
 
-        assertThat(encryptedData.getEType()).isEqualTo(EncryptionType.RC4_HMAC);
-        assertThat(encryptedData.getKvno()).isEqualTo(3);
-        assertThat(encryptedData.getCipher()).containsExactly(plainText);
-        assertThat(decryptedData).containsExactly(plainText);
+        sessionKey.destroy();
+
+        assertThat(keyValue).containsOnly((byte) 0x00);
+        assertThat(sessionKey.getKeyValue()).containsOnly((byte) 0x00);
     }
 }

--- a/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org_apache_directory_server.apacheds_kerberos_codec.ChecksumHandlerTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_directory_server.apacheds_kerberos_codec.ChecksumHandlerTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/user-code-filter.json
+++ b/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/user-code-filter.json
@@ -10,6 +10,12 @@
       "includeClasses" : "org.apache.directory.shared.kerberos.**"
     },
     {
+      "includeClasses" : "org.apache.directory.server.kerberos.shared.crypto.encryption.**"
+    },
+    {
+      "includeClasses" : "org.apache.directory.server.kerberos.shared.store.**"
+    },
+    {
       "includeClasses" : "org_apache_directory_server.apacheds_kerberos_codec.**"
     }
   ]

--- a/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/user-code-filter.json
+++ b/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/user-code-filter.json
@@ -1,0 +1,16 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.directory.server.kerberos.**"
+    },
+    {
+      "includeClasses" : "org.apache.directory.shared.kerberos.**"
+    },
+    {
+      "includeClasses" : "org_apache_directory_server.apacheds_kerberos_codec.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6937

This PR provides test fixes and new metadata for org.apache.directory.server:apacheds-kerberos-codec:2.0.0.AM27, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 70711
- Cached input tokens: 588800
- Output tokens: 9175
- Metadata entries: 13
- Test-only metadata entries: 2
- Iterations: 2
- Library coverage percentage: 36.08
- Previous library version metadata entries: 7
- Previous library version coverage percentage: 2.53

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `da08d7a48fce53f6c6266e822538b41d7f3ced4e`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.directory.server:apacheds-kerberos-codec:2.0.0-M15: 2/2 covered calls (100.00%)
- org.apache.directory.server:apacheds-kerberos-codec:2.0.0.AM27: 0/0 covered calls (100.00%)

**Reflection:**
- org.apache.directory.server:apacheds-kerberos-codec:2.0.0-M15: 2/2 covered calls (100.00%)
- org.apache.directory.server:apacheds-kerberos-codec:2.0.0.AM27: N/A

#### Library coverage

**Instruction:**
- org.apache.directory.server:apacheds-kerberos-codec:2.0.0-M15: 1862/50745 (3.67%)
- org.apache.directory.server:apacheds-kerberos-codec:2.0.0.AM27: 1694/3842 (44.09%)

**Line:**
- org.apache.directory.server:apacheds-kerberos-codec:2.0.0-M15: 247/9782 (2.53%)
- org.apache.directory.server:apacheds-kerberos-codec:2.0.0.AM27: 250/693 (36.08%)

**Method:**
- org.apache.directory.server:apacheds-kerberos-codec:2.0.0-M15: 45/2180 (2.06%)
- org.apache.directory.server:apacheds-kerberos-codec:2.0.0.AM27: 41/142 (28.87%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0-M15/src/test/java/org_apache_directory_server/apacheds_kerberos_codec/ChecksumHandlerTest.java b/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/src/test/java/org_apache_directory_server/apacheds_kerberos_codec/ChecksumHandlerTest.java
index 331b62a34c..955a4b76c7 100644
--- a/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0-M15/src/test/java/org_apache_directory_server/apacheds_kerberos_codec/ChecksumHandlerTest.java
+++ b/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/src/test/java/org_apache_directory_server/apacheds_kerberos_codec/ChecksumHandlerTest.java
@@ -7,41 +7,42 @@
 package org_apache_directory_server.apacheds_kerberos_codec;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.apache.directory.server.kerberos.shared.crypto.checksum.ChecksumHandler;
-import org.apache.directory.shared.kerberos.components.Checksum;
-import org.apache.directory.shared.kerberos.crypto.checksum.ChecksumType;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.directory.shared.kerberos.codec.KerberosDecoder;
+import org.apache.directory.shared.kerberos.codec.types.EncryptionType;
+import org.apache.directory.shared.kerberos.components.EncryptionKey;
 import org.apache.directory.shared.kerberos.exceptions.KerberosException;
 import org.junit.jupiter.api.Test;
 
 public class ChecksumHandlerTest {
     @Test
-    void calculatesAndVerifiesRsaMd5Checksum() throws Exception {
-        ChecksumHandler handler = new ChecksumHandler();
-        byte[] data = "Apache Directory Kerberos checksum".getBytes("UTF-8");
-
-        Checksum checksum = handler.calculateChecksum(ChecksumType.RSA_MD5, data, null, null);
-
-        assertThat(checksum.getChecksumType()).isEqualTo(ChecksumType.RSA_MD5);
-        assertThat(checksum.getChecksumValue()).containsExactly(
-                (byte) 0x30, (byte) 0x1e, (byte) 0x33, (byte) 0xbc,
-                (byte) 0xe2, (byte) 0xdb, (byte) 0xc3, (byte) 0x2f,
-                (byte) 0x05, (byte) 0x85, (byte) 0x98, (byte) 0x92,
-                (byte) 0x49, (byte) 0x02, (byte) 0x72, (byte) 0x2e);
-        assertThatCode(() -> handler.verifyChecksum(checksum, data, null, null)).doesNotThrowAnyException();
+    void encodesAndDecodesEncryptionKey() throws Exception {
+        byte[] keyValue = "Apache Directory Kerberos key".getBytes(StandardCharsets.UTF_8);
+        EncryptionKey originalKey = new EncryptionKey(EncryptionType.AES128_CTS_HMAC_SHA1_96, keyValue, 5);
+        ByteBuffer encodedKey = ByteBuffer.allocate(originalKey.computeLength());
+
+        originalKey.encode(encodedKey);
+        EncryptionKey decodedKey = KerberosDecoder.decodeEncryptionKey(encodedKey.array());
+
+        assertThat(decodedKey.getKeyType()).isEqualTo(EncryptionType.AES128_CTS_HMAC_SHA1_96);
+        assertThat(decodedKey.getKeyValue()).containsExactly(keyValue);
+        assertThat(decodedKey).isEqualTo(new EncryptionKey(EncryptionType.AES128_CTS_HMAC_SHA1_96, keyValue));
     }
 
     @Test
-    void rejectsMismatchedRsaMd5Checksum() throws Exception {
-        ChecksumHandler handler = new ChecksumHandler();
-        byte[] data = "Apache Directory Kerberos checksum".getBytes("UTF-8");
-        Checksum checksum = handler.calculateChecksum(ChecksumType.RSA_MD5, data, null, null);
-        byte[] alteredChecksum = checksum.getChecksumValue().clone();
-        alteredChecksum[0] ^= 0x01;
-
-        assertThatThrownBy(() -> handler.verifyChecksum(new Checksum(ChecksumType.RSA_MD5, alteredChecksum), data, null, null))
+    void rejectsInvalidEncryptionKeyEncoding() throws Exception {
+        byte[] keyValue = "Apache Directory Kerberos key".getBytes(StandardCharsets.UTF_8);
+        EncryptionKey originalKey = new EncryptionKey(EncryptionType.AES128_CTS_HMAC_SHA1_96, keyValue);
+        ByteBuffer encodedKey = ByteBuffer.allocate(originalKey.computeLength());
+        originalKey.encode(encodedKey);
+        byte[] invalidEncoding = encodedKey.array().clone();
+        invalidEncoding[0] = 0x31;
+
+        assertThatThrownBy(() -> KerberosDecoder.decodeEncryptionKey(invalidEncoding))
                 .isInstanceOf(KerberosException.class);
     }
 }
diff --git a/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0-M15/src/test/java/org_apache_directory_server/apacheds_kerberos_codec/CipherTextHandlerTest.java b/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/src/test/java/org_apache_directory_server/apacheds_kerberos_codec/CipherTextHandlerTest.java
index 24b5a8cc73..2f8ad92f2a 100644
--- a/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0-M15/src/test/java/org_apache_directory_server/apacheds_kerberos_codec/CipherTextHandlerTest.java
+++ b/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/src/test/java/org_apache_directory_server/apacheds_kerberos_codec/CipherTextHandlerTest.java
@@ -8,29 +8,24 @@ package org_apache_directory_server.apacheds_kerberos_codec;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.nio.charset.StandardCharsets;
-
-import org.apache.directory.server.kerberos.shared.crypto.encryption.CipherTextHandler;
-import org.apache.directory.server.kerberos.shared.crypto.encryption.KeyUsage;
+import org.apache.directory.server.kerberos.shared.crypto.encryption.RandomKeyFactory;
 import org.apache.directory.shared.kerberos.codec.types.EncryptionType;
-import org.apache.directory.shared.kerberos.components.EncryptedData;
 import org.apache.directory.shared.kerberos.components.EncryptionKey;
 import org.junit.jupiter.api.Test;
 
 public class CipherTextHandlerTest {
     @Test
-    void encryptsAndDecryptsRc4HmacData() throws Exception {
-        CipherTextHandler handler = new CipherTextHandler();
-        byte[] keyBytes = "deterministic-key".getBytes(StandardCharsets.UTF_8);
-        EncryptionKey key = new EncryptionKey(EncryptionType.RC4_HMAC, keyBytes, 3);
-        byte[] plainText = "Apache Directory Kerberos cipher text".getBytes(StandardCharsets.UTF_8);
+    void createsAndDestroysAesSessionKey() throws Exception {
+        EncryptionKey sessionKey = RandomKeyFactory.getRandomKey(EncryptionType.AES128_CTS_HMAC_SHA1_96);
+        byte[] keyValue = sessionKey.getKeyValue();
+
+        assertThat(sessionKey.getKeyType()).isEqualTo(EncryptionType.AES128_CTS_HMAC_SHA1_96);
+        assertThat(sessionKey.getKeyVersion()).isZero();
+        assertThat(keyValue).hasSize(16);
 
-        EncryptedData encryptedData = handler.encrypt(key, plainText, KeyUsage.AP_REQ_AUTHNT_SESS_KEY);
-        byte[] decryptedData = handler.decrypt(key, encryptedData, KeyUsage.AP_REQ_AUTHNT_SESS_KEY);
+        sessionKey.destroy();
 
-        assertThat(encryptedData.getEType()).isEqualTo(EncryptionType.RC4_HMAC);
-        assertThat(encryptedData.getKvno()).isEqualTo(3);
-        assertThat(encryptedData.getCipher()).containsExactly(plainText);
-        assertThat(decryptedData).containsExactly(plainText);
+        assertThat(keyValue).containsOnly((byte) 0x00);
+        assertThat(sessionKey.getKeyValue()).containsOnly((byte) 0x00);
     }
 }
diff --git a/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0-M15/user-code-filter.json b/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/user-code-filter.json
index 8855fca55d..a2ef677c2c 100644
--- a/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0-M15/user-code-filter.json
+++ b/tests/src/org.apache.directory.server/apacheds-kerberos-codec/2.0.0.AM27/user-code-filter.json
@@ -9,6 +9,12 @@
     {
       "includeClasses" : "org.apache.directory.shared.kerberos.**"
     },
+    {
+      "includeClasses" : "org.apache.directory.server.kerberos.shared.crypto.encryption.**"
+    },
+    {
+      "includeClasses" : "org.apache.directory.server.kerberos.shared.store.**"
+    },
     {
       "includeClasses" : "org_apache_directory_server.apacheds_kerberos_codec.**"
     }

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
