### PR TITLE
[GenAI] Add support for org.springframework.retry:spring-retry:2.0.12 using gpt-5.5

### DIFF
--- a/metadata/org.springframework.retry/spring-retry/2.0.12/reachability-metadata.json
+++ b/metadata/org.springframework.retry/spring-retry/2.0.12/reachability-metadata.json
@@ -1,0 +1,28 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.retry.support.RetryTemplate"
+      },
+      "type" : "org.apache.logging.log4j.spi.ExtendedLogger"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.retry.support.RetryTemplate"
+      },
+      "type" : "org.apache.logging.slf4j.SLF4JProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.retry.support.RetryTemplate"
+      },
+      "type" : "org.slf4j.Logger"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.retry.support.RetryTemplate"
+      },
+      "type" : "org.slf4j.spi.LocationAwareLogger"
+    }
+  ]
+}

--- a/metadata/org.springframework.retry/spring-retry/index.json
+++ b/metadata/org.springframework.retry/spring-retry/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.0.12",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/retry/spring-retry/$version$/spring-retry-$version$-sources.jar",
+    "repository-url" : "https://github.com/spring-projects/spring-retry",
+    "test-code-url" : "https://github.com/spring-projects/spring-retry/tree/v$version$/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/springframework/retry/spring-retry/$version$/spring-retry-$version$-javadoc.jar",
+    "description" : "Spring Retry provides reusable support for retrying failed operations with configurable retry policies, backoff strategies, and declarative Spring integration. It can wrap ordinary Java operations so transient failures, such as selected exception types, are retried consistently before the failure is propagated.",
+    "tested-versions" : [
+      "2.0.12"
+    ],
+    "allowed-packages" : [
+      "org.springframework"
+    ]
+  }
+]

--- a/stats/org.springframework.retry/spring-retry/2.0.12/execution-metrics.json
+++ b/stats/org.springframework.retry/spring-retry/2.0.12/execution-metrics.json
@@ -1,0 +1,63 @@
+{
+  "add_new_library_support:2026-06-07": {
+    "timestamp": "2026-06-07T05:21:01.858621Z",
+    "library": "org.springframework.retry:spring-retry:2.0.12",
+    "starting_commit": "bbf78319c48149a4a17e996bdb979eeabeff1e71",
+    "ending_commit": "b9f31f0ba79226e6fcfb4508cd2a203a9e1a1fe6",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.0.12",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.0,
+            "coveredCalls": 0,
+            "totalCalls": 3
+          }
+        },
+        "coverageRatio": 0.0,
+        "coveredCalls": 0,
+        "totalCalls": 3
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2441,
+          "missed": 6703,
+          "ratio": 0.266951,
+          "total": 9144
+        },
+        "line": {
+          "covered": 647,
+          "missed": 1649,
+          "ratio": 0.281794,
+          "total": 2296
+        },
+        "method": {
+          "covered": 209,
+          "missed": 387,
+          "ratio": 0.350671,
+          "total": 596
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 223195,
+      "cached_input_tokens_used": 2091008,
+      "output_tokens_used": 24073,
+      "iterations": 5,
+      "cost_usd": 1.7677,
+      "generated_loc": 311,
+      "tested_library_loc": 647,
+      "metadata_entries": 4,
+      "test_only_metadata_entries": 2,
+      "code_coverage_percent": 28.18
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.springframework.retry/spring-retry/2.0.12/src/test/java/org_springframework_retry/spring_retry/Spring_retryTest.java",
+      "metadata_file": "metadata/org.springframework.retry/spring-retry/2.0.12/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.springframework.retry/spring-retry/2.0.12/stats.json
+++ b/stats/org.springframework.retry/spring-retry/2.0.12/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "2.0.12",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.0,
+          "coveredCalls" : 0,
+          "totalCalls" : 3
+        }
+      },
+      "coverageRatio" : 0.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 3
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2441,
+        "missed" : 6703,
+        "ratio" : 0.266951,
+        "total" : 9144
+      },
+      "line" : {
+        "covered" : 647,
+        "missed" : 1649,
+        "ratio" : 0.281794,
+        "total" : 2296
+      },
+      "method" : {
+        "covered" : 209,
+        "missed" : 387,
+        "ratio" : 0.350671,
+        "total" : 596
+      }
+    }
+  } ]
+}

--- a/tests/src/org.springframework.retry/spring-retry/2.0.12/.gitignore
+++ b/tests/src/org.springframework.retry/spring-retry/2.0.12/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.springframework.retry/spring-retry/2.0.12/build.gradle
+++ b/tests/src/org.springframework.retry/spring-retry/2.0.12/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.springframework.retry:spring-retry:$libraryVersion"
+    testImplementation 'org.springframework:spring-core:6.0.23'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.springframework.retry/spring-retry/2.0.12/build.gradle
+++ b/tests/src/org.springframework.retry/spring-retry/2.0.12/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.springframework.retry:spring-retry:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.springframework.retry/spring-retry/2.0.12/gradle.properties
+++ b/tests/src/org.springframework.retry/spring-retry/2.0.12/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.springframework.retry:spring-retry:2.0.12
+library.version = 2.0.12
+metadata.dir = org.springframework.retry/spring-retry/2.0.12/

--- a/tests/src/org.springframework.retry/spring-retry/2.0.12/settings.gradle
+++ b/tests/src/org.springframework.retry/spring-retry/2.0.12/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.springframework.retry.spring-retry_tests'

--- a/tests/src/org.springframework.retry/spring-retry/2.0.12/src/test/java/org_springframework_retry/spring_retry/Spring_retryTest.java
+++ b/tests/src/org.springframework.retry/spring-retry/2.0.12/src/test/java/org_springframework_retry/spring_retry/Spring_retryTest.java
@@ -34,9 +34,11 @@ import org.springframework.retry.backoff.ExponentialBackOffPolicy;
 import org.springframework.retry.backoff.Sleeper;
 import org.springframework.retry.policy.AlwaysRetryPolicy;
 import org.springframework.retry.policy.CompositeRetryPolicy;
+import org.springframework.retry.policy.ExceptionClassifierRetryPolicy;
 import org.springframework.retry.policy.MapRetryContextCache;
 import org.springframework.retry.policy.NeverRetryPolicy;
 import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.policy.TimeoutRetryPolicy;
 import org.springframework.retry.stats.DefaultStatisticsRepository;
 import org.springframework.retry.stats.ExponentialAverageRetryStatistics;
 import org.springframework.retry.support.DefaultRetryState;
@@ -182,6 +184,49 @@ public class Spring_retryTest {
 
         assertThat(patternClassifier.classify("invoice.created")).isEqualTo("invoice-route");
         assertThat(patternClassifier.classify("unknown.created")).isEqualTo("default-route");
+    }
+
+    @Test
+    void exceptionClassifierRetryPolicyChoosesDelegatePolicyFromThrowableType() {
+        ExceptionClassifierRetryPolicy retryPolicy = new ExceptionClassifierRetryPolicy();
+        RetryPolicy retryablePolicy = new SimpleRetryPolicy(2);
+        RetryPolicy fatalPolicy = new NeverRetryPolicy();
+        retryPolicy.setExceptionClassifier(throwable -> {
+            if (throwable instanceof TemporaryServiceException) {
+                return retryablePolicy;
+            }
+            return fatalPolicy;
+        });
+
+        RetryContext retryableContext = retryPolicy.open(null);
+        assertThat(retryPolicy.canRetry(retryableContext)).isTrue();
+        retryPolicy.registerThrowable(retryableContext, new TemporaryServiceException("first"));
+        assertThat(retryPolicy.canRetry(retryableContext)).isTrue();
+        retryPolicy.registerThrowable(retryableContext, new TemporaryServiceException("second"));
+        assertThat(retryPolicy.canRetry(retryableContext)).isFalse();
+        retryPolicy.close(retryableContext);
+
+        RetryContext fatalContext = retryPolicy.open(null);
+        assertThat(retryPolicy.canRetry(fatalContext)).isTrue();
+        retryPolicy.registerThrowable(fatalContext, new OptimisticLockingFailure());
+        assertThat(retryPolicy.canRetry(fatalContext)).isFalse();
+        retryPolicy.close(fatalContext);
+    }
+
+    @Test
+    void timeoutRetryPolicyStopsRetryingAfterConfiguredDeadline() throws InterruptedException {
+        TimeoutRetryPolicy retryPolicy = new TimeoutRetryPolicy();
+        retryPolicy.setTimeout(10);
+        RetryContext context = retryPolicy.open(null);
+
+        assertThat(retryPolicy.canRetry(context)).isTrue();
+        retryPolicy.registerThrowable(context, new TemporaryServiceException("first"));
+        Thread.sleep(25);
+
+        assertThat(retryPolicy.canRetry(context)).isFalse();
+        assertThat(context.getRetryCount()).isEqualTo(1);
+        assertThat(context.getLastThrowable()).isInstanceOf(TemporaryServiceException.class);
+        retryPolicy.close(context);
     }
 
     @Test

--- a/tests/src/org.springframework.retry/spring-retry/2.0.12/src/test/java/org_springframework_retry/spring_retry/Spring_retryTest.java
+++ b/tests/src/org.springframework.retry/spring-retry/2.0.12/src/test/java/org_springframework_retry/spring_retry/Spring_retryTest.java
@@ -6,11 +6,281 @@
  */
 package org_springframework_retry.spring_retry;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
-class Spring_retryTest {
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.classify.BinaryExceptionClassifier;
+import org.springframework.classify.PatternMatcher;
+import org.springframework.classify.PatternMatchingClassifier;
+import org.springframework.classify.SubclassClassifier;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.RetryListener;
+import org.springframework.retry.RetryStatistics;
+import org.springframework.retry.backoff.BackOffContext;
+import org.springframework.retry.backoff.BackOffPolicy;
+import org.springframework.retry.backoff.BackOffPolicyBuilder;
+import org.springframework.retry.backoff.ExponentialBackOffPolicy;
+import org.springframework.retry.backoff.Sleeper;
+import org.springframework.retry.policy.MapRetryContextCache;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.stats.DefaultStatisticsRepository;
+import org.springframework.retry.stats.ExponentialAverageRetryStatistics;
+import org.springframework.retry.support.DefaultRetryState;
+import org.springframework.retry.support.RetrySynchronizationManager;
+import org.springframework.retry.support.RetryTemplate;
+
+public class Spring_retryTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void retryTemplateRetriesSelectedExceptionsAndNotifiesListener() {
+        RecordingRetryListener listener = new RecordingRetryListener();
+        RetryTemplate retryTemplate = RetryTemplate.builder()
+                .maxAttempts(3)
+                .noBackoff()
+                .retryOn(IllegalStateException.class)
+                .withListener(listener)
+                .build();
+        AtomicInteger attempts = new AtomicInteger();
+
+        String result = retryTemplate.execute(context -> {
+            assertThat(RetrySynchronizationManager.getContext()).isSameAs(context);
+            int attempt = attempts.incrementAndGet();
+            assertThat(context.getRetryCount()).isEqualTo(attempt - 1);
+            if (attempt < 3) {
+                throw new IllegalStateException("temporary failure " + attempt);
+            }
+            return "ok after " + context.getRetryCount() + " retries";
+        });
+
+        assertThat(result).isEqualTo("ok after 2 retries");
+        assertThat(attempts).hasValue(3);
+        assertThat(RetrySynchronizationManager.getContext()).isNull();
+        assertThat(listener.events).containsExactly(
+                "open:0",
+                "error:1:IllegalStateException",
+                "error:2:IllegalStateException",
+                "success:2:ok after 2 retries",
+                "close:2:none");
+
+        AtomicInteger fatalAttempts = new AtomicInteger();
+        Throwable thrown = catchThrowable(() -> retryTemplate.execute(context -> {
+            fatalAttempts.incrementAndGet();
+            throw new IllegalArgumentException("non retryable");
+        }));
+
+        assertThat(thrown).isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("non retryable");
+        assertThat(fatalAttempts).hasValue(1);
+    }
+
+    @Test
+    void exhaustedRetryInvokesRecoveryWithLastThrowable() {
+        RetryTemplate retryTemplate = RetryTemplate.builder()
+                .maxAttempts(2)
+                .noBackoff()
+                .retryOn(TemporaryServiceException.class)
+                .build();
+        AtomicInteger attempts = new AtomicInteger();
+
+        String result = retryTemplate.execute(context -> {
+            attempts.incrementAndGet();
+            throw new TemporaryServiceException("service unavailable");
+        }, context -> "recovered after " + context.getRetryCount() + " attempts from "
+                + context.getLastThrowable().getClass().getSimpleName());
+
+        assertThat(result).isEqualTo("recovered after 2 attempts from TemporaryServiceException");
+        assertThat(attempts).hasValue(2);
+    }
+
+    @Test
+    void retryPoliciesExposeAttemptStateAndExceptionClassification() {
+        Map<Class<? extends Throwable>, Boolean> retryableExceptions = new LinkedHashMap<>();
+        retryableExceptions.put(IllegalStateException.class, true);
+        retryableExceptions.put(IllegalArgumentException.class, false);
+        SimpleRetryPolicy retryPolicy = new SimpleRetryPolicy(2, retryableExceptions, true);
+
+        RetryContext retryableContext = retryPolicy.open(null);
+        assertThat(retryPolicy.canRetry(retryableContext)).isTrue();
+        retryPolicy.registerThrowable(retryableContext, new IllegalStateException("first"));
+        assertThat(retryableContext.getRetryCount()).isEqualTo(1);
+        assertThat(retryPolicy.canRetry(retryableContext)).isTrue();
+        retryPolicy.registerThrowable(retryableContext, new IllegalStateException("second"));
+        assertThat(retryableContext.getRetryCount()).isEqualTo(2);
+        assertThat(retryPolicy.canRetry(retryableContext)).isFalse();
+        retryPolicy.close(retryableContext);
+
+        RetryContext nonRetryableContext = retryPolicy.open(null);
+        retryPolicy.registerThrowable(nonRetryableContext, new IllegalArgumentException("fatal"));
+        assertThat(retryPolicy.canRetry(nonRetryableContext)).isFalse();
+        retryPolicy.close(nonRetryableContext);
+    }
+
+    @Test
+    void backOffPoliciesUseConfiguredSleeperWithoutRealWaiting() {
+        RecordingSleeper exponentialSleeper = new RecordingSleeper();
+        ExponentialBackOffPolicy exponentialBackOffPolicy = new ExponentialBackOffPolicy();
+        exponentialBackOffPolicy.setInitialInterval(5);
+        exponentialBackOffPolicy.setMultiplier(3.0);
+        exponentialBackOffPolicy.setMaxInterval(20);
+        exponentialBackOffPolicy.setSleeper(exponentialSleeper);
+
+        BackOffContext exponentialContext = exponentialBackOffPolicy.start(null);
+        exponentialBackOffPolicy.backOff(exponentialContext);
+        exponentialBackOffPolicy.backOff(exponentialContext);
+        exponentialBackOffPolicy.backOff(exponentialContext);
+
+        assertThat(exponentialSleeper.periods).containsExactly(5L, 15L, 20L);
+
+        RecordingSleeper fixedSleeper = new RecordingSleeper();
+        BackOffPolicy fixedBackOffPolicy = BackOffPolicyBuilder.newBuilder()
+                .delay(7)
+                .sleeper(fixedSleeper)
+                .build();
+        BackOffContext fixedContext = fixedBackOffPolicy.start(null);
+        fixedBackOffPolicy.backOff(fixedContext);
+        fixedBackOffPolicy.backOff(fixedContext);
+
+        assertThat(fixedSleeper.periods).containsExactly(7L, 7L);
+    }
+
+    @Test
+    void classifiersMatchThrowableHierarchiesCausesAndPatterns() {
+        SubclassClassifier<Throwable, String> subclassClassifier = new SubclassClassifier<>("other");
+        subclassClassifier.add(IOException.class, "io");
+
+        assertThat(subclassClassifier.classify(new FileNotFoundException("missing"))).isEqualTo("io");
+        assertThat(subclassClassifier.classify(new IllegalStateException("state"))).isEqualTo("other");
+
+        BinaryExceptionClassifier binaryClassifier = BinaryExceptionClassifier.builder()
+                .retryOn(IOException.class)
+                .traversingCauses()
+                .build();
+
+        assertThat(binaryClassifier.classify(new IllegalStateException(new IOException("nested")))).isTrue();
+        assertThat(binaryClassifier.classify(new IllegalArgumentException("fatal"))).isFalse();
+
+        assertThat(PatternMatcher.match("invoice.*", "invoice.created")).isTrue();
+        assertThat(PatternMatcher.match("invoice.*", "payment.created")).isFalse();
+
+        PatternMatchingClassifier<String> patternClassifier = new PatternMatchingClassifier<>(Map.of(
+                "invoice.*", "invoice-route",
+                "payment.*", "payment-route",
+                "*", "default-route"));
+
+        assertThat(patternClassifier.classify("invoice.created")).isEqualTo("invoice-route");
+        assertThat(patternClassifier.classify("unknown.created")).isEqualTo("default-route");
+    }
+
+    @Test
+    void statisticsRepositoryAccumulatesNamedRetryOutcomes() {
+        DefaultStatisticsRepository repository = new DefaultStatisticsRepository();
+
+        repository.addStarted("checkout");
+        repository.addStarted("checkout");
+        repository.addError("checkout");
+        repository.addRecovery("checkout");
+        repository.addComplete("checkout");
+        repository.addAbort("checkout");
+
+        RetryStatistics statistics = repository.findOne("checkout");
+        assertThat(statistics.getName()).isEqualTo("checkout");
+        assertThat(statistics.getStartedCount()).isEqualTo(2);
+        assertThat(statistics.getErrorCount()).isEqualTo(1);
+        assertThat(statistics.getRecoveryCount()).isEqualTo(1);
+        assertThat(statistics.getCompleteCount()).isEqualTo(1);
+        assertThat(statistics.getAbortCount()).isEqualTo(1);
+        assertThat(repository.findAll()).extracting(RetryStatistics::getName).containsExactly("checkout");
+
+        ExponentialAverageRetryStatistics rollingStatistics = new ExponentialAverageRetryStatistics("payments");
+        rollingStatistics.setWindow(1_000_000);
+        rollingStatistics.incrementStartedCount();
+        rollingStatistics.incrementStartedCount();
+        rollingStatistics.incrementErrorCount();
+        rollingStatistics.incrementRecoveryCount();
+        rollingStatistics.incrementCompleteCount();
+
+        assertThat(rollingStatistics.getRollingStartedCount()).isEqualTo(2);
+        assertThat(rollingStatistics.getRollingErrorCount()).isEqualTo(1);
+        assertThat(rollingStatistics.getRollingRecoveryCount()).isEqualTo(1);
+        assertThat(rollingStatistics.getRollingCompleteCount()).isEqualTo(1);
+        assertThat(rollingStatistics.getRollingErrorRate()).isPositive();
+    }
+
+    @Test
+    void retryStateAndContextCacheTrackKeysAndRollbackRules() {
+        DefaultRetryState retryState = new DefaultRetryState("order-42", false,
+                throwable -> throwable instanceof OptimisticLockingFailure);
+        MapRetryContextCache contextCache = new MapRetryContextCache(2);
+        SimpleRetryPolicy retryPolicy = new SimpleRetryPolicy(1);
+        RetryContext context = retryPolicy.open(null);
+
+        contextCache.put(retryState.getKey(), context);
+
+        assertThat(retryState.getKey()).isEqualTo("order-42");
+        assertThat(retryState.isForceRefresh()).isFalse();
+        assertThat(retryState.rollbackFor(new OptimisticLockingFailure())).isTrue();
+        assertThat(retryState.rollbackFor(new IllegalStateException())).isFalse();
+        assertThat(contextCache.containsKey("order-42")).isTrue();
+        assertThat(contextCache.get("order-42")).isSameAs(context);
+
+        contextCache.remove("order-42");
+
+        assertThat(contextCache.containsKey("order-42")).isFalse();
+        retryPolicy.close(context);
+    }
+
+    private static final class RecordingRetryListener implements RetryListener {
+        private final List<String> events = new ArrayList<>();
+
+        @Override
+        public <T, E extends Throwable> boolean open(RetryContext context, RetryCallback<T, E> callback) {
+            events.add("open:" + context.getRetryCount());
+            return true;
+        }
+
+        @Override
+        public <T, E extends Throwable> void onError(RetryContext context, RetryCallback<T, E> callback,
+                Throwable throwable) {
+            events.add("error:" + context.getRetryCount() + ":" + throwable.getClass().getSimpleName());
+        }
+
+        @Override
+        public <T, E extends Throwable> void onSuccess(RetryContext context, RetryCallback<T, E> callback, T result) {
+            events.add("success:" + context.getRetryCount() + ":" + result);
+        }
+
+        @Override
+        public <T, E extends Throwable> void close(RetryContext context, RetryCallback<T, E> callback,
+                Throwable throwable) {
+            String failure = throwable == null ? "none" : throwable.getClass().getSimpleName();
+            events.add("close:" + context.getRetryCount() + ":" + failure);
+        }
+    }
+
+    private static final class RecordingSleeper implements Sleeper {
+        private final List<Long> periods = new ArrayList<>();
+
+        @Override
+        public void sleep(long backOffPeriod) {
+            periods.add(backOffPeriod);
+        }
+    }
+
+    private static final class TemporaryServiceException extends RuntimeException {
+        private TemporaryServiceException(String message) {
+            super(message);
+        }
+    }
+
+    private static final class OptimisticLockingFailure extends RuntimeException {
     }
 }

--- a/tests/src/org.springframework.retry/spring-retry/2.0.12/src/test/java/org_springframework_retry/spring_retry/Spring_retryTest.java
+++ b/tests/src/org.springframework.retry/spring-retry/2.0.12/src/test/java/org_springframework_retry/spring_retry/Spring_retryTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework_retry.spring_retry;
+
+import org.junit.jupiter.api.Test;
+
+class Spring_retryTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.springframework.retry/spring-retry/2.0.12/src/test/java/org_springframework_retry/spring_retry/Spring_retryTest.java
+++ b/tests/src/org.springframework.retry/spring-retry/2.0.12/src/test/java/org_springframework_retry/spring_retry/Spring_retryTest.java
@@ -25,13 +25,17 @@ import org.springframework.classify.SubclassClassifier;
 import org.springframework.retry.RetryCallback;
 import org.springframework.retry.RetryContext;
 import org.springframework.retry.RetryListener;
+import org.springframework.retry.RetryPolicy;
 import org.springframework.retry.RetryStatistics;
 import org.springframework.retry.backoff.BackOffContext;
 import org.springframework.retry.backoff.BackOffPolicy;
 import org.springframework.retry.backoff.BackOffPolicyBuilder;
 import org.springframework.retry.backoff.ExponentialBackOffPolicy;
 import org.springframework.retry.backoff.Sleeper;
+import org.springframework.retry.policy.AlwaysRetryPolicy;
+import org.springframework.retry.policy.CompositeRetryPolicy;
 import org.springframework.retry.policy.MapRetryContextCache;
+import org.springframework.retry.policy.NeverRetryPolicy;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.stats.DefaultStatisticsRepository;
 import org.springframework.retry.stats.ExponentialAverageRetryStatistics;
@@ -181,6 +185,31 @@ public class Spring_retryTest {
     }
 
     @Test
+    void compositeRetryPolicyCoordinatesChildPoliciesWithPessimisticAndOptimisticModes() {
+        CompositeRetryPolicy pessimisticPolicy = compositeRetryPolicy(false, new AlwaysRetryPolicy(),
+                new NeverRetryPolicy());
+        RetryContext pessimisticContext = pessimisticPolicy.open(null);
+
+        assertThat(pessimisticPolicy.canRetry(pessimisticContext)).isTrue();
+        pessimisticPolicy.registerThrowable(pessimisticContext, new IllegalStateException("first failure"));
+        assertThat(pessimisticContext.getRetryCount()).isEqualTo(1);
+        assertThat(pessimisticContext.getLastThrowable()).isInstanceOf(IllegalStateException.class);
+        assertThat(pessimisticPolicy.canRetry(pessimisticContext)).isFalse();
+        pessimisticPolicy.close(pessimisticContext);
+
+        CompositeRetryPolicy optimisticPolicy = compositeRetryPolicy(true, new AlwaysRetryPolicy(),
+                new NeverRetryPolicy());
+        RetryContext optimisticContext = optimisticPolicy.open(null);
+
+        assertThat(optimisticPolicy.canRetry(optimisticContext)).isTrue();
+        optimisticPolicy.registerThrowable(optimisticContext, new IllegalStateException("first failure"));
+        assertThat(optimisticContext.getRetryCount()).isEqualTo(1);
+        assertThat(optimisticContext.getLastThrowable()).isInstanceOf(IllegalStateException.class);
+        assertThat(optimisticPolicy.canRetry(optimisticContext)).isTrue();
+        optimisticPolicy.close(optimisticContext);
+    }
+
+    @Test
     void statisticsRepositoryAccumulatesNamedRetryOutcomes() {
         DefaultStatisticsRepository repository = new DefaultStatisticsRepository();
 
@@ -236,6 +265,13 @@ public class Spring_retryTest {
 
         assertThat(contextCache.containsKey("order-42")).isFalse();
         retryPolicy.close(context);
+    }
+
+    private static CompositeRetryPolicy compositeRetryPolicy(boolean optimistic, RetryPolicy... policies) {
+        CompositeRetryPolicy compositeRetryPolicy = new CompositeRetryPolicy();
+        compositeRetryPolicy.setOptimistic(optimistic);
+        compositeRetryPolicy.setPolicies(policies);
+        return compositeRetryPolicy;
     }
 
     private static final class RecordingRetryListener implements RetryListener {

--- a/tests/src/org.springframework.retry/spring-retry/2.0.12/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.springframework.retry/spring-retry/2.0.12/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_retry.spring_retry.Spring_retryTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_retry.spring_retry.Spring_retryTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/tests/src/org.springframework.retry/spring-retry/2.0.12/user-code-filter.json
+++ b/tests/src/org.springframework.retry/spring-retry/2.0.12/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.springframework.**"
+    }
+  ]
+}

--- a/tests/src/org.springframework.retry/spring-retry/2.0.12/user-code-filter.json
+++ b/tests/src/org.springframework.retry/spring-retry/2.0.12/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.springframework.**"
+      "includeClasses" : "org.springframework.**"
+    },
+    {
+      "includeClasses" : "org_springframework_retry.spring_retry.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #7691

This PR introduces tests and metadata for org.springframework.retry:spring-retry:2.0.12, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 223195
- Cached input tokens: 2091008
- Output tokens: 24073
- Metadata entries: 4
- Test-only metadata entries: 2
- Iterations: 5
- Library coverage percentage: 28.18
- Generated lines of code: 311
- Tested library lines of code: 647

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `da08d7a48fce53f6c6266e822538b41d7f3ced4e`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/3 covered calls (0.00%)
- Reflection: 0/3 covered calls (0.00%)

Library coverage:
- Instruction: 2441/9144 (26.70%)
- Line: 647/2296 (28.18%)
- Method: 209/596 (35.07%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
