### PR TITLE
Make human-intervention failed-run follow-up evidence based

### DIFF
--- a/forge/docs/functional-spec.md
+++ b/forge/docs/functional-spec.md
@@ -341,12 +341,23 @@ Forge's responsibility boundary, including:
   the PR unsafe to auto-review as a normal generated result.
 
 Forge must not use `human-intervention` for failures that are only external or
-transient infrastructure conditions. Connection errors, Maven repository
-download failures, GitHub API/status failures, rate limits, runner outages,
-temporary registry unavailability, and similar environmental failures must be
-reported as infrastructure failures, retried or preserved with diagnostics as
-appropriate, and left without the `human-intervention` label unless later
-evidence shows a semantic Forge, repository, generation, or library problem.
+transient infrastructure conditions. The issue-side classification is by failure
+origin, not by log keywords: a workflow failure is **logical** — and gets the
+label — when it comes from the driver script, the core workflow, or the local
+CI-equivalent verification (compile, test, native-test, and finalization gates),
+which includes the rare case of an agent timeout. A workflow failure is
+**external** — and must not get the label — only when it surfaces as a typed
+exception from the dependency boundary Forge itself crosses: GitHub (`gh`: rate
+limits and 5xx/network) as `GitHubError` / `GitHubRateLimitExceeded`, and remote
+git operations (push/pull/fetch/clone/ls-remote) as `GitTransportError`. Maven
+Central and Docker registry failures have no such boundary — Gradle owns them
+inside `./gradlew test` and they reach Forge only as an opaque CI-check `rc != 0`,
+indistinguishable from a real test failure once the in-workflow retries have run —
+so they are not special-cased and fall through to the safe logical default. When a
+failure is external, Forge takes no issue action: it applies no
+`human-intervention` label and posts no comment, and silently releases the issue
+claim (status back to `Todo`, assignees cleared) so the issue is retried later.
+Rate limits additionally stop the current run for retry after reset.
 
 The label can appear on issues or pull requests. On an issue, it means Forge
 could not safely produce a PR-ready result and posted enough diagnostics for a

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -66,7 +66,12 @@ from ai_workflows.drivers.fix_ni_run import (
 from ai_workflows.drivers.improve_library_coverage import (
     main as run_improve_library_coverage_workflow,
 )
-from ai_workflows.core.workflow_strategy import RUN_STATUS_CHUNK_READY, RUN_STATUS_FAILURE
+from ai_workflows.core.workflow_strategy import (
+    RUN_STATUS_CHUNK_READY,
+    RUN_STATUS_FAILURE,
+    RUN_STATUS_SUCCESS,
+    SUCCESS_WITH_INTERVENTION_STATUS,
+)
 from git_scripts.common_git import (
     GITHUB_TRANSIENT_RETRY_ATTEMPTS,
     GitHubRateLimitExceeded,
@@ -241,6 +246,47 @@ HUMAN_INTERVENTION_LABEL_COLOR = "B60205"
 HUMAN_INTERVENTION_LABEL_DESCRIPTION = (
     "Requires manual follow-up because automated processing needs human attention"
 )
+HUMAN_INTERVENTION_NON_FAILURE_STATUSES = {
+    RUN_STATUS_SUCCESS,
+    RUN_STATUS_CHUNK_READY,
+    SUCCESS_WITH_INTERVENTION_STATUS,
+}
+HUMAN_INTERVENTION_SEMANTIC_FAILURE_PATTERNS = (
+    "analysis: stage=",
+    "coverage_did_not_reach_zero_uncovered_calls",
+    "generated-test-quality",
+    "metadata-gap-exhausted",
+    "native-test gate failed",
+    "post-generation-fix",
+    "scaffold placeholder quality gate",
+    "suspicious generated test target requires human review",
+    "test_failures_prevented_reaching_nativeTest",
+)
+HUMAN_INTERVENTION_TRANSIENT_FAILURE_PATTERNS = (
+    "api rate limit",
+    "bad gateway",
+    "connection reset",
+    "connection timed out",
+    "could not get resource",
+    "could not head",
+    "could not resolve all files",
+    "docker registry",
+    "github api transient failure",
+    "http 502",
+    "http 503",
+    "http 504",
+    "i/o timeout",
+    "maven repository",
+    "network is unreachable",
+    "rate limit",
+    "registry unavailable",
+    "remote end hung up",
+    "service unavailable",
+    "temporary failure",
+    "tls handshake timeout",
+    "too many requests",
+)
+FAILED_RUN_EVIDENCE_LOG_TAIL_BYTES = 200_000
 NOT_FOR_NATIVE_IMAGE_LABEL_COLOR = "5319E7"
 NOT_FOR_NATIVE_IMAGE_LABEL_DESCRIPTION = (
     "Artifact is tracked but is not applicable to GraalVM Native Image reachability metadata"
@@ -3081,20 +3127,70 @@ def _load_dynamic_access_snapshot_from_report(claimed_issue: ClaimedIssue) -> Dy
     )
 
 
+def _read_failed_run_evidence_log_tail(log_path: str) -> str:
+    """Read the actual bounded tail of a failed-run log."""
+    log_size: int = os.path.getsize(log_path)
+    start_offset: int = max(0, log_size - FAILED_RUN_EVIDENCE_LOG_TAIL_BYTES)
+    with open(log_path, "rb") as log_file:
+        log_file.seek(start_offset)
+        return log_file.read().decode("utf-8", errors="replace")
+
+
+def _collect_failed_run_evidence_text(
+        claimed_issue: ClaimedIssue,
+        run_metrics: dict | None,
+        started_at: float | None,
+) -> str:
+    """Collect bounded failed-run evidence for policy classification. §FS-human-intervention-policy"""
+    evidence_parts: list[str] = []
+    if isinstance(run_metrics, dict):
+        evidence_parts.append(json.dumps(run_metrics, sort_keys=True))
+
+    for log_path in collect_issue_log_paths(claimed_issue, started_at):
+        try:
+            evidence_parts.append(_read_failed_run_evidence_log_tail(log_path))
+        except OSError:
+            continue
+
+    return "\n".join(evidence_parts).lower()
+
+
+def _failed_run_has_transient_evidence(evidence_text: str) -> bool:
+    """Return True when failure evidence points to external or transient infrastructure."""
+    return any(
+        pattern.lower() in evidence_text
+        for pattern in HUMAN_INTERVENTION_TRANSIENT_FAILURE_PATTERNS
+    )
+
+
+def _failed_run_has_semantic_human_intervention_evidence(
+        run_metrics: dict | None,
+        coverage_snapshot: DynamicAccessCoverageSnapshot | None,
+        evidence_text: str,
+) -> bool:
+    """Return True when failed-run evidence supports the issue-side label."""
+    if coverage_snapshot is not None and coverage_snapshot.total_calls > 0:
+        return True
+
+    if isinstance(run_metrics, dict):
+        metrics = run_metrics.get("metrics")
+        if isinstance(metrics, dict) and int(metrics.get("generated_loc", 0) or 0) > 0:
+            return True
+
+    return any(
+        pattern.lower() in evidence_text
+        for pattern in HUMAN_INTERVENTION_SEMANTIC_FAILURE_PATTERNS
+    )
+
+
 def resolve_human_intervention_candidate(
         claimed_issue: ClaimedIssue,
         workflow_success: bool = True,
+        started_at: float | None = None,
 ) -> HumanInterventionCandidate | None:
     """Return follow-up data when an issue run needs human intervention."""
     if claimed_issue.label not in {LABEL_LIBRARY_NEW, LABEL_LIBRARY_UPDATE}:
-        if workflow_success:
-            return None
-        return HumanInterventionCandidate(
-            strategy_name=None,
-            workflow_status=RUN_STATUS_FAILURE,
-            coverage=None,
-            reason="job_failed",
-        )
+        return None
 
     run_metrics = _load_pending_run_metrics(claimed_issue.scratch_metrics_repo_path)
     if not workflow_success:
@@ -3105,8 +3201,33 @@ def resolve_human_intervention_candidate(
             strategy_name = run_metrics.get("strategy_name")
             workflow_status = str(run_metrics.get("status") or RUN_STATUS_FAILURE)
             coverage_snapshot = _load_dynamic_access_snapshot_from_metrics(run_metrics)
+        if workflow_status in HUMAN_INTERVENTION_NON_FAILURE_STATUSES:
+            return None
         if coverage_snapshot is None:
             coverage_snapshot = _load_dynamic_access_snapshot_from_report(claimed_issue)
+        evidence_text = _collect_failed_run_evidence_text(claimed_issue, run_metrics, started_at)
+        if _failed_run_has_transient_evidence(evidence_text):
+            log_stage(
+                "human-intervention",
+                (
+                    f"Not labeling issue #{claimed_issue.issue['number']}: failed-run evidence "
+                    "matches external or transient infrastructure."
+                ),
+            )
+            return None
+        if not _failed_run_has_semantic_human_intervention_evidence(
+                run_metrics,
+                coverage_snapshot,
+                evidence_text,
+        ):
+            log_stage(
+                "human-intervention",
+                (
+                    f"Not labeling issue #{claimed_issue.issue['number']}: failed-run evidence "
+                    "does not identify a semantic generated-result, metadata, or library problem."
+                ),
+            )
+            return None
         return HumanInterventionCandidate(
             strategy_name=strategy_name,
             workflow_status=workflow_status,
@@ -3908,6 +4029,49 @@ def ensure_preserved_branch_link_in_comment(
     )
 
 
+def build_failed_run_diagnostic_comment(
+        claimed_issue: ClaimedIssue,
+        started_at: float | None,
+        preservation_result: FailurePreservationResult | None,
+) -> str:
+    """Build a non-labeling failed-run diagnostic comment. §FS-human-intervention-policy"""
+    log_paths = collect_issue_log_paths(claimed_issue, started_at)
+    preserved_work_section = "Preserved work branch: unavailable"
+    if preservation_result is not None:
+        preserved_work_section = (
+            f"Preserved work branch: {preservation_result.branch_url}\n"
+            f"Branch name: `{preservation_result.branch_name}`"
+        )
+
+    return (
+        "Automation failed\n\n"
+        f"The automated `{claimed_issue.label}` job failed for `{claimed_issue.issue_coordinates}`. "
+        "Forge did not find evidence that this failure requires the `human-intervention` label, so the "
+        "issue was returned to the normal queue with diagnostics preserved.\n\n"
+        f"{preserved_work_section}\n\n"
+        "Relevant logs:\n"
+        f"{_format_log_path_list(log_paths)}\n\n"
+        "Suggested follow-up:\n"
+        "- Retry the workflow if the failure came from a transient service or runner condition.\n"
+        "- Inspect the preserved branch and logs if the same failure repeats."
+    )
+
+
+def post_failed_run_diagnostic_comment(issue_number: int, comment_body: str | None) -> None:
+    """Post a failed-run diagnostic without applying `human-intervention`."""
+    if is_user_interrupt_requested() or not comment_body:
+        return
+
+    try:
+        post_issue_comment(issue_number, comment_body)
+    except Exception as exc:
+        print(
+            f"ERROR: Failed to post failed-run diagnostic comment to issue #{issue_number}: {exc!r}",
+            file=sys.stderr,
+        )
+        traceback.print_exc()
+
+
 def post_human_intervention_comment_and_label(issue_number: int, comment_body: str | None) -> None:
     """Post the human-intervention comment and always attempt to apply the label."""
     if is_user_interrupt_requested():
@@ -3943,7 +4107,7 @@ def maybe_apply_human_intervention_follow_up(
     if is_user_interrupt_requested():
         return False
 
-    candidate = resolve_human_intervention_candidate(claimed_issue, workflow_success)
+    candidate = resolve_human_intervention_candidate(claimed_issue, workflow_success, started_at)
     if candidate is None:
         return False
 
@@ -3977,14 +4141,21 @@ def apply_failed_run_follow_up(
     if is_user_interrupt_requested():
         raise KeyboardInterrupt
 
-    candidate = resolve_human_intervention_candidate(claimed_issue, workflow_success=False)
+    candidate = resolve_human_intervention_candidate(
+        claimed_issue,
+        workflow_success=False,
+        started_at=started_at,
+    )
     if candidate is None:
-        candidate = HumanInterventionCandidate(
-            strategy_name=None,
-            workflow_status=RUN_STATUS_FAILURE,
-            coverage=None,
-            reason="job_failed",
+        comment_body = build_failed_run_diagnostic_comment(
+            claimed_issue,
+            started_at,
+            preservation_result,
         )
+        if is_user_interrupt_requested():
+            raise KeyboardInterrupt
+        post_failed_run_diagnostic_comment(claimed_issue.issue["number"], comment_body)
+        return
 
     try:
         comment_body = run_codex_failed_generation_analysis(

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -74,7 +74,10 @@ from ai_workflows.core.workflow_strategy import (
 )
 from git_scripts.common_git import (
     GITHUB_TRANSIENT_RETRY_ATTEMPTS,
+    GitHubError,
     GitHubRateLimitExceeded,
+    GitTransportError,
+    _format_github_retry_reason,
     _github_retry_delay_seconds,
     _log_github_transient_retry,
     ensure_gh_authenticated,
@@ -83,6 +86,7 @@ from git_scripts.common_git import (
     is_github_rate_limit_text,
     is_github_transient_failure_text,
     log_github_query,
+    run_git_transport,
     run_github_command_with_retries,
     run_github_json_with_retries,
     run_github_with_retries,
@@ -251,42 +255,13 @@ HUMAN_INTERVENTION_NON_FAILURE_STATUSES = {
     RUN_STATUS_CHUNK_READY,
     SUCCESS_WITH_INTERVENTION_STATUS,
 }
-HUMAN_INTERVENTION_SEMANTIC_FAILURE_PATTERNS = (
-    "analysis: stage=",
-    "coverage_did_not_reach_zero_uncovered_calls",
-    "generated-test-quality",
-    "metadata-gap-exhausted",
-    "native-test gate failed",
-    "post-generation-fix",
-    "scaffold placeholder quality gate",
-    "suspicious generated test target requires human review",
-    "test_failures_prevented_reaching_nativeTest",
-)
-HUMAN_INTERVENTION_TRANSIENT_FAILURE_PATTERNS = (
-    "api rate limit",
-    "bad gateway",
-    "connection reset",
-    "connection timed out",
-    "could not get resource",
-    "could not head",
-    "could not resolve all files",
-    "docker registry",
-    "github api transient failure",
-    "http 502",
-    "http 503",
-    "http 504",
-    "i/o timeout",
-    "maven repository",
-    "network is unreachable",
-    "rate limit",
-    "registry unavailable",
-    "remote end hung up",
-    "service unavailable",
-    "temporary failure",
-    "tls handshake timeout",
-    "too many requests",
-)
-FAILED_RUN_EVIDENCE_LOG_TAIL_BYTES = 200_000
+# A workflow failure is logical (driver/core/CI-check) and gets `human-intervention`
+# by default. The only exception is an external dependency failure, which surfaces
+# as a typed exception at the Python boundary that issues it: GitHub (`gh`) as
+# `GitHubError` / `GitHubRateLimitExceeded`, and remote git as `GitTransportError`.
+# Maven Central and Docker registry failures have no such boundary (Gradle owns
+# them inside `./gradlew test`); they fall through to the safe logical default.
+# §FS-human-intervention-policy
 NOT_FOR_NATIVE_IMAGE_LABEL_COLOR = "5319E7"
 NOT_FOR_NATIVE_IMAGE_LABEL_DESCRIPTION = (
     "Artifact is tracked but is not applicable to GraalVM Native Image reachability metadata"
@@ -380,6 +355,7 @@ class WorkflowRunResult:
     claimed_issue: ClaimedIssue
     success: bool
     started_at: float | None = None
+    failure_was_external: bool = False
 
 
 @dataclass(frozen=True)
@@ -601,10 +577,19 @@ def gh(
         error_text = "\n".join(part for part in (result.stderr, result.stdout) if part)
         if check and is_github_rate_limit_text(error_text):
             raise GitHubRateLimitExceeded("GitHub API rate limit exceeded")
-        if attempt < max_attempts and is_github_transient_failure_text(error_text):
-            _log_github_transient_retry(error_text, attempt, max_attempts, quiet)
-            time.sleep(_github_retry_delay_seconds(attempt))
-            continue
+        if is_github_transient_failure_text(error_text):
+            if attempt < max_attempts:
+                _log_github_transient_retry(error_text, attempt, max_attempts, quiet)
+                time.sleep(_github_retry_delay_seconds(attempt))
+                continue
+            # Only type the failure when this loop owns the retries; a single attempt
+            # (max_attempts == 1) is driven by an outer retrier that needs the raw
+            # CalledProcessError so it can retry and decide.
+            if max_attempts > 1:
+                raise GitHubError(
+                    f"GitHub transient failure after {max_attempts} attempts: "
+                    f"{_format_github_retry_reason(error_text)}"
+                )
         if check:
             if not quiet:
                 print(f"ERROR: {' '.join(cmd)}\n{result.stderr}", file=sys.stderr)
@@ -2339,11 +2324,17 @@ def validate_index_files_on_current_master_candidate(
         f"Failed to create final index validation worktree for PR #{pr_number}",
     )
     try:
-        run_checked_command(
-            ["git", "fetch", "--quiet", "origin", f"refs/pull/{pr_number}/head"],
-            validation_worktree_path,
-            f"Failed to fetch PR #{pr_number} head for final index validation",
-        )
+        try:
+            run_git_transport(
+                ["fetch", "--quiet", "origin", f"refs/pull/{pr_number}/head"],
+                cwd=validation_worktree_path,
+            )
+        except GitTransportError as exc:
+            print(
+                f"ERROR: Failed to fetch PR #{pr_number} head for final index validation: {exc}",
+                file=sys.stderr,
+            )
+            raise
         fetched_head = run_checked_command(
             ["git", "rev-parse", "FETCH_HEAD"],
             validation_worktree_path,
@@ -3127,68 +3118,33 @@ def _load_dynamic_access_snapshot_from_report(claimed_issue: ClaimedIssue) -> Dy
     )
 
 
-def _read_failed_run_evidence_log_tail(log_path: str) -> str:
-    """Read the actual bounded tail of a failed-run log."""
-    log_size: int = os.path.getsize(log_path)
-    start_offset: int = max(0, log_size - FAILED_RUN_EVIDENCE_LOG_TAIL_BYTES)
-    with open(log_path, "rb") as log_file:
-        log_file.seek(start_offset)
-        return log_file.read().decode("utf-8", errors="replace")
+def is_external_failure_exception(exc: BaseException | None) -> bool:
+    """Return True when a workflow exception is an external dependency failure.
 
-
-def _collect_failed_run_evidence_text(
-        claimed_issue: ClaimedIssue,
-        run_metrics: dict | None,
-        started_at: float | None,
-) -> str:
-    """Collect bounded failed-run evidence for policy classification. §FS-human-intervention-policy"""
-    evidence_parts: list[str] = []
-    if isinstance(run_metrics, dict):
-        evidence_parts.append(json.dumps(run_metrics, sort_keys=True))
-
-    for log_path in collect_issue_log_paths(claimed_issue, started_at):
-        try:
-            evidence_parts.append(_read_failed_run_evidence_log_tail(log_path))
-        except OSError:
-            continue
-
-    return "\n".join(evidence_parts).lower()
-
-
-def _failed_run_has_transient_evidence(evidence_text: str) -> bool:
-    """Return True when failure evidence points to external or transient infrastructure."""
-    return any(
-        pattern.lower() in evidence_text
-        for pattern in HUMAN_INTERVENTION_TRANSIENT_FAILURE_PATTERNS
-    )
-
-
-def _failed_run_has_semantic_human_intervention_evidence(
-        run_metrics: dict | None,
-        coverage_snapshot: DynamicAccessCoverageSnapshot | None,
-        evidence_text: str,
-) -> bool:
-    """Return True when failed-run evidence supports the issue-side label."""
-    if coverage_snapshot is not None and coverage_snapshot.total_calls > 0:
-        return True
-
-    if isinstance(run_metrics, dict):
-        metrics = run_metrics.get("metrics")
-        if isinstance(metrics, dict) and int(metrics.get("generated_loc", 0) or 0) > 0:
+    GitHub (rate-limit or transient) and git transport surface as typed exceptions
+    (`GitHubError` / `GitTransportError`). An external failure releases the issue
+    claim for retry without `human-intervention`, while any other exception
+    (including agent timeouts) is logical. The cause/context chain is walked so a
+    wrapped external error is still recognized. §FS-human-intervention-policy
+    """
+    error: BaseException | None = exc
+    while error is not None:
+        if isinstance(error, (GitHubError, GitTransportError)):
             return True
-
-    return any(
-        pattern.lower() in evidence_text
-        for pattern in HUMAN_INTERVENTION_SEMANTIC_FAILURE_PATTERNS
-    )
+        error = error.__cause__ or error.__context__
+    return False
 
 
 def resolve_human_intervention_candidate(
         claimed_issue: ClaimedIssue,
         workflow_success: bool = True,
-        started_at: float | None = None,
 ) -> HumanInterventionCandidate | None:
-    """Return follow-up data when an issue run needs human intervention."""
+    """Return follow-up data for a logical issue failure that needs human intervention.
+
+    External failures are filtered out upstream (see `handle_failed_claimed_issue`),
+    so any library-issue failure that reaches here is logical (driver/core/CI check,
+    including agent timeouts) and is labeled. §FS-human-intervention-policy
+    """
     if claimed_issue.label not in {LABEL_LIBRARY_NEW, LABEL_LIBRARY_UPDATE}:
         return None
 
@@ -3205,29 +3161,6 @@ def resolve_human_intervention_candidate(
             return None
         if coverage_snapshot is None:
             coverage_snapshot = _load_dynamic_access_snapshot_from_report(claimed_issue)
-        evidence_text = _collect_failed_run_evidence_text(claimed_issue, run_metrics, started_at)
-        if _failed_run_has_transient_evidence(evidence_text):
-            log_stage(
-                "human-intervention",
-                (
-                    f"Not labeling issue #{claimed_issue.issue['number']}: failed-run evidence "
-                    "matches external or transient infrastructure."
-                ),
-            )
-            return None
-        if not _failed_run_has_semantic_human_intervention_evidence(
-                run_metrics,
-                coverage_snapshot,
-                evidence_text,
-        ):
-            log_stage(
-                "human-intervention",
-                (
-                    f"Not labeling issue #{claimed_issue.issue['number']}: failed-run evidence "
-                    "does not identify a semantic generated-result, metadata, or library problem."
-                ),
-            )
-            return None
         return HumanInterventionCandidate(
             strategy_name=strategy_name,
             workflow_status=workflow_status,
@@ -3924,7 +3857,7 @@ def preserve_failed_work_branch(claimed_issue: ClaimedIssue) -> FailurePreservat
     else:
         log_stage("preserve-failed-work", f"No uncommitted work found for issue #{issue_number}; pushing branch at current HEAD.")
 
-    subprocess.run(["git", "push", "-u", "origin", branch_name], cwd=repo_path, env=git_env, check=True)
+    run_git_transport(["push", "-u", "origin", branch_name], cwd=repo_path, env=git_env)
     branch_url = build_origin_branch_url(repo_path, branch_name)
     log_stage("preserve-failed-work", f"Preserved failed work for issue #{issue_number}: {branch_url}")
     return FailurePreservationResult(
@@ -4011,7 +3944,7 @@ def refresh_preserved_branch_logs(
         env=git_env,
         check=True,
     )
-    subprocess.run(["git", "push"], cwd=repo_path, env=git_env, check=True)
+    run_git_transport(["push"], cwd=repo_path, env=git_env)
     log_stage("preserve-failed-work", f"Updated preserved branch logs for issue #{issue_number}.")
 
 
@@ -4027,49 +3960,6 @@ def ensure_preserved_branch_link_in_comment(
         "Preserved work branch:\n"
         f"{preservation_result.branch_url}"
     )
-
-
-def build_failed_run_diagnostic_comment(
-        claimed_issue: ClaimedIssue,
-        started_at: float | None,
-        preservation_result: FailurePreservationResult | None,
-) -> str:
-    """Build a non-labeling failed-run diagnostic comment. §FS-human-intervention-policy"""
-    log_paths = collect_issue_log_paths(claimed_issue, started_at)
-    preserved_work_section = "Preserved work branch: unavailable"
-    if preservation_result is not None:
-        preserved_work_section = (
-            f"Preserved work branch: {preservation_result.branch_url}\n"
-            f"Branch name: `{preservation_result.branch_name}`"
-        )
-
-    return (
-        "Automation failed\n\n"
-        f"The automated `{claimed_issue.label}` job failed for `{claimed_issue.issue_coordinates}`. "
-        "Forge did not find evidence that this failure requires the `human-intervention` label, so the "
-        "issue was returned to the normal queue with diagnostics preserved.\n\n"
-        f"{preserved_work_section}\n\n"
-        "Relevant logs:\n"
-        f"{_format_log_path_list(log_paths)}\n\n"
-        "Suggested follow-up:\n"
-        "- Retry the workflow if the failure came from a transient service or runner condition.\n"
-        "- Inspect the preserved branch and logs if the same failure repeats."
-    )
-
-
-def post_failed_run_diagnostic_comment(issue_number: int, comment_body: str | None) -> None:
-    """Post a failed-run diagnostic without applying `human-intervention`."""
-    if is_user_interrupt_requested() or not comment_body:
-        return
-
-    try:
-        post_issue_comment(issue_number, comment_body)
-    except Exception as exc:
-        print(
-            f"ERROR: Failed to post failed-run diagnostic comment to issue #{issue_number}: {exc!r}",
-            file=sys.stderr,
-        )
-        traceback.print_exc()
 
 
 def post_human_intervention_comment_and_label(issue_number: int, comment_body: str | None) -> None:
@@ -4107,7 +3997,7 @@ def maybe_apply_human_intervention_follow_up(
     if is_user_interrupt_requested():
         return False
 
-    candidate = resolve_human_intervention_candidate(claimed_issue, workflow_success, started_at)
+    candidate = resolve_human_intervention_candidate(claimed_issue, workflow_success)
     if candidate is None:
         return False
 
@@ -4137,24 +4027,19 @@ def apply_failed_run_follow_up(
         started_at: float | None = None,
         preservation_result: FailurePreservationResult | None = None,
 ) -> None:
-    """Run Codex failure analysis and post the failed-run follow-up comment."""
+    """Run Codex failure analysis and apply the `human-intervention` follow-up.
+
+    Only reached for logical failures; external failures are released upstream
+    without any issue action. §FS-human-intervention-policy
+    """
     if is_user_interrupt_requested():
         raise KeyboardInterrupt
 
     candidate = resolve_human_intervention_candidate(
         claimed_issue,
         workflow_success=False,
-        started_at=started_at,
     )
     if candidate is None:
-        comment_body = build_failed_run_diagnostic_comment(
-            claimed_issue,
-            started_at,
-            preservation_result,
-        )
-        if is_user_interrupt_requested():
-            raise KeyboardInterrupt
-        post_failed_run_diagnostic_comment(claimed_issue.issue["number"], comment_body)
         return
 
     try:
@@ -4674,23 +4559,18 @@ def fetch_review_base_ref(repo_path: str) -> None:
     """Refresh the upstream PR base ref used by local review diffs."""
     remote_tracking_ref = f"refs/remotes/origin/{DEFAULT_WORKTREE_BASE_REF}"
     try:
-        subprocess.run(
+        run_git_transport(
             [
-                "git",
                 "fetch",
                 "--quiet",
                 "origin",
                 f"+{DEFAULT_WORKTREE_BASE_REF}:{remote_tracking_ref}",
             ],
             cwd=repo_path,
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
         )
-    except subprocess.CalledProcessError as exc:
+    except GitTransportError as exc:
         print(
-            f"ERROR: Failed to fetch origin/{DEFAULT_WORKTREE_BASE_REF} before PR review: {exc.stdout}",
+            f"ERROR: Failed to fetch origin/{DEFAULT_WORKTREE_BASE_REF} before PR review: {exc}",
             file=sys.stderr,
         )
         raise
@@ -5159,6 +5039,7 @@ def run_claimed_issue(
 ) -> WorkflowRunResult:
     """Execute the claimed issue workflow inside its isolated worktree."""
     started_at = time.time()
+    failure_was_external = False
     try:
         success = invoke_pipeline(
             claimed_issue,
@@ -5177,9 +5058,15 @@ def run_claimed_issue(
         )
         traceback.print_exc()
         success = False
+        failure_was_external = is_external_failure_exception(exc)
     if is_user_interrupt_requested():
         raise KeyboardInterrupt
-    return WorkflowRunResult(claimed_issue=claimed_issue, success=success, started_at=started_at)
+    return WorkflowRunResult(
+        claimed_issue=claimed_issue,
+        success=success,
+        started_at=started_at,
+        failure_was_external=failure_was_external,
+    )
 
 
 def revert_issue_claim(item_id: str, issue_number: int, reason: str) -> None:
@@ -5650,10 +5537,27 @@ def handle_failed_claimed_issue(
         claimed_issue: ClaimedIssue,
         reason: str,
         started_at: float | None = None,
+        external: bool = False,
 ) -> None:
-    """Preserve failed work, run Codex analysis, apply follow-up, and revert the claim."""
+    """Handle a failed claimed issue, then revert its claim.
+
+    An external failure (a typed GitHub or git-transport exception) is not the
+    issue's fault: release the claim silently so it is retried, with no preserved
+    branch, comment, or `human-intervention` label. A logical failure preserves
+    work and applies the follow-up. §FS-human-intervention-policy
+    """
     if is_user_interrupt_requested():
         raise KeyboardInterrupt
+    if external:
+        log_stage(
+            "issue-external-failure",
+            (
+                f"Issue #{claimed_issue.issue['number']} failed on an external dependency "
+                f"({reason}); releasing the claim for retry without human-intervention."
+            ),
+        )
+        revert_claimed_issue(claimed_issue, reason)
+        return
     preservation_result = preserve_failed_work_for_follow_up(claimed_issue)
     if is_user_interrupt_requested():
         raise KeyboardInterrupt
@@ -5684,6 +5588,7 @@ def handle_completed_run(run_result: WorkflowRunResult) -> bool:
                 claimed_issue,
                 "workflow failure",
                 started_at=run_result.started_at,
+                external=run_result.failure_was_external,
             )
             return False
         try:
@@ -5698,6 +5603,7 @@ def handle_completed_run(run_result: WorkflowRunResult) -> bool:
                 claimed_issue,
                 "finalization failure",
                 started_at=run_result.started_at,
+                external=is_external_failure_exception(exc),
             )
             return False
         apply_large_library_completion_follow_up(claimed_issue)
@@ -5769,6 +5675,7 @@ def process_claimed_issue_lifecycle(
                         claimed_issue,
                         f"unhandled lifecycle failure ({type(exc).__name__})",
                         started_at=started_at,
+                        external=is_external_failure_exception(exc),
                     )
                     log_failure_banner(
                         format_issue_result_message(

--- a/forge/git_scripts/common_git.py
+++ b/forge/git_scripts/common_git.py
@@ -99,8 +99,40 @@ def ensure_gh_authenticated() -> None:
         sys.exit(1)
 
 
-class GitHubRateLimitExceeded(RuntimeError):
-    """Raised when GitHub reports an exhausted API rate-limit bucket."""
+class GitHubError(RuntimeError):
+    """A GitHub API failure that survived common_git's retries.
+
+    Treated as an external failure: the issue automation should release its claim
+    for a later retry rather than apply a `human-intervention` follow-up.
+    """
+
+
+class GitHubRateLimitExceeded(GitHubError):
+    """GitHub reported an exhausted API rate-limit bucket.
+
+    A `GitHubError` whose quota semantics also tell the top-level run to stop and
+    retry after the reset (exit code 75), unlike a one-off transient failure.
+    """
+
+
+class GitTransportError(RuntimeError):
+    """A `git` remote transport operation failed.
+
+    Treated as an external failure for the same reason as `GitHubError`.
+    """
+
+    def __init__(
+            self,
+            message: str,
+            *,
+            returncode: int | None = None,
+            command: list[str] | None = None,
+            output: str | None = None,
+    ):
+        super().__init__(message)
+        self.returncode = returncode
+        self.command = command
+        self.output = output
 
 
 GITHUB_TRANSIENT_RETRY_ATTEMPTS = 5
@@ -304,10 +336,19 @@ def gh(
         error_text = "\n".join(part for part in (result.stderr, result.stdout) if part)
         if check and is_github_rate_limit_text(error_text):
             raise GitHubRateLimitExceeded("GitHub API rate limit exceeded")
-        if attempt < max_attempts and is_github_transient_failure_text(error_text):
-            _log_github_transient_retry(error_text, attempt, max_attempts, quiet)
-            time.sleep(_github_retry_delay_seconds(attempt))
-            continue
+        if is_github_transient_failure_text(error_text):
+            if attempt < max_attempts:
+                _log_github_transient_retry(error_text, attempt, max_attempts, quiet)
+                time.sleep(_github_retry_delay_seconds(attempt))
+                continue
+            # Only type the failure when this loop owns the retries; a single attempt
+            # (max_attempts == 1) is driven by an outer retrier that needs the raw
+            # CalledProcessError so it can retry and decide.
+            if max_attempts > 1:
+                raise GitHubError(
+                    f"GitHub transient failure after {max_attempts} attempts: "
+                    f"{_format_github_retry_reason(error_text)}"
+                )
         if check:
             if not quiet:
                 print(f"ERROR: {' '.join(cmd)}\n{result.stderr}", file=sys.stderr)
@@ -331,20 +372,27 @@ def run_github_json_with_retries(
             result = _run_gh_runner_once(gh_runner, args, command_quiet)
         except subprocess.CalledProcessError as exc:
             error_text = _github_error_text_from_exception(exc)
-            if attempt < max_attempts and is_github_transient_failure_text(error_text):
-                _log_github_transient_retry(error_text, attempt, max_attempts, quiet)
-                time.sleep(_github_retry_delay_seconds(attempt))
-                continue
+            if is_github_transient_failure_text(error_text):
+                if attempt < max_attempts:
+                    _log_github_transient_retry(error_text, attempt, max_attempts, quiet)
+                    time.sleep(_github_retry_delay_seconds(attempt))
+                    continue
+                raise GitHubError(
+                    f"GitHub transient failure after {max_attempts} attempts: "
+                    f"{_format_github_retry_reason(error_text)}"
+                ) from exc
             raise
 
         data = json.loads(result.stdout)
         if isinstance(data, dict) and data.get("errors"):
             if is_github_rate_limit_errors(data["errors"]):
                 raise GitHubRateLimitExceeded("GitHub API rate limit exceeded")
-            if attempt < max_attempts and is_github_transient_errors(data["errors"]):
-                _log_github_transient_retry(str(data["errors"]), attempt, max_attempts, quiet)
-                time.sleep(_github_retry_delay_seconds(attempt))
-                continue
+            if is_github_transient_errors(data["errors"]):
+                if attempt < max_attempts:
+                    _log_github_transient_retry(str(data["errors"]), attempt, max_attempts, quiet)
+                    time.sleep(_github_retry_delay_seconds(attempt))
+                    continue
+                raise GitHubError(f"GitHub transient GraphQL failure after {max_attempts} attempts")
             if not quiet:
                 print(f"ERROR: GraphQL errors: {data['errors']}", file=sys.stderr)
             raise RuntimeError(f"GraphQL error: {data['errors']}")
@@ -367,10 +415,15 @@ def run_github_command_with_retries(
             return _run_gh_runner_once(gh_runner, args, command_quiet)
         except subprocess.CalledProcessError as exc:
             error_text = _github_error_text_from_exception(exc)
-            if attempt < max_attempts and is_github_transient_failure_text(error_text):
-                _log_github_transient_retry(error_text, attempt, max_attempts, quiet)
-                time.sleep(_github_retry_delay_seconds(attempt))
-                continue
+            if is_github_transient_failure_text(error_text):
+                if attempt < max_attempts:
+                    _log_github_transient_retry(error_text, attempt, max_attempts, quiet)
+                    time.sleep(_github_retry_delay_seconds(attempt))
+                    continue
+                raise GitHubError(
+                    f"GitHub transient failure after {max_attempts} attempts: "
+                    f"{_format_github_retry_reason(error_text)}"
+                ) from exc
             raise
 
     raise RuntimeError("GitHub command exhausted retries")
@@ -425,24 +478,54 @@ def build_ai_branch_name(branch_suffix: str, cwd=None) -> str:
 
 def git_remote_branch_exists(branch: str, remote: str = "origin", cwd: str | None = None) -> bool:
     """Return True when the remote has a branch with this name."""
-    result = subprocess.run(
-        ["git", "ls-remote", "--exit-code", "--heads", remote, branch],
+    result = run_git_transport(
+        ["ls-remote", "--exit-code", "--heads", remote, branch],
         cwd=cwd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        check=False,
+        allowed_returncodes=(0, 2),
     )
     if result.returncode == 0:
         return True
     if result.returncode == 2:
         return False
-    print(
-        f"ERROR: Failed to check whether `{remote}/{branch}` exists:\n{result.stderr.strip()}",
-        file=sys.stderr,
-    )
-    result.check_returncode()
     return False
+
+
+def run_git_transport(
+        args: list[str],
+        *,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        timeout: int | None = None,
+        allowed_returncodes: Iterable[int] = (0,),
+) -> subprocess.CompletedProcess:
+    """Run a `git` remote transport command, typing its failures.
+
+    Captures output so a transport failure surfaces as a typed `GitTransportError`
+    instead of a bare `CalledProcessError`, letting the issue automation treat it
+    as external (release the claim, no `human-intervention`).
+    §FS-human-intervention-policy
+    """
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if result.returncode not in set(allowed_returncodes):
+        detail = "\n".join(
+            stream.strip()
+            for stream in (result.stderr, result.stdout)
+            if stream and stream.strip()
+        )
+        raise GitTransportError(
+            f"git {' '.join(args)} failed (exit {result.returncode}): {detail}",
+            returncode=result.returncode,
+            command=["git", *args],
+            output=detail,
+        )
+    return result
 
 
 def delete_remote_branch_if_exists(branch: str, remote: str = "origin", cwd: str | None = None) -> bool:
@@ -450,7 +533,7 @@ def delete_remote_branch_if_exists(branch: str, remote: str = "origin", cwd: str
     if not git_remote_branch_exists(branch, remote=remote, cwd=cwd):
         return False
     print(f"[git-branch] Deleting existing remote branch {remote}/{branch}.")
-    subprocess.run(["git", "push", remote, "--delete", branch], cwd=cwd, check=True)
+    run_git_transport(["push", remote, "--delete", branch], cwd=cwd)
     return True
 
 

--- a/forge/git_scripts/make_pr_improve_coverage.py
+++ b/forge/git_scripts/make_pr_improve_coverage.py
@@ -26,6 +26,7 @@ from git_scripts.common_git import (
     build_ai_branch_name,
     delete_remote_branch_if_exists,
     get_configured_reviewers,
+    run_git_transport,
 )
 from utility_scripts.library_stats import stats_artifact_dir
 from utility_scripts.metadata_index import resolve_metadata_version, resolve_test_version
@@ -321,9 +322,9 @@ def _fetch_pr_base(repo_path: str) -> str:
         check=False,
     )
     if upstream_remote_url.returncode == 0 and REPO in upstream_remote_url.stdout.strip():
-        subprocess.run(["git", "fetch", "upstream", BASE_BRANCH], check=True, cwd=repo_path)
+        run_git_transport(["fetch", "upstream", BASE_BRANCH], cwd=repo_path)
         return f"upstream/{BASE_BRANCH}"
-    subprocess.run(["git", "fetch", upstream_url, BASE_BRANCH], check=True, cwd=repo_path)
+    run_git_transport(["fetch", upstream_url, BASE_BRANCH], cwd=repo_path)
     return "FETCH_HEAD"
 
 
@@ -517,7 +518,7 @@ def push_current_branch_to_origin(
         base_commit=base_ref,
         metrics_repo_path=metrics_repo_path,
     )
-    subprocess.run(["git", "push", "origin", new_branch], check=True, cwd=repo_path)
+    run_git_transport(["push", "origin", new_branch], cwd=repo_path)
 
     return new_branch
 

--- a/forge/git_scripts/make_pr_java_run_fix.py
+++ b/forge/git_scripts/make_pr_java_run_fix.py
@@ -22,6 +22,7 @@ from git_scripts.common_git import (
     assert_no_dynamic_access_category_regressions,
     build_ai_branch_name,
     delete_remote_branch_if_exists,
+    run_git_transport,
 )
 from git_scripts.make_pr_javac_fix import generate_diff_text
 from utility_scripts.library_stats import stats_artifact_dir
@@ -293,11 +294,7 @@ def push_current_branch_to_origin(
     )
     assert_no_dynamic_access_category_regressions(repo_path, old_coordinates, new_coordinates)
 
-    subprocess.run(
-        ["git", "push", "origin", branch],
-        check=True,
-        cwd=repo_path,
-    )
+    run_git_transport(["push", "origin", branch], cwd=repo_path)
 
     return branch, group, artifact, old_version, new_coordinates
 

--- a/forge/git_scripts/make_pr_javac_fix.py
+++ b/forge/git_scripts/make_pr_javac_fix.py
@@ -27,6 +27,7 @@ from git_scripts.common_git import (
     build_ai_branch_name,
     delete_remote_branch_if_exists,
     get_configured_reviewers,
+    run_git_transport,
 )
 from utility_scripts.library_stats import stats_artifact_dir
 from utility_scripts.local_ci_verification import (
@@ -380,11 +381,7 @@ def push_current_branch_to_origin(
     )
     assert_no_dynamic_access_category_regressions(repo_path, old_coordinates, new_coordinates)
 
-    subprocess.run(
-        ["git", "push", "origin", branch],
-        check=True,
-        cwd=repo_path,
-    )
+    run_git_transport(["push", "origin", branch], cwd=repo_path)
 
     return branch, group, artifact, old_version, new_coordinates
 

--- a/forge/git_scripts/make_pr_new_library_support.py
+++ b/forge/git_scripts/make_pr_new_library_support.py
@@ -27,6 +27,7 @@ from git_scripts.common_git import (
     build_ai_branch_name,
     delete_remote_branch_if_exists,
     get_configured_reviewers,
+    run_git_transport,
 )
 from utility_scripts.metrics_writer import (
     collect_new_library_support_quality_issues,
@@ -382,10 +383,10 @@ def _fetch_pr_base(repo_path: str) -> str:
         check=False,
     )
     if upstream_remote_url.returncode == 0 and REPO in upstream_remote_url.stdout.strip():
-        subprocess.run(["git", "fetch", "upstream", BASE_BRANCH], check=True, cwd=repo_path)
+        run_git_transport(["fetch", "upstream", BASE_BRANCH], cwd=repo_path)
         return f"upstream/{BASE_BRANCH}"
 
-    subprocess.run(["git", "fetch", upstream_url, BASE_BRANCH], check=True, cwd=repo_path)
+    run_git_transport(["fetch", upstream_url, BASE_BRANCH], cwd=repo_path)
     return "FETCH_HEAD"
 
 
@@ -617,11 +618,7 @@ def push_current_branch_to_origin(
         base_commit=base_ref,
         metrics_repo_path=metrics_repo_path,
     )
-    subprocess.run(
-        ["git", "push", "origin", new_branch],
-        check=True,
-        cwd=repo_path,
-    )
+    run_git_transport(["push", "origin", new_branch], cwd=repo_path)
 
     return new_branch
 

--- a/forge/git_scripts/make_pr_ni_run_fix.py
+++ b/forge/git_scripts/make_pr_ni_run_fix.py
@@ -20,6 +20,7 @@ from git_scripts.common_git import (
     build_ai_branch_name,
     delete_remote_branch_if_exists,
     get_configured_reviewers,
+    run_git_transport,
 )
 from utility_scripts.metrics_writer import (
     count_metadata_entries,
@@ -332,11 +333,7 @@ def push_current_branch_to_origin(
         metrics_repo_path=metrics_repo_path,
     )
 
-    subprocess.run(
-        ["git", "push", "origin", branch],
-        cwd=repo_path,
-        check=True,
-    )
+    run_git_transport(["push", "origin", branch], cwd=repo_path)
 
     return branch, group, artifact, new_coordinates, local_ci_verification
 

--- a/forge/git_scripts/make_pr_not_for_native_image.py
+++ b/forge/git_scripts/make_pr_not_for_native_image.py
@@ -20,6 +20,7 @@ from git_scripts.common_git import (
     get_origin_owner,
     gh,
     parse_coordinate_parts,
+    run_git_transport,
     stage_and_commit,
 )
 from utility_scripts.metadata_index import get_not_for_native_image_marker
@@ -84,7 +85,7 @@ def push_marker_branch(
         base_commit=base_ref,
         metrics_repo_path=metrics_repo_path,
     )
-    subprocess.run(["git", "push", "origin", branch], check=True, cwd=repo_path)
+    run_git_transport(["push", "origin", branch], cwd=repo_path)
     return branch, local_ci_verification
 
 

--- a/forge/utility_scripts/local_ci_verification.py
+++ b/forge/utility_scripts/local_ci_verification.py
@@ -26,6 +26,7 @@ import tempfile
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
+from git_scripts.common_git import run_git_transport
 from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.metadata_index import resolve_test_version
 from utility_scripts.metrics_writer import PENDING_METRICS_FILENAME, read_pending_metrics, write_pending_metrics
@@ -186,10 +187,10 @@ def fetch_pr_base_ref(repo_path: str, repo: str, base_branch: str = DEFAULT_BASE
         )
         remote_repo = _github_repo_slug_from_url(remote_url.stdout.strip()) if remote_url.returncode == 0 else None
         if remote_repo == target_repo:
-            subprocess.run(["git", "fetch", remote_name, base_branch], cwd=repo_path, check=True)
+            run_git_transport(["fetch", remote_name, base_branch], cwd=repo_path)
             return f"{remote_name}/{base_branch}"
 
-    subprocess.run(["git", "fetch", f"https://github.com/{target_repo}.git", base_branch], cwd=repo_path, check=True)
+    run_git_transport(["fetch", f"https://github.com/{target_repo}.git", base_branch], cwd=repo_path)
     return "FETCH_HEAD"
 
 
@@ -345,14 +346,11 @@ def _run_spring_aot_verification(
     with tempfile.TemporaryDirectory(prefix="forge-spring-aot-") as spring_parent:
         os.symlink(os.path.join(repo_path, "metadata"), os.path.join(spring_parent, "metadata"))
         spring_path = os.path.join(spring_parent, "spring-aot-smoke-tests")
-        failed = _run_recorded_command(
-            repo_path,
-            "checkout-spring-aot-smoke-tests",
-            ["git", "clone", "--depth", "1", "--branch", SPRING_AOT_BRANCH, SPRING_AOT_REPO_URL, spring_path],
-            result,
+        _log_local_ci("Fetching Spring AOT smoke tests", indent_level=1)
+        run_git_transport(
+            ["clone", "--depth", "1", "--branch", SPRING_AOT_BRANCH, SPRING_AOT_REPO_URL, spring_path],
+            cwd=repo_path,
         )
-        if failed is not None:
-            return failed
 
         try:
             spring_matrix = _gradle_json_output(

--- a/forge/utility_scripts/metrics_writer.py
+++ b/forge/utility_scripts/metrics_writer.py
@@ -25,7 +25,7 @@ from utility_scripts.native_image_config_policy import (
 )
 from utility_scripts.source_context import resolve_test_source_layout
 from utility_scripts.strategy_loader import load_strategy_by_name
-from git_scripts.common_git import git_remote_exists
+from git_scripts.common_git import GitTransportError, git_remote_exists, run_git_transport
 
 # Rates are attached to the workflow model name.
 DEFAULT_INPUT_RATE_PER_1M = 3.00
@@ -1024,7 +1024,7 @@ def commit_run_metrics_with_retry(
     snapshot_root = _snapshot_extra_paths(metrics_repo_root, extra_paths)
     try:
         for attempt in range(1, max_attempts + 1):
-            subprocess.run(["git", "fetch", "origin", "master"], check=True, cwd=metrics_repo_root)
+            run_git_transport(["fetch", "origin", "master"], cwd=metrics_repo_root)
             subprocess.run(["git", "reset", "--hard", "origin/master"], check=True, cwd=metrics_repo_root)
 
             append_run_metrics(run_metrics, metrics_json_absolute_path)
@@ -1040,33 +1040,24 @@ def commit_run_metrics_with_retry(
                 return
 
             subprocess.run(["git", "commit", "-m", commit_message], check=True, cwd=metrics_repo_root)
-            push_result = subprocess.run(
-                ["git", "push", "origin", "HEAD:master"],
-                cwd=metrics_repo_root,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
-            )
-            if push_result.returncode == 0:
+            try:
+                run_git_transport(["push", "origin", "HEAD:master"], cwd=metrics_repo_root)
                 return
+            except GitTransportError as exc:
+                push_output = exc.output or str(exc)
 
-            if attempt < max_attempts:
+                if attempt < max_attempts:
+                    print(
+                        f"Retrying metrics push after attempt {attempt} failed: {push_output}",
+                        file=sys.stderr,
+                    )
+                    continue
+
                 print(
-                    f"Retrying metrics push after attempt {attempt} failed: {push_result.stdout}",
+                    f"ERROR: Failed to push metrics after {max_attempts} attempts: {push_output}",
                     file=sys.stderr,
                 )
-                continue
-
-            if attempt == max_attempts:
-                print(
-                    f"ERROR: Failed to push metrics after {max_attempts} attempts: {push_result.stdout}",
-                    file=sys.stderr,
-                )
-                raise subprocess.CalledProcessError(
-                    push_result.returncode,
-                    ["git", "push", "origin", "HEAD:master"],
-                    output=push_result.stdout,
-                )
+                raise
     finally:
         if snapshot_root:
             shutil.rmtree(snapshot_root, ignore_errors=True)

--- a/forge/utility_scripts/repo_path_resolver.py
+++ b/forge/utility_scripts/repo_path_resolver.py
@@ -7,6 +7,8 @@ import os
 import subprocess
 import sys
 
+from git_scripts.common_git import GitTransportError, run_git_transport
+
 REACHABILITY_REPO_CLONE_URL = "git@github.com:oracle/graalvm-reachability-metadata.git"
 
 
@@ -29,6 +31,14 @@ def git_env_limited_to_repo_root(repo_root: str) -> dict[str, str]:
 
 def _run_git(cmd: list[str], cwd: str) -> None:
     """Run a git command and exit with a clear error on failure."""
+    if cmd[:2] == ["git", "clone"]:
+        try:
+            run_git_transport(cmd[1:], cwd=cwd)
+        except GitTransportError as exc:
+            print(f"ERROR: Failed to run `{' '.join(cmd)}` in {cwd}: {exc}", file=sys.stderr)
+            raise
+        return
+
     result = subprocess.run(
         cmd,
         cwd=cwd,


### PR DESCRIPTION
## Summary

Make Forge's issue-side `human-intervention` decision **evidence based** and
classify a failed run by **failure origin**, not by scanning logs for keywords.
A workflow failure is treated as *logical* (and gets `human-intervention`) by
default; it is treated as *external* (and must not get the label) only when it
surfaces as a **typed exception at the Python boundary Forge itself crosses**.

## What changed

- **Typed external failures.** External dependency failures are now recognized
  by exception type rather than log text:
  - GitHub (`gh`) failures → `GitHubError` / `GitHubRateLimitExceeded`.
  - Remote git transport (`push`/`pull`/`fetch`/`clone`/`ls-remote`) →
    `GitTransportError`, raised through a shared `run_git_transport` helper that
    all remote git calls now route through.
- **External handling.** On an external failure Forge takes no issue action: it
  applies no `human-intervention` label, posts no comment, preserves no branch,
  and **silently releases the claim** (status back to `Todo`, assignees cleared)
  so the issue is retried on a later cycle. Rate limits additionally stop the
  current run for retry after reset.
- **Logical handling.** Every other failure — driver script, core workflow,
  local CI-equivalent verification (compile/test/native-test/finalization), and
  the rare agent timeout — stays logical and keeps the evidence-based
  `human-intervention` follow-up (dynamic-access coverage, generated-code
  metrics, preserved branch and log references).
- **Spec.** `§FS-human-intervention-policy` updated to describe origin-based
  classification.

## Why no log-keyword matching for Maven / Docker

Maven Central and Docker registry failures have **no Python boundary** to wrap —
Gradle owns them inside `./gradlew test` (e.g. Testcontainers pulls images from
within the test JVM), so they reach Forge only as an opaque CI-check `rc != 0`,
indistinguishable from a real test failure once the in-workflow retries have run.
Rather than guess from a brittle log vocabulary, they are **not special-cased**
and fall through to the safe logical default.

Resolves #7631
