### PR TITLE
[GenAI] Mark io.awspring.cloud:spring-cloud-aws-starter-parameter-store as not for Native Image

### DIFF
--- a/metadata/io.awspring.cloud/spring-cloud-aws-starter-parameter-store/index.json
+++ b/metadata/io.awspring.cloud/spring-cloud-aws-starter-parameter-store/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published spring-cloud-aws-starter-parameter-store-4.0.2 JAR contains only Maven metadata under META-INF and no JVM class files; it is a dependency starter whose runtime classes are supplied by dependencies.",
+    "replacement": "io.awspring.cloud:spring-cloud-aws-parameter-store:4.0.2"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #7673

This PR records `io.awspring.cloud:spring-cloud-aws-starter-parameter-store` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published spring-cloud-aws-starter-parameter-store-4.0.2 JAR contains only Maven metadata under META-INF and no JVM class files; it is a dependency starter whose runtime classes are supplied by dependencies.

Replacement guidance:
- io.awspring.cloud:spring-cloud-aws-parameter-store:4.0.2

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `1b26b9c9b2b1c94ed7f8e6e382f328a6971c3f5e`

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
