### PR TITLE
[GenAI] Test fix for jakarta.ejb:jakarta.ejb-api:3.2.4 using gpt-5.5

### DIFF
--- a/metadata/jakarta.ejb/jakarta.ejb-api/3.2.4/reachability-metadata.json
+++ b/metadata/jakarta.ejb/jakarta.ejb-api/3.2.4/reachability-metadata.json
@@ -1,0 +1,30 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "javax.ejb.ScheduleExpression"
+      },
+      "type" : "sun.util.resources.cldr.TimeZoneNames"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javax.ejb.ScheduleExpression"
+      },
+      "type" : "sun.util.resources.cldr.TimeZoneNames_en"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javax.ejb.ScheduleExpression"
+      },
+      "type" : "sun.util.resources.cldr.TimeZoneNames_en_US"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "javax.ejb.embeddable.EJBContainer"
+      },
+      "glob" : "META-INF/services/javax.ejb.spi.EJBContainerProvider"
+    }
+  ]
+}

--- a/metadata/jakarta.ejb/jakarta.ejb-api/index.json
+++ b/metadata/jakarta.ejb/jakarta.ejb-api/index.json
@@ -1,6 +1,16 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.2.4",
+    "tested-versions" : [
+      "3.2.4"
+    ],
+    "allowed-packages" : [
+      "javax.ejb",
+      "javax.xml.rpc.handler"
+    ]
+  },
+  {
     "metadata-version" : "3.2.3",
     "source-code-url" : "https://repo1.maven.org/maven2/jakarta/ejb/jakarta.ejb-api/$version$/jakarta.ejb-api-$version$-sources.jar",
     "repository-url" : "https://github.com/jakartaee/enterprise-beans",

--- a/metadata/jakarta.ejb/jakarta.ejb-api/index.json
+++ b/metadata/jakarta.ejb/jakarta.ejb-api/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "3.2.4",
+    "source-code-url" : "https://repo1.maven.org/maven2/jakarta/ejb/jakarta.ejb-api/$version$/jakarta.ejb-api-$version$-sources.jar",
+    "repository-url" : "https://github.com/jakartaee/enterprise-beans",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://repo1.maven.org/maven2/jakarta/ejb/jakarta.ejb-api/$version$/jakarta.ejb-api-$version$-javadoc.jar",
+    "description" : "Jakarta Enterprise Beans API defines the javax.ejb contracts, annotations, and exceptions used to write and access Enterprise JavaBeans components. It covers session and message-driven beans, timers, transactions, interceptors, security, and embeddable-container integration for Jakarta EE runtimes and clients.",
     "tested-versions" : [
       "3.2.4"
     ],

--- a/stats/jakarta.ejb/jakarta.ejb-api/3.2.4/execution-metrics.json
+++ b/stats/jakarta.ejb/jakarta.ejb-api/3.2.4/execution-metrics.json
@@ -1,0 +1,88 @@
+{
+  "fix_javac_fail:2026-06-07": {
+    "timestamp": "2026-06-07T15:17:37.062573Z",
+    "library": "jakarta.ejb:jakarta.ejb-api:3.2.4",
+    "starting_commit": "e59524dc94b5c53f7874279b98d0d59e5623044c",
+    "ending_commit": "ab3c50fb4b514d8daf2a215999b5c6682b49ffeb",
+    "previous_library": "jakarta.ejb:jakarta.ejb-api:3.2.3",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.2.4",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 648,
+          "missed": 237,
+          "ratio": 0.732203,
+          "total": 885
+        },
+        "line": {
+          "covered": 152,
+          "missed": 82,
+          "ratio": 0.649573,
+          "total": 234
+        },
+        "method": {
+          "covered": 70,
+          "missed": 30,
+          "ratio": 0.7,
+          "total": 100
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.2.3",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 742,
+          "missed": 253,
+          "ratio": 0.745729,
+          "total": 995
+        },
+        "line": {
+          "covered": 182,
+          "missed": 87,
+          "ratio": 0.67658,
+          "total": 269
+        },
+        "method": {
+          "covered": 83,
+          "missed": 31,
+          "ratio": 0.72807,
+          "total": 114
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 24317,
+      "cached_input_tokens_used": 342528,
+      "output_tokens_used": 2543,
+      "iterations": 1,
+      "cost_usd": 0.2476,
+      "tested_library_loc": 152,
+      "metadata_entries": 4,
+      "test_only_metadata_entries": 3,
+      "previous_library_metadata_entries": 0,
+      "code_coverage_percent": 64.96,
+      "previous_library_coverage_percent": 67.66
+    },
+    "artifacts": {
+      "test_file": "tests/src/jakarta.ejb/jakarta.ejb-api/3.2.4/src/test/java/jakarta_ejb/jakarta_ejb_api/Jakarta_ejb_apiTest.java",
+      "metadata_file": "metadata/jakarta.ejb/jakarta.ejb-api/3.2.4/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/jakarta.ejb/jakarta.ejb-api/3.2.4/stats.json
+++ b/stats/jakarta.ejb/jakarta.ejb-api/3.2.4/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.2.4",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 648,
+        "missed" : 237,
+        "ratio" : 0.732203,
+        "total" : 885
+      },
+      "line" : {
+        "covered" : 152,
+        "missed" : 82,
+        "ratio" : 0.649573,
+        "total" : 234
+      },
+      "method" : {
+        "covered" : 70,
+        "missed" : 30,
+        "ratio" : 0.7,
+        "total" : 100
+      }
+    }
+  } ]
+}

--- a/tests/src/jakarta.ejb/jakarta.ejb-api/3.2.4/.gitignore
+++ b/tests/src/jakarta.ejb/jakarta.ejb-api/3.2.4/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/jakarta.ejb/jakarta.ejb-api/3.2.4/build.gradle
+++ b/tests/src/jakarta.ejb/jakarta.ejb-api/3.2.4/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "jakarta.ejb:jakarta.ejb-api:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/jakarta.ejb/jakarta.ejb-api/3.2.4/build.gradle
+++ b/tests/src/jakarta.ejb/jakarta.ejb-api/3.2.4/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "jakarta.ejb:jakarta.ejb-api:$libraryVersion"
+    testImplementation 'jakarta.xml.rpc:jakarta.xml.rpc-api:1.1.3'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/jakarta.ejb/jakarta.ejb-api/3.2.4/gradle.properties
+++ b/tests/src/jakarta.ejb/jakarta.ejb-api/3.2.4/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = jakarta.ejb:jakarta.ejb-api:3.2.4
+library.version = 3.2.4
+metadata.dir = jakarta.ejb/jakarta.ejb-api/3.2.4/

--- a/tests/src/jakarta.ejb/jakarta.ejb-api/3.2.4/settings.gradle
+++ b/tests/src/jakarta.ejb/jakarta.ejb-api/3.2.4/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'jakarta.ejb.jakarta.ejb-api_tests'

--- a/tests/src/jakarta.ejb/jakarta.ejb-api/3.2.4/src/test/java/jakarta_ejb/jakarta_ejb_api/Jakarta_ejb_apiTest.java
+++ b/tests/src/jakarta.ejb/jakarta.ejb-api/3.2.4/src/test/java/jakarta_ejb/jakarta_ejb_api/Jakarta_ejb_apiTest.java
@@ -1,0 +1,801 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_ejb.jakarta_ejb_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import javax.ejb.AccessLocalException;
+import javax.ejb.AccessTimeout;
+import javax.ejb.ActivationConfigProperty;
+import javax.ejb.AfterBegin;
+import javax.ejb.AfterCompletion;
+import javax.ejb.ApplicationException;
+import javax.ejb.Asynchronous;
+import javax.ejb.AsyncResult;
+import javax.ejb.BeforeCompletion;
+import javax.ejb.ConcurrencyManagement;
+import javax.ejb.ConcurrencyManagementType;
+import javax.ejb.ConcurrentAccessException;
+import javax.ejb.ConcurrentAccessTimeoutException;
+import javax.ejb.CreateException;
+import javax.ejb.DependsOn;
+import javax.ejb.DuplicateKeyException;
+import javax.ejb.EJB;
+import javax.ejb.EJBAccessException;
+import javax.ejb.EJBException;
+import javax.ejb.EJBTransactionRequiredException;
+import javax.ejb.EJBTransactionRolledbackException;
+import javax.ejb.EJBs;
+import javax.ejb.FinderException;
+import javax.ejb.IllegalLoopbackException;
+import javax.ejb.Init;
+import javax.ejb.Local;
+import javax.ejb.LocalBean;
+import javax.ejb.Lock;
+import javax.ejb.LockType;
+import javax.ejb.MessageDriven;
+import javax.ejb.NoMoreTimeoutsException;
+import javax.ejb.NoSuchEJBException;
+import javax.ejb.NoSuchEntityException;
+import javax.ejb.NoSuchObjectLocalException;
+import javax.ejb.ObjectNotFoundException;
+import javax.ejb.PostActivate;
+import javax.ejb.PrePassivate;
+import javax.ejb.Remote;
+import javax.ejb.Remove;
+import javax.ejb.RemoveException;
+import javax.ejb.Schedule;
+import javax.ejb.ScheduleExpression;
+import javax.ejb.Schedules;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+import javax.ejb.Stateful;
+import javax.ejb.StatefulTimeout;
+import javax.ejb.Stateless;
+import javax.ejb.Timeout;
+import javax.ejb.Timer;
+import javax.ejb.TimerConfig;
+import javax.ejb.TimerHandle;
+import javax.ejb.TimerService;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.ejb.TransactionManagement;
+import javax.ejb.TransactionManagementType;
+import javax.ejb.TransactionRequiredLocalException;
+import javax.ejb.TransactionRolledbackLocalException;
+import javax.ejb.embeddable.EJBContainer;
+import javax.ejb.spi.EJBContainerProvider;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.xml.namespace.QName;
+import javax.xml.rpc.handler.GenericHandler;
+import javax.xml.rpc.handler.HandlerInfo;
+import javax.xml.rpc.handler.MessageContext;
+import org.junit.jupiter.api.Test;
+
+public class Jakarta_ejb_apiTest {
+    @Test
+    void asyncResultReturnsValueAndRejectsFutureControlOperations()
+            throws ExecutionException, InterruptedException {
+        AsyncResult<String> result = new AsyncResult<>("completed-value");
+
+        assertThat(result.get()).isEqualTo("completed-value");
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(result::isDone)
+                .withMessageContaining("Object does not represent an acutal Future");
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(result::isCancelled)
+                .withMessageContaining("Object does not represent an acutal Future");
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> result.cancel(true))
+                .withMessageContaining("Object does not represent an acutal Future");
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> result.get(1, TimeUnit.MILLISECONDS))
+                .withMessageContaining("Object does not represent an acutal Future");
+    }
+
+    @Test
+    void scheduleExpressionSupportsDefaultsFluentSettersAndDefensiveDateCopies() {
+        ScheduleExpression defaults = new ScheduleExpression();
+
+        assertThat(defaults.getSecond()).isEqualTo("0");
+        assertThat(defaults.getMinute()).isEqualTo("0");
+        assertThat(defaults.getHour()).isEqualTo("0");
+        assertThat(defaults.getDayOfMonth()).isEqualTo("*");
+        assertThat(defaults.getMonth()).isEqualTo("*");
+        assertThat(defaults.getDayOfWeek()).isEqualTo("*");
+        assertThat(defaults.getYear()).isEqualTo("*");
+        assertThat(defaults.getTimezone()).isNull();
+        assertThat(defaults.getStart()).isNull();
+        assertThat(defaults.getEnd()).isNull();
+
+        Date start = new Date(1_000L);
+        Date end = new Date(2_000L);
+        ScheduleExpression expression = new ScheduleExpression()
+                .second(15)
+                .minute("10/20")
+                .hour(9)
+                .dayOfMonth("Last")
+                .month(12)
+                .dayOfWeek("Mon-Fri")
+                .year(2030)
+                .timezone("UTC")
+                .start(start)
+                .end(end);
+
+        start.setTime(5_000L);
+        end.setTime(6_000L);
+
+        assertThat(expression.getSecond()).isEqualTo("15");
+        assertThat(expression.getMinute()).isEqualTo("10/20");
+        assertThat(expression.getHour()).isEqualTo("9");
+        assertThat(expression.getDayOfMonth()).isEqualTo("Last");
+        assertThat(expression.getMonth()).isEqualTo("12");
+        assertThat(expression.getDayOfWeek()).isEqualTo("Mon-Fri");
+        assertThat(expression.getYear()).isEqualTo("2030");
+        assertThat(expression.getTimezone()).isEqualTo("UTC");
+        assertThat(expression.getStart()).isEqualTo(new Date(1_000L));
+        assertThat(expression.getEnd()).isEqualTo(new Date(2_000L));
+
+        Date returnedStart = expression.getStart();
+        returnedStart.setTime(7_000L);
+        assertThat(expression.getStart()).isEqualTo(new Date(1_000L));
+        assertThat(expression.toString())
+                .contains("second=15", "minute=10/20", "hour=9", "dayOfMonth=Last", "timezoneID=UTC");
+    }
+
+    @Test
+    void timerConfigStoresInfoPersistenceFlagAndStringRepresentation() {
+        TimerConfig defaultConfig = new TimerConfig();
+
+        assertThat(defaultConfig.getInfo()).isNull();
+        assertThat(defaultConfig.isPersistent()).isTrue();
+
+        TimerConfig config = new TimerConfig("batch-42", false);
+        assertThat(config.getInfo()).isEqualTo("batch-42");
+        assertThat(config.isPersistent()).isFalse();
+        assertThat(config.toString()).isEqualTo("TimerConfig [persistent=false;info=batch-42]");
+
+        config.setInfo("batch-43");
+        config.setPersistent(true);
+
+        assertThat(config.getInfo()).isEqualTo("batch-43");
+        assertThat(config.isPersistent()).isTrue();
+        assertThat(config.toString()).isEqualTo("TimerConfig [persistent=true;info=batch-43]");
+    }
+
+    @Test
+    void ejbExceptionsExposeMessagesAndCauses() {
+        Exception cause = new Exception("root cause");
+
+        EJBException empty = new EJBException();
+        assertThat(empty).hasNoCause();
+        assertThat(empty.getCausedByException()).isNull();
+
+        EJBException messageOnly = new EJBException("ejb failure");
+        assertThat(messageOnly).hasMessage("ejb failure");
+        assertThat(messageOnly).hasNoCause();
+
+        EJBException fromCause = new EJBException(cause);
+        assertThat(fromCause).hasCause(cause);
+        assertThat(fromCause.getCausedByException()).isSameAs(cause);
+
+        EJBException messageAndCause = new EJBException("wrapped", cause);
+        assertThat(messageAndCause).hasMessage("wrapped");
+        assertThat(messageAndCause.getCausedByException()).isSameAs(cause);
+
+        assertRuntimeFailure(new AccessLocalException("access", cause), "access", cause);
+        assertRuntimeFailure(new ConcurrentAccessException("concurrent", cause), "concurrent", cause);
+        assertRuntimeFailure(new EJBTransactionRolledbackException("rolled back", cause), "rolled back", cause);
+        assertRuntimeFailure(new NoSuchEJBException("missing", cause), "missing", cause);
+        assertRuntimeFailure(new NoSuchEntityException(cause), "root cause", cause);
+        assertRuntimeFailure(new NoSuchObjectLocalException("missing local", cause), "missing local", cause);
+        assertRuntimeFailure(new TransactionRolledbackLocalException("local rollback", cause), "local rollback", cause);
+
+        assertRuntimeFailure(new EJBAccessException("denied"), "denied", null);
+        assertRuntimeFailure(new EJBTransactionRequiredException("transaction required"), "transaction required", null);
+        assertRuntimeFailure(new ConcurrentAccessTimeoutException("timeout"), "timeout", null);
+        assertRuntimeFailure(new IllegalLoopbackException("loopback"), "loopback", null);
+        assertRuntimeFailure(new NoMoreTimeoutsException("no more"), "no more", null);
+        assertRuntimeFailure(new NoSuchEntityException("entity"), "entity", null);
+        assertRuntimeFailure(new TransactionRequiredLocalException("local required"), "local required", null);
+
+        assertCheckedFailure(new CreateException("create"), "create");
+        assertCheckedFailure(new DuplicateKeyException("duplicate"), "duplicate");
+        assertCheckedFailure(new FinderException("find"), "find");
+        assertCheckedFailure(new ObjectNotFoundException("not found"), "not found");
+        assertCheckedFailure(new RemoveException("remove"), "remove");
+    }
+
+    @Test
+    void enumConstantsRoundTripByName() {
+        assertThat(LockType.values()).containsExactly(LockType.READ, LockType.WRITE);
+        assertThat(LockType.valueOf("WRITE")).isSameAs(LockType.WRITE);
+
+        assertThat(ConcurrencyManagementType.values())
+                .containsExactly(ConcurrencyManagementType.CONTAINER, ConcurrencyManagementType.BEAN);
+        assertThat(ConcurrencyManagementType.valueOf("BEAN")).isSameAs(ConcurrencyManagementType.BEAN);
+
+        assertThat(TransactionManagementType.values())
+                .containsExactly(TransactionManagementType.CONTAINER, TransactionManagementType.BEAN);
+        assertThat(TransactionManagementType.valueOf("CONTAINER")).isSameAs(TransactionManagementType.CONTAINER);
+
+        assertThat(TransactionAttributeType.values())
+                .containsExactly(
+                        TransactionAttributeType.MANDATORY,
+                        TransactionAttributeType.REQUIRED,
+                        TransactionAttributeType.REQUIRES_NEW,
+                        TransactionAttributeType.SUPPORTS,
+                        TransactionAttributeType.NOT_SUPPORTED,
+                        TransactionAttributeType.NEVER);
+        assertThat(TransactionAttributeType.valueOf("REQUIRES_NEW")).isSameAs(TransactionAttributeType.REQUIRES_NEW);
+    }
+
+    @Test
+    void embeddableContainerReportsMissingProviderThroughEjbException() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put(EJBContainer.PROVIDER, "missing-provider");
+        properties.put(EJBContainer.APP_NAME, "metadata-test-app");
+
+        assertThat(EJBContainer.PROVIDER).isEqualTo("javax.ejb.embeddable.provider");
+        assertThat(EJBContainer.MODULES).isEqualTo("javax.ejb.embeddable.modules");
+        assertThat(EJBContainer.APP_NAME).isEqualTo("javax.ejb.embeddable.appName");
+        assertThatExceptionOfType(EJBException.class)
+                .isThrownBy(() -> EJBContainer.createEJBContainer(properties))
+                .withMessageContaining("No EJBContainer provider available")
+                .withMessageContaining("missing-provider");
+    }
+
+    @Test
+    void embeddableContainerProviderCreatesCloseableContainers() throws Exception {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put(EJBContainer.APP_NAME, "provider-test-app");
+        Context context = new InitialContext();
+        RecordingEJBContainerProvider provider = new RecordingEJBContainerProvider(context);
+
+        EJBContainer createdContainer = provider.createEJBContainer(properties);
+
+        assertThat(provider.getReceivedProperties()).isSameAs(properties);
+        assertThat(createdContainer.getContext()).isSameAs(context);
+        assertThat(createdContainer).isInstanceOf(RecordingEJBContainer.class);
+
+        RecordingEJBContainer container = (RecordingEJBContainer) createdContainer;
+        assertThat(container.isClosed()).isFalse();
+
+        try (EJBContainer closeableContainer = container) {
+            assertThat(closeableContainer.getContext()).isSameAs(context);
+        }
+
+        assertThat(container.isClosed()).isTrue();
+    }
+
+    @Test
+    void handlerInfoAndGenericHandlerManageHandlerMetadata() {
+        QName firstHeader = new QName("urn:test", "first");
+        QName secondHeader = new QName("urn:test", "second");
+        Map<String, String> config = new LinkedHashMap<>();
+        config.put("encoding", "utf-8");
+        HandlerInfo info = new HandlerInfo(TestHandler.class, config, new QName[] {firstHeader});
+
+        assertThat(info.getHandlerClass()).isEqualTo(TestHandler.class);
+        assertThat(info.getHandlerConfig()).isSameAs(config);
+        assertThat(info.getHeaders()).containsExactly(firstHeader);
+
+        QName[] returnedHeaders = info.getHeaders();
+        returnedHeaders[0] = secondHeader;
+        assertThat(info.getHeaders()).containsExactly(firstHeader);
+
+        info.setHandlerClass(GenericHandler.class);
+        info.setHandlerConfig(Map.of("mode", "test"));
+        info.setHeaders(new QName[] {firstHeader, secondHeader});
+
+        assertThat(info.getHandlerClass()).isEqualTo(GenericHandler.class);
+        assertThat(info.getHandlerConfig()).containsEntry("mode", "test");
+        assertThat(info.getHeaders()).containsExactly(firstHeader, secondHeader);
+
+        info.setHeaders(null);
+        assertThat(info.getHeaders()).isNull();
+
+        TestHandler handler = new TestHandler(firstHeader);
+        MessageContext messageContext = new SimpleMessageContext();
+        handler.init(info);
+        assertThat(handler.handleRequest(messageContext)).isTrue();
+        assertThat(handler.handleResponse(messageContext)).isTrue();
+        assertThat(handler.handleFault(messageContext)).isTrue();
+        assertThat(handler.getHeaders()).containsExactly(firstHeader);
+        handler.destroy();
+    }
+
+    @Test
+    void timerServiceCreatesProgrammaticTimersAndExposesTimerState() {
+        RecordingTimerService timerService = new RecordingTimerService();
+        TimerConfig oneShotConfig = new TimerConfig("refresh-cache", false);
+        Timer oneShot = timerService.createSingleActionTimer(5_000L, oneShotConfig);
+        ScheduleExpression calendarSchedule = new ScheduleExpression().hour(2).minute(30).second(0);
+        TimerConfig calendarConfig = new TimerConfig("calendar-job", true);
+        Timer calendar = timerService.createCalendarTimer(calendarSchedule, calendarConfig);
+
+        assertThat(timerService.getTimers()).containsExactly(oneShot, calendar);
+        assertThat(timerService.getAllTimers()).containsExactly(oneShot, calendar);
+        assertThat(oneShot.isPersistent()).isFalse();
+        assertThat(oneShot.isCalendarTimer()).isFalse();
+        assertThat(oneShot.getInfo()).isEqualTo("refresh-cache");
+        assertThat(oneShot.getTimeRemaining()).isPositive();
+        assertThat(oneShot.getNextTimeout()).isAfter(new Date());
+
+        Date returnedTimeout = oneShot.getNextTimeout();
+        returnedTimeout.setTime(0L);
+        assertThat(oneShot.getNextTimeout()).isAfter(new Date());
+
+        TimerHandle handle = oneShot.getHandle();
+        assertThat(handle.getTimer()).isSameAs(oneShot);
+        assertThat(calendar.isPersistent()).isTrue();
+        assertThat(calendar.isCalendarTimer()).isTrue();
+        assertThat(calendar.getInfo()).isEqualTo("calendar-job");
+        assertThat(calendar.getSchedule()).isSameAs(calendarSchedule);
+
+        oneShot.cancel();
+        assertThat(timerService.getTimers()).containsExactly(calendar);
+        assertThatExceptionOfType(NoSuchObjectLocalException.class)
+                .isThrownBy(oneShot::getInfo)
+                .withMessage("Timer has been cancelled");
+    }
+
+    @Test
+    void annotatedBeanTypesUseEjbAnnotationsAndBusinessMethods() throws Exception {
+        AnnotatedSessionBean sessionBean = new AnnotatedSessionBean();
+
+        assertThat(sessionBean.process("job")).isEqualTo("processed job");
+        assertThat(sessionBean.processRemotely("job")).isEqualTo("remote job");
+        assertThat(sessionBean.computeAsync("job").get()).isEqualTo("async job");
+        sessionBean.afterBegin();
+        sessionBean.beforeCompletion();
+        sessionBean.afterCompletion(true);
+        sessionBean.timeout();
+        sessionBean.postActivate();
+        sessionBean.prePassivate();
+        sessionBean.remove();
+        assertThat(sessionBean.lifecycleEvents)
+                .containsExactly(
+                        "afterBegin",
+                        "beforeCompletion",
+                        "afterCompletion:true",
+                        "timeout",
+                        "postActivate",
+                        "prePassivate",
+                        "remove");
+
+        StatefulWorkflow statefulWorkflow = new StatefulWorkflow();
+        statefulWorkflow.create("workflow-1");
+        assertThat(statefulWorkflow.getName()).isEqualTo("workflow-1");
+
+        StartupSingleton startupSingleton = new StartupSingleton();
+        assertThat(startupSingleton.status()).isEqualTo("started");
+
+        MessageListenerBean messageListenerBean = new MessageListenerBean();
+        messageListenerBean.run();
+        assertThat(messageListenerBean.wasRun()).isTrue();
+
+        assertThat(new BusinessFailure("business failure")).hasMessage("business failure");
+    }
+
+    private static void assertRuntimeFailure(EJBException exception, String message, Exception cause) {
+        assertThat(exception).hasMessageContaining(message);
+        assertThat(exception.getCausedByException()).isSameAs(cause);
+    }
+
+    private static void assertCheckedFailure(Exception exception, String message) {
+        assertThat(exception).hasMessage(message);
+        assertThat(exception).hasNoCause();
+    }
+
+    private interface LocalBusiness {
+        String process(String input);
+    }
+
+    private interface RemoteBusiness {
+        String processRemotely(String input);
+    }
+
+    @Stateless(name = "annotatedSession", mappedName = "ejb/AnnotatedSession", description = "Session bean")
+    @Local(LocalBusiness.class)
+    @Remote(RemoteBusiness.class)
+    @LocalBean
+    @TransactionManagement(TransactionManagementType.CONTAINER)
+    @TransactionAttribute(TransactionAttributeType.REQUIRED)
+    @ConcurrencyManagement(ConcurrencyManagementType.CONTAINER)
+    @Lock(LockType.WRITE)
+    @AccessTimeout(value = 5, unit = TimeUnit.SECONDS)
+    @DependsOn({"database", "messaging"})
+    @EJBs({
+        @EJB(
+                name = "localBusiness",
+                description = "Local business dependency",
+                beanName = "annotatedSession",
+                beanInterface = LocalBusiness.class,
+                mappedName = "ejb/AnnotatedSession",
+                lookup = "java:module/AnnotatedSession")
+    })
+    private static final class AnnotatedSessionBean implements LocalBusiness, RemoteBusiness {
+        private final List<String> lifecycleEvents = new ArrayList<>();
+
+        @Override
+        public String process(String input) {
+            return "processed " + input;
+        }
+
+        @Override
+        public String processRemotely(String input) {
+            return "remote " + input;
+        }
+
+        @Asynchronous
+        public AsyncResult<String> computeAsync(String input) {
+            return new AsyncResult<>("async " + input);
+        }
+
+        @Schedules({
+            @Schedule(hour = "1", minute = "15", second = "0", info = "nightly", persistent = false),
+            @Schedule(hour = "13", minute = "45", second = "30", timezone = "UTC", info = "midday")
+        })
+        public void scheduledWork() {
+            lifecycleEvents.add("scheduledWork");
+        }
+
+        @Timeout
+        public void timeout() {
+            lifecycleEvents.add("timeout");
+        }
+
+        @Remove(retainIfException = true)
+        public void remove() {
+            lifecycleEvents.add("remove");
+        }
+
+        @AfterBegin
+        public void afterBegin() {
+            lifecycleEvents.add("afterBegin");
+        }
+
+        @BeforeCompletion
+        public void beforeCompletion() {
+            lifecycleEvents.add("beforeCompletion");
+        }
+
+        @AfterCompletion
+        public void afterCompletion(boolean committed) {
+            lifecycleEvents.add("afterCompletion:" + committed);
+        }
+
+        @PostActivate
+        public void postActivate() {
+            lifecycleEvents.add("postActivate");
+        }
+
+        @PrePassivate
+        public void prePassivate() {
+            lifecycleEvents.add("prePassivate");
+        }
+    }
+
+    @Stateful(
+            name = "statefulWorkflow",
+            mappedName = "ejb/StatefulWorkflow",
+            description = "Stateful workflow",
+            passivationCapable = true)
+    @StatefulTimeout(value = 10, unit = TimeUnit.MINUTES)
+    private static final class StatefulWorkflow {
+        private String name;
+
+        @Init("create")
+        public void create(String workflowName) {
+            name = workflowName;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+    @Singleton(name = "startupSingleton", mappedName = "ejb/StartupSingleton", description = "Startup singleton")
+    @Startup
+    private static final class StartupSingleton {
+        public String status() {
+            return "started";
+        }
+    }
+
+    @MessageDriven(
+            name = "messageListener",
+            messageListenerInterface = Runnable.class,
+            activationConfig = {
+                @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "queue"),
+                @ActivationConfigProperty(propertyName = "destination", propertyValue = "jobs")
+            },
+            mappedName = "jms/jobs",
+            description = "Message listener")
+    private static final class MessageListenerBean implements Runnable {
+        private boolean run;
+
+        @Override
+        public void run() {
+            run = true;
+        }
+
+        public boolean wasRun() {
+            return run;
+        }
+    }
+
+    @ApplicationException(rollback = true, inherited = false)
+    private static final class BusinessFailure extends Exception {
+        private BusinessFailure(String message) {
+            super(message);
+        }
+    }
+
+    private static final class RecordingEJBContainerProvider implements EJBContainerProvider {
+        private final Context context;
+        private Map<?, ?> receivedProperties;
+
+        private RecordingEJBContainerProvider(Context context) {
+            this.context = context;
+        }
+
+        @Override
+        public EJBContainer createEJBContainer(Map<?, ?> properties) {
+            receivedProperties = properties;
+            return new RecordingEJBContainer(context);
+        }
+
+        private Map<?, ?> getReceivedProperties() {
+            return receivedProperties;
+        }
+    }
+
+    private static final class RecordingTimerService implements TimerService {
+        private final List<RecordingTimer> timers = new ArrayList<>();
+
+        @Override
+        public Timer createTimer(long duration, Serializable info) {
+            return createSingleActionTimer(duration, new TimerConfig(info, true));
+        }
+
+        @Override
+        public Timer createSingleActionTimer(long duration, TimerConfig timerConfig) {
+            return addTimer(new RecordingTimer(new Date(System.currentTimeMillis() + duration), null, timerConfig));
+        }
+
+        @Override
+        public Timer createTimer(long initialDuration, long intervalDuration, Serializable info) {
+            return createIntervalTimer(initialDuration, intervalDuration, new TimerConfig(info, true));
+        }
+
+        @Override
+        public Timer createIntervalTimer(long initialDuration, long intervalDuration, TimerConfig timerConfig) {
+            return addTimer(new RecordingTimer(
+                    new Date(System.currentTimeMillis() + initialDuration), null, timerConfig));
+        }
+
+        @Override
+        public Timer createTimer(Date expiration, Serializable info) {
+            return createSingleActionTimer(expiration, new TimerConfig(info, true));
+        }
+
+        @Override
+        public Timer createSingleActionTimer(Date expiration, TimerConfig timerConfig) {
+            return addTimer(new RecordingTimer(expiration, null, timerConfig));
+        }
+
+        @Override
+        public Timer createTimer(Date initialExpiration, long intervalDuration, Serializable info) {
+            return createIntervalTimer(initialExpiration, intervalDuration, new TimerConfig(info, true));
+        }
+
+        @Override
+        public Timer createIntervalTimer(Date initialExpiration, long intervalDuration, TimerConfig timerConfig) {
+            return addTimer(new RecordingTimer(initialExpiration, null, timerConfig));
+        }
+
+        @Override
+        public Timer createCalendarTimer(ScheduleExpression schedule) {
+            return createCalendarTimer(schedule, new TimerConfig(null, true));
+        }
+
+        @Override
+        public Timer createCalendarTimer(ScheduleExpression schedule, TimerConfig timerConfig) {
+            return addTimer(new RecordingTimer(new Date(System.currentTimeMillis() + 60_000L), schedule, timerConfig));
+        }
+
+        @Override
+        public Collection<Timer> getTimers() {
+            return activeTimers();
+        }
+
+        @Override
+        public Collection<Timer> getAllTimers() {
+            return activeTimers();
+        }
+
+        private Timer addTimer(RecordingTimer timer) {
+            timers.add(timer);
+            return timer;
+        }
+
+        private List<Timer> activeTimers() {
+            List<Timer> activeTimers = new ArrayList<>();
+            for (RecordingTimer timer : timers) {
+                if (!timer.isCancelled()) {
+                    activeTimers.add(timer);
+                }
+            }
+            return activeTimers;
+        }
+    }
+
+    private static final class RecordingTimer implements Timer {
+        private final Date nextTimeout;
+        private final ScheduleExpression schedule;
+        private final Serializable info;
+        private final boolean persistent;
+        private boolean cancelled;
+
+        private RecordingTimer(Date nextTimeout, ScheduleExpression schedule, TimerConfig timerConfig) {
+            this.nextTimeout = new Date(nextTimeout.getTime());
+            this.schedule = schedule;
+            info = timerConfig.getInfo();
+            persistent = timerConfig.isPersistent();
+        }
+
+        @Override
+        public void cancel() {
+            ensureActive();
+            cancelled = true;
+        }
+
+        @Override
+        public long getTimeRemaining() {
+            ensureActive();
+            return Math.max(0L, nextTimeout.getTime() - System.currentTimeMillis());
+        }
+
+        @Override
+        public Date getNextTimeout() {
+            ensureActive();
+            return new Date(nextTimeout.getTime());
+        }
+
+        @Override
+        public ScheduleExpression getSchedule() {
+            ensureActive();
+            return schedule;
+        }
+
+        @Override
+        public boolean isPersistent() {
+            ensureActive();
+            return persistent;
+        }
+
+        @Override
+        public boolean isCalendarTimer() {
+            ensureActive();
+            return schedule != null;
+        }
+
+        @Override
+        public Serializable getInfo() {
+            ensureActive();
+            return info;
+        }
+
+        @Override
+        public TimerHandle getHandle() {
+            ensureActive();
+            return new RecordingTimerHandle(this);
+        }
+
+        private boolean isCancelled() {
+            return cancelled;
+        }
+
+        private void ensureActive() {
+            if (cancelled) {
+                throw new NoSuchObjectLocalException("Timer has been cancelled");
+            }
+        }
+    }
+
+    private static final class RecordingTimerHandle implements TimerHandle {
+        private final Timer timer;
+
+        private RecordingTimerHandle(Timer timer) {
+            this.timer = timer;
+        }
+
+        @Override
+        public Timer getTimer() {
+            return timer;
+        }
+    }
+
+    private static final class RecordingEJBContainer extends EJBContainer {
+        private final Context context;
+        private boolean closed;
+
+        private RecordingEJBContainer(Context context) {
+            this.context = context;
+        }
+
+        @Override
+        public Context getContext() {
+            return context;
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+
+        private boolean isClosed() {
+            return closed;
+        }
+    }
+
+    private static final class TestHandler extends GenericHandler {
+        private final QName[] headers;
+
+        private TestHandler(QName... headers) {
+            this.headers = headers;
+        }
+
+        @Override
+        public QName[] getHeaders() {
+            return headers;
+        }
+    }
+
+    private static final class SimpleMessageContext implements MessageContext {
+        private final Map<String, Object> properties = new LinkedHashMap<>();
+
+        @Override
+        public void setProperty(String name, Object value) {
+            properties.put(name, value);
+        }
+
+        @Override
+        public Object getProperty(String name) {
+            return properties.get(name);
+        }
+
+        @Override
+        public void removeProperty(String name) {
+            properties.remove(name);
+        }
+
+        @Override
+        public boolean containsProperty(String name) {
+            return properties.containsKey(name);
+        }
+
+        @Override
+        public Iterator<String> getPropertyNames() {
+            return properties.keySet().iterator();
+        }
+    }
+}

--- a/tests/src/jakarta.ejb/jakarta.ejb-api/3.2.4/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/jakarta.ejb/jakarta.ejb-api/3.2.4/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,22 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "jakarta_ejb.jakarta_ejb_api.Jakarta_ejb_apiTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta_ejb.jakarta_ejb_api.Jakarta_ejb_apiTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta_ejb.jakarta_ejb_api.Jakarta_ejb_apiTest"
+      },
+      "glob" : "jndi.properties"
+    }
+  ]
+}

--- a/tests/src/jakarta.ejb/jakarta.ejb-api/3.2.4/user-code-filter.json
+++ b/tests/src/jakarta.ejb/jakarta.ejb-api/3.2.4/user-code-filter.json
@@ -1,0 +1,16 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "javax.ejb.**"
+    },
+    {
+      "includeClasses" : "javax.xml.rpc.handler.**"
+    },
+    {
+      "includeClasses" : "jakarta_ejb.jakarta_ejb_api.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7377

This PR provides test fixes and new metadata for jakarta.ejb:jakarta.ejb-api:3.2.4, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 24317
- Cached input tokens: 342528
- Output tokens: 2543
- Metadata entries: 4
- Test-only metadata entries: 3
- Iterations: 1
- Library coverage percentage: 64.96
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 67.66

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `317c880e42585cffa5101d2f9e044a7f272539ec`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- jakarta.ejb:jakarta.ejb-api:3.2.3: 0/0 covered calls (100.00%)
- jakarta.ejb:jakarta.ejb-api:3.2.4: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- jakarta.ejb:jakarta.ejb-api:3.2.3: 742/995 (74.57%)
- jakarta.ejb:jakarta.ejb-api:3.2.4: 648/885 (73.22%)

**Line:**
- jakarta.ejb:jakarta.ejb-api:3.2.3: 182/269 (67.66%)
- jakarta.ejb:jakarta.ejb-api:3.2.4: 152/234 (64.96%)

**Method:**
- jakarta.ejb:jakarta.ejb-api:3.2.3: 83/114 (72.81%)
- jakarta.ejb:jakarta.ejb-api:3.2.4: 70/100 (70.00%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/jakarta.ejb/jakarta.ejb-api/3.2.3/build.gradle b/tests/src/jakarta.ejb/jakarta.ejb-api/3.2.4/build.gradle
index 45d62c11c1..1199b3f74c 100644
--- a/tests/src/jakarta.ejb/jakarta.ejb-api/3.2.3/build.gradle
+++ b/tests/src/jakarta.ejb/jakarta.ejb-api/3.2.4/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "jakarta.ejb:jakarta.ejb-api:$libraryVersion"
+    testImplementation 'jakarta.xml.rpc:jakarta.xml.rpc-api:1.1.3'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
