### PR TITLE
[GenAI] Add support for io.awspring.cloud:spring-cloud-aws-core:4.0.2 using gpt-5.5

### DIFF
--- a/metadata/io.awspring.cloud/spring-cloud-aws-core/4.0.2/reachability-metadata.json
+++ b/metadata/io.awspring.cloud/spring-cloud-aws-core/4.0.2/reachability-metadata.json
@@ -1,0 +1,144 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.io.support.SpringFactoriesLoader"
+      },
+      "type" : "io.awspring.cloud.core.AWSCoreRuntimeHints",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : []
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.io.support.SpringFactoriesLoader"
+      },
+      "type" : "org.springframework.aot.hint.support.KotlinDetectorRuntimeHints",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : []
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.io.support.SpringFactoriesLoader"
+      },
+      "type" : "org.springframework.aot.hint.support.ObjectToObjectConverterRuntimeHints",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : []
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.io.support.SpringFactoriesLoader"
+      },
+      "type" : "org.springframework.aot.hint.support.PathMatchingResourcePatternResolverRuntimeHints",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : []
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.io.support.SpringFactoriesLoader"
+      },
+      "type" : "org.springframework.aot.hint.support.SpringFactoriesLoaderRuntimeHints",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : []
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.io.support.SpringFactoriesLoader"
+      },
+      "type" : "org.springframework.aot.hint.support.SpringPropertiesRuntimeHints",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : []
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.io.support.SpringFactoriesLoader"
+      },
+      "glob" : "/"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.io.support.SpringFactoriesLoader"
+      },
+      "glob" : "META-INF"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.io.support.SpringFactoriesLoader"
+      },
+      "glob" : "META-INF/spring"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.io.support.SpringFactoriesLoader"
+      },
+      "glob" : "META-INF/spring/*"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.io.support.SpringFactoriesLoader"
+      },
+      "glob" : "META-INF/spring/aot.factories"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.awspring.cloud.core.SpringCloudClientConfiguration"
+      },
+      "glob" : "io"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.awspring.cloud.core.SpringCloudClientConfiguration"
+      },
+      "glob" : "io/awspring"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.awspring.cloud.core.SpringCloudClientConfiguration"
+      },
+      "glob" : "io/awspring/cloud"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.awspring.cloud.core.SpringCloudClientConfiguration"
+      },
+      "glob" : "io/awspring/cloud/core"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.awspring.cloud.core.SpringCloudClientConfiguration"
+      },
+      "glob" : "io/awspring/cloud/core/*"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.awspring.cloud.core.SpringCloudClientConfiguration"
+      },
+      "glob" : "io/awspring/cloud/core/SpringCloudClientConfiguration.properties"
+    }
+  ]
+}

--- a/metadata/io.awspring.cloud/spring-cloud-aws-core/index.json
+++ b/metadata/io.awspring.cloud/spring-cloud-aws-core/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.0.2",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/awspring/cloud/spring-cloud-aws-core/$version$/spring-cloud-aws-core-$version$-sources.jar",
+    "repository-url" : "https://github.com/awspring/spring-cloud-aws",
+    "test-code-url" : "https://github.com/awspring/spring-cloud-aws/tree/v$version$/spring-cloud-aws-core/src/test/java",
+    "documentation-url" : "https://docs.awspring.io/spring-cloud-aws/docs/$version$/reference/html/index.html#spring-cloud-aws-core",
+    "description" : "Spring Cloud AWS Core provides shared infrastructure for Spring applications using AWS services, including credentials and region provider support. It supplies core client configuration and runtime hints used by other Spring Cloud AWS modules to integrate with the AWS SDK.",
+    "tested-versions" : [
+      "4.0.2"
+    ],
+    "allowed-packages" : [
+      "io.awspring.cloud.core"
+    ]
+  }
+]

--- a/metadata/io.awspring.cloud/spring-cloud-aws-core/index.json
+++ b/metadata/io.awspring.cloud/spring-cloud-aws-core/index.json
@@ -11,7 +11,8 @@
       "4.0.2"
     ],
     "allowed-packages" : [
-      "io.awspring.cloud.core"
+      "io.awspring.cloud.core",
+      "org.springframework.core.io.support"
     ]
   }
 ]

--- a/stats/io.awspring.cloud/spring-cloud-aws-core/4.0.2/execution-metrics.json
+++ b/stats/io.awspring.cloud/spring-cloud-aws-core/4.0.2/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-06-07": {
+    "timestamp": "2026-06-07T08:57:21.527367Z",
+    "library": "io.awspring.cloud:spring-cloud-aws-core:4.0.2",
+    "starting_commit": "83b7cbf235a50fa9b812c5de779c4ce03a28f02e",
+    "ending_commit": "d96f1e130c6a0d16c8b87eb6a56d63896c50d792",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.0.2",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 91,
+          "missed": 19,
+          "ratio": 0.827273,
+          "total": 110
+        },
+        "line": {
+          "covered": 32,
+          "missed": 2,
+          "ratio": 0.941176,
+          "total": 34
+        },
+        "method": {
+          "covered": 13,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 13
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 113859,
+      "cached_input_tokens_used": 1285120,
+      "output_tokens_used": 13447,
+      "iterations": 3,
+      "cost_usd": 1.046,
+      "generated_loc": 124,
+      "tested_library_loc": 32,
+      "metadata_entries": 23,
+      "code_coverage_percent": 94.12
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/src/test/java/io_awspring_cloud/spring_cloud_aws_core/Spring_cloud_aws_coreTest.java",
+      "metadata_file": "metadata/io.awspring.cloud/spring-cloud-aws-core/4.0.2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.awspring.cloud/spring-cloud-aws-core/4.0.2/stats.json
+++ b/stats/io.awspring.cloud/spring-cloud-aws-core/4.0.2/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.0.2",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 91,
+        "missed" : 19,
+        "ratio" : 0.827273,
+        "total" : 110
+      },
+      "line" : {
+        "covered" : 32,
+        "missed" : 2,
+        "ratio" : 0.941176,
+        "total" : 34
+      },
+      "method" : {
+        "covered" : 13,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 13
+      }
+    }
+  } ]
+}

--- a/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/.gitignore
+++ b/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/build.gradle
+++ b/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.awspring.cloud:spring-cloud-aws-core:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/gradle.properties
+++ b/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.awspring.cloud:spring-cloud-aws-core:4.0.2
+library.version = 4.0.2
+metadata.dir = io.awspring.cloud/spring-cloud-aws-core/4.0.2/

--- a/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/settings.gradle
+++ b/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.awspring.cloud.spring-cloud-aws-core_tests'

--- a/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/src/test/java/io_awspring_cloud/spring_cloud_aws_core/Spring_cloud_aws_coreTest.java
+++ b/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/src/test/java/io_awspring_cloud/spring_cloud_aws_core/Spring_cloud_aws_coreTest.java
@@ -6,11 +6,121 @@
  */
 package io_awspring_cloud.spring_cloud_aws_core;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class Spring_cloud_aws_coreTest {
+import io.awspring.cloud.core.AWSCoreRuntimeHints;
+import io.awspring.cloud.core.SpringCloudClientConfiguration;
+import io.awspring.cloud.core.config.AwsPropertySource;
+import io.awspring.cloud.core.region.StaticRegionProvider;
+import io.awspring.cloud.core.support.JacksonPresent;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
+import software.amazon.awssdk.regions.Region;
+
+public class Spring_cloud_aws_coreTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void staticRegionProviderReturnsConfiguredRegion() {
+        StaticRegionProvider provider = new StaticRegionProvider(Region.US_EAST_1.id());
+
+        assertThat(provider.getRegion()).isEqualTo(Region.US_EAST_1);
+        assertThat(provider.getRegion().id()).isEqualTo("us-east-1");
+    }
+
+    @Test
+    void staticRegionProviderRejectsMissingOrBlankRegion() {
+        assertThatThrownBy(() -> new StaticRegionProvider(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("region is required");
+
+        assertThatThrownBy(() -> new StaticRegionProvider(""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("The region '' is not a valid region!");
+    }
+
+    @Test
+    void clientConfigurationBuildsSpringCloudAwsUserAgentSuffix() {
+        SpringCloudClientConfiguration configuration = new SpringCloudClientConfiguration("test-suite");
+
+        ClientOverrideConfiguration overrideConfiguration = configuration.clientOverrideConfiguration();
+
+        assertThat(overrideConfiguration.advancedOption(SdkAdvancedClientOption.USER_AGENT_SUFFIX))
+                .hasValue("spring-cloud-aws/test-suite");
+        assertThat(overrideConfiguration.advancedOption(SdkAdvancedClientOption.USER_AGENT_PREFIX)).isEmpty();
+    }
+
+    @Test
+    void runtimeHintsRegisterClientConfigurationPropertiesResource() {
+        RuntimeHints hints = new RuntimeHints();
+
+        new AWSCoreRuntimeHints().registerHints(hints, getClass().getClassLoader());
+
+        assertThat(RuntimeHintsPredicates.resource()
+                .forResource("io/awspring/cloud/core/SpringCloudClientConfiguration.properties"))
+                .accepts(hints);
+    }
+
+    @Test
+    void jacksonPresenceFlagsMatchCoreClasspath() {
+        assertThat(JacksonPresent.isJackson2Present()).isFalse();
+        assertThat(JacksonPresent.isJackson3Present()).isFalse();
+    }
+
+    @Test
+    void awsPropertySourceKeepsNameSourceAndCreatesUninitializedCopy() {
+        InMemoryAwsPropertySource propertySource = new InMemoryAwsPropertySource("aws-source",
+                Map.of("first", "one", "second", "two"));
+
+        assertThat(propertySource.getName()).isEqualTo("aws-source");
+        assertThat(propertySource.getProperty("first")).isEqualTo("one");
+        assertThat(propertySource.getPropertyNames()).containsExactlyInAnyOrder("first", "second");
+        assertThat(propertySource.isInitialized()).isFalse();
+
+        propertySource.init();
+        InMemoryAwsPropertySource copy = propertySource.copy();
+
+        assertThat(propertySource.isInitialized()).isTrue();
+        assertThat(copy).isNotSameAs(propertySource);
+        assertThat(copy.getName()).isEqualTo(propertySource.getName());
+        assertThat(copy.getSource()).containsExactlyInAnyOrderEntriesOf(propertySource.getSource());
+        assertThat(copy.isInitialized()).isFalse();
+    }
+
+    private static final class InMemoryAwsPropertySource
+            extends AwsPropertySource<InMemoryAwsPropertySource, Map<String, String>> {
+        private boolean initialized;
+
+        private InMemoryAwsPropertySource(String name, Map<String, String> source) {
+            super(name, new LinkedHashMap<>(source));
+        }
+
+        @Override
+        public void init() {
+            initialized = true;
+        }
+
+        @Override
+        public InMemoryAwsPropertySource copy() {
+            return new InMemoryAwsPropertySource(getName(), getSource());
+        }
+
+        @Override
+        public Object getProperty(String name) {
+            return getSource().get(name);
+        }
+
+        @Override
+        public String[] getPropertyNames() {
+            return getSource().keySet().toArray(String[]::new);
+        }
+
+        private boolean isInitialized() {
+            return initialized;
+        }
     }
 }

--- a/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/src/test/java/io_awspring_cloud/spring_cloud_aws_core/Spring_cloud_aws_coreTest.java
+++ b/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/src/test/java/io_awspring_cloud/spring_cloud_aws_core/Spring_cloud_aws_coreTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_awspring_cloud.spring_cloud_aws_core;
+
+import org.junit.jupiter.api.Test;
+
+class Spring_cloud_aws_coreTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/src/test/java/io_awspring_cloud/spring_cloud_aws_core/Spring_cloud_aws_coreTest.java
+++ b/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/src/test/java/io_awspring_cloud/spring_cloud_aws_core/Spring_cloud_aws_coreTest.java
@@ -55,6 +55,20 @@ public class Spring_cloud_aws_coreTest {
     }
 
     @Test
+    void defaultClientConfigurationLoadsVersionFromPropertiesResource() {
+        SpringCloudClientConfiguration configuration = new SpringCloudClientConfiguration();
+
+        ClientOverrideConfiguration overrideConfiguration = configuration.clientOverrideConfiguration();
+
+        assertThat(overrideConfiguration.advancedOption(SdkAdvancedClientOption.USER_AGENT_SUFFIX))
+                .hasValueSatisfying(userAgent -> {
+                    String expectedPrefix = "spring-cloud-aws/";
+                    assertThat(userAgent).startsWith(expectedPrefix);
+                    assertThat(userAgent.substring(expectedPrefix.length())).isNotBlank();
+                });
+    }
+
+    @Test
     void runtimeHintsRegisterClientConfigurationPropertiesResource() {
         RuntimeHints hints = new RuntimeHints();
 

--- a/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/src/test/java/io_awspring_cloud/spring_cloud_aws_core/Spring_cloud_aws_coreTest.java
+++ b/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/src/test/java/io_awspring_cloud/spring_cloud_aws_core/Spring_cloud_aws_coreTest.java
@@ -15,10 +15,13 @@ import io.awspring.cloud.core.config.AwsPropertySource;
 import io.awspring.cloud.core.region.StaticRegionProvider;
 import io.awspring.cloud.core.support.JacksonPresent;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
 import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
+import org.springframework.core.io.support.SpringFactoriesLoader;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.regions.Region;
@@ -77,6 +80,17 @@ public class Spring_cloud_aws_coreTest {
         assertThat(RuntimeHintsPredicates.resource()
                 .forResource("io/awspring/cloud/core/SpringCloudClientConfiguration.properties"))
                 .accepts(hints);
+    }
+
+    @Test
+    void runtimeHintsRegistrarIsLoadedFromSpringAotFactories() {
+        ClassLoader classLoader = getClass().getClassLoader();
+
+        List<RuntimeHintsRegistrar> registrars = SpringFactoriesLoader
+                .forResourceLocation("META-INF/spring/aot.factories", classLoader)
+                .load(RuntimeHintsRegistrar.class);
+
+        assertThat(registrars).hasAtLeastOneElementOfType(AWSCoreRuntimeHints.class);
     }
 
     @Test

--- a/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/user-code-filter.json
+++ b/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.awspring.cloud.core.**"
+    }
+  ]
+}

--- a/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/user-code-filter.json
+++ b/tests/src/io.awspring.cloud/spring-cloud-aws-core/4.0.2/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.awspring.cloud.core.**"
+      "includeClasses" : "io.awspring.cloud.core.**"
+    },
+    {
+      "includeClasses" : "io_awspring_cloud.spring_cloud_aws_core.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #7683

This PR introduces tests and metadata for io.awspring.cloud:spring-cloud-aws-core:4.0.2, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 113859
- Cached input tokens: 1285120
- Output tokens: 13447
- Metadata entries: 23
- Iterations: 3
- Library coverage percentage: 94.12
- Generated lines of code: 124
- Tested library lines of code: 32

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3ccb9e3d754ddf74cd1eb850a6f55d5641f9d7ac`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 91/110 (82.73%)
- Line: 32/34 (94.12%)
- Method: 13/13 (100.00%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
