### PR TITLE
[Automation] Generated metadata for com.barchart.udt:barchart-udt-bundle:2.3.0

### DIFF
--- a/metadata/com.barchart.udt/barchart-udt-bundle/2.3.0/reachability-metadata.json
+++ b/metadata/com.barchart.udt/barchart-udt-bundle/2.3.0/reachability-metadata.json
@@ -50,6 +50,10 @@
           "parameterTypes": [
             "boolean"
           ]
+        },
+        {
+          "name": "booleanValue",
+          "parameterTypes": []
         }
       ]
     },

--- a/stats/com.barchart.udt/barchart-udt-bundle/2.3.0/stats.json
+++ b/stats/com.barchart.udt/barchart-udt-bundle/2.3.0/stats.json
@@ -20,21 +20,21 @@
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 1437,
-        "missed" : 6292,
-        "ratio" : 0.185923,
+        "covered" : 1712,
+        "missed" : 6017,
+        "ratio" : 0.221503,
         "total" : 7729
       },
       "line" : {
-        "covered" : 326,
-        "missed" : 1532,
-        "ratio" : 0.175457,
+        "covered" : 391,
+        "missed" : 1467,
+        "ratio" : 0.210441,
         "total" : 1858
       },
       "method" : {
-        "covered" : 72,
-        "missed" : 421,
-        "ratio" : 0.146045,
+        "covered" : 91,
+        "missed" : 402,
+        "ratio" : 0.184584,
         "total" : 493
       }
     }

--- a/tests/src/com.barchart.udt/barchart-udt-bundle/2.3.0/src/test/java/com_barchart_udt/barchart_udt_bundle/FactoryUDTTest.java
+++ b/tests/src/com.barchart.udt/barchart-udt-bundle/2.3.0/src/test/java/com_barchart_udt/barchart_udt_bundle/FactoryUDTTest.java
@@ -12,6 +12,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.barchart.udt.CCC;
 import com.barchart.udt.FactoryInterfaceUDT;
 import com.barchart.udt.FactoryUDT;
+import com.barchart.udt.SocketUDT;
+import com.barchart.udt.TypeUDT;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import org.junit.jupiter.api.Test;
 
 public class FactoryUDTTest {
@@ -40,5 +44,40 @@ public class FactoryUDTTest {
         assertThatThrownBy(() -> new FactoryUDT<>(String.class))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("CCC");
+    }
+
+    @Test
+    void socketOptionSnapshotIncludesNamedOptions() throws Exception {
+        final SocketUDT socket = new SocketUDT(TypeUDT.STREAM);
+        try {
+            socket.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+
+            final String snapshot = socket.toStringOptions();
+
+            assertThat(snapshot)
+                    .contains("Maximum_Transfer_Unit = ")
+                    .contains("Protocol_Send_Buffer_Size = ")
+                    .contains("Protocol_Receive_Buffer_Size = ")
+                    .contains("Is_Address_Reuse_Enabled = ")
+                    .contains("Maximum_Bandwidth = ");
+        } finally {
+            socket.close();
+        }
+    }
+
+    @Test
+    void socketBooleanOptionsCanBeConfigured() throws Exception {
+        final SocketUDT socket = new SocketUDT(TypeUDT.STREAM);
+        try {
+            socket.setReuseAddress(true);
+            socket.setBlocking(false);
+            socket.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+
+            assertThat(socket.getReuseAddress()).isTrue();
+            assertThat(socket.isBlocking()).isFalse();
+            assertThat(socket.isNonBlocking()).isTrue();
+        } finally {
+            socket.close();
+        }
     }
 }


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#7639

This PR provides new metadata needed for the com.barchart.udt:barchart-udt-bundle:2.3.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `com.barchart.udt:barchart-udt-bundle:2.3.0`): 72
- Metadata entries (new `com.barchart.udt:barchart-udt-bundle:2.3.0`): 72
- Library coverage (previous): 21.04%
- Library coverage (new): 21.04%

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `1b26b9c9b2b1c94ed7f8e6e382f328a6971c3f5e`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `com.barchart.udt:barchart-udt-bundle:2.3.0` and `com.barchart.udt:barchart-udt-bundle:2.3.0`.

### Local CI Verification

- Status: `success`
- Commands run: 0
- Fixup attempts: 0
