### PR TITLE
[GenAI] Mark io.awspring.cloud:spring-cloud-aws-dependencies as not for Native Image

### DIFF
--- a/metadata/io.awspring.cloud/spring-cloud-aws-dependencies/index.json
+++ b/metadata/io.awspring.cloud/spring-cloud-aws-dependencies/index.json
@@ -1,0 +1,6 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published artifact is packaging pom only and Maven Central has no JAR, sources JAR, or tests JAR for 4.0.2, so it has no JVM class files for native-image reachability metadata."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #7672

This PR records `io.awspring.cloud:spring-cloud-aws-dependencies` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published artifact is packaging pom only and Maven Central has no JAR, sources JAR, or tests JAR for 4.0.2, so it has no JVM class files for native-image reachability metadata.

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `dc0678041c17d86b81989ac05a5e0bfd226deae3`

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
