### PR TITLE
[Automation] Generated metadata for com.github.luben:zstd-jni:1.5.2-5

### DIFF
--- a/metadata/com.github.luben/zstd-jni/1.5.2-5/reachability-metadata.json
+++ b/metadata/com.github.luben/zstd-jni/1.5.2-5/reachability-metadata.json
@@ -2,6 +2,12 @@
   "reflection": [
     {
       "condition": {
+        "typeReached": "com.github.luben.zstd.AutoCloseBase"
+      },
+      "type": "com.github.luben.zstd.AutoCloseBase"
+    },
+    {
+      "condition": {
         "typeReached": "com.github.luben.zstd.ZstdCompressCtx"
       },
       "type": "com.github.luben.zstd.ZstdCompressCtx",
@@ -126,12 +132,6 @@
       "condition": {
         "typeReached": "com.github.luben.zstd.util.Native"
       },
-      "type": "java.security.SecureRandomParameters"
-    },
-    {
-      "condition": {
-        "typeReached": "com.github.luben.zstd.util.Native"
-      },
       "type": "org.osgi.framework.BundleEvent"
     },
     {
@@ -142,7 +142,9 @@
       "methods": [
         {
           "name": "<init>",
-          "parameterTypes": []
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
         }
       ]
     },

--- a/metadata/com.github.luben/zstd-jni/index.json
+++ b/metadata/com.github.luben/zstd-jni/index.json
@@ -2,8 +2,8 @@
   {
     "metadata-version" : "1.5.2-5",
     "source-code-url" : "https://repo1.maven.org/maven2/com/github/luben/zstd-jni/$version$/zstd-jni-$version$-sources.jar",
-    "repository-url" : "https://github.com/luben/zstd-jni/tree/c1.5.2-5",
-    "test-code-url" : "https://github.com/luben/zstd-jni/tree/c1.5.2-5/src/test",
+    "repository-url" : "https://github.com/luben/zstd-jni",
+    "test-code-url" : "https://github.com/luben/zstd-jni/tree/c$version$/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/com/github/luben/zstd-jni/$version$/zstd-jni-$version$-javadoc.jar",
     "description" : "zstd-jni provides Java and JVM JNI bindings for the Zstandard compression library, including APIs for compressing and decompressing byte arrays. It also includes stream-based InputStream and OutputStream implementations that transparently read and write Zstandard-compressed data.",
     "tested-versions" : [


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7640

This PR provides new metadata needed for the com.github.luben:zstd-jni:1.5.2-5, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `com.github.luben:zstd-jni:1.5.2-5`): 41
- Metadata entries (new `com.github.luben:zstd-jni:1.5.2-5`): 41
- Library coverage (previous): 36.76%
- Library coverage (new): 36.76%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `1b26b9c9b2b1c94ed7f8e6e382f328a6971c3f5e`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `com.github.luben:zstd-jni:1.5.2-5` and `com.github.luben:zstd-jni:1.5.2-5`.

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
