### PR TITLE
[Automation] Generated metadata for com.github.luben:zstd-jni:1.5.4-1

### DIFF
--- a/metadata/com.github.luben/zstd-jni/1.5.4-1/reachability-metadata.json
+++ b/metadata/com.github.luben/zstd-jni/1.5.4-1/reachability-metadata.json
@@ -164,7 +164,19 @@
       "condition": {
         "typeReached": "com.github.luben.zstd.util.Native"
       },
-      "glob": "linux/amd64/libzstd-jni-1.5.4-1.so"
+      "glob": "*/*/libzstd-jni-*.dll"
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.util.Native"
+      },
+      "glob": "*/*/libzstd-jni-*.dylib"
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.util.Native"
+      },
+      "glob": "*/*/libzstd-jni-*.so"
     }
   ]
 }


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7641

This PR provides new metadata needed for the com.github.luben:zstd-jni:1.5.4-1, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `com.github.luben:zstd-jni:1.5.2-5`): 41
- Metadata entries (new `com.github.luben:zstd-jni:1.5.4-1`): 39
- Library coverage (previous): 36.76%
- Library coverage (new): 35.38%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `1b26b9c9b2b1c94ed7f8e6e382f328a6971c3f5e`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.github.luben:zstd-jni:1.5.2-5: 1/1 covered calls (100.00%)
- com.github.luben:zstd-jni:1.5.4-1: 1/1 covered calls (100.00%)

**Resources:**
- com.github.luben:zstd-jni:1.5.2-5: 1/1 covered calls (100.00%)
- com.github.luben:zstd-jni:1.5.4-1: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.github.luben:zstd-jni:1.5.2-5: 1549/4679 (33.11%)
- com.github.luben:zstd-jni:1.5.4-1: 1597/4946 (32.29%)

**Line:**
- com.github.luben:zstd-jni:1.5.2-5: 426/1159 (36.76%)
- com.github.luben:zstd-jni:1.5.4-1: 437/1235 (35.38%)

**Method:**
- com.github.luben:zstd-jni:1.5.2-5: 90/260 (34.62%)
- com.github.luben:zstd-jni:1.5.4-1: 97/302 (32.12%)

### Local CI Verification

- Status: `success`
- Commands run: 0
- Fixup attempts: 0
