### PR TITLE
[GenAI] Test fix for org.springframework.boot:spring-boot-amqp:4.1.0-M3 using gpt-5.5

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-amqp/4.1.0-M3/reachability-metadata.json
+++ b/metadata/org.springframework.boot/spring-boot-amqp/4.1.0-M3/reachability-metadata.json
@@ -1,0 +1,206 @@
+{
+  "reflection": [
+    {
+      "type": "org.springframework.boot.amqp.autoconfigure.AmqpAutoConfiguration",
+      "allDeclaredConstructors": true
+    },
+    {
+      "type": "org.springframework.boot.amqp.autoconfigure.AmqpAutoConfiguration$AmqpConnectionFactoryConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "protonClient",
+          "parameterTypes": []
+        },
+        {
+          "name": "amqpConnectionDetails",
+          "parameterTypes": [
+            "org.springframework.boot.amqp.autoconfigure.AmqpProperties"
+          ]
+        },
+        {
+          "name": "amqpConnectionFactory",
+          "parameterTypes": [
+            "org.springframework.boot.amqp.autoconfigure.AmqpConnectionDetails",
+            "org.apache.qpid.protonj2.client.Client",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.amqp.autoconfigure.AmqpAutoConfiguration$AmqpClientConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "amqpClient",
+          "parameterTypes": [
+            "org.springframework.amqp.client.AmqpConnectionFactory",
+            "org.springframework.boot.amqp.autoconfigure.AmqpProperties",
+            "org.springframework.beans.factory.ObjectProvider",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.amqp.autoconfigure.AmqpAutoConfiguration$JacksonMessageConverterConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "jacksonJsonMessageConverter",
+          "parameterTypes": [
+            "tools.jackson.databind.json.JsonMapper"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.amqp.autoconfigure.AmqpProperties",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.amqp.autoconfigure.AmqpProperties$Client",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.OnClassCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.OnBeanCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.OnPropertyCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.springframework.boot.autoconfigure.AutoConfiguration"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.springframework.boot.autoconfigure.condition.ConditionalOnClass"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.springframework.boot.context.properties.EnableConfigurationProperties"
+        ]
+      }
+    },
+    {
+      "type": "org.springframework.boot.context.properties.EnableConfigurationPropertiesRegistrar",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.properties.ConfigurationPropertiesBindingPostProcessor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.properties.ConfigurationPropertiesBinder$ConfigurationPropertiesBinderFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.properties.BoundConfigurationProperties",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.validation.beanvalidation.MethodValidationExcludeFilter",
+      "methods": [
+        {
+          "name": "byAnnotation",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.springframework.context.ConfigurableApplicationContext",
+          "org.springframework.boot.test.context.assertj.AssertableApplicationContext"
+        ]
+      }
+    }
+  ],
+  "resources": [
+    {
+      "glob": "org/springframework/boot/amqp/autoconfigure/*.class"
+    },
+    {
+      "glob": "META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports"
+    },
+    {
+      "glob": "META-INF/spring-autoconfigure-metadata.properties"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/AutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/condition/ConditionalOnClass.class"
+    },
+    {
+      "glob": "org/springframework/boot/context/properties/EnableConfigurationProperties.class"
+    },
+    {
+      "glob": "org/springframework/boot/context/properties/EnableConfigurationPropertiesRegistrar.class"
+    }
+  ]
+}

--- a/metadata/org.springframework.boot/spring-boot-amqp/index.json
+++ b/metadata/org.springframework.boot/spring-boot-amqp/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "4.1.0-M3",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-amqp/$version$/spring-boot-amqp-$version$-sources.jar",
+    "repository-url" : "https://github.com/spring-projects/spring-boot",
+    "test-code-url" : "https://github.com/spring-projects/spring-boot/tree/v$version$/module/spring-boot-amqp/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-amqp/$version$/spring-boot-amqp-$version$-javadoc.jar",
+    "description" : "Spring Boot AMQP provides auto-configuration and support classes for AMQP 1.0 messaging in Spring Boot applications. It configures ProtonJ2-backed connection factories, AMQP clients, Jackson message conversion, connection properties, Docker Compose integration, and Testcontainers connection details.",
     "tested-versions" : [
       "4.1.0-M3"
     ],

--- a/metadata/org.springframework.boot/spring-boot-amqp/index.json
+++ b/metadata/org.springframework.boot/spring-boot-amqp/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "4.1.0-M3",
+    "tested-versions" : [
+      "4.1.0-M3"
+    ],
+    "allowed-packages" : [
+      "org.springframework.boot.amqp"
+    ]
+  },
+  {
     "metadata-version" : "4.0.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-amqp/$version$/spring-boot-amqp-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-boot",

--- a/stats/org.springframework.boot/spring-boot-amqp/4.1.0-M3/execution-metrics.json
+++ b/stats/org.springframework.boot/spring-boot-amqp/4.1.0-M3/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_javac_fail:2026-06-07": {
+    "timestamp": "2026-06-07T13:43:50.530051Z",
+    "library": "org.springframework.boot:spring-boot-amqp:4.1.0-M3",
+    "starting_commit": "1af5506c62b5ac43c961a99bb48f8a690cec6010",
+    "ending_commit": "31b0e2e36df93eb992362b6802e86a893a47c45e",
+    "previous_library": "org.springframework.boot:spring-boot-amqp:4.0.2",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.1.0-M3",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 262,
+          "missed": 123,
+          "ratio": 0.680519,
+          "total": 385
+        },
+        "line": {
+          "covered": 62,
+          "missed": 28,
+          "ratio": 0.688889,
+          "total": 90
+        },
+        "method": {
+          "covered": 33,
+          "missed": 17,
+          "ratio": 0.66,
+          "total": 50
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "4.0.2",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2149,
+          "missed": 1136,
+          "ratio": 0.654186,
+          "total": 3285
+        },
+        "line": {
+          "covered": 538,
+          "missed": 277,
+          "ratio": 0.660123,
+          "total": 815
+        },
+        "method": {
+          "covered": 202,
+          "missed": 112,
+          "ratio": 0.643312,
+          "total": 314
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 61480,
+      "cached_input_tokens_used": 774144,
+      "output_tokens_used": 7805,
+      "iterations": 1,
+      "cost_usd": 0.6212,
+      "tested_library_loc": 62,
+      "metadata_entries": 48,
+      "previous_library_metadata_entries": 0,
+      "code_coverage_percent": 68.89,
+      "previous_library_coverage_percent": 66.01
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M3/src/test/java/org_springframework_boot/spring_boot_amqp/Spring_boot_amqpTest.java",
+      "metadata_file": "metadata/org.springframework.boot/spring-boot-amqp/4.1.0-M3/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.springframework.boot/spring-boot-amqp/4.1.0-M3/stats.json
+++ b/stats/org.springframework.boot/spring-boot-amqp/4.1.0-M3/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.1.0-M3",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 262,
+        "missed" : 123,
+        "ratio" : 0.680519,
+        "total" : 385
+      },
+      "line" : {
+        "covered" : 62,
+        "missed" : 28,
+        "ratio" : 0.688889,
+        "total" : 90
+      },
+      "method" : {
+        "covered" : 33,
+        "missed" : 17,
+        "ratio" : 0.66,
+        "total" : 50
+      }
+    }
+  } ]
+}

--- a/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M3/.gitignore
+++ b/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M3/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M3/build.gradle
+++ b/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M3/build.gradle
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.springframework.boot:spring-boot-amqp:$libraryVersion"
+    testImplementation "org.springframework.boot:spring-boot-autoconfigure:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M3/build.gradle
+++ b/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M3/build.gradle
@@ -13,6 +13,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.springframework.boot:spring-boot-amqp:$libraryVersion"
     testImplementation "org.springframework.boot:spring-boot-autoconfigure:$libraryVersion"
+    testImplementation "org.springframework.boot:spring-boot-test:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M3/gradle.properties
+++ b/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M3/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.springframework.boot:spring-boot-amqp:4.1.0-M3
+library.version = 4.1.0-M3
+metadata.dir = org.springframework.boot/spring-boot-amqp/4.1.0-M3/

--- a/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M3/settings.gradle
+++ b/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M3/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.springframework.boot.spring-boot-amqp_tests'

--- a/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M3/src/test/java/org_springframework_boot/spring_boot_amqp/Spring_boot_amqpTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M3/src/test/java/org_springframework_boot/spring_boot_amqp/Spring_boot_amqpTest.java
@@ -6,988 +6,129 @@
  */
 package org_springframework_boot.spring_boot_amqp;
 
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import com.rabbitmq.client.impl.CredentialsProvider;
-import com.rabbitmq.client.impl.CredentialsRefreshService;
-import org.aopalliance.aop.Advice;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.amqp.core.AcknowledgeMode;
-import org.springframework.amqp.core.Message;
-import org.springframework.amqp.core.MessageProperties;
-import org.springframework.amqp.rabbit.config.DirectRabbitListenerContainerFactory;
-import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
-import org.springframework.amqp.rabbit.config.SimpleRabbitListenerEndpoint;
-import org.springframework.amqp.rabbit.connection.AbstractConnectionFactory.AddressShuffleMode;
-import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
-import org.springframework.amqp.rabbit.connection.CachingConnectionFactory.CacheMode;
-import org.springframework.amqp.rabbit.connection.CachingConnectionFactory.ConfirmType;
-import org.springframework.amqp.rabbit.connection.ConnectionFactory;
-import org.springframework.amqp.rabbit.connection.ConnectionNameStrategy;
-import org.springframework.amqp.rabbit.connection.RabbitConnectionFactoryBean;
-import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.amqp.rabbit.listener.DirectMessageListenerContainer;
-import org.springframework.amqp.support.converter.MessageConverter;
-import org.springframework.amqp.support.converter.SimpleMessageConverter;
-import org.springframework.boot.amqp.autoconfigure.CachingConnectionFactoryConfigurer;
-import org.springframework.boot.amqp.autoconfigure.DirectRabbitListenerContainerFactoryConfigurer;
-import org.springframework.boot.amqp.autoconfigure.RabbitConnectionDetails;
-import org.springframework.boot.amqp.autoconfigure.RabbitConnectionFactoryBeanConfigurer;
-import org.springframework.boot.amqp.autoconfigure.RabbitProperties;
-import org.springframework.boot.amqp.autoconfigure.RabbitProperties.ContainerType;
-import org.springframework.boot.amqp.autoconfigure.RabbitTemplateConfigurer;
-import org.springframework.boot.amqp.autoconfigure.SimpleRabbitListenerContainerFactoryConfigurer;
-import org.springframework.boot.context.properties.source.InvalidConfigurationPropertyValueException;
-import org.springframework.core.io.DefaultResourceLoader;
-import org.springframework.core.retry.RetryTemplate;
-import org.springframework.util.unit.DataSize;
+import org.springframework.amqp.client.AmqpClient;
+import org.springframework.amqp.client.AmqpConnectionFactory;
+import org.springframework.amqp.client.SingleAmqpConnectionFactory;
+import org.springframework.boot.amqp.autoconfigure.AmqpAutoConfiguration;
+import org.springframework.boot.amqp.autoconfigure.AmqpClientCustomizer;
+import org.springframework.boot.amqp.autoconfigure.AmqpConnectionDetails;
+import org.springframework.boot.amqp.autoconfigure.AmqpProperties;
+import org.springframework.boot.amqp.autoconfigure.ConnectionOptionsCustomizer;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class Spring_boot_amqpTest {
 
-    @Test
-    void rabbitPropertiesDetermineConnectionValuesFromDefaultsSslAndAddresses() {
-        RabbitProperties properties = new RabbitProperties();
-
-        assertThat(properties.determineHost()).isEqualTo("localhost");
-        assertThat(properties.determinePort()).isEqualTo(5672);
-        assertThat(properties.determineAddresses()).containsExactly("localhost:5672");
-        assertThat(properties.determineUsername()).isEqualTo("guest");
-        assertThat(properties.determinePassword()).isEqualTo("guest");
-        assertThat(properties.getSsl().determineEnabled()).isFalse();
-
-        properties.getSsl().setEnabled(true);
-        properties.setAddresses(
-                List.of("amqps://alice:secret@rabbit-one.example.test/orders", "rabbit-two.example.test:5673"));
-
-        assertThat(properties.determineHost()).isEqualTo("rabbit-one.example.test");
-        assertThat(properties.determinePort()).isEqualTo(5671);
-        assertThat(properties.determineAddresses()).containsExactly("rabbit-one.example.test:5671",
-                "rabbit-two.example.test:5673");
-        assertThat(properties.determineUsername()).isEqualTo("alice");
-        assertThat(properties.determinePassword()).isEqualTo("secret");
-        assertThat(properties.determineVirtualHost()).isEqualTo("orders");
-        assertThat(properties.getSsl().determineEnabled()).isTrue();
-    }
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(AmqpAutoConfiguration.class));
 
     @Test
-    void rabbitPropertiesExposeNestedTemplateListenerCacheAndStreamSettings() {
-        RabbitProperties properties = new RabbitProperties();
+    void amqpPropertiesExposeConnectionAndClientSettings() {
+        AmqpProperties properties = new AmqpProperties();
+
+        assertThat(properties.getHost()).isEqualTo("localhost");
+        assertThat(properties.getPort()).isEqualTo(5672);
+        assertThat(properties.getUsername()).isNull();
+        assertThat(properties.getPassword()).isNull();
+        assertThat(properties.getClient().getDefaultToAddress()).isNull();
+        assertThat(properties.getClient().getCompletionTimeout()).isEqualTo(Duration.ofSeconds(60));
+
         properties.setHost("broker.example.test");
         properties.setPort(5678);
-        properties.setVirtualHost("");
-        properties.setRequestedHeartbeat(Duration.ofSeconds(9));
-        properties.setConnectionTimeout(Duration.ofMillis(750));
-        properties.setChannelRpcTimeout(Duration.ofSeconds(2));
-        properties.setMaxInboundMessageBodySize(DataSize.ofKilobytes(128));
-        properties.setAddressShuffleMode(AddressShuffleMode.INORDER);
-        properties.getCache().getChannel().setSize(12);
-        properties.getCache().getChannel().setCheckoutTimeout(Duration.ofMillis(25));
-        properties.getCache().getConnection().setMode(CacheMode.CONNECTION);
-        properties.getCache().getConnection().setSize(3);
-        properties.getListener().setType(ContainerType.DIRECT);
-        properties.getListener().getDirect().setConsumersPerQueue(4);
-        properties.getListener().getStream().setNativeListener(true);
-        properties.getTemplate().setExchange("events");
-        properties.getTemplate().setRoutingKey("created");
-        properties.getTemplate().setDefaultReceiveQueue("events.in");
-        properties.getTemplate().setAllowedListPatterns(List.of("java.util.*"));
-        properties.getTemplate().getRetry().setEnabled(true);
-        properties.getTemplate().getRetry().setMaxRetries(5);
-        properties.getStream().setHost("stream.example.test");
-        properties.getStream().setPort(5553);
-        properties.getStream().setName("orders-stream");
+        properties.setUsername("alice");
+        properties.setPassword("secret");
+        properties.getClient().setDefaultToAddress("orders.created");
+        properties.getClient().setCompletionTimeout(Duration.ofMillis(750));
 
-        assertThat(properties.determineAddresses()).containsExactly("broker.example.test:5678");
-        assertThat(properties.determineVirtualHost()).isEqualTo("/");
-        assertThat(properties.getRequestedHeartbeat()).isEqualTo(Duration.ofSeconds(9));
-        assertThat(properties.getConnectionTimeout()).isEqualTo(Duration.ofMillis(750));
-        assertThat(properties.getChannelRpcTimeout()).isEqualTo(Duration.ofSeconds(2));
-        assertThat(properties.getMaxInboundMessageBodySize()).isEqualTo(DataSize.ofKilobytes(128));
-        assertThat(properties.getAddressShuffleMode()).isEqualTo(AddressShuffleMode.INORDER);
-        assertThat(properties.getCache().getChannel().getSize()).isEqualTo(12);
-        assertThat(properties.getCache().getChannel().getCheckoutTimeout()).isEqualTo(Duration.ofMillis(25));
-        assertThat(properties.getCache().getConnection().getMode()).isEqualTo(CacheMode.CONNECTION);
-        assertThat(properties.getCache().getConnection().getSize()).isEqualTo(3);
-        assertThat(properties.getListener().getType()).isEqualTo(ContainerType.DIRECT);
-        assertThat(properties.getListener().getDirect().getConsumersPerQueue()).isEqualTo(4);
-        assertThat(properties.getListener().getStream().isNativeListener()).isTrue();
-        assertThat(properties.getTemplate().getExchange()).isEqualTo("events");
-        assertThat(properties.getTemplate().getRoutingKey()).isEqualTo("created");
-        assertThat(properties.getTemplate().getDefaultReceiveQueue()).isEqualTo("events.in");
-        assertThat(properties.getTemplate().getAllowedListPatterns()).containsExactly("java.util.*");
-        assertThat(properties.getTemplate().getRetry().isEnabled()).isTrue();
-        assertThat(properties.getTemplate().getRetry().getMaxRetries()).isEqualTo(5);
-        assertThat(properties.getStream().getHost()).isEqualTo("stream.example.test");
-        assertThat(properties.getStream().getPort()).isEqualTo(5553);
-        assertThat(properties.getStream().getName()).isEqualTo("orders-stream");
+        assertThat(properties.getHost()).isEqualTo("broker.example.test");
+        assertThat(properties.getPort()).isEqualTo(5678);
+        assertThat(properties.getUsername()).isEqualTo("alice");
+        assertThat(properties.getPassword()).isEqualTo("secret");
+        assertThat(properties.getClient().getDefaultToAddress()).isEqualTo("orders.created");
+        assertThat(properties.getClient().getCompletionTimeout()).isEqualTo(Duration.ofMillis(750));
     }
 
     @Test
-    void rabbitPropertiesRejectCommaSeparatedHostWhenDeterminingAddresses() {
-        RabbitProperties properties = new RabbitProperties();
-        properties.setHost("one.example.test,two.example.test");
+    void amqpConnectionDetailsAddressRecordAndDefaultsAreUsable() {
+        AmqpConnectionDetails.Address address = new AmqpConnectionDetails.Address("broker.example.test", 5679);
+        AmqpConnectionDetails details = () -> address;
 
-        assertThatThrownBy(properties::determineAddresses)
-                .isInstanceOf(InvalidConfigurationPropertyValueException.class)
-                .hasMessageContaining("spring.rabbitmq.host")
-                .hasMessageContaining("spring.rabbitmq.addresses");
-    }
-
-    @Test
-    void rabbitConnectionDetailsDefaultsAndAddressRecordAreUsable() {
-        RabbitConnectionDetails.Address first = new RabbitConnectionDetails.Address("first.example.test", 6001);
-        RabbitConnectionDetails.Address second = new RabbitConnectionDetails.Address("second.example.test", 6002);
-        RabbitConnectionDetails details = connectionDetails(List.of(first, second));
-
-        assertThat(details.getAddresses()).containsExactly(first, second);
-        assertThat(details.getFirstAddress()).isEqualTo(first);
+        assertThat(details.getAddress()).isEqualTo(address);
+        assertThat(details.getAddress().host()).isEqualTo("broker.example.test");
+        assertThat(details.getAddress().port()).isEqualTo(5679);
         assertThat(details.getUsername()).isNull();
         assertThat(details.getPassword()).isNull();
-        assertThat(details.getVirtualHost()).isNull();
-        assertThat(details.getSslBundle()).isNull();
-        assertThat(first.host()).isEqualTo("first.example.test");
-        assertThat(first.port()).isEqualTo(6001);
-    }
 
-    @Test
-    void rabbitTemplateConfigurerAppliesTemplateSettingsAndRetryCustomizers() {
-        RabbitProperties properties = new RabbitProperties();
-        properties.setPublisherReturns(true);
-        properties.getTemplate().setReceiveTimeout(Duration.ofMillis(125));
-        properties.getTemplate().setReplyTimeout(Duration.ofMillis(250));
-        properties.getTemplate().setExchange("orders.exchange");
-        properties.getTemplate().setRoutingKey("orders.created");
-        properties.getTemplate().setDefaultReceiveQueue("orders.in");
-        properties.getTemplate().setObservationEnabled(true);
-        properties.getTemplate().getRetry().setEnabled(true);
-        properties.getTemplate().getRetry().setInitialInterval(Duration.ofMillis(10));
-        properties.getTemplate().getRetry().setMaxInterval(Duration.ofMillis(20));
-        CapturingRabbitTemplate template = new CapturingRabbitTemplate();
-        MessageConverter converter = new SimpleMessageConverter();
-        RabbitTemplateConfigurer configurer = new RabbitTemplateConfigurer(properties);
-        AtomicBoolean customizerInvoked = new AtomicBoolean();
-        configurer.setMessageConverter(converter);
-        configurer.setRetrySettingsCustomizers(List.of((settings) -> {
-            customizerInvoked.set(true);
-            settings.getRetryPolicySettings().setMaxRetries(2L);
-        }));
-        CachingConnectionFactory connectionFactory = newCachingConnectionFactory();
+        AmqpConnectionDetails authenticatedDetails = new AmqpConnectionDetails() {
 
-        try {
-            configurer.configure(template, connectionFactory);
-        } finally {
-            connectionFactory.destroy();
-        }
-
-        assertThat(template.getMessageConverter()).isSameAs(converter);
-        assertThat(template.receiveTimeout).isEqualTo(125L);
-        assertThat(template.replyTimeout).isEqualTo(250L);
-        assertThat(template.getExchange()).isEqualTo("orders.exchange");
-        assertThat(template.getRoutingKey()).isEqualTo("orders.created");
-        assertThat(template.getDefaultReceiveQueue()).isEqualTo("orders.in");
-        assertThat(template.observationEnabled).isTrue();
-        assertThat(template.retryTemplate).isNotNull();
-        assertThat(customizerInvoked).isTrue();
-        assertThat(template.isMandatoryFor(new Message(new byte[0], new MessageProperties()))).isTrue();
-    }
-
-    @Test
-    void rabbitTemplateConfigurerUsesExplicitMandatoryFlagOverPublisherReturns() {
-        RabbitProperties properties = new RabbitProperties();
-        properties.setPublisherReturns(true);
-        properties.getTemplate().setMandatory(false);
-        CapturingRabbitTemplate template = new CapturingRabbitTemplate();
-        CachingConnectionFactory connectionFactory = newCachingConnectionFactory();
-
-        try {
-            new RabbitTemplateConfigurer(properties).configure(template, connectionFactory);
-        } finally {
-            connectionFactory.destroy();
-        }
-
-        assertThat(template.isMandatoryFor(new Message(new byte[0], new MessageProperties()))).isFalse();
-    }
-
-    @Test
-    void rabbitTemplateConfigurerReportsInvalidAllowedListConverter() {
-        RabbitProperties properties = new RabbitProperties();
-        properties.getTemplate().setAllowedListPatterns(List.of("java.util.*"));
-        CapturingRabbitTemplate template = new CapturingRabbitTemplate();
-        template.setMessageConverter(new PassThroughMessageConverter());
-        CachingConnectionFactory connectionFactory = newCachingConnectionFactory();
-
-        try {
-            RabbitTemplateConfigurer configurer = new RabbitTemplateConfigurer(properties);
-
-            assertThatThrownBy(() -> configurer.configure(template, connectionFactory))
-                    .isInstanceOf(InvalidConfigurationPropertyValueException.class)
-                    .hasMessageContaining("spring.rabbitmq.template.allowed-list-patterns");
-        } finally {
-            connectionFactory.destroy();
-        }
-    }
-
-    @Test
-    void cachingConnectionFactoryConfigurerAppliesConnectionFactorySettings() {
-        RabbitProperties properties = new RabbitProperties();
-        properties.setPublisherReturns(true);
-        properties.setPublisherConfirmType(ConfirmType.CORRELATED);
-        properties.setAddressShuffleMode(AddressShuffleMode.RANDOM);
-        properties.getCache().getChannel().setSize(8);
-        properties.getCache().getChannel().setCheckoutTimeout(Duration.ofMillis(50));
-        RabbitConnectionDetails details = connectionDetails(
-                List.of(new RabbitConnectionDetails.Address("rabbit-a.example.test", 6100),
-                        new RabbitConnectionDetails.Address("rabbit-b.example.test", 6101)));
-        CapturingCachingConnectionFactory connectionFactory = new CapturingCachingConnectionFactory();
-        ConnectionNameStrategy nameStrategy = (factory) -> "orders-connection";
-        CachingConnectionFactoryConfigurer configurer = new CachingConnectionFactoryConfigurer(properties, details);
-        configurer.setConnectionNameStrategy(nameStrategy);
-
-        try {
-            configurer.configure(connectionFactory);
-        } finally {
-            connectionFactory.destroy();
-        }
-
-        assertThat(connectionFactory.addresses).isEqualTo("rabbit-a.example.test:6100,rabbit-b.example.test:6101");
-        assertThat(connectionFactory.addressShuffleMode).isEqualTo(AddressShuffleMode.RANDOM);
-        assertThat(connectionFactory.connectionNameStrategy).isSameAs(nameStrategy);
-        assertThat(connectionFactory.publisherReturns).isTrue();
-        assertThat(connectionFactory.publisherConfirmType).isEqualTo(ConfirmType.CORRELATED);
-        assertThat(connectionFactory.channelCacheSize).isEqualTo(8);
-        assertThat(connectionFactory.channelCheckoutTimeout).isEqualTo(50L);
-        assertThat(connectionFactory.cacheMode).isEqualTo(CacheMode.CHANNEL);
-    }
-
-    @Test
-    void rabbitConnectionFactoryBeanConfigurerUsesConnectionDetailsBeforeProperties() throws Exception {
-        RabbitProperties properties = new RabbitProperties();
-        properties.setHost("ignored.example.test");
-        properties.setPort(9999);
-        properties.setUsername("ignored-user");
-        properties.setPassword("ignored-password");
-        properties.setVirtualHost("ignored-vhost");
-        properties.setRequestedHeartbeat(Duration.ofSeconds(7));
-        properties.setRequestedChannelMax(32);
-        properties.setConnectionTimeout(Duration.ofMillis(450));
-        properties.setChannelRpcTimeout(Duration.ofMillis(650));
-        properties.setMaxInboundMessageBodySize(DataSize.ofKilobytes(64));
-        RabbitConnectionDetails details = connectionDetails("detail-user", "detail-password", "detail-vhost",
-                List.of(new RabbitConnectionDetails.Address("details.example.test", 6200)));
-        RabbitConnectionFactoryBean factoryBean = new RabbitConnectionFactoryBean();
-        RabbitConnectionFactoryBeanConfigurer configurer = new RabbitConnectionFactoryBeanConfigurer(
-                new DefaultResourceLoader(), properties, details);
-
-        configurer.configure(factoryBean);
-        factoryBean.afterPropertiesSet();
-
-        com.rabbitmq.client.ConnectionFactory rabbitFactory = factoryBean.getRabbitConnectionFactory();
-        assertThat(rabbitFactory.getHost()).isEqualTo("details.example.test");
-        assertThat(rabbitFactory.getPort()).isEqualTo(6200);
-        assertThat(rabbitFactory.getUsername()).isEqualTo("detail-user");
-        assertThat(rabbitFactory.getPassword()).isEqualTo("detail-password");
-        assertThat(rabbitFactory.getVirtualHost()).isEqualTo("detail-vhost");
-        assertThat(rabbitFactory.getRequestedHeartbeat()).isEqualTo(7);
-        assertThat(rabbitFactory.getRequestedChannelMax()).isEqualTo(32);
-        assertThat(rabbitFactory.getConnectionTimeout()).isEqualTo(450);
-        assertThat(rabbitFactory.getChannelRpcTimeout()).isEqualTo(650);
-    }
-
-    @Test
-    void rabbitConnectionFactoryBeanConfigurerAppliesCredentialsProviderAndRefreshService() {
-        RabbitProperties properties = new RabbitProperties();
-        RabbitConnectionDetails details = connectionDetails(
-                List.of(new RabbitConnectionDetails.Address("credentials.example.test", 6300)));
-        CredentialsProvider credentialsProvider = new StaticCredentialsProvider("rotating-user", "rotating-password");
-        CredentialsRefreshService credentialsRefreshService = new NoOpCredentialsRefreshService();
-        CapturingRabbitConnectionFactoryBean factoryBean = new CapturingRabbitConnectionFactoryBean();
-        RabbitConnectionFactoryBeanConfigurer configurer = new RabbitConnectionFactoryBeanConfigurer(
-                new DefaultResourceLoader(), properties, details);
-
-        configurer.setCredentialsProvider(credentialsProvider);
-        configurer.setCredentialsRefreshService(credentialsRefreshService);
-        configurer.configure(factoryBean);
-
-        assertThat(factoryBean.credentialsProvider).isSameAs(credentialsProvider);
-        assertThat(factoryBean.credentialsRefreshService).isSameAs(credentialsRefreshService);
-        assertThat(factoryBean.credentialsProvider.getUsername()).isEqualTo("rotating-user");
-        assertThat(factoryBean.credentialsProvider.getPassword()).isEqualTo("rotating-password");
-    }
-
-    @Test
-    void rabbitConnectionFactoryBeanConfigurerAppliesSslSettings() {
-        RabbitProperties properties = new RabbitProperties();
-        RabbitProperties.Ssl ssl = properties.getSsl();
-        ssl.setEnabled(true);
-        ssl.setAlgorithm("TLSv1.3");
-        ssl.setKeyStore("classpath:client.p12");
-        ssl.setKeyStoreType("PKCS12");
-        ssl.setKeyStorePassword("key-password");
-        ssl.setKeyStoreAlgorithm("SunX509");
-        ssl.setTrustStore("classpath:trust.p12");
-        ssl.setTrustStoreType("PKCS12");
-        ssl.setTrustStorePassword("trust-password");
-        ssl.setTrustStoreAlgorithm("SunX509");
-        ssl.setValidateServerCertificate(false);
-        ssl.setVerifyHostname(true);
-        RabbitConnectionDetails details = connectionDetails(
-                List.of(new RabbitConnectionDetails.Address("secure.example.test", 5671)));
-        CapturingRabbitConnectionFactoryBean factoryBean = new CapturingRabbitConnectionFactoryBean();
-        RabbitConnectionFactoryBeanConfigurer configurer = new RabbitConnectionFactoryBeanConfigurer(
-                new DefaultResourceLoader(), properties, details);
-
-        configurer.configure(factoryBean);
-
-        assertThat(factoryBean.useSsl).isTrue();
-        assertThat(factoryBean.sslAlgorithm).isEqualTo("TLSv1.3");
-        assertThat(factoryBean.keyStore).isEqualTo("classpath:client.p12");
-        assertThat(factoryBean.keyStoreType).isEqualTo("PKCS12");
-        assertThat(factoryBean.keyStorePassphrase).isEqualTo("key-password");
-        assertThat(factoryBean.keyStoreAlgorithm).isEqualTo("SunX509");
-        assertThat(factoryBean.trustStore).isEqualTo("classpath:trust.p12");
-        assertThat(factoryBean.trustStoreType).isEqualTo("PKCS12");
-        assertThat(factoryBean.trustStorePassphrase).isEqualTo("trust-password");
-        assertThat(factoryBean.trustStoreAlgorithm).isEqualTo("SunX509");
-        assertThat(factoryBean.skipServerCertificateValidation).isTrue();
-        assertThat(factoryBean.enableHostnameVerification).isTrue();
-    }
-
-    @Test
-    void simpleListenerContainerFactoryConfigurerAppliesCommonSimpleAndRetrySettings() {
-        RabbitProperties properties = new RabbitProperties();
-        RabbitProperties.SimpleContainer simple = properties.getListener().getSimple();
-        simple.setAutoStartup(false);
-        simple.setAcknowledgeMode(AcknowledgeMode.MANUAL);
-        simple.setPrefetch(5);
-        simple.setDefaultRequeueRejected(false);
-        simple.setIdleEventInterval(Duration.ofMillis(75));
-        simple.setMissingQueuesFatal(false);
-        simple.setDeBatchingEnabled(false);
-        simple.setForceStop(true);
-        simple.setObservationEnabled(true);
-        simple.setConcurrency(2);
-        simple.setMaxConcurrency(4);
-        simple.setBatchSize(10);
-        simple.setConsumerBatchEnabled(true);
-        simple.getRetry().setEnabled(true);
-        simple.getRetry().setMaxRetries(2);
-        CapturingSimpleRabbitListenerContainerFactory factory = new CapturingSimpleRabbitListenerContainerFactory();
-        Executor executor = Runnable::run;
-        SimpleRabbitListenerContainerFactoryConfigurer configurer = new SimpleRabbitListenerContainerFactoryConfigurer(
-                properties);
-        CachingConnectionFactory connectionFactory = newCachingConnectionFactory();
-        configurer.setTaskExecutor(executor);
-
-        try {
-            configurer.configure(factory, connectionFactory);
-        } finally {
-            connectionFactory.destroy();
-        }
-
-        assertCommonListenerSettings(factory, connectionFactory, executor);
-        assertThat(factory.concurrentConsumers).isEqualTo(2);
-        assertThat(factory.maxConcurrentConsumers).isEqualTo(4);
-        assertThat(factory.batchSize).isEqualTo(10);
-        assertThat(factory.consumerBatchEnabled).isTrue();
-        assertThat(factory.adviceChain).isNotEmpty();
-    }
-
-    @Test
-    void directListenerContainerFactoryConfigurerAppliesCommonAndDirectSettings() {
-        RabbitProperties properties = new RabbitProperties();
-        RabbitProperties.DirectContainer direct = properties.getListener().getDirect();
-        direct.setAutoStartup(false);
-        direct.setAcknowledgeMode(AcknowledgeMode.AUTO);
-        direct.setPrefetch(6);
-        direct.setDefaultRequeueRejected(true);
-        direct.setIdleEventInterval(Duration.ofMillis(80));
-        direct.setMissingQueuesFatal(true);
-        direct.setDeBatchingEnabled(false);
-        direct.setForceStop(true);
-        direct.setObservationEnabled(true);
-        direct.setConsumersPerQueue(3);
-        DirectRabbitListenerContainerFactory factory = new DirectRabbitListenerContainerFactory();
-        Executor executor = Runnable::run;
-        DirectRabbitListenerContainerFactoryConfigurer configurer = new DirectRabbitListenerContainerFactoryConfigurer(
-                properties);
-        CachingConnectionFactory connectionFactory = newCachingConnectionFactory();
-        configurer.setTaskExecutor(executor);
-
-        try {
-            configurer.configure(factory, connectionFactory);
-            SimpleRabbitListenerEndpoint endpoint = new SimpleRabbitListenerEndpoint();
-            endpoint.setId("direct-orders");
-            endpoint.setQueueNames("orders.in");
-            endpoint.setMessageListener((message) -> {
-                throw new AssertionError("Listener should not be invoked");
-            });
-            DirectMessageListenerContainer container = factory.createListenerContainer(endpoint);
-
-            try {
-                assertThat(container.getConnectionFactory()).isSameAs(connectionFactory);
-                assertThat(container.isAutoStartup()).isFalse();
-                assertThat(container.getAcknowledgeMode()).isEqualTo(AcknowledgeMode.AUTO);
-                assertThat(container.getQueueNames()).containsExactly("orders.in");
-            } finally {
-                container.destroy();
+            @Override
+            public AmqpConnectionDetails.Address getAddress() {
+                return address;
             }
-        } finally {
-            connectionFactory.destroy();
-        }
-    }
-
-    private static RabbitConnectionDetails connectionDetails(List<RabbitConnectionDetails.Address> addresses) {
-        return connectionDetails(null, null, null, addresses);
-    }
-
-    private static RabbitConnectionDetails connectionDetails(String username, String password, String virtualHost,
-            List<RabbitConnectionDetails.Address> addresses) {
-        return new RabbitConnectionDetails() {
 
             @Override
             public String getUsername() {
-                return username;
+                return "alice";
             }
 
             @Override
             public String getPassword() {
-                return password;
-            }
-
-            @Override
-            public String getVirtualHost() {
-                return virtualHost;
-            }
-
-            @Override
-            public List<RabbitConnectionDetails.Address> getAddresses() {
-                return addresses;
+                return "secret";
             }
 
         };
+
+        assertThat(authenticatedDetails.getAddress()).isSameAs(address);
+        assertThat(authenticatedDetails.getUsername()).isEqualTo("alice");
+        assertThat(authenticatedDetails.getPassword()).isEqualTo("secret");
     }
 
-    private static CachingConnectionFactory newCachingConnectionFactory() {
-        return new CachingConnectionFactory(new com.rabbitmq.client.ConnectionFactory());
-    }
-
-    private static void assertCommonListenerSettings(CapturingListenerSettings factory,
-            CachingConnectionFactory connectionFactory, Executor executor) {
-        assertThat(factory.connectionFactory()).isSameAs(connectionFactory);
-        assertThat(factory.autoStartup()).isFalse();
-        assertThat(factory.acknowledgeMode()).isNotNull();
-        assertThat(factory.prefetchCount()).isGreaterThan(0);
-        assertThat(factory.defaultRequeueRejected()).isNotNull();
-        assertThat(factory.idleEventInterval()).isGreaterThan(0L);
-        assertThat(factory.deBatchingEnabled()).isFalse();
-        assertThat(factory.forceStop()).isTrue();
-        assertThat(factory.observationEnabled()).isTrue();
-        assertThat(factory.taskExecutor()).isSameAs(executor);
-    }
-
-    private static class CapturingRabbitTemplate extends RabbitTemplate {
-
-        private long receiveTimeout;
-
-        private long replyTimeout;
-
-        private boolean observationEnabled;
-
-        private RetryTemplate retryTemplate;
-
-        @Override
-        public void setReceiveTimeout(long receiveTimeout) {
-            super.setReceiveTimeout(receiveTimeout);
-            this.receiveTimeout = receiveTimeout;
-        }
-
-        @Override
-        public void setReplyTimeout(long replyTimeout) {
-            super.setReplyTimeout(replyTimeout);
-            this.replyTimeout = replyTimeout;
-        }
-
-        @Override
-        public void setObservationEnabled(boolean observationEnabled) {
-            super.setObservationEnabled(observationEnabled);
-            this.observationEnabled = observationEnabled;
-        }
-
-        @Override
-        public void setRetryTemplate(RetryTemplate retryTemplate) {
-            super.setRetryTemplate(retryTemplate);
-            this.retryTemplate = retryTemplate;
-        }
-
-    }
-
-    private static class CapturingRabbitConnectionFactoryBean extends RabbitConnectionFactoryBean {
-
-        private CredentialsProvider credentialsProvider;
-
-        private CredentialsRefreshService credentialsRefreshService;
-
-        private boolean useSsl;
-
-        private String sslAlgorithm;
-
-        private String keyStore;
-
-        private String keyStoreType;
-
-        private String keyStorePassphrase;
-
-        private String keyStoreAlgorithm;
-
-        private String trustStore;
-
-        private String trustStoreType;
-
-        private String trustStorePassphrase;
-
-        private String trustStoreAlgorithm;
-
-        private boolean skipServerCertificateValidation;
-
-        private boolean enableHostnameVerification;
-
-        @Override
-        public void setCredentialsProvider(CredentialsProvider credentialsProvider) {
-            super.setCredentialsProvider(credentialsProvider);
-            this.credentialsProvider = credentialsProvider;
-        }
-
-        @Override
-        public void setCredentialsRefreshService(CredentialsRefreshService credentialsRefreshService) {
-            super.setCredentialsRefreshService(credentialsRefreshService);
-            this.credentialsRefreshService = credentialsRefreshService;
-        }
-
-        @Override
-        public void setUseSSL(boolean useSsl) {
-            super.setUseSSL(useSsl);
-            this.useSsl = useSsl;
-        }
-
-        @Override
-        public void setSslAlgorithm(String sslAlgorithm) {
-            super.setSslAlgorithm(sslAlgorithm);
-            this.sslAlgorithm = sslAlgorithm;
-        }
-
-        @Override
-        public void setKeyStore(String keyStore) {
-            super.setKeyStore(keyStore);
-            this.keyStore = keyStore;
-        }
-
-        @Override
-        public void setKeyStoreType(String keyStoreType) {
-            super.setKeyStoreType(keyStoreType);
-            this.keyStoreType = keyStoreType;
-        }
-
-        @Override
-        public void setKeyStorePassphrase(String keyStorePassphrase) {
-            super.setKeyStorePassphrase(keyStorePassphrase);
-            this.keyStorePassphrase = keyStorePassphrase;
-        }
-
-        @Override
-        public void setKeyStoreAlgorithm(String keyStoreAlgorithm) {
-            super.setKeyStoreAlgorithm(keyStoreAlgorithm);
-            this.keyStoreAlgorithm = keyStoreAlgorithm;
-        }
-
-        @Override
-        public void setTrustStore(String trustStore) {
-            super.setTrustStore(trustStore);
-            this.trustStore = trustStore;
-        }
-
-        @Override
-        public void setTrustStoreType(String trustStoreType) {
-            super.setTrustStoreType(trustStoreType);
-            this.trustStoreType = trustStoreType;
-        }
-
-        @Override
-        public void setTrustStorePassphrase(String trustStorePassphrase) {
-            super.setTrustStorePassphrase(trustStorePassphrase);
-            this.trustStorePassphrase = trustStorePassphrase;
-        }
-
-        @Override
-        public void setTrustStoreAlgorithm(String trustStoreAlgorithm) {
-            super.setTrustStoreAlgorithm(trustStoreAlgorithm);
-            this.trustStoreAlgorithm = trustStoreAlgorithm;
-        }
-
-        @Override
-        public void setSkipServerCertificateValidation(boolean skipServerCertificateValidation) {
-            super.setSkipServerCertificateValidation(skipServerCertificateValidation);
-            this.skipServerCertificateValidation = skipServerCertificateValidation;
-        }
-
-        @Override
-        public void setEnableHostnameVerification(boolean enableHostnameVerification) {
-            super.setEnableHostnameVerification(enableHostnameVerification);
-            this.enableHostnameVerification = enableHostnameVerification;
-        }
-
-    }
-
-    private static class CapturingCachingConnectionFactory extends CachingConnectionFactory {
-
-        private String addresses;
-
-        private AddressShuffleMode addressShuffleMode;
-
-        private ConnectionNameStrategy connectionNameStrategy;
-
-        private boolean publisherReturns;
-
-        private ConfirmType publisherConfirmType;
-
-        private int channelCacheSize;
-
-        private long channelCheckoutTimeout;
-
-        private CacheMode cacheMode;
-
-        private int connectionCacheSize;
-
-        @Override
-        public void setAddresses(String addresses) {
-            super.setAddresses(addresses);
-            this.addresses = addresses;
-        }
-
-        @Override
-        public void setAddressShuffleMode(AddressShuffleMode addressShuffleMode) {
-            super.setAddressShuffleMode(addressShuffleMode);
-            this.addressShuffleMode = addressShuffleMode;
-        }
-
-        @Override
-        public void setConnectionNameStrategy(ConnectionNameStrategy connectionNameStrategy) {
-            super.setConnectionNameStrategy(connectionNameStrategy);
-            this.connectionNameStrategy = connectionNameStrategy;
-        }
-
-        @Override
-        public void setPublisherReturns(boolean publisherReturns) {
-            super.setPublisherReturns(publisherReturns);
-            this.publisherReturns = publisherReturns;
-        }
-
-        @Override
-        public void setPublisherConfirmType(ConfirmType confirmType) {
-            super.setPublisherConfirmType(confirmType);
-            this.publisherConfirmType = confirmType;
-        }
-
-        @Override
-        public void setChannelCacheSize(int sessionCacheSize) {
-            super.setChannelCacheSize(sessionCacheSize);
-            this.channelCacheSize = sessionCacheSize;
-        }
-
-        @Override
-        public void setChannelCheckoutTimeout(long channelCheckoutTimeout) {
-            super.setChannelCheckoutTimeout(channelCheckoutTimeout);
-            this.channelCheckoutTimeout = channelCheckoutTimeout;
-        }
-
-        @Override
-        public void setCacheMode(CacheMode cacheMode) {
-            super.setCacheMode(cacheMode);
-            this.cacheMode = cacheMode;
-        }
-
-        @Override
-        public void setConnectionCacheSize(int connectionCacheSize) {
-            super.setConnectionCacheSize(connectionCacheSize);
-            this.connectionCacheSize = connectionCacheSize;
-        }
-
-    }
-
-    private interface CapturingListenerSettings {
-
-        ConnectionFactory connectionFactory();
-
-        Boolean autoStartup();
-
-        AcknowledgeMode acknowledgeMode();
-
-        Integer prefetchCount();
-
-        Boolean defaultRequeueRejected();
-
-        Long idleEventInterval();
-
-        Boolean deBatchingEnabled();
-
-        Boolean forceStop();
-
-        Boolean observationEnabled();
-
-        Executor taskExecutor();
-
-    }
-
-    private static class CapturingSimpleRabbitListenerContainerFactory extends SimpleRabbitListenerContainerFactory
-            implements CapturingListenerSettings {
-
-        private ConnectionFactory connectionFactory;
-
-        private Boolean autoStartup;
-
-        private AcknowledgeMode acknowledgeMode;
-
-        private Integer prefetchCount;
-
-        private Boolean defaultRequeueRejected;
-
-        private Long idleEventInterval;
-
-        private Boolean missingQueuesFatal;
-
-        private Boolean deBatchingEnabled;
-
-        private Boolean forceStop;
-
-        private Boolean observationEnabled;
-
-        private Executor taskExecutor;
-
-        private Advice[] adviceChain = new Advice[0];
-
-        private Integer concurrentConsumers;
-
-        private Integer maxConcurrentConsumers;
-
-        private Integer batchSize;
-
-        private boolean consumerBatchEnabled;
-
-        @Override
-        public void setConnectionFactory(ConnectionFactory connectionFactory) {
-            super.setConnectionFactory(connectionFactory);
-            this.connectionFactory = connectionFactory;
-        }
-
-        @Override
-        public void setAutoStartup(Boolean autoStartup) {
-            super.setAutoStartup(autoStartup);
-            this.autoStartup = autoStartup;
-        }
-
-        @Override
-        public void setAcknowledgeMode(AcknowledgeMode acknowledgeMode) {
-            super.setAcknowledgeMode(acknowledgeMode);
-            this.acknowledgeMode = acknowledgeMode;
-        }
-
-        @Override
-        public void setPrefetchCount(Integer prefetchCount) {
-            super.setPrefetchCount(prefetchCount);
-            this.prefetchCount = prefetchCount;
-        }
-
-        @Override
-        public void setDefaultRequeueRejected(Boolean defaultRequeueRejected) {
-            super.setDefaultRequeueRejected(defaultRequeueRejected);
-            this.defaultRequeueRejected = defaultRequeueRejected;
-        }
-
-        @Override
-        public void setIdleEventInterval(Long idleEventInterval) {
-            super.setIdleEventInterval(idleEventInterval);
-            this.idleEventInterval = idleEventInterval;
-        }
-
-        @Override
-        public void setMissingQueuesFatal(Boolean missingQueuesFatal) {
-            super.setMissingQueuesFatal(missingQueuesFatal);
-            this.missingQueuesFatal = missingQueuesFatal;
-        }
-
-        @Override
-        public void setDeBatchingEnabled(Boolean deBatchingEnabled) {
-            super.setDeBatchingEnabled(deBatchingEnabled);
-            this.deBatchingEnabled = deBatchingEnabled;
-        }
-
-        @Override
-        public void setForceStop(boolean forceStop) {
-            super.setForceStop(forceStop);
-            this.forceStop = forceStop;
-        }
-
-        @Override
-        public void setObservationEnabled(boolean observationEnabled) {
-            super.setObservationEnabled(observationEnabled);
-            this.observationEnabled = observationEnabled;
-        }
-
-        @Override
-        public void setTaskExecutor(Executor taskExecutor) {
-            super.setTaskExecutor(taskExecutor);
-            this.taskExecutor = taskExecutor;
-        }
-
-        @Override
-        public void setAdviceChain(Advice... adviceChain) {
-            super.setAdviceChain(adviceChain);
-            this.adviceChain = adviceChain;
-        }
-
-        @Override
-        public void setConcurrentConsumers(Integer concurrentConsumers) {
-            super.setConcurrentConsumers(concurrentConsumers);
-            this.concurrentConsumers = concurrentConsumers;
-        }
-
-        @Override
-        public void setMaxConcurrentConsumers(Integer maxConcurrentConsumers) {
-            super.setMaxConcurrentConsumers(maxConcurrentConsumers);
-            this.maxConcurrentConsumers = maxConcurrentConsumers;
-        }
-
-        @Override
-        public void setBatchSize(Integer batchSize) {
-            super.setBatchSize(batchSize);
-            this.batchSize = batchSize;
-        }
-
-        @Override
-        public void setConsumerBatchEnabled(boolean consumerBatchEnabled) {
-            super.setConsumerBatchEnabled(consumerBatchEnabled);
-            this.consumerBatchEnabled = consumerBatchEnabled;
-        }
-
-        @Override
-        public ConnectionFactory connectionFactory() {
-            return this.connectionFactory;
-        }
-
-        @Override
-        public Boolean autoStartup() {
-            return this.autoStartup;
-        }
-
-        @Override
-        public AcknowledgeMode acknowledgeMode() {
-            return this.acknowledgeMode;
-        }
-
-        @Override
-        public Integer prefetchCount() {
-            return this.prefetchCount;
-        }
-
-        @Override
-        public Boolean defaultRequeueRejected() {
-            return this.defaultRequeueRejected;
-        }
-
-        @Override
-        public Long idleEventInterval() {
-            return this.idleEventInterval;
-        }
-
-        @Override
-        public Boolean deBatchingEnabled() {
-            return this.deBatchingEnabled;
-        }
-
-        @Override
-        public Boolean forceStop() {
-            return this.forceStop;
-        }
-
-        @Override
-        public Boolean observationEnabled() {
-            return this.observationEnabled;
-        }
-
-        @Override
-        public Executor taskExecutor() {
-            return this.taskExecutor;
-        }
-
-    }
-
-    private static final class StaticCredentialsProvider implements CredentialsProvider {
-
-        private final String username;
-
-        private final String password;
-
-        private StaticCredentialsProvider(String username, String password) {
-            this.username = username;
-            this.password = password;
-        }
-
-        @Override
-        public String getUsername() {
-            return this.username;
-        }
-
-        @Override
-        public String getPassword() {
-            return this.password;
-        }
-
-    }
-
-    private static final class NoOpCredentialsRefreshService implements CredentialsRefreshService {
-
-        private CredentialsProvider unregisteredCredentialsProvider;
-
-        private String unregisteredRegistrationId;
-
-        @Override
-        public String register(CredentialsProvider credentialsProvider, Callable<Boolean> refreshAction) {
-            return "registration";
-        }
-
-        @Override
-        public void unregister(CredentialsProvider credentialsProvider, String registrationId) {
-            this.unregisteredCredentialsProvider = credentialsProvider;
-            this.unregisteredRegistrationId = registrationId;
-        }
-
-        @Override
-        public boolean isApproachingExpiration(Duration timeBeforeExpiration) {
-            return false;
-        }
-
-    }
-
-    private static final class PassThroughMessageConverter implements MessageConverter {
-
-        @Override
-        public Message toMessage(Object object, MessageProperties messageProperties) {
-            return new Message(object.toString().getBytes(StandardCharsets.UTF_8), messageProperties);
-        }
-
-        @Override
-        public Object fromMessage(Message message) {
-            return message.getBody();
-        }
-
+    @Test
+    void autoConfigurationCreatesConnectionFactoryClientAndAppliesCustomizers() {
+        AtomicBoolean connectionOptionsCustomizerInvoked = new AtomicBoolean();
+        AtomicBoolean clientCustomizerInvoked = new AtomicBoolean();
+
+        this.contextRunner
+                .withPropertyValues("spring.amqp.host=broker.example.test", "spring.amqp.port=5679",
+                        "spring.amqp.username=alice", "spring.amqp.password=secret",
+                        "spring.amqp.client.default-to-address=orders.created",
+                        "spring.amqp.client.completion-timeout=750ms")
+                .withBean(ConnectionOptionsCustomizer.class,
+                        () -> (connectionOptions) -> connectionOptionsCustomizerInvoked.set(true))
+                .withBean(AmqpClientCustomizer.class, () -> (builder) -> clientCustomizerInvoked.set(true))
+                .run((context) -> {
+                    assertThat(context).hasSingleBean(AmqpProperties.class);
+                    assertThat(context).hasSingleBean(AmqpConnectionDetails.class);
+                    assertThat(context).hasSingleBean(AmqpConnectionFactory.class);
+                    assertThat(context).hasSingleBean(AmqpClient.class);
+
+                    AmqpProperties properties = context.getBean(AmqpProperties.class);
+                    assertThat(properties.getHost()).isEqualTo("broker.example.test");
+                    assertThat(properties.getPort()).isEqualTo(5679);
+                    assertThat(properties.getUsername()).isEqualTo("alice");
+                    assertThat(properties.getPassword()).isEqualTo("secret");
+                    assertThat(properties.getClient().getDefaultToAddress()).isEqualTo("orders.created");
+                    assertThat(properties.getClient().getCompletionTimeout()).isEqualTo(Duration.ofMillis(750));
+
+                    AmqpConnectionDetails connectionDetails = context.getBean(AmqpConnectionDetails.class);
+                    assertThat(connectionDetails.getAddress().host()).isEqualTo("broker.example.test");
+                    assertThat(connectionDetails.getAddress().port()).isEqualTo(5679);
+                    assertThat(connectionDetails.getUsername()).isEqualTo("alice");
+                    assertThat(connectionDetails.getPassword()).isEqualTo("secret");
+
+                    assertThat(context.getBean(AmqpConnectionFactory.class))
+                            .isInstanceOf(SingleAmqpConnectionFactory.class);
+                    assertThat(context.getBean(AmqpClient.class)).isNotNull();
+                    assertThat(connectionOptionsCustomizerInvoked).isTrue();
+                    assertThat(clientCustomizerInvoked).isTrue();
+                });
     }
 
 }

--- a/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M3/src/test/java/org_springframework_boot/spring_boot_amqp/Spring_boot_amqpTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M3/src/test/java/org_springframework_boot/spring_boot_amqp/Spring_boot_amqpTest.java
@@ -1,0 +1,993 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework_boot.spring_boot_amqp;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.rabbitmq.client.impl.CredentialsProvider;
+import com.rabbitmq.client.impl.CredentialsRefreshService;
+import org.aopalliance.aop.Advice;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.amqp.core.AcknowledgeMode;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.rabbit.config.DirectRabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerEndpoint;
+import org.springframework.amqp.rabbit.connection.AbstractConnectionFactory.AddressShuffleMode;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory.CacheMode;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory.ConfirmType;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionNameStrategy;
+import org.springframework.amqp.rabbit.connection.RabbitConnectionFactoryBean;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.listener.DirectMessageListenerContainer;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.amqp.support.converter.SimpleMessageConverter;
+import org.springframework.boot.amqp.autoconfigure.CachingConnectionFactoryConfigurer;
+import org.springframework.boot.amqp.autoconfigure.DirectRabbitListenerContainerFactoryConfigurer;
+import org.springframework.boot.amqp.autoconfigure.RabbitConnectionDetails;
+import org.springframework.boot.amqp.autoconfigure.RabbitConnectionFactoryBeanConfigurer;
+import org.springframework.boot.amqp.autoconfigure.RabbitProperties;
+import org.springframework.boot.amqp.autoconfigure.RabbitProperties.ContainerType;
+import org.springframework.boot.amqp.autoconfigure.RabbitTemplateConfigurer;
+import org.springframework.boot.amqp.autoconfigure.SimpleRabbitListenerContainerFactoryConfigurer;
+import org.springframework.boot.context.properties.source.InvalidConfigurationPropertyValueException;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.retry.RetryTemplate;
+import org.springframework.util.unit.DataSize;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class Spring_boot_amqpTest {
+
+    @Test
+    void rabbitPropertiesDetermineConnectionValuesFromDefaultsSslAndAddresses() {
+        RabbitProperties properties = new RabbitProperties();
+
+        assertThat(properties.determineHost()).isEqualTo("localhost");
+        assertThat(properties.determinePort()).isEqualTo(5672);
+        assertThat(properties.determineAddresses()).containsExactly("localhost:5672");
+        assertThat(properties.determineUsername()).isEqualTo("guest");
+        assertThat(properties.determinePassword()).isEqualTo("guest");
+        assertThat(properties.getSsl().determineEnabled()).isFalse();
+
+        properties.getSsl().setEnabled(true);
+        properties.setAddresses(
+                List.of("amqps://alice:secret@rabbit-one.example.test/orders", "rabbit-two.example.test:5673"));
+
+        assertThat(properties.determineHost()).isEqualTo("rabbit-one.example.test");
+        assertThat(properties.determinePort()).isEqualTo(5671);
+        assertThat(properties.determineAddresses()).containsExactly("rabbit-one.example.test:5671",
+                "rabbit-two.example.test:5673");
+        assertThat(properties.determineUsername()).isEqualTo("alice");
+        assertThat(properties.determinePassword()).isEqualTo("secret");
+        assertThat(properties.determineVirtualHost()).isEqualTo("orders");
+        assertThat(properties.getSsl().determineEnabled()).isTrue();
+    }
+
+    @Test
+    void rabbitPropertiesExposeNestedTemplateListenerCacheAndStreamSettings() {
+        RabbitProperties properties = new RabbitProperties();
+        properties.setHost("broker.example.test");
+        properties.setPort(5678);
+        properties.setVirtualHost("");
+        properties.setRequestedHeartbeat(Duration.ofSeconds(9));
+        properties.setConnectionTimeout(Duration.ofMillis(750));
+        properties.setChannelRpcTimeout(Duration.ofSeconds(2));
+        properties.setMaxInboundMessageBodySize(DataSize.ofKilobytes(128));
+        properties.setAddressShuffleMode(AddressShuffleMode.INORDER);
+        properties.getCache().getChannel().setSize(12);
+        properties.getCache().getChannel().setCheckoutTimeout(Duration.ofMillis(25));
+        properties.getCache().getConnection().setMode(CacheMode.CONNECTION);
+        properties.getCache().getConnection().setSize(3);
+        properties.getListener().setType(ContainerType.DIRECT);
+        properties.getListener().getDirect().setConsumersPerQueue(4);
+        properties.getListener().getStream().setNativeListener(true);
+        properties.getTemplate().setExchange("events");
+        properties.getTemplate().setRoutingKey("created");
+        properties.getTemplate().setDefaultReceiveQueue("events.in");
+        properties.getTemplate().setAllowedListPatterns(List.of("java.util.*"));
+        properties.getTemplate().getRetry().setEnabled(true);
+        properties.getTemplate().getRetry().setMaxRetries(5);
+        properties.getStream().setHost("stream.example.test");
+        properties.getStream().setPort(5553);
+        properties.getStream().setName("orders-stream");
+
+        assertThat(properties.determineAddresses()).containsExactly("broker.example.test:5678");
+        assertThat(properties.determineVirtualHost()).isEqualTo("/");
+        assertThat(properties.getRequestedHeartbeat()).isEqualTo(Duration.ofSeconds(9));
+        assertThat(properties.getConnectionTimeout()).isEqualTo(Duration.ofMillis(750));
+        assertThat(properties.getChannelRpcTimeout()).isEqualTo(Duration.ofSeconds(2));
+        assertThat(properties.getMaxInboundMessageBodySize()).isEqualTo(DataSize.ofKilobytes(128));
+        assertThat(properties.getAddressShuffleMode()).isEqualTo(AddressShuffleMode.INORDER);
+        assertThat(properties.getCache().getChannel().getSize()).isEqualTo(12);
+        assertThat(properties.getCache().getChannel().getCheckoutTimeout()).isEqualTo(Duration.ofMillis(25));
+        assertThat(properties.getCache().getConnection().getMode()).isEqualTo(CacheMode.CONNECTION);
+        assertThat(properties.getCache().getConnection().getSize()).isEqualTo(3);
+        assertThat(properties.getListener().getType()).isEqualTo(ContainerType.DIRECT);
+        assertThat(properties.getListener().getDirect().getConsumersPerQueue()).isEqualTo(4);
+        assertThat(properties.getListener().getStream().isNativeListener()).isTrue();
+        assertThat(properties.getTemplate().getExchange()).isEqualTo("events");
+        assertThat(properties.getTemplate().getRoutingKey()).isEqualTo("created");
+        assertThat(properties.getTemplate().getDefaultReceiveQueue()).isEqualTo("events.in");
+        assertThat(properties.getTemplate().getAllowedListPatterns()).containsExactly("java.util.*");
+        assertThat(properties.getTemplate().getRetry().isEnabled()).isTrue();
+        assertThat(properties.getTemplate().getRetry().getMaxRetries()).isEqualTo(5);
+        assertThat(properties.getStream().getHost()).isEqualTo("stream.example.test");
+        assertThat(properties.getStream().getPort()).isEqualTo(5553);
+        assertThat(properties.getStream().getName()).isEqualTo("orders-stream");
+    }
+
+    @Test
+    void rabbitPropertiesRejectCommaSeparatedHostWhenDeterminingAddresses() {
+        RabbitProperties properties = new RabbitProperties();
+        properties.setHost("one.example.test,two.example.test");
+
+        assertThatThrownBy(properties::determineAddresses)
+                .isInstanceOf(InvalidConfigurationPropertyValueException.class)
+                .hasMessageContaining("spring.rabbitmq.host")
+                .hasMessageContaining("spring.rabbitmq.addresses");
+    }
+
+    @Test
+    void rabbitConnectionDetailsDefaultsAndAddressRecordAreUsable() {
+        RabbitConnectionDetails.Address first = new RabbitConnectionDetails.Address("first.example.test", 6001);
+        RabbitConnectionDetails.Address second = new RabbitConnectionDetails.Address("second.example.test", 6002);
+        RabbitConnectionDetails details = connectionDetails(List.of(first, second));
+
+        assertThat(details.getAddresses()).containsExactly(first, second);
+        assertThat(details.getFirstAddress()).isEqualTo(first);
+        assertThat(details.getUsername()).isNull();
+        assertThat(details.getPassword()).isNull();
+        assertThat(details.getVirtualHost()).isNull();
+        assertThat(details.getSslBundle()).isNull();
+        assertThat(first.host()).isEqualTo("first.example.test");
+        assertThat(first.port()).isEqualTo(6001);
+    }
+
+    @Test
+    void rabbitTemplateConfigurerAppliesTemplateSettingsAndRetryCustomizers() {
+        RabbitProperties properties = new RabbitProperties();
+        properties.setPublisherReturns(true);
+        properties.getTemplate().setReceiveTimeout(Duration.ofMillis(125));
+        properties.getTemplate().setReplyTimeout(Duration.ofMillis(250));
+        properties.getTemplate().setExchange("orders.exchange");
+        properties.getTemplate().setRoutingKey("orders.created");
+        properties.getTemplate().setDefaultReceiveQueue("orders.in");
+        properties.getTemplate().setObservationEnabled(true);
+        properties.getTemplate().getRetry().setEnabled(true);
+        properties.getTemplate().getRetry().setInitialInterval(Duration.ofMillis(10));
+        properties.getTemplate().getRetry().setMaxInterval(Duration.ofMillis(20));
+        CapturingRabbitTemplate template = new CapturingRabbitTemplate();
+        MessageConverter converter = new SimpleMessageConverter();
+        RabbitTemplateConfigurer configurer = new RabbitTemplateConfigurer(properties);
+        AtomicBoolean customizerInvoked = new AtomicBoolean();
+        configurer.setMessageConverter(converter);
+        configurer.setRetrySettingsCustomizers(List.of((settings) -> {
+            customizerInvoked.set(true);
+            settings.getRetryPolicySettings().setMaxRetries(2L);
+        }));
+        CachingConnectionFactory connectionFactory = newCachingConnectionFactory();
+
+        try {
+            configurer.configure(template, connectionFactory);
+        } finally {
+            connectionFactory.destroy();
+        }
+
+        assertThat(template.getMessageConverter()).isSameAs(converter);
+        assertThat(template.receiveTimeout).isEqualTo(125L);
+        assertThat(template.replyTimeout).isEqualTo(250L);
+        assertThat(template.getExchange()).isEqualTo("orders.exchange");
+        assertThat(template.getRoutingKey()).isEqualTo("orders.created");
+        assertThat(template.getDefaultReceiveQueue()).isEqualTo("orders.in");
+        assertThat(template.observationEnabled).isTrue();
+        assertThat(template.retryTemplate).isNotNull();
+        assertThat(customizerInvoked).isTrue();
+        assertThat(template.isMandatoryFor(new Message(new byte[0], new MessageProperties()))).isTrue();
+    }
+
+    @Test
+    void rabbitTemplateConfigurerUsesExplicitMandatoryFlagOverPublisherReturns() {
+        RabbitProperties properties = new RabbitProperties();
+        properties.setPublisherReturns(true);
+        properties.getTemplate().setMandatory(false);
+        CapturingRabbitTemplate template = new CapturingRabbitTemplate();
+        CachingConnectionFactory connectionFactory = newCachingConnectionFactory();
+
+        try {
+            new RabbitTemplateConfigurer(properties).configure(template, connectionFactory);
+        } finally {
+            connectionFactory.destroy();
+        }
+
+        assertThat(template.isMandatoryFor(new Message(new byte[0], new MessageProperties()))).isFalse();
+    }
+
+    @Test
+    void rabbitTemplateConfigurerReportsInvalidAllowedListConverter() {
+        RabbitProperties properties = new RabbitProperties();
+        properties.getTemplate().setAllowedListPatterns(List.of("java.util.*"));
+        CapturingRabbitTemplate template = new CapturingRabbitTemplate();
+        template.setMessageConverter(new PassThroughMessageConverter());
+        CachingConnectionFactory connectionFactory = newCachingConnectionFactory();
+
+        try {
+            RabbitTemplateConfigurer configurer = new RabbitTemplateConfigurer(properties);
+
+            assertThatThrownBy(() -> configurer.configure(template, connectionFactory))
+                    .isInstanceOf(InvalidConfigurationPropertyValueException.class)
+                    .hasMessageContaining("spring.rabbitmq.template.allowed-list-patterns");
+        } finally {
+            connectionFactory.destroy();
+        }
+    }
+
+    @Test
+    void cachingConnectionFactoryConfigurerAppliesConnectionFactorySettings() {
+        RabbitProperties properties = new RabbitProperties();
+        properties.setPublisherReturns(true);
+        properties.setPublisherConfirmType(ConfirmType.CORRELATED);
+        properties.setAddressShuffleMode(AddressShuffleMode.RANDOM);
+        properties.getCache().getChannel().setSize(8);
+        properties.getCache().getChannel().setCheckoutTimeout(Duration.ofMillis(50));
+        RabbitConnectionDetails details = connectionDetails(
+                List.of(new RabbitConnectionDetails.Address("rabbit-a.example.test", 6100),
+                        new RabbitConnectionDetails.Address("rabbit-b.example.test", 6101)));
+        CapturingCachingConnectionFactory connectionFactory = new CapturingCachingConnectionFactory();
+        ConnectionNameStrategy nameStrategy = (factory) -> "orders-connection";
+        CachingConnectionFactoryConfigurer configurer = new CachingConnectionFactoryConfigurer(properties, details);
+        configurer.setConnectionNameStrategy(nameStrategy);
+
+        try {
+            configurer.configure(connectionFactory);
+        } finally {
+            connectionFactory.destroy();
+        }
+
+        assertThat(connectionFactory.addresses).isEqualTo("rabbit-a.example.test:6100,rabbit-b.example.test:6101");
+        assertThat(connectionFactory.addressShuffleMode).isEqualTo(AddressShuffleMode.RANDOM);
+        assertThat(connectionFactory.connectionNameStrategy).isSameAs(nameStrategy);
+        assertThat(connectionFactory.publisherReturns).isTrue();
+        assertThat(connectionFactory.publisherConfirmType).isEqualTo(ConfirmType.CORRELATED);
+        assertThat(connectionFactory.channelCacheSize).isEqualTo(8);
+        assertThat(connectionFactory.channelCheckoutTimeout).isEqualTo(50L);
+        assertThat(connectionFactory.cacheMode).isEqualTo(CacheMode.CHANNEL);
+    }
+
+    @Test
+    void rabbitConnectionFactoryBeanConfigurerUsesConnectionDetailsBeforeProperties() throws Exception {
+        RabbitProperties properties = new RabbitProperties();
+        properties.setHost("ignored.example.test");
+        properties.setPort(9999);
+        properties.setUsername("ignored-user");
+        properties.setPassword("ignored-password");
+        properties.setVirtualHost("ignored-vhost");
+        properties.setRequestedHeartbeat(Duration.ofSeconds(7));
+        properties.setRequestedChannelMax(32);
+        properties.setConnectionTimeout(Duration.ofMillis(450));
+        properties.setChannelRpcTimeout(Duration.ofMillis(650));
+        properties.setMaxInboundMessageBodySize(DataSize.ofKilobytes(64));
+        RabbitConnectionDetails details = connectionDetails("detail-user", "detail-password", "detail-vhost",
+                List.of(new RabbitConnectionDetails.Address("details.example.test", 6200)));
+        RabbitConnectionFactoryBean factoryBean = new RabbitConnectionFactoryBean();
+        RabbitConnectionFactoryBeanConfigurer configurer = new RabbitConnectionFactoryBeanConfigurer(
+                new DefaultResourceLoader(), properties, details);
+
+        configurer.configure(factoryBean);
+        factoryBean.afterPropertiesSet();
+
+        com.rabbitmq.client.ConnectionFactory rabbitFactory = factoryBean.getRabbitConnectionFactory();
+        assertThat(rabbitFactory.getHost()).isEqualTo("details.example.test");
+        assertThat(rabbitFactory.getPort()).isEqualTo(6200);
+        assertThat(rabbitFactory.getUsername()).isEqualTo("detail-user");
+        assertThat(rabbitFactory.getPassword()).isEqualTo("detail-password");
+        assertThat(rabbitFactory.getVirtualHost()).isEqualTo("detail-vhost");
+        assertThat(rabbitFactory.getRequestedHeartbeat()).isEqualTo(7);
+        assertThat(rabbitFactory.getRequestedChannelMax()).isEqualTo(32);
+        assertThat(rabbitFactory.getConnectionTimeout()).isEqualTo(450);
+        assertThat(rabbitFactory.getChannelRpcTimeout()).isEqualTo(650);
+    }
+
+    @Test
+    void rabbitConnectionFactoryBeanConfigurerAppliesCredentialsProviderAndRefreshService() {
+        RabbitProperties properties = new RabbitProperties();
+        RabbitConnectionDetails details = connectionDetails(
+                List.of(new RabbitConnectionDetails.Address("credentials.example.test", 6300)));
+        CredentialsProvider credentialsProvider = new StaticCredentialsProvider("rotating-user", "rotating-password");
+        CredentialsRefreshService credentialsRefreshService = new NoOpCredentialsRefreshService();
+        CapturingRabbitConnectionFactoryBean factoryBean = new CapturingRabbitConnectionFactoryBean();
+        RabbitConnectionFactoryBeanConfigurer configurer = new RabbitConnectionFactoryBeanConfigurer(
+                new DefaultResourceLoader(), properties, details);
+
+        configurer.setCredentialsProvider(credentialsProvider);
+        configurer.setCredentialsRefreshService(credentialsRefreshService);
+        configurer.configure(factoryBean);
+
+        assertThat(factoryBean.credentialsProvider).isSameAs(credentialsProvider);
+        assertThat(factoryBean.credentialsRefreshService).isSameAs(credentialsRefreshService);
+        assertThat(factoryBean.credentialsProvider.getUsername()).isEqualTo("rotating-user");
+        assertThat(factoryBean.credentialsProvider.getPassword()).isEqualTo("rotating-password");
+    }
+
+    @Test
+    void rabbitConnectionFactoryBeanConfigurerAppliesSslSettings() {
+        RabbitProperties properties = new RabbitProperties();
+        RabbitProperties.Ssl ssl = properties.getSsl();
+        ssl.setEnabled(true);
+        ssl.setAlgorithm("TLSv1.3");
+        ssl.setKeyStore("classpath:client.p12");
+        ssl.setKeyStoreType("PKCS12");
+        ssl.setKeyStorePassword("key-password");
+        ssl.setKeyStoreAlgorithm("SunX509");
+        ssl.setTrustStore("classpath:trust.p12");
+        ssl.setTrustStoreType("PKCS12");
+        ssl.setTrustStorePassword("trust-password");
+        ssl.setTrustStoreAlgorithm("SunX509");
+        ssl.setValidateServerCertificate(false);
+        ssl.setVerifyHostname(true);
+        RabbitConnectionDetails details = connectionDetails(
+                List.of(new RabbitConnectionDetails.Address("secure.example.test", 5671)));
+        CapturingRabbitConnectionFactoryBean factoryBean = new CapturingRabbitConnectionFactoryBean();
+        RabbitConnectionFactoryBeanConfigurer configurer = new RabbitConnectionFactoryBeanConfigurer(
+                new DefaultResourceLoader(), properties, details);
+
+        configurer.configure(factoryBean);
+
+        assertThat(factoryBean.useSsl).isTrue();
+        assertThat(factoryBean.sslAlgorithm).isEqualTo("TLSv1.3");
+        assertThat(factoryBean.keyStore).isEqualTo("classpath:client.p12");
+        assertThat(factoryBean.keyStoreType).isEqualTo("PKCS12");
+        assertThat(factoryBean.keyStorePassphrase).isEqualTo("key-password");
+        assertThat(factoryBean.keyStoreAlgorithm).isEqualTo("SunX509");
+        assertThat(factoryBean.trustStore).isEqualTo("classpath:trust.p12");
+        assertThat(factoryBean.trustStoreType).isEqualTo("PKCS12");
+        assertThat(factoryBean.trustStorePassphrase).isEqualTo("trust-password");
+        assertThat(factoryBean.trustStoreAlgorithm).isEqualTo("SunX509");
+        assertThat(factoryBean.skipServerCertificateValidation).isTrue();
+        assertThat(factoryBean.enableHostnameVerification).isTrue();
+    }
+
+    @Test
+    void simpleListenerContainerFactoryConfigurerAppliesCommonSimpleAndRetrySettings() {
+        RabbitProperties properties = new RabbitProperties();
+        RabbitProperties.SimpleContainer simple = properties.getListener().getSimple();
+        simple.setAutoStartup(false);
+        simple.setAcknowledgeMode(AcknowledgeMode.MANUAL);
+        simple.setPrefetch(5);
+        simple.setDefaultRequeueRejected(false);
+        simple.setIdleEventInterval(Duration.ofMillis(75));
+        simple.setMissingQueuesFatal(false);
+        simple.setDeBatchingEnabled(false);
+        simple.setForceStop(true);
+        simple.setObservationEnabled(true);
+        simple.setConcurrency(2);
+        simple.setMaxConcurrency(4);
+        simple.setBatchSize(10);
+        simple.setConsumerBatchEnabled(true);
+        simple.getRetry().setEnabled(true);
+        simple.getRetry().setMaxRetries(2);
+        CapturingSimpleRabbitListenerContainerFactory factory = new CapturingSimpleRabbitListenerContainerFactory();
+        Executor executor = Runnable::run;
+        SimpleRabbitListenerContainerFactoryConfigurer configurer = new SimpleRabbitListenerContainerFactoryConfigurer(
+                properties);
+        CachingConnectionFactory connectionFactory = newCachingConnectionFactory();
+        configurer.setTaskExecutor(executor);
+
+        try {
+            configurer.configure(factory, connectionFactory);
+        } finally {
+            connectionFactory.destroy();
+        }
+
+        assertCommonListenerSettings(factory, connectionFactory, executor);
+        assertThat(factory.concurrentConsumers).isEqualTo(2);
+        assertThat(factory.maxConcurrentConsumers).isEqualTo(4);
+        assertThat(factory.batchSize).isEqualTo(10);
+        assertThat(factory.consumerBatchEnabled).isTrue();
+        assertThat(factory.adviceChain).isNotEmpty();
+    }
+
+    @Test
+    void directListenerContainerFactoryConfigurerAppliesCommonAndDirectSettings() {
+        RabbitProperties properties = new RabbitProperties();
+        RabbitProperties.DirectContainer direct = properties.getListener().getDirect();
+        direct.setAutoStartup(false);
+        direct.setAcknowledgeMode(AcknowledgeMode.AUTO);
+        direct.setPrefetch(6);
+        direct.setDefaultRequeueRejected(true);
+        direct.setIdleEventInterval(Duration.ofMillis(80));
+        direct.setMissingQueuesFatal(true);
+        direct.setDeBatchingEnabled(false);
+        direct.setForceStop(true);
+        direct.setObservationEnabled(true);
+        direct.setConsumersPerQueue(3);
+        DirectRabbitListenerContainerFactory factory = new DirectRabbitListenerContainerFactory();
+        Executor executor = Runnable::run;
+        DirectRabbitListenerContainerFactoryConfigurer configurer = new DirectRabbitListenerContainerFactoryConfigurer(
+                properties);
+        CachingConnectionFactory connectionFactory = newCachingConnectionFactory();
+        configurer.setTaskExecutor(executor);
+
+        try {
+            configurer.configure(factory, connectionFactory);
+            SimpleRabbitListenerEndpoint endpoint = new SimpleRabbitListenerEndpoint();
+            endpoint.setId("direct-orders");
+            endpoint.setQueueNames("orders.in");
+            endpoint.setMessageListener((message) -> {
+                throw new AssertionError("Listener should not be invoked");
+            });
+            DirectMessageListenerContainer container = factory.createListenerContainer(endpoint);
+
+            try {
+                assertThat(container.getConnectionFactory()).isSameAs(connectionFactory);
+                assertThat(container.isAutoStartup()).isFalse();
+                assertThat(container.getAcknowledgeMode()).isEqualTo(AcknowledgeMode.AUTO);
+                assertThat(container.getQueueNames()).containsExactly("orders.in");
+            } finally {
+                container.destroy();
+            }
+        } finally {
+            connectionFactory.destroy();
+        }
+    }
+
+    private static RabbitConnectionDetails connectionDetails(List<RabbitConnectionDetails.Address> addresses) {
+        return connectionDetails(null, null, null, addresses);
+    }
+
+    private static RabbitConnectionDetails connectionDetails(String username, String password, String virtualHost,
+            List<RabbitConnectionDetails.Address> addresses) {
+        return new RabbitConnectionDetails() {
+
+            @Override
+            public String getUsername() {
+                return username;
+            }
+
+            @Override
+            public String getPassword() {
+                return password;
+            }
+
+            @Override
+            public String getVirtualHost() {
+                return virtualHost;
+            }
+
+            @Override
+            public List<RabbitConnectionDetails.Address> getAddresses() {
+                return addresses;
+            }
+
+        };
+    }
+
+    private static CachingConnectionFactory newCachingConnectionFactory() {
+        return new CachingConnectionFactory(new com.rabbitmq.client.ConnectionFactory());
+    }
+
+    private static void assertCommonListenerSettings(CapturingListenerSettings factory,
+            CachingConnectionFactory connectionFactory, Executor executor) {
+        assertThat(factory.connectionFactory()).isSameAs(connectionFactory);
+        assertThat(factory.autoStartup()).isFalse();
+        assertThat(factory.acknowledgeMode()).isNotNull();
+        assertThat(factory.prefetchCount()).isGreaterThan(0);
+        assertThat(factory.defaultRequeueRejected()).isNotNull();
+        assertThat(factory.idleEventInterval()).isGreaterThan(0L);
+        assertThat(factory.deBatchingEnabled()).isFalse();
+        assertThat(factory.forceStop()).isTrue();
+        assertThat(factory.observationEnabled()).isTrue();
+        assertThat(factory.taskExecutor()).isSameAs(executor);
+    }
+
+    private static class CapturingRabbitTemplate extends RabbitTemplate {
+
+        private long receiveTimeout;
+
+        private long replyTimeout;
+
+        private boolean observationEnabled;
+
+        private RetryTemplate retryTemplate;
+
+        @Override
+        public void setReceiveTimeout(long receiveTimeout) {
+            super.setReceiveTimeout(receiveTimeout);
+            this.receiveTimeout = receiveTimeout;
+        }
+
+        @Override
+        public void setReplyTimeout(long replyTimeout) {
+            super.setReplyTimeout(replyTimeout);
+            this.replyTimeout = replyTimeout;
+        }
+
+        @Override
+        public void setObservationEnabled(boolean observationEnabled) {
+            super.setObservationEnabled(observationEnabled);
+            this.observationEnabled = observationEnabled;
+        }
+
+        @Override
+        public void setRetryTemplate(RetryTemplate retryTemplate) {
+            super.setRetryTemplate(retryTemplate);
+            this.retryTemplate = retryTemplate;
+        }
+
+    }
+
+    private static class CapturingRabbitConnectionFactoryBean extends RabbitConnectionFactoryBean {
+
+        private CredentialsProvider credentialsProvider;
+
+        private CredentialsRefreshService credentialsRefreshService;
+
+        private boolean useSsl;
+
+        private String sslAlgorithm;
+
+        private String keyStore;
+
+        private String keyStoreType;
+
+        private String keyStorePassphrase;
+
+        private String keyStoreAlgorithm;
+
+        private String trustStore;
+
+        private String trustStoreType;
+
+        private String trustStorePassphrase;
+
+        private String trustStoreAlgorithm;
+
+        private boolean skipServerCertificateValidation;
+
+        private boolean enableHostnameVerification;
+
+        @Override
+        public void setCredentialsProvider(CredentialsProvider credentialsProvider) {
+            super.setCredentialsProvider(credentialsProvider);
+            this.credentialsProvider = credentialsProvider;
+        }
+
+        @Override
+        public void setCredentialsRefreshService(CredentialsRefreshService credentialsRefreshService) {
+            super.setCredentialsRefreshService(credentialsRefreshService);
+            this.credentialsRefreshService = credentialsRefreshService;
+        }
+
+        @Override
+        public void setUseSSL(boolean useSsl) {
+            super.setUseSSL(useSsl);
+            this.useSsl = useSsl;
+        }
+
+        @Override
+        public void setSslAlgorithm(String sslAlgorithm) {
+            super.setSslAlgorithm(sslAlgorithm);
+            this.sslAlgorithm = sslAlgorithm;
+        }
+
+        @Override
+        public void setKeyStore(String keyStore) {
+            super.setKeyStore(keyStore);
+            this.keyStore = keyStore;
+        }
+
+        @Override
+        public void setKeyStoreType(String keyStoreType) {
+            super.setKeyStoreType(keyStoreType);
+            this.keyStoreType = keyStoreType;
+        }
+
+        @Override
+        public void setKeyStorePassphrase(String keyStorePassphrase) {
+            super.setKeyStorePassphrase(keyStorePassphrase);
+            this.keyStorePassphrase = keyStorePassphrase;
+        }
+
+        @Override
+        public void setKeyStoreAlgorithm(String keyStoreAlgorithm) {
+            super.setKeyStoreAlgorithm(keyStoreAlgorithm);
+            this.keyStoreAlgorithm = keyStoreAlgorithm;
+        }
+
+        @Override
+        public void setTrustStore(String trustStore) {
+            super.setTrustStore(trustStore);
+            this.trustStore = trustStore;
+        }
+
+        @Override
+        public void setTrustStoreType(String trustStoreType) {
+            super.setTrustStoreType(trustStoreType);
+            this.trustStoreType = trustStoreType;
+        }
+
+        @Override
+        public void setTrustStorePassphrase(String trustStorePassphrase) {
+            super.setTrustStorePassphrase(trustStorePassphrase);
+            this.trustStorePassphrase = trustStorePassphrase;
+        }
+
+        @Override
+        public void setTrustStoreAlgorithm(String trustStoreAlgorithm) {
+            super.setTrustStoreAlgorithm(trustStoreAlgorithm);
+            this.trustStoreAlgorithm = trustStoreAlgorithm;
+        }
+
+        @Override
+        public void setSkipServerCertificateValidation(boolean skipServerCertificateValidation) {
+            super.setSkipServerCertificateValidation(skipServerCertificateValidation);
+            this.skipServerCertificateValidation = skipServerCertificateValidation;
+        }
+
+        @Override
+        public void setEnableHostnameVerification(boolean enableHostnameVerification) {
+            super.setEnableHostnameVerification(enableHostnameVerification);
+            this.enableHostnameVerification = enableHostnameVerification;
+        }
+
+    }
+
+    private static class CapturingCachingConnectionFactory extends CachingConnectionFactory {
+
+        private String addresses;
+
+        private AddressShuffleMode addressShuffleMode;
+
+        private ConnectionNameStrategy connectionNameStrategy;
+
+        private boolean publisherReturns;
+
+        private ConfirmType publisherConfirmType;
+
+        private int channelCacheSize;
+
+        private long channelCheckoutTimeout;
+
+        private CacheMode cacheMode;
+
+        private int connectionCacheSize;
+
+        @Override
+        public void setAddresses(String addresses) {
+            super.setAddresses(addresses);
+            this.addresses = addresses;
+        }
+
+        @Override
+        public void setAddressShuffleMode(AddressShuffleMode addressShuffleMode) {
+            super.setAddressShuffleMode(addressShuffleMode);
+            this.addressShuffleMode = addressShuffleMode;
+        }
+
+        @Override
+        public void setConnectionNameStrategy(ConnectionNameStrategy connectionNameStrategy) {
+            super.setConnectionNameStrategy(connectionNameStrategy);
+            this.connectionNameStrategy = connectionNameStrategy;
+        }
+
+        @Override
+        public void setPublisherReturns(boolean publisherReturns) {
+            super.setPublisherReturns(publisherReturns);
+            this.publisherReturns = publisherReturns;
+        }
+
+        @Override
+        public void setPublisherConfirmType(ConfirmType confirmType) {
+            super.setPublisherConfirmType(confirmType);
+            this.publisherConfirmType = confirmType;
+        }
+
+        @Override
+        public void setChannelCacheSize(int sessionCacheSize) {
+            super.setChannelCacheSize(sessionCacheSize);
+            this.channelCacheSize = sessionCacheSize;
+        }
+
+        @Override
+        public void setChannelCheckoutTimeout(long channelCheckoutTimeout) {
+            super.setChannelCheckoutTimeout(channelCheckoutTimeout);
+            this.channelCheckoutTimeout = channelCheckoutTimeout;
+        }
+
+        @Override
+        public void setCacheMode(CacheMode cacheMode) {
+            super.setCacheMode(cacheMode);
+            this.cacheMode = cacheMode;
+        }
+
+        @Override
+        public void setConnectionCacheSize(int connectionCacheSize) {
+            super.setConnectionCacheSize(connectionCacheSize);
+            this.connectionCacheSize = connectionCacheSize;
+        }
+
+    }
+
+    private interface CapturingListenerSettings {
+
+        ConnectionFactory connectionFactory();
+
+        Boolean autoStartup();
+
+        AcknowledgeMode acknowledgeMode();
+
+        Integer prefetchCount();
+
+        Boolean defaultRequeueRejected();
+
+        Long idleEventInterval();
+
+        Boolean deBatchingEnabled();
+
+        Boolean forceStop();
+
+        Boolean observationEnabled();
+
+        Executor taskExecutor();
+
+    }
+
+    private static class CapturingSimpleRabbitListenerContainerFactory extends SimpleRabbitListenerContainerFactory
+            implements CapturingListenerSettings {
+
+        private ConnectionFactory connectionFactory;
+
+        private Boolean autoStartup;
+
+        private AcknowledgeMode acknowledgeMode;
+
+        private Integer prefetchCount;
+
+        private Boolean defaultRequeueRejected;
+
+        private Long idleEventInterval;
+
+        private Boolean missingQueuesFatal;
+
+        private Boolean deBatchingEnabled;
+
+        private Boolean forceStop;
+
+        private Boolean observationEnabled;
+
+        private Executor taskExecutor;
+
+        private Advice[] adviceChain = new Advice[0];
+
+        private Integer concurrentConsumers;
+
+        private Integer maxConcurrentConsumers;
+
+        private Integer batchSize;
+
+        private boolean consumerBatchEnabled;
+
+        @Override
+        public void setConnectionFactory(ConnectionFactory connectionFactory) {
+            super.setConnectionFactory(connectionFactory);
+            this.connectionFactory = connectionFactory;
+        }
+
+        @Override
+        public void setAutoStartup(Boolean autoStartup) {
+            super.setAutoStartup(autoStartup);
+            this.autoStartup = autoStartup;
+        }
+
+        @Override
+        public void setAcknowledgeMode(AcknowledgeMode acknowledgeMode) {
+            super.setAcknowledgeMode(acknowledgeMode);
+            this.acknowledgeMode = acknowledgeMode;
+        }
+
+        @Override
+        public void setPrefetchCount(Integer prefetchCount) {
+            super.setPrefetchCount(prefetchCount);
+            this.prefetchCount = prefetchCount;
+        }
+
+        @Override
+        public void setDefaultRequeueRejected(Boolean defaultRequeueRejected) {
+            super.setDefaultRequeueRejected(defaultRequeueRejected);
+            this.defaultRequeueRejected = defaultRequeueRejected;
+        }
+
+        @Override
+        public void setIdleEventInterval(Long idleEventInterval) {
+            super.setIdleEventInterval(idleEventInterval);
+            this.idleEventInterval = idleEventInterval;
+        }
+
+        @Override
+        public void setMissingQueuesFatal(Boolean missingQueuesFatal) {
+            super.setMissingQueuesFatal(missingQueuesFatal);
+            this.missingQueuesFatal = missingQueuesFatal;
+        }
+
+        @Override
+        public void setDeBatchingEnabled(Boolean deBatchingEnabled) {
+            super.setDeBatchingEnabled(deBatchingEnabled);
+            this.deBatchingEnabled = deBatchingEnabled;
+        }
+
+        @Override
+        public void setForceStop(boolean forceStop) {
+            super.setForceStop(forceStop);
+            this.forceStop = forceStop;
+        }
+
+        @Override
+        public void setObservationEnabled(boolean observationEnabled) {
+            super.setObservationEnabled(observationEnabled);
+            this.observationEnabled = observationEnabled;
+        }
+
+        @Override
+        public void setTaskExecutor(Executor taskExecutor) {
+            super.setTaskExecutor(taskExecutor);
+            this.taskExecutor = taskExecutor;
+        }
+
+        @Override
+        public void setAdviceChain(Advice... adviceChain) {
+            super.setAdviceChain(adviceChain);
+            this.adviceChain = adviceChain;
+        }
+
+        @Override
+        public void setConcurrentConsumers(Integer concurrentConsumers) {
+            super.setConcurrentConsumers(concurrentConsumers);
+            this.concurrentConsumers = concurrentConsumers;
+        }
+
+        @Override
+        public void setMaxConcurrentConsumers(Integer maxConcurrentConsumers) {
+            super.setMaxConcurrentConsumers(maxConcurrentConsumers);
+            this.maxConcurrentConsumers = maxConcurrentConsumers;
+        }
+
+        @Override
+        public void setBatchSize(Integer batchSize) {
+            super.setBatchSize(batchSize);
+            this.batchSize = batchSize;
+        }
+
+        @Override
+        public void setConsumerBatchEnabled(boolean consumerBatchEnabled) {
+            super.setConsumerBatchEnabled(consumerBatchEnabled);
+            this.consumerBatchEnabled = consumerBatchEnabled;
+        }
+
+        @Override
+        public ConnectionFactory connectionFactory() {
+            return this.connectionFactory;
+        }
+
+        @Override
+        public Boolean autoStartup() {
+            return this.autoStartup;
+        }
+
+        @Override
+        public AcknowledgeMode acknowledgeMode() {
+            return this.acknowledgeMode;
+        }
+
+        @Override
+        public Integer prefetchCount() {
+            return this.prefetchCount;
+        }
+
+        @Override
+        public Boolean defaultRequeueRejected() {
+            return this.defaultRequeueRejected;
+        }
+
+        @Override
+        public Long idleEventInterval() {
+            return this.idleEventInterval;
+        }
+
+        @Override
+        public Boolean deBatchingEnabled() {
+            return this.deBatchingEnabled;
+        }
+
+        @Override
+        public Boolean forceStop() {
+            return this.forceStop;
+        }
+
+        @Override
+        public Boolean observationEnabled() {
+            return this.observationEnabled;
+        }
+
+        @Override
+        public Executor taskExecutor() {
+            return this.taskExecutor;
+        }
+
+    }
+
+    private static final class StaticCredentialsProvider implements CredentialsProvider {
+
+        private final String username;
+
+        private final String password;
+
+        private StaticCredentialsProvider(String username, String password) {
+            this.username = username;
+            this.password = password;
+        }
+
+        @Override
+        public String getUsername() {
+            return this.username;
+        }
+
+        @Override
+        public String getPassword() {
+            return this.password;
+        }
+
+    }
+
+    private static final class NoOpCredentialsRefreshService implements CredentialsRefreshService {
+
+        private CredentialsProvider unregisteredCredentialsProvider;
+
+        private String unregisteredRegistrationId;
+
+        @Override
+        public String register(CredentialsProvider credentialsProvider, Callable<Boolean> refreshAction) {
+            return "registration";
+        }
+
+        @Override
+        public void unregister(CredentialsProvider credentialsProvider, String registrationId) {
+            this.unregisteredCredentialsProvider = credentialsProvider;
+            this.unregisteredRegistrationId = registrationId;
+        }
+
+        @Override
+        public boolean isApproachingExpiration(Duration timeBeforeExpiration) {
+            return false;
+        }
+
+    }
+
+    private static final class PassThroughMessageConverter implements MessageConverter {
+
+        @Override
+        public Message toMessage(Object object, MessageProperties messageProperties) {
+            return new Message(object.toString().getBytes(StandardCharsets.UTF_8), messageProperties);
+        }
+
+        @Override
+        public Object fromMessage(Message message) {
+            return message.getBody();
+        }
+
+    }
+
+}

--- a/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M3/user-code-filter.json
+++ b/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M3/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.springframework.boot.amqp.**"
+    },
+    {
+      "includeClasses" : "org_springframework_boot.spring_boot_amqp.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7186

This PR provides test fixes and new metadata for org.springframework.boot:spring-boot-amqp:4.1.0-M3, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 61480
- Cached input tokens: 774144
- Output tokens: 7805
- Metadata entries: 48
- Iterations: 1
- Library coverage percentage: 68.89
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 66.01

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `a02a60d1ff46eda0d11aa3fad709aba71d534a12`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.springframework.boot:spring-boot-amqp:4.0.2: 0/0 covered calls (100.00%)
- org.springframework.boot:spring-boot-amqp:4.1.0-M3: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.springframework.boot:spring-boot-amqp:4.0.2: 2149/3285 (65.42%)
- org.springframework.boot:spring-boot-amqp:4.1.0-M3: 262/385 (68.05%)

**Line:**
- org.springframework.boot:spring-boot-amqp:4.0.2: 538/815 (66.01%)
- org.springframework.boot:spring-boot-amqp:4.1.0-M3: 62/90 (68.89%)

**Method:**
- org.springframework.boot:spring-boot-amqp:4.0.2: 202/314 (64.33%)
- org.springframework.boot:spring-boot-amqp:4.1.0-M3: 33/50 (66.00%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.springframework.boot/spring-boot-amqp/4.0.2/build.gradle 2/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M3/build.gradle
index 1c9b0b3e5d..ba8835c958 100644
--- 1/tests/src/org.springframework.boot/spring-boot-amqp/4.0.2/build.gradle
+++ 2/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M3/build.gradle
@@ -13,6 +13,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.springframework.boot:spring-boot-amqp:$libraryVersion"
     testImplementation "org.springframework.boot:spring-boot-autoconfigure:$libraryVersion"
+    testImplementation "org.springframework.boot:spring-boot-test:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
diff --git 1/tests/src/org.springframework.boot/spring-boot-amqp/4.0.2/src/test/java/org_springframework_boot/spring_boot_amqp/Spring_boot_amqpTest.java 2/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M3/src/test/java/org_springframework_boot/spring_boot_amqp/Spring_boot_amqpTest.java
index dd2753b664..3b037a3ddd 100644
--- 1/tests/src/org.springframework.boot/spring-boot-amqp/4.0.2/src/test/java/org_springframework_boot/spring_boot_amqp/Spring_boot_amqpTest.java
+++ 2/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M3/src/test/java/org_springframework_boot/spring_boot_amqp/Spring_boot_amqpTest.java
@@ -6,988 +6,129 @@
  */
 package org_springframework_boot.spring_boot_amqp;
 
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import com.rabbitmq.client.impl.CredentialsProvider;
-import com.rabbitmq.client.impl.CredentialsRefreshService;
-import org.aopalliance.aop.Advice;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.amqp.core.AcknowledgeMode;
-import org.springframework.amqp.core.Message;
-import org.springframework.amqp.core.MessageProperties;
-import org.springframework.amqp.rabbit.config.DirectRabbitListenerContainerFactory;
-import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
-import org.springframework.amqp.rabbit.config.SimpleRabbitListenerEndpoint;
-import org.springframework.amqp.rabbit.connection.AbstractConnectionFactory.AddressShuffleMode;
-import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
-import org.springframework.amqp.rabbit.connection.CachingConnectionFactory.CacheMode;
-import org.springframework.amqp.rabbit.connection.CachingConnectionFactory.ConfirmType;
-import org.springframework.amqp.rabbit.connection.ConnectionFactory;
-import org.springframework.amqp.rabbit.connection.ConnectionNameStrategy;
-import org.springframework.amqp.rabbit.connection.RabbitConnectionFactoryBean;
-import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.amqp.rabbit.listener.DirectMessageListenerContainer;
-import org.springframework.amqp.support.converter.MessageConverter;
-import org.springframework.amqp.support.converter.SimpleMessageConverter;
-import org.springframework.boot.amqp.autoconfigure.CachingConnectionFactoryConfigurer;
-import org.springframework.boot.amqp.autoconfigure.DirectRabbitListenerContainerFactoryConfigurer;
-import org.springframework.boot.amqp.autoconfigure.RabbitConnectionDetails;
-import org.springframework.boot.amqp.autoconfigure.RabbitConnectionFactoryBeanConfigurer;
-import org.springframework.boot.amqp.autoconfigure.RabbitProperties;
-import org.springframework.boot.amqp.autoconfigure.RabbitProperties.ContainerType;
-import org.springframework.boot.amqp.autoconfigure.RabbitTemplateConfigurer;
-import org.springframework.boot.amqp.autoconfigure.SimpleRabbitListenerContainerFactoryConfigurer;
-import org.springframework.boot.context.properties.source.InvalidConfigurationPropertyValueException;
-import org.springframework.core.io.DefaultResourceLoader;
-import org.springframework.core.retry.RetryTemplate;
-import org.springframework.util.unit.DataSize;
+import org.springframework.amqp.client.AmqpClient;
+import org.springframework.amqp.client.AmqpConnectionFactory;
+import org.springframework.amqp.client.SingleAmqpConnectionFactory;
+import org.springframework.boot.amqp.autoconfigure.AmqpAutoConfiguration;
+import org.springframework.boot.amqp.autoconfigure.AmqpClientCustomizer;
+import org.springframework.boot.amqp.autoconfigure.AmqpConnectionDetails;
+import org.springframework.boot.amqp.autoconfigure.AmqpProperties;
+import org.springframework.boot.amqp.autoconfigure.ConnectionOptionsCustomizer;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class Spring_boot_amqpTest {
 
-    @Test
-    void rabbitPropertiesDetermineConnectionValuesFromDefaultsSslAndAddresses() {
-        RabbitProperties properties = new RabbitProperties();
-
-        assertThat(properties.determineHost()).isEqualTo("localhost");
-        assertThat(properties.determinePort()).isEqualTo(5672);
-        assertThat(properties.determineAddresses()).containsExactly("localhost:5672");
-        assertThat(properties.determineUsername()).isEqualTo("guest");
-        assertThat(properties.determinePassword()).isEqualTo("guest");
-        assertThat(properties.getSsl().determineEnabled()).isFalse();
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(AmqpAutoConfiguration.class));
 
-        properties.getSsl().setEnabled(true);
-        properties.setAddresses(
-                List.of("amqps://alice:secret@rabbit-one.example.test/orders", "rabbit-two.example.test:5673"));
+    @Test
+    void amqpPropertiesExposeConnectionAndClientSettings() {
+        AmqpProperties properties = new AmqpProperties();
 
-        assertThat(properties.determineHost()).isEqualTo("rabbit-one.example.test");
-        assertThat(properties.determinePort()).isEqualTo(5671);
-        assertThat(properties.determineAddresses()).containsExactly("rabbit-one.example.test:5671",
-                "rabbit-two.example.test:5673");
-        assertThat(properties.determineUsername()).isEqualTo("alice");
-        assertThat(properties.determinePassword()).isEqualTo("secret");
-        assertThat(properties.determineVirtualHost()).isEqualTo("orders");
-        assertThat(properties.getSsl().determineEnabled()).isTrue();
-    }
+        assertThat(properties.getHost()).isEqualTo("localhost");
+        assertThat(properties.getPort()).isEqualTo(5672);
+        assertThat(properties.getUsername()).isNull();
+        assertThat(properties.getPassword()).isNull();
+        assertThat(properties.getClient().getDefaultToAddress()).isNull();
+        assertThat(properties.getClient().getCompletionTimeout()).isEqualTo(Duration.ofSeconds(60));
 
-    @Test
-    void rabbitPropertiesExposeNestedTemplateListenerCacheAndStreamSettings() {
-        RabbitProperties properties = new RabbitProperties();
         properties.setHost("broker.example.test");
         properties.setPort(5678);
-        properties.setVirtualHost("");
-        properties.setRequestedHeartbeat(Duration.ofSeconds(9));
-        properties.setConnectionTimeout(Duration.ofMillis(750));
-        properties.setChannelRpcTimeout(Duration.ofSeconds(2));
-        properties.setMaxInboundMessageBodySize(DataSize.ofKilobytes(128));
-        properties.setAddressShuffleMode(AddressShuffleMode.INORDER);
-        properties.getCache().getChannel().setSize(12);
-        properties.getCache().getChannel().setCheckoutTimeout(Duration.ofMillis(25));
-        properties.getCache().getConnection().setMode(CacheMode.CONNECTION);
-        properties.getCache().getConnection().setSize(3);
-        properties.getListener().setType(ContainerType.DIRECT);
-        properties.getListener().getDirect().setConsumersPerQueue(4);
-        properties.getListener().getStream().setNativeListener(true);
-        properties.getTemplate().setExchange("events");
-        properties.getTemplate().setRoutingKey("created");
-        properties.getTemplate().setDefaultReceiveQueue("events.in");
-        properties.getTemplate().setAllowedListPatterns(List.of("java.util.*"));
-        properties.getTemplate().getRetry().setEnabled(true);
-        properties.getTemplate().getRetry().setMaxRetries(5);
-        properties.getStream().setHost("stream.example.test");
-        properties.getStream().setPort(5553);
-        properties.getStream().setName("orders-stream");
+        properties.setUsername("alice");
+        properties.setPassword("secret");
+        properties.getClient().setDefaultToAddress("orders.created");
+        properties.getClient().setCompletionTimeout(Duration.ofMillis(750));
 
-        assertThat(properties.determineAddresses()).containsExactly("broker.example.test:5678");
-        assertThat(properties.determineVirtualHost()).isEqualTo("/");
-        assertThat(properties.getRequestedHeartbeat()).isEqualTo(Duration.ofSeconds(9));
-        assertThat(properties.getConnectionTimeout()).isEqualTo(Duration.ofMillis(750));
-        assertThat(properties.getChannelRpcTimeout()).isEqualTo(Duration.ofSeconds(2));
-        assertThat(properties.getMaxInboundMessageBodySize()).isEqualTo(DataSize.ofKilobytes(128));
-        assertThat(properties.getAddressShuffleMode()).isEqualTo(AddressShuffleMode.INORDER);
-        assertThat(properties.getCache().getChannel().getSize()).isEqualTo(12);
-        assertThat(properties.getCache().getChannel().getCheckoutTimeout()).isEqualTo(Duration.ofMillis(25));
-        assertThat(properties.getCache().getConnection().getMode()).isEqualTo(CacheMode.CONNECTION);
-        assertThat(properties.getCache().getConnection().getSize()).isEqualTo(3);
-        assertThat(properties.getListener().getType()).isEqualTo(ContainerType.DIRECT);
-        assertThat(properties.getListener().getDirect().getConsumersPerQueue()).isEqualTo(4);
-        assertThat(properties.getListener().getStream().isNativeListener()).isTrue();
-        assertThat(properties.getTemplate().getExchange()).isEqualTo("events");
-        assertThat(properties.getTemplate().getRoutingKey()).isEqualTo("created");
-        assertThat(properties.getTemplate().getDefaultReceiveQueue()).isEqualTo("events.in");
-        assertThat(properties.getTemplate().getAllowedListPatterns()).containsExactly("java.util.*");
-        assertThat(properties.getTemplate().getRetry().isEnabled()).isTrue();
-        assertThat(properties.getTemplate().getRetry().getMaxRetries()).isEqualTo(5);
-        assertThat(properties.getStream().getHost()).isEqualTo("stream.example.test");
-        assertThat(properties.getStream().getPort()).isEqualTo(5553);
-        assertThat(properties.getStream().getName()).isEqualTo("orders-stream");
+        assertThat(properties.getHost()).isEqualTo("broker.example.test");
+        assertThat(properties.getPort()).isEqualTo(5678);
+        assertThat(properties.getUsername()).isEqualTo("alice");
+        assertThat(properties.getPassword()).isEqualTo("secret");
+        assertThat(properties.getClient().getDefaultToAddress()).isEqualTo("orders.created");
+        assertThat(properties.getClient().getCompletionTimeout()).isEqualTo(Duration.ofMillis(750));
     }
 
     @Test
-    void rabbitPropertiesRejectCommaSeparatedHostWhenDeterminingAddresses() {
-        RabbitProperties properties = new RabbitProperties();
-        properties.setHost("one.example.test,two.example.test");
-
-        assertThatThrownBy(properties::determineAddresses)
-                .isInstanceOf(InvalidConfigurationPropertyValueException.class)
-                .hasMessageContaining("spring.rabbitmq.host")
-                .hasMessageContaining("spring.rabbitmq.addresses");
-    }
+    void amqpConnectionDetailsAddressRecordAndDefaultsAreUsable() {
+        AmqpConnectionDetails.Address address = new AmqpConnectionDetails.Address("broker.example.test", 5679);
+        AmqpConnectionDetails details = () -> address;
 
-    @Test
-    void rabbitConnectionDetailsDefaultsAndAddressRecordAreUsable() {
-        RabbitConnectionDetails.Address first = new RabbitConnectionDetails.Address("first.example.test", 6001);
-        RabbitConnectionDetails.Address second = new RabbitConnectionDetails.Address("second.example.test", 6002);
-        RabbitConnectionDetails details = connectionDetails(List.of(first, second));
-
-        assertThat(details.getAddresses()).containsExactly(first, second);
-        assertThat(details.getFirstAddress()).isEqualTo(first);
+        assertThat(details.getAddress()).isEqualTo(address);
+        assertThat(details.getAddress().host()).isEqualTo("broker.example.test");
+        assertThat(details.getAddress().port()).isEqualTo(5679);
         assertThat(details.getUsername()).isNull();
         assertThat(details.getPassword()).isNull();
-        assertThat(details.getVirtualHost()).isNull();
-        assertThat(details.getSslBundle()).isNull();
-        assertThat(first.host()).isEqualTo("first.example.test");
-        assertThat(first.port()).isEqualTo(6001);
-    }
-
-    @Test
-    void rabbitTemplateConfigurerAppliesTemplateSettingsAndRetryCustomizers() {
-        RabbitProperties properties = new RabbitProperties();
-        properties.setPublisherReturns(true);
-        properties.getTemplate().setReceiveTimeout(Duration.ofMillis(125));
-        properties.getTemplate().setReplyTimeout(Duration.ofMillis(250));
-        properties.getTemplate().setExchange("orders.exchange");
-        properties.getTemplate().setRoutingKey("orders.created");
-        properties.getTemplate().setDefaultReceiveQueue("orders.in");
-        properties.getTemplate().setObservationEnabled(true);
-        properties.getTemplate().getRetry().setEnabled(true);
-        properties.getTemplate().getRetry().setInitialInterval(Duration.ofMillis(10));
-        properties.getTemplate().getRetry().setMaxInterval(Duration.ofMillis(20));
-        CapturingRabbitTemplate template = new CapturingRabbitTemplate();
-        MessageConverter converter = new SimpleMessageConverter();
-        RabbitTemplateConfigurer configurer = new RabbitTemplateConfigurer(properties);
-        AtomicBoolean customizerInvoked = new AtomicBoolean();
-        configurer.setMessageConverter(converter);
-        configurer.setRetrySettingsCustomizers(List.of((settings) -> {
-            customizerInvoked.set(true);
-            settings.getRetryPolicySettings().setMaxRetries(2L);
-        }));
-        CachingConnectionFactory connectionFactory = newCachingConnectionFactory();
-
-        try {
-            configurer.configure(template, connectionFactory);
-        } finally {
-            connectionFactory.destroy();
-        }
-
-        assertThat(template.getMessageConverter()).isSameAs(converter);
-        assertThat(template.receiveTimeout).isEqualTo(125L);
-        assertThat(template.replyTimeout).isEqualTo(250L);
-        assertThat(template.getExchange()).isEqualTo("orders.exchange");
-        assertThat(template.getRoutingKey()).isEqualTo("orders.created");
-        assertThat(template.getDefaultReceiveQueue()).isEqualTo("orders.in");
-        assertThat(template.observationEnabled).isTrue();
-        assertThat(template.retryTemplate).isNotNull();
-        assertThat(customizerInvoked).isTrue();
-        assertThat(template.isMandatoryFor(new Message(new byte[0], new MessageProperties()))).isTrue();
-    }
-
-    @Test
-    void rabbitTemplateConfigurerUsesExplicitMandatoryFlagOverPublisherReturns() {
-        RabbitProperties properties = new RabbitProperties();
-        properties.setPublisherReturns(true);
-        properties.getTemplate().setMandatory(false);
-        CapturingRabbitTemplate template = new CapturingRabbitTemplate();
-        CachingConnectionFactory connectionFactory = newCachingConnectionFactory();
-
-        try {
-            new RabbitTemplateConfigurer(properties).configure(template, connectionFactory);
-        } finally {
-            connectionFactory.destroy();
-        }
-
-        assertThat(template.isMandatoryFor(new Message(new byte[0], new MessageProperties()))).isFalse();
-    }
-
-    @Test
-    void rabbitTemplateConfigurerReportsInvalidAllowedListConverter() {
-        RabbitProperties properties = new RabbitProperties();
-        properties.getTemplate().setAllowedListPatterns(List.of("java.util.*"));
-        CapturingRabbitTemplate template = new CapturingRabbitTemplate();
-        template.setMessageConverter(new PassThroughMessageConverter());
-        CachingConnectionFactory connectionFactory = newCachingConnectionFactory();
-
-        try {
-            RabbitTemplateConfigurer configurer = new RabbitTemplateConfigurer(properties);
-
-            assertThatThrownBy(() -> configurer.configure(template, connectionFactory))
-                    .isInstanceOf(InvalidConfigurationPropertyValueException.class)
-                    .hasMessageContaining("spring.rabbitmq.template.allowed-list-patterns");
-        } finally {
-            connectionFactory.destroy();
-        }
-    }
-
-    @Test
-    void cachingConnectionFactoryConfigurerAppliesConnectionFactorySettings() {
-        RabbitProperties properties = new RabbitProperties();
-        properties.setPublisherReturns(true);
-        properties.setPublisherConfirmType(ConfirmType.CORRELATED);
-        properties.setAddressShuffleMode(AddressShuffleMode.RANDOM);
-        properties.getCache().getChannel().setSize(8);
-        properties.getCache().getChannel().setCheckoutTimeout(Duration.ofMillis(50));
-        RabbitConnectionDetails details = connectionDetails(
-                List.of(new RabbitConnectionDetails.Address("rabbit-a.example.test", 6100),
-                        new RabbitConnectionDetails.Address("rabbit-b.example.test", 6101)));
-        CapturingCachingConnectionFactory connectionFactory = new CapturingCachingConnectionFactory();
-        ConnectionNameStrategy nameStrategy = (factory) -> "orders-connection";
-        CachingConnectionFactoryConfigurer configurer = new CachingConnectionFactoryConfigurer(properties, details);
-        configurer.setConnectionNameStrategy(nameStrategy);
-
-        try {
-            configurer.configure(connectionFactory);
-        } finally {
-            connectionFactory.destroy();
-        }
-
-        assertThat(connectionFactory.addresses).isEqualTo("rabbit-a.example.test:6100,rabbit-b.example.test:6101");
-        assertThat(connectionFactory.addressShuffleMode).isEqualTo(AddressShuffleMode.RANDOM);
-        assertThat(connectionFactory.connectionNameStrategy).isSameAs(nameStrategy);
-        assertThat(connectionFactory.publisherReturns).isTrue();
-        assertThat(connectionFactory.publisherConfirmType).isEqualTo(ConfirmType.CORRELATED);
-        assertThat(connectionFactory.channelCacheSize).isEqualTo(8);
-        assertThat(connectionFactory.channelCheckoutTimeout).isEqualTo(50L);
-        assertThat(connectionFactory.cacheMode).isEqualTo(CacheMode.CHANNEL);
-    }
-
-    @Test
-    void rabbitConnectionFactoryBeanConfigurerUsesConnectionDetailsBeforeProperties() throws Exception {
-        RabbitProperties properties = new RabbitProperties();
-        properties.setHost("ignored.example.test");
-        properties.setPort(9999);
-        properties.setUsername("ignored-user");
-        properties.setPassword("ignored-password");
-        properties.setVirtualHost("ignored-vhost");
-        properties.setRequestedHeartbeat(Duration.ofSeconds(7));
-        properties.setRequestedChannelMax(32);
-        properties.setConnectionTimeout(Duration.ofMillis(450));
-        properties.setChannelRpcTimeout(Duration.ofMillis(650));
-        properties.setMaxInboundMessageBodySize(DataSize.ofKilobytes(64));
-        RabbitConnectionDetails details = connectionDetails("detail-user", "detail-password", "detail-vhost",
-                List.of(new RabbitConnectionDetails.Address("details.example.test", 6200)));
-        RabbitConnectionFactoryBean factoryBean = new RabbitConnectionFactoryBean();
-        RabbitConnectionFactoryBeanConfigurer configurer = new RabbitConnectionFactoryBeanConfigurer(
-                new DefaultResourceLoader(), properties, details);
-
-        configurer.configure(factoryBean);
-        factoryBean.afterPropertiesSet();
-
-        com.rabbitmq.client.ConnectionFactory rabbitFactory = factoryBean.getRabbitConnectionFactory();
-        assertThat(rabbitFactory.getHost()).isEqualTo("details.example.test");
-        assertThat(rabbitFactory.getPort()).isEqualTo(6200);
-        assertThat(rabbitFactory.getUsername()).isEqualTo("detail-user");
-        assertThat(rabbitFactory.getPassword()).isEqualTo("detail-password");
-        assertThat(rabbitFactory.getVirtualHost()).isEqualTo("detail-vhost");
-        assertThat(rabbitFactory.getRequestedHeartbeat()).isEqualTo(7);
-        assertThat(rabbitFactory.getRequestedChannelMax()).isEqualTo(32);
-        assertThat(rabbitFactory.getConnectionTimeout()).isEqualTo(450);
-        assertThat(rabbitFactory.getChannelRpcTimeout()).isEqualTo(650);
-    }
-
-    @Test
-    void rabbitConnectionFactoryBeanConfigurerAppliesCredentialsProviderAndRefreshService() {
-        RabbitProperties properties = new RabbitProperties();
-        RabbitConnectionDetails details = connectionDetails(
-                List.of(new RabbitConnectionDetails.Address("credentials.example.test", 6300)));
-        CredentialsProvider credentialsProvider = new StaticCredentialsProvider("rotating-user", "rotating-password");
-        CredentialsRefreshService credentialsRefreshService = new NoOpCredentialsRefreshService();
-        CapturingRabbitConnectionFactoryBean factoryBean = new CapturingRabbitConnectionFactoryBean();
-        RabbitConnectionFactoryBeanConfigurer configurer = new RabbitConnectionFactoryBeanConfigurer(
-                new DefaultResourceLoader(), properties, details);
-
-        configurer.setCredentialsProvider(credentialsProvider);
-        configurer.setCredentialsRefreshService(credentialsRefreshService);
-        configurer.configure(factoryBean);
-
-        assertThat(factoryBean.credentialsProvider).isSameAs(credentialsProvider);
-        assertThat(factoryBean.credentialsRefreshService).isSameAs(credentialsRefreshService);
-        assertThat(factoryBean.credentialsProvider.getUsername()).isEqualTo("rotating-user");
-        assertThat(factoryBean.credentialsProvider.getPassword()).isEqualTo("rotating-password");
-    }
-
-    @Test
-    void rabbitConnectionFactoryBeanConfigurerAppliesSslSettings() {
-        RabbitProperties properties = new RabbitProperties();
-        RabbitProperties.Ssl ssl = properties.getSsl();
-        ssl.setEnabled(true);
-        ssl.setAlgorithm("TLSv1.3");
-        ssl.setKeyStore("classpath:client.p12");
-        ssl.setKeyStoreType("PKCS12");
-        ssl.setKeyStorePassword("key-password");
-        ssl.setKeyStoreAlgorithm("SunX509");
-        ssl.setTrustStore("classpath:trust.p12");
-        ssl.setTrustStoreType("PKCS12");
-        ssl.setTrustStorePassword("trust-password");
-        ssl.setTrustStoreAlgorithm("SunX509");
-        ssl.setValidateServerCertificate(false);
-        ssl.setVerifyHostname(true);
-        RabbitConnectionDetails details = connectionDetails(
-                List.of(new RabbitConnectionDetails.Address("secure.example.test", 5671)));
-        CapturingRabbitConnectionFactoryBean factoryBean = new CapturingRabbitConnectionFactoryBean();
-        RabbitConnectionFactoryBeanConfigurer configurer = new RabbitConnectionFactoryBeanConfigurer(
-                new DefaultResourceLoader(), properties, details);
-
-        configurer.configure(factoryBean);
-
-        assertThat(factoryBean.useSsl).isTrue();
-        assertThat(factoryBean.sslAlgorithm).isEqualTo("TLSv1.3");
-        assertThat(factoryBean.keyStore).isEqualTo("classpath:client.p12");
-        assertThat(factoryBean.keyStoreType).isEqualTo("PKCS12");
-        assertThat(factoryBean.keyStorePassphrase).isEqualTo("key-password");
-        assertThat(factoryBean.keyStoreAlgorithm).isEqualTo("SunX509");
-        assertThat(factoryBean.trustStore).isEqualTo("classpath:trust.p12");
-        assertThat(factoryBean.trustStoreType).isEqualTo("PKCS12");
-        assertThat(factoryBean.trustStorePassphrase).isEqualTo("trust-password");
-        assertThat(factoryBean.trustStoreAlgorithm).isEqualTo("SunX509");
-        assertThat(factoryBean.skipServerCertificateValidation).isTrue();
-        assertThat(factoryBean.enableHostnameVerification).isTrue();
-    }
-
-    @Test
-    void simpleListenerContainerFactoryConfigurerAppliesCommonSimpleAndRetrySettings() {
-        RabbitProperties properties = new RabbitProperties();
-        RabbitProperties.SimpleContainer simple = properties.getListener().getSimple();
-        simple.setAutoStartup(false);
-        simple.setAcknowledgeMode(AcknowledgeMode.MANUAL);
-        simple.setPrefetch(5);
-        simple.setDefaultRequeueRejected(false);
-        simple.setIdleEventInterval(Duration.ofMillis(75));
-        simple.setMissingQueuesFatal(false);
-        simple.setDeBatchingEnabled(false);
-        simple.setForceStop(true);
-        simple.setObservationEnabled(true);
-        simple.setConcurrency(2);
-        simple.setMaxConcurrency(4);
-        simple.setBatchSize(10);
-        simple.setConsumerBatchEnabled(true);
-        simple.getRetry().setEnabled(true);
-        simple.getRetry().setMaxRetries(2);
-        CapturingSimpleRabbitListenerContainerFactory factory = new CapturingSimpleRabbitListenerContainerFactory();
-        Executor executor = Runnable::run;
-        SimpleRabbitListenerContainerFactoryConfigurer configurer = new SimpleRabbitListenerContainerFactoryConfigurer(
-                properties);
-        CachingConnectionFactory connectionFactory = newCachingConnectionFactory();
-        configurer.setTaskExecutor(executor);
-
-        try {
-            configurer.configure(factory, connectionFactory);
-        } finally {
-            connectionFactory.destroy();
-        }
-
-        assertCommonListenerSettings(factory, connectionFactory, executor);
-        assertThat(factory.concurrentConsumers).isEqualTo(2);
-        assertThat(factory.maxConcurrentConsumers).isEqualTo(4);
-        assertThat(factory.batchSize).isEqualTo(10);
-        assertThat(factory.consumerBatchEnabled).isTrue();
-        assertThat(factory.adviceChain).isNotEmpty();
-    }
-
-    @Test
-    void directListenerContainerFactoryConfigurerAppliesCommonAndDirectSettings() {
-        RabbitProperties properties = new RabbitProperties();
-        RabbitProperties.DirectContainer direct = properties.getListener().getDirect();
-        direct.setAutoStartup(false);
-        direct.setAcknowledgeMode(AcknowledgeMode.AUTO);
-        direct.setPrefetch(6);
-        direct.setDefaultRequeueRejected(true);
-        direct.setIdleEventInterval(Duration.ofMillis(80));
-        direct.setMissingQueuesFatal(true);
-        direct.setDeBatchingEnabled(false);
-        direct.setForceStop(true);
-        direct.setObservationEnabled(true);
-        direct.setConsumersPerQueue(3);
-        DirectRabbitListenerContainerFactory factory = new DirectRabbitListenerContainerFactory();
-        Executor executor = Runnable::run;
-        DirectRabbitListenerContainerFactoryConfigurer configurer = new DirectRabbitListenerContainerFactoryConfigurer(
-                properties);
-        CachingConnectionFactory connectionFactory = newCachingConnectionFactory();
-        configurer.setTaskExecutor(executor);
 
-        try {
-            configurer.configure(factory, connectionFactory);
-            SimpleRabbitListenerEndpoint endpoint = new SimpleRabbitListenerEndpoint();
-            endpoint.setId("direct-orders");
-            endpoint.setQueueNames("orders.in");
-            endpoint.setMessageListener((message) -> {
-                throw new AssertionError("Listener should not be invoked");
-            });
-            DirectMessageListenerContainer container = factory.createListenerContainer(endpoint);
+        AmqpConnectionDetails authenticatedDetails = new AmqpConnectionDetails() {
 
-            try {
-                assertThat(container.getConnectionFactory()).isSameAs(connectionFactory);
-                assertThat(container.isAutoStartup()).isFalse();
-                assertThat(container.getAcknowledgeMode()).isEqualTo(AcknowledgeMode.AUTO);
-                assertThat(container.getQueueNames()).containsExactly("orders.in");
-            } finally {
-                container.destroy();
+            @Override
+            public AmqpConnectionDetails.Address getAddress() {
+                return address;
             }
-        } finally {
-            connectionFactory.destroy();
-        }
-    }
-
-    private static RabbitConnectionDetails connectionDetails(List<RabbitConnectionDetails.Address> addresses) {
-        return connectionDetails(null, null, null, addresses);
-    }
-
-    private static RabbitConnectionDetails connectionDetails(String username, String password, String virtualHost,
-            List<RabbitConnectionDetails.Address> addresses) {
-        return new RabbitConnectionDetails() {
 
             @Override
             public String getUsername() {
-                return username;
+                return "alice";
             }
 
             @Override
             public String getPassword() {
-                return password;
-            }
-
-            @Override
-            public String getVirtualHost() {
-                return virtualHost;
-            }
-
-            @Override
-            public List<RabbitConnectionDetails.Address> getAddresses() {
-                return addresses;
+                return "secret";
             }
 
         };
-    }
-
-    private static CachingConnectionFactory newCachingConnectionFactory() {
-        return new CachingConnectionFactory(new com.rabbitmq.client.ConnectionFactory());
-    }
 
-    private static void assertCommonListenerSettings(CapturingListenerSettings factory,
-            CachingConnectionFactory connectionFactory, Executor executor) {
-        assertThat(factory.connectionFactory()).isSameAs(connectionFactory);
-        assertThat(factory.autoStartup()).isFalse();
-        assertThat(factory.acknowledgeMode()).isNotNull();
-        assertThat(factory.prefetchCount()).isGreaterThan(0);
-        assertThat(factory.defaultRequeueRejected()).isNotNull();
-        assertThat(factory.idleEventInterval()).isGreaterThan(0L);
-        assertThat(factory.deBatchingEnabled()).isFalse();
-        assertThat(factory.forceStop()).isTrue();
-        assertThat(factory.observationEnabled()).isTrue();
-        assertThat(factory.taskExecutor()).isSameAs(executor);
+        assertThat(authenticatedDetails.getAddress()).isSameAs(address);
+        assertThat(authenticatedDetails.getUsername()).isEqualTo("alice");
+        assertThat(authenticatedDetails.getPassword()).isEqualTo("secret");
     }
 
-    private static class CapturingRabbitTemplate extends RabbitTemplate {
-
-        private long receiveTimeout;
-
-        private long replyTimeout;
-
-        private boolean observationEnabled;
-
-        private RetryTemplate retryTemplate;
-
-        @Override
-        public void setReceiveTimeout(long receiveTimeout) {
-            super.setReceiveTimeout(receiveTimeout);
-            this.receiveTimeout = receiveTimeout;
-        }
-
-        @Override
-        public void setReplyTimeout(long replyTimeout) {
-            super.setReplyTimeout(replyTimeout);
-            this.replyTimeout = replyTimeout;
-        }
-
-        @Override
-        public void setObservationEnabled(boolean observationEnabled) {
-            super.setObservationEnabled(observationEnabled);
-            this.observationEnabled = observationEnabled;
-        }
-
-        @Override
-        public void setRetryTemplate(RetryTemplate retryTemplate) {
-            super.setRetryTemplate(retryTemplate);
-            this.retryTemplate = retryTemplate;
-        }
-
-    }
-
-    private static class CapturingRabbitConnectionFactoryBean extends RabbitConnectionFactoryBean {
-
-        private CredentialsProvider credentialsProvider;
-
-        private CredentialsRefreshService credentialsRefreshService;
-
-        private boolean useSsl;
-
-        private String sslAlgorithm;
-
-        private String keyStore;
-
-        private String keyStoreType;
-
-        private String keyStorePassphrase;
-
-        private String keyStoreAlgorithm;
-
-        private String trustStore;
-
-        private String trustStoreType;
-
-        private String trustStorePassphrase;
-
-        private String trustStoreAlgorithm;
-
-        private boolean skipServerCertificateValidation;
-
-        private boolean enableHostnameVerification;
-
-        @Override
-        public void setCredentialsProvider(CredentialsProvider credentialsProvider) {
-            super.setCredentialsProvider(credentialsProvider);
-            this.credentialsProvider = credentialsProvider;
-        }
-
-        @Override
-        public void setCredentialsRefreshService(CredentialsRefreshService credentialsRefreshService) {
-            super.setCredentialsRefreshService(credentialsRefreshService);
-            this.credentialsRefreshService = credentialsRefreshService;
-        }
-
-        @Override
-        public void setUseSSL(boolean useSsl) {
-            super.setUseSSL(useSsl);
-            this.useSsl = useSsl;
-        }
-
-        @Override
-        public void setSslAlgorithm(String sslAlgorithm) {
-            super.setSslAlgorithm(sslAlgorithm);
-            this.sslAlgorithm = sslAlgorithm;
-        }
-
-        @Override
-        public void setKeyStore(String keyStore) {
-            super.setKeyStore(keyStore);
-            this.keyStore = keyStore;
-        }
-
-        @Override
-        public void setKeyStoreType(String keyStoreType) {
-            super.setKeyStoreType(keyStoreType);
-            this.keyStoreType = keyStoreType;
-        }
-
-        @Override
-        public void setKeyStorePassphrase(String keyStorePassphrase) {
-            super.setKeyStorePassphrase(keyStorePassphrase);
-            this.keyStorePassphrase = keyStorePassphrase;
-        }
-
-        @Override
-        public void setKeyStoreAlgorithm(String keyStoreAlgorithm) {
-            super.setKeyStoreAlgorithm(keyStoreAlgorithm);
-            this.keyStoreAlgorithm = keyStoreAlgorithm;
-        }
-
-        @Override
-        public void setTrustStore(String trustStore) {
-            super.setTrustStore(trustStore);
-            this.trustStore = trustStore;
-        }
-
-        @Override
-        public void setTrustStoreType(String trustStoreType) {
-            super.setTrustStoreType(trustStoreType);
-            this.trustStoreType = trustStoreType;
-        }
-
-        @Override
-        public void setTrustStorePassphrase(String trustStorePassphrase) {
-            super.setTrustStorePassphrase(trustStorePassphrase);
-            this.trustStorePassphrase = trustStorePassphrase;
-        }
-
-        @Override
-        public void setTrustStoreAlgorithm(String trustStoreAlgorithm) {
-            super.setTrustStoreAlgorithm(trustStoreAlgorithm);
-            this.trustStoreAlgorithm = trustStoreAlgorithm;
-        }
-
-        @Override
-        public void setSkipServerCertificateValidation(boolean skipServerCertificateValidation) {
-            super.setSkipServerCertificateValidation(skipServerCertificateValidation);
-            this.skipServerCertificateValidation = skipServerCertificateValidation;
-        }
-
-        @Override
-        public void setEnableHostnameVerification(boolean enableHostnameVerification) {
-            super.setEnableHostnameVerification(enableHostnameVerification);
-            this.enableHostnameVerification = enableHostnameVerification;
-        }
-
-    }
-
-    private static class CapturingCachingConnectionFactory extends CachingConnectionFactory {
-
-        private String addresses;
-
-        private AddressShuffleMode addressShuffleMode;
-
-        private ConnectionNameStrategy connectionNameStrategy;
-
-        private boolean publisherReturns;
-
-        private ConfirmType publisherConfirmType;
-
-        private int channelCacheSize;
-
-        private long channelCheckoutTimeout;
-
-        private CacheMode cacheMode;
-
-        private int connectionCacheSize;
-
-        @Override
-        public void setAddresses(String addresses) {
-            super.setAddresses(addresses);
-            this.addresses = addresses;
-        }
-
-        @Override
-        public void setAddressShuffleMode(AddressShuffleMode addressShuffleMode) {
-            super.setAddressShuffleMode(addressShuffleMode);
-            this.addressShuffleMode = addressShuffleMode;
-        }
-
-        @Override
-        public void setConnectionNameStrategy(ConnectionNameStrategy connectionNameStrategy) {
-            super.setConnectionNameStrategy(connectionNameStrategy);
-            this.connectionNameStrategy = connectionNameStrategy;
-        }
-
-        @Override
-        public void setPublisherReturns(boolean publisherReturns) {
-            super.setPublisherReturns(publisherReturns);
-            this.publisherReturns = publisherReturns;
-        }
-
-        @Override
-        public void setPublisherConfirmType(ConfirmType confirmType) {
-            super.setPublisherConfirmType(confirmType);
-            this.publisherConfirmType = confirmType;
-        }
-
-        @Override
-        public void setChannelCacheSize(int sessionCacheSize) {
-            super.setChannelCacheSize(sessionCacheSize);
-            this.channelCacheSize = sessionCacheSize;
-        }
-
-        @Override
-        public void setChannelCheckoutTimeout(long channelCheckoutTimeout) {
-            super.setChannelCheckoutTimeout(channelCheckoutTimeout);
-            this.channelCheckoutTimeout = channelCheckoutTimeout;
-        }
-
-        @Override
-        public void setCacheMode(CacheMode cacheMode) {
-            super.setCacheMode(cacheMode);
-            this.cacheMode = cacheMode;
-        }
-
-        @Override
-        public void setConnectionCacheSize(int connectionCacheSize) {
-            super.setConnectionCacheSize(connectionCacheSize);
-            this.connectionCacheSize = connectionCacheSize;
-        }
-
-    }
-
-    private interface CapturingListenerSettings {
-
-        ConnectionFactory connectionFactory();
-
-        Boolean autoStartup();
-
-        AcknowledgeMode acknowledgeMode();
-
-        Integer prefetchCount();
-
-        Boolean defaultRequeueRejected();
-
-        Long idleEventInterval();
-
-        Boolean deBatchingEnabled();
-
-        Boolean forceStop();
-
-        Boolean observationEnabled();
-
-        Executor taskExecutor();
-
-    }
-
-    private static class CapturingSimpleRabbitListenerContainerFactory extends SimpleRabbitListenerContainerFactory
-            implements CapturingListenerSettings {
-
-        private ConnectionFactory connectionFactory;
-
-        private Boolean autoStartup;
-
-        private AcknowledgeMode acknowledgeMode;
-
-        private Integer prefetchCount;
-
-        private Boolean defaultRequeueRejected;
-
-        private Long idleEventInterval;
-
-        private Boolean missingQueuesFatal;
-
-        private Boolean deBatchingEnabled;
-
-        private Boolean forceStop;
-
-        private Boolean observationEnabled;
-
-        private Executor taskExecutor;
-
-        private Advice[] adviceChain = new Advice[0];
-
-        private Integer concurrentConsumers;
-
-        private Integer maxConcurrentConsumers;
-
-        private Integer batchSize;
-
-        private boolean consumerBatchEnabled;
-
-        @Override
-        public void setConnectionFactory(ConnectionFactory connectionFactory) {
-            super.setConnectionFactory(connectionFactory);
-            this.connectionFactory = connectionFactory;
-        }
-
-        @Override
-        public void setAutoStartup(Boolean autoStartup) {
-            super.setAutoStartup(autoStartup);
-            this.autoStartup = autoStartup;
-        }
-
-        @Override
-        public void setAcknowledgeMode(AcknowledgeMode acknowledgeMode) {
-            super.setAcknowledgeMode(acknowledgeMode);
-            this.acknowledgeMode = acknowledgeMode;
-        }
-
-        @Override
-        public void setPrefetchCount(Integer prefetchCount) {
-            super.setPrefetchCount(prefetchCount);
-            this.prefetchCount = prefetchCount;
-        }
-
-        @Override
-        public void setDefaultRequeueRejected(Boolean defaultRequeueRejected) {
-            super.setDefaultRequeueRejected(defaultRequeueRejected);
-            this.defaultRequeueRejected = defaultRequeueRejected;
-        }
-
-        @Override
-        public void setIdleEventInterval(Long idleEventInterval) {
-            super.setIdleEventInterval(idleEventInterval);
-            this.idleEventInterval = idleEventInterval;
-        }
-
-        @Override
-        public void setMissingQueuesFatal(Boolean missingQueuesFatal) {
-            super.setMissingQueuesFatal(missingQueuesFatal);
-            this.missingQueuesFatal = missingQueuesFatal;
-        }
-
-        @Override
-        public void setDeBatchingEnabled(Boolean deBatchingEnabled) {
-            super.setDeBatchingEnabled(deBatchingEnabled);
-            this.deBatchingEnabled = deBatchingEnabled;
-        }
-
-        @Override
-        public void setForceStop(boolean forceStop) {
-            super.setForceStop(forceStop);
-            this.forceStop = forceStop;
-        }
-
-        @Override
-        public void setObservationEnabled(boolean observationEnabled) {
-            super.setObservationEnabled(observationEnabled);
-            this.observationEnabled = observationEnabled;
-        }
-
-        @Override
-        public void setTaskExecutor(Executor taskExecutor) {
-            super.setTaskExecutor(taskExecutor);
-            this.taskExecutor = taskExecutor;
-        }
-
-        @Override
-        public void setAdviceChain(Advice... adviceChain) {
-            super.setAdviceChain(adviceChain);
-            this.adviceChain = adviceChain;
-        }
-
-        @Override
-        public void setConcurrentConsumers(Integer concurrentConsumers) {
-            super.setConcurrentConsumers(concurrentConsumers);
-            this.concurrentConsumers = concurrentConsumers;
-        }
-
-        @Override
-        public void setMaxConcurrentConsumers(Integer maxConcurrentConsumers) {
-            super.setMaxConcurrentConsumers(maxConcurrentConsumers);
-            this.maxConcurrentConsumers = maxConcurrentConsumers;
-        }
-
-        @Override
-        public void setBatchSize(Integer batchSize) {
-            super.setBatchSize(batchSize);
-            this.batchSize = batchSize;
-        }
-
-        @Override
-        public void setConsumerBatchEnabled(boolean consumerBatchEnabled) {
-            super.setConsumerBatchEnabled(consumerBatchEnabled);
-            this.consumerBatchEnabled = consumerBatchEnabled;
-        }
-
-        @Override
-        public ConnectionFactory connectionFactory() {
-            return this.connectionFactory;
-        }
-
-        @Override
-        public Boolean autoStartup() {
-            return this.autoStartup;
-        }
-
-        @Override
-        public AcknowledgeMode acknowledgeMode() {
-            return this.acknowledgeMode;
-        }
-
-        @Override
-        public Integer prefetchCount() {
-            return this.prefetchCount;
-        }
-
-        @Override
-        public Boolean defaultRequeueRejected() {
-            return this.defaultRequeueRejected;
-        }
-
-        @Override
-        public Long idleEventInterval() {
-            return this.idleEventInterval;
-        }
-
-        @Override
-        public Boolean deBatchingEnabled() {
-            return this.deBatchingEnabled;
-        }
-
-        @Override
-        public Boolean forceStop() {
-            return this.forceStop;
-        }
-
-        @Override
-        public Boolean observationEnabled() {
-            return this.observationEnabled;
-        }
-
-        @Override
-        public Executor taskExecutor() {
-            return this.taskExecutor;
-        }
-
-    }
-
-    private static final class StaticCredentialsProvider implements CredentialsProvider {
-
-        private final String username;
-
-        private final String password;
-
-        private StaticCredentialsProvider(String username, String password) {
-            this.username = username;
-            this.password = password;
-        }
-
-        @Override
-        public String getUsername() {
-            return this.username;
-        }
-
-        @Override
-        public String getPassword() {
-            return this.password;
-        }
-
-    }
-
-    private static final class NoOpCredentialsRefreshService implements CredentialsRefreshService {
-
-        private CredentialsProvider unregisteredCredentialsProvider;
-
-        private String unregisteredRegistrationId;
-
-        @Override
-        public String register(CredentialsProvider credentialsProvider, Callable<Boolean> refreshAction) {
-            return "registration";
-        }
-
-        @Override
-        public void unregister(CredentialsProvider credentialsProvider, String registrationId) {
-            this.unregisteredCredentialsProvider = credentialsProvider;
-            this.unregisteredRegistrationId = registrationId;
-        }
-
-        @Override
-        public boolean isApproachingExpiration(Duration timeBeforeExpiration) {
-            return false;
-        }
-
-    }
-
-    private static final class PassThroughMessageConverter implements MessageConverter {
-
-        @Override
-        public Message toMessage(Object object, MessageProperties messageProperties) {
-            return new Message(object.toString().getBytes(StandardCharsets.UTF_8), messageProperties);
-        }
-
-        @Override
-        public Object fromMessage(Message message) {
-            return message.getBody();
-        }
-
+    @Test
+    void autoConfigurationCreatesConnectionFactoryClientAndAppliesCustomizers() {
+        AtomicBoolean connectionOptionsCustomizerInvoked = new AtomicBoolean();
+        AtomicBoolean clientCustomizerInvoked = new AtomicBoolean();
+
+        this.contextRunner
+                .withPropertyValues("spring.amqp.host=broker.example.test", "spring.amqp.port=5679",
+                        "spring.amqp.username=alice", "spring.amqp.password=secret",
+                        "spring.amqp.client.default-to-address=orders.created",
+                        "spring.amqp.client.completion-timeout=750ms")
+                .withBean(ConnectionOptionsCustomizer.class,
+                        () -> (connectionOptions) -> connectionOptionsCustomizerInvoked.set(true))
+                .withBean(AmqpClientCustomizer.class, () -> (builder) -> clientCustomizerInvoked.set(true))
+                .run((context) -> {
+                    assertThat(context).hasSingleBean(AmqpProperties.class);
+                    assertThat(context).hasSingleBean(AmqpConnectionDetails.class);
+                    assertThat(context).hasSingleBean(AmqpConnectionFactory.class);
+                    assertThat(context).hasSingleBean(AmqpClient.class);
+
+                    AmqpProperties properties = context.getBean(AmqpProperties.class);
+                    assertThat(properties.getHost()).isEqualTo("broker.example.test");
+                    assertThat(properties.getPort()).isEqualTo(5679);
+                    assertThat(properties.getUsername()).isEqualTo("alice");
+                    assertThat(properties.getPassword()).isEqualTo("secret");
+                    assertThat(properties.getClient().getDefaultToAddress()).isEqualTo("orders.created");
+                    assertThat(properties.getClient().getCompletionTimeout()).isEqualTo(Duration.ofMillis(750));
+
+                    AmqpConnectionDetails connectionDetails = context.getBean(AmqpConnectionDetails.class);
+                    assertThat(connectionDetails.getAddress().host()).isEqualTo("broker.example.test");
+                    assertThat(connectionDetails.getAddress().port()).isEqualTo(5679);
+                    assertThat(connectionDetails.getUsername()).isEqualTo("alice");
+                    assertThat(connectionDetails.getPassword()).isEqualTo("secret");
+
+                    assertThat(context.getBean(AmqpConnectionFactory.class))
+                            .isInstanceOf(SingleAmqpConnectionFactory.class);
+                    assertThat(context.getBean(AmqpClient.class)).isNotNull();
+                    assertThat(connectionOptionsCustomizerInvoked).isTrue();
+                    assertThat(clientCustomizerInvoked).isTrue();
+                });
     }
 
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
