### PR TITLE
[GenAI] Test fix for org.apache.maven.plugins:maven-surefire-plugin:3.3.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.maven.plugins/maven-surefire-plugin/3.3.0/reachability-metadata.json
+++ b/metadata/org.apache.maven.plugins/maven-surefire-plugin/3.3.0/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.plugins.maven_surefire_plugin.HelpMojo"
+      },
+      "glob": "META-INF/maven/org.apache.maven.plugins/maven-surefire-plugin/plugin-help.xml"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.plugins.maven_surefire_plugin.HelpMojo"
+      },
+      "glob": "META-INF/services/javax.xml.parsers.DocumentBuilderFactory"
+    }
+  ]
+}

--- a/metadata/org.apache.maven.plugins/maven-surefire-plugin/index.json
+++ b/metadata/org.apache.maven.plugins/maven-surefire-plugin/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.3.0",
+    "tested-versions" : [
+      "3.3.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.maven.plugins.maven_surefire_plugin"
+    ]
+  },
+  {
     "metadata-version" : "3.0.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/$version$/maven-surefire-plugin-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/maven-surefire",

--- a/metadata/org.apache.maven.plugins/maven-surefire-plugin/index.json
+++ b/metadata/org.apache.maven.plugins/maven-surefire-plugin/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "3.3.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/$version$/maven-surefire-plugin-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/maven-surefire",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire/$version$/surefire-$version$-source-release.zip",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/$version$/maven-surefire-plugin-$version$-site-source.zip",
+    "description" : "The Maven Surefire Plugin runs a Maven project's unit tests during the test phase and reports the results. It integrates test providers such as JUnit, TestNG, and POJO-based tests with Maven's lifecycle, including options for filtering, forking, and failure handling.",
     "tested-versions" : [
       "3.3.0"
     ],

--- a/stats/org.apache.maven.plugins/maven-surefire-plugin/3.3.0/execution-metrics.json
+++ b/stats/org.apache.maven.plugins/maven-surefire-plugin/3.3.0/execution-metrics.json
@@ -1,0 +1,99 @@
+{
+  "fix_javac_fail:2026-06-07": {
+    "timestamp": "2026-06-07T20:36:48.936237Z",
+    "library": "org.apache.maven.plugins:maven-surefire-plugin:3.3.0",
+    "starting_commit": "c1dcda03ba397bc3f724c41eb635edc3dabf5ef7",
+    "ending_commit": "6ebdad34c0711faed34918e1b0b8a9eee8aedef4",
+    "previous_library": "org.apache.maven.plugins:maven-surefire-plugin:3.0.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.3.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 540,
+          "missed": 673,
+          "ratio": 0.445177,
+          "total": 1213
+        },
+        "line": {
+          "covered": 103,
+          "missed": 172,
+          "ratio": 0.374545,
+          "total": 275
+        },
+        "method": {
+          "covered": 14,
+          "missed": 83,
+          "ratio": 0.14433,
+          "total": 97
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.0.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 538,
+          "missed": 670,
+          "ratio": 0.445364,
+          "total": 1208
+        },
+        "line": {
+          "covered": 103,
+          "missed": 171,
+          "ratio": 0.375912,
+          "total": 274
+        },
+        "method": {
+          "covered": 14,
+          "missed": 83,
+          "ratio": 0.14433,
+          "total": 97
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 26732,
+      "cached_input_tokens_used": 310784,
+      "output_tokens_used": 4382,
+      "iterations": 1,
+      "cost_usd": 0.2869,
+      "tested_library_loc": 103,
+      "metadata_entries": 2,
+      "previous_library_metadata_entries": 2,
+      "code_coverage_percent": 37.45,
+      "previous_library_coverage_percent": 37.59
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.maven.plugins/maven-surefire-plugin/3.3.0/src/test/java/org_apache_maven_plugins/maven_surefire_plugin/HelpMojoTest.java",
+      "metadata_file": "metadata/org.apache.maven.plugins/maven-surefire-plugin/3.3.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.maven.plugins/maven-surefire-plugin/3.3.0/stats.json
+++ b/stats/org.apache.maven.plugins/maven-surefire-plugin/3.3.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "3.3.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 1,
+      "totalCalls" : 1
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 540,
+        "missed" : 673,
+        "ratio" : 0.445177,
+        "total" : 1213
+      },
+      "line" : {
+        "covered" : 103,
+        "missed" : 172,
+        "ratio" : 0.374545,
+        "total" : 275
+      },
+      "method" : {
+        "covered" : 14,
+        "missed" : 83,
+        "ratio" : 0.14433,
+        "total" : 97
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.maven.plugins/maven-surefire-plugin/3.3.0/.gitignore
+++ b/tests/src/org.apache.maven.plugins/maven-surefire-plugin/3.3.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.maven.plugins/maven-surefire-plugin/3.3.0/build.gradle
+++ b/tests/src/org.apache.maven.plugins/maven-surefire-plugin/3.3.0/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.apache.maven.plugins:maven-surefire-plugin:$libraryVersion"
+    testImplementation 'org.apache.maven:maven-plugin-api:3.6.3'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.apache.maven.plugins/maven-surefire-plugin/3.3.0/build.gradle
+++ b/tests/src/org.apache.maven.plugins/maven-surefire-plugin/3.3.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.maven.plugins:maven-surefire-plugin:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.maven.plugins/maven-surefire-plugin/3.3.0/gradle.properties
+++ b/tests/src/org.apache.maven.plugins/maven-surefire-plugin/3.3.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.maven.plugins:maven-surefire-plugin:3.3.0
+library.version = 3.3.0
+metadata.dir = org.apache.maven.plugins/maven-surefire-plugin/3.3.0/

--- a/tests/src/org.apache.maven.plugins/maven-surefire-plugin/3.3.0/settings.gradle
+++ b/tests/src/org.apache.maven.plugins/maven-surefire-plugin/3.3.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.maven.plugins.maven-surefire-plugin_tests'

--- a/tests/src/org.apache.maven.plugins/maven-surefire-plugin/3.3.0/src/test/java/org_apache_maven_plugins/maven_surefire_plugin/HelpMojoTest.java
+++ b/tests/src/org.apache.maven.plugins/maven-surefire-plugin/3.3.0/src/test/java/org_apache_maven_plugins/maven_surefire_plugin/HelpMojoTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_plugins.maven_surefire_plugin;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.SystemStreamLog;
+import org.apache.maven.plugins.maven_surefire_plugin.HelpMojo;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HelpMojoTest {
+
+    @Test
+    void executeLoadsPluginHelpResource() throws MojoExecutionException {
+        HelpMojo mojo = new HelpMojo();
+        RecordingLog log = new RecordingLog();
+        mojo.setLog(log);
+
+        mojo.execute();
+
+        assertThat(log.infoMessages)
+                .anySatisfy(message -> assertThat(message)
+                        .contains("Surefire")
+                        .contains("surefire:test"));
+    }
+
+    private static final class RecordingLog extends SystemStreamLog {
+
+        private final List<String> infoMessages = new ArrayList<>();
+
+        @Override
+        public boolean isInfoEnabled() {
+            return true;
+        }
+
+        @Override
+        public void info(CharSequence content) {
+            infoMessages.add(content.toString());
+        }
+
+        @Override
+        public void info(CharSequence content, Throwable error) {
+            info(content);
+        }
+    }
+}

--- a/tests/src/org.apache.maven.plugins/maven-surefire-plugin/3.3.0/user-code-filter.json
+++ b/tests/src/org.apache.maven.plugins/maven-surefire-plugin/3.3.0/user-code-filter.json
@@ -1,0 +1,16 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.maven.plugin.surefire.**"
+    },
+    {
+      "includeClasses" : "org.apache.maven.plugins.maven_surefire_plugin.**"
+    },
+    {
+      "includeClasses" : "org_apache_maven_plugins.maven_surefire_plugin.**"
+    }
+  ]
+}

--- a/tests/src/org.apache.maven.plugins/maven-surefire-plugin/3.3.0/user-code-filter.json
+++ b/tests/src/org.apache.maven.plugins/maven-surefire-plugin/3.3.0/user-code-filter.json
@@ -4,10 +4,10 @@
       "excludeClasses" : "**"
     },
     {
-      "includeClasses" : "org.apache.maven.plugin.surefire.**"
+      "includeClasses" : "org.apache.maven.plugins.maven_surefire_plugin.**"
     },
     {
-      "includeClasses" : "org.apache.maven.plugins.maven_surefire_plugin.**"
+      "includeClasses" : "org.apache.maven.plugin.surefire.**"
     },
     {
       "includeClasses" : "org_apache_maven_plugins.maven_surefire_plugin.**"


### PR DESCRIPTION
## What does this PR do?

Fixes: #8155

This PR provides test fixes and new metadata for org.apache.maven.plugins:maven-surefire-plugin:3.3.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 26732
- Cached input tokens: 310784
- Output tokens: 4382
- Metadata entries: 2
- Iterations: 1
- Library coverage percentage: 37.45
- Previous library version metadata entries: 2
- Previous library version coverage percentage: 37.59

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `9748d9d68f2d5a9d527d771bd7e6cb7b948a116d`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.maven.plugins:maven-surefire-plugin:3.0.0: 1/1 covered calls (100.00%)
- org.apache.maven.plugins:maven-surefire-plugin:3.3.0: 1/1 covered calls (100.00%)

**Resources:**
- org.apache.maven.plugins:maven-surefire-plugin:3.0.0: 1/1 covered calls (100.00%)
- org.apache.maven.plugins:maven-surefire-plugin:3.3.0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.maven.plugins:maven-surefire-plugin:3.0.0: 538/1208 (44.54%)
- org.apache.maven.plugins:maven-surefire-plugin:3.3.0: 540/1213 (44.52%)

**Line:**
- org.apache.maven.plugins:maven-surefire-plugin:3.0.0: 103/274 (37.59%)
- org.apache.maven.plugins:maven-surefire-plugin:3.3.0: 103/275 (37.45%)

**Method:**
- org.apache.maven.plugins:maven-surefire-plugin:3.0.0: 14/97 (14.43%)
- org.apache.maven.plugins:maven-surefire-plugin:3.3.0: 14/97 (14.43%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.maven.plugins/maven-surefire-plugin/3.0.0/build.gradle 2/tests/src/org.apache.maven.plugins/maven-surefire-plugin/3.3.0/build.gradle
index eceb807e1b..7b23804a3c 100644
--- 1/tests/src/org.apache.maven.plugins/maven-surefire-plugin/3.0.0/build.gradle
+++ 2/tests/src/org.apache.maven.plugins/maven-surefire-plugin/3.3.0/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.apache.maven.plugins:maven-surefire-plugin:$libraryVersion"
+    testImplementation 'org.apache.maven:maven-plugin-api:3.6.3'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
diff --git 1/tests/src/org.apache.maven.plugins/maven-surefire-plugin/3.0.0/user-code-filter.json 2/tests/src/org.apache.maven.plugins/maven-surefire-plugin/3.3.0/user-code-filter.json
index 5397a8031a..bbe0bf40e5 100644
--- 1/tests/src/org.apache.maven.plugins/maven-surefire-plugin/3.0.0/user-code-filter.json
+++ 2/tests/src/org.apache.maven.plugins/maven-surefire-plugin/3.3.0/user-code-filter.json
@@ -4,10 +4,10 @@
       "excludeClasses" : "**"
     },
     {
-      "includeClasses" : "org.apache.maven.plugin.surefire.**"
+      "includeClasses" : "org.apache.maven.plugins.maven_surefire_plugin.**"
     },
     {
-      "includeClasses" : "org.apache.maven.plugins.maven_surefire_plugin.**"
+      "includeClasses" : "org.apache.maven.plugin.surefire.**"
     },
     {
       "includeClasses" : "org_apache_maven_plugins.maven_surefire_plugin.**"

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
