### PR TITLE
[GenAI] Mark org.springframework.boot:spring-boot-starter-webmvc as not for Native Image

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-starter-webmvc/index.json
+++ b/metadata/org.springframework.boot/spring-boot-starter-webmvc/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published spring-boot-starter-webmvc-4.0.6 JAR contains only META-INF/MANIFEST.MF, LICENSE.txt, and NOTICE.txt and no JVM class files; it is a dependency starter whose runtime classes are supplied by dependencies.",
+    "replacement": "Use the class-bearing dependency org.springframework.boot:spring-boot-webmvc:4.0.6 for Spring Boot Web MVC reachability metadata."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #7678

This PR records `org.springframework.boot:spring-boot-starter-webmvc` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published spring-boot-starter-webmvc-4.0.6 JAR contains only META-INF/MANIFEST.MF, LICENSE.txt, and NOTICE.txt and no JVM class files; it is a dependency starter whose runtime classes are supplied by dependencies.

Replacement guidance:
- Use the class-bearing dependency org.springframework.boot:spring-boot-webmvc:4.0.6 for Spring Boot Web MVC reachability metadata.

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `f37db851c2ce1eaa16cad82920e80e3102644aee`

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
