### PR TITLE
[GenAI] Test fix for org.codehaus.plexus:plexus-container-default:1.0-alpha-11 using gpt-5.5

### DIFF
--- a/metadata/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/reachability-metadata.json
+++ b/metadata/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/reachability-metadata.json
@@ -1,0 +1,1349 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.composition.setter.SetterComponentComposer"
+      },
+      "type" : "java.lang.Class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.composition.setter.SetterComponentComposer"
+      },
+      "type" : "java.lang.ObjectBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.composition.setter.SetterComponentComposer"
+      },
+      "type" : "java.lang.ObjectCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.composition.FieldComponentComposer"
+      },
+      "type" : "java.lang.Object[][]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.composite.ArrayConverter"
+      },
+      "type" : "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.basic.DateConverter"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.composite.ArrayConverter"
+      },
+      "type" : "java.lang.Unknown"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.composition.FieldComponentComposer"
+      },
+      "type" : "java.lang.reflect.Field[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.composition.setter.SetterComponentComposer"
+      },
+      "type" : "java.lang.reflect.Method[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "java.util.ArrayList"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.composite.CollectionConverter"
+      },
+      "type" : "java.util.ArrayList",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.basic.DateConverter"
+      },
+      "type" : "sun.util.resources.cldr.CalendarData"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.composite.CollectionConverter"
+      },
+      "type" : "java.util.ArrayList"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.ComponentValueSetter"
+      },
+      "type" : "org.codehaus.plexus.DefaultPlexusContainer",
+      "fields" : [
+        {
+          "name" : "componentComposerManager"
+        },
+        {
+          "name" : "componentDiscovererManager"
+        },
+        {
+          "name" : "componentFactoryManager"
+        },
+        {
+          "name" : "componentManagerManager"
+        },
+        {
+          "name" : "componentRepository"
+        },
+        {
+          "name" : "initializationPhases"
+        },
+        {
+          "name" : "lifecycleHandlerManager"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "setComponentComposerManager",
+          "parameterTypes" : [
+            "org.codehaus.plexus.component.composition.ComponentComposerManager"
+          ]
+        },
+        {
+          "name" : "setComponentDiscovererManager",
+          "parameterTypes" : [
+            "org.codehaus.plexus.component.discovery.ComponentDiscovererManager"
+          ]
+        },
+        {
+          "name" : "setComponentFactoryManager",
+          "parameterTypes" : [
+            "org.codehaus.plexus.component.factory.ComponentFactoryManager"
+          ]
+        },
+        {
+          "name" : "setComponentLookupManager",
+          "parameterTypes" : [
+            "org.codehaus.plexus.ComponentLookupManager"
+          ]
+        },
+        {
+          "name" : "setComponentManagerManager",
+          "parameterTypes" : [
+            "org.codehaus.plexus.component.manager.ComponentManagerManager"
+          ]
+        },
+        {
+          "name" : "setComponentRepository",
+          "parameterTypes" : [
+            "org.codehaus.plexus.component.repository.ComponentRepository"
+          ]
+        },
+        {
+          "name" : "setLifecycleHandlerManager",
+          "parameterTypes" : [
+            "org.codehaus.plexus.lifecycle.LifecycleHandlerManager"
+          ]
+        },
+        {
+          "name" : "setLoggerManager",
+          "parameterTypes" : [
+            "org.codehaus.plexus.logging.LoggerManager"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.DefaultPlexusContainer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.PlexusContainerManager$1"
+      },
+      "type" : "org.codehaus.plexus.PlexusContainerManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.DefaultComponentLookupManager",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.ComponentValueSetter"
+      },
+      "type" : "org.codehaus.plexus.DefaultComponentLookupManager",
+      "methods" : [
+        {
+          "name" : "setContainer",
+          "parameterTypes" : [
+            "org.codehaus.plexus.MutablePlexusContainer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.ComponentValueSetter"
+      },
+      "type" : "org.codehaus.plexus.SimplePlexusContainerManager",
+      "fields" : [
+        {
+          "name" : "plexusConfig"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.SimplePlexusContainerManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.component.composition.AbstractComponentComposer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.composition.DefaultComponentComposerManager",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.ComponentValueSetter"
+      },
+      "type" : "org.codehaus.plexus.component.composition.DefaultComponentComposerManager",
+      "fields" : [
+        {
+          "name" : "componentComposers"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.component.composition.DefaultComponentComposerManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.composition.DefaultCompositionResolver",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.composition.FieldComponentComposer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.component.composition.FieldComponentComposer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.composition.MapOrientedComponentComposer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.component.composition.MapOrientedComponentComposer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.composition.NoOpComponentComposer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.component.composition.NoOpComponentComposer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.strategy.ForeignStrategy"
+      },
+      "type" : "org.codehaus.plexus.component.composition.setter.SetterComponentComposer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.composition.setter.SetterComponentComposer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.component.composition.setter.SetterComponentComposer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.composition.SetterComponentComposer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.component.composition.SetterComponentComposer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.discovery.DefaultComponentDiscoverer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.discovery.DefaultComponentDiscovererManager",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.ComponentValueSetter"
+      },
+      "type" : "org.codehaus.plexus.component.discovery.DefaultComponentDiscovererManager",
+      "fields" : [
+        {
+          "name" : "componentDiscoverers"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.component.discovery.DefaultComponentDiscovererManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.discovery.PlexusXmlComponentDiscoverer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.factory.DefaultComponentFactoryManager",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.ComponentValueSetter"
+      },
+      "type" : "org.codehaus.plexus.component.factory.DefaultComponentFactoryManager",
+      "fields" : [
+        {
+          "name" : "defaultComponentFactory"
+        },
+        {
+          "name" : "defaultComponentFactoryId"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.component.factory.DefaultComponentFactoryManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.factory.java.JavaComponentFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.factory.java.JavaComponentFactory"
+      },
+      "type" : "org.codehaus.plexus.component.configurator.BasicComponentConfigurator",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.factory.java.JavaComponentFactory"
+      },
+      "type" : "org.codehaus.plexus.component.configurator.MapOrientedComponentConfigurator",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.ComponentValueSetter"
+      },
+      "type" : "org.codehaus.plexus.component.manager.AbstractComponentManager",
+      "fields" : [
+        {
+          "name" : "id"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.component.manager.AbstractComponentManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.manager.ClassicSingletonComponentManager",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.component.manager.ClassicSingletonComponentManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.manager.DefaultComponentManagerManager",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.ComponentValueSetter"
+      },
+      "type" : "org.codehaus.plexus.component.manager.DefaultComponentManagerManager",
+      "fields" : [
+        {
+          "name" : "componentManagers"
+        },
+        {
+          "name" : "defaultComponentManagerId"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.component.manager.DefaultComponentManagerManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.manager.ContainerComponentManager",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.manager.KeepAliveSingletonComponentManager",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.component.manager.KeepAliveSingletonComponentManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.manager.PerLookupComponentManager",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.component.manager.PerLookupComponentManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.repository.DefaultComponentRepository",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.ComponentValueSetter"
+      },
+      "type" : "org.codehaus.plexus.component.repository.DefaultComponentRepository",
+      "fields" : [
+        {
+          "name" : "compositionResolver"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.component.repository.DefaultComponentRepository"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.container.initialization.ComponentDiscoveryPhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.container.initialization.InitializeComponentComposerPhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.container.initialization.InitializeComponentDiscovererManagerPhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.container.initialization.InitializeComponentFactoryManagerPhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.container.initialization.InitializeComponentLookupManagerPhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.container.initialization.InitializeComponentManagerManagerPhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.container.initialization.InitializeComponentRepositoryPhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.container.initialization.InitializeContextPhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.container.initialization.InitializeLifecycleHandlerManagerPhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.container.initialization.InitializeLoggerManagerPhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.container.initialization.InitializeResourcesPhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.container.initialization.InitializeSystemPropertiesPhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.container.initialization.RegisterComponentDiscoveryListenersPhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.container.initialization.StartLoadOnStartComponentsPhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.ComponentValueSetter"
+      },
+      "type" : "org.codehaus.plexus.lifecycle.AbstractLifecycleHandler",
+      "fields" : [
+        {
+          "name" : "beginSegment"
+        },
+        {
+          "name" : "endSegment"
+        },
+        {
+          "name" : "id"
+        },
+        {
+          "name" : "name"
+        },
+        {
+          "name" : "resumeSegment"
+        },
+        {
+          "name" : "suspendSegment"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.lifecycle.AbstractLifecycleHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.lifecycle.BasicLifecycleHandler",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.lifecycle.BasicLifecycleHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.lifecycle.DefaultLifecycleHandlerManager",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.ComponentValueSetter"
+      },
+      "type" : "org.codehaus.plexus.lifecycle.DefaultLifecycleHandlerManager",
+      "fields" : [
+        {
+          "name" : "defaultLifecycleHandlerId"
+        },
+        {
+          "name" : "lifecycleHandlers"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.lifecycle.DefaultLifecycleHandlerManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.lifecycle.PassiveLifecycleHandler",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.lifecycle.PassiveLifecycleHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.PlexusLifecycleHandler",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.PlexusLifecycleHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.AutoConfigurePhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.CompositionPhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.ConfigurablePhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.ContextualizePhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.DisposePhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.InitializePhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.LogDisablePhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.LogEnablePhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.ResumePhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.ServiceablePhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.StartPhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.StopPhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.SuspendPhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.xml.Xpp3Dom"
+      },
+      "type" : "org.codehaus.plexus.util.xml.Xpp3Dom[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.composition.ComponentComposerManager$1"
+      },
+      "type" : "org.codehaus.plexus.component.composition.ComponentComposerManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.composition.DefaultComponentComposerManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.composition.DefaultCompositionResolver"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.composition.MapOrientedComponentComposer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.composition.NoOpComponentComposer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.composition.SetterComponentComposer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.ComponentConfigurator$1"
+      },
+      "type" : "org.codehaus.plexus.component.configurator.ComponentConfigurator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.discovery.ComponentDiscoverer$1"
+      },
+      "type" : "org.codehaus.plexus.component.discovery.ComponentDiscoverer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.discovery.DefaultComponentDiscoverer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.discovery.DefaultComponentDiscovererManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.discovery.PlexusXmlComponentDiscoverer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.factory.ComponentFactory$1"
+      },
+      "type" : "org.codehaus.plexus.component.factory.ComponentFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.factory.DefaultComponentFactoryManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.factory.java.JavaComponentFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.manager.ClassicSingletonComponentManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.manager.DefaultComponentManagerManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.manager.KeepAliveSingletonComponentManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.manager.PerLookupComponentManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.repository.DefaultComponentRepository"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.lifecycle.BasicLifecycleHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.lifecycle.DefaultLifecycleHandlerManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.lifecycle.PassiveLifecycleHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.PlexusLifecycleHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.AutoConfigurePhase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.CompositionPhase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.ConfigurablePhase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.ContextualizePhase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.DisposePhase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.InitializePhase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.LogDisablePhase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.LogEnablePhase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.ResumePhase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.ServiceablePhase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.StartPhase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.StopPhase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.SuspendPhase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.manager.ComponentManager$1"
+      },
+      "type" : "org.codehaus.plexus.component.manager.ComponentManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.manager.ComponentManagerManager$1"
+      },
+      "type" : "org.codehaus.plexus.component.manager.ComponentManagerManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.factory.java.JavaComponentFactory"
+      },
+      "type" : "org.codehaus.plexus.logging.console.ConsoleLoggerManager",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.ComponentValueSetter"
+      },
+      "type" : "org.codehaus.plexus.logging.console.ConsoleLoggerManager",
+      "fields" : [
+        {
+          "name" : "threshold"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.logging.LoggerManager$1"
+      },
+      "type" : "org.codehaus.plexus.logging.LoggerManager"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.discovery.PlexusXmlComponentDiscoverer"
+      },
+      "glob" : "META-INF/plexus/components.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.discovery.PlexusXmlComponentDiscoverer"
+      },
+      "glob" : "META-INF/plexus/plexus.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "glob" : "org/codehaus/plexus/plexus-bootstrap.xml"
+    }
+  ]
+}

--- a/metadata/org.codehaus.plexus/plexus-container-default/index.json
+++ b/metadata/org.codehaus.plexus/plexus-container-default/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.0-alpha-11",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/$version$/plexus-container-default-$version$-sources.jar",
+    "repository-url" : "https://github.com/codehaus-plexus/plexus-containers",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/$version$/plexus-container-default-$version$-javadoc.jar",
+    "description" : "Plexus Container Default is the original Plexus inversion-of-control container implementation used to discover, configure, compose, and manage Plexus components. It provides component descriptors, lifecycle handling, dependency injection, configuration conversion, logging hooks, and embeddable container APIs for Java applications.",
     "tested-versions" : [
       "1.0-alpha-11"
     ],

--- a/metadata/org.codehaus.plexus/plexus-container-default/index.json
+++ b/metadata/org.codehaus.plexus/plexus-container-default/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.0-alpha-11",
+    "tested-versions" : [
+      "1.0-alpha-11"
+    ],
+    "allowed-packages" : [
+      "org.codehaus.plexus"
+    ]
+  },
+  {
     "metadata-version" : "1.0-alpha-10",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/$version$/plexus-container-default-$version$-sources.jar",
     "repository-url" : "https://github.com/codehaus-plexus/plexus-containers",

--- a/stats/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/execution-metrics.json
+++ b/stats/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/execution-metrics.json
@@ -1,0 +1,106 @@
+{
+  "fix_javac_fail:2026-06-07": {
+    "timestamp": "2026-06-07T10:26:52.790541Z",
+    "library": "org.codehaus.plexus:plexus-container-default:1.0-alpha-11",
+    "starting_commit": "89cba8d5c6d93bea9172bcfa580d861b26c59e13",
+    "ending_commit": "9de559c09e2eb844252a31307ed7b410ea032b67",
+    "previous_library": "org.codehaus.plexus:plexus-container-default:1.0-alpha-10",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.0-alpha-11",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.961538,
+            "coveredCalls": 50,
+            "totalCalls": 52
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 0.962264,
+        "coveredCalls": 51,
+        "totalCalls": 53
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4903,
+          "missed": 6250,
+          "ratio": 0.439613,
+          "total": 11153
+        },
+        "line": {
+          "covered": 1245,
+          "missed": 1461,
+          "ratio": 0.460089,
+          "total": 2706
+        },
+        "method": {
+          "covered": 372,
+          "missed": 323,
+          "ratio": 0.535252,
+          "total": 695
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.0-alpha-10",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.966102,
+            "coveredCalls": 57,
+            "totalCalls": 59
+          }
+        },
+        "coverageRatio": 0.966102,
+        "coveredCalls": 57,
+        "totalCalls": 59
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5322,
+          "missed": 6383,
+          "ratio": 0.454677,
+          "total": 11705
+        },
+        "line": {
+          "covered": 1375,
+          "missed": 1524,
+          "ratio": 0.474301,
+          "total": 2899
+        },
+        "method": {
+          "covered": 432,
+          "missed": 345,
+          "ratio": 0.555985,
+          "total": 777
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 472759,
+      "cached_input_tokens_used": 8984576,
+      "output_tokens_used": 56787,
+      "iterations": 9,
+      "cost_usd": 6.1959,
+      "tested_library_loc": 1245,
+      "metadata_entries": 232,
+      "test_only_metadata_entries": 11,
+      "previous_library_metadata_entries": 228,
+      "previous_library_test_only_metadata_entries": 11,
+      "code_coverage_percent": 46.01,
+      "previous_library_coverage_percent": 47.43
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/AbstractConfigurationConverterTest.java",
+      "metadata_file": "metadata/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/stats.json
+++ b/stats/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "1.0-alpha-11",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.961538,
+          "coveredCalls" : 50,
+          "totalCalls" : 52
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 0.962264,
+      "coveredCalls" : 51,
+      "totalCalls" : 53
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 4903,
+        "missed" : 6250,
+        "ratio" : 0.439613,
+        "total" : 11153
+      },
+      "line" : {
+        "covered" : 1245,
+        "missed" : 1461,
+        "ratio" : 0.460089,
+        "total" : 2706
+      },
+      "method" : {
+        "covered" : 372,
+        "missed" : 323,
+        "ratio" : 0.535252,
+        "total" : 695
+      }
+    }
+  } ]
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/.gitignore
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/build.gradle
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.codehaus.plexus:plexus-container-default:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/gradle.properties
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.codehaus.plexus:plexus-container-default:1.0-alpha-11
+library.version = 1.0-alpha-11
+metadata.dir = org.codehaus.plexus/plexus-container-default/1.0-alpha-11/

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/settings.gradle
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.codehaus.plexus.plexus-container-default_tests'

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/AbstractConfigurationConverterTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/AbstractConfigurationConverterTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+import org.codehaus.plexus.component.configurator.ConfigurationListener;
+import org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter;
+import org.codehaus.plexus.component.configurator.converters.lookup.ConverterLookup;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
+import org.codehaus.plexus.configuration.PlexusConfiguration;
+import org.codehaus.plexus.configuration.xml.XmlPlexusConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AbstractConfigurationConverterTest {
+    @Test
+    public void loadsImplementationHintsAndInstantiatesLoadedClasses() throws Exception {
+        ExposingConfigurationConverter converter = new ExposingConfigurationConverter();
+        ClassLoader classLoader = AbstractConfigurationConverterTest.class.getClassLoader();
+        XmlPlexusConfiguration configuration = new XmlPlexusConfiguration("component");
+        configuration.setAttribute("implementation", ArrayList.class.getName());
+
+        Class implementation = converter.getImplementationClass(Object.class, configuration, classLoader);
+        Object instance = converter.instantiate(InstantiableComponent.class.getName(), classLoader);
+
+        assertSame(ArrayList.class, implementation);
+        assertTrue(instance instanceof InstantiableComponent);
+    }
+
+    public static final class InstantiableComponent {
+    }
+
+    private static final class ExposingConfigurationConverter extends AbstractConfigurationConverter {
+        private Class getImplementationClass(Class type, PlexusConfiguration configuration, ClassLoader classLoader)
+            throws ComponentConfigurationException {
+            return getClassForImplementationHint(type, configuration, classLoader);
+        }
+
+        private Object instantiate(String className, ClassLoader classLoader) throws ComponentConfigurationException {
+            return instantiateObject(className, classLoader);
+        }
+
+        @Override
+        public boolean canConvert(Class type) {
+            return false;
+        }
+
+        @Override
+        public Object fromConfiguration(ConverterLookup converterLookup, PlexusConfiguration configuration, Class type,
+                                        Class baseType, ClassLoader classLoader,
+                                        ExpressionEvaluator expressionEvaluator) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Object fromConfiguration(ConverterLookup converterLookup, PlexusConfiguration configuration, Class type,
+                                        Class baseType, ClassLoader classLoader,
+                                        ExpressionEvaluator expressionEvaluator, ConfigurationListener listener) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/AbstractConfigurationConverterTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/AbstractConfigurationConverterTest.java
@@ -6,6 +6,9 @@
  */
 package org_codehaus_plexus.plexus_container_default;
 
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.classworlds.realm.NoSuchRealmException;
 import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
 import org.codehaus.plexus.component.configurator.ConfigurationListener;
 import org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter;
@@ -25,10 +28,11 @@ public class AbstractConfigurationConverterTest {
     public void loadsImplementationHintsAndInstantiatesLoadedClasses() throws Exception {
         ExposingConfigurationConverter converter = new ExposingConfigurationConverter();
         ClassLoader classLoader = AbstractConfigurationConverterTest.class.getClassLoader();
+        ClassRealm classRealm = testRealm("abstract-configuration-converter-test");
         XmlPlexusConfiguration configuration = new XmlPlexusConfiguration("component");
         configuration.setAttribute("implementation", ArrayList.class.getName());
 
-        Class implementation = converter.getImplementationClass(Object.class, configuration, classLoader);
+        Class implementation = converter.getImplementationClass(Object.class, configuration, classRealm);
         Object instance = converter.instantiate(InstantiableComponent.class.getName(), classLoader);
 
         assertSame(ArrayList.class, implementation);
@@ -38,10 +42,14 @@ public class AbstractConfigurationConverterTest {
     public static final class InstantiableComponent {
     }
 
+    private static ClassRealm testRealm(String id) throws NoSuchRealmException {
+        return new ClassWorld(id, AbstractConfigurationConverterTest.class.getClassLoader()).getRealm(id);
+    }
+
     private static final class ExposingConfigurationConverter extends AbstractConfigurationConverter {
-        private Class getImplementationClass(Class type, PlexusConfiguration configuration, ClassLoader classLoader)
+        private Class getImplementationClass(Class type, PlexusConfiguration configuration, ClassRealm classRealm)
             throws ComponentConfigurationException {
-            return getClassForImplementationHint(type, configuration, classLoader);
+            return getClassForImplementationHint(type, configuration, classRealm);
         }
 
         private Object instantiate(String className, ClassLoader classLoader) throws ComponentConfigurationException {
@@ -55,14 +63,14 @@ public class AbstractConfigurationConverterTest {
 
         @Override
         public Object fromConfiguration(ConverterLookup converterLookup, PlexusConfiguration configuration, Class type,
-                                        Class baseType, ClassLoader classLoader,
+                                        Class baseType, ClassRealm classRealm,
                                         ExpressionEvaluator expressionEvaluator) {
             throw new UnsupportedOperationException();
         }
 
         @Override
         public Object fromConfiguration(ConverterLookup converterLookup, PlexusConfiguration configuration, Class type,
-                                        Class baseType, ClassLoader classLoader,
+                                        Class baseType, ClassRealm classRealm,
                                         ExpressionEvaluator expressionEvaluator, ConfigurationListener listener) {
             throw new UnsupportedOperationException();
         }

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ArrayConverterTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ArrayConverterTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.component.configurator.converters.composite.ArrayConverter;
+import org.codehaus.plexus.component.configurator.converters.lookup.DefaultConverterLookup;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
+import org.codehaus.plexus.configuration.xml.XmlPlexusConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ArrayConverterTest {
+    @Test
+    public void convertsArrayElementsResolvedByClassNameBasePackageAndComponentType() throws Exception {
+        ExposingArrayConverter converter = new ExposingArrayConverter();
+        XmlPlexusConfiguration configuration = new XmlPlexusConfiguration("items");
+        addChild(configuration, "java.lang.String", "resolved from fully qualified element name");
+        addChild(configuration, "string", "resolved from base package");
+        addChild(configuration, "unknown", "resolved from array component type");
+
+        Object value = converter.fromConfiguration(
+            new DefaultConverterLookup(),
+            configuration,
+            String[].class,
+            String.class,
+            ArrayConverterTest.class.getClassLoader(),
+            new LiteralExpressionEvaluator()
+        );
+
+        assertArrayEquals(
+            new String[] {
+                "resolved from fully qualified element name",
+                "resolved from base package",
+                "resolved from array component type"
+            },
+            (String[]) value
+        );
+    }
+
+    @Test
+    public void createsDefaultListCollection() {
+        ExposingArrayConverter converter = new ExposingArrayConverter();
+
+        Collection collection = converter.defaultCollection(ArrayList.class);
+
+        assertTrue(collection instanceof ArrayList);
+        assertTrue(collection.isEmpty());
+    }
+
+    private static void addChild(XmlPlexusConfiguration parent, String name, String value) {
+        XmlPlexusConfiguration child = new XmlPlexusConfiguration(name);
+        child.setValue(value);
+        parent.addChild(child);
+    }
+
+    private static final class ExposingArrayConverter extends ArrayConverter {
+        private Collection defaultCollection(Class collectionType) {
+            return getDefaultCollection(collectionType);
+        }
+    }
+
+    private static final class LiteralExpressionEvaluator implements ExpressionEvaluator {
+        @Override
+        public Object evaluate(String expression) throws ExpressionEvaluationException {
+            return expression;
+        }
+
+        @Override
+        public File alignToBaseDirectory(File file) {
+            return file;
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ArrayConverterTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ArrayConverterTest.java
@@ -6,6 +6,9 @@
  */
 package org_codehaus_plexus.plexus_container_default;
 
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.classworlds.realm.NoSuchRealmException;
 import org.codehaus.plexus.component.configurator.converters.composite.ArrayConverter;
 import org.codehaus.plexus.component.configurator.converters.lookup.DefaultConverterLookup;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
@@ -34,7 +37,7 @@ public class ArrayConverterTest {
             configuration,
             String[].class,
             String.class,
-            ArrayConverterTest.class.getClassLoader(),
+            testRealm("array-converter-test"),
             new LiteralExpressionEvaluator()
         );
 
@@ -56,6 +59,10 @@ public class ArrayConverterTest {
 
         assertTrue(collection instanceof ArrayList);
         assertTrue(collection.isEmpty());
+    }
+
+    private static ClassRealm testRealm(String id) throws NoSuchRealmException {
+        return new ClassWorld(id, ArrayConverterTest.class.getClassLoader()).getRealm(id);
     }
 
     private static void addChild(XmlPlexusConfiguration parent, String name, String value) {

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ClassConverterTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ClassConverterTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.component.configurator.converters.basic.ClassConverter;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ClassConverterTest {
+    @Test
+    public void recognizesClassValuesOnly() {
+        ClassConverter converter = new ClassConverter();
+
+        assertTrue(converter.canConvert(Class.class));
+        assertFalse(converter.canConvert(String.class));
+    }
+
+    @Test
+    public void convertsFullyQualifiedClassNameToClass() throws Exception {
+        ClassConverter converter = new ClassConverter();
+
+        Object converted = converter.fromString(ArrayList.class.getName());
+
+        assertSame(ArrayList.class, converted);
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/CollectionConverterTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/CollectionConverterTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+import org.codehaus.plexus.component.configurator.ConfigurationListener;
+import org.codehaus.plexus.component.configurator.converters.ConfigurationConverter;
+import org.codehaus.plexus.component.configurator.converters.composite.CollectionConverter;
+import org.codehaus.plexus.component.configurator.converters.lookup.ConverterLookup;
+import org.codehaus.plexus.component.configurator.converters.lookup.DefaultConverterLookup;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
+import org.codehaus.plexus.configuration.PlexusConfiguration;
+import org.codehaus.plexus.configuration.xml.XmlPlexusConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CollectionConverterTest {
+    @Test
+    public void recognizesCollectionsButNotMaps() {
+        CollectionConverter converter = new CollectionConverter();
+
+        assertTrue(converter.canConvert(ArrayList.class));
+        assertFalse(converter.canConvert(Map.class));
+    }
+
+    @Test
+    public void instantiatesRequestedConcreteCollectionClass() throws Exception {
+        CollectionConverter converter = new CollectionConverter();
+        XmlPlexusConfiguration configuration = new XmlPlexusConfiguration("items");
+        addChild(configuration, "item", "created by the requested concrete type");
+
+        Object value = converter.fromConfiguration(
+            new DefaultConverterLookup(),
+            configuration,
+            ArrayList.class,
+            CollectionConverterTest.class,
+            CollectionConverterTest.class.getClassLoader(),
+            new LiteralExpressionEvaluator()
+        );
+
+        assertTrue(value instanceof ArrayList);
+        assertEquals(1, ((ArrayList) value).size());
+        assertEquals("created by the requested concrete type", ((ArrayList) value).get(0));
+    }
+
+    @Test
+    public void createsConcreteCollectionAndResolvesChildrenByClassNameAndBasePackage() throws Exception {
+        CollectionConverter converter = new CollectionConverter();
+        DefaultConverterLookup converterLookup = new DefaultConverterLookup();
+        converterLookup.registerConverter(new NamedElementConverter());
+        XmlPlexusConfiguration configuration = new XmlPlexusConfiguration("items");
+        addChild(configuration, "java.lang.String", "loaded from fully qualified child element");
+        addChild(configuration, "collectionConverterTest$NamedElement", "loaded from base package child element");
+
+        Object value = converter.fromConfiguration(
+            converterLookup,
+            configuration,
+            List.class,
+            CollectionConverterTest.class,
+            CollectionConverterTest.class.getClassLoader(),
+            new LiteralExpressionEvaluator()
+        );
+
+        assertTrue(value instanceof ArrayList);
+        Collection collection = (Collection) value;
+        assertEquals(2, collection.size());
+        assertTrue(collection.contains("loaded from fully qualified child element"));
+        assertTrue(collection.contains(new NamedElement("loaded from base package child element")));
+    }
+
+    private static void addChild(XmlPlexusConfiguration parent, String name, String value) {
+        XmlPlexusConfiguration child = new XmlPlexusConfiguration(name);
+        child.setValue(value);
+        parent.addChild(child);
+    }
+
+    public static final class NamedElement {
+        private final String value;
+
+        private NamedElement(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (!(other instanceof NamedElement)) {
+                return false;
+            }
+            NamedElement that = (NamedElement) other;
+            return value.equals(that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return value.hashCode();
+        }
+    }
+
+    private static final class NamedElementConverter implements ConfigurationConverter {
+        @Override
+        public boolean canConvert(Class type) {
+            return NamedElement.class.equals(type);
+        }
+
+        @Override
+        public Object fromConfiguration(ConverterLookup converterLookup, PlexusConfiguration configuration, Class type,
+                                        Class baseType, ClassLoader classLoader,
+                                        ExpressionEvaluator expressionEvaluator)
+            throws ComponentConfigurationException {
+            try {
+                return new NamedElement((String) expressionEvaluator.evaluate(configuration.getValue(null)));
+            } catch (ExpressionEvaluationException e) {
+                throw new ComponentConfigurationException("Could not create named element", e);
+            }
+        }
+
+        @Override
+        public Object fromConfiguration(ConverterLookup converterLookup, PlexusConfiguration configuration, Class type,
+                                        Class baseType, ClassLoader classLoader,
+                                        ExpressionEvaluator expressionEvaluator, ConfigurationListener listener)
+            throws ComponentConfigurationException {
+            return fromConfiguration(converterLookup, configuration, type, baseType, classLoader, expressionEvaluator);
+        }
+    }
+
+    private static final class LiteralExpressionEvaluator implements ExpressionEvaluator {
+        @Override
+        public Object evaluate(String expression) throws ExpressionEvaluationException {
+            return expression;
+        }
+
+        @Override
+        public File alignToBaseDirectory(File file) {
+            return file;
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/CollectionConverterTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/CollectionConverterTest.java
@@ -6,6 +6,9 @@
  */
 package org_codehaus_plexus.plexus_container_default;
 
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.classworlds.realm.NoSuchRealmException;
 import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
 import org.codehaus.plexus.component.configurator.ConfigurationListener;
 import org.codehaus.plexus.component.configurator.converters.ConfigurationConverter;
@@ -48,7 +51,7 @@ public class CollectionConverterTest {
             configuration,
             ArrayList.class,
             CollectionConverterTest.class,
-            CollectionConverterTest.class.getClassLoader(),
+            testRealm("collection-converter-concrete-test"),
             new LiteralExpressionEvaluator()
         );
 
@@ -71,7 +74,7 @@ public class CollectionConverterTest {
             configuration,
             List.class,
             CollectionConverterTest.class,
-            CollectionConverterTest.class.getClassLoader(),
+            testRealm("collection-converter-children-test"),
             new LiteralExpressionEvaluator()
         );
 
@@ -80,6 +83,10 @@ public class CollectionConverterTest {
         assertEquals(2, collection.size());
         assertTrue(collection.contains("loaded from fully qualified child element"));
         assertTrue(collection.contains(new NamedElement("loaded from base package child element")));
+    }
+
+    private static ClassRealm testRealm(String id) throws NoSuchRealmException {
+        return new ClassWorld(id, CollectionConverterTest.class.getClassLoader()).getRealm(id);
     }
 
     private static void addChild(XmlPlexusConfiguration parent, String name, String value) {
@@ -121,7 +128,7 @@ public class CollectionConverterTest {
 
         @Override
         public Object fromConfiguration(ConverterLookup converterLookup, PlexusConfiguration configuration, Class type,
-                                        Class baseType, ClassLoader classLoader,
+                                        Class baseType, ClassRealm classRealm,
                                         ExpressionEvaluator expressionEvaluator)
             throws ComponentConfigurationException {
             try {
@@ -133,10 +140,10 @@ public class CollectionConverterTest {
 
         @Override
         public Object fromConfiguration(ConverterLookup converterLookup, PlexusConfiguration configuration, Class type,
-                                        Class baseType, ClassLoader classLoader,
+                                        Class baseType, ClassRealm classRealm,
                                         ExpressionEvaluator expressionEvaluator, ConfigurationListener listener)
             throws ComponentConfigurationException {
-            return fromConfiguration(converterLookup, configuration, type, baseType, classLoader, expressionEvaluator);
+            return fromConfiguration(converterLookup, configuration, type, baseType, classRealm, expressionEvaluator);
         }
     }
 

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentComposerAnonymous1Test.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentComposerAnonymous1Test.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.component.composition.ComponentComposer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ComponentComposerAnonymous1Test {
+    @Test
+    public void exposesInterfaceRoleName() {
+        assertEquals(ComponentComposer.class.getName(), ComponentComposer.ROLE);
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentComposerManagerAnonymous1Test.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentComposerManagerAnonymous1Test.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.component.composition.ComponentComposerManager;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ComponentComposerManagerAnonymous1Test {
+    @Test
+    public void exposesInterfaceRoleName() {
+        assertThat(ComponentComposerManager.ROLE)
+            .isEqualTo("org.codehaus.plexus.component.composition.ComponentComposerManager");
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentConfiguratorAnonymous1Test.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentConfiguratorAnonymous1Test.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.component.configurator.ComponentConfigurator;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ComponentConfiguratorAnonymous1Test {
+    @Test
+    public void exposesInterfaceRoleName() {
+        assertEquals(ComponentConfigurator.class.getName(), ComponentConfigurator.ROLE);
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentDiscovererAnonymous1Test.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentDiscovererAnonymous1Test.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.component.discovery.ComponentDiscoverer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ComponentDiscovererAnonymous1Test {
+    @Test
+    public void exposesInterfaceRoleName() {
+        assertEquals(ComponentDiscoverer.class.getName(), ComponentDiscoverer.ROLE);
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentFactoryAnonymous1Test.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentFactoryAnonymous1Test.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.component.factory.ComponentFactory;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ComponentFactoryAnonymous1Test {
+    @Test
+    public void exposesInterfaceRoleName() {
+        assertEquals(ComponentFactory.class.getName(), ComponentFactory.ROLE);
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentLookupManagerAnonymous1Test.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentLookupManagerAnonymous1Test.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.ComponentLookupManager;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ComponentLookupManagerAnonymous1Test {
+    @Test
+    public void exposesInterfaceRoleName() {
+        assertEquals(ComponentLookupManager.class.getName(), ComponentLookupManager.ROLE);
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentManagerAnonymous1Test.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentManagerAnonymous1Test.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.component.manager.ComponentManager;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ComponentManagerAnonymous1Test {
+    @Test
+    public void exposesRoleName() {
+        assertThat(ComponentManager.ROLE)
+            .isEqualTo("org.codehaus.plexus.component.manager.ComponentManager");
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentManagerManagerAnonymous1Test.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentManagerManagerAnonymous1Test.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.component.manager.ComponentManagerManager;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ComponentManagerManagerAnonymous1Test {
+    @Test
+    public void exposesRoleConstantInitializedFromInterfaceTypeName() {
+        assertThat(ComponentManagerManager.ROLE)
+            .isEqualTo("org.codehaus.plexus.component.manager.ComponentManagerManager");
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentValueSetterTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentValueSetterTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.component.configurator.converters.ComponentValueSetter;
+import org.codehaus.plexus.component.configurator.converters.lookup.DefaultConverterLookup;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
+import org.codehaus.plexus.configuration.xml.XmlPlexusConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ComponentValueSetterTest {
+    @Test
+    public void configuresPrivateFieldWhenNoSetterExists() throws Exception {
+        FieldOnlyComponent component = new FieldOnlyComponent();
+
+        configure(component, "configuredValue", "field value");
+
+        assertEquals("field value", component.getConfiguredValue());
+    }
+
+    @Test
+    public void configuresUsingSetterWhenSetterExists() throws Exception {
+        SetterOnlyComponent component = new SetterOnlyComponent();
+
+        configure(component, "configuredValue", "setter value");
+
+        assertEquals("setter value", component.getAssignedValue());
+    }
+
+    private static void configure(Object component, String fieldName, String value) throws Exception {
+        XmlPlexusConfiguration configuration = new XmlPlexusConfiguration(fieldName);
+        configuration.setValue(value);
+
+        ComponentValueSetter setter = new ComponentValueSetter(fieldName, component, new DefaultConverterLookup());
+        setter.configure(
+            configuration,
+            ComponentValueSetterTest.class.getClassLoader(),
+            new LiteralExpressionEvaluator()
+        );
+    }
+
+    public static final class FieldOnlyComponent {
+        private String configuredValue;
+
+        public String getConfiguredValue() {
+            return configuredValue;
+        }
+    }
+
+    public static final class SetterOnlyComponent {
+        private String assignedValue;
+
+        public void setConfiguredValue(String configuredValue) {
+            assignedValue = configuredValue;
+        }
+
+        public String getAssignedValue() {
+            return assignedValue;
+        }
+    }
+
+    private static final class LiteralExpressionEvaluator implements ExpressionEvaluator {
+        @Override
+        public Object evaluate(String expression) throws ExpressionEvaluationException {
+            return expression;
+        }
+
+        @Override
+        public File alignToBaseDirectory(File file) {
+            return file;
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentValueSetterTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentValueSetterTest.java
@@ -6,6 +6,9 @@
  */
 package org_codehaus_plexus.plexus_container_default;
 
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.classworlds.realm.NoSuchRealmException;
 import org.codehaus.plexus.component.configurator.converters.ComponentValueSetter;
 import org.codehaus.plexus.component.configurator.converters.lookup.DefaultConverterLookup;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
@@ -43,9 +46,13 @@ public class ComponentValueSetterTest {
         ComponentValueSetter setter = new ComponentValueSetter(fieldName, component, new DefaultConverterLookup());
         setter.configure(
             configuration,
-            ComponentValueSetterTest.class.getClassLoader(),
+            testRealm("component-value-setter-test"),
             new LiteralExpressionEvaluator()
         );
+    }
+
+    private static ClassRealm testRealm(String id) throws NoSuchRealmException {
+        return new ClassWorld(id, ComponentValueSetterTest.class.getClassLoader()).getRealm(id);
     }
 
     public static final class FieldOnlyComponent {

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ContainerInitializationPhaseAnonymous1Test.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ContainerInitializationPhaseAnonymous1Test.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.container.initialization.ContainerInitializationPhase;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ContainerInitializationPhaseAnonymous1Test {
+    @Test
+    void roleUsesTheContainerInitializationPhaseTypeName() {
+        assertThat(ContainerInitializationPhase.ROLE).isEqualTo(ContainerInitializationPhase.class.getName());
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/DefaultPlexusContainerTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/DefaultPlexusContainerTest.java
@@ -15,10 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class DefaultPlexusContainerTest {
     @Test
     void constructorInitializesCoreRealmAndContainerContext() throws Exception {
-        DefaultPlexusContainer container = new DefaultPlexusContainer(
-            "test-container",
-            DefaultPlexusContainerTest.class.getClassLoader()
-        );
+        DefaultPlexusContainer container = new DefaultPlexusContainer("test-container", null);
 
         try {
             container.setReloadingEnabled(true);
@@ -35,10 +32,7 @@ public class DefaultPlexusContainerTest {
 
     @Test
     void createAndAutowireInstantiatesNamedComponentFromContainerRealm() throws Exception {
-        DefaultPlexusContainer container = new DefaultPlexusContainer(
-            "autowire-container",
-            DefaultPlexusContainerTest.class.getClassLoader()
-        );
+        DefaultPlexusContainer container = new DefaultPlexusContainer("autowire-container", null);
 
         try {
             Object component = container.createAndAutowire(SimpleAutowirableComponent.class.getName());

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/DefaultPlexusContainerTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/DefaultPlexusContainerTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.DefaultPlexusContainer;
+import org.codehaus.plexus.PlexusConstants;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DefaultPlexusContainerTest {
+    @Test
+    void constructorInitializesCoreRealmAndContainerContext() throws Exception {
+        DefaultPlexusContainer container = new DefaultPlexusContainer(
+            "test-container",
+            DefaultPlexusContainerTest.class.getClassLoader()
+        );
+
+        try {
+            container.setReloadingEnabled(true);
+
+            assertThat(container.getName()).isEqualTo("test-container");
+            assertThat(container.getContainerRealm()).isNotNull();
+            assertThat(container.getLoggerManager()).isNotNull();
+            assertThat(container.getContext().get(PlexusConstants.PLEXUS_KEY)).isSameAs(container);
+            assertThat(container.isReloadingEnabled()).isTrue();
+        } finally {
+            container.dispose();
+        }
+    }
+
+    @Test
+    void createAndAutowireInstantiatesNamedComponentFromContainerRealm() throws Exception {
+        DefaultPlexusContainer container = new DefaultPlexusContainer(
+            "autowire-container",
+            DefaultPlexusContainerTest.class.getClassLoader()
+        );
+
+        try {
+            Object component = container.createAndAutowire(SimpleAutowirableComponent.class.getName());
+
+            assertThat(component).isInstanceOf(SimpleAutowirableComponent.class);
+            assertThat(((SimpleAutowirableComponent) component).isConstructed()).isTrue();
+        } finally {
+            container.dispose();
+        }
+    }
+
+    public static final class SimpleAutowirableComponent {
+        private final boolean constructed;
+
+        public SimpleAutowirableComponent() {
+            constructed = true;
+        }
+
+        public boolean isConstructed() {
+            return constructed;
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ExpressionEvaluatorAnonymous1Test.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ExpressionEvaluatorAnonymous1Test.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ExpressionEvaluatorAnonymous1Test {
+    @Test
+    public void exposesInterfaceRoleName() {
+        assertEquals(ExpressionEvaluator.class.getName(), ExpressionEvaluator.ROLE);
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/FieldComponentComposerTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/FieldComponentComposerTest.java
@@ -6,19 +6,29 @@
  */
 package org_codehaus_plexus.plexus_container_default;
 
-import org.codehaus.classworlds.ClassRealm;
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.ComponentLookupManager;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.PlexusContainerException;
+import org.codehaus.plexus.component.composition.ComponentComposerManager;
 import org.codehaus.plexus.component.composition.CompositionException;
 import org.codehaus.plexus.component.composition.FieldComponentComposer;
+import org.codehaus.plexus.component.discovery.ComponentDiscovererManager;
 import org.codehaus.plexus.component.discovery.ComponentDiscoveryListener;
+import org.codehaus.plexus.component.factory.ComponentFactoryManager;
+import org.codehaus.plexus.component.manager.ComponentManagerManager;
 import org.codehaus.plexus.component.repository.ComponentDescriptor;
+import org.codehaus.plexus.component.repository.ComponentRepository;
 import org.codehaus.plexus.component.repository.ComponentRequirement;
 import org.codehaus.plexus.component.repository.exception.ComponentLifecycleException;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.codehaus.plexus.component.repository.exception.ComponentRepositoryException;
+import org.codehaus.plexus.configuration.PlexusConfiguration;
+import org.codehaus.plexus.configuration.PlexusConfigurationException;
 import org.codehaus.plexus.configuration.PlexusConfigurationResourceException;
 import org.codehaus.plexus.context.Context;
+import org.codehaus.plexus.lifecycle.LifecycleHandlerManager;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.logging.LoggerManager;
 import org.junit.jupiter.api.Test;
@@ -169,6 +179,10 @@ public class FieldComponentComposerTest {
         }
 
         @Override
+        public void setName(String name) {
+        }
+
+        @Override
         public Date getCreationDate() {
             return new Date(0L);
         }
@@ -187,6 +201,14 @@ public class FieldComponentComposerTest {
             return lookup(role + roleHint);
         }
 
+        public Object lookup(Class componentClass) throws ComponentLookupException {
+            return lookup(componentClass.getName());
+        }
+
+        public Object lookup(Class role, String roleHint) throws ComponentLookupException {
+            return lookup(role.getName(), roleHint);
+        }
+
         @Override
         public Map lookupMap(String role) throws ComponentLookupException {
             Map dependencies = maps.get(role);
@@ -203,6 +225,14 @@ public class FieldComponentComposerTest {
                 throw new ComponentLookupException("Missing list: " + role);
             }
             return dependencies;
+        }
+
+        public Map lookupMap(Class role) throws ComponentLookupException {
+            return lookupMap(role.getName());
+        }
+
+        public List lookupList(Class role) throws ComponentLookupException {
+            return lookupList(role.getName());
         }
 
         @Override
@@ -293,11 +323,9 @@ public class FieldComponentComposerTest {
             throw new UnsupportedOperationException();
         }
 
-        @Override
         public void initialize() throws PlexusContainerException {
         }
 
-        @Override
         public void start() throws PlexusContainerException {
         }
 
@@ -314,7 +342,6 @@ public class FieldComponentComposerTest {
         public void addContextValue(Object key, Object value) {
         }
 
-        @Override
         public void setConfigurationResource(Reader configuration) throws PlexusConfigurationResourceException {
             throw new UnsupportedOperationException();
         }
@@ -349,6 +376,23 @@ public class FieldComponentComposerTest {
             return null;
         }
 
+        public ClassWorld getClassWorld() {
+            return null;
+        }
+
+        public List discoverComponents(ClassRealm classRealm)
+            throws PlexusConfigurationException, ComponentRepositoryException {
+            return new ArrayList();
+        }
+
+        @Override
+        public void setParentPlexusContainer(PlexusContainer parentContainer) {
+        }
+
+        public PlexusContainer getParentContainer() {
+            return null;
+        }
+
         @Override
         public Object autowire(Object component) throws CompositionException {
             throw new UnsupportedOperationException();
@@ -369,8 +413,66 @@ public class FieldComponentComposerTest {
             return false;
         }
 
-        @Override
+        public ComponentRepository getComponentRepository() {
+            return null;
+        }
+
+        public void setComponentRepository(ComponentRepository componentRepository) {
+        }
+
+        public LifecycleHandlerManager getLifecycleHandlerManager() {
+            return null;
+        }
+
+        public void setLifecycleHandlerManager(LifecycleHandlerManager lifecycleHandlerManager) {
+        }
+
+        public ComponentManagerManager getComponentManagerManager() {
+            return null;
+        }
+
+        public void setComponentManagerManager(ComponentManagerManager componentManagerManager) {
+        }
+
+        public ComponentDiscovererManager getComponentDiscovererManager() {
+            return null;
+        }
+
+        public void setComponentDiscovererManager(ComponentDiscovererManager componentDiscovererManager) {
+        }
+
+        public ComponentFactoryManager getComponentFactoryManager() {
+            return null;
+        }
+
+        public void setComponentFactoryManager(ComponentFactoryManager componentFactoryManager) {
+        }
+
+        public ComponentLookupManager getComponentLookupManager() {
+            return null;
+        }
+
+        public void setComponentLookupManager(ComponentLookupManager componentLookupManager) {
+        }
+
+        public ComponentComposerManager getComponentComposerManager() {
+            return null;
+        }
+
+        public void setComponentComposerManager(ComponentComposerManager componentComposerManager) {
+        }
+
         public LoggerManager getLoggerManager() {
+            return null;
+        }
+
+        public void setLoggerManager(LoggerManager loggerManager) {
+        }
+
+        public void setConfiguration(PlexusConfiguration configuration) {
+        }
+
+        public PlexusConfiguration getConfiguration() {
             return null;
         }
     }

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/FieldComponentComposerTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/FieldComponentComposerTest.java
@@ -1,0 +1,377 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.classworlds.ClassRealm;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.PlexusContainerException;
+import org.codehaus.plexus.component.composition.CompositionException;
+import org.codehaus.plexus.component.composition.FieldComponentComposer;
+import org.codehaus.plexus.component.discovery.ComponentDiscoveryListener;
+import org.codehaus.plexus.component.repository.ComponentDescriptor;
+import org.codehaus.plexus.component.repository.ComponentRequirement;
+import org.codehaus.plexus.component.repository.exception.ComponentLifecycleException;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.codehaus.plexus.component.repository.exception.ComponentRepositoryException;
+import org.codehaus.plexus.configuration.PlexusConfigurationResourceException;
+import org.codehaus.plexus.context.Context;
+import org.codehaus.plexus.logging.Logger;
+import org.codehaus.plexus.logging.LoggerManager;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.Reader;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class FieldComponentComposerTest {
+    @Test
+    public void assignsRequirementsToSupportedFieldShapes() throws Exception {
+        FieldComponentComposer composer = new FieldComponentComposer();
+        ComponentWithAllFieldKinds component = new ComponentWithAllFieldKinds();
+        RecordingPlexusContainer container = new RecordingPlexusContainer();
+        ComponentDescriptor componentDescriptor = descriptor(ComponentWithAllFieldKinds.class.getName());
+
+        Object[] arrayDependency = new Object[] {"nested dependency" };
+        List<String> listDependencies = new ArrayList<>();
+        listDependencies.add("list dependency");
+        Map<String, String> mapDependencies = new HashMap<>();
+        mapDependencies.put("key", "map dependency");
+        Dependency ordinaryDependency = new Dependency();
+
+        String arrayRole = "arrayRole";
+        String mapRole = "mapRole";
+        String listRole = "listRole";
+        String ordinaryRole = Dependency.class.getName();
+
+        container.addList(arrayRole, listOf(arrayDependency));
+        container.addList(listRole, listDependencies);
+        container.addMap(mapRole, mapDependencies);
+        container.addComponent(ordinaryRole, ordinaryDependency);
+
+        componentDescriptor.addRequirement(requirement(arrayRole, "arrayDependencies"));
+        componentDescriptor.addRequirement(requirement(mapRole, "mapDependencies"));
+        componentDescriptor.addRequirement(requirement(listRole, "listDependencies"));
+        componentDescriptor.addRequirement(requirement(ordinaryRole, "ordinaryDependency"));
+
+        composer.assembleComponent(component, componentDescriptor, container);
+
+        assertEquals(1, component.arrayDependencies.length);
+        assertSame(arrayDependency, component.arrayDependencies[0]);
+        assertSame(mapDependencies, component.mapDependencies);
+        assertSame(listDependencies, component.listDependencies);
+        assertSame(ordinaryDependency, component.ordinaryDependency);
+    }
+
+    @Test
+    public void findsRequirementFieldByRoleUsingThreadContextClassLoader() throws Exception {
+        ExposingFieldComponentComposer composer = new ExposingFieldComponentComposer();
+        ComponentDescriptor descriptor = descriptor(DerivedComponent.class.getName());
+        ComponentRequirement requirement = requirement(Dependency.class.getName(), null);
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+
+        Thread.currentThread().setContextClassLoader(FieldComponentComposerTest.class.getClassLoader());
+        try {
+            Field field = composer.findField(new DerivedComponent(), descriptor, requirement);
+
+            assertEquals("inheritedDependency", field.getName());
+            assertSame(BaseComponent.class, field.getDeclaringClass());
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    private static ComponentRequirement requirement(String role, String fieldName) {
+        ComponentRequirement requirement = new ComponentRequirement();
+        requirement.setRole(role);
+        requirement.setFieldName(fieldName);
+        return requirement;
+    }
+
+    private static ComponentDescriptor descriptor(String role) {
+        ComponentDescriptor descriptor = new ComponentDescriptor();
+        descriptor.setRole(role);
+        descriptor.setImplementation(role);
+        return descriptor;
+    }
+
+    private static List<Object> listOf(Object value) {
+        List<Object> values = new ArrayList<>();
+        values.add(value);
+        return values;
+    }
+
+    public static final class Dependency {
+    }
+
+    public static class BaseComponent {
+        private Dependency inheritedDependency;
+    }
+
+    public static final class DerivedComponent extends BaseComponent {
+    }
+
+    public static final class ComponentWithAllFieldKinds {
+        private Object[] arrayDependencies;
+
+        private Map mapDependencies;
+
+        private List listDependencies;
+
+        private Dependency ordinaryDependency;
+    }
+
+    private static final class ExposingFieldComponentComposer extends FieldComponentComposer {
+        private Field findField(Object component, ComponentDescriptor descriptor, ComponentRequirement requirement)
+            throws CompositionException {
+            return findMatchingField(component, descriptor, requirement, null);
+        }
+    }
+
+    private static final class RecordingPlexusContainer implements PlexusContainer {
+        private final Map<String, Object> components = new HashMap<>();
+
+        private final Map<String, List> lists = new HashMap<>();
+
+        private final Map<String, Map> maps = new HashMap<>();
+
+        private final Map<String, ComponentDescriptor> descriptors = new HashMap<>();
+
+        private void addComponent(String key, Object component) {
+            components.put(key, component);
+            descriptors.put(key, descriptor(key));
+        }
+
+        private void addList(String role, List dependencies) {
+            lists.put(role, dependencies);
+            descriptors.put(role, descriptor(role));
+        }
+
+        private void addMap(String role, Map dependencies) {
+            maps.put(role, dependencies);
+            descriptors.put(role, descriptor(role));
+        }
+
+        @Override
+        public String getName() {
+            return "recording";
+        }
+
+        @Override
+        public Date getCreationDate() {
+            return new Date(0L);
+        }
+
+        @Override
+        public Object lookup(String componentKey) throws ComponentLookupException {
+            Object component = components.get(componentKey);
+            if (component == null) {
+                throw new ComponentLookupException("Missing component: " + componentKey);
+            }
+            return component;
+        }
+
+        @Override
+        public Object lookup(String role, String roleHint) throws ComponentLookupException {
+            return lookup(role + roleHint);
+        }
+
+        @Override
+        public Map lookupMap(String role) throws ComponentLookupException {
+            Map dependencies = maps.get(role);
+            if (dependencies == null) {
+                throw new ComponentLookupException("Missing map: " + role);
+            }
+            return dependencies;
+        }
+
+        @Override
+        public List lookupList(String role) throws ComponentLookupException {
+            List dependencies = lists.get(role);
+            if (dependencies == null) {
+                throw new ComponentLookupException("Missing list: " + role);
+            }
+            return dependencies;
+        }
+
+        @Override
+        public ComponentDescriptor getComponentDescriptor(String componentKey) {
+            return descriptors.get(componentKey);
+        }
+
+        @Override
+        public Map getComponentDescriptorMap(String role) {
+            Map<String, ComponentDescriptor> descriptorMap = new HashMap<>();
+            descriptorMap.put(role, descriptors.get(role));
+            return descriptorMap;
+        }
+
+        @Override
+        public List getComponentDescriptorList(String role) {
+            return listOf(descriptors.get(role));
+        }
+
+        @Override
+        public boolean hasChildContainer(String name) {
+            return false;
+        }
+
+        @Override
+        public void removeChildContainer(String name) {
+        }
+
+        @Override
+        public PlexusContainer getChildContainer(String name) {
+            return null;
+        }
+
+        @Override
+        public PlexusContainer createChildContainer(String name, List classpathJars, Map context)
+            throws PlexusContainerException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public PlexusContainer createChildContainer(
+            String name,
+            List classpathJars,
+            Map context,
+            List discoveryListeners
+        ) throws PlexusContainerException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void addComponentDescriptor(ComponentDescriptor componentDescriptor)
+            throws ComponentRepositoryException {
+            descriptors.put(componentDescriptor.getComponentKey(), componentDescriptor);
+        }
+
+        @Override
+        public void release(Object component) throws ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void releaseAll(Map components) throws ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void releaseAll(List components) throws ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean hasComponent(String componentKey) {
+            return components.containsKey(componentKey);
+        }
+
+        @Override
+        public boolean hasComponent(String role, String roleHint) {
+            return hasComponent(role + roleHint);
+        }
+
+        @Override
+        public void suspend(Object component) throws ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void resume(Object component) throws ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void initialize() throws PlexusContainerException {
+        }
+
+        @Override
+        public void start() throws PlexusContainerException {
+        }
+
+        @Override
+        public void dispose() {
+        }
+
+        @Override
+        public Context getContext() {
+            return null;
+        }
+
+        @Override
+        public void addContextValue(Object key, Object value) {
+        }
+
+        @Override
+        public void setConfigurationResource(Reader configuration) throws PlexusConfigurationResourceException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Logger getLogger() {
+            return null;
+        }
+
+        @Override
+        public void registerComponentDiscoveryListener(ComponentDiscoveryListener listener) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void removeComponentDiscoveryListener(ComponentDiscoveryListener listener) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void addJarRepository(File repository) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void addJarResource(File resource) throws PlexusContainerException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ClassRealm getContainerRealm() {
+            return null;
+        }
+
+        @Override
+        public Object autowire(Object component) throws CompositionException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Object createAndAutowire(String clazz)
+            throws CompositionException, ClassNotFoundException, InstantiationException, IllegalAccessException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setReloadingEnabled(boolean reloadingEnabled) {
+        }
+
+        @Override
+        public boolean isReloadingEnabled() {
+            return false;
+        }
+
+        @Override
+        public LoggerManager getLoggerManager() {
+            return null;
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/JavaComponentFactoryTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/JavaComponentFactoryTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.classworlds.ClassRealm;
+import org.codehaus.classworlds.ClassWorld;
+import org.codehaus.plexus.component.factory.java.JavaComponentFactory;
+import org.codehaus.plexus.component.repository.ComponentDescriptor;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JavaComponentFactoryTest {
+    @Test
+    void createsComponentImplementationWithDefaultConstructor() throws Exception {
+        ComponentDescriptor descriptor = new ComponentDescriptor();
+        descriptor.setRole(SampleComponent.class.getName());
+        descriptor.setImplementation(SampleComponent.class.getName());
+
+        ClassWorld classWorld = new ClassWorld();
+        ClassRealm realm = classWorld.newRealm(
+            "java-component-factory-test",
+            JavaComponentFactoryTest.class.getClassLoader()
+        );
+
+        Object component = new JavaComponentFactory().newInstance(descriptor, realm, null);
+
+        assertThat(component).isInstanceOf(SampleComponent.class);
+        assertThat(((SampleComponent) component).message()).isEqualTo("created by JavaComponentFactory");
+    }
+
+    public static class SampleComponent {
+        public String message() {
+            return "created by JavaComponentFactory";
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/JavaComponentFactoryTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/JavaComponentFactoryTest.java
@@ -6,8 +6,8 @@
  */
 package org_codehaus_plexus.plexus_container_default;
 
-import org.codehaus.classworlds.ClassRealm;
-import org.codehaus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
 import org.codehaus.plexus.component.factory.java.JavaComponentFactory;
 import org.codehaus.plexus.component.repository.ComponentDescriptor;
 import org.junit.jupiter.api.Test;
@@ -21,11 +21,10 @@ public class JavaComponentFactoryTest {
         descriptor.setRole(SampleComponent.class.getName());
         descriptor.setImplementation(SampleComponent.class.getName());
 
-        ClassWorld classWorld = new ClassWorld();
-        ClassRealm realm = classWorld.newRealm(
+        ClassRealm realm = new ClassWorld(
             "java-component-factory-test",
             JavaComponentFactoryTest.class.getClassLoader()
-        );
+        ).getRealm("java-component-factory-test");
 
         Object component = new JavaComponentFactory().newInstance(descriptor, realm, null);
 

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/LoggerManagerAnonymous1Test.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/LoggerManagerAnonymous1Test.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.logging.LoggerManager;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class LoggerManagerAnonymous1Test {
+    @Test
+    public void exposesInterfaceRoleName() {
+        assertEquals(LoggerManager.class.getName(), LoggerManager.ROLE);
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/MapOrientedComponentComposerTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/MapOrientedComponentComposerTest.java
@@ -1,0 +1,456 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.classworlds.ClassRealm;
+import org.codehaus.plexus.DefaultPlexusContainer;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.PlexusContainerException;
+import org.codehaus.plexus.component.MapOrientedComponent;
+import org.codehaus.plexus.component.composition.CompositionException;
+import org.codehaus.plexus.component.composition.MapOrientedComponentComposer;
+import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+import org.codehaus.plexus.component.discovery.ComponentDiscoveryListener;
+import org.codehaus.plexus.component.repository.ComponentDescriptor;
+import org.codehaus.plexus.component.repository.ComponentRequirement;
+import org.codehaus.plexus.component.repository.exception.ComponentLifecycleException;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.codehaus.plexus.component.repository.exception.ComponentRepositoryException;
+import org.codehaus.plexus.configuration.PlexusConfigurationResourceException;
+import org.codehaus.plexus.context.Context;
+import org.codehaus.plexus.logging.Logger;
+import org.codehaus.plexus.logging.LoggerManager;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.io.File;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class MapOrientedComponentComposerTest {
+    @Test
+    @Order(2)
+    public void containerComposerManagerRejectsPlainComponentsForMapOrientedComposer() throws Exception {
+        DefaultPlexusContainer container = new DefaultPlexusContainer(
+            "map-oriented-composer-test",
+            MapOrientedComponentComposerTest.class.getClassLoader()
+        );
+        ComponentDescriptor descriptor = descriptor(PlainComponent.class.getName());
+        descriptor.setComponentComposer("map-oriented");
+        descriptor.addRequirement(requirement("ignoredRole", "single"));
+
+        try {
+            CompositionException exception = assertThrows(
+                CompositionException.class,
+                () -> container.getComponentComposerManager().assembleComponent(
+                    new PlainComponent(),
+                    descriptor,
+                    container
+                )
+            );
+
+            assertTrue(exception.getMessage().contains(PlainComponent.class.getName()));
+            assertTrue(exception.getMessage().contains(MapOrientedComponent.class.getName()));
+        } finally {
+            container.dispose();
+        }
+    }
+
+    @Test
+    @Order(3)
+    public void rejectsComponentsThatAreNotMapOriented() {
+        MapOrientedComponentComposer composer = new MapOrientedComponentComposer();
+        ComponentDescriptor descriptor = descriptor(PlainComponent.class.getName());
+        RecordingPlexusContainer container = new RecordingPlexusContainer();
+
+        assertMapOrientedRejection(composer, new PlainComponent(), descriptor, container);
+        assertMapOrientedRejection(composer, "not a map-oriented component", descriptor, container);
+    }
+
+    @Test
+    @Order(1)
+    public void lookupFailsWhenDescriptorSelectsMapOrientedComposerForPlainComponent() throws Exception {
+        DefaultPlexusContainer container = new DefaultPlexusContainer(
+            "map-oriented-composer-lookup-test",
+            MapOrientedComponentComposerTest.class.getClassLoader()
+        );
+        ComponentDescriptor descriptor = descriptor(PlainComponent.class.getName());
+        descriptor.setComponentComposer("map-oriented");
+        descriptor.addRequirement(requirement("ignoredRole", "single"));
+        container.addComponentDescriptor(descriptor);
+
+        try {
+            ComponentLookupException exception = assertThrows(
+                ComponentLookupException.class,
+                () -> container.lookup(PlainComponent.class.getName())
+            );
+
+            assertTrue(rootCauseMessage(exception).contains(PlainComponent.class.getName()));
+            assertTrue(rootCauseMessage(exception).contains(MapOrientedComponent.class.getName()));
+        } finally {
+            container.dispose();
+        }
+    }
+
+    @Test
+    @Order(4)
+    public void addsMappedRequirementsToMapOrientedComponents() throws Exception {
+        MapOrientedComponentComposer composer = new MapOrientedComponentComposer();
+        RecordingMapOrientedComponent component = new RecordingMapOrientedComponent();
+        RecordingPlexusContainer container = new RecordingPlexusContainer();
+        ComponentDescriptor descriptor = descriptor(RecordingMapOrientedComponent.class.getName());
+
+        Object hintedDependency = new Object();
+        Object singleDependency = new Object();
+        Object fallbackDependency = new Object();
+        Map<String, Object> mappedDependencies = new HashMap<>();
+        mappedDependencies.put("mapped", new Object());
+        List<Object> listedDependencies = new ArrayList<>();
+        listedDependencies.add(new Object());
+        listedDependencies.add(new Object());
+
+        container.addComponent("hintedRolehint", hintedDependency);
+        container.addComponent("singleRole", singleDependency);
+        container.addComponent("fallbackRole", fallbackDependency);
+        container.addMap("mapRole", mappedDependencies);
+        container.addList("setRole", listedDependencies);
+
+        ComponentRequirement hinted = requirement("hintedRole", null);
+        hinted.setRoleHint("hint");
+        ComponentRequirement single = requirement("singleRole", "single");
+        ComponentRequirement mapped = requirement("mapRole", "map");
+        ComponentRequirement set = requirement("setRole", "set");
+        ComponentRequirement fallback = requirement("fallbackRole", "unexpected");
+
+        descriptor.addRequirement(hinted);
+        descriptor.addRequirement(single);
+        descriptor.addRequirement(mapped);
+        descriptor.addRequirement(set);
+        descriptor.addRequirement(fallback);
+
+        composer.assembleComponent(component, descriptor, container);
+
+        assertSame(hintedDependency, component.valueFor(hinted));
+        assertSame(singleDependency, component.valueFor(single));
+        assertSame(mappedDependencies, component.valueFor(mapped));
+        assertSame(fallbackDependency, component.valueFor(fallback));
+        assertEquals(new HashSet<>(listedDependencies), component.valueFor(set));
+    }
+
+    private static void assertMapOrientedRejection(
+        MapOrientedComponentComposer composer,
+        Object component,
+        ComponentDescriptor descriptor,
+        PlexusContainer container
+    ) {
+        CompositionException exception = assertThrows(
+            CompositionException.class,
+            () -> composer.assembleComponent(component, descriptor, container)
+        );
+
+        assertTrue(exception.getMessage().contains(component.getClass().getName()));
+        assertTrue(exception.getMessage().contains("org.codehaus.plexus.component.MapOrientedComponent"));
+    }
+
+    private static ComponentRequirement requirement(String role, String mappingType) {
+        ComponentRequirement requirement = new ComponentRequirement();
+        requirement.setRole(role);
+        requirement.setFieldMappingType(mappingType);
+        return requirement;
+    }
+
+    private static ComponentDescriptor descriptor(String role) {
+        ComponentDescriptor descriptor = new ComponentDescriptor();
+        descriptor.setRole(role);
+        descriptor.setImplementation(role);
+        return descriptor;
+    }
+
+    private static List<Object> listOf(Object value) {
+        List<Object> values = new ArrayList<>();
+        values.add(value);
+        return values;
+    }
+
+    private static String rootCauseMessage(Throwable throwable) {
+        Throwable cause = throwable;
+        while (cause.getCause() != null) {
+            cause = cause.getCause();
+        }
+        return cause.getMessage();
+    }
+
+    public static final class PlainComponent {
+    }
+
+    private static final class RecordingMapOrientedComponent implements MapOrientedComponent {
+        private final Map<ComponentRequirement, Object> values = new HashMap<>();
+
+        @Override
+        public void addComponentRequirement(ComponentRequirement requirementDescriptor, Object requirementValue)
+            throws ComponentConfigurationException {
+            values.put(requirementDescriptor, requirementValue);
+        }
+
+        @Override
+        public void setComponentConfiguration(Map componentConfiguration) throws ComponentConfigurationException {
+        }
+
+        private Object valueFor(ComponentRequirement requirement) {
+            return values.get(requirement);
+        }
+    }
+
+    private static final class RecordingPlexusContainer implements PlexusContainer {
+        private final Map<String, Object> components = new HashMap<>();
+
+        private final Map<String, List> lists = new HashMap<>();
+
+        private final Map<String, Map> maps = new HashMap<>();
+
+        private final Map<String, ComponentDescriptor> descriptors = new HashMap<>();
+
+        private void addComponent(String key, Object component) {
+            components.put(key, component);
+            descriptors.put(key, descriptor(key));
+        }
+
+        private void addMap(String role, Map dependencies) {
+            maps.put(role, dependencies);
+            descriptors.put(role, descriptor(role));
+        }
+
+        private void addList(String role, List dependencies) {
+            lists.put(role, dependencies);
+            descriptors.put(role, descriptor(role));
+        }
+
+        @Override
+        public String getName() {
+            return "recording";
+        }
+
+        @Override
+        public Date getCreationDate() {
+            return new Date(0L);
+        }
+
+        @Override
+        public Object lookup(String componentKey) throws ComponentLookupException {
+            Object component = components.get(componentKey);
+            if (component == null) {
+                throw new ComponentLookupException("Missing component: " + componentKey);
+            }
+            return component;
+        }
+
+        @Override
+        public Object lookup(String role, String roleHint) throws ComponentLookupException {
+            return lookup(role + roleHint);
+        }
+
+        @Override
+        public Map lookupMap(String role) throws ComponentLookupException {
+            Map dependencies = maps.get(role);
+            if (dependencies == null) {
+                throw new ComponentLookupException("Missing map: " + role);
+            }
+            return dependencies;
+        }
+
+        @Override
+        public List lookupList(String role) throws ComponentLookupException {
+            List dependencies = lists.get(role);
+            if (dependencies == null) {
+                throw new ComponentLookupException("Missing list: " + role);
+            }
+            return dependencies;
+        }
+
+        @Override
+        public ComponentDescriptor getComponentDescriptor(String componentKey) {
+            return descriptors.get(componentKey);
+        }
+
+        @Override
+        public Map getComponentDescriptorMap(String role) {
+            Map<String, ComponentDescriptor> descriptorMap = new HashMap<>();
+            descriptorMap.put(role, descriptors.get(role));
+            return descriptorMap;
+        }
+
+        @Override
+        public List getComponentDescriptorList(String role) {
+            return listOf(descriptors.get(role));
+        }
+
+        @Override
+        public boolean hasChildContainer(String name) {
+            return false;
+        }
+
+        @Override
+        public void removeChildContainer(String name) {
+        }
+
+        @Override
+        public PlexusContainer getChildContainer(String name) {
+            return null;
+        }
+
+        @Override
+        public PlexusContainer createChildContainer(String name, List classpathJars, Map context)
+            throws PlexusContainerException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public PlexusContainer createChildContainer(
+            String name,
+            List classpathJars,
+            Map context,
+            List discoveryListeners
+        ) throws PlexusContainerException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void addComponentDescriptor(ComponentDescriptor componentDescriptor)
+            throws ComponentRepositoryException {
+            descriptors.put(componentDescriptor.getComponentKey(), componentDescriptor);
+        }
+
+        @Override
+        public void release(Object component) throws ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void releaseAll(Map components) throws ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void releaseAll(List components) throws ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean hasComponent(String componentKey) {
+            return components.containsKey(componentKey);
+        }
+
+        @Override
+        public boolean hasComponent(String role, String roleHint) {
+            return hasComponent(role + roleHint);
+        }
+
+        @Override
+        public void suspend(Object component) throws ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void resume(Object component) throws ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void initialize() throws PlexusContainerException {
+        }
+
+        @Override
+        public void start() throws PlexusContainerException {
+        }
+
+        @Override
+        public void dispose() {
+        }
+
+        @Override
+        public Context getContext() {
+            return null;
+        }
+
+        @Override
+        public void addContextValue(Object key, Object value) {
+        }
+
+        @Override
+        public void setConfigurationResource(Reader configuration) throws PlexusConfigurationResourceException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Logger getLogger() {
+            return null;
+        }
+
+        @Override
+        public void registerComponentDiscoveryListener(ComponentDiscoveryListener listener) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void removeComponentDiscoveryListener(ComponentDiscoveryListener listener) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void addJarRepository(File repository) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void addJarResource(File resource) throws PlexusContainerException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ClassRealm getContainerRealm() {
+            return null;
+        }
+
+        @Override
+        public Object autowire(Object component) throws CompositionException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Object createAndAutowire(String clazz)
+            throws CompositionException, ClassNotFoundException, InstantiationException, IllegalAccessException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setReloadingEnabled(boolean reloadingEnabled) {
+        }
+
+        @Override
+        public boolean isReloadingEnabled() {
+            return false;
+        }
+
+        @Override
+        public LoggerManager getLoggerManager() {
+            return null;
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/MapOrientedComponentComposerTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/MapOrientedComponentComposerTest.java
@@ -6,22 +6,32 @@
  */
 package org_codehaus_plexus.plexus_container_default;
 
-import org.codehaus.classworlds.ClassRealm;
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.ComponentLookupManager;
 import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.PlexusContainerException;
 import org.codehaus.plexus.component.MapOrientedComponent;
+import org.codehaus.plexus.component.composition.ComponentComposerManager;
 import org.codehaus.plexus.component.composition.CompositionException;
 import org.codehaus.plexus.component.composition.MapOrientedComponentComposer;
 import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+import org.codehaus.plexus.component.discovery.ComponentDiscovererManager;
 import org.codehaus.plexus.component.discovery.ComponentDiscoveryListener;
+import org.codehaus.plexus.component.factory.ComponentFactoryManager;
+import org.codehaus.plexus.component.manager.ComponentManagerManager;
 import org.codehaus.plexus.component.repository.ComponentDescriptor;
+import org.codehaus.plexus.component.repository.ComponentRepository;
 import org.codehaus.plexus.component.repository.ComponentRequirement;
 import org.codehaus.plexus.component.repository.exception.ComponentLifecycleException;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.codehaus.plexus.component.repository.exception.ComponentRepositoryException;
+import org.codehaus.plexus.configuration.PlexusConfiguration;
+import org.codehaus.plexus.configuration.PlexusConfigurationException;
 import org.codehaus.plexus.configuration.PlexusConfigurationResourceException;
 import org.codehaus.plexus.context.Context;
+import org.codehaus.plexus.lifecycle.LifecycleHandlerManager;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.logging.LoggerManager;
 import org.junit.jupiter.api.MethodOrderer;
@@ -46,12 +56,24 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class MapOrientedComponentComposerTest {
     @Test
+    @Order(1)
+    public void verifySuitabilityRejectsPlainComponents() throws Exception {
+        MapOrientedComponentComposer composer = new MapOrientedComponentComposer();
+        PlainComponent component = new PlainComponent();
+
+        CompositionException exception = assertThrows(
+            CompositionException.class,
+            () -> composer.verifyComponentSuitability(component)
+        );
+
+        assertTrue(exception.getMessage().contains(component.getClass().getName()));
+        assertTrue(exception.getMessage().contains(MapOrientedComponent.class.getName()));
+    }
+
+    @Test
     @Order(2)
     public void containerComposerManagerRejectsPlainComponentsForMapOrientedComposer() throws Exception {
-        DefaultPlexusContainer container = new DefaultPlexusContainer(
-            "map-oriented-composer-test",
-            MapOrientedComponentComposerTest.class.getClassLoader()
-        );
+        DefaultPlexusContainer container = new DefaultPlexusContainer("map-oriented-composer-test", null);
         ComponentDescriptor descriptor = descriptor(PlainComponent.class.getName());
         descriptor.setComponentComposer("map-oriented");
         descriptor.addRequirement(requirement("ignoredRole", "single"));
@@ -85,12 +107,9 @@ public class MapOrientedComponentComposerTest {
     }
 
     @Test
-    @Order(1)
+    @Order(4)
     public void lookupFailsWhenDescriptorSelectsMapOrientedComposerForPlainComponent() throws Exception {
-        DefaultPlexusContainer container = new DefaultPlexusContainer(
-            "map-oriented-composer-lookup-test",
-            MapOrientedComponentComposerTest.class.getClassLoader()
-        );
+        DefaultPlexusContainer container = new DefaultPlexusContainer("map-oriented-composer-lookup-test", null);
         ComponentDescriptor descriptor = descriptor(PlainComponent.class.getName());
         descriptor.setComponentComposer("map-oriented");
         descriptor.addRequirement(requirement("ignoredRole", "single"));
@@ -110,7 +129,7 @@ public class MapOrientedComponentComposerTest {
     }
 
     @Test
-    @Order(4)
+    @Order(5)
     public void addsMappedRequirementsToMapOrientedComponents() throws Exception {
         MapOrientedComponentComposer composer = new MapOrientedComponentComposer();
         RecordingMapOrientedComponent component = new RecordingMapOrientedComponent();
@@ -248,6 +267,10 @@ public class MapOrientedComponentComposerTest {
         }
 
         @Override
+        public void setName(String name) {
+        }
+
+        @Override
         public Date getCreationDate() {
             return new Date(0L);
         }
@@ -266,6 +289,14 @@ public class MapOrientedComponentComposerTest {
             return lookup(role + roleHint);
         }
 
+        public Object lookup(Class componentClass) throws ComponentLookupException {
+            return lookup(componentClass.getName());
+        }
+
+        public Object lookup(Class role, String roleHint) throws ComponentLookupException {
+            return lookup(role.getName(), roleHint);
+        }
+
         @Override
         public Map lookupMap(String role) throws ComponentLookupException {
             Map dependencies = maps.get(role);
@@ -282,6 +313,14 @@ public class MapOrientedComponentComposerTest {
                 throw new ComponentLookupException("Missing list: " + role);
             }
             return dependencies;
+        }
+
+        public Map lookupMap(Class role) throws ComponentLookupException {
+            return lookupMap(role.getName());
+        }
+
+        public List lookupList(Class role) throws ComponentLookupException {
+            return lookupList(role.getName());
         }
 
         @Override
@@ -372,11 +411,9 @@ public class MapOrientedComponentComposerTest {
             throw new UnsupportedOperationException();
         }
 
-        @Override
         public void initialize() throws PlexusContainerException {
         }
 
-        @Override
         public void start() throws PlexusContainerException {
         }
 
@@ -393,7 +430,6 @@ public class MapOrientedComponentComposerTest {
         public void addContextValue(Object key, Object value) {
         }
 
-        @Override
         public void setConfigurationResource(Reader configuration) throws PlexusConfigurationResourceException {
             throw new UnsupportedOperationException();
         }
@@ -428,6 +464,23 @@ public class MapOrientedComponentComposerTest {
             return null;
         }
 
+        public ClassWorld getClassWorld() {
+            return null;
+        }
+
+        public List discoverComponents(ClassRealm classRealm)
+            throws PlexusConfigurationException, ComponentRepositoryException {
+            return new ArrayList();
+        }
+
+        @Override
+        public void setParentPlexusContainer(PlexusContainer parentContainer) {
+        }
+
+        public PlexusContainer getParentContainer() {
+            return null;
+        }
+
         @Override
         public Object autowire(Object component) throws CompositionException {
             throw new UnsupportedOperationException();
@@ -448,8 +501,66 @@ public class MapOrientedComponentComposerTest {
             return false;
         }
 
-        @Override
+        public ComponentRepository getComponentRepository() {
+            return null;
+        }
+
+        public void setComponentRepository(ComponentRepository componentRepository) {
+        }
+
+        public LifecycleHandlerManager getLifecycleHandlerManager() {
+            return null;
+        }
+
+        public void setLifecycleHandlerManager(LifecycleHandlerManager lifecycleHandlerManager) {
+        }
+
+        public ComponentManagerManager getComponentManagerManager() {
+            return null;
+        }
+
+        public void setComponentManagerManager(ComponentManagerManager componentManagerManager) {
+        }
+
+        public ComponentDiscovererManager getComponentDiscovererManager() {
+            return null;
+        }
+
+        public void setComponentDiscovererManager(ComponentDiscovererManager componentDiscovererManager) {
+        }
+
+        public ComponentFactoryManager getComponentFactoryManager() {
+            return null;
+        }
+
+        public void setComponentFactoryManager(ComponentFactoryManager componentFactoryManager) {
+        }
+
+        public ComponentLookupManager getComponentLookupManager() {
+            return null;
+        }
+
+        public void setComponentLookupManager(ComponentLookupManager componentLookupManager) {
+        }
+
+        public ComponentComposerManager getComponentComposerManager() {
+            return null;
+        }
+
+        public void setComponentComposerManager(ComponentComposerManager componentComposerManager) {
+        }
+
         public LoggerManager getLoggerManager() {
+            return null;
+        }
+
+        public void setLoggerManager(LoggerManager loggerManager) {
+        }
+
+        public void setConfiguration(PlexusConfiguration configuration) {
+        }
+
+        public PlexusConfiguration getConfiguration() {
             return null;
         }
     }

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/MapOrientedComponentConfiguratorTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/MapOrientedComponentConfiguratorTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.classworlds.ClassRealm;
+import org.codehaus.classworlds.ClassWorld;
+import org.codehaus.plexus.component.MapOrientedComponent;
+import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+import org.codehaus.plexus.component.configurator.MapOrientedComponentConfigurator;
+import org.codehaus.plexus.component.repository.ComponentRequirement;
+import org.codehaus.plexus.configuration.xml.XmlPlexusConfiguration;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class MapOrientedComponentConfiguratorTest {
+    @Test
+    @Order(1)
+    public void rejectsComponentsThatDoNotAcceptMapConfiguration() throws Exception {
+        MapOrientedComponentConfigurator configurator = new MapOrientedComponentConfigurator();
+        Object component = nonMapOrientedComponentSelectedAtRuntime();
+        clearCompilerGeneratedClassCache();
+        assertNull(cachedMapOrientedComponentType());
+
+        ComponentConfigurationException exception = assertThrows(
+            ComponentConfigurationException.class,
+            () -> configurator.configureComponent(
+                component,
+                new XmlPlexusConfiguration("configuration"),
+                null,
+                null,
+                null
+            )
+        );
+
+        assertTrue(exception.getMessage().contains("can only process implementations"));
+        assertTrue(exception.getMessage().contains(MapOrientedComponent.class.getName()));
+        assertEquals(MapOrientedComponent.class, cachedMapOrientedComponentType());
+    }
+
+    @Test
+    @Order(2)
+    public void passesConvertedConfigurationMapToMapOrientedComponent() throws Exception {
+        MapOrientedComponentConfigurator configurator = new MapOrientedComponentConfigurator();
+        RecordingMapOrientedComponent component = new RecordingMapOrientedComponent();
+        XmlPlexusConfiguration configuration = new XmlPlexusConfiguration("configuration");
+        addChild(configuration, "host", "localhost");
+        addChild(configuration, "port", "8080");
+
+        configurator.configureComponent(
+            component,
+            configuration,
+            testRealm("map-oriented-component-configurator-conversion-test")
+        );
+
+        assertEquals("localhost", component.configuration.get("host"));
+        assertEquals("8080", component.configuration.get("port"));
+    }
+
+    private static void clearCompilerGeneratedClassCache() throws Exception {
+        classCacheHandle().set(null);
+    }
+
+    private static Class<?> cachedMapOrientedComponentType() throws Exception {
+        return (Class<?>) classCacheHandle().get();
+    }
+
+    private static VarHandle classCacheHandle() throws Exception {
+        MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(
+            MapOrientedComponentConfigurator.class,
+            MethodHandles.lookup()
+        );
+        return lookup.findStaticVarHandle(
+            MapOrientedComponentConfigurator.class,
+            "class$org$codehaus$plexus$component$MapOrientedComponent",
+            Class.class
+        );
+    }
+
+    private static Object nonMapOrientedComponentSelectedAtRuntime() {
+        Object[] candidates = new Object[] {new Object(), "not map oriented" };
+        return candidates[(int) (System.nanoTime() & 1L)];
+    }
+
+    private static ClassRealm testRealm(String id) throws Exception {
+        ClassWorld classWorld = new ClassWorld();
+        return classWorld.newRealm(id, MapOrientedComponentConfiguratorTest.class.getClassLoader());
+    }
+
+    private static void addChild(XmlPlexusConfiguration parent, String name, String value) {
+        XmlPlexusConfiguration child = new XmlPlexusConfiguration(name);
+        child.setValue(value);
+        parent.addChild(child);
+    }
+
+    private static final class RecordingMapOrientedComponent implements MapOrientedComponent {
+        private Map configuration;
+
+        @Override
+        public void addComponentRequirement(ComponentRequirement requirementDescriptor, Object requirementValue) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setComponentConfiguration(Map componentConfiguration) {
+            configuration = componentConfiguration;
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/MapOrientedComponentConfiguratorTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/MapOrientedComponentConfiguratorTest.java
@@ -6,10 +6,11 @@
  */
 package org_codehaus_plexus.plexus_container_default;
 
-import org.codehaus.classworlds.ClassRealm;
-import org.codehaus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
 import org.codehaus.plexus.component.MapOrientedComponent;
 import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+import org.codehaus.plexus.component.configurator.ComponentConfigurator;
 import org.codehaus.plexus.component.configurator.MapOrientedComponentConfigurator;
 import org.codehaus.plexus.component.repository.ComponentRequirement;
 import org.codehaus.plexus.configuration.xml.XmlPlexusConfiguration;
@@ -55,6 +56,57 @@ public class MapOrientedComponentConfiguratorTest {
 
     @Test
     @Order(2)
+    public void rejectsPlainComponentsThroughConfiguratorInterface() throws Exception {
+        ComponentConfigurator configurator = new MapOrientedComponentConfigurator();
+        Object component = nonMapOrientedComponentSelectedAtRuntime();
+        clearCompilerGeneratedClassCache();
+        assertNull(cachedMapOrientedComponentType());
+
+        ComponentConfigurationException exception = assertThrows(
+            ComponentConfigurationException.class,
+            () -> configurator.configureComponent(
+                component,
+                new XmlPlexusConfiguration("configuration"),
+                testRealm("map-oriented-component-configurator-rejection-test")
+            )
+        );
+
+        assertTrue(exception.getMessage().contains("can only process implementations"));
+        assertTrue(exception.getMessage().contains(MapOrientedComponent.class.getName()));
+        assertEquals(MapOrientedComponent.class, cachedMapOrientedComponentType());
+    }
+
+    @Test
+    @Order(3)
+    public void reusesCachedMapOrientedTypeWhenBuildingRejectionMessage() throws Exception {
+        ComponentConfigurator configurator = new MapOrientedComponentConfigurator();
+        clearCompilerGeneratedClassCache();
+
+        assertThrows(
+            ComponentConfigurationException.class,
+            () -> configurator.configureComponent(
+                nonMapOrientedComponentSelectedAtRuntime(),
+                new XmlPlexusConfiguration("configuration"),
+                testRealm("map-oriented-component-configurator-cache-miss-test")
+            )
+        );
+        assertEquals(MapOrientedComponent.class, cachedMapOrientedComponentType());
+
+        ComponentConfigurationException exception = assertThrows(
+            ComponentConfigurationException.class,
+            () -> configurator.configureComponent(
+                nonMapOrientedComponentSelectedAtRuntime(),
+                new XmlPlexusConfiguration("configuration"),
+                testRealm("map-oriented-component-configurator-cache-hit-test")
+            )
+        );
+
+        assertTrue(exception.getMessage().contains(MapOrientedComponent.class.getName()));
+        assertEquals(MapOrientedComponent.class, cachedMapOrientedComponentType());
+    }
+
+    @Test
+    @Order(4)
     public void passesConvertedConfigurationMapToMapOrientedComponent() throws Exception {
         MapOrientedComponentConfigurator configurator = new MapOrientedComponentConfigurator();
         RecordingMapOrientedComponent component = new RecordingMapOrientedComponent();
@@ -98,8 +150,7 @@ public class MapOrientedComponentConfiguratorTest {
     }
 
     private static ClassRealm testRealm(String id) throws Exception {
-        ClassWorld classWorld = new ClassWorld();
-        return classWorld.newRealm(id, MapOrientedComponentConfiguratorTest.class.getClassLoader());
+        return new ClassWorld(id, MapOrientedComponentConfiguratorTest.class.getClassLoader()).getRealm(id);
     }
 
     private static void addChild(XmlPlexusConfiguration parent, String name, String value) {

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/PlexusContainerManagerAnonymous1Test.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/PlexusContainerManagerAnonymous1Test.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.PlexusContainer;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PlexusContainerManagerAnonymous1Test {
+    @Test
+    void roleUsesThePlexusContainerTypeName() {
+        assertThat(PlexusContainer.ROLE).isEqualTo(PlexusContainer.class.getName());
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ResourceBundleConfigurationResourceHandlerTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ResourceBundleConfigurationResourceHandlerTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.configuration.PlexusConfiguration;
+import org.codehaus.plexus.configuration.processor.ConfigurationProcessor;
+import org.codehaus.plexus.configuration.processor.ConfigurationResourceHandler;
+import org.codehaus.plexus.configuration.processor.ResourceBundleConfigurationResourceHandler;
+import org.codehaus.plexus.configuration.xml.XmlPlexusConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ResourceBundleConfigurationResourceHandlerTest {
+    private static final String BUNDLE_NAME =
+        "org_codehaus_plexus.plexus_container_default.ResourceBundleConfigurationResourceHandlerMessages";
+
+    @Test
+    void configurationProcessorInlinesPropertiesFromResourceBundle() throws Exception {
+        ResourceBundleConfigurationResourceHandler handler = new ResourceBundleConfigurationResourceHandler();
+        ConfigurationProcessor processor = new ConfigurationProcessor();
+        processor.addConfigurationResourceHandler(handler);
+
+        XmlPlexusConfiguration configuration = new XmlPlexusConfiguration("configuration");
+        XmlPlexusConfiguration bundleReference = new XmlPlexusConfiguration(handler.getId());
+        bundleReference.setAttribute(ConfigurationResourceHandler.SOURCE, BUNDLE_NAME);
+        configuration.addChild(bundleReference);
+
+        PlexusConfiguration processed = processor.process(configuration, Collections.emptyMap());
+        PlexusConfiguration bundleConfiguration = processed.getChild(BUNDLE_NAME, false);
+
+        assertThat(bundleConfiguration).isNotNull();
+        assertThat(bundleConfiguration.getChild("componentRole", false).getValue())
+            .isEqualTo("org.example.Component");
+        assertThat(bundleConfiguration.getChild("implementation", false).getValue())
+            .isEqualTo("org.example.DefaultComponent");
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/SetterComponentComposerTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/SetterComponentComposerTest.java
@@ -1,0 +1,327 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.classworlds.ClassRealm;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.PlexusContainerException;
+import org.codehaus.plexus.component.composition.CompositionException;
+import org.codehaus.plexus.component.composition.SetterComponentComposer;
+import org.codehaus.plexus.component.discovery.ComponentDiscoveryListener;
+import org.codehaus.plexus.component.repository.ComponentDescriptor;
+import org.codehaus.plexus.component.repository.ComponentRequirement;
+import org.codehaus.plexus.component.repository.exception.ComponentLifecycleException;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.codehaus.plexus.component.repository.exception.ComponentRepositoryException;
+import org.codehaus.plexus.configuration.PlexusConfigurationResourceException;
+import org.codehaus.plexus.context.Context;
+import org.codehaus.plexus.logging.Logger;
+import org.codehaus.plexus.logging.LoggerManager;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class SetterComponentComposerTest {
+    @Test
+    public void assignsArrayAndMapRequirementsThroughBeanSetters() throws Exception {
+        SetterComponentComposer composer = new SetterComponentComposer();
+        ComponentWithSetterDependencies component = new ComponentWithSetterDependencies();
+        RecordingPlexusContainer container = new RecordingPlexusContainer();
+        ComponentDescriptor componentDescriptor = descriptor(ComponentWithSetterDependencies.class.getName());
+
+        String arrayRole = "arrayRole";
+        String mapRole = "mapRole";
+        List<Object> emptyArrayDependencies = new ArrayList<>();
+        Map<String, String> mapDependencies = new HashMap<>();
+        mapDependencies.put("key", "map dependency");
+
+        container.addList(arrayRole, emptyArrayDependencies);
+        container.addMap(mapRole, mapDependencies);
+
+        componentDescriptor.addRequirement(requirement(arrayRole, "arrayDependencies"));
+        componentDescriptor.addRequirement(requirement(mapRole, "mapDependencies"));
+
+        composer.assembleComponent(component, componentDescriptor, container);
+
+        assertEquals(0, component.arrayDependencies.length);
+        assertSame(mapDependencies, component.mapDependencies);
+    }
+
+    private static ComponentRequirement requirement(String role, String fieldName) {
+        ComponentRequirement requirement = new ComponentRequirement();
+        requirement.setRole(role);
+        requirement.setFieldName(fieldName);
+        return requirement;
+    }
+
+    private static ComponentDescriptor descriptor(String role) {
+        ComponentDescriptor descriptor = new ComponentDescriptor();
+        descriptor.setRole(role);
+        descriptor.setImplementation(role);
+        return descriptor;
+    }
+
+    private static List<Object> listOf(Object value) {
+        List<Object> values = new ArrayList<>();
+        values.add(value);
+        return values;
+    }
+
+    public static final class ComponentWithSetterDependencies {
+        private Object[] arrayDependencies;
+
+        private Map mapDependencies;
+
+        public void setArrayDependencies(Object[] arrayDependencies) {
+            this.arrayDependencies = arrayDependencies;
+        }
+
+        public void setMapDependencies(Map mapDependencies) {
+            this.mapDependencies = mapDependencies;
+        }
+    }
+
+    private static final class RecordingPlexusContainer implements PlexusContainer {
+        private final Map<String, Object> components = new HashMap<>();
+
+        private final Map<String, List> lists = new HashMap<>();
+
+        private final Map<String, Map> maps = new HashMap<>();
+
+        private final Map<String, ComponentDescriptor> descriptors = new HashMap<>();
+
+        private void addMap(String role, Map dependencies) {
+            maps.put(role, dependencies);
+            descriptors.put(role, descriptor(role));
+        }
+
+        private void addList(String role, List dependencies) {
+            lists.put(role, dependencies);
+            descriptors.put(role, descriptor(role));
+        }
+
+        @Override
+        public String getName() {
+            return "recording";
+        }
+
+        @Override
+        public Date getCreationDate() {
+            return new Date(0L);
+        }
+
+        @Override
+        public Object lookup(String componentKey) throws ComponentLookupException {
+            Object component = components.get(componentKey);
+            if (component == null) {
+                throw new ComponentLookupException("Missing component: " + componentKey);
+            }
+            return component;
+        }
+
+        @Override
+        public Object lookup(String role, String roleHint) throws ComponentLookupException {
+            return lookup(role + roleHint);
+        }
+
+        @Override
+        public Map lookupMap(String role) throws ComponentLookupException {
+            Map dependencies = maps.get(role);
+            if (dependencies == null) {
+                throw new ComponentLookupException("Missing map: " + role);
+            }
+            return dependencies;
+        }
+
+        @Override
+        public List lookupList(String role) throws ComponentLookupException {
+            List dependencies = lists.get(role);
+            if (dependencies == null) {
+                throw new ComponentLookupException("Missing list: " + role);
+            }
+            return dependencies;
+        }
+
+        @Override
+        public ComponentDescriptor getComponentDescriptor(String componentKey) {
+            return descriptors.get(componentKey);
+        }
+
+        @Override
+        public Map getComponentDescriptorMap(String role) {
+            Map<String, ComponentDescriptor> descriptorMap = new HashMap<>();
+            descriptorMap.put(role, descriptors.get(role));
+            return descriptorMap;
+        }
+
+        @Override
+        public List getComponentDescriptorList(String role) {
+            return listOf(descriptors.get(role));
+        }
+
+        @Override
+        public boolean hasChildContainer(String name) {
+            return false;
+        }
+
+        @Override
+        public void removeChildContainer(String name) {
+        }
+
+        @Override
+        public PlexusContainer getChildContainer(String name) {
+            return null;
+        }
+
+        @Override
+        public PlexusContainer createChildContainer(String name, List classpathJars, Map context)
+            throws PlexusContainerException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public PlexusContainer createChildContainer(
+            String name,
+            List classpathJars,
+            Map context,
+            List discoveryListeners
+        ) throws PlexusContainerException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void addComponentDescriptor(ComponentDescriptor componentDescriptor)
+            throws ComponentRepositoryException {
+            descriptors.put(componentDescriptor.getComponentKey(), componentDescriptor);
+        }
+
+        @Override
+        public void release(Object component) throws ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void releaseAll(Map components) throws ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void releaseAll(List components) throws ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean hasComponent(String componentKey) {
+            return components.containsKey(componentKey);
+        }
+
+        @Override
+        public boolean hasComponent(String role, String roleHint) {
+            return hasComponent(role + roleHint);
+        }
+
+        @Override
+        public void suspend(Object component) throws ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void resume(Object component) throws ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void initialize() throws PlexusContainerException {
+        }
+
+        @Override
+        public void start() throws PlexusContainerException {
+        }
+
+        @Override
+        public void dispose() {
+        }
+
+        @Override
+        public Context getContext() {
+            return null;
+        }
+
+        @Override
+        public void addContextValue(Object key, Object value) {
+        }
+
+        @Override
+        public void setConfigurationResource(Reader configuration) throws PlexusConfigurationResourceException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Logger getLogger() {
+            return null;
+        }
+
+        @Override
+        public void registerComponentDiscoveryListener(ComponentDiscoveryListener listener) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void removeComponentDiscoveryListener(ComponentDiscoveryListener listener) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void addJarRepository(File repository) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void addJarResource(File resource) throws PlexusContainerException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ClassRealm getContainerRealm() {
+            return null;
+        }
+
+        @Override
+        public Object autowire(Object component) throws CompositionException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Object createAndAutowire(String clazz)
+            throws CompositionException, ClassNotFoundException, InstantiationException, IllegalAccessException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setReloadingEnabled(boolean reloadingEnabled) {
+        }
+
+        @Override
+        public boolean isReloadingEnabled() {
+            return false;
+        }
+
+        @Override
+        public LoggerManager getLoggerManager() {
+            return null;
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/SetterComponentComposerTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/SetterComponentComposerTest.java
@@ -6,19 +6,29 @@
  */
 package org_codehaus_plexus.plexus_container_default;
 
-import org.codehaus.classworlds.ClassRealm;
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.ComponentLookupManager;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.PlexusContainerException;
+import org.codehaus.plexus.component.composition.ComponentComposerManager;
 import org.codehaus.plexus.component.composition.CompositionException;
-import org.codehaus.plexus.component.composition.SetterComponentComposer;
+import org.codehaus.plexus.component.composition.setter.SetterComponentComposer;
+import org.codehaus.plexus.component.discovery.ComponentDiscovererManager;
 import org.codehaus.plexus.component.discovery.ComponentDiscoveryListener;
+import org.codehaus.plexus.component.factory.ComponentFactoryManager;
+import org.codehaus.plexus.component.manager.ComponentManagerManager;
 import org.codehaus.plexus.component.repository.ComponentDescriptor;
+import org.codehaus.plexus.component.repository.ComponentRepository;
 import org.codehaus.plexus.component.repository.ComponentRequirement;
 import org.codehaus.plexus.component.repository.exception.ComponentLifecycleException;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.codehaus.plexus.component.repository.exception.ComponentRepositoryException;
+import org.codehaus.plexus.configuration.PlexusConfiguration;
+import org.codehaus.plexus.configuration.PlexusConfigurationException;
 import org.codehaus.plexus.configuration.PlexusConfigurationResourceException;
 import org.codehaus.plexus.context.Context;
+import org.codehaus.plexus.lifecycle.LifecycleHandlerManager;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.logging.LoggerManager;
 import org.junit.jupiter.api.Test;
@@ -119,6 +129,10 @@ public class SetterComponentComposerTest {
         }
 
         @Override
+        public void setName(String name) {
+        }
+
+        @Override
         public Date getCreationDate() {
             return new Date(0L);
         }
@@ -137,6 +151,14 @@ public class SetterComponentComposerTest {
             return lookup(role + roleHint);
         }
 
+        public Object lookup(Class componentClass) throws ComponentLookupException {
+            return lookup(componentClass.getName());
+        }
+
+        public Object lookup(Class role, String roleHint) throws ComponentLookupException {
+            return lookup(role.getName(), roleHint);
+        }
+
         @Override
         public Map lookupMap(String role) throws ComponentLookupException {
             Map dependencies = maps.get(role);
@@ -153,6 +175,14 @@ public class SetterComponentComposerTest {
                 throw new ComponentLookupException("Missing list: " + role);
             }
             return dependencies;
+        }
+
+        public Map lookupMap(Class role) throws ComponentLookupException {
+            return lookupMap(role.getName());
+        }
+
+        public List lookupList(Class role) throws ComponentLookupException {
+            return lookupList(role.getName());
         }
 
         @Override
@@ -243,11 +273,9 @@ public class SetterComponentComposerTest {
             throw new UnsupportedOperationException();
         }
 
-        @Override
         public void initialize() throws PlexusContainerException {
         }
 
-        @Override
         public void start() throws PlexusContainerException {
         }
 
@@ -264,7 +292,6 @@ public class SetterComponentComposerTest {
         public void addContextValue(Object key, Object value) {
         }
 
-        @Override
         public void setConfigurationResource(Reader configuration) throws PlexusConfigurationResourceException {
             throw new UnsupportedOperationException();
         }
@@ -299,6 +326,23 @@ public class SetterComponentComposerTest {
             return null;
         }
 
+        public ClassWorld getClassWorld() {
+            return null;
+        }
+
+        public List discoverComponents(ClassRealm classRealm)
+            throws PlexusConfigurationException, ComponentRepositoryException {
+            return new ArrayList();
+        }
+
+        @Override
+        public void setParentPlexusContainer(PlexusContainer parentContainer) {
+        }
+
+        public PlexusContainer getParentContainer() {
+            return null;
+        }
+
         @Override
         public Object autowire(Object component) throws CompositionException {
             throw new UnsupportedOperationException();
@@ -319,8 +363,66 @@ public class SetterComponentComposerTest {
             return false;
         }
 
-        @Override
+        public ComponentRepository getComponentRepository() {
+            return null;
+        }
+
+        public void setComponentRepository(ComponentRepository componentRepository) {
+        }
+
+        public LifecycleHandlerManager getLifecycleHandlerManager() {
+            return null;
+        }
+
+        public void setLifecycleHandlerManager(LifecycleHandlerManager lifecycleHandlerManager) {
+        }
+
+        public ComponentManagerManager getComponentManagerManager() {
+            return null;
+        }
+
+        public void setComponentManagerManager(ComponentManagerManager componentManagerManager) {
+        }
+
+        public ComponentDiscovererManager getComponentDiscovererManager() {
+            return null;
+        }
+
+        public void setComponentDiscovererManager(ComponentDiscovererManager componentDiscovererManager) {
+        }
+
+        public ComponentFactoryManager getComponentFactoryManager() {
+            return null;
+        }
+
+        public void setComponentFactoryManager(ComponentFactoryManager componentFactoryManager) {
+        }
+
+        public ComponentLookupManager getComponentLookupManager() {
+            return null;
+        }
+
+        public void setComponentLookupManager(ComponentLookupManager componentLookupManager) {
+        }
+
+        public ComponentComposerManager getComponentComposerManager() {
+            return null;
+        }
+
+        public void setComponentComposerManager(ComponentComposerManager componentComposerManager) {
+        }
+
         public LoggerManager getLoggerManager() {
+            return null;
+        }
+
+        public void setLoggerManager(LoggerManager loggerManager) {
+        }
+
+        public void setConfiguration(PlexusConfiguration configuration) {
+        }
+
+        public PlexusConfiguration getConfiguration() {
             return null;
         }
     }

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/SimplePlexusContainerManagerTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/SimplePlexusContainerManagerTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.DefaultPlexusContainer;
+import org.codehaus.plexus.PlexusConstants;
+import org.codehaus.plexus.component.configurator.ComponentConfigurator;
+import org.junit.jupiter.api.Test;
+
+import java.io.StringReader;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SimplePlexusContainerManagerTest {
+    @Test
+    public void defaultContainerExposesItselfThroughContext() throws Exception {
+        DefaultPlexusContainer container = new DefaultPlexusContainer();
+
+        try {
+            assertThat(container.getName()).isEqualTo("default");
+            assertThat(container.getContext().get(PlexusConstants.PLEXUS_KEY)).isSameAs(container);
+            assertThat(container.getContainerRealm()).isNotNull();
+        } finally {
+            container.dispose();
+        }
+    }
+
+    @Test
+    public void constructorInitializesConfiguredContextAndCoreComponents() throws Exception {
+        Map context = new HashMap();
+        context.put("configured-key", "configured-value");
+        DefaultPlexusContainer container = new DefaultPlexusContainer(
+            new StringReader("<plexus><components/></plexus>"),
+            context
+        );
+
+        try {
+            ComponentConfigurator configurator = (ComponentConfigurator) container.lookup(
+                ComponentConfigurator.ROLE,
+                "basic"
+            );
+
+            assertThat(configurator).isNotNull();
+            assertThat(container.getContext().get("configured-key")).isEqualTo("configured-value");
+        } finally {
+            container.dispose();
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/SimplePlexusContainerManagerTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/SimplePlexusContainerManagerTest.java
@@ -11,7 +11,6 @@ import org.codehaus.plexus.PlexusConstants;
 import org.codehaus.plexus.component.configurator.ComponentConfigurator;
 import org.junit.jupiter.api.Test;
 
-import java.io.StringReader;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,10 +34,7 @@ public class SimplePlexusContainerManagerTest {
     public void constructorInitializesConfiguredContextAndCoreComponents() throws Exception {
         Map context = new HashMap();
         context.put("configured-key", "configured-value");
-        DefaultPlexusContainer container = new DefaultPlexusContainer(
-            new StringReader("<plexus><components/></plexus>"),
-            context
-        );
+        DefaultPlexusContainer container = new DefaultPlexusContainer("configured-container", context);
 
         try {
             ComponentConfigurator configurator = (ComponentConfigurator) container.lookup(

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -20,25 +20,25 @@
     },
     {
       "condition" : {
-        "typeReached" : "org.codehaus.plexus.component.composition.SetterComponentComposer"
+        "typeReached" : "org.codehaus.plexus.component.composition.setter.SetterComponentComposer"
       },
       "type" : "org_codehaus_plexus.plexus_container_default.DefaultPlexusContainerTest$SimpleAutowirableComponentBeanInfo"
     },
     {
       "condition" : {
-        "typeReached" : "org.codehaus.plexus.component.composition.SetterComponentComposer"
+        "typeReached" : "org.codehaus.plexus.component.composition.setter.SetterComponentComposer"
       },
       "type" : "org_codehaus_plexus.plexus_container_default.DefaultPlexusContainerTest$SimpleAutowirableComponentCustomizer"
     },
     {
       "condition" : {
-        "typeReached" : "org.codehaus.plexus.component.composition.SetterComponentComposer"
+        "typeReached" : "org.codehaus.plexus.component.composition.setter.SetterComponentComposer"
       },
       "type" : "org_codehaus_plexus.plexus_container_default.SetterComponentComposerTest$ComponentWithSetterDependenciesBeanInfo"
     },
     {
       "condition" : {
-        "typeReached" : "org.codehaus.plexus.component.composition.SetterComponentComposer"
+        "typeReached" : "org.codehaus.plexus.component.composition.setter.SetterComponentComposer"
       },
       "type" : "org_codehaus_plexus.plexus_container_default.SetterComponentComposerTest$ComponentWithSetterDependenciesCustomizer"
     },
@@ -67,6 +67,12 @@
         "typeReached" : "org.codehaus.plexus.SimplePlexusContainerManager"
       },
       "glob" : "org_codehaus_plexus/plexus_container_default/simple-manager-plexus.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.configuration.processor.ResourceBundleConfigurationResourceHandler"
+      },
+      "bundle" : "org_codehaus_plexus.plexus_container_default.ResourceBundleConfigurationResourceHandlerMessages"
     }
   ]
 }

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,72 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org_codehaus_plexus.plexus_container_default.AbstractConfigurationConverterTest$InstantiableComponent"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org_codehaus_plexus.plexus_container_default.FieldComponentComposerTest$ComponentWithAllFieldKinds"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.composition.FieldComponentComposer"
+      },
+      "type" : "org_codehaus_plexus.plexus_container_default.FieldComponentComposerTest$Dependency[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.composition.SetterComponentComposer"
+      },
+      "type" : "org_codehaus_plexus.plexus_container_default.DefaultPlexusContainerTest$SimpleAutowirableComponentBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.composition.SetterComponentComposer"
+      },
+      "type" : "org_codehaus_plexus.plexus_container_default.DefaultPlexusContainerTest$SimpleAutowirableComponentCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.composition.SetterComponentComposer"
+      },
+      "type" : "org_codehaus_plexus.plexus_container_default.SetterComponentComposerTest$ComponentWithSetterDependenciesBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.composition.SetterComponentComposer"
+      },
+      "type" : "org_codehaus_plexus.plexus_container_default.SetterComponentComposerTest$ComponentWithSetterDependenciesCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org_codehaus_plexus.plexus_container_default.ComponentValueSetterTest$FieldOnlyComponent"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org_codehaus_plexus.plexus_container_default.ComponentValueSetterTest$SetterOnlyComponent"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.factory.java.JavaComponentFactory"
+      },
+      "type" : "org_codehaus_plexus.plexus_container_default.JavaComponentFactoryTest$SampleComponent"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.SimplePlexusContainerManager"
+      },
+      "glob" : "org_codehaus_plexus/plexus_container_default/simple-manager-plexus.xml"
+    }
+  ]
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -67,12 +67,6 @@
         "typeReached" : "org.codehaus.plexus.SimplePlexusContainerManager"
       },
       "glob" : "org_codehaus_plexus/plexus_container_default/simple-manager-plexus.xml"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.codehaus.plexus.configuration.processor.ResourceBundleConfigurationResourceHandler"
-      },
-      "bundle" : "org_codehaus_plexus.plexus_container_default.ResourceBundleConfigurationResourceHandlerMessages"
     }
   ]
 }

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/resources/org_codehaus_plexus/plexus_container_default/ResourceBundleConfigurationResourceHandlerMessages.properties
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/resources/org_codehaus_plexus/plexus_container_default/ResourceBundleConfigurationResourceHandlerMessages.properties
@@ -1,0 +1,2 @@
+componentRole=org.example.Component
+implementation=org.example.DefaultComponent

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/resources/org_codehaus_plexus/plexus_container_default/simple-manager-plexus.xml
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/resources/org_codehaus_plexus/plexus_container_default/simple-manager-plexus.xml
@@ -1,0 +1,3 @@
+<plexus>
+  <components/>
+</plexus>

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/user-code-filter.json
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.codehaus.plexus.**"
+    },
+    {
+      "includeClasses" : "org_codehaus_plexus.plexus_container_default.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #8125

This PR provides test fixes and new metadata for org.codehaus.plexus:plexus-container-default:1.0-alpha-11, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 472759
- Cached input tokens: 8984576
- Output tokens: 56787
- Metadata entries: 232
- Test-only metadata entries: 11
- Iterations: 9
- Library coverage percentage: 46.01
- Previous library version metadata entries: 228
- Previous library version test-only metadata entries: 11
- Previous library version coverage percentage: 47.43

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3ccb9e3d754ddf74cd1eb850a6f55d5641f9d7ac`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.codehaus.plexus:plexus-container-default:1.0-alpha-10: 57/59 covered calls (96.61%)
- org.codehaus.plexus:plexus-container-default:1.0-alpha-11: 51/53 covered calls (96.23%)

**Reflection:**
- org.codehaus.plexus:plexus-container-default:1.0-alpha-10: 57/59 covered calls (96.61%)
- org.codehaus.plexus:plexus-container-default:1.0-alpha-11: 50/52 covered calls (96.15%)

**Resources:**
- org.codehaus.plexus:plexus-container-default:1.0-alpha-10: N/A
- org.codehaus.plexus:plexus-container-default:1.0-alpha-11: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.codehaus.plexus:plexus-container-default:1.0-alpha-10: 5322/11705 (45.47%)
- org.codehaus.plexus:plexus-container-default:1.0-alpha-11: 4903/11153 (43.96%)

**Line:**
- org.codehaus.plexus:plexus-container-default:1.0-alpha-10: 1375/2899 (47.43%)
- org.codehaus.plexus:plexus-container-default:1.0-alpha-11: 1245/2706 (46.01%)

**Method:**
- org.codehaus.plexus:plexus-container-default:1.0-alpha-10: 432/777 (55.60%)
- org.codehaus.plexus:plexus-container-default:1.0-alpha-11: 372/695 (53.53%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-10/src/test/java/org_codehaus_plexus/plexus_container_default/AbstractConfigurationConverterTest.java 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/AbstractConfigurationConverterTest.java
index ca3cbf16ed..5e68685bfe 100644
--- 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-10/src/test/java/org_codehaus_plexus/plexus_container_default/AbstractConfigurationConverterTest.java
+++ 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/AbstractConfigurationConverterTest.java
@@ -6,6 +6,9 @@
  */
 package org_codehaus_plexus.plexus_container_default;
 
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.classworlds.realm.NoSuchRealmException;
 import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
 import org.codehaus.plexus.component.configurator.ConfigurationListener;
 import org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter;
@@ -25,10 +28,11 @@ public class AbstractConfigurationConverterTest {
     public void loadsImplementationHintsAndInstantiatesLoadedClasses() throws Exception {
         ExposingConfigurationConverter converter = new ExposingConfigurationConverter();
         ClassLoader classLoader = AbstractConfigurationConverterTest.class.getClassLoader();
+        ClassRealm classRealm = testRealm("abstract-configuration-converter-test");
         XmlPlexusConfiguration configuration = new XmlPlexusConfiguration("component");
         configuration.setAttribute("implementation", ArrayList.class.getName());
 
-        Class implementation = converter.getImplementationClass(Object.class, configuration, classLoader);
+        Class implementation = converter.getImplementationClass(Object.class, configuration, classRealm);
         Object instance = converter.instantiate(InstantiableComponent.class.getName(), classLoader);
 
         assertSame(ArrayList.class, implementation);
@@ -38,10 +42,14 @@ public class AbstractConfigurationConverterTest {
     public static final class InstantiableComponent {
     }
 
+    private static ClassRealm testRealm(String id) throws NoSuchRealmException {
+        return new ClassWorld(id, AbstractConfigurationConverterTest.class.getClassLoader()).getRealm(id);
+    }
+
     private static final class ExposingConfigurationConverter extends AbstractConfigurationConverter {
-        private Class getImplementationClass(Class type, PlexusConfiguration configuration, ClassLoader classLoader)
+        private Class getImplementationClass(Class type, PlexusConfiguration configuration, ClassRealm classRealm)
             throws ComponentConfigurationException {
-            return getClassForImplementationHint(type, configuration, classLoader);
+            return getClassForImplementationHint(type, configuration, classRealm);
         }
 
         private Object instantiate(String className, ClassLoader classLoader) throws ComponentConfigurationException {
@@ -55,14 +63,14 @@ public class AbstractConfigurationConverterTest {
 
         @Override
         public Object fromConfiguration(ConverterLookup converterLookup, PlexusConfiguration configuration, Class type,
-                                        Class baseType, ClassLoader classLoader,
+                                        Class baseType, ClassRealm classRealm,
                                         ExpressionEvaluator expressionEvaluator) {
             throw new UnsupportedOperationException();
         }
 
         @Override
         public Object fromConfiguration(ConverterLookup converterLookup, PlexusConfiguration configuration, Class type,
-                                        Class baseType, ClassLoader classLoader,
+                                        Class baseType, ClassRealm classRealm,
                                         ExpressionEvaluator expressionEvaluator, ConfigurationListener listener) {
             throw new UnsupportedOperationException();
         }
diff --git 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-10/src/test/java/org_codehaus_plexus/plexus_container_default/ArrayConverterTest.java 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ArrayConverterTest.java
index b991db7cba..87feb8c806 100644
--- 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-10/src/test/java/org_codehaus_plexus/plexus_container_default/ArrayConverterTest.java
+++ 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ArrayConverterTest.java
@@ -6,6 +6,9 @@
  */
 package org_codehaus_plexus.plexus_container_default;
 
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.classworlds.realm.NoSuchRealmException;
 import org.codehaus.plexus.component.configurator.converters.composite.ArrayConverter;
 import org.codehaus.plexus.component.configurator.converters.lookup.DefaultConverterLookup;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
@@ -34,7 +37,7 @@ public class ArrayConverterTest {
             configuration,
             String[].class,
             String.class,
-            ArrayConverterTest.class.getClassLoader(),
+            testRealm("array-converter-test"),
             new LiteralExpressionEvaluator()
         );
 
@@ -58,6 +61,10 @@ public class ArrayConverterTest {
         assertTrue(collection.isEmpty());
     }
 
+    private static ClassRealm testRealm(String id) throws NoSuchRealmException {
+        return new ClassWorld(id, ArrayConverterTest.class.getClassLoader()).getRealm(id);
+    }
+
     private static void addChild(XmlPlexusConfiguration parent, String name, String value) {
         XmlPlexusConfiguration child = new XmlPlexusConfiguration(name);
         child.setValue(value);
diff --git 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-10/src/test/java/org_codehaus_plexus/plexus_container_default/CollectionConverterTest.java 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/CollectionConverterTest.java
index 5195e87896..ce333fd471 100644
--- 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-10/src/test/java/org_codehaus_plexus/plexus_container_default/CollectionConverterTest.java
+++ 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/CollectionConverterTest.java
@@ -6,6 +6,9 @@
  */
 package org_codehaus_plexus.plexus_container_default;
 
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.classworlds.realm.NoSuchRealmException;
 import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
 import org.codehaus.plexus.component.configurator.ConfigurationListener;
 import org.codehaus.plexus.component.configurator.converters.ConfigurationConverter;
@@ -48,7 +51,7 @@ public class CollectionConverterTest {
             configuration,
             ArrayList.class,
             CollectionConverterTest.class,
-            CollectionConverterTest.class.getClassLoader(),
+            testRealm("collection-converter-concrete-test"),
             new LiteralExpressionEvaluator()
         );
 
@@ -71,7 +74,7 @@ public class CollectionConverterTest {
             configuration,
             List.class,
             CollectionConverterTest.class,
-            CollectionConverterTest.class.getClassLoader(),
+            testRealm("collection-converter-children-test"),
             new LiteralExpressionEvaluator()
         );
 
@@ -82,6 +85,10 @@ public class CollectionConverterTest {
         assertTrue(collection.contains(new NamedElement("loaded from base package child element")));
     }
 
+    private static ClassRealm testRealm(String id) throws NoSuchRealmException {
+        return new ClassWorld(id, CollectionConverterTest.class.getClassLoader()).getRealm(id);
+    }
+
     private static void addChild(XmlPlexusConfiguration parent, String name, String value) {
         XmlPlexusConfiguration child = new XmlPlexusConfiguration(name);
         child.setValue(value);
@@ -121,7 +128,7 @@ public class CollectionConverterTest {
 
         @Override
         public Object fromConfiguration(ConverterLookup converterLookup, PlexusConfiguration configuration, Class type,
-                                        Class baseType, ClassLoader classLoader,
+                                        Class baseType, ClassRealm classRealm,
                                         ExpressionEvaluator expressionEvaluator)
             throws ComponentConfigurationException {
             try {
@@ -133,10 +140,10 @@ public class CollectionConverterTest {
 
         @Override
         public Object fromConfiguration(ConverterLookup converterLookup, PlexusConfiguration configuration, Class type,
-                                        Class baseType, ClassLoader classLoader,
+                                        Class baseType, ClassRealm classRealm,
                                         ExpressionEvaluator expressionEvaluator, ConfigurationListener listener)
             throws ComponentConfigurationException {
-            return fromConfiguration(converterLookup, configuration, type, baseType, classLoader, expressionEvaluator);
+            return fromConfiguration(converterLookup, configuration, type, baseType, classRealm, expressionEvaluator);
         }
     }
 
diff --git 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-10/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentValueSetterTest.java 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentValueSetterTest.java
index 3000f6d135..71714707a1 100644
--- 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-10/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentValueSetterTest.java
+++ 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentValueSetterTest.java
@@ -6,6 +6,9 @@
  */
 package org_codehaus_plexus.plexus_container_default;
 
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.classworlds.realm.NoSuchRealmException;
 import org.codehaus.plexus.component.configurator.converters.ComponentValueSetter;
 import org.codehaus.plexus.component.configurator.converters.lookup.DefaultConverterLookup;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
@@ -43,11 +46,15 @@ public class ComponentValueSetterTest {
         ComponentValueSetter setter = new ComponentValueSetter(fieldName, component, new DefaultConverterLookup());
         setter.configure(
             configuration,
-            ComponentValueSetterTest.class.getClassLoader(),
+            testRealm("component-value-setter-test"),
             new LiteralExpressionEvaluator()
         );
     }
 
+    private static ClassRealm testRealm(String id) throws NoSuchRealmException {
+        return new ClassWorld(id, ComponentValueSetterTest.class.getClassLoader()).getRealm(id);
+    }
+
     public static final class FieldOnlyComponent {
         private String configuredValue;
 
diff --git 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-10/src/test/java/org_codehaus_plexus/plexus_container_default/DefaultPlexusContainerTest.java 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/DefaultPlexusContainerTest.java
index bd8d9d7deb..97af436a41 100644
--- 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-10/src/test/java/org_codehaus_plexus/plexus_container_default/DefaultPlexusContainerTest.java
+++ 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/DefaultPlexusContainerTest.java
@@ -15,10 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class DefaultPlexusContainerTest {
     @Test
     void constructorInitializesCoreRealmAndContainerContext() throws Exception {
-        DefaultPlexusContainer container = new DefaultPlexusContainer(
-            "test-container",
-            DefaultPlexusContainerTest.class.getClassLoader()
-        );
+        DefaultPlexusContainer container = new DefaultPlexusContainer("test-container", null);
 
         try {
             container.setReloadingEnabled(true);
@@ -35,10 +32,7 @@ public class DefaultPlexusContainerTest {
 
     @Test
     void createAndAutowireInstantiatesNamedComponentFromContainerRealm() throws Exception {
-        DefaultPlexusContainer container = new DefaultPlexusContainer(
-            "autowire-container",
-            DefaultPlexusContainerTest.class.getClassLoader()
-        );
+        DefaultPlexusContainer container = new DefaultPlexusContainer("autowire-container", null);
 
         try {
             Object component = container.createAndAutowire(SimpleAutowirableComponent.class.getName());
diff --git 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-10/src/test/java/org_codehaus_plexus/plexus_container_default/FieldComponentComposerTest.java 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/FieldComponentComposerTest.java
index ede38e28a8..9c431526bb 100644
--- 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-10/src/test/java/org_codehaus_plexus/plexus_container_default/FieldComponentComposerTest.java
+++ 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/FieldComponentComposerTest.java
@@ -6,19 +6,29 @@
  */
 package org_codehaus_plexus.plexus_container_default;
 
-import org.codehaus.classworlds.ClassRealm;
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.ComponentLookupManager;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.PlexusContainerException;
+import org.codehaus.plexus.component.composition.ComponentComposerManager;
 import org.codehaus.plexus.component.composition.CompositionException;
 import org.codehaus.plexus.component.composition.FieldComponentComposer;
+import org.codehaus.plexus.component.discovery.ComponentDiscovererManager;
 import org.codehaus.plexus.component.discovery.ComponentDiscoveryListener;
+import org.codehaus.plexus.component.factory.ComponentFactoryManager;
+import org.codehaus.plexus.component.manager.ComponentManagerManager;
 import org.codehaus.plexus.component.repository.ComponentDescriptor;
+import org.codehaus.plexus.component.repository.ComponentRepository;
 import org.codehaus.plexus.component.repository.ComponentRequirement;
 import org.codehaus.plexus.component.repository.exception.ComponentLifecycleException;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.codehaus.plexus.component.repository.exception.ComponentRepositoryException;
+import org.codehaus.plexus.configuration.PlexusConfiguration;
+import org.codehaus.plexus.configuration.PlexusConfigurationException;
 import org.codehaus.plexus.configuration.PlexusConfigurationResourceException;
 import org.codehaus.plexus.context.Context;
+import org.codehaus.plexus.lifecycle.LifecycleHandlerManager;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.logging.LoggerManager;
 import org.junit.jupiter.api.Test;
@@ -168,6 +178,10 @@ public class FieldComponentComposerTest {
             return "recording";
         }
 
+        @Override
+        public void setName(String name) {
+        }
+
         @Override
         public Date getCreationDate() {
             return new Date(0L);
@@ -187,6 +201,14 @@ public class FieldComponentComposerTest {
             return lookup(role + roleHint);
         }
 
+        public Object lookup(Class componentClass) throws ComponentLookupException {
+            return lookup(componentClass.getName());
+        }
+
+        public Object lookup(Class role, String roleHint) throws ComponentLookupException {
+            return lookup(role.getName(), roleHint);
+        }
+
         @Override
         public Map lookupMap(String role) throws ComponentLookupException {
             Map dependencies = maps.get(role);
@@ -205,6 +227,14 @@ public class FieldComponentComposerTest {
             return dependencies;
         }
 
+        public Map lookupMap(Class role) throws ComponentLookupException {
+            return lookupMap(role.getName());
+        }
+
+        public List lookupList(Class role) throws ComponentLookupException {
+            return lookupList(role.getName());
+        }
+
         @Override
         public ComponentDescriptor getComponentDescriptor(String componentKey) {
             return descriptors.get(componentKey);
@@ -293,11 +323,9 @@ public class FieldComponentComposerTest {
             throw new UnsupportedOperationException();
         }
 
-        @Override
         public void initialize() throws PlexusContainerException {
         }
 
-        @Override
         public void start() throws PlexusContainerException {
         }
 
@@ -314,7 +342,6 @@ public class FieldComponentComposerTest {
         public void addContextValue(Object key, Object value) {
         }
 
-        @Override
         public void setConfigurationResource(Reader configuration) throws PlexusConfigurationResourceException {
             throw new UnsupportedOperationException();
         }
@@ -349,6 +376,23 @@ public class FieldComponentComposerTest {
             return null;
         }
 
+        public ClassWorld getClassWorld() {
+            return null;
+        }
+
+        public List discoverComponents(ClassRealm classRealm)
+            throws PlexusConfigurationException, ComponentRepositoryException {
+            return new ArrayList();
+        }
+
+        @Override
+        public void setParentPlexusContainer(PlexusContainer parentContainer) {
+        }
+
+        public PlexusContainer getParentContainer() {
+            return null;
+        }
+
         @Override
         public Object autowire(Object component) throws CompositionException {
             throw new UnsupportedOperationException();
@@ -369,9 +413,67 @@ public class FieldComponentComposerTest {
             return false;
         }
 
-        @Override
+        public ComponentRepository getComponentRepository() {
+            return null;
+        }
+
+        public void setComponentRepository(ComponentRepository componentRepository) {
+        }
+
+        public LifecycleHandlerManager getLifecycleHandlerManager() {
+            return null;
+        }
+
+        public void setLifecycleHandlerManager(LifecycleHandlerManager lifecycleHandlerManager) {
+        }
+
+        public ComponentManagerManager getComponentManagerManager() {
+            return null;
+        }
+
+        public void setComponentManagerManager(ComponentManagerManager componentManagerManager) {
+        }
+
+        public ComponentDiscovererManager getComponentDiscovererManager() {
+            return null;
+        }
+
+        public void setComponentDiscovererManager(ComponentDiscovererManager componentDiscovererManager) {
+        }
+
+        public ComponentFactoryManager getComponentFactoryManager() {
+            return null;
+        }
+
+        public void setComponentFactoryManager(ComponentFactoryManager componentFactoryManager) {
+        }
+
+        public ComponentLookupManager getComponentLookupManager() {
+            return null;
+        }
+
+        public void setComponentLookupManager(ComponentLookupManager componentLookupManager) {
+        }
+
+        public ComponentComposerManager getComponentComposerManager() {
+            return null;
+        }
+
+        public void setComponentComposerManager(ComponentComposerManager componentComposerManager) {
+        }
+
         public LoggerManager getLoggerManager() {
             return null;
         }
+
+        public void setLoggerManager(LoggerManager loggerManager) {
+        }
+
+        public void setConfiguration(PlexusConfiguration configuration) {
+        }
+
+        public PlexusConfiguration getConfiguration() {
+            return null;
+        }
     }
 }
diff --git 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-10/src/test/java/org_codehaus_plexus/plexus_container_default/JavaComponentFactoryTest.java 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/JavaComponentFactoryTest.java
index 26bde6cb84..add0cca343 100644
--- 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-10/src/test/java/org_codehaus_plexus/plexus_container_default/JavaComponentFactoryTest.java
+++ 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/JavaComponentFactoryTest.java
@@ -6,8 +6,8 @@
  */
 package org_codehaus_plexus.plexus_container_default;
 
-import org.codehaus.classworlds.ClassRealm;
-import org.codehaus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
 import org.codehaus.plexus.component.factory.java.JavaComponentFactory;
 import org.codehaus.plexus.component.repository.ComponentDescriptor;
 import org.junit.jupiter.api.Test;
@@ -21,11 +21,10 @@ public class JavaComponentFactoryTest {
         descriptor.setRole(SampleComponent.class.getName());
         descriptor.setImplementation(SampleComponent.class.getName());
 
-        ClassWorld classWorld = new ClassWorld();
-        ClassRealm realm = classWorld.newRealm(
+        ClassRealm realm = new ClassWorld(
             "java-component-factory-test",
             JavaComponentFactoryTest.class.getClassLoader()
-        );
+        ).getRealm("java-component-factory-test");
 
         Object component = new JavaComponentFactory().newInstance(descriptor, realm, null);
 
diff --git 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-10/src/test/java/org_codehaus_plexus/plexus_container_default/MapOrientedComponentComposerTest.java 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/MapOrientedComponentComposerTest.java
index ec83dd99d4..bb9c08fc44 100644
--- 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-10/src/test/java/org_codehaus_plexus/plexus_container_default/MapOrientedComponentComposerTest.java
+++ 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/MapOrientedComponentComposerTest.java
@@ -6,22 +6,32 @@
  */
 package org_codehaus_plexus.plexus_container_default;
 
-import org.codehaus.classworlds.ClassRealm;
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.ComponentLookupManager;
 import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.PlexusContainerException;
 import org.codehaus.plexus.component.MapOrientedComponent;
+import org.codehaus.plexus.component.composition.ComponentComposerManager;
 import org.codehaus.plexus.component.composition.CompositionException;
 import org.codehaus.plexus.component.composition.MapOrientedComponentComposer;
 import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+import org.codehaus.plexus.component.discovery.ComponentDiscovererManager;
 import org.codehaus.plexus.component.discovery.ComponentDiscoveryListener;
+import org.codehaus.plexus.component.factory.ComponentFactoryManager;
+import org.codehaus.plexus.component.manager.ComponentManagerManager;
 import org.codehaus.plexus.component.repository.ComponentDescriptor;
+import org.codehaus.plexus.component.repository.ComponentRepository;
 import org.codehaus.plexus.component.repository.ComponentRequirement;
 import org.codehaus.plexus.component.repository.exception.ComponentLifecycleException;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.codehaus.plexus.component.repository.exception.ComponentRepositoryException;
+import org.codehaus.plexus.configuration.PlexusConfiguration;
+import org.codehaus.plexus.configuration.PlexusConfigurationException;
 import org.codehaus.plexus.configuration.PlexusConfigurationResourceException;
 import org.codehaus.plexus.context.Context;
+import org.codehaus.plexus.lifecycle.LifecycleHandlerManager;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.logging.LoggerManager;
 import org.junit.jupiter.api.MethodOrderer;
@@ -45,13 +55,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class MapOrientedComponentComposerTest {
+    @Test
+    @Order(1)
+    public void verifySuitabilityRejectsPlainComponents() throws Exception {
+        MapOrientedComponentComposer composer = new MapOrientedComponentComposer();
+        PlainComponent component = new PlainComponent();
+
+        CompositionException exception = assertThrows(
+            CompositionException.class,
+            () -> composer.verifyComponentSuitability(component)
+        );
+
+        assertTrue(exception.getMessage().contains(component.getClass().getName()));
+        assertTrue(exception.getMessage().contains(MapOrientedComponent.class.getName()));
+    }
+
     @Test
     @Order(2)
     public void containerComposerManagerRejectsPlainComponentsForMapOrientedComposer() throws Exception {
-        DefaultPlexusContainer container = new DefaultPlexusContainer(
-            "map-oriented-composer-test",
-            MapOrientedComponentComposerTest.class.getClassLoader()
-        );
+        DefaultPlexusContainer container = new DefaultPlexusContainer("map-oriented-composer-test", null);
         ComponentDescriptor descriptor = descriptor(PlainComponent.class.getName());
         descriptor.setComponentComposer("map-oriented");
         descriptor.addRequirement(requirement("ignoredRole", "single"));
@@ -85,12 +107,9 @@ public class MapOrientedComponentComposerTest {
     }
 
     @Test
-    @Order(1)
+    @Order(4)
     public void lookupFailsWhenDescriptorSelectsMapOrientedComposerForPlainComponent() throws Exception {
-        DefaultPlexusContainer container = new DefaultPlexusContainer(
-            "map-oriented-composer-lookup-test",
-            MapOrientedComponentComposerTest.class.getClassLoader()
-        );
+        DefaultPlexusContainer container = new DefaultPlexusContainer("map-oriented-composer-lookup-test", null);
         ComponentDescriptor descriptor = descriptor(PlainComponent.class.getName());
         descriptor.setComponentComposer("map-oriented");
         descriptor.addRequirement(requirement("ignoredRole", "single"));
@@ -110,7 +129,7 @@ public class MapOrientedComponentComposerTest {
     }
 
     @Test
-    @Order(4)
+    @Order(5)
     public void addsMappedRequirementsToMapOrientedComponents() throws Exception {
         MapOrientedComponentComposer composer = new MapOrientedComponentComposer();
         RecordingMapOrientedComponent component = new RecordingMapOrientedComponent();
@@ -247,6 +266,10 @@ public class MapOrientedComponentComposerTest {
             return "recording";
         }
 
+        @Override
+        public void setName(String name) {
+        }
+
         @Override
         public Date getCreationDate() {
             return new Date(0L);
@@ -266,6 +289,14 @@ public class MapOrientedComponentComposerTest {
             return lookup(role + roleHint);
         }
 
+        public Object lookup(Class componentClass) throws ComponentLookupException {
+            return lookup(componentClass.getName());
+        }
+
+        public Object lookup(Class role, String roleHint) throws ComponentLookupException {
+            return lookup(role.getName(), roleHint);
+        }
+
         @Override
         public Map lookupMap(String role) throws ComponentLookupException {
             Map dependencies = maps.get(role);
@@ -284,6 +315,14 @@ public class MapOrientedComponentComposerTest {
             return dependencies;
         }
 
+        public Map lookupMap(Class role) throws ComponentLookupException {
+            return lookupMap(role.getName());
+        }
+
+        public List lookupList(Class role) throws ComponentLookupException {
+            return lookupList(role.getName());
+        }
+
         @Override
         public ComponentDescriptor getComponentDescriptor(String componentKey) {
             return descriptors.get(componentKey);
@@ -372,11 +411,9 @@ public class MapOrientedComponentComposerTest {
             throw new UnsupportedOperationException();
         }
 
-        @Override
         public void initialize() throws PlexusContainerException {
         }
 
-        @Override
         public void start() throws PlexusContainerException {
         }
 
@@ -393,7 +430,6 @@ public class MapOrientedComponentComposerTest {
         public void addContextValue(Object key, Object value) {
         }
 
-        @Override
         public void setConfigurationResource(Reader configuration) throws PlexusConfigurationResourceException {
             throw new UnsupportedOperationException();
         }
@@ -428,6 +464,23 @@ public class MapOrientedComponentComposerTest {
             return null;
         }
 
+        public ClassWorld getClassWorld() {
+            return null;
+        }
+
+        public List discoverComponents(ClassRealm classRealm)
+            throws PlexusConfigurationException, ComponentRepositoryException {
+            return new ArrayList();
+        }
+
+        @Override
+        public void setParentPlexusContainer(PlexusContainer parentContainer) {
+        }
+
+        public PlexusContainer getParentContainer() {
+            return null;
+        }
+
         @Override
         public Object autowire(Object component) throws CompositionException {
             throw new UnsupportedOperationException();
@@ -448,9 +501,67 @@ public class MapOrientedComponentComposerTest {
             return false;
         }
 
-        @Override
+        public ComponentRepository getComponentRepository() {
+            return null;
+        }
+
+        public void setComponentRepository(ComponentRepository componentRepository) {
+        }
+
+        public LifecycleHandlerManager getLifecycleHandlerManager() {
+            return null;
+        }
+
+        public void setLifecycleHandlerManager(LifecycleHandlerManager lifecycleHandlerManager) {
+        }
+
+        public ComponentManagerManager getComponentManagerManager() {
+            return null;
+        }
+
+        public void setComponentManagerManager(ComponentManagerManager componentManagerManager) {
+        }
+
+        public ComponentDiscovererManager getComponentDiscovererManager() {
+            return null;
+        }
+
+        public void setComponentDiscovererManager(ComponentDiscovererManager componentDiscovererManager) {
+        }
+
+        public ComponentFactoryManager getComponentFactoryManager() {
+            return null;
+        }
+
+        public void setComponentFactoryManager(ComponentFactoryManager componentFactoryManager) {
+        }
+
+        public ComponentLookupManager getComponentLookupManager() {
+            return null;
+        }
+
+        public void setComponentLookupManager(ComponentLookupManager componentLookupManager) {
+        }
+
+        public ComponentComposerManager getComponentComposerManager() {
+            return null;
+        }
+
+        public void setComponentComposerManager(ComponentComposerManager componentComposerManager) {
+        }
+
         public LoggerManager getLoggerManager() {
             return null;
         }
+
+        public void setLoggerManager(LoggerManager loggerManager) {
+        }
+
+        public void setConfiguration(PlexusConfiguration configuration) {
+        }
+
+        public PlexusConfiguration getConfiguration() {
+            return null;
+        }
     }
 }
diff --git 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-10/src/test/java/org_codehaus_plexus/plexus_container_default/MapOrientedComponentConfiguratorTest.java 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/MapOrientedComponentConfiguratorTest.java
index fcea7d3a2d..6b46fa836f 100644
--- 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-10/src/test/java/org_codehaus_plexus/plexus_container_default/MapOrientedComponentConfiguratorTest.java
+++ 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/MapOrientedComponentConfiguratorTest.java
@@ -6,10 +6,11 @@
  */
 package org_codehaus_plexus.plexus_container_default;
 
-import org.codehaus.classworlds.ClassRealm;
-import org.codehaus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
 import org.codehaus.plexus.component.MapOrientedComponent;
 import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+import org.codehaus.plexus.component.configurator.ComponentConfigurator;
 import org.codehaus.plexus.component.configurator.MapOrientedComponentConfigurator;
 import org.codehaus.plexus.component.repository.ComponentRequirement;
 import org.codehaus.plexus.configuration.xml.XmlPlexusConfiguration;
@@ -55,6 +56,57 @@ public class MapOrientedComponentConfiguratorTest {
 
     @Test
     @Order(2)
+    public void rejectsPlainComponentsThroughConfiguratorInterface() throws Exception {
+        ComponentConfigurator configurator = new MapOrientedComponentConfigurator();
+        Object component = nonMapOrientedComponentSelectedAtRuntime();
+        clearCompilerGeneratedClassCache();
+        assertNull(cachedMapOrientedComponentType());
+
+        ComponentConfigurationException exception = assertThrows(
+            ComponentConfigurationException.class,
+            () -> configurator.configureComponent(
+                component,
+                new XmlPlexusConfiguration("configuration"),
+                testRealm("map-oriented-component-configurator-rejection-test")
+            )
+        );
+
+        assertTrue(exception.getMessage().contains("can only process implementations"));
+        assertTrue(exception.getMessage().contains(MapOrientedComponent.class.getName()));
+        assertEquals(MapOrientedComponent.class, cachedMapOrientedComponentType());
+    }
+
+    @Test
+    @Order(3)
+    public void reusesCachedMapOrientedTypeWhenBuildingRejectionMessage() throws Exception {
+        ComponentConfigurator configurator = new MapOrientedComponentConfigurator();
+        clearCompilerGeneratedClassCache();
+
+        assertThrows(
+            ComponentConfigurationException.class,
+            () -> configurator.configureComponent(
+                nonMapOrientedComponentSelectedAtRuntime(),
+                new XmlPlexusConfiguration("configuration"),
+                testRealm("map-oriented-component-configurator-cache-miss-test")
+            )
+        );
+        assertEquals(MapOrientedComponent.class, cachedMapOrientedComponentType());
+
+        ComponentConfigurationException exception = assertThrows(
+            ComponentConfigurationException.class,
+            () -> configurator.configureComponent(
+                nonMapOrientedComponentSelectedAtRuntime(),
+                new XmlPlexusConfiguration("configuration"),
+                testRealm("map-oriented-component-configurator-cache-hit-test")
+            )
+        );
+
+        assertTrue(exception.getMessage().contains(MapOrientedComponent.class.getName()));
+        assertEquals(MapOrientedComponent.class, cachedMapOrientedComponentType());
+    }
+
+    @Test
+    @Order(4)
     public void passesConvertedConfigurationMapToMapOrientedComponent() throws Exception {
         MapOrientedComponentConfigurator configurator = new MapOrientedComponentConfigurator();
         RecordingMapOrientedComponent component = new RecordingMapOrientedComponent();
@@ -98,8 +150,7 @@ public class MapOrientedComponentConfiguratorTest {
     }
 
     private static ClassRealm testRealm(String id) throws Exception {
-        ClassWorld classWorld = new ClassWorld();
-        return classWorld.newRealm(id, MapOrientedComponentConfiguratorTest.class.getClassLoader());
+        return new ClassWorld(id, MapOrientedComponentConfiguratorTest.class.getClassLoader()).getRealm(id);
     }
 
     private static void addChild(XmlPlexusConfiguration parent, String name, String value) {
diff --git 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ResourceBundleConfigurationResourceHandlerTest.java 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ResourceBundleConfigurationResourceHandlerTest.java
new file mode 100644
index 0000000000..15e2331f03
--- /dev/null
+++ 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/ResourceBundleConfigurationResourceHandlerTest.java
@@ -0,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.configuration.PlexusConfiguration;
+import org.codehaus.plexus.configuration.processor.ConfigurationProcessor;
+import org.codehaus.plexus.configuration.processor.ConfigurationResourceHandler;
+import org.codehaus.plexus.configuration.processor.ResourceBundleConfigurationResourceHandler;
+import org.codehaus.plexus.configuration.xml.XmlPlexusConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ResourceBundleConfigurationResourceHandlerTest {
+    private static final String BUNDLE_NAME =
+        "org_codehaus_plexus.plexus_container_default.ResourceBundleConfigurationResourceHandlerMessages";
+
+    @Test
+    void configurationProcessorInlinesPropertiesFromResourceBundle() throws Exception {
+        ResourceBundleConfigurationResourceHandler handler = new ResourceBundleConfigurationResourceHandler();
+        ConfigurationProcessor processor = new ConfigurationProcessor();
+        processor.addConfigurationResourceHandler(handler);
+
+        XmlPlexusConfiguration configuration = new XmlPlexusConfiguration("configuration");
+        XmlPlexusConfiguration bundleReference = new XmlPlexusConfiguration(handler.getId());
+        bundleReference.setAttribute(ConfigurationResourceHandler.SOURCE, BUNDLE_NAME);
+        configuration.addChild(bundleReference);
+
+        PlexusConfiguration processed = processor.process(configuration, Collections.emptyMap());
+        PlexusConfiguration bundleConfiguration = processed.getChild(BUNDLE_NAME, false);
+
+        assertThat(bundleConfiguration).isNotNull();
+        assertThat(bundleConfiguration.getChild("componentRole", false).getValue())
+            .isEqualTo("org.example.Component");
+        assertThat(bundleConfiguration.getChild("implementation", false).getValue())
+            .isEqualTo("org.example.DefaultComponent");
+    }
+}
diff --git 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-10/src/test/java/org_codehaus_plexus/plexus_container_default/SetterComponentComposerTest.java 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/SetterComponentComposerTest.java
index a615eb6048..1f15ee371d 100644
--- 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-10/src/test/java/org_codehaus_plexus/plexus_container_default/SetterComponentComposerTest.java
+++ 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/SetterComponentComposerTest.java
@@ -6,19 +6,29 @@
  */
 package org_codehaus_plexus.plexus_container_default;
 
-import org.codehaus.classworlds.ClassRealm;
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.ComponentLookupManager;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.PlexusContainerException;
+import org.codehaus.plexus.component.composition.ComponentComposerManager;
 import org.codehaus.plexus.component.composition.CompositionException;
-import org.codehaus.plexus.component.composition.SetterComponentComposer;
+import org.codehaus.plexus.component.composition.setter.SetterComponentComposer;
+import org.codehaus.plexus.component.discovery.ComponentDiscovererManager;
 import org.codehaus.plexus.component.discovery.ComponentDiscoveryListener;
+import org.codehaus.plexus.component.factory.ComponentFactoryManager;
+import org.codehaus.plexus.component.manager.ComponentManagerManager;
 import org.codehaus.plexus.component.repository.ComponentDescriptor;
+import org.codehaus.plexus.component.repository.ComponentRepository;
 import org.codehaus.plexus.component.repository.ComponentRequirement;
 import org.codehaus.plexus.component.repository.exception.ComponentLifecycleException;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.codehaus.plexus.component.repository.exception.ComponentRepositoryException;
+import org.codehaus.plexus.configuration.PlexusConfiguration;
+import org.codehaus.plexus.configuration.PlexusConfigurationException;
 import org.codehaus.plexus.configuration.PlexusConfigurationResourceException;
 import org.codehaus.plexus.context.Context;
+import org.codehaus.plexus.lifecycle.LifecycleHandlerManager;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.logging.LoggerManager;
 import org.junit.jupiter.api.Test;
@@ -118,6 +128,10 @@ public class SetterComponentComposerTest {
             return "recording";
         }
 
+        @Override
+        public void setName(String name) {
+        }
+
         @Override
         public Date getCreationDate() {
             return new Date(0L);
@@ -137,6 +151,14 @@ public class SetterComponentComposerTest {
             return lookup(role + roleHint);
         }
 
+        public Object lookup(Class componentClass) throws ComponentLookupException {
+            return lookup(componentClass.getName());
+        }
+
+        public Object lookup(Class role, String roleHint) throws ComponentLookupException {
+            return lookup(role.getName(), roleHint);
+        }
+
         @Override
         public Map lookupMap(String role) throws ComponentLookupException {
             Map dependencies = maps.get(role);
@@ -155,6 +177,14 @@ public class SetterComponentComposerTest {
             return dependencies;
         }
 
+        public Map lookupMap(Class role) throws ComponentLookupException {
+            return lookupMap(role.getName());
+        }
+
+        public List lookupList(Class role) throws ComponentLookupException {
+            return lookupList(role.getName());
+        }
+
         @Override
         public ComponentDescriptor getComponentDescriptor(String componentKey) {
             return descriptors.get(componentKey);
@@ -243,11 +273,9 @@ public class SetterComponentComposerTest {
             throw new UnsupportedOperationException();
         }
 
-        @Override
         public void initialize() throws PlexusContainerException {
         }
 
-        @Override
         public void start() throws PlexusContainerException {
         }
 
@@ -264,7 +292,6 @@ public class SetterComponentComposerTest {
         public void addContextValue(Object key, Object value) {
         }
 
-        @Override
         public void setConfigurationResource(Reader configuration) throws PlexusConfigurationResourceException {
             throw new UnsupportedOperationException();
         }
@@ -299,6 +326,23 @@ public class SetterComponentComposerTest {
             return null;
         }
 
+        public ClassWorld getClassWorld() {
+            return null;
+        }
+
+        public List discoverComponents(ClassRealm classRealm)
+            throws PlexusConfigurationException, ComponentRepositoryException {
+            return new ArrayList();
+        }
+
+        @Override
+        public void setParentPlexusContainer(PlexusContainer parentContainer) {
+        }
+
+        public PlexusContainer getParentContainer() {
+            return null;
+        }
+
         @Override
         public Object autowire(Object component) throws CompositionException {
             throw new UnsupportedOperationException();
@@ -319,9 +363,67 @@ public class SetterComponentComposerTest {
             return false;
         }
 
-        @Override
+        public ComponentRepository getComponentRepository() {
+            return null;
+        }
+
+        public void setComponentRepository(ComponentRepository componentRepository) {
+        }
+
+        public LifecycleHandlerManager getLifecycleHandlerManager() {
+            return null;
+        }
+
+        public void setLifecycleHandlerManager(LifecycleHandlerManager lifecycleHandlerManager) {
+        }
+
+        public ComponentManagerManager getComponentManagerManager() {
+            return null;
+        }
+
+        public void setComponentManagerManager(ComponentManagerManager componentManagerManager) {
+        }
+
+        public ComponentDiscovererManager getComponentDiscovererManager() {
+            return null;
+        }
+
+        public void setComponentDiscovererManager(ComponentDiscovererManager componentDiscovererManager) {
+        }
+
+        public ComponentFactoryManager getComponentFactoryManager() {
+            return null;
+        }
+
+        public void setComponentFactoryManager(ComponentFactoryManager componentFactoryManager) {
+        }
+
+        public ComponentLookupManager getComponentLookupManager() {
+            return null;
+        }
+
+        public void setComponentLookupManager(ComponentLookupManager componentLookupManager) {
+        }
+
+        public ComponentComposerManager getComponentComposerManager() {
+            return null;
+        }
+
+        public void setComponentComposerManager(ComponentComposerManager componentComposerManager) {
+        }
+
         public LoggerManager getLoggerManager() {
             return null;
         }
+
+        public void setLoggerManager(LoggerManager loggerManager) {
+        }
+
+        public void setConfiguration(PlexusConfiguration configuration) {
+        }
+
+        public PlexusConfiguration getConfiguration() {
+            return null;
+        }
     }
 }
diff --git 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-10/src/test/java/org_codehaus_plexus/plexus_container_default/SimplePlexusContainerManagerTest.java 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/SimplePlexusContainerManagerTest.java
index 0a9a144c59..2d2371594e 100644
--- 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-10/src/test/java/org_codehaus_plexus/plexus_container_default/SimplePlexusContainerManagerTest.java
+++ 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-11/src/test/java/org_codehaus_plexus/plexus_container_default/SimplePlexusContainerManagerTest.java
@@ -11,7 +11,6 @@ import org.codehaus.plexus.PlexusConstants;
 import org.codehaus.plexus.component.configurator.ComponentConfigurator;
 import org.junit.jupiter.api.Test;
 
-import java.io.StringReader;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,10 +34,7 @@ public class SimplePlexusContainerManagerTest {
     public void constructorInitializesConfiguredContextAndCoreComponents() throws Exception {
         Map context = new HashMap();
         context.put("configured-key", "configured-value");
-        DefaultPlexusContainer container = new DefaultPlexusContainer(
-            new StringReader("<plexus><components/></plexus>"),
-            context
-        );
+        DefaultPlexusContainer container = new DefaultPlexusContainer("configured-container", context);
 
         try {
             ComponentConfigurator configurator = (ComponentConfigurator) container.lookup(

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
