### PR TITLE
[GenAI] Add support for org.jboss.xnio:xnio-api:3.8.7.Final using gpt-5.5

### DIFF
--- a/metadata/org.jboss.xnio/xnio-api/3.8.7.Final/reachability-metadata.json
+++ b/metadata/org.jboss.xnio/xnio-api/3.8.7.Final/reachability-metadata.json
@@ -1,0 +1,73 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.xnio._private.Messages"
+      },
+      "type" : "ch.qos.logback.classic.Logger"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.xnio._private.Messages"
+      },
+      "type" : "org.apache.log4j.LogManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.xnio._private.Messages"
+      },
+      "type" : "org.apache.logging.log4j.Logger"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.xnio._private.Messages"
+      },
+      "type" : "org.jboss.logmanager.LogManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.xnio.Option"
+      },
+      "type" : "org.xnio.Options",
+      "fields" : [
+        {
+          "name" : "WORKER_IO_THREADS"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.xnio._private.Messages"
+      },
+      "type" : "org.xnio._private.Messages_$logger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.jboss.logging.Logger"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.xnio._private.Messages"
+      },
+      "type" : "org.xnio._private.Messages_$logger_en"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.xnio._private.Messages"
+      },
+      "type" : "org.xnio._private.Messages_$logger_en_US"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.xnio._private.Messages"
+      },
+      "glob" : "META-INF/services/org.jboss.logging.LoggerProvider"
+    }
+  ]
+}

--- a/metadata/org.jboss.xnio/xnio-api/index.json
+++ b/metadata/org.jboss.xnio/xnio-api/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.8.7.Final",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/jboss/xnio/xnio-api/$version$/xnio-api-$version$-sources.jar",
+    "repository-url" : "https://github.com/xnio/xnio",
+    "test-code-url" : "https://github.com/xnio/xnio/tree/$version$/api/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/jboss/xnio/xnio-api/$version$/xnio-api-$version$-javadoc.jar",
+    "description" : "XNIO is a Java NIO-based framework that supports blocking and non-blocking I/O. The xnio-api artifact contains the public API classes for creating, closing, reading from, and writing to channels, while implementations live in separate modules.",
+    "tested-versions" : [
+      "3.8.7.Final"
+    ],
+    "allowed-packages" : [
+      "org.xnio"
+    ]
+  }
+]

--- a/stats/org.jboss.xnio/xnio-api/3.8.7.Final/execution-metrics.json
+++ b/stats/org.jboss.xnio/xnio-api/3.8.7.Final/execution-metrics.json
@@ -1,0 +1,63 @@
+{
+  "add_new_library_support:2026-06-07": {
+    "timestamp": "2026-06-07T22:16:07.070880Z",
+    "library": "org.jboss.xnio:xnio-api:3.8.7.Final",
+    "starting_commit": "c50c8a401489c1ee17b3cbe9f2bc56ac9c6c2ce0",
+    "ending_commit": "78656b54d6588a4a72cd08996dc29b7ed2835f48",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.8.7.Final",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.3,
+            "coveredCalls": 3,
+            "totalCalls": 10
+          }
+        },
+        "coverageRatio": 0.3,
+        "coveredCalls": 3,
+        "totalCalls": 10
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3534,
+          "missed": 46270,
+          "ratio": 0.070958,
+          "total": 49804
+        },
+        "line": {
+          "covered": 823,
+          "missed": 11249,
+          "ratio": 0.068174,
+          "total": 12072
+        },
+        "method": {
+          "covered": 257,
+          "missed": 2790,
+          "ratio": 0.084345,
+          "total": 3047
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 221589,
+      "cached_input_tokens_used": 3421696,
+      "output_tokens_used": 29446,
+      "iterations": 6,
+      "cost_usd": 2.5942,
+      "generated_loc": 250,
+      "tested_library_loc": 823,
+      "metadata_entries": 11,
+      "test_only_metadata_entries": 2,
+      "code_coverage_percent": 6.82
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/src/test/java/org_jboss_xnio/xnio_api/Xnio_apiTest.java",
+      "metadata_file": "metadata/org.jboss.xnio/xnio-api/3.8.7.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.jboss.xnio/xnio-api/3.8.7.Final/stats.json
+++ b/stats/org.jboss.xnio/xnio-api/3.8.7.Final/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "3.8.7.Final",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.3,
+          "coveredCalls" : 3,
+          "totalCalls" : 10
+        }
+      },
+      "coverageRatio" : 0.3,
+      "coveredCalls" : 3,
+      "totalCalls" : 10
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3534,
+        "missed" : 46270,
+        "ratio" : 0.070958,
+        "total" : 49804
+      },
+      "line" : {
+        "covered" : 823,
+        "missed" : 11249,
+        "ratio" : 0.068174,
+        "total" : 12072
+      },
+      "method" : {
+        "covered" : 257,
+        "missed" : 2790,
+        "ratio" : 0.084345,
+        "total" : 3047
+      }
+    }
+  } ]
+}

--- a/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/.gitignore
+++ b/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/build.gradle
+++ b/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.jboss.xnio:xnio-api:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/build.gradle
+++ b/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.jboss.xnio:xnio-api:$libraryVersion"
+    testImplementation 'org.wildfly.common:wildfly-common:1.7.0.Final'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/gradle.properties
+++ b/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.jboss.xnio:xnio-api:3.8.7.Final
+library.version = 3.8.7.Final
+metadata.dir = org.jboss.xnio/xnio-api/3.8.7.Final/

--- a/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/settings.gradle
+++ b/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.jboss.xnio.xnio-api_tests'

--- a/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/src/test/java/org_jboss_xnio/xnio_api/Xnio_apiTest.java
+++ b/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/src/test/java/org_jboss_xnio/xnio_api/Xnio_apiTest.java
@@ -44,6 +44,8 @@ import org.xnio.Pooled;
 import org.xnio.Property;
 import org.xnio.Sequence;
 import org.xnio.SslClientAuthMode;
+import org.xnio.streams.LimitedInputStream;
+import org.xnio.streams.LimitedOutputStream;
 import org.xnio.streams.Streams;
 
 public class Xnio_apiTest {
@@ -229,6 +231,32 @@ public class Xnio_apiTest {
         assertThat(channel.isOpen()).isFalse();
         assertThat(attachment.closed).isTrue();
         assertThat(IoUtils.nullCloseable()).isNotNull();
+    }
+
+    @Test
+    void limitedStreamsExposeConfiguredByteRangesAndRejectOverflowWrites() throws IOException {
+        byte[] source = "abcdef".getBytes(StandardCharsets.UTF_8);
+        try (LimitedInputStream input = new LimitedInputStream(new ByteArrayInputStream(source), 5)) {
+            assertThat(input.markSupported()).isTrue();
+            assertThat(input.available()).isEqualTo(5);
+
+            input.mark(source.length);
+            assertThat(input.readNBytes(3)).containsExactly((byte) 'a', (byte) 'b', (byte) 'c');
+            input.reset();
+            assertThat(input.readNBytes(8)).containsExactly((byte) 'a', (byte) 'b', (byte) 'c', (byte) 'd',
+                    (byte) 'e');
+            assertThat(input.read()).isEqualTo(-1);
+        }
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (LimitedOutputStream limitedOutput = new LimitedOutputStream(output, 4)) {
+            limitedOutput.write("abc".getBytes(StandardCharsets.UTF_8));
+            limitedOutput.write('d');
+            assertThatThrownBy(() -> limitedOutput.write('e')).isInstanceOf(IOException.class);
+            limitedOutput.flush();
+        }
+
+        assertThat(output.toString(StandardCharsets.UTF_8)).isEqualTo("abcd");
     }
 
     @Test

--- a/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/src/test/java/org_jboss_xnio/xnio_api/Xnio_apiTest.java
+++ b/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/src/test/java/org_jboss_xnio/xnio_api/Xnio_apiTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_xnio.xnio_api;
+
+import org.junit.jupiter.api.Test;
+
+class Xnio_apiTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/src/test/java/org_jboss_xnio/xnio_api/Xnio_apiTest.java
+++ b/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/src/test/java/org_jboss_xnio/xnio_api/Xnio_apiTest.java
@@ -6,11 +6,228 @@
  */
 package org_jboss_xnio.xnio_api;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class Xnio_apiTest {
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channel;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.net.ssl.KeyManager;
+
+import org.junit.jupiter.api.Test;
+import org.xnio.Buffers;
+import org.xnio.ByteString;
+import org.xnio.ChannelListeners;
+import org.xnio.FileAccess;
+import org.xnio.FutureResult;
+import org.xnio.IoFuture;
+import org.xnio.IoUtils;
+import org.xnio.LocalSocketAddress;
+import org.xnio.Option;
+import org.xnio.OptionMap;
+import org.xnio.Options;
+import org.xnio.Property;
+import org.xnio.Sequence;
+import org.xnio.SslClientAuthMode;
+import org.xnio.streams.Streams;
+
+public class Xnio_apiTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void optionsCanBeResolvedParsedAndStoredInOptionMaps() {
+        ClassLoader classLoader = Xnio_apiTest.class.getClassLoader();
+        Option<?> resolvedOption = Option.fromString("org.xnio.Options.WORKER_IO_THREADS", classLoader);
+
+        OptionMap optionMap = OptionMap.builder()
+                .parse(Options.WORKER_IO_THREADS, "3", classLoader)
+                .parse(Options.ALLOW_BLOCKING, "true", classLoader)
+                .parse(Options.FILE_ACCESS, "READ_WRITE", classLoader)
+                .parse(Options.SSL_CLIENT_AUTH_MODE, "REQUESTED", classLoader)
+                .set(Options.WORKER_NAME, "xnio-test-worker")
+                .setSequence(Options.SSL_ENABLED_PROTOCOLS, "TLSv1.3", "TLSv1.2")
+                .set(Options.SSL_JSSE_KEY_MANAGER_CLASSES,
+                        Sequence.of(List.<Class<? extends KeyManager>>of(KeyManager.class)))
+                .getMap();
+
+        assertThat(resolvedOption).isSameAs(Options.WORKER_IO_THREADS);
+        assertThat(optionMap.get(Options.WORKER_IO_THREADS, 0)).isEqualTo(3);
+        assertThat(optionMap.get(Options.ALLOW_BLOCKING, false)).isTrue();
+        assertThat(optionMap.get(Options.FILE_ACCESS)).isEqualTo(FileAccess.READ_WRITE);
+        assertThat(optionMap.get(Options.SSL_CLIENT_AUTH_MODE)).isEqualTo(SslClientAuthMode.REQUESTED);
+        assertThat(optionMap.get(Options.WORKER_NAME)).isEqualTo("xnio-test-worker");
+        assertThat(optionMap.get(Options.SSL_ENABLED_PROTOCOLS))
+                .containsExactly("TLSv1.3", "TLSv1.2");
+        assertThat(optionMap.get(Options.SSL_JSSE_KEY_MANAGER_CLASSES))
+                .containsExactly(KeyManager.class);
+        assertThat(optionMap).contains(Options.WORKER_IO_THREADS, Options.SSL_ENABLED_PROTOCOLS);
+        assertThat(optionMap).isEqualTo(OptionMap.builder().addAll(optionMap).getMap());
+    }
+
+    @Test
+    void sequencesPropertiesAndOptionSetsPreserveTypedValues() {
+        Sequence<Property> saslProperties = Sequence.of(
+                Property.of("realm", "ApplicationRealm"),
+                Property.of("trace", Boolean.TRUE));
+        OptionMap optionMap = OptionMap.create(Options.SASL_PROPERTIES, saslProperties);
+        Set<Option<?>> options = Option.setBuilder()
+                .add(Options.SASL_PROPERTIES, Options.TCP_NODELAY)
+                .add(Options.REUSE_ADDRESSES)
+                .create();
+
+        assertThat(optionMap.get(Options.SASL_PROPERTIES)).containsExactlyElementsOf(saslProperties);
+        assertThat(saslProperties.cast(Property.class)).containsExactlyElementsOf(saslProperties);
+        assertThat(Property.of("realm", "ApplicationRealm").getKey()).isEqualTo("realm");
+        assertThat(Property.of("realm", "ApplicationRealm").getValue()).isEqualTo("ApplicationRealm");
+        assertThat(options).containsExactlyInAnyOrder(
+                Options.SASL_PROPERTIES,
+                Options.TCP_NODELAY,
+                Options.REUSE_ADDRESSES);
+    }
+
+    @Test
+    void byteStringSupportsAsciiSearchingCaseInsensitiveMatchingAndNumericConversion() throws IOException {
+        ByteString value = ByteString.getBytes("Hello-XNIO-123", StandardCharsets.UTF_8);
+        ByteString suffix = value.substring(6);
+        ByteBuffer target = ByteBuffer.allocate(16);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        suffix.appendTo(target);
+        target.flip();
+        value.writeTo(output);
+
+        assertThat(value.length()).isEqualTo(14);
+        assertThat(suffix.toUtf8String()).isEqualTo("XNIO-123");
+        assertThat(value.contains("XNIO")).isTrue();
+        assertThat(value.containsIgnoreCase("xnio")).isTrue();
+        assertThat(value.startsWith("Hello")).isTrue();
+        assertThat(value.endsWith('3')).isTrue();
+        assertThat(value.regionMatches(false, 6, "XNIO", 0, 4)).isTrue();
+        assertThat(ByteString.fromInt(12345).toInt()).isEqualTo(12345);
+        assertThat(ByteString.fromLong(987654321L).toLong()).isEqualTo(987654321L);
+        assertThat(new String(Buffers.take(target), StandardCharsets.UTF_8)).isEqualTo("XNIO-123");
+        assertThat(output.toString(StandardCharsets.UTF_8)).isEqualTo("Hello-XNIO-123");
+    }
+
+    @Test
+    void bufferUtilitiesCopyEncodeAndDecodeData() throws IOException {
+        ByteBuffer source = ByteBuffer.wrap("abcdef".getBytes(StandardCharsets.UTF_8));
+        ByteBuffer destination = ByteBuffer.allocate(8);
+        ByteBuffer encoded = ByteBuffer.allocate(32);
+
+        int copied = Buffers.copy(3, destination, source);
+        Buffers.putModifiedUtf8(encoded, "A\u0000\u20ac");
+        encoded.flip();
+        destination.flip();
+
+        assertThat(copied).isEqualTo(3);
+        assertThat(new String(Buffers.take(destination), StandardCharsets.UTF_8)).isEqualTo("abc");
+        assertThat(source.position()).isEqualTo(3);
+        assertThat(Buffers.getModifiedUtf8(encoded)).isEqualTo("A\u0000\u20ac");
+
+        ByteBuffer filled = ByteBuffer.allocate(4);
+        Buffers.fill(filled, 'Z', 4).flip();
+        assertThat(Buffers.take(filled)).containsExactly((byte) 'Z', (byte) 'Z', (byte) 'Z', (byte) 'Z');
+    }
+
+    @Test
+    void futureResultsNotifySuccessFailureAndCancellation() throws Exception {
+        FutureResult<String> successfulResult = new FutureResult<>(IoUtils.directExecutor());
+        AtomicReference<String> notification = new AtomicReference<>();
+        IoFuture<String> successfulFuture = successfulResult.getIoFuture();
+        successfulFuture.addNotifier((future, attachment) -> attachment.set(future.getStatus().name()), notification);
+
+        assertThat(successfulResult.setResult("ready")).isTrue();
+        assertThat(successfulFuture.await(1, TimeUnit.SECONDS)).isEqualTo(IoFuture.Status.DONE);
+        assertThat(successfulFuture.get()).isEqualTo("ready");
+        assertThat(notification).hasValue("DONE");
+        Future<String> javaFuture = IoUtils.getFuture(successfulFuture);
+        assertThat(javaFuture.get(1, TimeUnit.SECONDS)).isEqualTo("ready");
+
+        IOException failure = new IOException("expected failure");
+        FutureResult<String> failedResult = new FutureResult<>();
+        assertThat(failedResult.setException(failure)).isTrue();
+        IoFuture<String> failedFuture = failedResult.getIoFuture();
+        assertThat(failedFuture.await(1, TimeUnit.SECONDS)).isEqualTo(IoFuture.Status.FAILED);
+        assertThat(failedFuture.getException()).isSameAs(failure);
+        assertThatThrownBy(failedFuture::get).isSameAs(failure);
+
+        FutureResult<String> cancelledResult = new FutureResult<>();
+        AtomicBoolean cancelHandlerInvoked = new AtomicBoolean();
+        cancelledResult.addCancelHandler(() -> {
+            cancelHandlerInvoked.set(true);
+            return IoUtils.nullCancellable();
+        });
+        cancelledResult.getIoFuture().cancel();
+        assertThat(cancelHandlerInvoked).isTrue();
+        assertThat(cancelledResult.setCancelled()).isTrue();
+        assertThat(cancelledResult.getIoFuture().await(1, TimeUnit.SECONDS)).isEqualTo(IoFuture.Status.CANCELLED);
+        assertThatThrownBy(() -> cancelledResult.getIoFuture().get()).isInstanceOf(CancellationException.class);
+    }
+
+    @Test
+    void streamAndChannelHelpersCloseAndTransferData() throws IOException {
+        ByteArrayInputStream input = new ByteArrayInputStream("stream-copy".getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        Streams.copyStream(input, output, true, 4);
+
+        assertThat(output.toString(StandardCharsets.UTF_8)).isEqualTo("stream-copy");
+
+        RecordingChannel channel = new RecordingChannel();
+        RecordingCloseable attachment = new RecordingCloseable();
+        AtomicReference<RecordingChannel> invoked = new AtomicReference<>();
+
+        assertThat(ChannelListeners.invokeChannelListener(channel, invoked::set)).isTrue();
+        ChannelListeners.closingChannelListener(attachment).handleEvent(channel);
+        ChannelListeners.closingChannelListener().handleEvent(channel);
+        IoUtils.safeClose((Closeable) () -> {
+            throw new IOException("ignored");
+        });
+
+        assertThat(invoked).hasValue(channel);
+        assertThat(channel.isOpen()).isFalse();
+        assertThat(attachment.closed).isTrue();
+        assertThat(IoUtils.nullCloseable()).isNotNull();
+    }
+
+    @Test
+    void localSocketAddressHasStableNameAndDisplayForm() {
+        LocalSocketAddress address = new LocalSocketAddress("xnio-local-test");
+
+        assertThat(address.getName()).isEqualTo("xnio-local-test");
+        assertThat(address.toString()).contains("xnio-local-test");
+    }
+
+    private static final class RecordingChannel implements Channel {
+        private boolean open = true;
+
+        @Override
+        public boolean isOpen() {
+            return open;
+        }
+
+        @Override
+        public void close() {
+            open = false;
+        }
+    }
+
+    private static final class RecordingCloseable implements Closeable {
+        private boolean closed;
+
+        @Override
+        public void close() {
+            closed = true;
+        }
     }
 }

--- a/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/src/test/java/org_jboss_xnio/xnio_api/Xnio_apiTest.java
+++ b/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/src/test/java/org_jboss_xnio/xnio_api/Xnio_apiTest.java
@@ -27,7 +27,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.net.ssl.KeyManager;
 
 import org.junit.jupiter.api.Test;
+import org.xnio.BufferAllocator;
 import org.xnio.Buffers;
+import org.xnio.ByteBufferSlicePool;
 import org.xnio.ByteString;
 import org.xnio.ChannelListeners;
 import org.xnio.FileAccess;
@@ -38,6 +40,7 @@ import org.xnio.LocalSocketAddress;
 import org.xnio.Option;
 import org.xnio.OptionMap;
 import org.xnio.Options;
+import org.xnio.Pooled;
 import org.xnio.Property;
 import org.xnio.Sequence;
 import org.xnio.SslClientAuthMode;
@@ -138,6 +141,34 @@ public class Xnio_apiTest {
         ByteBuffer filled = ByteBuffer.allocate(4);
         Buffers.fill(filled, 'Z', 4).flip();
         assertThat(Buffers.take(filled)).containsExactly((byte) 'Z', (byte) 'Z', (byte) 'Z', (byte) 'Z');
+    }
+
+    @Test
+    void byteBufferSlicePoolsAllocateAndReleasePooledBuffers() {
+        ByteBufferSlicePool pool = new ByteBufferSlicePool(BufferAllocator.BYTE_BUFFER_ALLOCATOR, 16, 64);
+
+        Pooled<ByteBuffer> firstAllocation = pool.allocate();
+        ByteBuffer firstBuffer = firstAllocation.getResource();
+        firstBuffer.put("pooled".getBytes(StandardCharsets.UTF_8));
+        firstBuffer.flip();
+
+        assertThat(pool.getBufferSize()).isEqualTo(16);
+        assertThat(firstBuffer.capacity()).isEqualTo(pool.getBufferSize());
+        assertThat(new String(Buffers.take(firstBuffer), StandardCharsets.UTF_8)).isEqualTo("pooled");
+
+        firstAllocation.close();
+
+        Pooled<ByteBuffer> secondAllocation = pool.allocate();
+        try {
+            ByteBuffer secondBuffer = secondAllocation.getResource();
+
+            assertThat(secondBuffer.position()).isZero();
+            assertThat(secondBuffer.limit()).isEqualTo(pool.getBufferSize());
+            assertThat(secondBuffer.capacity()).isEqualTo(pool.getBufferSize());
+        } finally {
+            secondAllocation.close();
+            pool.clean();
+        }
     }
 
     @Test

--- a/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org_jboss_xnio.xnio_api.Xnio_apiTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_jboss_xnio.xnio_api.Xnio_apiTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/user-code-filter.json
+++ b/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.xnio.**"
+    }
+  ]
+}

--- a/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/user-code-filter.json
+++ b/tests/src/org.jboss.xnio/xnio-api/3.8.7.Final/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.xnio.**"
+      "includeClasses" : "org.xnio.**"
+    },
+    {
+      "includeClasses" : "org_jboss_xnio.xnio_api.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #1537

This PR introduces tests and metadata for org.jboss.xnio:xnio-api:3.8.7.Final, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 221589
- Cached input tokens: 3421696
- Output tokens: 29446
- Metadata entries: 11
- Test-only metadata entries: 2
- Iterations: 6
- Library coverage percentage: 6.82
- Generated lines of code: 250
- Tested library lines of code: 823

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `780aa1730872dde82327f6bfab6846eac7ec6628`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 3/10 covered calls (30.00%)
- Reflection: 3/10 covered calls (30.00%)

Library coverage:
- Instruction: 3534/49804 (7.10%)
- Line: 823/12072 (6.82%)
- Method: 257/3047 (8.43%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
