### PR TITLE
[GenAI] Test fix for com.oracle.oci.sdk:oci-java-sdk-certificates:3.77.1 using gpt-5.5

### DIFF
--- a/metadata/com.oracle.oci.sdk/oci-java-sdk-certificates/3.77.1/reachability-metadata.json
+++ b/metadata/com.oracle.oci.sdk/oci-java-sdk-certificates/3.77.1/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.oracle.bmc.certificates.model.CertificateBundle"
+      },
+      "type" : "com.oracle.bmc.http.client.internal.ExplicitlySetBmcModel"
+    }
+  ]
+}

--- a/metadata/com.oracle.oci.sdk/oci-java-sdk-certificates/3.77.1/reachability-metadata.json
+++ b/metadata/com.oracle.oci.sdk/oci-java-sdk-certificates/3.77.1/reachability-metadata.json
@@ -5,6 +5,229 @@
         "typeReached" : "com.oracle.bmc.certificates.model.CertificateBundle"
       },
       "type" : "com.oracle.bmc.http.client.internal.ExplicitlySetBmcModel"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.oracle.bmc.certificates.CertificatesClient"
+      },
+      "type" : "sun.security.x509.X509CertInfo",
+      "allPublicConstructors" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.oracle.bmc.certificates.CertificatesClient"
+      },
+      "type" : "sun.security.ssl.SSLContextImpl$DefaultSSLContext",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.oracle.bmc.certificates.CertificatesClient"
+      },
+      "type" : "sun.security.ssl.SSLContextImpl$TLSContext",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.oracle.bmc.certificates.CertificatesClient"
+      },
+      "type" : "sun.security.ssl.TrustManagerFactoryImpl$PKIXFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.oracle.bmc.certificates.CertificatesClient"
+      },
+      "type" : "sun.security.x509.AuthorityInfoAccessExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.oracle.bmc.certificates.CertificatesClient"
+      },
+      "type" : "sun.security.x509.AuthorityKeyIdentifierExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.oracle.bmc.certificates.CertificatesClient"
+      },
+      "type" : "sun.security.x509.BasicConstraintsExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.oracle.bmc.certificates.CertificatesClient"
+      },
+      "type" : "sun.security.x509.CRLDistributionPointsExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.oracle.bmc.certificates.CertificatesClient"
+      },
+      "type" : "sun.security.x509.CertificatePoliciesExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.oracle.bmc.certificates.CertificatesClient"
+      },
+      "type" : "sun.security.x509.ExtendedKeyUsageExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.oracle.bmc.certificates.CertificatesClient"
+      },
+      "type" : "sun.security.x509.IssuerAlternativeNameExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.oracle.bmc.certificates.CertificatesClient"
+      },
+      "type" : "sun.security.x509.KeyUsageExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.oracle.bmc.certificates.CertificatesClient"
+      },
+      "type" : "sun.security.x509.NetscapeCertTypeExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.oracle.bmc.certificates.CertificatesClient"
+      },
+      "type" : "sun.security.x509.PrivateKeyUsageExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.oracle.bmc.certificates.CertificatesClient"
+      },
+      "type" : "sun.security.x509.SubjectAlternativeNameExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.oracle.bmc.certificates.CertificatesClient"
+      },
+      "type" : "sun.security.x509.SubjectKeyIdentifierExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/metadata/com.oracle.oci.sdk/oci-java-sdk-certificates/index.json
+++ b/metadata/com.oracle.oci.sdk/oci-java-sdk-certificates/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "3.77.1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/oracle/oci/sdk/oci-java-sdk-certificates/$version$/oci-java-sdk-certificates-$version$-sources.jar",
+    "repository-url" : "https://github.com/oracle/oci-java-sdk",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/oracle/oci/sdk/oci-java-sdk-certificates/$version$/oci-java-sdk-certificates-$version$-javadoc.jar",
+    "description" : "The Oracle Cloud Infrastructure Java SDK Certificates module provides client APIs and model classes for the OCI Certificates service. It lets Java applications retrieve certificate, certificate authority, and CA bundle data and list certificate bundle versions through OCI SDK clients.",
     "tested-versions" : [
       "3.77.1"
     ],

--- a/metadata/com.oracle.oci.sdk/oci-java-sdk-certificates/index.json
+++ b/metadata/com.oracle.oci.sdk/oci-java-sdk-certificates/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.77.1",
+    "tested-versions" : [
+      "3.77.1"
+    ],
+    "allowed-packages" : [
+      "com.oracle.bmc.certificates"
+    ]
+  },
+  {
     "metadata-version" : "3.63.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/com/oracle/oci/sdk/oci-java-sdk-certificates/$version$/oci-java-sdk-certificates-$version$-sources.jar",
     "repository-url" : "https://github.com/oracle/oci-java-sdk",

--- a/stats/com.oracle.oci.sdk/oci-java-sdk-certificates/3.77.1/execution-metrics.json
+++ b/stats/com.oracle.oci.sdk/oci-java-sdk-certificates/3.77.1/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_java_run_fail:2026-06-07": {
+    "timestamp": "2026-06-07T20:52:01.226763Z",
+    "library": "com.oracle.oci.sdk:oci-java-sdk-certificates:3.77.1",
+    "starting_commit": "dca7ac94c36f05a87501f0ce662cd045322b0646",
+    "ending_commit": "bd66b2943594903a86f90a01f209cf1860a2bf90",
+    "previous_library": "com.oracle.oci.sdk:oci-java-sdk-certificates:3.63.1",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.77.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4242,
+          "missed": 4560,
+          "ratio": 0.481936,
+          "total": 8802
+        },
+        "line": {
+          "covered": 1013,
+          "missed": 1011,
+          "ratio": 0.500494,
+          "total": 2024
+        },
+        "method": {
+          "covered": 323,
+          "missed": 155,
+          "ratio": 0.675732,
+          "total": 478
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.63.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4241,
+          "missed": 4559,
+          "ratio": 0.481932,
+          "total": 8800
+        },
+        "line": {
+          "covered": 1013,
+          "missed": 1011,
+          "ratio": 0.500494,
+          "total": 2024
+        },
+        "method": {
+          "covered": 323,
+          "missed": 155,
+          "ratio": 0.675732,
+          "total": 478
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 17238,
+      "cached_input_tokens_used": 131072,
+      "output_tokens_used": 1189,
+      "iterations": 1,
+      "cost_usd": 0.1012,
+      "tested_library_loc": 1013,
+      "metadata_entries": 33,
+      "previous_library_metadata_entries": 0,
+      "code_coverage_percent": 50.05,
+      "previous_library_coverage_percent": 50.05
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.oracle.oci.sdk/oci-java-sdk-certificates/3.77.1/src/test/java/com_oracle_oci_sdk/oci_java_sdk_certificates/Oci_java_sdk_certificatesTest.java",
+      "metadata_file": "metadata/com.oracle.oci.sdk/oci-java-sdk-certificates/3.77.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.oracle.oci.sdk/oci-java-sdk-certificates/3.77.1/stats.json
+++ b/stats/com.oracle.oci.sdk/oci-java-sdk-certificates/3.77.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.77.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 4242,
+        "missed" : 4560,
+        "ratio" : 0.481936,
+        "total" : 8802
+      },
+      "line" : {
+        "covered" : 1013,
+        "missed" : 1011,
+        "ratio" : 0.500494,
+        "total" : 2024
+      },
+      "method" : {
+        "covered" : 323,
+        "missed" : 155,
+        "ratio" : 0.675732,
+        "total" : 478
+      }
+    }
+  } ]
+}

--- a/tests/src/com.oracle.oci.sdk/oci-java-sdk-certificates/3.77.1/.gitignore
+++ b/tests/src/com.oracle.oci.sdk/oci-java-sdk-certificates/3.77.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.oracle.oci.sdk/oci-java-sdk-certificates/3.77.1/build.gradle
+++ b/tests/src/com.oracle.oci.sdk/oci-java-sdk-certificates/3.77.1/build.gradle
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.oracle.oci.sdk:oci-java-sdk-certificates:$libraryVersion"
+    testImplementation 'com.fasterxml.jackson.core:jackson-core:2.17.1'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.oracle.oci.sdk/oci-java-sdk-certificates/3.77.1/gradle.properties
+++ b/tests/src/com.oracle.oci.sdk/oci-java-sdk-certificates/3.77.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.oracle.oci.sdk:oci-java-sdk-certificates:3.77.1
+library.version = 3.77.1
+metadata.dir = com.oracle.oci.sdk/oci-java-sdk-certificates/3.77.1/

--- a/tests/src/com.oracle.oci.sdk/oci-java-sdk-certificates/3.77.1/settings.gradle
+++ b/tests/src/com.oracle.oci.sdk/oci-java-sdk-certificates/3.77.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.oracle.oci.sdk.oci-java-sdk-certificates_tests'

--- a/tests/src/com.oracle.oci.sdk/oci-java-sdk-certificates/3.77.1/src/test/java/com_oracle_oci_sdk/oci_java_sdk_certificates/Oci_java_sdk_certificatesTest.java
+++ b/tests/src/com.oracle.oci.sdk/oci-java-sdk-certificates/3.77.1/src/test/java/com_oracle_oci_sdk/oci_java_sdk_certificates/Oci_java_sdk_certificatesTest.java
@@ -1,0 +1,513 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_oracle_oci_sdk.oci_java_sdk_certificates;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oracle.bmc.certificates.CertificatesClient;
+import com.oracle.bmc.certificates.model.CaBundle;
+import com.oracle.bmc.certificates.model.CertificateAuthorityBundle;
+import com.oracle.bmc.certificates.model.CertificateAuthorityBundleVersionCollection;
+import com.oracle.bmc.certificates.model.CertificateAuthorityBundleVersionSummary;
+import com.oracle.bmc.certificates.model.CertificateBundle;
+import com.oracle.bmc.certificates.model.CertificateBundlePublicOnly;
+import com.oracle.bmc.certificates.model.CertificateBundleVersionCollection;
+import com.oracle.bmc.certificates.model.CertificateBundleVersionSummary;
+import com.oracle.bmc.certificates.model.CertificateBundleWithPrivateKey;
+import com.oracle.bmc.certificates.model.RevocationReason;
+import com.oracle.bmc.certificates.model.RevocationStatus;
+import com.oracle.bmc.certificates.model.Validity;
+import com.oracle.bmc.certificates.model.VersionStage;
+import com.oracle.bmc.certificates.requests.GetCaBundleRequest;
+import com.oracle.bmc.certificates.requests.GetCertificateAuthorityBundleRequest;
+import com.oracle.bmc.certificates.requests.GetCertificateBundleRequest;
+import com.oracle.bmc.certificates.requests.ListCertificateAuthorityBundleVersionsRequest;
+import com.oracle.bmc.certificates.requests.ListCertificateBundleVersionsRequest;
+import com.oracle.bmc.certificates.responses.GetCaBundleResponse;
+import com.oracle.bmc.certificates.responses.GetCertificateAuthorityBundleResponse;
+import com.oracle.bmc.certificates.responses.GetCertificateBundleResponse;
+import com.oracle.bmc.certificates.responses.ListCertificateAuthorityBundleVersionsResponse;
+import com.oracle.bmc.certificates.responses.ListCertificateBundleVersionsResponse;
+import com.oracle.bmc.http.client.RequestInterceptor;
+import com.oracle.bmc.retrier.RetryConfiguration;
+import java.util.Date;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class Oci_java_sdk_certificatesTest {
+    private static final Date CREATED = new Date(1_710_000_000_000L);
+    private static final Date NOT_BEFORE = new Date(1_709_000_000_000L);
+    private static final Date NOT_AFTER = new Date(1_809_000_000_000L);
+    private static final Date REVOKED = new Date(1_711_000_000_000L);
+    private static final Date DELETION = new Date(1_812_000_000_000L);
+
+    @Test
+    void certificateBundleBuildersCopyAndExposeAllPublicFields() {
+        Validity validity = validity();
+        RevocationStatus revocationStatus = revocationStatus();
+        CertificateBundlePublicOnly publicBundle =
+                CertificateBundlePublicOnly.builder()
+                        .certificateId("certificate-1")
+                        .certificateName("leaf-certificate")
+                        .versionNumber(7L)
+                        .serialNumber("00:11:22")
+                        .certificatePem(
+                                "-----BEGIN CERTIFICATE-----public-----END CERTIFICATE-----")
+                        .certChainPem("-----BEGIN CERTIFICATE-----chain-----END CERTIFICATE-----")
+                        .timeCreated(CREATED)
+                        .validity(validity)
+                        .versionName("version-a")
+                        .stages(List.of(VersionStage.Current, VersionStage.Latest))
+                        .revocationStatus(revocationStatus)
+                        .build();
+
+        assertThat(publicBundle.getCertificateId()).isEqualTo("certificate-1");
+        assertThat(publicBundle.getCertificateName()).isEqualTo("leaf-certificate");
+        assertThat(publicBundle.getVersionNumber()).isEqualTo(7L);
+        assertThat(publicBundle.getSerialNumber()).isEqualTo("00:11:22");
+        assertThat(publicBundle.getCertificatePem()).contains("public");
+        assertThat(publicBundle.getCertChainPem()).contains("chain");
+        assertThat(publicBundle.getTimeCreated()).isEqualTo(CREATED);
+        assertThat(publicBundle.getValidity()).isEqualTo(validity);
+        assertThat(publicBundle.getVersionName()).isEqualTo("version-a");
+        assertThat(publicBundle.getStages())
+                .containsExactly(VersionStage.Current, VersionStage.Latest);
+        assertThat(publicBundle.getRevocationStatus()).isEqualTo(revocationStatus);
+        assertThat(publicBundle.toString()).contains("leaf-certificate", "version-a");
+
+        CertificateBundlePublicOnly renamedBundle =
+                publicBundle.toBuilder().versionName("version-b").build();
+        assertThat(renamedBundle)
+                .isNotEqualTo(publicBundle)
+                .extracting(CertificateBundlePublicOnly::getVersionName)
+                .isEqualTo("version-b");
+        assertThat(renamedBundle.toBuilder().build()).isEqualTo(renamedBundle);
+
+        CertificateBundleWithPrivateKey privateBundle =
+                CertificateBundleWithPrivateKey.builder()
+                        .certificateId("certificate-1")
+                        .certificateName("leaf-certificate")
+                        .versionNumber(8L)
+                        .serialNumber("00:11:23")
+                        .certificatePem("certificate-pem")
+                        .certChainPem("chain-pem")
+                        .timeCreated(CREATED)
+                        .validity(validity)
+                        .versionName("version-private")
+                        .stages(List.of(VersionStage.Pending))
+                        .revocationStatus(revocationStatus)
+                        .privateKeyPem("private-key-pem")
+                        .privateKeyPemPassphrase("passphrase")
+                        .build();
+
+        assertThat(privateBundle.getPrivateKeyPem()).isEqualTo("private-key-pem");
+        assertThat(privateBundle.getPrivateKeyPemPassphrase()).isEqualTo("passphrase");
+        assertThat(privateBundle.toBuilder().privateKeyPem("new-key").build().getPrivateKeyPem())
+                .isEqualTo("new-key");
+    }
+
+    @Test
+    void modelsTrackExplicitlySetNullPropertiesSeparatelyFromUnsetProperties() {
+        CaBundle unsetNameBundle =
+                CaBundle.builder()
+                        .id("ca-bundle-1")
+                        .caBundlePem("ca-bundle-pem")
+                        .build();
+        CaBundle explicitNullNameBundle =
+                CaBundle.builder()
+                        .id("ca-bundle-1")
+                        .name(null)
+                        .caBundlePem("ca-bundle-pem")
+                        .build();
+
+        assertThat(unsetNameBundle.getName()).isNull();
+        assertThat(explicitNullNameBundle.getName()).isNull();
+        assertThat(unsetNameBundle.wasPropertyExplicitlySet("name")).isFalse();
+        assertThat(explicitNullNameBundle.wasPropertyExplicitlySet("name")).isTrue();
+        assertThat(explicitNullNameBundle.wasPropertyExplicitlySet("id")).isTrue();
+        assertThat(explicitNullNameBundle).isNotEqualTo(unsetNameBundle);
+
+        CaBundle copiedExplicitNullNameBundle = explicitNullNameBundle.toBuilder().build();
+        CaBundle copiedUnsetNameBundle = unsetNameBundle.toBuilder().build();
+
+        assertThat(copiedExplicitNullNameBundle).isEqualTo(explicitNullNameBundle);
+        assertThat(copiedExplicitNullNameBundle.wasPropertyExplicitlySet("name")).isTrue();
+        assertThat(copiedUnsetNameBundle).isEqualTo(unsetNameBundle);
+        assertThat(copiedUnsetNameBundle.wasPropertyExplicitlySet("name")).isFalse();
+    }
+
+    @Test
+    void caBundleAndVersionCollectionsPreserveNestedModels() {
+        Validity validity = validity();
+        RevocationStatus revocationStatus = revocationStatus();
+        CertificateAuthorityBundle authorityBundle =
+                CertificateAuthorityBundle.builder()
+                        .certificateAuthorityId("authority-1")
+                        .certificateAuthorityName("root-ca")
+                        .serialNumber("ca-serial")
+                        .certificatePem("ca-certificate")
+                        .certChainPem("ca-chain")
+                        .versionName("ca-version")
+                        .timeCreated(CREATED)
+                        .versionNumber(11L)
+                        .validity(validity)
+                        .stages(List.of(VersionStage.Current))
+                        .revocationStatus(revocationStatus)
+                        .build();
+        CertificateBundleVersionSummary certificateSummary =
+                CertificateBundleVersionSummary.builder()
+                        .certificateId("certificate-1")
+                        .serialNumber("leaf-serial")
+                        .versionName("leaf-version")
+                        .certificateName("leaf")
+                        .versionNumber(12L)
+                        .timeCreated(CREATED)
+                        .validity(validity)
+                        .timeOfDeletion(DELETION)
+                        .stages(List.of(VersionStage.Previous))
+                        .revocationStatus(revocationStatus)
+                        .build();
+        CertificateAuthorityBundleVersionSummary authoritySummary =
+                CertificateAuthorityBundleVersionSummary.builder()
+                        .certificateAuthorityId("authority-1")
+                        .serialNumber("authority-serial")
+                        .timeCreated(CREATED)
+                        .versionNumber(13L)
+                        .versionName("authority-version")
+                        .certificateAuthorityName("root-ca")
+                        .timeOfDeletion(DELETION)
+                        .validity(validity)
+                        .stages(List.of(VersionStage.Deprecated))
+                        .revocationStatus(revocationStatus)
+                        .build();
+
+        assertThat(authorityBundle.getCertificateAuthorityId()).isEqualTo("authority-1");
+        assertThat(authorityBundle.getCertificateAuthorityName()).isEqualTo("root-ca");
+        assertThat(authorityBundle.getSerialNumber()).isEqualTo("ca-serial");
+        assertThat(authorityBundle.getCertificatePem()).isEqualTo("ca-certificate");
+        assertThat(authorityBundle.getCertChainPem()).isEqualTo("ca-chain");
+        assertThat(authorityBundle.getVersionName()).isEqualTo("ca-version");
+        assertThat(authorityBundle.getVersionNumber()).isEqualTo(11L);
+        assertThat(
+                        authorityBundle
+                                .toBuilder()
+                                .versionName("ca-version-copy")
+                                .build()
+                                .getVersionName())
+                .isEqualTo("ca-version-copy");
+
+        CertificateBundleVersionCollection certificateCollection =
+                CertificateBundleVersionCollection.builder()
+                        .items(List.of(certificateSummary))
+                        .build();
+        CertificateAuthorityBundleVersionCollection authorityCollection =
+                CertificateAuthorityBundleVersionCollection.builder()
+                        .items(List.of(authoritySummary))
+                        .build();
+
+        assertThat(certificateCollection.getItems()).containsExactly(certificateSummary);
+        assertThat(certificateCollection.toBuilder().build()).isEqualTo(certificateCollection);
+        assertThat(authorityCollection.getItems()).containsExactly(authoritySummary);
+        assertThat(authorityCollection.toBuilder().build()).isEqualTo(authorityCollection);
+        assertThat(certificateSummary.getTimeOfDeletion()).isEqualTo(DELETION);
+        assertThat(authoritySummary.getTimeOfDeletion()).isEqualTo(DELETION);
+    }
+
+    @Test
+    void requestBuildersCopyQueryHeaderAndSortingOptions() {
+        GetCertificateBundleRequest certificateRequest =
+                GetCertificateBundleRequest.builder()
+                        .certificateId("certificate-1")
+                        .opcRequestId("request-1")
+                        .versionNumber(3L)
+                        .certificateVersionName("leaf-version")
+                        .stage(GetCertificateBundleRequest.Stage.Current)
+                        .certificateBundleType(
+                                GetCertificateBundleRequest.CertificateBundleType
+                                        .CertificateContentWithPrivateKey)
+                        .build();
+        GetCertificateAuthorityBundleRequest authorityRequest =
+                GetCertificateAuthorityBundleRequest.builder()
+                        .certificateAuthorityId("authority-1")
+                        .opcRequestId("request-2")
+                        .versionNumber(4L)
+                        .certificateAuthorityVersionName("authority-version")
+                        .stage(GetCertificateAuthorityBundleRequest.Stage.Pending)
+                        .build();
+        GetCaBundleRequest caBundleRequest =
+                GetCaBundleRequest.builder()
+                        .caBundleId("ca-bundle-1")
+                        .opcRequestId("request-3")
+                        .build();
+        ListCertificateBundleVersionsRequest listCertificateRequest =
+                ListCertificateBundleVersionsRequest.builder()
+                        .certificateId("certificate-1")
+                        .opcRequestId("request-4")
+                        .sortBy(ListCertificateBundleVersionsRequest.SortBy.VersionNumber)
+                        .sortOrder(ListCertificateBundleVersionsRequest.SortOrder.Desc)
+                        .build();
+        ListCertificateAuthorityBundleVersionsRequest listAuthorityRequest =
+                ListCertificateAuthorityBundleVersionsRequest.builder()
+                        .certificateAuthorityId("authority-1")
+                        .opcRequestId("request-5")
+                        .sortBy(ListCertificateAuthorityBundleVersionsRequest.SortBy.VersionNumber)
+                        .sortOrder(ListCertificateAuthorityBundleVersionsRequest.SortOrder.Asc)
+                        .build();
+
+        assertThat(certificateRequest.getCertificateId()).isEqualTo("certificate-1");
+        assertThat(certificateRequest.getOpcRequestId()).isEqualTo("request-1");
+        assertThat(certificateRequest.getVersionNumber()).isEqualTo(3L);
+        assertThat(certificateRequest.getCertificateVersionName()).isEqualTo("leaf-version");
+        assertThat(certificateRequest.getStage())
+                .isEqualTo(GetCertificateBundleRequest.Stage.Current);
+        assertThat(certificateRequest.getCertificateBundleType().getValue())
+                .isEqualTo("CERTIFICATE_CONTENT_WITH_PRIVATE_KEY");
+        assertThat(certificateRequest.toBuilder().versionNumber(5L).build().getVersionNumber())
+                .isEqualTo(5L);
+
+        assertThat(authorityRequest.getCertificateAuthorityId()).isEqualTo("authority-1");
+        assertThat(authorityRequest.getCertificateAuthorityVersionName())
+                .isEqualTo("authority-version");
+        assertThat(authorityRequest.getStage())
+                .isEqualTo(GetCertificateAuthorityBundleRequest.Stage.Pending);
+        assertThat(caBundleRequest.getCaBundleId()).isEqualTo("ca-bundle-1");
+        assertThat(listCertificateRequest.getSortBy())
+                .isEqualTo(ListCertificateBundleVersionsRequest.SortBy.VersionNumber);
+        assertThat(listCertificateRequest.getSortOrder())
+                .isEqualTo(ListCertificateBundleVersionsRequest.SortOrder.Desc);
+        assertThat(listAuthorityRequest.getSortBy())
+                .isEqualTo(ListCertificateAuthorityBundleVersionsRequest.SortBy.VersionNumber);
+        assertThat(listAuthorityRequest.getSortOrder())
+                .isEqualTo(ListCertificateAuthorityBundleVersionsRequest.SortOrder.Asc);
+    }
+
+    @Test
+    void requestBuildersSupportInvocationCallbacksAndRetryConfiguration() {
+        RequestInterceptor interceptor = httpRequest -> assertThat(httpRequest).isNotNull();
+        RetryConfiguration retryConfiguration = RetryConfiguration.NO_RETRY_CONFIGURATION;
+
+        GetCaBundleRequest request =
+                GetCaBundleRequest.builder()
+                        .caBundleId("ca-bundle-1")
+                        .invocationCallback(interceptor)
+                        .retryConfiguration(retryConfiguration)
+                        .build();
+
+        assertThat(request.getInvocationCallback()).isSameAs(interceptor);
+        assertThat(request.getRetryConfiguration()).isSameAs(retryConfiguration);
+
+        GetCaBundleRequest requestWithoutCallback =
+                GetCaBundleRequest.builder()
+                        .caBundleId("ca-bundle-1")
+                        .invocationCallback(interceptor)
+                        .retryConfiguration(retryConfiguration)
+                        .buildWithoutInvocationCallback();
+        assertThat(requestWithoutCallback.getCaBundleId()).isEqualTo("ca-bundle-1");
+        assertThat(requestWithoutCallback.getInvocationCallback()).isNull();
+    }
+
+    @Test
+    void responseBuildersCopyStatusHeadersAndBodies() {
+        CaBundle caBundle =
+                CaBundle.builder()
+                        .id("ca-bundle-1")
+                        .name("downloadable-ca-bundle")
+                        .caBundlePem("ca-bundle-pem")
+                        .build();
+        CertificateBundlePublicOnly certificateBundle =
+                CertificateBundlePublicOnly.builder()
+                        .certificateId("certificate-1")
+                        .certificateName("leaf")
+                        .versionNumber(1L)
+                        .build();
+        CertificateAuthorityBundle authorityBundle =
+                CertificateAuthorityBundle.builder()
+                        .certificateAuthorityId("authority-1")
+                        .certificateAuthorityName("root-ca")
+                        .versionNumber(2L)
+                        .build();
+        CertificateBundleVersionCollection certificateCollection =
+                CertificateBundleVersionCollection.builder()
+                        .items(
+                                List.of(
+                                        CertificateBundleVersionSummary.builder()
+                                                .certificateId("certificate-1")
+                                                .build()))
+                        .build();
+        CertificateAuthorityBundleVersionCollection authorityCollection =
+                CertificateAuthorityBundleVersionCollection.builder()
+                        .items(
+                                List.of(
+                                        CertificateAuthorityBundleVersionSummary.builder()
+                                                .certificateAuthorityId("authority-1")
+                                                .build()))
+                        .build();
+
+        GetCaBundleResponse caResponse =
+                GetCaBundleResponse.builder()
+                        .__httpStatusCode__(200)
+                        .etag("etag-ca")
+                        .opcRequestId("opc-ca")
+                        .caBundle(caBundle)
+                        .build();
+        GetCertificateBundleResponse certificateResponse =
+                GetCertificateBundleResponse.builder()
+                        .__httpStatusCode__(200)
+                        .etag("etag-certificate")
+                        .opcRequestId("opc-certificate")
+                        .certificateBundle(certificateBundle)
+                        .build();
+        GetCertificateAuthorityBundleResponse authorityResponse =
+                GetCertificateAuthorityBundleResponse.builder()
+                        .__httpStatusCode__(200)
+                        .etag("etag-authority")
+                        .opcRequestId("opc-authority")
+                        .certificateAuthorityBundle(authorityBundle)
+                        .build();
+        ListCertificateBundleVersionsResponse listCertificateResponse =
+                ListCertificateBundleVersionsResponse.builder()
+                        .__httpStatusCode__(200)
+                        .opcRequestId("opc-list-certificate")
+                        .certificateBundleVersionCollection(certificateCollection)
+                        .build();
+        ListCertificateAuthorityBundleVersionsResponse listAuthorityResponse =
+                ListCertificateAuthorityBundleVersionsResponse.builder()
+                        .__httpStatusCode__(200)
+                        .opcRequestId("opc-list-authority")
+                        .certificateAuthorityBundleVersionCollection(authorityCollection)
+                        .build();
+
+        assertThat(caResponse.getEtag()).isEqualTo("etag-ca");
+        assertThat(caResponse.getOpcRequestId()).isEqualTo("opc-ca");
+        assertThat(caResponse.getCaBundle()).isEqualTo(caBundle);
+        assertThat(caResponse.toString()).contains("etag-ca", "opc-ca");
+        assertThat(caResponse.toString()).contains("ca-bundle-1");
+
+        assertThat(certificateResponse.getEtag()).isEqualTo("etag-certificate");
+        assertThat(certificateResponse.getOpcRequestId()).isEqualTo("opc-certificate");
+        assertThat(certificateResponse.getCertificateBundle()).isEqualTo(certificateBundle);
+        GetCertificateBundleResponse copiedCertificateResponse =
+                GetCertificateBundleResponse.builder().copy(certificateResponse).build();
+        assertThat(certificateResponse).isEqualTo(copiedCertificateResponse);
+
+        assertThat(authorityResponse.getCertificateAuthorityBundle()).isEqualTo(authorityBundle);
+        assertThat(authorityResponse.getEtag()).isEqualTo("etag-authority");
+        assertThat(listCertificateResponse.getCertificateBundleVersionCollection())
+                .isEqualTo(certificateCollection);
+        assertThat(listAuthorityResponse.getCertificateAuthorityBundleVersionCollection())
+                .isEqualTo(authorityCollection);
+    }
+
+    @Test
+    void enumsExposeWireValuesAndDifferentiateRequestFromResponseUnknownValues() {
+        assertThat(VersionStage.Current.getValue()).isEqualTo("CURRENT");
+        assertThat(VersionStage.create("FUTURE_STAGE")).isEqualTo(VersionStage.UnknownEnumValue);
+        assertThat(RevocationReason.KeyCompromise.getValue()).isEqualTo("KEY_COMPROMISE");
+        assertThat(RevocationReason.create("NEW_REASON"))
+                .isEqualTo(RevocationReason.UnknownEnumValue);
+        assertThat(CertificateBundle.CertificateBundleType.CertificateContentPublicOnly.getValue())
+                .isEqualTo("CERTIFICATE_CONTENT_PUBLIC_ONLY");
+        assertThat(CertificateBundle.CertificateBundleType.create("NEW_BUNDLE_TYPE"))
+                .isEqualTo(CertificateBundle.CertificateBundleType.UnknownEnumValue);
+        assertThat(GetCertificateBundleRequest.Stage.create("LATEST"))
+                .isEqualTo(GetCertificateBundleRequest.Stage.Latest);
+        assertThat(GetCertificateBundleRequest.CertificateBundleType.create(
+                        "CERTIFICATE_CONTENT_PUBLIC_ONLY"))
+                .isEqualTo(
+                        GetCertificateBundleRequest.CertificateBundleType
+                                .CertificateContentPublicOnly);
+        assertThat(CertificatesClient.SERVICE.getServiceName()).isEqualTo("CERTIFICATES");
+        assertThat(CertificatesClient.SERVICE.getServiceEndpointTemplate())
+                .isEqualTo("https://certificates.{region}.oci.{secondLevelDomain}");
+
+        assertThatThrownBy(() -> GetCertificateBundleRequest.Stage.create("FUTURE_STAGE"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid Stage: FUTURE_STAGE");
+        assertThatThrownBy(
+                        () ->
+                                GetCertificateBundleRequest.CertificateBundleType.create(
+                                        "NEW_BUNDLE_TYPE"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid CertificateBundleType: NEW_BUNDLE_TYPE");
+    }
+
+    @Test
+    void jacksonUsesCertificateBundleDiscriminatorForPolymorphicModels() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        String privateKeyBundleJson =
+                """
+                {
+                  "certificateBundleType": "CERTIFICATE_CONTENT_WITH_PRIVATE_KEY",
+                  "certificateId": "certificate-1",
+                  "certificateName": "leaf-certificate",
+                  "versionNumber": 9,
+                  "serialNumber": "serial-1",
+                  "certificatePem": "certificate-pem",
+                  "certChainPem": "chain-pem",
+                  "versionName": "version-private",
+                  "stages": ["CURRENT", "LATEST"],
+                  "revocationStatus": {
+                    "timeRevoked": 1711000000000,
+                    "revocationReason": "KEY_COMPROMISE"
+                  },
+                  "privateKeyPem": "private-key-pem",
+                  "privateKeyPemPassphrase": "passphrase"
+                }
+                """;
+        String publicBundleJson =
+                """
+                {
+                  "certificateBundleType": "CERTIFICATE_CONTENT_PUBLIC_ONLY",
+                  "certificateId": "certificate-2",
+                  "certificateName": "public-certificate",
+                  "versionNumber": 10,
+                  "validity": {
+                    "timeOfValidityNotBefore": 1709000000000,
+                    "timeOfValidityNotAfter": 1809000000000
+                  }
+                }
+                """;
+
+        CertificateBundle privateBundle =
+                objectMapper.readValue(privateKeyBundleJson, CertificateBundle.class);
+        CertificateBundle publicBundle =
+                objectMapper.readValue(publicBundleJson, CertificateBundle.class);
+
+        assertThat(privateBundle).isInstanceOf(CertificateBundleWithPrivateKey.class);
+        CertificateBundleWithPrivateKey withPrivateKey =
+                (CertificateBundleWithPrivateKey) privateBundle;
+        assertThat(withPrivateKey.getCertificateId()).isEqualTo("certificate-1");
+        assertThat(withPrivateKey.getVersionNumber()).isEqualTo(9L);
+        assertThat(withPrivateKey.getStages())
+                .containsExactly(VersionStage.Current, VersionStage.Latest);
+        assertThat(withPrivateKey.getRevocationStatus().getRevocationReason())
+                .isEqualTo(RevocationReason.KeyCompromise);
+        assertThat(withPrivateKey.getPrivateKeyPem()).isEqualTo("private-key-pem");
+        assertThat(withPrivateKey.getPrivateKeyPemPassphrase()).isEqualTo("passphrase");
+
+        assertThat(publicBundle).isInstanceOf(CertificateBundlePublicOnly.class);
+        assertThat(publicBundle.getCertificateId()).isEqualTo("certificate-2");
+        assertThat(publicBundle.getValidity().getTimeOfValidityNotBefore()).isEqualTo(NOT_BEFORE);
+        assertThat(publicBundle.getValidity().getTimeOfValidityNotAfter()).isEqualTo(NOT_AFTER);
+    }
+
+    private static Validity validity() {
+        return Validity.builder()
+                .timeOfValidityNotBefore(NOT_BEFORE)
+                .timeOfValidityNotAfter(NOT_AFTER)
+                .build();
+    }
+
+    private static RevocationStatus revocationStatus() {
+        return RevocationStatus.builder()
+                .timeRevoked(REVOKED)
+                .revocationReason(RevocationReason.KeyCompromise)
+                .build();
+    }
+}

--- a/tests/src/com.oracle.oci.sdk/oci-java-sdk-certificates/3.77.1/src/test/java/com_oracle_oci_sdk/oci_java_sdk_certificates/Oci_java_sdk_certificatesTest.java
+++ b/tests/src/com.oracle.oci.sdk/oci-java-sdk-certificates/3.77.1/src/test/java/com_oracle_oci_sdk/oci_java_sdk_certificates/Oci_java_sdk_certificatesTest.java
@@ -422,7 +422,8 @@ public class Oci_java_sdk_certificatesTest {
                 .isEqualTo(
                         GetCertificateBundleRequest.CertificateBundleType
                                 .CertificateContentPublicOnly);
-        assertThat(CertificatesClient.SERVICE.getServiceName()).isEqualTo("CERTIFICATES");
+        assertThat(CertificatesClient.SERVICE.getServiceName())
+                .isEqualTo(CertificatesClient.class.getName());
         assertThat(CertificatesClient.SERVICE.getServiceEndpointTemplate())
                 .isEqualTo("https://certificates.{region}.oci.{secondLevelDomain}");
 

--- a/tests/src/com.oracle.oci.sdk/oci-java-sdk-certificates/3.77.1/user-code-filter.json
+++ b/tests/src/com.oracle.oci.sdk/oci-java-sdk-certificates/3.77.1/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.oracle.bmc.certificates.**"
+    },
+    {
+      "includeClasses" : "com_oracle_oci_sdk.oci_java_sdk_certificates.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #8150

This PR provides test fixes and new metadata for com.oracle.oci.sdk:oci-java-sdk-certificates:3.77.1, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 17238
- Cached input tokens: 131072
- Output tokens: 1189
- Metadata entries: 33
- Iterations: 1
- Library coverage percentage: 50.05
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 50.05

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `9748d9d68f2d5a9d527d771bd7e6cb7b948a116d`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.oracle.oci.sdk:oci-java-sdk-certificates:3.63.1: 0/0 covered calls (100.00%)
- com.oracle.oci.sdk:oci-java-sdk-certificates:3.77.1: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.oracle.oci.sdk:oci-java-sdk-certificates:3.63.1: 4241/8800 (48.19%)
- com.oracle.oci.sdk:oci-java-sdk-certificates:3.77.1: 4242/8802 (48.19%)

**Line:**
- com.oracle.oci.sdk:oci-java-sdk-certificates:3.63.1: 1013/2024 (50.05%)
- com.oracle.oci.sdk:oci-java-sdk-certificates:3.77.1: 1013/2024 (50.05%)

**Method:**
- com.oracle.oci.sdk:oci-java-sdk-certificates:3.63.1: 323/478 (67.57%)
- com.oracle.oci.sdk:oci-java-sdk-certificates:3.77.1: 323/478 (67.57%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/com.oracle.oci.sdk/oci-java-sdk-certificates/3.63.1/src/test/java/com_oracle_oci_sdk/oci_java_sdk_certificates/Oci_java_sdk_certificatesTest.java 2/tests/src/com.oracle.oci.sdk/oci-java-sdk-certificates/3.77.1/src/test/java/com_oracle_oci_sdk/oci_java_sdk_certificates/Oci_java_sdk_certificatesTest.java
index b9ee638191..f02c0ca41d 100644
--- 1/tests/src/com.oracle.oci.sdk/oci-java-sdk-certificates/3.63.1/src/test/java/com_oracle_oci_sdk/oci_java_sdk_certificates/Oci_java_sdk_certificatesTest.java
+++ 2/tests/src/com.oracle.oci.sdk/oci-java-sdk-certificates/3.77.1/src/test/java/com_oracle_oci_sdk/oci_java_sdk_certificates/Oci_java_sdk_certificatesTest.java
@@ -422,7 +422,8 @@ public class Oci_java_sdk_certificatesTest {
                 .isEqualTo(
                         GetCertificateBundleRequest.CertificateBundleType
                                 .CertificateContentPublicOnly);
-        assertThat(CertificatesClient.SERVICE.getServiceName()).isEqualTo("CERTIFICATES");
+        assertThat(CertificatesClient.SERVICE.getServiceName())
+                .isEqualTo(CertificatesClient.class.getName());
         assertThat(CertificatesClient.SERVICE.getServiceEndpointTemplate())
                 .isEqualTo("https://certificates.{region}.oci.{secondLevelDomain}");
 

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
