### PR TITLE
[Automation] Generated metadata for com.github.luben:zstd-jni:1.5.5-1

### DIFF
--- a/metadata/com.github.luben/zstd-jni/1.5.5-1/reachability-metadata.json
+++ b/metadata/com.github.luben/zstd-jni/1.5.5-1/reachability-metadata.json
@@ -164,7 +164,19 @@
       "condition": {
         "typeReached": "com.github.luben.zstd.util.Native"
       },
-      "glob": "linux/amd64/libzstd-jni-1.5.5-1.so"
+      "glob": "*/*/libzstd-jni-*dll"
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.util.Native"
+      },
+      "glob": "*/*/libzstd-jni-*dylib"
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.util.Native"
+      },
+      "glob": "*/*/libzstd-jni-*so"
     }
   ]
 }


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7643

This PR provides new metadata needed for the com.github.luben:zstd-jni:1.5.5-1, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `com.github.luben:zstd-jni:1.5.2-5`): 41
- Metadata entries (new `com.github.luben:zstd-jni:1.5.5-1`): 39
- Library coverage (previous): 36.76%
- Library coverage (new): 11.79%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `ba3bc3a41c511483fdc0c09ee76856a341047083`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.github.luben:zstd-jni:1.5.2-5: 1/1 covered calls (100.00%)
- com.github.luben:zstd-jni:1.5.5-1: 1/1 covered calls (100.00%)

**Resources:**
- com.github.luben:zstd-jni:1.5.2-5: 1/1 covered calls (100.00%)
- com.github.luben:zstd-jni:1.5.5-1: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.github.luben:zstd-jni:1.5.2-5: 1549/4679 (33.11%)
- com.github.luben:zstd-jni:1.5.5-1: 490/4887 (10.03%)

**Line:**
- com.github.luben:zstd-jni:1.5.2-5: 426/1159 (36.76%)
- com.github.luben:zstd-jni:1.5.5-1: 145/1230 (11.79%)

**Method:**
- com.github.luben:zstd-jni:1.5.2-5: 90/260 (34.62%)
- com.github.luben:zstd-jni:1.5.5-1: 35/302 (11.59%)

### Local CI Verification

- Status: `success`
- Commands run: 0
- Fixup attempts: 0
