### PR TITLE
[GenAI] Test fix for org.springframework.boot:spring-boot-amqp:4.1.0-M4 using gpt-5.5

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-amqp/4.1.0-M4/reachability-metadata.json
+++ b/metadata/org.springframework.boot/spring-boot-amqp/4.1.0-M4/reachability-metadata.json
@@ -1,0 +1,508 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "com.sun.crypto.provider.AESCipher$General",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "com.sun.crypto.provider.ARCFOURCipher",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Poly1305",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "com.sun.crypto.provider.DESCipher",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "com.sun.crypto.provider.DESedeCipher",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "com.sun.crypto.provider.DHParameters",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "com.sun.crypto.provider.GaloisCounterMode$AESGCM",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "com.sun.crypto.provider.TlsMasterSecretGenerator",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "java.security.AlgorithmParametersSpi"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "java.security.KeyStoreSpi"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "sun.security.pkcs12.PKCS12KeyStore",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "sun.security.pkcs12.PKCS12KeyStore$DualFormatPKCS12",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "sun.security.provider.DSA$SHA224withDSA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "sun.security.provider.DSA$SHA256withDSA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitTemplateConfiguration"
+      },
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "sun.security.provider.SHA2$SHA224",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "sun.security.provider.SHA5$SHA384",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "sun.security.provider.SHA5$SHA512",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "sun.security.provider.X509Factory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "sun.security.rsa.PSSParameters",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "sun.security.rsa.RSAKeyFactory$Legacy",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "sun.security.rsa.RSAPSSSignature",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "sun.security.rsa.RSASignature$SHA224withRSA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "sun.security.ssl.KeyManagerFactoryImpl$SunX509",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "sun.security.ssl.SSLContextImpl$DefaultSSLContext",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "sun.security.ssl.TrustManagerFactoryImpl$PKIXFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "sun.security.x509.AuthorityInfoAccessExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "sun.security.x509.AuthorityKeyIdentifierExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "sun.security.x509.BasicConstraintsExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "sun.security.x509.CRLDistributionPointsExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "sun.security.x509.CertificatePoliciesExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "sun.security.x509.ExtendedKeyUsageExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "sun.security.x509.KeyUsageExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "sun.security.x509.NetscapeCertTypeExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "sun.security.x509.PrivateKeyUsageExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "type" : "sun.security.x509.SubjectKeyIdentifierExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator"
+      },
+      "glob" : "META-INF/services/java.net.spi.URLStreamHandlerProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.amqp.autoconfigure.SslBundleRabbitConnectionFactoryBean"
+      },
+      "glob" : "rabbitmq-amqp-client.properties"
+    }
+  ]
+}

--- a/metadata/org.springframework.boot/spring-boot-amqp/index.json
+++ b/metadata/org.springframework.boot/spring-boot-amqp/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "4.1.0-M4",
+    "tested-versions" : [
+      "4.1.0-M4"
+    ],
+    "allowed-packages" : [
+      "org.springframework.boot.amqp"
+    ]
+  },
+  {
     "metadata-version" : "4.1.0-M3",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-amqp/$version$/spring-boot-amqp-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-boot",

--- a/metadata/org.springframework.boot/spring-boot-amqp/index.json
+++ b/metadata/org.springframework.boot/spring-boot-amqp/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "4.1.0-M4",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-amqp/$version$/spring-boot-amqp-$version$-sources.jar",
+    "repository-url" : "https://github.com/spring-projects/spring-boot",
+    "test-code-url" : "https://github.com/spring-projects/spring-boot/tree/v$version$/module/spring-boot-amqp/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-amqp/$version$/spring-boot-amqp-$version$-javadoc.jar",
+    "description" : "Spring Boot AMQP provides auto-configuration and support classes for RabbitMQ messaging in Spring Boot applications. It configures Rabbit connection factories, templates, listener containers, health and metrics contributors, Docker Compose integration, and Testcontainers connection details.",
     "tested-versions" : [
       "4.1.0-M4"
     ],

--- a/stats/org.springframework.boot/spring-boot-amqp/4.1.0-M4/execution-metrics.json
+++ b/stats/org.springframework.boot/spring-boot-amqp/4.1.0-M4/execution-metrics.json
@@ -1,0 +1,88 @@
+{
+  "fix_javac_fail:2026-06-07": {
+    "timestamp": "2026-06-07T20:21:15.327364Z",
+    "library": "org.springframework.boot:spring-boot-amqp:4.1.0-M4",
+    "starting_commit": "0e0a66ffa7a4fb6f7fcef7d56935adf0e2a61dfe",
+    "ending_commit": "bfcfb96790c91c83f4ae570856d2ab7dcf17bb99",
+    "previous_library": "org.springframework.boot:spring-boot-amqp:4.1.0-M3",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.1.0-M4",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1537,
+          "missed": 2109,
+          "ratio": 0.421558,
+          "total": 3646
+        },
+        "line": {
+          "covered": 370,
+          "missed": 544,
+          "ratio": 0.404814,
+          "total": 914
+        },
+        "method": {
+          "covered": 138,
+          "missed": 218,
+          "ratio": 0.38764,
+          "total": 356
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "4.1.0-M3",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 262,
+          "missed": 123,
+          "ratio": 0.680519,
+          "total": 385
+        },
+        "line": {
+          "covered": 62,
+          "missed": 28,
+          "ratio": 0.688889,
+          "total": 90
+        },
+        "method": {
+          "covered": 33,
+          "missed": 17,
+          "ratio": 0.66,
+          "total": 50
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 55186,
+      "cached_input_tokens_used": 422912,
+      "output_tokens_used": 4014,
+      "iterations": 1,
+      "cost_usd": 0.3319,
+      "tested_library_loc": 370,
+      "metadata_entries": 78,
+      "test_only_metadata_entries": 218,
+      "previous_library_metadata_entries": 48,
+      "code_coverage_percent": 40.48,
+      "previous_library_coverage_percent": 68.89
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M4/src/test/java/org_springframework_boot/spring_boot_amqp/Spring_boot_amqpTest.java",
+      "metadata_file": "metadata/org.springframework.boot/spring-boot-amqp/4.1.0-M4/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.springframework.boot/spring-boot-amqp/4.1.0-M4/stats.json
+++ b/stats/org.springframework.boot/spring-boot-amqp/4.1.0-M4/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.1.0-M4",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1537,
+        "missed" : 2109,
+        "ratio" : 0.421558,
+        "total" : 3646
+      },
+      "line" : {
+        "covered" : 370,
+        "missed" : 544,
+        "ratio" : 0.404814,
+        "total" : 914
+      },
+      "method" : {
+        "covered" : 138,
+        "missed" : 218,
+        "ratio" : 0.38764,
+        "total" : 356
+      }
+    }
+  } ]
+}

--- a/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M4/.gitignore
+++ b/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M4/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M4/build.gradle
+++ b/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M4/build.gradle
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.springframework.boot:spring-boot-amqp:$libraryVersion"
+    testImplementation "org.springframework.boot:spring-boot-autoconfigure:$libraryVersion"
+    testImplementation "org.springframework.boot:spring-boot-test:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M4/gradle.properties
+++ b/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M4/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.springframework.boot:spring-boot-amqp:4.1.0-M4
+library.version = 4.1.0-M4
+metadata.dir = org.springframework.boot/spring-boot-amqp/4.1.0-M4/

--- a/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M4/settings.gradle
+++ b/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M4/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.springframework.boot.spring-boot-amqp_tests'

--- a/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M4/src/test/java/org_springframework_boot/spring_boot_amqp/Spring_boot_amqpTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M4/src/test/java/org_springframework_boot/spring_boot_amqp/Spring_boot_amqpTest.java
@@ -7,18 +7,19 @@
 package org_springframework_boot.spring_boot_amqp;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;
 
-import org.springframework.amqp.client.AmqpClient;
-import org.springframework.amqp.client.AmqpConnectionFactory;
-import org.springframework.amqp.client.SingleAmqpConnectionFactory;
-import org.springframework.boot.amqp.autoconfigure.AmqpAutoConfiguration;
-import org.springframework.boot.amqp.autoconfigure.AmqpClientCustomizer;
-import org.springframework.boot.amqp.autoconfigure.AmqpConnectionDetails;
-import org.springframework.boot.amqp.autoconfigure.AmqpProperties;
-import org.springframework.boot.amqp.autoconfigure.ConnectionOptionsCustomizer;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.boot.amqp.autoconfigure.ConnectionFactoryCustomizer;
+import org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration;
+import org.springframework.boot.amqp.autoconfigure.RabbitConnectionDetails;
+import org.springframework.boot.amqp.autoconfigure.RabbitProperties;
+import org.springframework.boot.amqp.autoconfigure.RabbitTemplateCustomizer;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
@@ -27,50 +28,54 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class Spring_boot_amqpTest {
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-            .withConfiguration(AutoConfigurations.of(AmqpAutoConfiguration.class));
+            .withConfiguration(AutoConfigurations.of(RabbitAutoConfiguration.class));
 
     @Test
-    void amqpPropertiesExposeConnectionAndClientSettings() {
-        AmqpProperties properties = new AmqpProperties();
+    void rabbitPropertiesExposeConnectionAndTemplateSettings() {
+        RabbitProperties properties = new RabbitProperties();
 
         assertThat(properties.getHost()).isEqualTo("localhost");
-        assertThat(properties.getPort()).isEqualTo(5672);
-        assertThat(properties.getUsername()).isNull();
-        assertThat(properties.getPassword()).isNull();
-        assertThat(properties.getClient().getDefaultToAddress()).isNull();
-        assertThat(properties.getClient().getCompletionTimeout()).isEqualTo(Duration.ofSeconds(60));
+        assertThat(properties.getPort()).isNull();
+        assertThat(properties.determinePort()).isEqualTo(5672);
+        assertThat(properties.getUsername()).isEqualTo("guest");
+        assertThat(properties.getPassword()).isEqualTo("guest");
+        assertThat(properties.getTemplate().getRoutingKey()).isEmpty();
+        assertThat(properties.getTemplate().getReplyTimeout()).isNull();
 
         properties.setHost("broker.example.test");
         properties.setPort(5678);
         properties.setUsername("alice");
         properties.setPassword("secret");
-        properties.getClient().setDefaultToAddress("orders.created");
-        properties.getClient().setCompletionTimeout(Duration.ofMillis(750));
+        properties.getTemplate().setRoutingKey("orders.created");
+        properties.getTemplate().setReplyTimeout(Duration.ofMillis(750));
 
         assertThat(properties.getHost()).isEqualTo("broker.example.test");
         assertThat(properties.getPort()).isEqualTo(5678);
+        assertThat(properties.determinePort()).isEqualTo(5678);
         assertThat(properties.getUsername()).isEqualTo("alice");
         assertThat(properties.getPassword()).isEqualTo("secret");
-        assertThat(properties.getClient().getDefaultToAddress()).isEqualTo("orders.created");
-        assertThat(properties.getClient().getCompletionTimeout()).isEqualTo(Duration.ofMillis(750));
+        assertThat(properties.getTemplate().getRoutingKey()).isEqualTo("orders.created");
+        assertThat(properties.getTemplate().getReplyTimeout()).isEqualTo(Duration.ofMillis(750));
     }
 
     @Test
-    void amqpConnectionDetailsAddressRecordAndDefaultsAreUsable() {
-        AmqpConnectionDetails.Address address = new AmqpConnectionDetails.Address("broker.example.test", 5679);
-        AmqpConnectionDetails details = () -> address;
+    void rabbitConnectionDetailsAddressRecordAndDefaultsAreUsable() {
+        RabbitConnectionDetails.Address address = new RabbitConnectionDetails.Address("broker.example.test", 5679);
+        RabbitConnectionDetails details = () -> List.of(address);
 
-        assertThat(details.getAddress()).isEqualTo(address);
-        assertThat(details.getAddress().host()).isEqualTo("broker.example.test");
-        assertThat(details.getAddress().port()).isEqualTo(5679);
+        assertThat(details.getAddresses()).containsExactly(address);
+        assertThat(details.getFirstAddress()).isEqualTo(address);
+        assertThat(details.getFirstAddress().host()).isEqualTo("broker.example.test");
+        assertThat(details.getFirstAddress().port()).isEqualTo(5679);
         assertThat(details.getUsername()).isNull();
         assertThat(details.getPassword()).isNull();
+        assertThat(details.getVirtualHost()).isNull();
 
-        AmqpConnectionDetails authenticatedDetails = new AmqpConnectionDetails() {
+        RabbitConnectionDetails authenticatedDetails = new RabbitConnectionDetails() {
 
             @Override
-            public AmqpConnectionDetails.Address getAddress() {
-                return address;
+            public List<RabbitConnectionDetails.Address> getAddresses() {
+                return List.of(address);
             }
 
             @Override
@@ -83,51 +88,56 @@ public class Spring_boot_amqpTest {
                 return "secret";
             }
 
+            @Override
+            public String getVirtualHost() {
+                return "orders";
+            }
+
         };
 
-        assertThat(authenticatedDetails.getAddress()).isSameAs(address);
+        assertThat(authenticatedDetails.getFirstAddress()).isSameAs(address);
         assertThat(authenticatedDetails.getUsername()).isEqualTo("alice");
         assertThat(authenticatedDetails.getPassword()).isEqualTo("secret");
+        assertThat(authenticatedDetails.getVirtualHost()).isEqualTo("orders");
     }
 
     @Test
-    void autoConfigurationCreatesConnectionFactoryClientAndAppliesCustomizers() {
-        AtomicBoolean connectionOptionsCustomizerInvoked = new AtomicBoolean();
-        AtomicBoolean clientCustomizerInvoked = new AtomicBoolean();
+    void autoConfigurationCreatesConnectionFactoryTemplateAndAppliesCustomizers() {
+        AtomicBoolean connectionFactoryCustomizerInvoked = new AtomicBoolean();
+        AtomicBoolean templateCustomizerInvoked = new AtomicBoolean();
 
         this.contextRunner
-                .withPropertyValues("spring.amqp.host=broker.example.test", "spring.amqp.port=5679",
-                        "spring.amqp.username=alice", "spring.amqp.password=secret",
-                        "spring.amqp.client.default-to-address=orders.created",
-                        "spring.amqp.client.completion-timeout=750ms")
-                .withBean(ConnectionOptionsCustomizer.class,
-                        () -> (connectionOptions) -> connectionOptionsCustomizerInvoked.set(true))
-                .withBean(AmqpClientCustomizer.class, () -> (builder) -> clientCustomizerInvoked.set(true))
+                .withPropertyValues("spring.rabbitmq.host=broker.example.test", "spring.rabbitmq.port=5679",
+                        "spring.rabbitmq.username=alice", "spring.rabbitmq.password=secret",
+                        "spring.rabbitmq.template.routing-key=orders.created",
+                        "spring.rabbitmq.template.reply-timeout=750ms")
+                .withBean(ConnectionFactoryCustomizer.class,
+                        () -> (connectionFactory) -> connectionFactoryCustomizerInvoked.set(true))
+                .withBean(RabbitTemplateCustomizer.class, () -> (template) -> templateCustomizerInvoked.set(true))
                 .run((context) -> {
-                    assertThat(context).hasSingleBean(AmqpProperties.class);
-                    assertThat(context).hasSingleBean(AmqpConnectionDetails.class);
-                    assertThat(context).hasSingleBean(AmqpConnectionFactory.class);
-                    assertThat(context).hasSingleBean(AmqpClient.class);
+                    assertThat(context).hasSingleBean(RabbitProperties.class);
+                    assertThat(context).hasSingleBean(RabbitConnectionDetails.class);
+                    assertThat(context).hasSingleBean(ConnectionFactory.class);
+                    assertThat(context).hasSingleBean(RabbitTemplate.class);
 
-                    AmqpProperties properties = context.getBean(AmqpProperties.class);
+                    RabbitProperties properties = context.getBean(RabbitProperties.class);
                     assertThat(properties.getHost()).isEqualTo("broker.example.test");
                     assertThat(properties.getPort()).isEqualTo(5679);
                     assertThat(properties.getUsername()).isEqualTo("alice");
                     assertThat(properties.getPassword()).isEqualTo("secret");
-                    assertThat(properties.getClient().getDefaultToAddress()).isEqualTo("orders.created");
-                    assertThat(properties.getClient().getCompletionTimeout()).isEqualTo(Duration.ofMillis(750));
+                    assertThat(properties.getTemplate().getRoutingKey()).isEqualTo("orders.created");
+                    assertThat(properties.getTemplate().getReplyTimeout()).isEqualTo(Duration.ofMillis(750));
 
-                    AmqpConnectionDetails connectionDetails = context.getBean(AmqpConnectionDetails.class);
-                    assertThat(connectionDetails.getAddress().host()).isEqualTo("broker.example.test");
-                    assertThat(connectionDetails.getAddress().port()).isEqualTo(5679);
+                    RabbitConnectionDetails connectionDetails = context.getBean(RabbitConnectionDetails.class);
+                    assertThat(connectionDetails.getFirstAddress().host()).isEqualTo("broker.example.test");
+                    assertThat(connectionDetails.getFirstAddress().port()).isEqualTo(5679);
                     assertThat(connectionDetails.getUsername()).isEqualTo("alice");
                     assertThat(connectionDetails.getPassword()).isEqualTo("secret");
 
-                    assertThat(context.getBean(AmqpConnectionFactory.class))
-                            .isInstanceOf(SingleAmqpConnectionFactory.class);
-                    assertThat(context.getBean(AmqpClient.class)).isNotNull();
-                    assertThat(connectionOptionsCustomizerInvoked).isTrue();
-                    assertThat(clientCustomizerInvoked).isTrue();
+                    assertThat(context.getBean(ConnectionFactory.class)).isInstanceOf(CachingConnectionFactory.class);
+                    assertThat(context.getBean(RabbitTemplate.class)).isNotNull();
+                    assertThat(connectionFactoryCustomizerInvoked).isTrue();
+                    assertThat(templateCustomizerInvoked).isTrue();
                 });
     }
 

--- a/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M4/src/test/java/org_springframework_boot/spring_boot_amqp/Spring_boot_amqpTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M4/src/test/java/org_springframework_boot/spring_boot_amqp/Spring_boot_amqpTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework_boot.spring_boot_amqp;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.amqp.client.AmqpClient;
+import org.springframework.amqp.client.AmqpConnectionFactory;
+import org.springframework.amqp.client.SingleAmqpConnectionFactory;
+import org.springframework.boot.amqp.autoconfigure.AmqpAutoConfiguration;
+import org.springframework.boot.amqp.autoconfigure.AmqpClientCustomizer;
+import org.springframework.boot.amqp.autoconfigure.AmqpConnectionDetails;
+import org.springframework.boot.amqp.autoconfigure.AmqpProperties;
+import org.springframework.boot.amqp.autoconfigure.ConnectionOptionsCustomizer;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Spring_boot_amqpTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(AmqpAutoConfiguration.class));
+
+    @Test
+    void amqpPropertiesExposeConnectionAndClientSettings() {
+        AmqpProperties properties = new AmqpProperties();
+
+        assertThat(properties.getHost()).isEqualTo("localhost");
+        assertThat(properties.getPort()).isEqualTo(5672);
+        assertThat(properties.getUsername()).isNull();
+        assertThat(properties.getPassword()).isNull();
+        assertThat(properties.getClient().getDefaultToAddress()).isNull();
+        assertThat(properties.getClient().getCompletionTimeout()).isEqualTo(Duration.ofSeconds(60));
+
+        properties.setHost("broker.example.test");
+        properties.setPort(5678);
+        properties.setUsername("alice");
+        properties.setPassword("secret");
+        properties.getClient().setDefaultToAddress("orders.created");
+        properties.getClient().setCompletionTimeout(Duration.ofMillis(750));
+
+        assertThat(properties.getHost()).isEqualTo("broker.example.test");
+        assertThat(properties.getPort()).isEqualTo(5678);
+        assertThat(properties.getUsername()).isEqualTo("alice");
+        assertThat(properties.getPassword()).isEqualTo("secret");
+        assertThat(properties.getClient().getDefaultToAddress()).isEqualTo("orders.created");
+        assertThat(properties.getClient().getCompletionTimeout()).isEqualTo(Duration.ofMillis(750));
+    }
+
+    @Test
+    void amqpConnectionDetailsAddressRecordAndDefaultsAreUsable() {
+        AmqpConnectionDetails.Address address = new AmqpConnectionDetails.Address("broker.example.test", 5679);
+        AmqpConnectionDetails details = () -> address;
+
+        assertThat(details.getAddress()).isEqualTo(address);
+        assertThat(details.getAddress().host()).isEqualTo("broker.example.test");
+        assertThat(details.getAddress().port()).isEqualTo(5679);
+        assertThat(details.getUsername()).isNull();
+        assertThat(details.getPassword()).isNull();
+
+        AmqpConnectionDetails authenticatedDetails = new AmqpConnectionDetails() {
+
+            @Override
+            public AmqpConnectionDetails.Address getAddress() {
+                return address;
+            }
+
+            @Override
+            public String getUsername() {
+                return "alice";
+            }
+
+            @Override
+            public String getPassword() {
+                return "secret";
+            }
+
+        };
+
+        assertThat(authenticatedDetails.getAddress()).isSameAs(address);
+        assertThat(authenticatedDetails.getUsername()).isEqualTo("alice");
+        assertThat(authenticatedDetails.getPassword()).isEqualTo("secret");
+    }
+
+    @Test
+    void autoConfigurationCreatesConnectionFactoryClientAndAppliesCustomizers() {
+        AtomicBoolean connectionOptionsCustomizerInvoked = new AtomicBoolean();
+        AtomicBoolean clientCustomizerInvoked = new AtomicBoolean();
+
+        this.contextRunner
+                .withPropertyValues("spring.amqp.host=broker.example.test", "spring.amqp.port=5679",
+                        "spring.amqp.username=alice", "spring.amqp.password=secret",
+                        "spring.amqp.client.default-to-address=orders.created",
+                        "spring.amqp.client.completion-timeout=750ms")
+                .withBean(ConnectionOptionsCustomizer.class,
+                        () -> (connectionOptions) -> connectionOptionsCustomizerInvoked.set(true))
+                .withBean(AmqpClientCustomizer.class, () -> (builder) -> clientCustomizerInvoked.set(true))
+                .run((context) -> {
+                    assertThat(context).hasSingleBean(AmqpProperties.class);
+                    assertThat(context).hasSingleBean(AmqpConnectionDetails.class);
+                    assertThat(context).hasSingleBean(AmqpConnectionFactory.class);
+                    assertThat(context).hasSingleBean(AmqpClient.class);
+
+                    AmqpProperties properties = context.getBean(AmqpProperties.class);
+                    assertThat(properties.getHost()).isEqualTo("broker.example.test");
+                    assertThat(properties.getPort()).isEqualTo(5679);
+                    assertThat(properties.getUsername()).isEqualTo("alice");
+                    assertThat(properties.getPassword()).isEqualTo("secret");
+                    assertThat(properties.getClient().getDefaultToAddress()).isEqualTo("orders.created");
+                    assertThat(properties.getClient().getCompletionTimeout()).isEqualTo(Duration.ofMillis(750));
+
+                    AmqpConnectionDetails connectionDetails = context.getBean(AmqpConnectionDetails.class);
+                    assertThat(connectionDetails.getAddress().host()).isEqualTo("broker.example.test");
+                    assertThat(connectionDetails.getAddress().port()).isEqualTo(5679);
+                    assertThat(connectionDetails.getUsername()).isEqualTo("alice");
+                    assertThat(connectionDetails.getPassword()).isEqualTo("secret");
+
+                    assertThat(context.getBean(AmqpConnectionFactory.class))
+                            .isInstanceOf(SingleAmqpConnectionFactory.class);
+                    assertThat(context.getBean(AmqpClient.class)).isNotNull();
+                    assertThat(connectionOptionsCustomizerInvoked).isTrue();
+                    assertThat(clientCustomizerInvoked).isTrue();
+                });
+    }
+
+}

--- a/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M4/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M4/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,1367 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "boolean[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "com.rabbitmq.client.Channel"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "com.rabbitmq.client.ShutdownListener"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "int[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "jakarta.annotation.PostConstruct"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "jakarta.inject.Inject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "jakarta.inject.Named"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "jakarta.inject.Provider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "jakarta.inject.Qualifier"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "jakarta.persistence.EntityManagerFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "jakarta.validation.Validator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "java.lang.Class[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "java.lang.FunctionalInterface"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "java.lang.annotation.Documented"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "java.lang.annotation.Retention"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "java.lang.annotation.Target"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "java.time.DurationEditor"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "java.util.EventListener"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "javax.money.MonetaryAmount"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "kotlin.Metadata"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "kotlin.reflect.full.KClasses"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "kotlinx.coroutines.reactor.MonoKt"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.apache.commons.logging.LogFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.apache.commons.logging.impl.Log4jApiLogFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.apache.commons.logging.impl.Slf4jLogFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.apache.commons.logging.impl.WeakHashtable",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.apache.logging.slf4j.SLF4JProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.eclipse.core.runtime.FileLocator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.reactivestreams.Publisher"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.amqp.core.AmqpAdmin"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.amqp.core.AmqpTemplate"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.amqp.core.MessageListener"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.amqp.listener.AbstractListenerAnnotationBeanPostProcessor"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.amqp.rabbit.annotation.EnableRabbit"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.amqp.rabbit.annotation.MultiRabbitBootstrapConfiguration",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.amqp.rabbit.annotation.RabbitBootstrapConfiguration",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.amqp.rabbit.annotation.RabbitListenerAnnotationBeanPostProcessor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.amqp.rabbit.annotation.RabbitListenerConfigurationSelector",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.amqp.rabbit.config.AbstractRabbitListenerContainerFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.amqp.rabbit.config.BaseRabbitListenerContainerFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.amqp.rabbit.connection.AbstractConnectionFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.amqp.rabbit.connection.CachingConnectionFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.amqp.rabbit.connection.ConnectionFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.amqp.rabbit.connection.PublisherCallbackChannel$Listener"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.amqp.rabbit.connection.RabbitAccessor"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.amqp.rabbit.core.RabbitAdmin"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.amqp.rabbit.core.RabbitMessageOperations"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.amqp.rabbit.core.RabbitMessagingTemplate"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.amqp.rabbit.core.RabbitOperations"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.amqp.rabbit.core.RabbitTemplate"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistry",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.amqp.rabbit.listener.api.ChannelAwareMessageListener"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.amqp.rabbit.support.ListenerContainerAware"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.beans.factory.Aware"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.beans.factory.BeanClassLoaderAware"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.beans.factory.BeanFactory",
+      "methods" : [
+        {
+          "name" : "getBean",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.beans.factory.BeanFactoryAware"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.beans.factory.BeanNameAware"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.beans.factory.DisposableBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.beans.factory.FactoryBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.beans.factory.HierarchicalBeanFactory",
+      "methods" : [
+        {
+          "name" : "getParentBeanFactory",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.beans.factory.InitializingBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.beans.factory.ListableBeanFactory",
+      "methods" : [
+        {
+          "name" : "getBeanNamesForType",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.beans.factory.SmartInitializingSingleton"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.beans.factory.config.BeanPostProcessor"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.amqp.autoconfigure.AbstractConnectionFactoryConfigurer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.amqp.autoconfigure.AbstractRabbitListenerContainerFactoryConfigurer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.amqp.autoconfigure.CachingConnectionFactoryConfigurer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.amqp.autoconfigure.ConnectionFactoryCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.amqp.autoconfigure.DirectRabbitListenerContainerFactoryConfigurer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.amqp.autoconfigure.PropertiesRabbitConnectionDetails"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.amqp.autoconfigure.RabbitAnnotationDrivenConfiguration",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.springframework.beans.factory.ObjectProvider",
+            "org.springframework.beans.factory.ObjectProvider",
+            "org.springframework.beans.factory.ObjectProvider",
+            "org.springframework.beans.factory.ObjectProvider",
+            "org.springframework.boot.amqp.autoconfigure.RabbitProperties"
+          ]
+        },
+        {
+          "name" : "directRabbitListenerContainerFactoryConfigurer",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "simpleRabbitListenerContainerFactory",
+          "parameterTypes" : [
+            "org.springframework.boot.amqp.autoconfigure.SimpleRabbitListenerContainerFactoryConfigurer",
+            "org.springframework.amqp.rabbit.connection.ConnectionFactory",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        },
+        {
+          "name" : "simpleRabbitListenerContainerFactoryConfigurer",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.amqp.autoconfigure.RabbitAnnotationDrivenConfiguration$EnableRabbitConfiguration",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitConnectionFactoryCreator",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.springframework.boot.amqp.autoconfigure.RabbitProperties"
+          ]
+        },
+        {
+          "name" : "rabbitConnectionDetails",
+          "parameterTypes" : [
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        },
+        {
+          "name" : "rabbitConnectionFactory",
+          "parameterTypes" : [
+            "org.springframework.boot.amqp.autoconfigure.RabbitConnectionFactoryBeanConfigurer",
+            "org.springframework.boot.amqp.autoconfigure.CachingConnectionFactoryConfigurer",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        },
+        {
+          "name" : "rabbitConnectionFactoryBeanConfigurer",
+          "parameterTypes" : [
+            "org.springframework.core.io.ResourceLoader",
+            "org.springframework.boot.amqp.autoconfigure.RabbitConnectionDetails",
+            "org.springframework.beans.factory.ObjectProvider",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        },
+        {
+          "name" : "rabbitConnectionFactoryConfigurer",
+          "parameterTypes" : [
+            "org.springframework.boot.amqp.autoconfigure.RabbitConnectionDetails",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitMessagingTemplateConfiguration",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "rabbitMessagingTemplate",
+          "parameterTypes" : [
+            "org.springframework.amqp.rabbit.core.RabbitTemplate"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration$RabbitTemplateConfiguration",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "amqpAdmin",
+          "parameterTypes" : [
+            "org.springframework.amqp.rabbit.connection.ConnectionFactory"
+          ]
+        },
+        {
+          "name" : "rabbitTemplate",
+          "parameterTypes" : [
+            "org.springframework.boot.amqp.autoconfigure.RabbitTemplateConfigurer",
+            "org.springframework.amqp.rabbit.connection.ConnectionFactory",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        },
+        {
+          "name" : "rabbitTemplateConfigurer",
+          "parameterTypes" : [
+            "org.springframework.boot.amqp.autoconfigure.RabbitProperties",
+            "org.springframework.beans.factory.ObjectProvider",
+            "org.springframework.beans.factory.ObjectProvider",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.amqp.autoconfigure.RabbitConnectionDetails"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.amqp.autoconfigure.RabbitConnectionFactoryBeanConfigurer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.amqp.autoconfigure.RabbitProperties",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getTemplate",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setHost",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setPassword",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setPort",
+          "parameterTypes" : [
+            "java.lang.Integer"
+          ]
+        },
+        {
+          "name" : "setUsername",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.amqp.autoconfigure.RabbitProperties$Template",
+      "methods" : [
+        {
+          "name" : "setReplyTimeout",
+          "parameterTypes" : [
+            "java.time.Duration"
+          ]
+        },
+        {
+          "name" : "setRoutingKey",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.amqp.autoconfigure.RabbitStreamConfiguration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.amqp.autoconfigure.RabbitTemplateConfigurer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.amqp.autoconfigure.RabbitTemplateCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.amqp.autoconfigure.SimpleRabbitListenerContainerFactoryConfigurer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.AutoConfiguration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.AutoConfigureAfter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.AutoConfigureBefore"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.condition.ConditionalOnBooleanProperty"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.condition.ConditionalOnClass",
+      "methods" : [
+        {
+          "name" : "value",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.condition.ConditionalOnProperty"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.condition.ConditionalOnThreading"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.condition.OnBeanCondition",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.condition.OnClassCondition",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.condition.OnPropertyCondition",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.condition.OnThreadingCondition",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.service.connection.ConnectionDetails"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.context.properties.BoundConfigurationProperties",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.context.properties.ConfigurationProperties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.context.properties.ConfigurationPropertiesBinder$ConfigurationPropertiesBinderFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.context.properties.ConfigurationPropertiesBindingPostProcessor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.context.properties.EnableConfigurationProperties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.context.properties.EnableConfigurationPropertiesRegistrar",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.convert.DurationUnit"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.thread.Threading"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.boot.validation.beanvalidation.MethodValidationExcludeFilter",
+      "methods" : [
+        {
+          "name" : "byAnnotation",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.context.ApplicationContextAware"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.context.ApplicationEventPublisherAware"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.context.ApplicationListener"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.context.EnvironmentAware"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.context.Lifecycle"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.context.Phased"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.context.SmartLifecycle"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.context.annotation.Bean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.context.annotation.Conditional"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.context.annotation.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.context.annotation.ConfigurationClassParser$DefaultDeferredImportSelectorGroup",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.context.annotation.ConfigurationClassPostProcessor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.context.annotation.Import"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.context.event.DefaultEventListenerFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.context.event.EventListenerMethodProcessor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.core.Ordered"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.core.annotation.AliasFor"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.core.annotation.Order"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.jmx.export.annotation.ManagedAttribute"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.jmx.export.annotation.ManagedOperation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.jmx.export.annotation.ManagedResource"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.messaging.core.AbstractMessageReceivingTemplate"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.messaging.core.AbstractMessageSendingTemplate"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.messaging.core.AbstractMessagingTemplate"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.messaging.core.MessageReceivingOperations"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.messaging.core.MessageRequestReplyOperations"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.messaging.core.MessageSendingOperations"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.rabbit.stream.config.StreamRabbitListenerContainerFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.stereotype.Component"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.stereotype.Indexed"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : "org.springframework.util.ConcurrentReferenceHashMap$Segment[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : {
+        "proxy" : [
+          "org.springframework.boot.context.properties.ConfigurationProperties"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : {
+        "proxy" : [
+          "org.springframework.context.ConfigurableApplicationContext",
+          "org.springframework.boot.test.context.assertj.AssertableApplicationContext"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : {
+        "lambda" : {
+          "declaringClass" : "org.springframework.boot.validation.beanvalidation.MethodValidationExcludeFilter",
+          "interfaces" : [
+            "org.springframework.boot.validation.beanvalidation.MethodValidationExcludeFilter"
+          ]
+        }
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : {
+        "lambda" : {
+          "declaringClass" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest",
+          "interfaces" : [
+            "org.springframework.boot.amqp.autoconfigure.ConnectionFactoryCustomizer"
+          ]
+        }
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "type" : {
+        "lambda" : {
+          "declaringClass" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest",
+          "interfaces" : [
+            "org.springframework.boot.amqp.autoconfigure.RabbitTemplateCustomizer"
+          ]
+        }
+      }
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "glob" : "META-INF/services/org.apache.commons.logging.LogFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "glob" : "META-INF/spring.components"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "glob" : "META-INF/spring.factories"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "glob" : "META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.replacements"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "glob" : "commons-logging.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "glob" : "org/slf4j/impl/StaticLoggerBinder.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "glob" : "org/springframework/amqp/rabbit/annotation/MultiRabbitBootstrapConfiguration.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "glob" : "org/springframework/amqp/rabbit/annotation/RabbitBootstrapConfiguration.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "glob" : "org/springframework/beans/factory/Aware.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "glob" : "org/springframework/boot/amqp/autoconfigure/RabbitAnnotationDrivenConfiguration.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "glob" : "org/springframework/boot/amqp/autoconfigure/RabbitAutoConfiguration$RabbitConnectionFactoryCreator.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "glob" : "org/springframework/boot/amqp/autoconfigure/RabbitAutoConfiguration$RabbitTemplateConfiguration.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "glob" : "org/springframework/boot/amqp/autoconfigure/RabbitAutoConfiguration.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "glob" : "org/springframework/boot/amqp/autoconfigure/RabbitStreamConfiguration.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "glob" : "org/springframework/context/EnvironmentAware.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "glob" : "org/springframework/context/annotation/ImportBeanDefinitionRegistrar.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_amqp.Spring_boot_amqpTest"
+      },
+      "glob" : "spring.properties"
+    }
+  ]
+}

--- a/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M4/user-code-filter.json
+++ b/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M4/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.springframework.boot.amqp.**"
+    },
+    {
+      "includeClasses" : "org_springframework_boot.spring_boot_amqp.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #8157

This PR provides test fixes and new metadata for org.springframework.boot:spring-boot-amqp:4.1.0-M4, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 55186
- Cached input tokens: 422912
- Output tokens: 4014
- Metadata entries: 78
- Test-only metadata entries: 218
- Iterations: 1
- Library coverage percentage: 40.48
- Previous library version metadata entries: 48
- Previous library version coverage percentage: 68.89

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `9fc7e9b5a5ca50fdaf8a0f4314f8bd15777e5d77`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.springframework.boot:spring-boot-amqp:4.1.0-M3: 0/0 covered calls (100.00%)
- org.springframework.boot:spring-boot-amqp:4.1.0-M4: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.springframework.boot:spring-boot-amqp:4.1.0-M3: 262/385 (68.05%)
- org.springframework.boot:spring-boot-amqp:4.1.0-M4: 1537/3646 (42.16%)

**Line:**
- org.springframework.boot:spring-boot-amqp:4.1.0-M3: 62/90 (68.89%)
- org.springframework.boot:spring-boot-amqp:4.1.0-M4: 370/914 (40.48%)

**Method:**
- org.springframework.boot:spring-boot-amqp:4.1.0-M3: 33/50 (66.00%)
- org.springframework.boot:spring-boot-amqp:4.1.0-M4: 138/356 (38.76%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M3/src/test/java/org_springframework_boot/spring_boot_amqp/Spring_boot_amqpTest.java b/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M4/src/test/java/org_springframework_boot/spring_boot_amqp/Spring_boot_amqpTest.java
index 3b037a3ddd..e8d20d1155 100644
--- a/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M3/src/test/java/org_springframework_boot/spring_boot_amqp/Spring_boot_amqpTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-amqp/4.1.0-M4/src/test/java/org_springframework_boot/spring_boot_amqp/Spring_boot_amqpTest.java
@@ -7,18 +7,19 @@
 package org_springframework_boot.spring_boot_amqp;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;
 
-import org.springframework.amqp.client.AmqpClient;
-import org.springframework.amqp.client.AmqpConnectionFactory;
-import org.springframework.amqp.client.SingleAmqpConnectionFactory;
-import org.springframework.boot.amqp.autoconfigure.AmqpAutoConfiguration;
-import org.springframework.boot.amqp.autoconfigure.AmqpClientCustomizer;
-import org.springframework.boot.amqp.autoconfigure.AmqpConnectionDetails;
-import org.springframework.boot.amqp.autoconfigure.AmqpProperties;
-import org.springframework.boot.amqp.autoconfigure.ConnectionOptionsCustomizer;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.boot.amqp.autoconfigure.ConnectionFactoryCustomizer;
+import org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration;
+import org.springframework.boot.amqp.autoconfigure.RabbitConnectionDetails;
+import org.springframework.boot.amqp.autoconfigure.RabbitProperties;
+import org.springframework.boot.amqp.autoconfigure.RabbitTemplateCustomizer;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
@@ -27,50 +28,54 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class Spring_boot_amqpTest {
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-            .withConfiguration(AutoConfigurations.of(AmqpAutoConfiguration.class));
+            .withConfiguration(AutoConfigurations.of(RabbitAutoConfiguration.class));
 
     @Test
-    void amqpPropertiesExposeConnectionAndClientSettings() {
-        AmqpProperties properties = new AmqpProperties();
+    void rabbitPropertiesExposeConnectionAndTemplateSettings() {
+        RabbitProperties properties = new RabbitProperties();
 
         assertThat(properties.getHost()).isEqualTo("localhost");
-        assertThat(properties.getPort()).isEqualTo(5672);
-        assertThat(properties.getUsername()).isNull();
-        assertThat(properties.getPassword()).isNull();
-        assertThat(properties.getClient().getDefaultToAddress()).isNull();
-        assertThat(properties.getClient().getCompletionTimeout()).isEqualTo(Duration.ofSeconds(60));
+        assertThat(properties.getPort()).isNull();
+        assertThat(properties.determinePort()).isEqualTo(5672);
+        assertThat(properties.getUsername()).isEqualTo("guest");
+        assertThat(properties.getPassword()).isEqualTo("guest");
+        assertThat(properties.getTemplate().getRoutingKey()).isEmpty();
+        assertThat(properties.getTemplate().getReplyTimeout()).isNull();
 
         properties.setHost("broker.example.test");
         properties.setPort(5678);
         properties.setUsername("alice");
         properties.setPassword("secret");
-        properties.getClient().setDefaultToAddress("orders.created");
-        properties.getClient().setCompletionTimeout(Duration.ofMillis(750));
+        properties.getTemplate().setRoutingKey("orders.created");
+        properties.getTemplate().setReplyTimeout(Duration.ofMillis(750));
 
         assertThat(properties.getHost()).isEqualTo("broker.example.test");
         assertThat(properties.getPort()).isEqualTo(5678);
+        assertThat(properties.determinePort()).isEqualTo(5678);
         assertThat(properties.getUsername()).isEqualTo("alice");
         assertThat(properties.getPassword()).isEqualTo("secret");
-        assertThat(properties.getClient().getDefaultToAddress()).isEqualTo("orders.created");
-        assertThat(properties.getClient().getCompletionTimeout()).isEqualTo(Duration.ofMillis(750));
+        assertThat(properties.getTemplate().getRoutingKey()).isEqualTo("orders.created");
+        assertThat(properties.getTemplate().getReplyTimeout()).isEqualTo(Duration.ofMillis(750));
     }
 
     @Test
-    void amqpConnectionDetailsAddressRecordAndDefaultsAreUsable() {
-        AmqpConnectionDetails.Address address = new AmqpConnectionDetails.Address("broker.example.test", 5679);
-        AmqpConnectionDetails details = () -> address;
-
-        assertThat(details.getAddress()).isEqualTo(address);
-        assertThat(details.getAddress().host()).isEqualTo("broker.example.test");
-        assertThat(details.getAddress().port()).isEqualTo(5679);
+    void rabbitConnectionDetailsAddressRecordAndDefaultsAreUsable() {
+        RabbitConnectionDetails.Address address = new RabbitConnectionDetails.Address("broker.example.test", 5679);
+        RabbitConnectionDetails details = () -> List.of(address);
+
+        assertThat(details.getAddresses()).containsExactly(address);
+        assertThat(details.getFirstAddress()).isEqualTo(address);
+        assertThat(details.getFirstAddress().host()).isEqualTo("broker.example.test");
+        assertThat(details.getFirstAddress().port()).isEqualTo(5679);
         assertThat(details.getUsername()).isNull();
         assertThat(details.getPassword()).isNull();
+        assertThat(details.getVirtualHost()).isNull();
 
-        AmqpConnectionDetails authenticatedDetails = new AmqpConnectionDetails() {
+        RabbitConnectionDetails authenticatedDetails = new RabbitConnectionDetails() {
 
             @Override
-            public AmqpConnectionDetails.Address getAddress() {
-                return address;
+            public List<RabbitConnectionDetails.Address> getAddresses() {
+                return List.of(address);
             }
 
             @Override
@@ -83,51 +88,56 @@ public class Spring_boot_amqpTest {
                 return "secret";
             }
 
+            @Override
+            public String getVirtualHost() {
+                return "orders";
+            }
+
         };
 
-        assertThat(authenticatedDetails.getAddress()).isSameAs(address);
+        assertThat(authenticatedDetails.getFirstAddress()).isSameAs(address);
         assertThat(authenticatedDetails.getUsername()).isEqualTo("alice");
         assertThat(authenticatedDetails.getPassword()).isEqualTo("secret");
+        assertThat(authenticatedDetails.getVirtualHost()).isEqualTo("orders");
     }
 
     @Test
-    void autoConfigurationCreatesConnectionFactoryClientAndAppliesCustomizers() {
-        AtomicBoolean connectionOptionsCustomizerInvoked = new AtomicBoolean();
-        AtomicBoolean clientCustomizerInvoked = new AtomicBoolean();
+    void autoConfigurationCreatesConnectionFactoryTemplateAndAppliesCustomizers() {
+        AtomicBoolean connectionFactoryCustomizerInvoked = new AtomicBoolean();
+        AtomicBoolean templateCustomizerInvoked = new AtomicBoolean();
 
         this.contextRunner
-                .withPropertyValues("spring.amqp.host=broker.example.test", "spring.amqp.port=5679",
-                        "spring.amqp.username=alice", "spring.amqp.password=secret",
-                        "spring.amqp.client.default-to-address=orders.created",
-                        "spring.amqp.client.completion-timeout=750ms")
-                .withBean(ConnectionOptionsCustomizer.class,
-                        () -> (connectionOptions) -> connectionOptionsCustomizerInvoked.set(true))
-                .withBean(AmqpClientCustomizer.class, () -> (builder) -> clientCustomizerInvoked.set(true))
+                .withPropertyValues("spring.rabbitmq.host=broker.example.test", "spring.rabbitmq.port=5679",
+                        "spring.rabbitmq.username=alice", "spring.rabbitmq.password=secret",
+                        "spring.rabbitmq.template.routing-key=orders.created",
+                        "spring.rabbitmq.template.reply-timeout=750ms")
+                .withBean(ConnectionFactoryCustomizer.class,
+                        () -> (connectionFactory) -> connectionFactoryCustomizerInvoked.set(true))
+                .withBean(RabbitTemplateCustomizer.class, () -> (template) -> templateCustomizerInvoked.set(true))
                 .run((context) -> {
-                    assertThat(context).hasSingleBean(AmqpProperties.class);
-                    assertThat(context).hasSingleBean(AmqpConnectionDetails.class);
-                    assertThat(context).hasSingleBean(AmqpConnectionFactory.class);
-                    assertThat(context).hasSingleBean(AmqpClient.class);
+                    assertThat(context).hasSingleBean(RabbitProperties.class);
+                    assertThat(context).hasSingleBean(RabbitConnectionDetails.class);
+                    assertThat(context).hasSingleBean(ConnectionFactory.class);
+                    assertThat(context).hasSingleBean(RabbitTemplate.class);
 
-                    AmqpProperties properties = context.getBean(AmqpProperties.class);
+                    RabbitProperties properties = context.getBean(RabbitProperties.class);
                     assertThat(properties.getHost()).isEqualTo("broker.example.test");
                     assertThat(properties.getPort()).isEqualTo(5679);
                     assertThat(properties.getUsername()).isEqualTo("alice");
                     assertThat(properties.getPassword()).isEqualTo("secret");
-                    assertThat(properties.getClient().getDefaultToAddress()).isEqualTo("orders.created");
-                    assertThat(properties.getClient().getCompletionTimeout()).isEqualTo(Duration.ofMillis(750));
+                    assertThat(properties.getTemplate().getRoutingKey()).isEqualTo("orders.created");
+                    assertThat(properties.getTemplate().getReplyTimeout()).isEqualTo(Duration.ofMillis(750));
 
-                    AmqpConnectionDetails connectionDetails = context.getBean(AmqpConnectionDetails.class);
-                    assertThat(connectionDetails.getAddress().host()).isEqualTo("broker.example.test");
-                    assertThat(connectionDetails.getAddress().port()).isEqualTo(5679);
+                    RabbitConnectionDetails connectionDetails = context.getBean(RabbitConnectionDetails.class);
+                    assertThat(connectionDetails.getFirstAddress().host()).isEqualTo("broker.example.test");
+                    assertThat(connectionDetails.getFirstAddress().port()).isEqualTo(5679);
                     assertThat(connectionDetails.getUsername()).isEqualTo("alice");
                     assertThat(connectionDetails.getPassword()).isEqualTo("secret");
 
-                    assertThat(context.getBean(AmqpConnectionFactory.class))
-                            .isInstanceOf(SingleAmqpConnectionFactory.class);
-                    assertThat(context.getBean(AmqpClient.class)).isNotNull();
-                    assertThat(connectionOptionsCustomizerInvoked).isTrue();
-                    assertThat(clientCustomizerInvoked).isTrue();
+                    assertThat(context.getBean(ConnectionFactory.class)).isInstanceOf(CachingConnectionFactory.class);
+                    assertThat(context.getBean(RabbitTemplate.class)).isNotNull();
+                    assertThat(connectionFactoryCustomizerInvoked).isTrue();
+                    assertThat(templateCustomizerInvoked).isTrue();
                 });
     }
 

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
