### PR TITLE
[GenAI] Test fix for org.codehaus.plexus:plexus-classworlds:2.1.0 using gpt-5.5

### DIFF
--- a/metadata/org.codehaus.plexus/plexus-classworlds/2.1.0/reachability-metadata.json
+++ b/metadata/org.codehaus.plexus/plexus-classworlds/2.1.0/reachability-metadata.json
@@ -1,34 +1,10 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org.codehaus.plexus.classworlds.launcher.Launcher"
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.launcher.Launcher"
       },
-      "type": "java.lang.reflect.Method[]"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.plexus.classworlds.launcher.Launcher"
-      },
-      "type": "org_codehaus_plexus.plexus_classworlds.LauncherTest$EnhancedMain"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.plexus.classworlds.launcher.Launcher"
-      },
-      "type": "org_codehaus_plexus.plexus_classworlds.LauncherTest$EnhancedResourceMain"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.plexus.classworlds.launcher.Launcher"
-      },
-      "type": "org_codehaus_plexus.plexus_classworlds.LauncherTest$StandardMain"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.plexus.classworlds.launcher.Launcher"
-      },
-      "type": "org_codehaus_plexus.plexus_classworlds.LauncherTest$StandardResourceMain"
+      "type" : "java.lang.reflect.Method[]"
     }
   ]
 }

--- a/metadata/org.codehaus.plexus/plexus-classworlds/2.1.0/reachability-metadata.json
+++ b/metadata/org.codehaus.plexus/plexus-classworlds/2.1.0/reachability-metadata.json
@@ -1,0 +1,34 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type": "org_codehaus_plexus.plexus_classworlds.LauncherTest$EnhancedMain"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type": "org_codehaus_plexus.plexus_classworlds.LauncherTest$EnhancedResourceMain"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type": "org_codehaus_plexus.plexus_classworlds.LauncherTest$StandardMain"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type": "org_codehaus_plexus.plexus_classworlds.LauncherTest$StandardResourceMain"
+    }
+  ]
+}

--- a/metadata/org.codehaus.plexus/plexus-classworlds/index.json
+++ b/metadata/org.codehaus.plexus/plexus-classworlds/index.json
@@ -1,6 +1,16 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.1.0",
+    "tested-versions" : [
+      "2.1.0"
+    ],
+    "allowed-packages" : [
+      "org.codehaus.classworlds",
+      "org.codehaus.plexus.classworlds"
+    ]
+  },
+  {
     "metadata-version" : "2.0.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/$version$/plexus-classworlds-$version$-sources.jar",
     "repository-url" : "https://github.com/codehaus-plexus/plexus-classworlds",

--- a/metadata/org.codehaus.plexus/plexus-classworlds/index.json
+++ b/metadata/org.codehaus.plexus/plexus-classworlds/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.1.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/$version$/plexus-classworlds-$version$-sources.jar",
+    "repository-url" : "https://github.com/codehaus-plexus/plexus-classworlds",
+    "test-code-url" : "https://github.com/codehaus-plexus/plexus-classworlds/tree/plexus-classworlds-$version$/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/$version$/plexus-classworlds-$version$-javadoc.jar",
+    "description" : "Plexus Classworlds is a framework for creating and managing isolated Java class loader realms. It lets container-style applications and build tools load components with controlled classpath separation and package imports between realms.",
     "tested-versions" : [
       "2.1.0"
     ],

--- a/stats/org.codehaus.plexus/plexus-classworlds/2.1.0/execution-metrics.json
+++ b/stats/org.codehaus.plexus/plexus-classworlds/2.1.0/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_java_run_fail:2026-06-07": {
+    "timestamp": "2026-06-07T19:44:01.062349Z",
+    "library": "org.codehaus.plexus:plexus-classworlds:2.1.0",
+    "starting_commit": "12e2ee7efb2fd865f147b3961b49013fe7e9eb66",
+    "ending_commit": "acfbfb10d0eeb96cc8f0a7101dc680f72408ffb7",
+    "previous_library": "org.codehaus.plexus:plexus-classworlds:2.0.0",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.1.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 8,
+            "totalCalls": 8
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 7,
+            "totalCalls": 7
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 15,
+        "totalCalls": 15
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 964,
+          "missed": 2314,
+          "ratio": 0.294082,
+          "total": 3278
+        },
+        "line": {
+          "covered": 267,
+          "missed": 575,
+          "ratio": 0.317102,
+          "total": 842
+        },
+        "method": {
+          "covered": 73,
+          "missed": 156,
+          "ratio": 0.318777,
+          "total": 229
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.0.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 8,
+            "totalCalls": 8
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 6,
+            "totalCalls": 6
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 14,
+        "totalCalls": 14
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 934,
+          "missed": 1426,
+          "ratio": 0.395763,
+          "total": 2360
+        },
+        "line": {
+          "covered": 254,
+          "missed": 340,
+          "ratio": 0.427609,
+          "total": 594
+        },
+        "method": {
+          "covered": 65,
+          "missed": 54,
+          "ratio": 0.546218,
+          "total": 119
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 72769,
+      "cached_input_tokens_used": 504832,
+      "output_tokens_used": 7157,
+      "iterations": 3,
+      "cost_usd": 0.4671,
+      "tested_library_loc": 267,
+      "metadata_entries": 1,
+      "test_only_metadata_entries": 23,
+      "previous_library_metadata_entries": 4,
+      "previous_library_test_only_metadata_entries": 21,
+      "code_coverage_percent": 31.71,
+      "previous_library_coverage_percent": 42.76
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/src/test/java/org_codehaus_plexus/plexus_classworlds/DefaultStrategyTest.java",
+      "metadata_file": "metadata/org.codehaus.plexus/plexus-classworlds/2.1.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.codehaus.plexus/plexus-classworlds/2.1.0/stats.json
+++ b/stats/org.codehaus.plexus/plexus-classworlds/2.1.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "2.1.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 8,
+          "totalCalls" : 8
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 7,
+          "totalCalls" : 7
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 15,
+      "totalCalls" : 15
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 964,
+        "missed" : 2314,
+        "ratio" : 0.294082,
+        "total" : 3278
+      },
+      "line" : {
+        "covered" : 267,
+        "missed" : 575,
+        "ratio" : 0.317102,
+        "total" : 842
+      },
+      "method" : {
+        "covered" : 73,
+        "missed" : 156,
+        "ratio" : 0.318777,
+        "total" : 229
+      }
+    }
+  } ]
+}

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/.gitignore
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/build.gradle
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.codehaus.plexus:plexus-classworlds:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/gradle.properties
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.codehaus.plexus:plexus-classworlds:2.1.0
+library.version = 2.1.0
+metadata.dir = org.codehaus.plexus/plexus-classworlds/2.1.0/

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/settings.gradle
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.codehaus.plexus.plexus-classworlds_tests'

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmAdapterTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmAdapterTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_classworlds;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URL;
+
+import org.codehaus.classworlds.ClassRealm;
+import org.codehaus.classworlds.ClassWorld;
+import org.junit.jupiter.api.Test;
+
+public class ClassRealmAdapterTest {
+    @Test
+    void getResourceDelegatesThroughLegacyRealmAdapter() throws Exception {
+        ClassWorld world = new ClassWorld();
+        ClassRealm realm = world.newRealm("legacy-adapter-realm", ClassRealmAdapterTest.class.getClassLoader());
+
+        URL resource = realm.getResource("classworlds.conf");
+
+        assertThat(resource).isNotNull();
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java
@@ -37,8 +37,18 @@ public class ClassRealmTest {
     }
 
     @Test
+    void loadClassUsesParentClassLoaderWhenRealmHasNoMatchingClass() throws Exception {
+        ClassRealm realm = new ClassWorld().newRealm("parent-class-loader-realm", null);
+        realm.setParentClassLoader(ClassRealmTest.class.getClassLoader());
+
+        Class<?> loadedClass = realm.loadClass(ClassRealmTest.class.getName());
+
+        assertThat(loadedClass).isSameAs(ClassRealmTest.class);
+    }
+
+    @Test
     void loadResourceFromParentUsesForeignClassLoader() throws Exception {
-        ClassRealm realm = newRealm();
+        ClassRealm realm = newRealmWithParentClassLoader();
 
         URL resource = realm.loadResourceFromParent("classworlds.conf");
 
@@ -47,7 +57,7 @@ public class ClassRealmTest {
 
     @Test
     void loadResourcesFromParentUsesForeignClassLoader() throws Exception {
-        ClassRealm realm = newRealm();
+        ClassRealm realm = newRealmWithParentClassLoader();
 
         Enumeration<?> resources = realm.loadResourcesFromParent("classworlds.conf");
 
@@ -58,5 +68,11 @@ public class ClassRealmTest {
     private static ClassRealm newRealm() throws Exception {
         ClassWorld world = new ClassWorld();
         return world.newRealm(REALM_ID, ClassRealmTest.class.getClassLoader());
+    }
+
+    private static ClassRealm newRealmWithParentClassLoader() throws Exception {
+        ClassRealm realm = newRealm();
+        realm.setParentClassLoader(ClassRealmTest.class.getClassLoader());
+        return realm;
     }
 }

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_classworlds;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URL;
+import java.util.Enumeration;
+
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.junit.jupiter.api.Test;
+
+public class ClassRealmTest {
+    private static final String REALM_ID = "direct-realm";
+
+    @Test
+    void loadClassLoadsClassThroughRealmClassLoader() throws Exception {
+        ClassRealm realm = newRealm();
+
+        Class<?> loadedClass = realm.loadClass(ClassRealmTest.class.getName());
+
+        assertThat(loadedClass).isSameAs(ClassRealmTest.class);
+    }
+
+    @Test
+    void getResourceLoadsResourceThroughRealmClassLoader() throws Exception {
+        ClassRealm realm = newRealm();
+
+        URL resource = realm.getResource("classworlds.conf");
+
+        assertThat(resource).isNotNull();
+    }
+
+    @Test
+    void loadResourceFromParentUsesForeignClassLoader() throws Exception {
+        ClassRealm realm = newRealm();
+
+        URL resource = realm.loadResourceFromParent("classworlds.conf");
+
+        assertThat(resource).isNotNull();
+    }
+
+    @Test
+    void loadResourcesFromParentUsesForeignClassLoader() throws Exception {
+        ClassRealm realm = newRealm();
+
+        Enumeration<?> resources = realm.loadResourcesFromParent("classworlds.conf");
+
+        assertThat(resources).isNotNull();
+        assertThat(resources.hasMoreElements()).isTrue();
+    }
+
+    private static ClassRealm newRealm() throws Exception {
+        ClassWorld world = new ClassWorld();
+        return world.newRealm(REALM_ID, ClassRealmTest.class.getClassLoader());
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/src/test/java/org_codehaus_plexus/plexus_classworlds/DefaultStrategyTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/src/test/java/org_codehaus_plexus/plexus_classworlds/DefaultStrategyTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_classworlds;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy;
+import org.junit.jupiter.api.Test;
+
+public class DefaultStrategyTest {
+    private static final String REALM_ID = "default-realm";
+
+    @Test
+    void loadClassDelegatesClassworldsClassesToClassworldsClassLoader() throws Exception {
+        ClassRealm realm = new ClassWorld().newRealm(REALM_ID);
+
+        Class<?> loadedClass = realm.loadClass(ClassWorld.class.getName());
+
+        assertThat(realm.getStrategy()).isInstanceOf(SelfFirstStrategy.class);
+        assertThat(loadedClass).isSameAs(ClassWorld.class);
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ForeignStrategyTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ForeignStrategyTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_classworlds;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy;
+import org.junit.jupiter.api.Test;
+
+public class ForeignStrategyTest {
+    private static final String CLASS_NAME = ForeignLoadTarget.class.getName();
+    private static final String REALM_ID = "foreign-realm";
+    private static final String RESOURCE_NAME = "foreign/resource.txt";
+
+    @Test
+    void loadClassConsultsImportedClassLoaderFirst() throws Exception {
+        ClassLoader foreignClassLoader = new ClassLoader(
+                ForeignStrategyTest.class.getClassLoader()) {
+        };
+        SelfFirstStrategy strategy = newSelfFirstStrategy(
+                foreignClassLoader, ForeignLoadTarget.class.getPackageName());
+
+        Class<?> loadedClass = strategy.loadClass(CLASS_NAME);
+
+        assertThat(loadedClass).isEqualTo(ForeignLoadTarget.class);
+    }
+
+    @Test
+    void getResourceConsultsImportedClassLoaderFirst() throws Exception {
+        RecordingClassLoader foreignClassLoader = new RecordingClassLoader();
+        SelfFirstStrategy strategy = newSelfFirstStrategy(foreignClassLoader, "foreign");
+
+        URL resource = strategy.getResource(RESOURCE_NAME);
+
+        assertThat(resource).isEqualTo(foreignClassLoader.resource);
+        assertThat(foreignClassLoader.resourceLookups).containsExactly(RESOURCE_NAME);
+    }
+
+    @Test
+    void getResourcesIncludesResourcesFromImportedClassLoader() throws Exception {
+        RecordingClassLoader foreignClassLoader = new RecordingClassLoader();
+        SelfFirstStrategy strategy = newSelfFirstStrategy(foreignClassLoader, "foreign");
+
+        List<URL> resources = resources(strategy.getResources(RESOURCE_NAME));
+
+        assertThat(resources).containsExactly(foreignClassLoader.enumeratedResource);
+        assertThat(foreignClassLoader.resourcesLookups).containsExactly(RESOURCE_NAME);
+    }
+
+    private static SelfFirstStrategy newSelfFirstStrategy(
+            ClassLoader foreignClassLoader, String importedPackage) throws Exception {
+        ClassWorld world = new ClassWorld();
+        ClassRealm realm = world.newRealm(REALM_ID);
+        realm.importFrom(foreignClassLoader, importedPackage);
+        return new SelfFirstStrategy(realm);
+    }
+
+    private static List<URL> resources(Enumeration<?> enumeration) {
+        List<URL> resources = new ArrayList<>();
+        while (enumeration.hasMoreElements()) {
+            resources.add((URL) enumeration.nextElement());
+        }
+        return resources;
+    }
+
+    private static URL fileUrl(String path) {
+        try {
+            return Path.of(path).toUri().toURL();
+        } catch (MalformedURLException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public static final class ForeignLoadTarget {
+    }
+
+    private static final class RecordingClassLoader extends ClassLoader {
+        private final URL resource = fileUrl("/foreign-resource.txt");
+        private final URL enumeratedResource = fileUrl("/foreign-enumerated-resource.txt");
+        private final List<String> resourceLookups = new ArrayList<>();
+        private final List<String> resourcesLookups = new ArrayList<>();
+
+        private RecordingClassLoader() {
+            super(null);
+        }
+
+        @Override
+        public URL getResource(String name) {
+            resourceLookups.add(name);
+            if (RESOURCE_NAME.equals(name)) {
+                return resource;
+            }
+            return null;
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            resourcesLookups.add(name);
+            if (RESOURCE_NAME.equals(name)) {
+                return Collections.enumeration(Collections.singletonList(enumeratedResource));
+            }
+            return Collections.emptyEnumeration();
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/src/test/java/org_codehaus_plexus/plexus_classworlds/LauncherTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/src/test/java/org_codehaus_plexus/plexus_classworlds/LauncherTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_classworlds;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.launcher.Launcher;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.junit.jupiter.api.Test;
+
+public class LauncherTest {
+    private static final String REALM_ID = "test";
+    private static final String CLASSWORLDS_CONF_PROPERTY = "classworlds.conf";
+    private static final String BOOTSTRAPPED_PROPERTY = "classworlds.bootstrapped";
+
+    @Test
+    void launchInvokesEnhancedMainMethodFromConfiguredRealm() throws Exception {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        EnhancedMain.reset();
+        Launcher launcher = configuredLauncher(EnhancedMain.class);
+        try {
+            launcher.launch(new String[] {"alpha", "beta"});
+
+            assertThat(EnhancedMain.args).containsExactly("alpha", "beta");
+            assertThat(EnhancedMain.world).isSameAs(launcher.getWorld());
+            assertThat(Thread.currentThread().getContextClassLoader()).isSameAs(launcher.getMainRealm());
+            assertThat(launcher.getExitCode()).isEqualTo(21);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    @Test
+    void launchFallsBackToStandardMainMethodFromConfiguredRealm() throws Exception {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        StandardMain.reset();
+        Launcher launcher = configuredLauncher(StandardMain.class);
+        try {
+            launcher.launch(new String[] {"gamma"});
+
+            assertThat(StandardMain.args).containsExactly("gamma");
+            assertThat(Thread.currentThread().getContextClassLoader()).isSameAs(launcher.getMainRealm());
+            assertThat(launcher.getExitCode()).isEqualTo(34);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    @Test
+    void mainWithExitCodeLoadsClasspathConfigurationResource() throws Exception {
+        StandardResourceMain.reset();
+        withLauncherResourceLookup(false, () -> {
+            int exitCode = Launcher.mainWithExitCode(new String[] {"from-classpath"});
+
+            assertThat(exitCode).isEqualTo(55);
+            assertThat(StandardResourceMain.args).containsExactly("from-classpath");
+        });
+    }
+
+    @Test
+    void mainWithExitCodeLoadsBootstrappedUberjarConfigurationResource() throws Exception {
+        EnhancedResourceMain.reset();
+        withLauncherResourceLookup(true, () -> {
+            int exitCode = Launcher.mainWithExitCode(new String[] {"from-uberjar"});
+
+            assertThat(exitCode).isEqualTo(89);
+            assertThat(EnhancedResourceMain.args).containsExactly("from-uberjar");
+            assertThat(EnhancedResourceMain.world).isNotNull();
+        });
+    }
+
+    private static Launcher configuredLauncher(Class<?> mainClass) throws Exception {
+        ClassLoader classLoader = LauncherTest.class.getClassLoader();
+        ClassWorld world = new ClassWorld();
+        ClassRealm realm = world.newRealm(REALM_ID, classLoader);
+        Launcher launcher = new Launcher();
+        launcher.setSystemClassLoader(classLoader);
+        launcher.setWorld(world);
+        launcher.setAppMain(mainClass.getName(), realm.getId());
+        return launcher;
+    }
+
+    private static void withLauncherResourceLookup(boolean bootstrapped, ThrowingRunnable runnable) throws Exception {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        String originalConf = System.getProperty(CLASSWORLDS_CONF_PROPERTY);
+        String originalBootstrapped = System.getProperty(BOOTSTRAPPED_PROPERTY);
+        try {
+            Thread.currentThread().setContextClassLoader(LauncherTest.class.getClassLoader());
+            System.clearProperty(CLASSWORLDS_CONF_PROPERTY);
+            if (bootstrapped) {
+                System.setProperty(BOOTSTRAPPED_PROPERTY, "true");
+            } else {
+                System.clearProperty(BOOTSTRAPPED_PROPERTY);
+            }
+            runnable.run();
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+            restoreProperty(CLASSWORLDS_CONF_PROPERTY, originalConf);
+            restoreProperty(BOOTSTRAPPED_PROPERTY, originalBootstrapped);
+        }
+    }
+
+    private static void restoreProperty(String property, String value) {
+        if (value == null) {
+            System.clearProperty(property);
+        } else {
+            System.setProperty(property, value);
+        }
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+
+    public static class EnhancedMain {
+        private static String[] args;
+        private static ClassWorld world;
+
+        public static int main(String[] arguments, ClassWorld classWorld) {
+            args = arguments.clone();
+            world = classWorld;
+            return 21;
+        }
+
+        private static void reset() {
+            args = null;
+            world = null;
+        }
+    }
+
+    public static class StandardMain {
+        private static String[] args;
+
+        public static int main(String[] arguments) {
+            args = arguments.clone();
+            return 34;
+        }
+
+        private static void reset() {
+            args = null;
+        }
+    }
+
+    public static class StandardResourceMain {
+        private static String[] args;
+
+        public static int main(String[] arguments) {
+            args = arguments.clone();
+            return 55;
+        }
+
+        private static void reset() {
+            args = null;
+        }
+    }
+
+    public static class EnhancedResourceMain {
+        private static String[] args;
+        private static ClassWorld world;
+
+        public static int main(String[] arguments, ClassWorld classWorld) {
+            args = arguments.clone();
+            world = classWorld;
+            return 89;
+        }
+
+        private static void reset() {
+            args = null;
+            world = null;
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,142 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type" : "org_codehaus_plexus.plexus_classworlds.LauncherTest$EnhancedMain"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type" : "org_codehaus_plexus.plexus_classworlds.LauncherTest$EnhancedResourceMain"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type" : "org_codehaus_plexus.plexus_classworlds.LauncherTest$StandardMain"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type" : "org_codehaus_plexus.plexus_classworlds.LauncherTest$StandardResourceMain"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.DefaultStrategyTest"
+      },
+      "type" : "org.codehaus.plexus.classworlds.ClassWorld"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.ClassRealmTest"
+      },
+      "type" : "org_codehaus_plexus.plexus_classworlds.ClassRealmTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.LauncherTest"
+      },
+      "type" : "org_codehaus_plexus.plexus_classworlds.LauncherTest$EnhancedMain",
+      "methods" : [
+        {
+          "name" : "main",
+          "parameterTypes" : [
+            "java.lang.String[]",
+            "org.codehaus.plexus.classworlds.ClassWorld"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.LauncherTest"
+      },
+      "type" : "org_codehaus_plexus.plexus_classworlds.LauncherTest$EnhancedResourceMain",
+      "methods" : [
+        {
+          "name" : "main",
+          "parameterTypes" : [
+            "java.lang.String[]",
+            "org.codehaus.plexus.classworlds.ClassWorld"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.LauncherTest"
+      },
+      "type" : "org_codehaus_plexus.plexus_classworlds.LauncherTest$StandardMain",
+      "methods" : [
+        {
+          "name" : "main",
+          "parameterTypes" : [
+            "java.lang.String[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.LauncherTest"
+      },
+      "type" : "org_codehaus_plexus.plexus_classworlds.LauncherTest$StandardResourceMain",
+      "methods" : [
+        {
+          "name" : "main",
+          "parameterTypes" : [
+            "java.lang.String[]"
+          ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "glob" : "WORLDS-INF/conf/classworlds.conf"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.realm.ClassRealm"
+      },
+      "glob" : "classworlds.conf"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.ClassRealmTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.ClassRealmTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.LauncherTest"
+      },
+      "glob" : "WORLDS-INF/conf/classworlds.conf"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.ClassRealmTest"
+      },
+      "glob" : "classworlds.conf"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.LauncherTest"
+      },
+      "glob" : "classworlds.conf"
+    }
+  ]
+}

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -134,7 +134,19 @@
     },
     {
       "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.ClassRealmAdapterTest"
+      },
+      "glob" : "classworlds.conf"
+    },
+    {
+      "condition" : {
         "typeReached" : "org_codehaus_plexus.plexus_classworlds.LauncherTest"
+      },
+      "glob" : "classworlds.conf"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.classworlds.ClassRealmAdapter"
       },
       "glob" : "classworlds.conf"
     }

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/src/test/resources/WORLDS-INF/conf/classworlds.conf
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/src/test/resources/WORLDS-INF/conf/classworlds.conf
@@ -1,0 +1,3 @@
+main is org_codehaus_plexus.plexus_classworlds.LauncherTest$EnhancedResourceMain from test
+
+[test]

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/src/test/resources/classworlds.conf
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/src/test/resources/classworlds.conf
@@ -1,0 +1,3 @@
+main is org_codehaus_plexus.plexus_classworlds.LauncherTest$StandardResourceMain from test
+
+[test]

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/user-code-filter.json
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/user-code-filter.json
@@ -1,0 +1,16 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.codehaus.classworlds.**"
+    },
+    {
+      "includeClasses" : "org.codehaus.plexus.classworlds.**"
+    },
+    {
+      "includeClasses" : "org_codehaus_plexus.plexus_classworlds.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #8156

This PR provides test fixes and new metadata for org.codehaus.plexus:plexus-classworlds:2.1.0, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 72769
- Cached input tokens: 504832
- Output tokens: 7157
- Metadata entries: 1
- Test-only metadata entries: 23
- Iterations: 3
- Library coverage percentage: 31.71
- Previous library version metadata entries: 4
- Previous library version test-only metadata entries: 21
- Previous library version coverage percentage: 42.76

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `4c300a84e828baa0dff407134881c77b9aeaa4b9`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.codehaus.plexus:plexus-classworlds:2.0.0: 14/14 covered calls (100.00%)
- org.codehaus.plexus:plexus-classworlds:2.1.0: 15/15 covered calls (100.00%)

**Reflection:**
- org.codehaus.plexus:plexus-classworlds:2.0.0: 8/8 covered calls (100.00%)
- org.codehaus.plexus:plexus-classworlds:2.1.0: 8/8 covered calls (100.00%)

**Resources:**
- org.codehaus.plexus:plexus-classworlds:2.0.0: 6/6 covered calls (100.00%)
- org.codehaus.plexus:plexus-classworlds:2.1.0: 7/7 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.codehaus.plexus:plexus-classworlds:2.0.0: 934/2360 (39.58%)
- org.codehaus.plexus:plexus-classworlds:2.1.0: 964/3278 (29.41%)

**Line:**
- org.codehaus.plexus:plexus-classworlds:2.0.0: 254/594 (42.76%)
- org.codehaus.plexus:plexus-classworlds:2.1.0: 267/842 (31.71%)

**Method:**
- org.codehaus.plexus:plexus-classworlds:2.0.0: 65/119 (54.62%)
- org.codehaus.plexus:plexus-classworlds:2.1.0: 73/229 (31.88%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmAdapterTest.java 2/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmAdapterTest.java
new file mode 100644
index 0000000000..b4ebce1894
--- /dev/null
+++ 2/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmAdapterTest.java
@@ -0,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_classworlds;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URL;
+
+import org.codehaus.classworlds.ClassRealm;
+import org.codehaus.classworlds.ClassWorld;
+import org.junit.jupiter.api.Test;
+
+public class ClassRealmAdapterTest {
+    @Test
+    void getResourceDelegatesThroughLegacyRealmAdapter() throws Exception {
+        ClassWorld world = new ClassWorld();
+        ClassRealm realm = world.newRealm("legacy-adapter-realm", ClassRealmAdapterTest.class.getClassLoader());
+
+        URL resource = realm.getResource("classworlds.conf");
+
+        assertThat(resource).isNotNull();
+    }
+}
diff --git 1/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java 2/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java
index a8c30a39e5..0336424446 100644
--- 1/tests/src/org.codehaus.plexus/plexus-classworlds/2.0.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java
+++ 2/tests/src/org.codehaus.plexus/plexus-classworlds/2.1.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java
@@ -36,9 +36,19 @@ public class ClassRealmTest {
         assertThat(resource).isNotNull();
     }
 
+    @Test
+    void loadClassUsesParentClassLoaderWhenRealmHasNoMatchingClass() throws Exception {
+        ClassRealm realm = new ClassWorld().newRealm("parent-class-loader-realm", null);
+        realm.setParentClassLoader(ClassRealmTest.class.getClassLoader());
+
+        Class<?> loadedClass = realm.loadClass(ClassRealmTest.class.getName());
+
+        assertThat(loadedClass).isSameAs(ClassRealmTest.class);
+    }
+
     @Test
     void loadResourceFromParentUsesForeignClassLoader() throws Exception {
-        ClassRealm realm = newRealm();
+        ClassRealm realm = newRealmWithParentClassLoader();
 
         URL resource = realm.loadResourceFromParent("classworlds.conf");
 
@@ -47,7 +57,7 @@ public class ClassRealmTest {
 
     @Test
     void loadResourcesFromParentUsesForeignClassLoader() throws Exception {
-        ClassRealm realm = newRealm();
+        ClassRealm realm = newRealmWithParentClassLoader();
 
         Enumeration<?> resources = realm.loadResourcesFromParent("classworlds.conf");
 
@@ -59,4 +69,10 @@ public class ClassRealmTest {
         ClassWorld world = new ClassWorld();
         return world.newRealm(REALM_ID, ClassRealmTest.class.getClassLoader());
     }
+
+    private static ClassRealm newRealmWithParentClassLoader() throws Exception {
+        ClassRealm realm = newRealm();
+        realm.setParentClassLoader(ClassRealmTest.class.getClassLoader());
+        return realm;
+    }
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
