### PR TITLE
[GenAI] Test fix for org.codehaus.plexus:plexus-classworlds:2.0.0 using gpt-5.5

### DIFF
--- a/metadata/org.codehaus.plexus/plexus-classworlds/2.0.0/reachability-metadata.json
+++ b/metadata/org.codehaus.plexus/plexus-classworlds/2.0.0/reachability-metadata.json
@@ -1,0 +1,30 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type" : "org.codehaus.plexus.classworlds.ClassWorld"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.strategy.AbstractStrategy"
+      },
+      "glob" : "foreign/resource.txt"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy"
+      },
+      "glob" : "foreign/resource.txt"
+    }
+  ]
+}

--- a/metadata/org.codehaus.plexus/plexus-classworlds/index.json
+++ b/metadata/org.codehaus.plexus/plexus-classworlds/index.json
@@ -1,6 +1,16 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.0.0",
+    "tested-versions" : [
+      "2.0.0"
+    ],
+    "allowed-packages" : [
+      "org.codehaus.classworlds",
+      "org.codehaus.plexus.classworlds"
+    ]
+  },
+  {
     "metadata-version" : "1.5.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/$version$/plexus-classworlds-$version$-sources.jar",
     "repository-url" : "https://github.com/codehaus-plexus/plexus-classworlds",

--- a/metadata/org.codehaus.plexus/plexus-classworlds/index.json
+++ b/metadata/org.codehaus.plexus/plexus-classworlds/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.0.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/$version$/plexus-classworlds-$version$-sources.jar",
+    "repository-url" : "https://github.com/codehaus-plexus/plexus-classworlds",
+    "test-code-url" : "https://github.com/codehaus-plexus/plexus-classworlds/tree/plexus-classworlds-$version$/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/$version$/plexus-classworlds-$version$-javadoc.jar",
+    "description" : "Plexus Classworlds is a framework for creating and managing isolated Java class loader realms. It lets container-style applications and build tools load components with controlled classpath separation and package imports between realms.",
     "tested-versions" : [
       "2.0.0"
     ],

--- a/stats/org.codehaus.plexus/plexus-classworlds/2.0.0/execution-metrics.json
+++ b/stats/org.codehaus.plexus/plexus-classworlds/2.0.0/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_javac_fail:2026-06-07": {
+    "timestamp": "2026-06-07T13:22:14.612737Z",
+    "library": "org.codehaus.plexus:plexus-classworlds:2.0.0",
+    "starting_commit": "747197e2dd5114bf97b801a104c989ed323bb6c2",
+    "ending_commit": "22bb4e6d5fcd52e6f76b7addc4fbc6c6d1da464e",
+    "previous_library": "org.codehaus.plexus:plexus-classworlds:1.5.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.0.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 8,
+            "totalCalls": 8
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 6,
+            "totalCalls": 6
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 14,
+        "totalCalls": 14
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 934,
+          "missed": 1426,
+          "ratio": 0.395763,
+          "total": 2360
+        },
+        "line": {
+          "covered": 254,
+          "missed": 340,
+          "ratio": 0.427609,
+          "total": 594
+        },
+        "method": {
+          "covered": 65,
+          "missed": 54,
+          "ratio": 0.546218,
+          "total": 119
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.5.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 9,
+            "totalCalls": 9
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 7,
+            "totalCalls": 7
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 16,
+        "totalCalls": 16
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 857,
+          "missed": 2700,
+          "ratio": 0.240933,
+          "total": 3557
+        },
+        "line": {
+          "covered": 235,
+          "missed": 685,
+          "ratio": 0.255435,
+          "total": 920
+        },
+        "method": {
+          "covered": 64,
+          "missed": 185,
+          "ratio": 0.257028,
+          "total": 249
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 66578,
+      "cached_input_tokens_used": 493568,
+      "output_tokens_used": 7325,
+      "iterations": 1,
+      "cost_usd": 0.4666,
+      "tested_library_loc": 254,
+      "metadata_entries": 4,
+      "test_only_metadata_entries": 21,
+      "previous_library_metadata_entries": 3,
+      "previous_library_test_only_metadata_entries": 6,
+      "code_coverage_percent": 42.76,
+      "previous_library_coverage_percent": 25.54
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java",
+      "metadata_file": "metadata/org.codehaus.plexus/plexus-classworlds/2.0.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.codehaus.plexus/plexus-classworlds/2.0.0/stats.json
+++ b/stats/org.codehaus.plexus/plexus-classworlds/2.0.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "2.0.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 8,
+          "totalCalls" : 8
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 6,
+          "totalCalls" : 6
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 14,
+      "totalCalls" : 14
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 934,
+        "missed" : 1426,
+        "ratio" : 0.395763,
+        "total" : 2360
+      },
+      "line" : {
+        "covered" : 254,
+        "missed" : 340,
+        "ratio" : 0.427609,
+        "total" : 594
+      },
+      "method" : {
+        "covered" : 65,
+        "missed" : 54,
+        "ratio" : 0.546218,
+        "total" : 119
+      }
+    }
+  } ]
+}

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/.gitignore
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/build.gradle
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.codehaus.plexus:plexus-classworlds:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/gradle.properties
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.codehaus.plexus:plexus-classworlds:2.0.0
+library.version = 2.0.0
+metadata.dir = org.codehaus.plexus/plexus-classworlds/2.0.0/

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/settings.gradle
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.codehaus.plexus.plexus-classworlds_tests'

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java
@@ -19,19 +19,19 @@ public class ClassRealmTest {
     private static final String REALM_ID = "direct-realm";
 
     @Test
-    void loadRealmClassLoadsClassThroughRealmClassLoader() throws Exception {
+    void loadClassLoadsClassThroughRealmClassLoader() throws Exception {
         ClassRealm realm = newRealm();
 
-        Class<?> loadedClass = realm.loadRealmClass(ClassRealmTest.class.getName());
+        Class<?> loadedClass = realm.loadClass(ClassRealmTest.class.getName());
 
         assertThat(loadedClass).isSameAs(ClassRealmTest.class);
     }
 
     @Test
-    void getRealmResourceLoadsResourceThroughRealmClassLoader() throws Exception {
+    void getResourceLoadsResourceThroughRealmClassLoader() throws Exception {
         ClassRealm realm = newRealm();
 
-        URL resource = realm.getRealmResource("classworlds.conf");
+        URL resource = realm.getResource("classworlds.conf");
 
         assertThat(resource).isNotNull();
     }

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_classworlds;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URL;
+import java.util.Enumeration;
+
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.junit.jupiter.api.Test;
+
+public class ClassRealmTest {
+    private static final String REALM_ID = "direct-realm";
+
+    @Test
+    void loadRealmClassLoadsClassThroughRealmClassLoader() throws Exception {
+        ClassRealm realm = newRealm();
+
+        Class<?> loadedClass = realm.loadRealmClass(ClassRealmTest.class.getName());
+
+        assertThat(loadedClass).isSameAs(ClassRealmTest.class);
+    }
+
+    @Test
+    void getRealmResourceLoadsResourceThroughRealmClassLoader() throws Exception {
+        ClassRealm realm = newRealm();
+
+        URL resource = realm.getRealmResource("classworlds.conf");
+
+        assertThat(resource).isNotNull();
+    }
+
+    @Test
+    void loadResourceFromParentUsesForeignClassLoader() throws Exception {
+        ClassRealm realm = newRealm();
+
+        URL resource = realm.loadResourceFromParent("classworlds.conf");
+
+        assertThat(resource).isNotNull();
+    }
+
+    @Test
+    void loadResourcesFromParentUsesForeignClassLoader() throws Exception {
+        ClassRealm realm = newRealm();
+
+        Enumeration<?> resources = realm.loadResourcesFromParent("classworlds.conf");
+
+        assertThat(resources).isNotNull();
+        assertThat(resources.hasMoreElements()).isTrue();
+    }
+
+    private static ClassRealm newRealm() throws Exception {
+        ClassWorld world = new ClassWorld();
+        return world.newRealm(REALM_ID, ClassRealmTest.class.getClassLoader());
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/src/test/java/org_codehaus_plexus/plexus_classworlds/DefaultStrategyTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/src/test/java/org_codehaus_plexus/plexus_classworlds/DefaultStrategyTest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.codehaus.plexus.classworlds.ClassWorld;
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
-import org.codehaus.plexus.classworlds.strategy.DefaultStrategy;
+import org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy;
 import org.junit.jupiter.api.Test;
 
 public class DefaultStrategyTest {
@@ -22,7 +22,7 @@ public class DefaultStrategyTest {
 
         Class<?> loadedClass = realm.loadClass(ClassWorld.class.getName());
 
-        assertThat(realm.getStrategy()).isInstanceOf(DefaultStrategy.class);
+        assertThat(realm.getStrategy()).isInstanceOf(SelfFirstStrategy.class);
         assertThat(loadedClass).isSameAs(ClassWorld.class);
     }
 }

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/src/test/java/org_codehaus_plexus/plexus_classworlds/DefaultStrategyTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/src/test/java/org_codehaus_plexus/plexus_classworlds/DefaultStrategyTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_classworlds;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.classworlds.strategy.DefaultStrategy;
+import org.junit.jupiter.api.Test;
+
+public class DefaultStrategyTest {
+    private static final String REALM_ID = "default-realm";
+
+    @Test
+    void loadClassDelegatesClassworldsClassesToClassworldsClassLoader() throws Exception {
+        ClassRealm realm = new ClassWorld().newRealm(REALM_ID);
+
+        Class<?> loadedClass = realm.loadClass(ClassWorld.class.getName());
+
+        assertThat(realm.getStrategy()).isInstanceOf(DefaultStrategy.class);
+        assertThat(loadedClass).isSameAs(ClassWorld.class);
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ForeignStrategyTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ForeignStrategyTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_classworlds;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.classworlds.strategy.ForeignStrategy;
+import org.junit.jupiter.api.Test;
+
+public class ForeignStrategyTest {
+    private static final String CLASS_NAME = ForeignLoadTarget.class.getName();
+    private static final String REALM_ID = "foreign-realm";
+    private static final String RESOURCE_NAME = "foreign/resource.txt";
+
+    @Test
+    void loadClassConsultsForeignClassLoaderFirst() throws Exception {
+        ClassLoader foreignClassLoader = new ClassLoader(ForeignStrategyTest.class.getClassLoader()) {
+        };
+        ForeignStrategy strategy = newForeignStrategy(foreignClassLoader);
+
+        Class<?> loadedClass = strategy.loadClass(CLASS_NAME);
+
+        assertThat(loadedClass).isEqualTo(ForeignLoadTarget.class);
+    }
+
+    @Test
+    void getResourceConsultsForeignClassLoaderFirst() throws Exception {
+        RecordingClassLoader foreignClassLoader = new RecordingClassLoader();
+        ForeignStrategy strategy = newForeignStrategy(foreignClassLoader);
+
+        URL resource = strategy.getResource("/" + RESOURCE_NAME);
+
+        assertThat(resource).isEqualTo(foreignClassLoader.resource);
+        assertThat(foreignClassLoader.resourceLookups).containsExactly(RESOURCE_NAME);
+    }
+
+    @Test
+    void findResourcesIncludesResourcesFromForeignClassLoader() throws Exception {
+        RecordingClassLoader foreignClassLoader = new RecordingClassLoader();
+        ForeignStrategy strategy = newForeignStrategy(foreignClassLoader);
+
+        List<URL> resources = resources(strategy.findResources("/" + RESOURCE_NAME));
+
+        assertThat(resources).containsExactly(foreignClassLoader.enumeratedResource);
+        assertThat(foreignClassLoader.resourcesLookups).containsExactly(RESOURCE_NAME);
+    }
+
+    private static ForeignStrategy newForeignStrategy(ClassLoader foreignClassLoader) throws Exception {
+        ClassWorld world = new ClassWorld();
+        ClassRealm realm = world.newRealm(REALM_ID);
+        return new ForeignStrategy(realm, foreignClassLoader);
+    }
+
+    private static List<URL> resources(Enumeration<?> enumeration) {
+        List<URL> resources = new ArrayList<>();
+        while (enumeration.hasMoreElements()) {
+            resources.add((URL) enumeration.nextElement());
+        }
+        return resources;
+    }
+
+    private static URL fileUrl(String path) {
+        try {
+            return new URL("file", "", path);
+        } catch (MalformedURLException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public static final class ForeignLoadTarget {
+    }
+
+    private static final class RecordingClassLoader extends ClassLoader {
+        private final URL resource = fileUrl("/foreign-resource.txt");
+        private final URL enumeratedResource = fileUrl("/foreign-enumerated-resource.txt");
+        private final List<String> resourceLookups = new ArrayList<>();
+        private final List<String> resourcesLookups = new ArrayList<>();
+
+        private RecordingClassLoader() {
+            super(null);
+        }
+
+        @Override
+        public URL getResource(String name) {
+            resourceLookups.add(name);
+            if (RESOURCE_NAME.equals(name)) {
+                return resource;
+            }
+            return null;
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            resourcesLookups.add(name);
+            if (RESOURCE_NAME.equals(name)) {
+                return Collections.enumeration(Collections.singletonList(enumeratedResource));
+            }
+            return Collections.emptyEnumeration();
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ForeignStrategyTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ForeignStrategyTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -18,7 +19,7 @@ import java.util.List;
 
 import org.codehaus.plexus.classworlds.ClassWorld;
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
-import org.codehaus.plexus.classworlds.strategy.ForeignStrategy;
+import org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy;
 import org.junit.jupiter.api.Test;
 
 public class ForeignStrategyTest {
@@ -27,10 +28,12 @@ public class ForeignStrategyTest {
     private static final String RESOURCE_NAME = "foreign/resource.txt";
 
     @Test
-    void loadClassConsultsForeignClassLoaderFirst() throws Exception {
-        ClassLoader foreignClassLoader = new ClassLoader(ForeignStrategyTest.class.getClassLoader()) {
+    void loadClassConsultsImportedClassLoaderFirst() throws Exception {
+        ClassLoader foreignClassLoader = new ClassLoader(
+                ForeignStrategyTest.class.getClassLoader()) {
         };
-        ForeignStrategy strategy = newForeignStrategy(foreignClassLoader);
+        SelfFirstStrategy strategy = newSelfFirstStrategy(
+                foreignClassLoader, ForeignLoadTarget.class.getPackageName());
 
         Class<?> loadedClass = strategy.loadClass(CLASS_NAME);
 
@@ -38,31 +41,33 @@ public class ForeignStrategyTest {
     }
 
     @Test
-    void getResourceConsultsForeignClassLoaderFirst() throws Exception {
+    void getResourceConsultsImportedClassLoaderFirst() throws Exception {
         RecordingClassLoader foreignClassLoader = new RecordingClassLoader();
-        ForeignStrategy strategy = newForeignStrategy(foreignClassLoader);
+        SelfFirstStrategy strategy = newSelfFirstStrategy(foreignClassLoader, "foreign");
 
-        URL resource = strategy.getResource("/" + RESOURCE_NAME);
+        URL resource = strategy.getResource(RESOURCE_NAME);
 
         assertThat(resource).isEqualTo(foreignClassLoader.resource);
         assertThat(foreignClassLoader.resourceLookups).containsExactly(RESOURCE_NAME);
     }
 
     @Test
-    void findResourcesIncludesResourcesFromForeignClassLoader() throws Exception {
+    void getResourcesIncludesResourcesFromImportedClassLoader() throws Exception {
         RecordingClassLoader foreignClassLoader = new RecordingClassLoader();
-        ForeignStrategy strategy = newForeignStrategy(foreignClassLoader);
+        SelfFirstStrategy strategy = newSelfFirstStrategy(foreignClassLoader, "foreign");
 
-        List<URL> resources = resources(strategy.findResources("/" + RESOURCE_NAME));
+        List<URL> resources = resources(strategy.getResources(RESOURCE_NAME));
 
         assertThat(resources).containsExactly(foreignClassLoader.enumeratedResource);
         assertThat(foreignClassLoader.resourcesLookups).containsExactly(RESOURCE_NAME);
     }
 
-    private static ForeignStrategy newForeignStrategy(ClassLoader foreignClassLoader) throws Exception {
+    private static SelfFirstStrategy newSelfFirstStrategy(
+            ClassLoader foreignClassLoader, String importedPackage) throws Exception {
         ClassWorld world = new ClassWorld();
         ClassRealm realm = world.newRealm(REALM_ID);
-        return new ForeignStrategy(realm, foreignClassLoader);
+        realm.importFrom(foreignClassLoader, importedPackage);
+        return new SelfFirstStrategy(realm);
     }
 
     private static List<URL> resources(Enumeration<?> enumeration) {
@@ -75,7 +80,7 @@ public class ForeignStrategyTest {
 
     private static URL fileUrl(String path) {
         try {
-            return new URL("file", "", path);
+            return Path.of(path).toUri().toURL();
         } catch (MalformedURLException e) {
             throw new IllegalStateException(e);
         }

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/src/test/java/org_codehaus_plexus/plexus_classworlds/LauncherTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/src/test/java/org_codehaus_plexus/plexus_classworlds/LauncherTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_classworlds;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.launcher.Launcher;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.junit.jupiter.api.Test;
+
+public class LauncherTest {
+    private static final String REALM_ID = "test";
+    private static final String CLASSWORLDS_CONF_PROPERTY = "classworlds.conf";
+    private static final String BOOTSTRAPPED_PROPERTY = "classworlds.bootstrapped";
+
+    @Test
+    void launchInvokesEnhancedMainMethodFromConfiguredRealm() throws Exception {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        EnhancedMain.reset();
+        Launcher launcher = configuredLauncher(EnhancedMain.class);
+        try {
+            launcher.launch(new String[] {"alpha", "beta"});
+
+            assertThat(EnhancedMain.args).containsExactly("alpha", "beta");
+            assertThat(EnhancedMain.world).isSameAs(launcher.getWorld());
+            assertThat(Thread.currentThread().getContextClassLoader()).isSameAs(launcher.getMainRealm());
+            assertThat(launcher.getExitCode()).isEqualTo(21);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    @Test
+    void launchFallsBackToStandardMainMethodFromConfiguredRealm() throws Exception {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        StandardMain.reset();
+        Launcher launcher = configuredLauncher(StandardMain.class);
+        try {
+            launcher.launch(new String[] {"gamma"});
+
+            assertThat(StandardMain.args).containsExactly("gamma");
+            assertThat(Thread.currentThread().getContextClassLoader()).isSameAs(launcher.getMainRealm());
+            assertThat(launcher.getExitCode()).isEqualTo(34);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    @Test
+    void mainWithExitCodeLoadsClasspathConfigurationResource() throws Exception {
+        StandardResourceMain.reset();
+        withLauncherResourceLookup(false, () -> {
+            int exitCode = Launcher.mainWithExitCode(new String[] {"from-classpath"});
+
+            assertThat(exitCode).isEqualTo(55);
+            assertThat(StandardResourceMain.args).containsExactly("from-classpath");
+        });
+    }
+
+    @Test
+    void mainWithExitCodeLoadsBootstrappedUberjarConfigurationResource() throws Exception {
+        EnhancedResourceMain.reset();
+        withLauncherResourceLookup(true, () -> {
+            int exitCode = Launcher.mainWithExitCode(new String[] {"from-uberjar"});
+
+            assertThat(exitCode).isEqualTo(89);
+            assertThat(EnhancedResourceMain.args).containsExactly("from-uberjar");
+            assertThat(EnhancedResourceMain.world).isNotNull();
+        });
+    }
+
+    private static Launcher configuredLauncher(Class<?> mainClass) throws Exception {
+        ClassLoader classLoader = LauncherTest.class.getClassLoader();
+        ClassWorld world = new ClassWorld();
+        ClassRealm realm = world.newRealm(REALM_ID, classLoader);
+        Launcher launcher = new Launcher();
+        launcher.setSystemClassLoader(classLoader);
+        launcher.setWorld(world);
+        launcher.setAppMain(mainClass.getName(), realm.getId());
+        return launcher;
+    }
+
+    private static void withLauncherResourceLookup(boolean bootstrapped, ThrowingRunnable runnable) throws Exception {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        String originalConf = System.getProperty(CLASSWORLDS_CONF_PROPERTY);
+        String originalBootstrapped = System.getProperty(BOOTSTRAPPED_PROPERTY);
+        try {
+            Thread.currentThread().setContextClassLoader(LauncherTest.class.getClassLoader());
+            System.clearProperty(CLASSWORLDS_CONF_PROPERTY);
+            if (bootstrapped) {
+                System.setProperty(BOOTSTRAPPED_PROPERTY, "true");
+            } else {
+                System.clearProperty(BOOTSTRAPPED_PROPERTY);
+            }
+            runnable.run();
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+            restoreProperty(CLASSWORLDS_CONF_PROPERTY, originalConf);
+            restoreProperty(BOOTSTRAPPED_PROPERTY, originalBootstrapped);
+        }
+    }
+
+    private static void restoreProperty(String property, String value) {
+        if (value == null) {
+            System.clearProperty(property);
+        } else {
+            System.setProperty(property, value);
+        }
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+
+    public static class EnhancedMain {
+        private static String[] args;
+        private static ClassWorld world;
+
+        public static int main(String[] arguments, ClassWorld classWorld) {
+            args = arguments.clone();
+            world = classWorld;
+            return 21;
+        }
+
+        private static void reset() {
+            args = null;
+            world = null;
+        }
+    }
+
+    public static class StandardMain {
+        private static String[] args;
+
+        public static int main(String[] arguments) {
+            args = arguments.clone();
+            return 34;
+        }
+
+        private static void reset() {
+            args = null;
+        }
+    }
+
+    public static class StandardResourceMain {
+        private static String[] args;
+
+        public static int main(String[] arguments) {
+            args = arguments.clone();
+            return 55;
+        }
+
+        private static void reset() {
+            args = null;
+        }
+    }
+
+    public static class EnhancedResourceMain {
+        private static String[] args;
+        private static ClassWorld world;
+
+        public static int main(String[] arguments, ClassWorld classWorld) {
+            args = arguments.clone();
+            world = classWorld;
+            return 89;
+        }
+
+        private static void reset() {
+            args = null;
+            world = null;
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,42 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type" : "org_codehaus_plexus.plexus_classworlds.LauncherTest$EnhancedMain"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type" : "org_codehaus_plexus.plexus_classworlds.LauncherTest$EnhancedResourceMain"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type" : "org_codehaus_plexus.plexus_classworlds.LauncherTest$StandardMain"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type" : "org_codehaus_plexus.plexus_classworlds.LauncherTest$StandardResourceMain"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "glob" : "WORLDS-INF/conf/classworlds.conf"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.realm.ClassRealm"
+      },
+      "glob" : "classworlds.conf"
+    }
+  ]
+}

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -23,6 +23,76 @@
         "typeReached" : "org.codehaus.plexus.classworlds.launcher.Launcher"
       },
       "type" : "org_codehaus_plexus.plexus_classworlds.LauncherTest$StandardResourceMain"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.DefaultStrategyTest"
+      },
+      "type" : "org.codehaus.plexus.classworlds.ClassWorld"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.ClassRealmTest"
+      },
+      "type" : "org_codehaus_plexus.plexus_classworlds.ClassRealmTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.LauncherTest"
+      },
+      "type" : "org_codehaus_plexus.plexus_classworlds.LauncherTest$EnhancedMain",
+      "methods" : [
+        {
+          "name" : "main",
+          "parameterTypes" : [
+            "java.lang.String[]",
+            "org.codehaus.plexus.classworlds.ClassWorld"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.LauncherTest"
+      },
+      "type" : "org_codehaus_plexus.plexus_classworlds.LauncherTest$EnhancedResourceMain",
+      "methods" : [
+        {
+          "name" : "main",
+          "parameterTypes" : [
+            "java.lang.String[]",
+            "org.codehaus.plexus.classworlds.ClassWorld"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.LauncherTest"
+      },
+      "type" : "org_codehaus_plexus.plexus_classworlds.LauncherTest$StandardMain",
+      "methods" : [
+        {
+          "name" : "main",
+          "parameterTypes" : [
+            "java.lang.String[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.LauncherTest"
+      },
+      "type" : "org_codehaus_plexus.plexus_classworlds.LauncherTest$StandardResourceMain",
+      "methods" : [
+        {
+          "name" : "main",
+          "parameterTypes" : [
+            "java.lang.String[]"
+          ]
+        }
+      ]
     }
   ],
   "resources" : [
@@ -35,6 +105,36 @@
     {
       "condition" : {
         "typeReached" : "org.codehaus.plexus.classworlds.realm.ClassRealm"
+      },
+      "glob" : "classworlds.conf"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.ClassRealmTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.ClassRealmTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.LauncherTest"
+      },
+      "glob" : "WORLDS-INF/conf/classworlds.conf"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.ClassRealmTest"
+      },
+      "glob" : "classworlds.conf"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.LauncherTest"
       },
       "glob" : "classworlds.conf"
     }

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/src/test/resources/WORLDS-INF/conf/classworlds.conf
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/src/test/resources/WORLDS-INF/conf/classworlds.conf
@@ -1,0 +1,3 @@
+main is org_codehaus_plexus.plexus_classworlds.LauncherTest$EnhancedResourceMain from test
+
+[test]

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/src/test/resources/classworlds.conf
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/src/test/resources/classworlds.conf
@@ -1,0 +1,3 @@
+main is org_codehaus_plexus.plexus_classworlds.LauncherTest$StandardResourceMain from test
+
+[test]

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/user-code-filter.json
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/user-code-filter.json
@@ -1,0 +1,16 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.codehaus.classworlds.**"
+    },
+    {
+      "includeClasses" : "org.codehaus.plexus.classworlds.**"
+    },
+    {
+      "includeClasses" : "org_codehaus_plexus.plexus_classworlds.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7179

This PR provides test fixes and new metadata for org.codehaus.plexus:plexus-classworlds:2.0.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 66578
- Cached input tokens: 493568
- Output tokens: 7325
- Metadata entries: 4
- Test-only metadata entries: 21
- Iterations: 1
- Library coverage percentage: 42.76
- Previous library version metadata entries: 3
- Previous library version test-only metadata entries: 6
- Previous library version coverage percentage: 25.54

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `a02a60d1ff46eda0d11aa3fad709aba71d534a12`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.codehaus.plexus:plexus-classworlds:1.5.0: 16/16 covered calls (100.00%)
- org.codehaus.plexus:plexus-classworlds:2.0.0: 14/14 covered calls (100.00%)

**Reflection:**
- org.codehaus.plexus:plexus-classworlds:1.5.0: 9/9 covered calls (100.00%)
- org.codehaus.plexus:plexus-classworlds:2.0.0: 8/8 covered calls (100.00%)

**Resources:**
- org.codehaus.plexus:plexus-classworlds:1.5.0: 7/7 covered calls (100.00%)
- org.codehaus.plexus:plexus-classworlds:2.0.0: 6/6 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.codehaus.plexus:plexus-classworlds:1.5.0: 857/3557 (24.09%)
- org.codehaus.plexus:plexus-classworlds:2.0.0: 934/2360 (39.58%)

**Line:**
- org.codehaus.plexus:plexus-classworlds:1.5.0: 235/920 (25.54%)
- org.codehaus.plexus:plexus-classworlds:2.0.0: 254/594 (42.76%)

**Method:**
- org.codehaus.plexus:plexus-classworlds:1.5.0: 64/249 (25.70%)
- org.codehaus.plexus:plexus-classworlds:2.0.0: 65/119 (54.62%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java b/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java
index 3e5cbca78d..a8c30a39e5 100644
--- a/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java
@@ -19,19 +19,19 @@ public class ClassRealmTest {
     private static final String REALM_ID = "direct-realm";
 
     @Test
-    void loadRealmClassLoadsClassThroughRealmClassLoader() throws Exception {
+    void loadClassLoadsClassThroughRealmClassLoader() throws Exception {
         ClassRealm realm = newRealm();
 
-        Class<?> loadedClass = realm.loadRealmClass(ClassRealmTest.class.getName());
+        Class<?> loadedClass = realm.loadClass(ClassRealmTest.class.getName());
 
         assertThat(loadedClass).isSameAs(ClassRealmTest.class);
     }
 
     @Test
-    void getRealmResourceLoadsResourceThroughRealmClassLoader() throws Exception {
+    void getResourceLoadsResourceThroughRealmClassLoader() throws Exception {
         ClassRealm realm = newRealm();
 
-        URL resource = realm.getRealmResource("classworlds.conf");
+        URL resource = realm.getResource("classworlds.conf");
 
         assertThat(resource).isNotNull();
     }
diff --git a/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/src/test/java/org_codehaus_plexus/plexus_classworlds/DefaultStrategyTest.java b/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/src/test/java/org_codehaus_plexus/plexus_classworlds/DefaultStrategyTest.java
index 3729c16066..1ee3eeb180 100644
--- a/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/src/test/java/org_codehaus_plexus/plexus_classworlds/DefaultStrategyTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/src/test/java/org_codehaus_plexus/plexus_classworlds/DefaultStrategyTest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.codehaus.plexus.classworlds.ClassWorld;
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
-import org.codehaus.plexus.classworlds.strategy.DefaultStrategy;
+import org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy;
 import org.junit.jupiter.api.Test;
 
 public class DefaultStrategyTest {
@@ -22,7 +22,7 @@ public class DefaultStrategyTest {
 
         Class<?> loadedClass = realm.loadClass(ClassWorld.class.getName());
 
-        assertThat(realm.getStrategy()).isInstanceOf(DefaultStrategy.class);
+        assertThat(realm.getStrategy()).isInstanceOf(SelfFirstStrategy.class);
         assertThat(loadedClass).isSameAs(ClassWorld.class);
     }
 }
diff --git a/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ForeignStrategyTest.java b/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ForeignStrategyTest.java
index ebf1e9e6d9..1c0da27059 100644
--- a/tests/src/org.codehaus.plexus/plexus-classworlds/1.5.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ForeignStrategyTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ForeignStrategyTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -18,7 +19,7 @@ import java.util.List;
 
 import org.codehaus.plexus.classworlds.ClassWorld;
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
-import org.codehaus.plexus.classworlds.strategy.ForeignStrategy;
+import org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy;
 import org.junit.jupiter.api.Test;
 
 public class ForeignStrategyTest {
@@ -27,10 +28,12 @@ public class ForeignStrategyTest {
     private static final String RESOURCE_NAME = "foreign/resource.txt";
 
     @Test
-    void loadClassConsultsForeignClassLoaderFirst() throws Exception {
-        ClassLoader foreignClassLoader = new ClassLoader(ForeignStrategyTest.class.getClassLoader()) {
+    void loadClassConsultsImportedClassLoaderFirst() throws Exception {
+        ClassLoader foreignClassLoader = new ClassLoader(
+                ForeignStrategyTest.class.getClassLoader()) {
         };
-        ForeignStrategy strategy = newForeignStrategy(foreignClassLoader);
+        SelfFirstStrategy strategy = newSelfFirstStrategy(
+                foreignClassLoader, ForeignLoadTarget.class.getPackageName());
 
         Class<?> loadedClass = strategy.loadClass(CLASS_NAME);
 
@@ -38,31 +41,33 @@ public class ForeignStrategyTest {
     }
 
     @Test
-    void getResourceConsultsForeignClassLoaderFirst() throws Exception {
+    void getResourceConsultsImportedClassLoaderFirst() throws Exception {
         RecordingClassLoader foreignClassLoader = new RecordingClassLoader();
-        ForeignStrategy strategy = newForeignStrategy(foreignClassLoader);
+        SelfFirstStrategy strategy = newSelfFirstStrategy(foreignClassLoader, "foreign");
 
-        URL resource = strategy.getResource("/" + RESOURCE_NAME);
+        URL resource = strategy.getResource(RESOURCE_NAME);
 
         assertThat(resource).isEqualTo(foreignClassLoader.resource);
         assertThat(foreignClassLoader.resourceLookups).containsExactly(RESOURCE_NAME);
     }
 
     @Test
-    void findResourcesIncludesResourcesFromForeignClassLoader() throws Exception {
+    void getResourcesIncludesResourcesFromImportedClassLoader() throws Exception {
         RecordingClassLoader foreignClassLoader = new RecordingClassLoader();
-        ForeignStrategy strategy = newForeignStrategy(foreignClassLoader);
+        SelfFirstStrategy strategy = newSelfFirstStrategy(foreignClassLoader, "foreign");
 
-        List<URL> resources = resources(strategy.findResources("/" + RESOURCE_NAME));
+        List<URL> resources = resources(strategy.getResources(RESOURCE_NAME));
 
         assertThat(resources).containsExactly(foreignClassLoader.enumeratedResource);
         assertThat(foreignClassLoader.resourcesLookups).containsExactly(RESOURCE_NAME);
     }
 
-    private static ForeignStrategy newForeignStrategy(ClassLoader foreignClassLoader) throws Exception {
+    private static SelfFirstStrategy newSelfFirstStrategy(
+            ClassLoader foreignClassLoader, String importedPackage) throws Exception {
         ClassWorld world = new ClassWorld();
         ClassRealm realm = world.newRealm(REALM_ID);
-        return new ForeignStrategy(realm, foreignClassLoader);
+        realm.importFrom(foreignClassLoader, importedPackage);
+        return new SelfFirstStrategy(realm);
     }
 
     private static List<URL> resources(Enumeration<?> enumeration) {
@@ -75,7 +80,7 @@ public class ForeignStrategyTest {
 
     private static URL fileUrl(String path) {
         try {
-            return new URL("file", "", path);
+            return Path.of(path).toUri().toURL();
         } catch (MalformedURLException e) {
             throw new IllegalStateException(e);
         }

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
