### PR TITLE
[GenAI] Test fix for org.codehaus.plexus:plexus-archiver:2.5 using gpt-5.5

### DIFF
--- a/metadata/org.codehaus.plexus/plexus-archiver/2.5/reachability-metadata.json
+++ b/metadata/org.codehaus.plexus/plexus-archiver/2.5/reachability-metadata.json
@@ -1,154 +1,33 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org.codehaus.plexus.archiver.util.ArchiveEntryUtils"
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.archiver.util.ArchiveEntryUtils"
       },
-      "type": "java.io.File",
-      "methods": [
+      "type" : "java.io.File",
+      "methods" : [
         {
-          "name": "setExecutable",
-          "parameterTypes": [
+          "name" : "setExecutable",
+          "parameterTypes" : [
             "boolean",
             "boolean"
           ]
         },
         {
-          "name": "setReadable",
-          "parameterTypes": [
+          "name" : "setReadable",
+          "parameterTypes" : [
             "boolean",
             "boolean"
           ]
         },
         {
-          "name": "setWritable",
-          "parameterTypes": [
+          "name" : "setWritable",
+          "parameterTypes" : [
             "boolean",
             "boolean"
           ]
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_plexus.plexus_archiver.ArchiveEntryUtilsTest$Java7DetectionRestorer"
-      },
-      "type": "java.nio.file.Files"
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_plexus.plexus_archiver.ExtraFieldUtilsTest"
-      },
-      "type": "org.apache.commons.compress.archivers.zip.AsiExtraField",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_plexus.plexus_archiver.ExtraFieldUtilsTest"
-      },
-      "type": "org.apache.commons.compress.archivers.zip.JarMarker",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_plexus.plexus_archiver.ExtraFieldUtilsTest"
-      },
-      "type": "org.apache.commons.compress.archivers.zip.UnicodeCommentExtraField",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_plexus.plexus_archiver.ExtraFieldUtilsTest"
-      },
-      "type": "org.apache.commons.compress.archivers.zip.UnicodePathExtraField",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_plexus.plexus_archiver.ExtraFieldUtilsTest"
-      },
-      "type": "org.apache.commons.compress.archivers.zip.X5455_ExtendedTimestamp",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_plexus.plexus_archiver.ExtraFieldUtilsTest"
-      },
-      "type": "org.apache.commons.compress.archivers.zip.X7875_NewUnix",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_plexus.plexus_archiver.ExtraFieldUtilsTest"
-      },
-      "type": "org.apache.commons.compress.archivers.zip.Zip64ExtendedInformationExtraField",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_plexus.plexus_archiver.ArchiveEntryUtilsTest$Java7DetectionRestorer"
-      },
-      "type": "org.codehaus.plexus.components.io.attributes.Java7Reflector"
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_plexus.plexus_archiver.ArchiveEntryUtilsTest"
-      },
-      "type": "sun.misc.Unsafe",
-      "fields": [
-        {
-          "name": "theUnsafe"
-        }
-      ]
-    }
-  ],
-  "resources": [
-    {
-      "condition": {
-        "typeReached": "org_codehaus_plexus.plexus_archiver.ArchiveEntryUtilsTest"
-      },
-      "glob": "META-INF/services/org.assertj.core.configuration.Configuration"
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_plexus.plexus_archiver.ArchiveEntryUtilsTest"
-      },
-      "glob": "META-INF/services/org.assertj.core.presentation.Representation"
     }
   ]
 }

--- a/metadata/org.codehaus.plexus/plexus-archiver/2.5/reachability-metadata.json
+++ b/metadata/org.codehaus.plexus/plexus-archiver/2.5/reachability-metadata.json
@@ -1,0 +1,154 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.codehaus.plexus.archiver.util.ArchiveEntryUtils"
+      },
+      "type": "java.io.File",
+      "methods": [
+        {
+          "name": "setExecutable",
+          "parameterTypes": [
+            "boolean",
+            "boolean"
+          ]
+        },
+        {
+          "name": "setReadable",
+          "parameterTypes": [
+            "boolean",
+            "boolean"
+          ]
+        },
+        {
+          "name": "setWritable",
+          "parameterTypes": [
+            "boolean",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_plexus.plexus_archiver.ArchiveEntryUtilsTest$Java7DetectionRestorer"
+      },
+      "type": "java.nio.file.Files"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_plexus.plexus_archiver.ExtraFieldUtilsTest"
+      },
+      "type": "org.apache.commons.compress.archivers.zip.AsiExtraField",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_plexus.plexus_archiver.ExtraFieldUtilsTest"
+      },
+      "type": "org.apache.commons.compress.archivers.zip.JarMarker",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_plexus.plexus_archiver.ExtraFieldUtilsTest"
+      },
+      "type": "org.apache.commons.compress.archivers.zip.UnicodeCommentExtraField",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_plexus.plexus_archiver.ExtraFieldUtilsTest"
+      },
+      "type": "org.apache.commons.compress.archivers.zip.UnicodePathExtraField",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_plexus.plexus_archiver.ExtraFieldUtilsTest"
+      },
+      "type": "org.apache.commons.compress.archivers.zip.X5455_ExtendedTimestamp",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_plexus.plexus_archiver.ExtraFieldUtilsTest"
+      },
+      "type": "org.apache.commons.compress.archivers.zip.X7875_NewUnix",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_plexus.plexus_archiver.ExtraFieldUtilsTest"
+      },
+      "type": "org.apache.commons.compress.archivers.zip.Zip64ExtendedInformationExtraField",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_plexus.plexus_archiver.ArchiveEntryUtilsTest$Java7DetectionRestorer"
+      },
+      "type": "org.codehaus.plexus.components.io.attributes.Java7Reflector"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_plexus.plexus_archiver.ArchiveEntryUtilsTest"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org_codehaus_plexus.plexus_archiver.ArchiveEntryUtilsTest"
+      },
+      "glob": "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_plexus.plexus_archiver.ArchiveEntryUtilsTest"
+      },
+      "glob": "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/metadata/org.codehaus.plexus/plexus-archiver/index.json
+++ b/metadata/org.codehaus.plexus/plexus-archiver/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.5",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/$version$/plexus-archiver-$version$-sources.jar",
+    "repository-url" : "https://github.com/sonatype/plexus-archiver",
+    "test-code-url" : "https://github.com/sonatype/plexus-archiver/tree/plexus-archiver-$version$/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/$version$/plexus-archiver-$version$-javadoc.jar",
+    "description" : "Plexus Archiver is a Java component for creating and extracting archive formats such as ZIP, TAR, JAR, and related compressed variants. It provides archiver and unarchiver abstractions used by Plexus and Maven tooling to add files, directories, resources, permissions, and metadata to archives.",
     "tested-versions" : [
       "2.5"
     ],

--- a/metadata/org.codehaus.plexus/plexus-archiver/index.json
+++ b/metadata/org.codehaus.plexus/plexus-archiver/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.5",
+    "tested-versions" : [
+      "2.5"
+    ],
+    "allowed-packages" : [
+      "org.codehaus.plexus.archiver"
+    ]
+  },
+  {
     "metadata-version" : "2.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/$version$/plexus-archiver-$version$-sources.jar",
     "repository-url" : "https://github.com/sonatype/plexus-archiver",

--- a/stats/org.codehaus.plexus/plexus-archiver/2.5/execution-metrics.json
+++ b/stats/org.codehaus.plexus/plexus-archiver/2.5/execution-metrics.json
@@ -1,0 +1,100 @@
+{
+  "fix_javac_fail:2026-06-07": {
+    "timestamp": "2026-06-07T04:49:21.044031Z",
+    "library": "org.codehaus.plexus:plexus-archiver:2.5",
+    "starting_commit": "f30f080c2209abcdd1defbe278c00a7b293b03b1",
+    "ending_commit": "9f58e9480d4e2ce4bc354fdcdba1504c9e3c10f7",
+    "previous_library": "org.codehaus.plexus:plexus-archiver:2.1",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.5",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 3,
+        "totalCalls": 3
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 265,
+          "missed": 9939,
+          "ratio": 0.02597,
+          "total": 10204
+        },
+        "line": {
+          "covered": 52,
+          "missed": 2295,
+          "ratio": 0.022156,
+          "total": 2347
+        },
+        "method": {
+          "covered": 11,
+          "missed": 520,
+          "ratio": 0.020716,
+          "total": 531
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 6,
+            "totalCalls": 6
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 6,
+        "totalCalls": 6
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 446,
+          "missed": 24778,
+          "ratio": 0.017682,
+          "total": 25224
+        },
+        "line": {
+          "covered": 108,
+          "missed": 4847,
+          "ratio": 0.021796,
+          "total": 4955
+        },
+        "method": {
+          "covered": 28,
+          "missed": 785,
+          "ratio": 0.03444,
+          "total": 813
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 134457,
+      "cached_input_tokens_used": 1700864,
+      "output_tokens_used": 15531,
+      "iterations": 2,
+      "cost_usd": 1.3163,
+      "tested_library_loc": 52,
+      "metadata_entries": 4,
+      "test_only_metadata_entries": 20,
+      "previous_library_metadata_entries": 3,
+      "code_coverage_percent": 2.22,
+      "previous_library_coverage_percent": 2.18
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.codehaus.plexus/plexus-archiver/2.5/src/test/java/org_codehaus_plexus/plexus_archiver/ZipEntryTest.java",
+      "metadata_file": "metadata/org.codehaus.plexus/plexus-archiver/2.5/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.codehaus.plexus/plexus-archiver/2.5/stats.json
+++ b/stats/org.codehaus.plexus/plexus-archiver/2.5/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "2.5",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 3,
+          "totalCalls" : 3
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 3,
+      "totalCalls" : 3
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 265,
+        "missed" : 9939,
+        "ratio" : 0.02597,
+        "total" : 10204
+      },
+      "line" : {
+        "covered" : 52,
+        "missed" : 2295,
+        "ratio" : 0.022156,
+        "total" : 2347
+      },
+      "method" : {
+        "covered" : 11,
+        "missed" : 520,
+        "ratio" : 0.020716,
+        "total" : 531
+      }
+    }
+  } ]
+}

--- a/tests/src/org.codehaus.plexus/plexus-archiver/2.5/.gitignore
+++ b/tests/src/org.codehaus.plexus/plexus-archiver/2.5/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.codehaus.plexus/plexus-archiver/2.5/build.gradle
+++ b/tests/src/org.codehaus.plexus/plexus-archiver/2.5/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.codehaus.plexus:plexus-archiver:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-archiver/2.5/gradle.properties
+++ b/tests/src/org.codehaus.plexus/plexus-archiver/2.5/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.codehaus.plexus:plexus-archiver:2.5
+library.version = 2.5
+metadata.dir = org.codehaus.plexus/plexus-archiver/2.5/

--- a/tests/src/org.codehaus.plexus/plexus-archiver/2.5/settings.gradle
+++ b/tests/src/org.codehaus.plexus/plexus-archiver/2.5/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.codehaus.plexus.plexus-archiver_tests'

--- a/tests/src/org.codehaus.plexus/plexus-archiver/2.5/src/test/java/org_codehaus_plexus/plexus_archiver/ArchiveEntryUtilsTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-archiver/2.5/src/test/java/org_codehaus_plexus/plexus_archiver/ArchiveEntryUtilsTest.java
@@ -7,14 +7,17 @@
 package org_codehaus_plexus.plexus_archiver;
 
 import java.io.File;
+import java.lang.reflect.Field;
 import java.nio.file.Path;
 
 import org.codehaus.plexus.archiver.util.ArchiveEntryUtils;
+import org.codehaus.plexus.components.io.attributes.Java7Reflector;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.logging.console.ConsoleLogger;
 import org.codehaus.plexus.util.Os;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import sun.misc.Unsafe;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,7 +32,7 @@ public class ArchiveEntryUtilsTest {
 
         boolean originalJvmFilePermAvailable = ArchiveEntryUtils.jvmFilePermAvailable;
         ArchiveEntryUtils.jvmFilePermAvailable = true;
-        try {
+        try (Java7DetectionRestorer ignored = Java7DetectionRestorer.forceJava6PermissionsPath()) {
             Logger logger = new ConsoleLogger(Logger.LEVEL_DISABLED, "archive-entry-utils-test");
             int ownerReadWriteExecuteMode = 0700;
 
@@ -45,5 +48,39 @@ public class ArchiveEntryUtilsTest {
         } finally {
             ArchiveEntryUtils.jvmFilePermAvailable = originalJvmFilePermAvailable;
         }
+    }
+
+    private static final class Java7DetectionRestorer implements AutoCloseable {
+        private final Object staticFieldBase;
+        private final long staticFieldOffset;
+        private final boolean originalValue;
+
+        private Java7DetectionRestorer(Object staticFieldBase, long staticFieldOffset, boolean originalValue) {
+            this.staticFieldBase = staticFieldBase;
+            this.staticFieldOffset = staticFieldOffset;
+            this.originalValue = originalValue;
+        }
+
+        private static Java7DetectionRestorer forceJava6PermissionsPath() throws ReflectiveOperationException {
+            Java7Reflector.isJava7();
+            Unsafe unsafe = getUnsafe();
+            Field java7Field = Java7Reflector.class.getDeclaredField("isJava7");
+            Object staticFieldBase = unsafe.staticFieldBase(java7Field);
+            long staticFieldOffset = unsafe.staticFieldOffset(java7Field);
+            boolean originalValue = unsafe.getBooleanVolatile(staticFieldBase, staticFieldOffset);
+            unsafe.putBooleanVolatile(staticFieldBase, staticFieldOffset, false);
+            return new Java7DetectionRestorer(staticFieldBase, staticFieldOffset, originalValue);
+        }
+
+        @Override
+        public void close() throws ReflectiveOperationException {
+            getUnsafe().putBooleanVolatile(staticFieldBase, staticFieldOffset, originalValue);
+        }
+    }
+
+    private static Unsafe getUnsafe() throws ReflectiveOperationException {
+        Field unsafeField = Unsafe.class.getDeclaredField("theUnsafe");
+        unsafeField.setAccessible(true);
+        return (Unsafe) unsafeField.get(null);
     }
 }

--- a/tests/src/org.codehaus.plexus/plexus-archiver/2.5/src/test/java/org_codehaus_plexus/plexus_archiver/ArchiveEntryUtilsTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-archiver/2.5/src/test/java/org_codehaus_plexus/plexus_archiver/ArchiveEntryUtilsTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_archiver;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import org.codehaus.plexus.archiver.util.ArchiveEntryUtils;
+import org.codehaus.plexus.logging.Logger;
+import org.codehaus.plexus.logging.console.ConsoleLogger;
+import org.codehaus.plexus.util.Os;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ArchiveEntryUtilsTest {
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void chmodWithJvmPermissionsAppliesAllFilePermissionMethods() throws Exception {
+        File file = temporaryDirectory.resolve("archive-entry-utils-permissions.txt").toFile();
+        assertThat(file.createNewFile()).isTrue();
+
+        boolean originalJvmFilePermAvailable = ArchiveEntryUtils.jvmFilePermAvailable;
+        ArchiveEntryUtils.jvmFilePermAvailable = true;
+        try {
+            Logger logger = new ConsoleLogger(Logger.LEVEL_DISABLED, "archive-entry-utils-test");
+            int ownerReadWriteExecuteMode = 0700;
+
+            ArchiveEntryUtils.chmod(file, ownerReadWriteExecuteMode, logger, true);
+
+            assertThat(file)
+                .isFile()
+                .canRead()
+                .canWrite();
+            if (Os.isFamily(Os.FAMILY_UNIX)) {
+                assertThat(file.canExecute()).isTrue();
+            }
+        } finally {
+            ArchiveEntryUtils.jvmFilePermAvailable = originalJvmFilePermAvailable;
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-archiver/2.5/src/test/java/org_codehaus_plexus/plexus_archiver/ExtraFieldUtilsTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-archiver/2.5/src/test/java/org_codehaus_plexus/plexus_archiver/ExtraFieldUtilsTest.java
@@ -6,10 +6,10 @@
  */
 package org_codehaus_plexus.plexus_archiver;
 
-import org.codehaus.plexus.archiver.zip.AsiExtraField;
-import org.codehaus.plexus.archiver.zip.ExtraFieldUtils;
-import org.codehaus.plexus.archiver.zip.ZipExtraField;
-import org.codehaus.plexus.archiver.zip.ZipShort;
+import org.apache.commons.compress.archivers.zip.AsiExtraField;
+import org.apache.commons.compress.archivers.zip.ExtraFieldUtils;
+import org.apache.commons.compress.archivers.zip.ZipExtraField;
+import org.apache.commons.compress.archivers.zip.ZipShort;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/tests/src/org.codehaus.plexus/plexus-archiver/2.5/src/test/java/org_codehaus_plexus/plexus_archiver/ExtraFieldUtilsTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-archiver/2.5/src/test/java/org_codehaus_plexus/plexus_archiver/ExtraFieldUtilsTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_archiver;
+
+import org.codehaus.plexus.archiver.zip.AsiExtraField;
+import org.codehaus.plexus.archiver.zip.ExtraFieldUtils;
+import org.codehaus.plexus.archiver.zip.ZipExtraField;
+import org.codehaus.plexus.archiver.zip.ZipShort;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExtraFieldUtilsTest {
+
+    @Test
+    void registerMakesExtraFieldAvailableForCreation() throws Exception {
+        AsiExtraField registeredField = new AsiExtraField();
+        ZipShort headerId = registeredField.getHeaderId();
+
+        ExtraFieldUtils.register(AsiExtraField.class);
+        ZipExtraField recreatedField = ExtraFieldUtils.createExtraField(headerId);
+
+        assertThat(recreatedField).isInstanceOf(AsiExtraField.class);
+        assertThat(recreatedField).isNotSameAs(registeredField);
+        assertThat(recreatedField.getHeaderId()).isEqualTo(headerId);
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-archiver/2.5/src/test/java/org_codehaus_plexus/plexus_archiver/ZipEntryTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-archiver/2.5/src/test/java/org_codehaus_plexus/plexus_archiver/ZipEntryTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_archiver;
+
+import org.codehaus.plexus.archiver.zip.ZipEntry;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ZipEntryTest {
+
+    @Test
+    void setComprSizeUpdatesCompressedSizeThroughJdkZipEntryApi() throws Exception {
+        ZipEntry entry = new ZipEntry("compressed-entry.txt");
+        long compressedSize = 23L;
+
+        entry.setComprSize(compressedSize);
+
+        assertThat(entry.getCompressedSize()).isEqualTo(compressedSize);
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-archiver/2.5/src/test/java/org_codehaus_plexus/plexus_archiver/ZipEntryTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-archiver/2.5/src/test/java/org_codehaus_plexus/plexus_archiver/ZipEntryTest.java
@@ -6,7 +6,7 @@
  */
 package org_codehaus_plexus.plexus_archiver;
 
-import org.codehaus.plexus.archiver.zip.ZipEntry;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -14,11 +14,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ZipEntryTest {
 
     @Test
-    void setComprSizeUpdatesCompressedSizeThroughJdkZipEntryApi() throws Exception {
-        ZipEntry entry = new ZipEntry("compressed-entry.txt");
+    void setCompressedSizeUpdatesCompressedSizeThroughJdkZipEntryApi() throws Exception {
+        ZipArchiveEntry entry = new ZipArchiveEntry("compressed-entry.txt");
         long compressedSize = 23L;
 
-        entry.setComprSize(compressedSize);
+        entry.setCompressedSize(compressedSize);
 
         assertThat(entry.getCompressedSize()).isEqualTo(compressedSize);
     }

--- a/tests/src/org.codehaus.plexus/plexus-archiver/2.5/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.codehaus.plexus/plexus-archiver/2.5/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,125 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_archiver.ArchiveEntryUtilsTest$Java7DetectionRestorer"
+      },
+      "type" : "java.nio.file.Files"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_archiver.ExtraFieldUtilsTest"
+      },
+      "type" : "org.apache.commons.compress.archivers.zip.AsiExtraField",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_archiver.ExtraFieldUtilsTest"
+      },
+      "type" : "org.apache.commons.compress.archivers.zip.JarMarker",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_archiver.ExtraFieldUtilsTest"
+      },
+      "type" : "org.apache.commons.compress.archivers.zip.UnicodeCommentExtraField",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_archiver.ExtraFieldUtilsTest"
+      },
+      "type" : "org.apache.commons.compress.archivers.zip.UnicodePathExtraField",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_archiver.ExtraFieldUtilsTest"
+      },
+      "type" : "org.apache.commons.compress.archivers.zip.X5455_ExtendedTimestamp",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_archiver.ExtraFieldUtilsTest"
+      },
+      "type" : "org.apache.commons.compress.archivers.zip.X7875_NewUnix",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_archiver.ExtraFieldUtilsTest"
+      },
+      "type" : "org.apache.commons.compress.archivers.zip.Zip64ExtendedInformationExtraField",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_archiver.ArchiveEntryUtilsTest$Java7DetectionRestorer"
+      },
+      "type" : "org.codehaus.plexus.components.io.attributes.Java7Reflector"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_archiver.ArchiveEntryUtilsTest"
+      },
+      "type" : "sun.misc.Unsafe",
+      "fields" : [
+        {
+          "name" : "theUnsafe"
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_archiver.ArchiveEntryUtilsTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_archiver.ArchiveEntryUtilsTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/tests/src/org.codehaus.plexus/plexus-archiver/2.5/user-code-filter.json
+++ b/tests/src/org.codehaus.plexus/plexus-archiver/2.5/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.codehaus.plexus.archiver.**"
+    },
+    {
+      "includeClasses" : "org_codehaus_plexus.plexus_archiver.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6942

This PR provides test fixes and new metadata for org.codehaus.plexus:plexus-archiver:2.5, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 134457
- Cached input tokens: 1700864
- Output tokens: 15531
- Metadata entries: 4
- Test-only metadata entries: 20
- Iterations: 2
- Library coverage percentage: 2.22
- Previous library version metadata entries: 3
- Previous library version coverage percentage: 2.18

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `da08d7a48fce53f6c6266e822538b41d7f3ced4e`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.codehaus.plexus:plexus-archiver:2.1: 6/6 covered calls (100.00%)
- org.codehaus.plexus:plexus-archiver:2.5: 3/3 covered calls (100.00%)

**Reflection:**
- org.codehaus.plexus:plexus-archiver:2.1: 6/6 covered calls (100.00%)
- org.codehaus.plexus:plexus-archiver:2.5: 3/3 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.codehaus.plexus:plexus-archiver:2.1: 446/25224 (1.77%)
- org.codehaus.plexus:plexus-archiver:2.5: 265/10204 (2.60%)

**Line:**
- org.codehaus.plexus:plexus-archiver:2.1: 108/4955 (2.18%)
- org.codehaus.plexus:plexus-archiver:2.5: 52/2347 (2.22%)

**Method:**
- org.codehaus.plexus:plexus-archiver:2.1: 28/813 (3.44%)
- org.codehaus.plexus:plexus-archiver:2.5: 11/531 (2.07%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/org.codehaus.plexus/plexus-archiver/2.1/src/test/java/org_codehaus_plexus/plexus_archiver/ArchiveEntryUtilsTest.java b/tests/src/org.codehaus.plexus/plexus-archiver/2.5/src/test/java/org_codehaus_plexus/plexus_archiver/ArchiveEntryUtilsTest.java
index 4bef2cffc4..8a9fdc4353 100644
--- a/tests/src/org.codehaus.plexus/plexus-archiver/2.1/src/test/java/org_codehaus_plexus/plexus_archiver/ArchiveEntryUtilsTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-archiver/2.5/src/test/java/org_codehaus_plexus/plexus_archiver/ArchiveEntryUtilsTest.java
@@ -7,14 +7,17 @@
 package org_codehaus_plexus.plexus_archiver;
 
 import java.io.File;
+import java.lang.reflect.Field;
 import java.nio.file.Path;
 
 import org.codehaus.plexus.archiver.util.ArchiveEntryUtils;
+import org.codehaus.plexus.components.io.attributes.Java7Reflector;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.logging.console.ConsoleLogger;
 import org.codehaus.plexus.util.Os;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import sun.misc.Unsafe;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,7 +32,7 @@ public class ArchiveEntryUtilsTest {
 
         boolean originalJvmFilePermAvailable = ArchiveEntryUtils.jvmFilePermAvailable;
         ArchiveEntryUtils.jvmFilePermAvailable = true;
-        try {
+        try (Java7DetectionRestorer ignored = Java7DetectionRestorer.forceJava6PermissionsPath()) {
             Logger logger = new ConsoleLogger(Logger.LEVEL_DISABLED, "archive-entry-utils-test");
             int ownerReadWriteExecuteMode = 0700;
 
@@ -46,4 +49,38 @@ public class ArchiveEntryUtilsTest {
             ArchiveEntryUtils.jvmFilePermAvailable = originalJvmFilePermAvailable;
         }
     }
+
+    private static final class Java7DetectionRestorer implements AutoCloseable {
+        private final Object staticFieldBase;
+        private final long staticFieldOffset;
+        private final boolean originalValue;
+
+        private Java7DetectionRestorer(Object staticFieldBase, long staticFieldOffset, boolean originalValue) {
+            this.staticFieldBase = staticFieldBase;
+            this.staticFieldOffset = staticFieldOffset;
+            this.originalValue = originalValue;
+        }
+
+        private static Java7DetectionRestorer forceJava6PermissionsPath() throws ReflectiveOperationException {
+            Java7Reflector.isJava7();
+            Unsafe unsafe = getUnsafe();
+            Field java7Field = Java7Reflector.class.getDeclaredField("isJava7");
+            Object staticFieldBase = unsafe.staticFieldBase(java7Field);
+            long staticFieldOffset = unsafe.staticFieldOffset(java7Field);
+            boolean originalValue = unsafe.getBooleanVolatile(staticFieldBase, staticFieldOffset);
+            unsafe.putBooleanVolatile(staticFieldBase, staticFieldOffset, false);
+            return new Java7DetectionRestorer(staticFieldBase, staticFieldOffset, originalValue);
+        }
+
+        @Override
+        public void close() throws ReflectiveOperationException {
+            getUnsafe().putBooleanVolatile(staticFieldBase, staticFieldOffset, originalValue);
+        }
+    }
+
+    private static Unsafe getUnsafe() throws ReflectiveOperationException {
+        Field unsafeField = Unsafe.class.getDeclaredField("theUnsafe");
+        unsafeField.setAccessible(true);
+        return (Unsafe) unsafeField.get(null);
+    }
 }
diff --git a/tests/src/org.codehaus.plexus/plexus-archiver/2.1/src/test/java/org_codehaus_plexus/plexus_archiver/ExtraFieldUtilsTest.java b/tests/src/org.codehaus.plexus/plexus-archiver/2.5/src/test/java/org_codehaus_plexus/plexus_archiver/ExtraFieldUtilsTest.java
index c6c9c13165..723f3d76ef 100644
--- a/tests/src/org.codehaus.plexus/plexus-archiver/2.1/src/test/java/org_codehaus_plexus/plexus_archiver/ExtraFieldUtilsTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-archiver/2.5/src/test/java/org_codehaus_plexus/plexus_archiver/ExtraFieldUtilsTest.java
@@ -6,10 +6,10 @@
  */
 package org_codehaus_plexus.plexus_archiver;
 
-import org.codehaus.plexus.archiver.zip.AsiExtraField;
-import org.codehaus.plexus.archiver.zip.ExtraFieldUtils;
-import org.codehaus.plexus.archiver.zip.ZipExtraField;
-import org.codehaus.plexus.archiver.zip.ZipShort;
+import org.apache.commons.compress.archivers.zip.AsiExtraField;
+import org.apache.commons.compress.archivers.zip.ExtraFieldUtils;
+import org.apache.commons.compress.archivers.zip.ZipExtraField;
+import org.apache.commons.compress.archivers.zip.ZipShort;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
diff --git a/tests/src/org.codehaus.plexus/plexus-archiver/2.1/src/test/java/org_codehaus_plexus/plexus_archiver/ZipEntryTest.java b/tests/src/org.codehaus.plexus/plexus-archiver/2.5/src/test/java/org_codehaus_plexus/plexus_archiver/ZipEntryTest.java
index 271863a814..17d072715f 100644
--- a/tests/src/org.codehaus.plexus/plexus-archiver/2.1/src/test/java/org_codehaus_plexus/plexus_archiver/ZipEntryTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-archiver/2.5/src/test/java/org_codehaus_plexus/plexus_archiver/ZipEntryTest.java
@@ -6,7 +6,7 @@
  */
 package org_codehaus_plexus.plexus_archiver;
 
-import org.codehaus.plexus.archiver.zip.ZipEntry;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -14,11 +14,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ZipEntryTest {
 
     @Test
-    void setComprSizeUpdatesCompressedSizeThroughJdkZipEntryApi() throws Exception {
-        ZipEntry entry = new ZipEntry("compressed-entry.txt");
+    void setCompressedSizeUpdatesCompressedSizeThroughJdkZipEntryApi() throws Exception {
+        ZipArchiveEntry entry = new ZipArchiveEntry("compressed-entry.txt");
         long compressedSize = 23L;
 
-        entry.setComprSize(compressedSize);
+        entry.setCompressedSize(compressedSize);
 
         assertThat(entry.getCompressedSize()).isEqualTo(compressedSize);
     }

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
