### PR TITLE
[GenAI] Test fix for org.seleniumhq.selenium:selenium-safari-driver:4.0.0 using gpt-5.5

### DIFF
--- a/metadata/org.seleniumhq.selenium/selenium-safari-driver/4.0.0/reachability-metadata.json
+++ b/metadata/org.seleniumhq.selenium/selenium-safari-driver/4.0.0/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.openqa.selenium.safari.SafariDriverService"
+      },
+      "glob" : "META-INF/services/java.net.spi.URLStreamHandlerProvider"
+    }
+  ]
+}

--- a/metadata/org.seleniumhq.selenium/selenium-safari-driver/index.json
+++ b/metadata/org.seleniumhq.selenium/selenium-safari-driver/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "4.0.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/seleniumhq/selenium/selenium-safari-driver/$version$/selenium-safari-driver-$version$-sources.jar",
+    "repository-url" : "https://github.com/SeleniumHQ/selenium",
+    "test-code-url" : "https://github.com/SeleniumHQ/selenium/tree/selenium-$version$/java/test/org/openqa/selenium/safari",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/seleniumhq/selenium/selenium-safari-driver/$version$/selenium-safari-driver-$version$-javadoc.jar",
+    "description" : "Selenium Safari Driver is the Java WebDriver implementation for controlling Apple's Safari browser through Selenium. It provides Safari-specific driver, service, options, and command execution classes used by Selenium tests and automation running on the JVM.",
     "tested-versions" : [
       "4.0.0"
     ],

--- a/metadata/org.seleniumhq.selenium/selenium-safari-driver/index.json
+++ b/metadata/org.seleniumhq.selenium/selenium-safari-driver/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "4.0.0",
+    "tested-versions" : [
+      "4.0.0"
+    ],
+    "allowed-packages" : [
+      "org.openqa.selenium.safari"
+    ]
+  },
+  {
     "metadata-version" : "3.141.59",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/seleniumhq/selenium/selenium-safari-driver/$version$/selenium-safari-driver-$version$-sources.jar",
     "repository-url" : "https://github.com/SeleniumHQ/selenium",

--- a/stats/org.seleniumhq.selenium/selenium-safari-driver/4.0.0/execution-metrics.json
+++ b/stats/org.seleniumhq.selenium/selenium-safari-driver/4.0.0/execution-metrics.json
@@ -1,0 +1,88 @@
+{
+  "fix_javac_fail:2026-06-07": {
+    "timestamp": "2026-06-07T09:42:40.061521Z",
+    "library": "org.seleniumhq.selenium:selenium-safari-driver:4.0.0",
+    "starting_commit": "bf4c7d2379e82fbd035a97a6153cd3ef15dad83b",
+    "ending_commit": "7de58e64397d70b2e89fc22cdcf9fdfd1e724807",
+    "previous_library": "org.seleniumhq.selenium:selenium-safari-driver:3.141.59",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.0.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 336,
+          "missed": 438,
+          "ratio": 0.434109,
+          "total": 774
+        },
+        "line": {
+          "covered": 83,
+          "missed": 97,
+          "ratio": 0.461111,
+          "total": 180
+        },
+        "method": {
+          "covered": 39,
+          "missed": 48,
+          "ratio": 0.448276,
+          "total": 87
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.141.59",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 390,
+          "missed": 176,
+          "ratio": 0.689046,
+          "total": 566
+        },
+        "line": {
+          "covered": 100,
+          "missed": 46,
+          "ratio": 0.684932,
+          "total": 146
+        },
+        "method": {
+          "covered": 38,
+          "missed": 18,
+          "ratio": 0.678571,
+          "total": 56
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 40577,
+      "cached_input_tokens_used": 294400,
+      "output_tokens_used": 4971,
+      "iterations": 2,
+      "cost_usd": 0.2963,
+      "tested_library_loc": 83,
+      "metadata_entries": 1,
+      "test_only_metadata_entries": 7,
+      "previous_library_metadata_entries": 0,
+      "code_coverage_percent": 46.11,
+      "previous_library_coverage_percent": 68.49
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.seleniumhq.selenium/selenium-safari-driver/4.0.0/src/test/java/org_seleniumhq_selenium/selenium_safari_driver/Selenium_safari_driverTest.java",
+      "metadata_file": "metadata/org.seleniumhq.selenium/selenium-safari-driver/4.0.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.seleniumhq.selenium/selenium-safari-driver/4.0.0/stats.json
+++ b/stats/org.seleniumhq.selenium/selenium-safari-driver/4.0.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.0.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 336,
+        "missed" : 438,
+        "ratio" : 0.434109,
+        "total" : 774
+      },
+      "line" : {
+        "covered" : 83,
+        "missed" : 97,
+        "ratio" : 0.461111,
+        "total" : 180
+      },
+      "method" : {
+        "covered" : 39,
+        "missed" : 48,
+        "ratio" : 0.448276,
+        "total" : 87
+      }
+    }
+  } ]
+}

--- a/tests/src/org.seleniumhq.selenium/selenium-safari-driver/4.0.0/.gitignore
+++ b/tests/src/org.seleniumhq.selenium/selenium-safari-driver/4.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.seleniumhq.selenium/selenium-safari-driver/4.0.0/build.gradle
+++ b/tests/src/org.seleniumhq.selenium/selenium-safari-driver/4.0.0/build.gradle
@@ -1,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.seleniumhq.selenium:selenium-safari-driver:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+    binaries {
+        test {
+            buildArgs.add('--enable-url-protocols=http')
+        }
+    }
+}

--- a/tests/src/org.seleniumhq.selenium/selenium-safari-driver/4.0.0/gradle.properties
+++ b/tests/src/org.seleniumhq.selenium/selenium-safari-driver/4.0.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.seleniumhq.selenium:selenium-safari-driver:4.0.0
+library.version = 4.0.0
+metadata.dir = org.seleniumhq.selenium/selenium-safari-driver/4.0.0/

--- a/tests/src/org.seleniumhq.selenium/selenium-safari-driver/4.0.0/settings.gradle
+++ b/tests/src/org.seleniumhq.selenium/selenium-safari-driver/4.0.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.seleniumhq.selenium.selenium-safari-driver_tests'

--- a/tests/src/org.seleniumhq.selenium/selenium-safari-driver/4.0.0/src/test/java/org_seleniumhq_selenium/selenium_safari_driver/Selenium_safari_driverTest.java
+++ b/tests/src/org.seleniumhq.selenium/selenium-safari-driver/4.0.0/src/test/java/org_seleniumhq_selenium/selenium_safari_driver/Selenium_safari_driverTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_seleniumhq_selenium.selenium_safari_driver;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.ImmutableCapabilities;
+import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.Proxy;
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.safari.ConnectionClosedException;
+import org.openqa.selenium.safari.SafariDriver;
+import org.openqa.selenium.safari.SafariDriverInfo;
+import org.openqa.selenium.safari.SafariDriverService;
+import org.openqa.selenium.safari.SafariOptions;
+import org.openqa.selenium.safari.SafariTechPreviewDriverInfo;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+public class Selenium_safari_driverTest {
+    private static final String SAFARI_OPTIONS_CAPABILITY = "safari.options";
+
+    @Test
+    void safariOptionsExposeDefaultCapabilitiesAndSafariSpecificOptions() {
+        SafariOptions options = new SafariOptions();
+
+        assertThat(options.getBrowserName()).isEqualTo("safari");
+        assertThat(options.getUseTechnologyPreview()).isFalse();
+        assertThat(options.getAutomaticInspection()).isFalse();
+        assertThat(options.getAutomaticProfiling()).isFalse();
+        assertThat(options.asMap())
+                .containsEntry("browserName", "safari")
+                .containsKey(SAFARI_OPTIONS_CAPABILITY);
+        assertThat(safariOptionsMap(options)).containsEntry("technologyPreview", false);
+
+        assertThat(options.setAutomaticInspection(true)).isSameAs(options);
+        assertThat(options.setAutomaticProfiling(true)).isSameAs(options);
+        assertThat(options.setUseTechnologyPreview(true)).isSameAs(options);
+
+        assertThat(options.getBrowserName()).isEqualTo("Safari Technology Preview");
+        assertThat(options.getUseTechnologyPreview()).isTrue();
+        assertThat(options.getAutomaticInspection()).isTrue();
+        assertThat(options.getAutomaticProfiling()).isTrue();
+        assertThat(options.asMap())
+                .containsEntry("safari:automaticInspection", true)
+                .containsEntry("safari:automaticProfiling", true);
+        assertThat(safariOptionsMap(options)).containsEntry("technologyPreview", true);
+    }
+
+    @Test
+    void safariOptionsAcceptSafariSpecificCapabilitiesThroughSetCapabilityOverloads() {
+        SafariOptions options = new SafariOptions();
+
+        options.setCapability("safari:automaticInspection", true);
+        options.setCapability("safari:automaticProfiling", Boolean.TRUE);
+
+        assertThat(options.getAutomaticInspection()).isTrue();
+        assertThat(options.getAutomaticProfiling()).isTrue();
+        assertThat(options.asMap())
+                .containsEntry("safari:automaticInspection", true)
+                .containsEntry("safari:automaticProfiling", true);
+    }
+
+    @Test
+    void safariOptionsAllowTechnologyPreviewCapabilityToBeSetDirectly() {
+        SafariOptions options = new SafariOptions();
+
+        options.setCapability("technologyPreview", true);
+        assertThat(options.getUseTechnologyPreview()).isTrue();
+        assertThat(options.getBrowserName()).isEqualTo("Safari Technology Preview");
+        assertThat(safariOptionsMap(options)).containsEntry("technologyPreview", true);
+        assertThat(options.asMap()).doesNotContainKey("technologyPreview");
+
+        options.setCapability("technologyPreview", Boolean.FALSE);
+        assertThat(options.getUseTechnologyPreview()).isFalse();
+        assertThat(options.getBrowserName()).isEqualTo("safari");
+        assertThat(safariOptionsMap(options)).containsEntry("technologyPreview", false);
+    }
+
+    @Test
+    void safariOptionsCanBeCreatedFromCapabilitiesAndNestedSafariOptionsMap() {
+        SafariOptions original = new SafariOptions().setUseTechnologyPreview(true);
+        assertThat(SafariOptions.fromCapabilities(original)).isSameAs(original);
+
+        MutableCapabilities nestedOptions = new MutableCapabilities();
+        nestedOptions.setCapability(SAFARI_OPTIONS_CAPABILITY, original);
+        SafariOptions fromNestedOptions = SafariOptions.fromCapabilities(nestedOptions);
+        assertThat(fromNestedOptions.getUseTechnologyPreview()).isTrue();
+        assertThat(fromNestedOptions.getBrowserName()).isEqualTo("Safari Technology Preview");
+
+        MutableCapabilities jsonLikeCapabilities = new MutableCapabilities();
+        jsonLikeCapabilities.setCapability(SAFARI_OPTIONS_CAPABILITY, ImmutableMap.of("technologyPreview", true));
+        SafariOptions fromJsonLikeMap = SafariOptions.fromCapabilities(jsonLikeCapabilities);
+
+        assertThat(fromJsonLikeMap).isNotSameAs(original);
+        assertThat(fromJsonLikeMap.getUseTechnologyPreview()).isTrue();
+        assertThat(fromJsonLikeMap.getBrowserName()).isEqualTo("Safari Technology Preview");
+        assertThat(safariOptionsMap(fromJsonLikeMap)).containsEntry("technologyPreview", true);
+    }
+
+    @Test
+    void safariOptionsConstructorCopiesCapabilitiesAndMergeKeepsSafariOptionsType() {
+        MutableCapabilities source = new MutableCapabilities();
+        source.setCapability("custom:capability", "custom-value");
+        source.setCapability(SAFARI_OPTIONS_CAPABILITY, ImmutableMap.of("technologyPreview", true));
+
+        SafariOptions copied = new SafariOptions(source);
+        assertThat(copied.getCapability("custom:capability")).isEqualTo("custom-value");
+        assertThat(copied.getUseTechnologyPreview()).isTrue();
+
+        Capabilities merged = copied.merge(new ImmutableCapabilities("another:capability", 42));
+        assertThat(merged).isSameAs(copied);
+        assertThat(merged.getCapability("another:capability")).isEqualTo(42);
+    }
+
+    @Test
+    void safariOptionsSupportProxyCapability() {
+        Proxy proxy = new Proxy();
+        proxy.setHttpProxy("localhost:8080");
+
+        SafariOptions options = new SafariOptions();
+        assertThat(options.setProxy(proxy)).isSameAs(options);
+
+        assertThat(options.getCapability("proxy")).isSameAs(proxy);
+        assertThat(options.asMap()).containsEntry("proxy", proxy);
+    }
+
+    @Test
+    void safariOptionsEqualityAndHashCodeIncludeTechnologyPreviewSetting() {
+        SafariOptions standard = new SafariOptions();
+        SafariOptions equivalentStandard = new SafariOptions().setUseTechnologyPreview(false);
+        SafariOptions technologyPreview = new SafariOptions().setUseTechnologyPreview(true);
+
+        assertThat(equivalentStandard).isEqualTo(standard);
+        assertThat(equivalentStandard).hasSameHashCodeAs(standard);
+        assertThat(technologyPreview).isNotEqualTo(standard);
+        assertThat(technologyPreview.hashCode()).isNotEqualTo(standard.hashCode());
+    }
+
+    @Test
+    void safariDriverInfoDescribesStandardSafariSupport() {
+        SafariDriverInfo info = new SafariDriverInfo();
+
+        assertThat(info.getDisplayName()).isEqualTo("Safari");
+        assertThat(info.getMaximumSimultaneousSessions()).isEqualTo(1);
+        assertThat(info.getCanonicalCapabilities().getBrowserName()).isEqualTo("safari");
+        assertThat(info.isSupporting(new SafariOptions())).isTrue();
+        assertThat(info.isSupporting(new ImmutableCapabilities("safari:automaticInspection", true))).isTrue();
+        assertThat(info.isSupporting(new ImmutableCapabilities("safari.extension", "enabled"))).isTrue();
+        assertThat(info.isSupporting(new ImmutableCapabilities("browserName", "firefox"))).isFalse();
+        assertThatCode(() -> {
+            info.isAvailable();
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    void safariTechPreviewDriverInfoDescribesTechnologyPreviewSupport() {
+        SafariTechPreviewDriverInfo info = new SafariTechPreviewDriverInfo();
+        SafariOptions technologyPreview = new SafariOptions().setUseTechnologyPreview(true);
+
+        assertThat(info.getDisplayName()).isEqualTo("Safari Technology Preview");
+        assertThat(info.getMaximumSimultaneousSessions()).isEqualTo(1);
+        assertThat(info.getCanonicalCapabilities().getBrowserName()).isEqualTo("Safari Technology Preview");
+        assertThat(info.isSupporting(technologyPreview)).isTrue();
+        assertThat(info.isSupporting(new ImmutableCapabilities("safari:automaticProfiling", true))).isTrue();
+        assertThat(info.isSupporting(new ImmutableCapabilities("browserName", "safari"))).isFalse();
+        assertThatCode(() -> {
+            info.isAvailable();
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    void safariDriverServiceBuilderScoresSafariCapabilities() {
+        SafariDriverService.Builder builder = new SafariDriverService.Builder();
+
+        assertThat(builder.score(new ImmutableCapabilities("browserName", "firefox"))).isZero();
+        assertThat(builder.score(new SafariOptions())).isEqualTo(1);
+        assertThat(builder.score(new SafariOptions().setUseTechnologyPreview(true))).isEqualTo(1);
+
+        MutableCapabilities richSafariCapabilities = new MutableCapabilities();
+        richSafariCapabilities.setCapability("browserName", "safari");
+        richSafariCapabilities.setCapability(SAFARI_OPTIONS_CAPABILITY, ImmutableMap.of("technologyPreview", false));
+        richSafariCapabilities.setCapability("se:safari:techPreview", false);
+        assertThat(builder.score(richSafariCapabilities)).isEqualTo(3);
+    }
+
+    @Test
+    void safariDriverServiceCanBeConstructedWithoutStartingExternalProcess() throws IOException {
+        File executable = Files.createTempFile("safaridriver-test", ".sh").toFile();
+        executable.deleteOnExit();
+        assertThat(executable.setExecutable(true)).isTrue();
+
+        SafariDriverService service = new SafariDriverService(
+                executable,
+                0,
+                ImmutableList.of("--port", "0"),
+                ImmutableMap.of("SAFARI_DRIVER_TEST", "true"));
+
+        assertThat(service.getUrl().getProtocol()).isEqualTo("http");
+        assertThat(service.getUrl().getHost()).isNotBlank();
+        assertThat(service.isRunning()).isFalse();
+    }
+
+    @Test
+    void safariSpecificExceptionsAndEnumsAreUsable() {
+        WebDriverException exception = new ConnectionClosedException("connection closed by peer");
+
+        assertThat(exception).isInstanceOf(ConnectionClosedException.class);
+        assertThat(exception.getMessage()).contains("connection closed by peer");
+        assertThat(SafariDriver.WindowType.values())
+                .containsExactly(SafariDriver.WindowType.TAB, SafariDriver.WindowType.WINDOW);
+        assertThat(SafariDriver.WindowType.valueOf("TAB")).isEqualTo(SafariDriver.WindowType.TAB);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> safariOptionsMap(SafariOptions options) {
+        return (Map<String, Object>) options.asMap().get(SAFARI_OPTIONS_CAPABILITY);
+    }
+}

--- a/tests/src/org.seleniumhq.selenium/selenium-safari-driver/4.0.0/src/test/java/org_seleniumhq_selenium/selenium_safari_driver/Selenium_safari_driverTest.java
+++ b/tests/src/org.seleniumhq.selenium/selenium-safari-driver/4.0.0/src/test/java/org_seleniumhq_selenium/selenium_safari_driver/Selenium_safari_driverTest.java
@@ -9,13 +9,12 @@ package org_seleniumhq_selenium.selenium_safari_driver;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.ImmutableCapabilities;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.WindowType;
 import org.openqa.selenium.safari.ConnectionClosedException;
-import org.openqa.selenium.safari.SafariDriver;
 import org.openqa.selenium.safari.SafariDriverInfo;
 import org.openqa.selenium.safari.SafariDriverService;
 import org.openqa.selenium.safari.SafariOptions;
@@ -24,14 +23,11 @@ import org.openqa.selenium.safari.SafariTechPreviewDriverInfo;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 public class Selenium_safari_driverTest {
-    private static final String SAFARI_OPTIONS_CAPABILITY = "safari.options";
-
     @Test
     void safariOptionsExposeDefaultCapabilitiesAndSafariSpecificOptions() {
         SafariOptions options = new SafariOptions();
@@ -41,9 +37,7 @@ public class Selenium_safari_driverTest {
         assertThat(options.getAutomaticInspection()).isFalse();
         assertThat(options.getAutomaticProfiling()).isFalse();
         assertThat(options.asMap())
-                .containsEntry("browserName", "safari")
-                .containsKey(SAFARI_OPTIONS_CAPABILITY);
-        assertThat(safariOptionsMap(options)).containsEntry("technologyPreview", false);
+                .containsEntry("browserName", "safari");
 
         assertThat(options.setAutomaticInspection(true)).isSameAs(options);
         assertThat(options.setAutomaticProfiling(true)).isSameAs(options);
@@ -54,9 +48,9 @@ public class Selenium_safari_driverTest {
         assertThat(options.getAutomaticInspection()).isTrue();
         assertThat(options.getAutomaticProfiling()).isTrue();
         assertThat(options.asMap())
+                .containsEntry("browserName", "Safari Technology Preview")
                 .containsEntry("safari:automaticInspection", true)
                 .containsEntry("safari:automaticProfiling", true);
-        assertThat(safariOptionsMap(options)).containsEntry("technologyPreview", true);
     }
 
     @Test
@@ -74,54 +68,48 @@ public class Selenium_safari_driverTest {
     }
 
     @Test
-    void safariOptionsAllowTechnologyPreviewCapabilityToBeSetDirectly() {
+    void safariOptionsAllowBrowserNameCapabilityToSelectTechnologyPreview() {
         SafariOptions options = new SafariOptions();
 
-        options.setCapability("technologyPreview", true);
+        options.setCapability("browserName", "Safari Technology Preview");
         assertThat(options.getUseTechnologyPreview()).isTrue();
         assertThat(options.getBrowserName()).isEqualTo("Safari Technology Preview");
-        assertThat(safariOptionsMap(options)).containsEntry("technologyPreview", true);
-        assertThat(options.asMap()).doesNotContainKey("technologyPreview");
 
-        options.setCapability("technologyPreview", Boolean.FALSE);
+        options.setCapability("browserName", "safari");
         assertThat(options.getUseTechnologyPreview()).isFalse();
         assertThat(options.getBrowserName()).isEqualTo("safari");
-        assertThat(safariOptionsMap(options)).containsEntry("technologyPreview", false);
     }
 
     @Test
-    void safariOptionsCanBeCreatedFromCapabilitiesAndNestedSafariOptionsMap() {
+    void safariOptionsCanBeCreatedFromCapabilities() {
         SafariOptions original = new SafariOptions().setUseTechnologyPreview(true);
         assertThat(SafariOptions.fromCapabilities(original)).isSameAs(original);
 
-        MutableCapabilities nestedOptions = new MutableCapabilities();
-        nestedOptions.setCapability(SAFARI_OPTIONS_CAPABILITY, original);
-        SafariOptions fromNestedOptions = SafariOptions.fromCapabilities(nestedOptions);
-        assertThat(fromNestedOptions.getUseTechnologyPreview()).isTrue();
-        assertThat(fromNestedOptions.getBrowserName()).isEqualTo("Safari Technology Preview");
+        MutableCapabilities capabilities = new MutableCapabilities();
+        capabilities.setCapability("browserName", "Safari Technology Preview");
+        capabilities.setCapability("safari:automaticInspection", true);
+        SafariOptions fromCapabilities = SafariOptions.fromCapabilities(capabilities);
 
-        MutableCapabilities jsonLikeCapabilities = new MutableCapabilities();
-        jsonLikeCapabilities.setCapability(SAFARI_OPTIONS_CAPABILITY, ImmutableMap.of("technologyPreview", true));
-        SafariOptions fromJsonLikeMap = SafariOptions.fromCapabilities(jsonLikeCapabilities);
-
-        assertThat(fromJsonLikeMap).isNotSameAs(original);
-        assertThat(fromJsonLikeMap.getUseTechnologyPreview()).isTrue();
-        assertThat(fromJsonLikeMap.getBrowserName()).isEqualTo("Safari Technology Preview");
-        assertThat(safariOptionsMap(fromJsonLikeMap)).containsEntry("technologyPreview", true);
+        assertThat(fromCapabilities).isNotSameAs(original);
+        assertThat(fromCapabilities.getUseTechnologyPreview()).isTrue();
+        assertThat(fromCapabilities.getBrowserName()).isEqualTo("Safari Technology Preview");
+        assertThat(fromCapabilities.getAutomaticInspection()).isTrue();
     }
 
     @Test
     void safariOptionsConstructorCopiesCapabilitiesAndMergeKeepsSafariOptionsType() {
         MutableCapabilities source = new MutableCapabilities();
         source.setCapability("custom:capability", "custom-value");
-        source.setCapability(SAFARI_OPTIONS_CAPABILITY, ImmutableMap.of("technologyPreview", true));
+        source.setCapability("browserName", "Safari Technology Preview");
 
         SafariOptions copied = new SafariOptions(source);
         assertThat(copied.getCapability("custom:capability")).isEqualTo("custom-value");
         assertThat(copied.getUseTechnologyPreview()).isTrue();
 
-        Capabilities merged = copied.merge(new ImmutableCapabilities("another:capability", 42));
-        assertThat(merged).isSameAs(copied);
+        SafariOptions merged = copied.merge(new ImmutableCapabilities("another:capability", 42));
+        assertThat(merged).isNotSameAs(copied);
+        assertThat(merged.getUseTechnologyPreview()).isTrue();
+        assertThat(merged.getCapability("custom:capability")).isEqualTo("custom-value");
         assertThat(merged.getCapability("another:capability")).isEqualTo(42);
     }
 
@@ -191,9 +179,9 @@ public class Selenium_safari_driverTest {
 
         MutableCapabilities richSafariCapabilities = new MutableCapabilities();
         richSafariCapabilities.setCapability("browserName", "safari");
-        richSafariCapabilities.setCapability(SAFARI_OPTIONS_CAPABILITY, ImmutableMap.of("technologyPreview", false));
+        richSafariCapabilities.setCapability("safari:automaticInspection", true);
         richSafariCapabilities.setCapability("se:safari:techPreview", false);
-        assertThat(builder.score(richSafariCapabilities)).isEqualTo(3);
+        assertThat(builder.score(richSafariCapabilities)).isEqualTo(1);
     }
 
     @Test
@@ -219,13 +207,8 @@ public class Selenium_safari_driverTest {
 
         assertThat(exception).isInstanceOf(ConnectionClosedException.class);
         assertThat(exception.getMessage()).contains("connection closed by peer");
-        assertThat(SafariDriver.WindowType.values())
-                .containsExactly(SafariDriver.WindowType.TAB, SafariDriver.WindowType.WINDOW);
-        assertThat(SafariDriver.WindowType.valueOf("TAB")).isEqualTo(SafariDriver.WindowType.TAB);
-    }
-
-    @SuppressWarnings("unchecked")
-    private static Map<String, Object> safariOptionsMap(SafariOptions options) {
-        return (Map<String, Object>) options.asMap().get(SAFARI_OPTIONS_CAPABILITY);
+        assertThat(WindowType.values())
+                .containsExactly(WindowType.WINDOW, WindowType.TAB);
+        assertThat(WindowType.valueOf("TAB")).isEqualTo(WindowType.TAB);
     }
 }

--- a/tests/src/org.seleniumhq.selenium/selenium-safari-driver/4.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.seleniumhq.selenium/selenium-safari-driver/4.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,50 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org_seleniumhq_selenium.selenium_safari_driver.Selenium_safari_driverTest"
+      },
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_seleniumhq_selenium.selenium_safari_driver.Selenium_safari_driverTest"
+      },
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org_seleniumhq_selenium.selenium_safari_driver.Selenium_safari_driverTest"
+      },
+      "glob" : "META-INF/selenium-build.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_seleniumhq_selenium.selenium_safari_driver.Selenium_safari_driverTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_seleniumhq_selenium.selenium_safari_driver.Selenium_safari_driverTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/tests/src/org.seleniumhq.selenium/selenium-safari-driver/4.0.0/user-code-filter.json
+++ b/tests/src/org.seleniumhq.selenium/selenium-safari-driver/4.0.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.openqa.selenium.safari.**"
+    },
+    {
+      "includeClasses" : "org_seleniumhq_selenium.selenium_safari_driver.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7041

This PR provides test fixes and new metadata for org.seleniumhq.selenium:selenium-safari-driver:4.0.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 40577
- Cached input tokens: 294400
- Output tokens: 4971
- Metadata entries: 1
- Test-only metadata entries: 7
- Iterations: 2
- Library coverage percentage: 46.11
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 68.49

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `da08d7a48fce53f6c6266e822538b41d7f3ced4e`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.seleniumhq.selenium:selenium-safari-driver:3.141.59: 0/0 covered calls (100.00%)
- org.seleniumhq.selenium:selenium-safari-driver:4.0.0: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.seleniumhq.selenium:selenium-safari-driver:3.141.59: 390/566 (68.90%)
- org.seleniumhq.selenium:selenium-safari-driver:4.0.0: 336/774 (43.41%)

**Line:**
- org.seleniumhq.selenium:selenium-safari-driver:3.141.59: 100/146 (68.49%)
- org.seleniumhq.selenium:selenium-safari-driver:4.0.0: 83/180 (46.11%)

**Method:**
- org.seleniumhq.selenium:selenium-safari-driver:3.141.59: 38/56 (67.86%)
- org.seleniumhq.selenium:selenium-safari-driver:4.0.0: 39/87 (44.83%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/org.seleniumhq.selenium/selenium-safari-driver/3.141.59/src/test/java/org_seleniumhq_selenium/selenium_safari_driver/Selenium_safari_driverTest.java b/tests/src/org.seleniumhq.selenium/selenium-safari-driver/4.0.0/src/test/java/org_seleniumhq_selenium/selenium_safari_driver/Selenium_safari_driverTest.java
index 82313b3b33..7ea889f1a6 100644
--- a/tests/src/org.seleniumhq.selenium/selenium-safari-driver/3.141.59/src/test/java/org_seleniumhq_selenium/selenium_safari_driver/Selenium_safari_driverTest.java
+++ b/tests/src/org.seleniumhq.selenium/selenium-safari-driver/4.0.0/src/test/java/org_seleniumhq_selenium/selenium_safari_driver/Selenium_safari_driverTest.java
@@ -9,13 +9,12 @@ package org_seleniumhq_selenium.selenium_safari_driver;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.ImmutableCapabilities;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.WindowType;
 import org.openqa.selenium.safari.ConnectionClosedException;
-import org.openqa.selenium.safari.SafariDriver;
 import org.openqa.selenium.safari.SafariDriverInfo;
 import org.openqa.selenium.safari.SafariDriverService;
 import org.openqa.selenium.safari.SafariOptions;
@@ -24,14 +23,11 @@ import org.openqa.selenium.safari.SafariTechPreviewDriverInfo;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 public class Selenium_safari_driverTest {
-    private static final String SAFARI_OPTIONS_CAPABILITY = "safari.options";
-
     @Test
     void safariOptionsExposeDefaultCapabilitiesAndSafariSpecificOptions() {
         SafariOptions options = new SafariOptions();
@@ -41,9 +37,7 @@ public class Selenium_safari_driverTest {
         assertThat(options.getAutomaticInspection()).isFalse();
         assertThat(options.getAutomaticProfiling()).isFalse();
         assertThat(options.asMap())
-                .containsEntry("browserName", "safari")
-                .containsKey(SAFARI_OPTIONS_CAPABILITY);
-        assertThat(safariOptionsMap(options)).containsEntry("technologyPreview", false);
+                .containsEntry("browserName", "safari");
 
         assertThat(options.setAutomaticInspection(true)).isSameAs(options);
         assertThat(options.setAutomaticProfiling(true)).isSameAs(options);
@@ -54,9 +48,9 @@ public class Selenium_safari_driverTest {
         assertThat(options.getAutomaticInspection()).isTrue();
         assertThat(options.getAutomaticProfiling()).isTrue();
         assertThat(options.asMap())
+                .containsEntry("browserName", "Safari Technology Preview")
                 .containsEntry("safari:automaticInspection", true)
                 .containsEntry("safari:automaticProfiling", true);
-        assertThat(safariOptionsMap(options)).containsEntry("technologyPreview", true);
     }
 
     @Test
@@ -74,54 +68,48 @@ public class Selenium_safari_driverTest {
     }
 
     @Test
-    void safariOptionsAllowTechnologyPreviewCapabilityToBeSetDirectly() {
+    void safariOptionsAllowBrowserNameCapabilityToSelectTechnologyPreview() {
         SafariOptions options = new SafariOptions();
 
-        options.setCapability("technologyPreview", true);
+        options.setCapability("browserName", "Safari Technology Preview");
         assertThat(options.getUseTechnologyPreview()).isTrue();
         assertThat(options.getBrowserName()).isEqualTo("Safari Technology Preview");
-        assertThat(safariOptionsMap(options)).containsEntry("technologyPreview", true);
-        assertThat(options.asMap()).doesNotContainKey("technologyPreview");
 
-        options.setCapability("technologyPreview", Boolean.FALSE);
+        options.setCapability("browserName", "safari");
         assertThat(options.getUseTechnologyPreview()).isFalse();
         assertThat(options.getBrowserName()).isEqualTo("safari");
-        assertThat(safariOptionsMap(options)).containsEntry("technologyPreview", false);
     }
 
     @Test
-    void safariOptionsCanBeCreatedFromCapabilitiesAndNestedSafariOptionsMap() {
+    void safariOptionsCanBeCreatedFromCapabilities() {
         SafariOptions original = new SafariOptions().setUseTechnologyPreview(true);
         assertThat(SafariOptions.fromCapabilities(original)).isSameAs(original);
 
-        MutableCapabilities nestedOptions = new MutableCapabilities();
-        nestedOptions.setCapability(SAFARI_OPTIONS_CAPABILITY, original);
-        SafariOptions fromNestedOptions = SafariOptions.fromCapabilities(nestedOptions);
-        assertThat(fromNestedOptions.getUseTechnologyPreview()).isTrue();
-        assertThat(fromNestedOptions.getBrowserName()).isEqualTo("Safari Technology Preview");
-
-        MutableCapabilities jsonLikeCapabilities = new MutableCapabilities();
-        jsonLikeCapabilities.setCapability(SAFARI_OPTIONS_CAPABILITY, ImmutableMap.of("technologyPreview", true));
-        SafariOptions fromJsonLikeMap = SafariOptions.fromCapabilities(jsonLikeCapabilities);
+        MutableCapabilities capabilities = new MutableCapabilities();
+        capabilities.setCapability("browserName", "Safari Technology Preview");
+        capabilities.setCapability("safari:automaticInspection", true);
+        SafariOptions fromCapabilities = SafariOptions.fromCapabilities(capabilities);
 
-        assertThat(fromJsonLikeMap).isNotSameAs(original);
-        assertThat(fromJsonLikeMap.getUseTechnologyPreview()).isTrue();
-        assertThat(fromJsonLikeMap.getBrowserName()).isEqualTo("Safari Technology Preview");
-        assertThat(safariOptionsMap(fromJsonLikeMap)).containsEntry("technologyPreview", true);
+        assertThat(fromCapabilities).isNotSameAs(original);
+        assertThat(fromCapabilities.getUseTechnologyPreview()).isTrue();
+        assertThat(fromCapabilities.getBrowserName()).isEqualTo("Safari Technology Preview");
+        assertThat(fromCapabilities.getAutomaticInspection()).isTrue();
     }
 
     @Test
     void safariOptionsConstructorCopiesCapabilitiesAndMergeKeepsSafariOptionsType() {
         MutableCapabilities source = new MutableCapabilities();
         source.setCapability("custom:capability", "custom-value");
-        source.setCapability(SAFARI_OPTIONS_CAPABILITY, ImmutableMap.of("technologyPreview", true));
+        source.setCapability("browserName", "Safari Technology Preview");
 
         SafariOptions copied = new SafariOptions(source);
         assertThat(copied.getCapability("custom:capability")).isEqualTo("custom-value");
         assertThat(copied.getUseTechnologyPreview()).isTrue();
 
-        Capabilities merged = copied.merge(new ImmutableCapabilities("another:capability", 42));
-        assertThat(merged).isSameAs(copied);
+        SafariOptions merged = copied.merge(new ImmutableCapabilities("another:capability", 42));
+        assertThat(merged).isNotSameAs(copied);
+        assertThat(merged.getUseTechnologyPreview()).isTrue();
+        assertThat(merged.getCapability("custom:capability")).isEqualTo("custom-value");
         assertThat(merged.getCapability("another:capability")).isEqualTo(42);
     }
 
@@ -191,9 +179,9 @@ public class Selenium_safari_driverTest {
 
         MutableCapabilities richSafariCapabilities = new MutableCapabilities();
         richSafariCapabilities.setCapability("browserName", "safari");
-        richSafariCapabilities.setCapability(SAFARI_OPTIONS_CAPABILITY, ImmutableMap.of("technologyPreview", false));
+        richSafariCapabilities.setCapability("safari:automaticInspection", true);
         richSafariCapabilities.setCapability("se:safari:techPreview", false);
-        assertThat(builder.score(richSafariCapabilities)).isEqualTo(3);
+        assertThat(builder.score(richSafariCapabilities)).isEqualTo(1);
     }
 
     @Test
@@ -219,13 +207,8 @@ public class Selenium_safari_driverTest {
 
         assertThat(exception).isInstanceOf(ConnectionClosedException.class);
         assertThat(exception.getMessage()).contains("connection closed by peer");
-        assertThat(SafariDriver.WindowType.values())
-                .containsExactly(SafariDriver.WindowType.TAB, SafariDriver.WindowType.WINDOW);
-        assertThat(SafariDriver.WindowType.valueOf("TAB")).isEqualTo(SafariDriver.WindowType.TAB);
-    }
-
-    @SuppressWarnings("unchecked")
-    private static Map<String, Object> safariOptionsMap(SafariOptions options) {
-        return (Map<String, Object>) options.asMap().get(SAFARI_OPTIONS_CAPABILITY);
+        assertThat(WindowType.values())
+                .containsExactly(WindowType.WINDOW, WindowType.TAB);
+        assertThat(WindowType.valueOf("TAB")).isEqualTo(WindowType.TAB);
     }
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
