### PR TITLE
[Automation] Generated metadata for com.github.luben:zstd-jni:1.5.4-2

### DIFF
--- a/metadata/com.github.luben/zstd-jni/1.5.4-2/reachability-metadata.json
+++ b/metadata/com.github.luben/zstd-jni/1.5.4-2/reachability-metadata.json
@@ -140,7 +140,19 @@
       "condition": {
         "typeReached": "com.github.luben.zstd.util.Native"
       },
-      "glob": "linux/amd64/libzstd-jni-1.5.4-2.so"
+      "glob": "*/*/libzstd-jni-*dll"
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.util.Native"
+      },
+      "glob": "*/*/libzstd-jni-*dylib"
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.util.Native"
+      },
+      "glob": "*/*/libzstd-jni-*so"
     }
   ]
 }

--- a/metadata/com.github.luben/zstd-jni/index.json
+++ b/metadata/com.github.luben/zstd-jni/index.json
@@ -35,6 +35,7 @@
     "repository-url" : "https://github.com/luben/zstd-jni",
     "test-code-url" : "https://github.com/luben/zstd-jni/tree/v$version$/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/com/github/luben/zstd-jni/$version$/zstd-jni-$version$-javadoc.jar",
+    "description" : "zstd-jni provides JNI bindings for the Zstandard compression library to Java and other JVM languages. It exposes byte-array and stream-based APIs for compressing and decompressing data using the bundled native implementation.",
     "tested-versions" : [
       "1.5.4-2"
     ],


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7642

This PR provides new metadata needed for the com.github.luben:zstd-jni:1.5.4-2, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `com.github.luben:zstd-jni:1.5.2-5`): 41
- Metadata entries (new `com.github.luben:zstd-jni:1.5.4-2`): 33
- Library coverage (previous): 36.76%
- Library coverage (new): 36.14%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `f37db851c2ce1eaa16cad82920e80e3102644aee`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.github.luben:zstd-jni:1.5.2-5: 1/1 covered calls (100.00%)
- com.github.luben:zstd-jni:1.5.4-2: 1/1 covered calls (100.00%)

**Resources:**
- com.github.luben:zstd-jni:1.5.2-5: 1/1 covered calls (100.00%)
- com.github.luben:zstd-jni:1.5.4-2: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.github.luben:zstd-jni:1.5.2-5: 1549/4679 (33.11%)
- com.github.luben:zstd-jni:1.5.4-2: 1602/4860 (32.96%)

**Line:**
- com.github.luben:zstd-jni:1.5.2-5: 426/1159 (36.76%)
- com.github.luben:zstd-jni:1.5.4-2: 442/1223 (36.14%)

**Method:**
- com.github.luben:zstd-jni:1.5.2-5: 90/260 (34.62%)
- com.github.luben:zstd-jni:1.5.4-2: 99/302 (32.78%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
