### PR TITLE
[GenAI] Mark org.scalatest:scalatest_3 as not for Native Image

### DIFF
--- a/metadata/org.scalatest/scalatest_3/index.json
+++ b/metadata/org.scalatest/scalatest_3/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published scalatest_3-3.2.19 JAR contains only META-INF/MANIFEST.MF and no JVM class files; the implementation classes are supplied by its class-bearing module dependencies.",
+    "replacement": "Use the class-bearing ScalaTest module artifacts such as org.scalatest:scalatest-core_3:3.2.19, org.scalatest:scalatest-funsuite_3:3.2.19, and org.scalatest:scalatest-matchers-core_3:3.2.19 as needed."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #2166

This PR records `org.scalatest:scalatest_3` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published scalatest_3-3.2.19 JAR contains only META-INF/MANIFEST.MF and no JVM class files; the implementation classes are supplied by its class-bearing module dependencies.

Replacement guidance:
- Use the class-bearing ScalaTest module artifacts such as org.scalatest:scalatest-core_3:3.2.19, org.scalatest:scalatest-funsuite_3:3.2.19, and org.scalatest:scalatest-matchers-core_3:3.2.19 as needed.

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `a02a60d1ff46eda0d11aa3fad709aba71d534a12`

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
