### PR TITLE
Add library-specific preparation preflight

### DIFF
--- a/forge/ai_workflows/core/fix_metadata_codex.py
+++ b/forge/ai_workflows/core/fix_metadata_codex.py
@@ -22,6 +22,7 @@ def run_codex_metadata_fix(
         reproduction_command: str | None = None,
         graalvm_home: str | None = None,
         base_env: dict[str, str] | None = None,
+        library_preparation_preflight_context: str | None = None,
 ) -> tuple[int, str, bool]:
     """Run Codex to update metadata entries for the target library.
 
@@ -53,6 +54,11 @@ def run_codex_metadata_fix(
     )
     if reproduction_command:
         prompt += f"\n\nReproduce the failure with:\n{reproduction_command}"
+    if library_preparation_preflight_context:
+        prompt += (
+            "\n\nLibrary preparation preflight context:\n"
+            f"{library_preparation_preflight_context}"
+        )
     cmd = [
         "codex", "exec",
         "--dangerously-bypass-approvals-and-sandbox",

--- a/forge/ai_workflows/core/workflow_strategy.py
+++ b/forge/ai_workflows/core/workflow_strategy.py
@@ -30,6 +30,7 @@ from utility_scripts.metadata_index import (
     resolve_test_version,
 )
 from utility_scripts.issue_requested_metadata import NO_REPORTER_METADATA_CONTEXT
+from utility_scripts.library_preparation_preflight import NO_LIBRARY_PREPARATION_PREFLIGHT_CONTEXT
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo
 from utility_scripts.stage_logger import log_stage
 from utility_scripts.strategy_loader import load_persistent_instructions, load_prompt_template
@@ -103,6 +104,10 @@ class WorkflowStrategy(ABC):
         self.context.setdefault(
             "issue_requested_metadata_context",
             NO_REPORTER_METADATA_CONTEXT,
+        )
+        self.context.setdefault(
+            "library_preparation_preflight_context",
+            NO_LIBRARY_PREPARATION_PREFLIGHT_CONTEXT,
         )
         self.context.setdefault("resolved_edit_scope_context", "")
         self.model_name = self.strategy_obj.get("model")

--- a/forge/ai_workflows/drivers/add_new_library_support.py
+++ b/forge/ai_workflows/drivers/add_new_library_support.py
@@ -44,6 +44,9 @@ from git_scripts.common_git import build_ai_branch_name, delete_remote_branch_if
 from utility_scripts import metrics_writer
 from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.large_library_progress import resolve_workflow_progress_state
+from utility_scripts.library_preparation_preflight import (
+    prepare_library_preparation_preflight,
+)
 from utility_scripts.metadata_index import is_not_for_native_image, write_not_for_native_image_marker
 from utility_scripts.native_image_artifact import evaluate_native_image_eligibility
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo, resolve_repo_roots
@@ -186,6 +189,10 @@ def build_parser():
         type=int,
         help="GitHub issue number for durable large-library progress state.",
     )
+    parser.add_argument(
+        "--library-preparation-preflight-path",
+        help="Path to the dispatcher-created library preparation preflight JSON record.",
+    )
     return parser
 
 
@@ -223,6 +230,7 @@ def parse_flags(argv_list):
         flags.chunk_call_limit,
         flags.resume_artifact,
         flags.issue_number,
+        flags.library_preparation_preflight_path,
     )
 
 
@@ -444,6 +452,7 @@ def main(argv=None):
         chunk_call_limit,
         resume_artifact,
         issue_number,
+        library_preparation_preflight_path,
     ) = parse_flags(argv if argv is not None else sys.argv[1:])
 
     strategy = require_strategy_by_name(strategy_name)
@@ -453,6 +462,14 @@ def main(argv=None):
         explicit_repo_path,
         explicit_metrics_repo_path,
         is_benchmark_mode,
+    )
+    # Apply deterministic preflight setup into the resolved worktree before
+    # generation; only advisory guidance reaches the prompt context.
+    library_preparation_preflight, library_preparation_preflight_context = (
+        prepare_library_preparation_preflight(
+            library_preparation_preflight_path,
+            reachability_repo_path,
+        )
     )
     resolve_graalvm_java_home()
 
@@ -531,6 +548,7 @@ def main(argv=None):
         test_language=test_source_layout.language,
         test_language_display_name=test_source_layout.display_language,
         test_source_dir_name=test_source_layout.source_dir_name,
+        library_preparation_preflight_context=library_preparation_preflight_context,
     )
 
     # Add generated files to git and commit; record commit hash (do not use it)
@@ -670,6 +688,7 @@ def main(argv=None):
             strategy_name=strategy_name,
             starting_commit=checkpoint_commit_hash,
             ending_commit=ending_commit_hash,
+            library_preparation_preflight=library_preparation_preflight,
         )
     else:
         run_metrics = metrics_writer.create_run_metrics_output_json(
@@ -686,6 +705,7 @@ def main(argv=None):
             starting_commit=checkpoint_commit_hash,
             ending_commit=ending_commit_hash,
             post_generation_intervention=strategy_obj.post_generation_intervention,
+            library_preparation_preflight=library_preparation_preflight,
         )
 
     metrics_json = resolve_add_new_library_support_metrics_json(

--- a/forge/ai_workflows/drivers/fix_ni_run.py
+++ b/forge/ai_workflows/drivers/fix_ni_run.py
@@ -15,6 +15,9 @@ from ai_workflows.core.fix_metadata_codex import run_codex_metadata_fix
 from git_scripts.common_git import build_ai_branch_name, delete_remote_branch_if_exists
 from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.library_finalization import run_library_finalization
+from utility_scripts.library_preparation_preflight import (
+    prepare_library_preparation_preflight,
+)
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo, resolve_repo_roots
 from utility_scripts.source_context import populate_artifact_urls
 
@@ -48,6 +51,14 @@ def build_parser():
             "Path to the graalvm-reachability-metadata repository. "
             "If omitted, the parent checkout of this Forge directory is used."
         ),
+    )
+    parser.add_argument(
+        "--metrics-repo-path",
+        help="Path where dispatcher-created workflow context artifacts are written.",
+    )
+    parser.add_argument(
+        "--library-preparation-preflight-path",
+        help="Path to the dispatcher-created library preparation preflight JSON record.",
     )
     return parser
 
@@ -106,11 +117,22 @@ def main(argv=None) -> int:
 
     reachability_metadata_path, _ = resolve_repo_roots(
         args.reachability_metadata_path,
-        None,
+        args.metrics_repo_path,
     )
 
     current_coordinates = args.coordinates
     new_version = args.new_version
+    # Apply deterministic preflight setup into the resolved worktree before
+    # generation; only advisory guidance reaches the prompt context.
+    library_preparation_preflight, library_preparation_preflight_context = (
+        prepare_library_preparation_preflight(
+            args.library_preparation_preflight_path,
+            reachability_metadata_path,
+        )
+    )
+    if library_preparation_preflight is not None:
+        print("[pipeline] Library preparation preflight:")
+        print(library_preparation_preflight_context)
 
     group, artifact, _ = current_coordinates.split(":")
     branch = build_ai_branch_name(
@@ -150,6 +172,7 @@ def main(argv=None) -> int:
             reachability_metadata_path,
             library,
             graalvm_home=gradle_env.get("GRAALVM_HOME"),
+            library_preparation_preflight_context=library_preparation_preflight_context,
         )
         if codex_rc != 0:
             print(f"ERROR: Codex failed with return code: {codex_rc}", file=sys.stderr)

--- a/forge/ai_workflows/drivers/improve_library_coverage.py
+++ b/forge/ai_workflows/drivers/improve_library_coverage.py
@@ -49,6 +49,9 @@ from utility_scripts.issue_requested_metadata import (
     format_issue_requested_test_requirements,
 )
 from utility_scripts.large_library_progress import resolve_workflow_progress_state
+from utility_scripts.library_preparation_preflight import (
+    prepare_library_preparation_preflight,
+)
 from utility_scripts.library_stats import stats_artifact_dir
 from utility_scripts.metadata_index import (
     MATCH_NEW_VERSION,
@@ -179,6 +182,10 @@ def build_parser() -> argparse.ArgumentParser:
         default="",
         help="Reporter-provided missing metadata context extracted from the GitHub issue body.",
     )
+    parser.add_argument(
+        "--library-preparation-preflight-path",
+        help="Path to the dispatcher-created library preparation preflight JSON record.",
+    )
     return parser
 
 
@@ -208,6 +215,7 @@ def parse_flags(argv_list: list[str]):
         flags.resume_artifact,
         flags.issue_number,
         flags.issue_requested_metadata_context,
+        flags.library_preparation_preflight_path,
     )
 
 
@@ -806,6 +814,7 @@ def main(argv=None) -> int:
         resume_artifact,
         issue_number,
         issue_requested_metadata_context,
+        library_preparation_preflight_path,
     ) = parse_flags(argv if argv is not None else sys.argv[1:])
 
     library = f"{group}:{artifact}:{version}"
@@ -813,6 +822,14 @@ def main(argv=None) -> int:
     reachability_repo_path, metrics_repo_dir, metrics_repo_root = resolve_repo_paths(
         explicit_repo_path,
         explicit_metrics_repo_path,
+    )
+    # Apply deterministic preflight setup into the resolved worktree before
+    # generation; only advisory guidance reaches the prompt context.
+    library_preparation_preflight, library_preparation_preflight_context = (
+        prepare_library_preparation_preflight(
+            library_preparation_preflight_path,
+            reachability_repo_path,
+        )
     )
     ensure_gh_authenticated()
     resolve_graalvm_java_home()
@@ -940,6 +957,7 @@ def main(argv=None) -> int:
         test_language_display_name=test_source_layout.display_language,
         test_source_dir_name=test_source_layout.source_dir_name,
         metadata_version=update_target.resolved_metadata_version,
+        library_preparation_preflight_context=library_preparation_preflight_context,
         large_library_progress_state=large_library_state,
         large_library_progress_state_path=large_library_state_path,
         large_library_issue_number=issue_number,
@@ -1008,6 +1026,7 @@ def main(argv=None) -> int:
             strategy_name=strategy_name,
             starting_commit=checkpoint_commit,
             ending_commit=ending_commit,
+            library_preparation_preflight=library_preparation_preflight,
         )
     else:
         if workflow_status == SUCCESS_WITH_INTERVENTION_STATUS:
@@ -1028,6 +1047,7 @@ def main(argv=None) -> int:
             starting_commit=checkpoint_commit,
             ending_commit=ending_commit,
             post_generation_intervention=strategy_obj.post_generation_intervention,
+            library_preparation_preflight=library_preparation_preflight,
         )
 
     write_library_update_target_sidecar(metrics_repo_root, update_target)

--- a/forge/ai_workflows/drivers/java_fail_workflow.py
+++ b/forge/ai_workflows/drivers/java_fail_workflow.py
@@ -25,6 +25,9 @@ from ai_workflows.core.workflow_strategy import WorkflowStrategy
 from git_scripts.common_git import build_ai_branch_name, delete_remote_branch_if_exists, ensure_gh_authenticated
 from utility_scripts import metrics_writer
 from utility_scripts.gradle_environment import gradle_command_environment
+from utility_scripts.library_preparation_preflight import (
+    prepare_library_preparation_preflight,
+)
 from utility_scripts.metadata_index import is_newer_than_latest_metadata_version
 from utility_scripts.metrics_writer import create_failure_run_metrics_output
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo, resolve_repo_roots
@@ -141,6 +144,10 @@ def build_parser(config: JavaFailWorkflowConfig):
         default=None,
         help="Optional path with additional read-only docs/sources for agent context",
     )
+    parser.add_argument(
+        "--library-preparation-preflight-path",
+        help="Path to the dispatcher-created library preparation preflight JSON record.",
+    )
     parser.add_argument("-v", "--verbose", action="store_true", help="enable verbose mode for the configured agent")
     return parser
 
@@ -168,6 +175,7 @@ def parse_flags(config: JavaFailWorkflowConfig, argv_list):
         flags.verbose,
         flags.reachability_metadata_path,
         flags.metrics_repo_path,
+        flags.library_preparation_preflight_path,
     )
 
 
@@ -457,12 +465,21 @@ def run_java_fail_workflow(config: JavaFailWorkflowConfig, argv=None):
         is_verbose,
         explicit_repo_path,
         explicit_metrics_repo_path,
+        library_preparation_preflight_path,
     ) = parse_flags(config, argv if argv is not None else sys.argv[1:])
 
     strategy = require_strategy_by_name(strategy_name)
     reachability_repo_path, metrics_repo_dir, metrics_repo_root = resolve_repo_paths(
         explicit_repo_path,
         explicit_metrics_repo_path,
+    )
+    # Apply deterministic preflight setup into the resolved worktree before
+    # generation; only advisory guidance reaches the prompt context.
+    library_preparation_preflight, library_preparation_preflight_context = (
+        prepare_library_preparation_preflight(
+            library_preparation_preflight_path,
+            reachability_repo_path,
+        )
     )
     ensure_gh_authenticated()
     resolve_graalvm_java_home()
@@ -531,6 +548,7 @@ def run_java_fail_workflow(config: JavaFailWorkflowConfig, argv=None):
         test_language=test_source_layout.language,
         test_language_display_name=test_source_layout.display_language,
         test_source_dir_name=test_source_layout.source_dir_name,
+        library_preparation_preflight_context=library_preparation_preflight_context,
     )
 
     model_name = strategy.get("model") or DEFAULT_MODEL_NAME
@@ -587,6 +605,7 @@ def run_java_fail_workflow(config: JavaFailWorkflowConfig, argv=None):
             strategy_name=strategy_name,
             starting_commit=commit_checkpoint,
             ending_commit=ending_commit,
+            library_preparation_preflight=library_preparation_preflight,
         )
     else:
         if workflow_status == SUCCESS_WITH_INTERVENTION_STATUS:
@@ -609,6 +628,7 @@ def run_java_fail_workflow(config: JavaFailWorkflowConfig, argv=None):
             starting_commit=commit_checkpoint,
             ending_commit=ending_commit,
             post_generation_intervention=strategy_obj.post_generation_intervention,
+            library_preparation_preflight=library_preparation_preflight,
         )
     write_fix_metrics(config, run_metrics, metrics_repo_dir, metrics_repo_root=metrics_repo_root)
     return 0 if workflow_status in {RUN_STATUS_SUCCESS, SUCCESS_WITH_INTERVENTION_STATUS} else 1

--- a/forge/docs/orchestration-scripts.md
+++ b/forge/docs/orchestration-scripts.md
@@ -47,28 +47,65 @@ optimistic and authoritative against live GitHub state.
 
 ## 1. Library-Specific Preparation Decision
 
-Before dispatching a workflow for a library coordinate, orchestration may run a
-bounded LLM preflight decision that identifies whether the library needs
-additional setup beyond the normal generated test scaffold. The decision should
-consider the issue body, resolved artifact metadata, existing tests, source
-context, documentation, and known CI constraints.
+After claiming a supported issue and preparing its isolated worktree, but before
+dispatching the workflow driver, orchestration runs an LLM preflight decision
+that identifies whether the library needs additional setup beyond the normal
+generated test scaffold. Orchestration gives the agent a small starting context
+— issue text and any existing tests — and instructs it to research the library
+itself (its resolved artifact, dependencies, usage, and documentation) rather
+than deciding solely from that context. The agent investigates but must not
+modify the repository or apply setup; it returns only the decision.
 
 The preflight decision exists for library-specific requirements that are hard
-to infer from labels alone, such as optional Maven dependencies, feature-module
-artifacts, Docker-backed services, required allowed Docker images, environment
-configuration, or library setup code that must exist before meaningful tests
-can be generated. When the decision finds such a requirement, orchestration
-must pass it to the selected workflow as explicit preparation context so the
-agent can implement the needed build/test setup as part of the generated work
-(§WF-forge-workflow-drivers).
+to infer from labels alone, such as optional Maven dependencies, Docker-backed
+services and their required allowed Docker images, or library setup the agent
+must perform before meaningful tests can be generated.
+
+### 1.1 Deterministic setup versus advisory guidance
+
+The preflight decision separates its output into two distinct kinds, and the
+workflow driver routes each kind to a different consumer:
+
+- **Deterministic setup** is a typed, structurally-validated list of one-time,
+  idempotent source/config edits the driver applies itself before generation —
+  not free text injected into a prompt. The supported kinds are a `dependency`
+  declaration added to the library's test `build.gradle`, and a `docker_image`
+  pin added to the `allowed-docker-images` directory. Because the model only
+  supplies typed fields (a `group:artifact:version` coordinate, an image
+  reference and slug), they are validated by shape rather than scanned as prose,
+  and the driver applies each one once and idempotently. These are source-tree
+  edits, not environment mutations: the driver does not pull images, download
+  dependencies, or mutate the environment from the decision — the actual image
+  pull and dependency resolution stay gated by the allow-list and the build, and
+  local CI-equivalent verification (§FS-local-ci-equivalent-verification) remains
+  the sole authority for rejecting work CI would not accept.
+
+- **Advisory guidance** is the residual reasoning the agent must apply inside the
+  generated test code (for example, exercise a driver against a stood-up
+  service, or set a system property before a factory lookup). Only this guidance
+  is passed to the workflow as prompt context, and it is evidence, not trusted
+  instructions. Deterministic setup the driver already applied is omitted from
+  the prompt so an iterating workflow does not re-attempt a completed edit; any
+  deterministic item the driver could not apply yet (for example, a `dependency`
+  edit for a new library whose scaffold does not exist until generation) falls
+  back into the advisory guidance so the agent still performs it.
+
+This split is what keeps deterministic, idempotent edits out of the iteration
+loop and confines the prompt to reasoning. The driver — not orchestration and
+not a generated-run LLM agent — owns the decision of what to do with each field
+of the persisted record.
 
 The LLM decision is advisory input to workflow preparation, not a verification
 result. It must be recorded in metrics with the prompt, model, decision,
-evidence, and selected preparation actions. Docker and dependency preparation
-must still satisfy local CI-equivalent verification; a preflight decision must
-not allow tests to rely on untracked downloads, undeclared optional
-dependencies, or Docker images that CI would reject
-(§FS-local-ci-equivalent-verification).
+evidence, selected deterministic setup, advisory guidance, and the result of
+applying each deterministic action. A preflight decision must not allow tests to
+rely on untracked downloads, undeclared optional dependencies, or Docker images
+that CI would reject (§FS-local-ci-equivalent-verification).
+
+If the preflight decision cannot run or returns invalid, unavailable, or unsafe
+output, orchestration must degrade to a recorded no-action advisory result. It
+must keep the collected evidence and failure reason visible in metrics rather
+than silently omitting the preflight record.
 
 Orchestration scripts must not let a failed workflow silently disappear.
 Successful or chunk-ready runs (§WF-chunked-dynamic-access-pr-linking) proceed to

--- a/forge/fixture_github_issues/library-new-request-dynamic-access.yaml
+++ b/forge/fixture_github_issues/library-new-request-dynamic-access.yaml
@@ -35,3 +35,13 @@ comments:
       dynamic-access path. Keep generated tests if no dynamic-access call sites
       are found so the fixture still verifies routing, metrics, and publication
       handoff.
+library_preparation_preflight_response:
+  action: advisory_preparation
+  summary: "Fixture advisory setup for Google HTTP Client exercises preflight context handoff."
+  agent_guidance: >-
+    Cover HTTP transport-independent data model parsing and serialization paths.
+    Avoid live network calls; use in-memory requests, a mock transport, or
+    byte-array content, and prefer deterministic Google HTTP Client helpers that
+    run without external services.
+  risks:
+    - "Network-dependent tests would not satisfy local CI-equivalent verification."

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -51,7 +51,6 @@ import ai_workflows.core  # noqa: F401 - triggers strategy registration
 from ai_workflows.drivers.add_new_library_support import (
     DEFAULT_MODEL_NAME,
     init_agent as init_workflow_agent,
-    list_all_files,
     main as run_add_new_library_support_workflow,
 )
 from ai_workflows.drivers.fix_javac_fail import (
@@ -119,6 +118,10 @@ from utility_scripts.large_library_progress import (
     copy_progress_artifacts,
     find_progress_state_path,
 )
+from utility_scripts.library_preparation_preflight import (
+    LIBRARY_PREPARATION_PREFLIGHT_FILENAME,
+    run_library_preparation_preflight as run_preflight_decision,
+)
 from utility_scripts.metadata_index import (
     coordinate_parts as metadata_coordinate_parts,
     get_not_for_native_image_marker,
@@ -126,7 +129,7 @@ from utility_scripts.metadata_index import (
     resolve_metadata_version,
     resolve_test_dir,
 )
-from utility_scripts.metrics_writer import read_pending_metrics
+from utility_scripts.metrics_writer import PENDING_METRICS_FILENAME, read_pending_metrics
 from utility_scripts.repo_path_resolver import (
     git_env_limited_to_repo_root,
     get_forge_subdir_name,
@@ -174,6 +177,7 @@ GITHUB_RATE_LIMIT_EXIT_CODE = 75
 FIXTURE_E2E_LOG_DIRNAME = "fixture-e2e-logs"
 FIXTURE_RUN_LOG_FILENAME = "run.log"
 FIXTURE_PUBLICATION_FILENAME = "publication.md"
+FIXTURE_PREFLIGHT_EVIDENCE_DIRNAME = "preflight-evidence"
 REVIEW_PERIOD_SUFFIX_SECONDS = {
     "s": 1,
     "m": 60,
@@ -4030,10 +4034,38 @@ def append_large_library_workflow_args(pipeline_argv: list[str], claimed_issue: 
         pipeline_argv.extend(["--chunk-call-limit", chunk_call_limit])
 
 
+def run_library_preparation_preflight(
+        claimed_issue: ClaimedIssue,
+        strategy_name: str | None,
+) -> str:
+    """Run and persist the library-specific preparation preflight before workflow dispatch."""
+    fixture_response = False
+    if is_fixture_testing_enabled():
+        fixture_response = require_fixture_github_state().get_issue_library_preparation_preflight_response(
+            int(claimed_issue.issue["number"])
+        )
+    return run_preflight_decision(
+        claimed_issue=claimed_issue,
+        strategy_name=strategy_name,
+        issue_body_provider=get_issue_body,
+        init_agent=init_workflow_agent,
+        default_strategy_name=DEFAULT_WORK_QUEUE_STRATEGY_NAME,
+        default_model_name=DEFAULT_MODEL_NAME,
+        fixture_response=fixture_response,
+    )
+
+
+def append_library_preparation_preflight_arg(pipeline_argv: list[str], preflight_path: str | None) -> None:
+    """Append the dispatcher preflight path when one was produced."""
+    if preflight_path:
+        pipeline_argv.extend(["--library-preparation-preflight-path", preflight_path])
+
+
 def build_workflow_driver_invocation(
         claimed_issue: ClaimedIssue,
         strategy_name: str | None,
         keep_tests_without_dynamic_access: bool,
+        library_preparation_preflight_path: str | None = None,
 ) -> WorkflowDriverInvocation:
     """Build the routed workflow-driver command for a claimed issue."""
     issue_number = claimed_issue.issue["number"]
@@ -4043,6 +4075,7 @@ def build_workflow_driver_invocation(
             "--reachability-metadata-path", claimed_issue.worktree_path,
             "--metrics-repo-path", claimed_issue.scratch_metrics_repo_path,
         ]
+        append_library_preparation_preflight_arg(pipeline_argv, library_preparation_preflight_path)
         if strategy_name:
             pipeline_argv.extend(["--strategy-name", strategy_name])
         if keep_tests_without_dynamic_access:
@@ -4074,6 +4107,7 @@ def build_workflow_driver_invocation(
             "--reachability-metadata-path", claimed_issue.worktree_path,
             "--metrics-repo-path", claimed_issue.scratch_metrics_repo_path,
         ]
+        append_library_preparation_preflight_arg(pipeline_argv, library_preparation_preflight_path)
         if strategy_name:
             pipeline_argv.extend(["--strategy-name", strategy_name])
         return WorkflowDriverInvocation(
@@ -4102,6 +4136,7 @@ def build_workflow_driver_invocation(
             "--reachability-metadata-path", claimed_issue.worktree_path,
             "--metrics-repo-path", claimed_issue.scratch_metrics_repo_path,
         ]
+        append_library_preparation_preflight_arg(pipeline_argv, library_preparation_preflight_path)
         if strategy_name:
             pipeline_argv.extend(["--strategy-name", strategy_name])
         return WorkflowDriverInvocation(
@@ -4128,7 +4163,9 @@ def build_workflow_driver_invocation(
             "--coordinates", claimed_issue.current_coordinates,
             "--new-version", claimed_issue.new_version,
             "--reachability-metadata-path", claimed_issue.worktree_path,
+            "--metrics-repo-path", claimed_issue.scratch_metrics_repo_path,
         ]
+        append_library_preparation_preflight_arg(pipeline_argv, library_preparation_preflight_path)
         return WorkflowDriverInvocation(
             driver_name="fix_ni_run",
             script_name="fix_ni_run.py",
@@ -4154,6 +4191,7 @@ def build_workflow_driver_invocation(
             "--reachability-metadata-path", claimed_issue.worktree_path,
             "--metrics-repo-path", claimed_issue.scratch_metrics_repo_path,
         ]
+        append_library_preparation_preflight_arg(pipeline_argv, library_preparation_preflight_path)
         issue_requested_metadata_context = extract_issue_requested_metadata_context(get_issue_body(issue_number))
         if issue_requested_metadata_context:
             pipeline_argv.extend(["--issue-requested-metadata-context", issue_requested_metadata_context])
@@ -4195,10 +4233,15 @@ def invoke_pipeline(
     strategy names, and chunk context.
     """
     require_claimed_issue_worktree(claimed_issue, "workflow execution")
+    library_preparation_preflight_path = run_library_preparation_preflight(
+        claimed_issue,
+        strategy_name,
+    )
     invocation = build_workflow_driver_invocation(
         claimed_issue,
         strategy_name,
         keep_tests_without_dynamic_access,
+        library_preparation_preflight_path,
     )
 
     print()
@@ -5405,6 +5448,38 @@ def write_fixture_publication_handoff(handoff: PublicationHandoff) -> str:
     return publication_path
 
 
+def preserve_fixture_preflight_evidence(claimed_issue: ClaimedIssue) -> None:
+    """Copy fixture metrics/preflight files before scratch worktree cleanup."""
+    issue_number = int(claimed_issue.issue["number"])
+    evidence_dir = os.path.join(
+        get_fixture_issue_artifact_dir(issue_number),
+        FIXTURE_PREFLIGHT_EVIDENCE_DIRNAME,
+    )
+    os.makedirs(evidence_dir, exist_ok=True)
+    evidence_files = [
+        (PENDING_METRICS_FILENAME, "pending-metrics.json"),
+        (LIBRARY_PREPARATION_PREFLIGHT_FILENAME, LIBRARY_PREPARATION_PREFLIGHT_FILENAME),
+        ("library-preflight-prompt.txt", "library-preflight-prompt.txt"),
+        ("library-preflight-response.txt", "library-preflight-response.txt"),
+    ]
+    copied_files: list[str] = []
+    for source_name, target_name in evidence_files:
+        source_path = os.path.join(claimed_issue.scratch_metrics_repo_path, source_name)
+        if not os.path.isfile(source_path):
+            continue
+        target_path = os.path.join(evidence_dir, target_name)
+        shutil.copy2(source_path, target_path)
+        copied_files.append(target_name)
+    if copied_files:
+        log_stage(
+            "fixture-evidence",
+            (
+                f"Preserved fixture preflight evidence for issue #{issue_number}: "
+                f"{', '.join(copied_files)}"
+            ),
+        )
+
+
 def apply_large_library_completion_follow_up(claimed_issue: ClaimedIssue) -> None:
     """Apply issue labels after a large-library part was published."""
     run_metrics = _load_pending_run_metrics(claimed_issue.scratch_metrics_repo_path)
@@ -5434,6 +5509,7 @@ def finalize_successful_issue(
     if is_fixture_testing_enabled():
         handoff = build_publication_handoff(claimed_issue)
         publication_path = write_fixture_publication_handoff(handoff)
+        preserve_fixture_preflight_evidence(claimed_issue)
         log_stage(
             "publication",
             (

--- a/forge/prompt_templates/dynamic_access/dynamic-access-iteration.md
+++ b/forge/prompt_templates/dynamic_access/dynamic-access-iteration.md
@@ -11,6 +11,9 @@ Source Context:
 Issue-Requested Metadata:
 {issue_requested_metadata_context}
 
+Library Preparation Preflight:
+{library_preparation_preflight_context}
+
 Active class:
 - Class: {active_class_name}
 - Source file: {active_class_source_file}

--- a/forge/prompt_templates/dynamic_access/optimistic-dynamic-access-iteration-update.md
+++ b/forge/prompt_templates/dynamic_access/optimistic-dynamic-access-iteration-update.md
@@ -9,6 +9,9 @@ Source Context:
 Issue-Requested Metadata:
 {issue_requested_metadata_context}
 
+Library Preparation Preflight:
+{library_preparation_preflight_context}
+
 Iteration progress:
 {iteration_progress}
 

--- a/forge/prompt_templates/dynamic_access/optimistic-dynamic-access-iteration.md
+++ b/forge/prompt_templates/dynamic_access/optimistic-dynamic-access-iteration.md
@@ -6,6 +6,9 @@ Generate test for `{library}` following provided dynamic access report, by cover
 Source Context:
 {source_context_overview}
 
+Library Preparation Preflight:
+{library_preparation_preflight_context}
+
 Iteration progress:
 {iteration_progress}
 

--- a/forge/prompt_templates/fix-java-run/initial-with-sources.md
+++ b/forge/prompt_templates/fix-java-run/initial-with-sources.md
@@ -5,6 +5,9 @@ Task:
 Source context:
 {source_context_overview}
 
+Library Preparation Preflight:
+{library_preparation_preflight_context}
+
 How to use the source context:
 - Focus on source files for the classes explicitly named in the Gradle error output below.
 - Look for API changes, including renamed methods, changed signatures, removed classes, changed behavior, or new exceptions that explain the runtime failures.

--- a/forge/prompt_templates/fix-javac/initial-with-sources.md
+++ b/forge/prompt_templates/fix-javac/initial-with-sources.md
@@ -5,6 +5,9 @@ Task:
 Source context:
 {source_context_overview}
 
+Library Preparation Preflight:
+{library_preparation_preflight_context}
+
 How to use the source context (strict):
 - Only open source files that correspond or are related to the classes explicitly named in the Gradle error output below.
 - Stop inspecting sources as soon as you have identified the renamed/removed/changed API for the failing symbols. Then make the minimal edit to the test.

--- a/forge/prompt_templates/initial/basic_initial.md
+++ b/forge/prompt_templates/initial/basic_initial.md
@@ -6,6 +6,9 @@ You need to generate comprehensive tests for the library defined by these Maven 
 Issue-Requested Metadata:
 {issue_requested_metadata_context}
 
+Library Preparation Preflight:
+{library_preparation_preflight_context}
+
 Rules:
 - Write tests in `{test_language_display_name}` under the module's existing `src/test/{test_source_dir_name}` tree.
 - Follow idiomatic `{test_language_display_name}` coding conventions.

--- a/forge/utility_scripts/fixture_github.py
+++ b/forge/utility_scripts/fixture_github.py
@@ -84,6 +84,7 @@ class FixtureIssue:
     comments: list[FixtureComment]
     fixture_path: str
     url: str
+    library_preparation_preflight_response: Any | None = None
 
     def issue_view_payload(self, include_body: bool = False, include_state: bool = True) -> JsonObject:
         payload: JsonObject = {
@@ -109,7 +110,7 @@ class FixtureIssue:
         }
 
     def to_json(self) -> JsonObject:
-        return {
+        payload: JsonObject = {
             "number": self.number,
             "title": self.title,
             "body": self.body,
@@ -126,6 +127,9 @@ class FixtureIssue:
             "comments": [comment.to_json() for comment in self.comments],
             "fixture_path": self.fixture_path,
         }
+        if self.library_preparation_preflight_response is not None:
+            payload["library_preparation_preflight_response"] = self.library_preparation_preflight_response
+        return payload
 
 
 class FixtureGitHubState:
@@ -168,6 +172,9 @@ class FixtureGitHubState:
 
     def get_issue_fixture_path(self, issue_number: int) -> str:
         return self._issue(issue_number).fixture_path
+
+    def get_issue_library_preparation_preflight_response(self, issue_number: int) -> Any | None:
+        return self._issue(issue_number).library_preparation_preflight_response
 
     def get_issue_project_number(self, issue_number: int) -> int:
         return self._issue(issue_number).project_number
@@ -614,6 +621,14 @@ def normalize_fixture_issue(raw_issue: JsonObject, fixture_path: str) -> Fixture
     blockers = _normalize_blockers(issue, context)
     comments = _normalize_comments(_optional_list(issue, "comments", context, default=[]), context)
     url = _optional_str(issue, "url", context, default=f"fixture://fixture_github_issues/{number}")
+    library_preparation_preflight_response = issue.get("library_preparation_preflight_response")
+    if library_preparation_preflight_response is not None and not isinstance(
+            library_preparation_preflight_response,
+            (dict, str),
+    ):
+        raise FixtureValidationError(
+            f"{context}: `library_preparation_preflight_response` must be an object or string"
+        )
 
     return FixtureIssue(
         number=number,
@@ -629,6 +644,7 @@ def normalize_fixture_issue(raw_issue: JsonObject, fixture_path: str) -> Fixture
         comments=comments,
         fixture_path=os.path.abspath(fixture_path),
         url=url,
+        library_preparation_preflight_response=library_preparation_preflight_response,
     )
 
 

--- a/forge/utility_scripts/library_preparation_preflight.py
+++ b/forge/utility_scripts/library_preparation_preflight.py
@@ -1,0 +1,802 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+"""Shared helpers for library-specific preparation preflight records."""
+
+import json
+import os
+import re
+from typing import Any, Callable
+
+from utility_scripts.metadata_index import (
+    coordinate_parts as metadata_coordinate_parts,
+    resolve_test_dir,
+)
+from utility_scripts.stage_logger import log_stage
+from utility_scripts.strategy_loader import load_strategy_by_name
+
+LIBRARY_PREPARATION_PREFLIGHT_FILENAME = ".library_preparation_preflight.json"
+NO_LIBRARY_PREPARATION_PREFLIGHT_CONTEXT = (
+    "Library preparation preflight did not request additional setup."
+)
+DEFAULT_LIBRARY_PREFLIGHT_STRATEGY_ENV = "FORGE_LIBRARY_PREFLIGHT_STRATEGY_NAME"
+DEFAULT_LIBRARY_PREFLIGHT_MODEL_NAME = "oca/gpt-5.4"
+LIBRARY_PREFLIGHT_MAX_ISSUE_BODY_CHARS = 8000
+LIBRARY_PREFLIGHT_MAX_TEST_FILES = 40
+LIBRARY_PREFLIGHT_MAX_DETERMINISTIC_SETUP = 8
+# Only the free-text advisory guidance is scanned for these; the deterministic
+# setup entries are validated structurally and cannot smuggle prose commands.
+LIBRARY_PREFLIGHT_UNSAFE_TERMS = (
+    "sudo",
+    "curl ",
+    "wget ",
+    "git clone",
+    "rm -rf",
+    "docker run",
+    "credential",
+    "secret",
+    "token",
+)
+# Deterministic setup the driver applies itself, idempotently, as source edits
+# (§ORCH-forge-orchestration-spec.1.1). Anything else stays advisory guidance.
+LIBRARY_PREFLIGHT_DETERMINISTIC_KINDS = ("dependency", "docker_image")
+LIBRARY_PREFLIGHT_DEPENDENCY_SCOPES = (
+    "testImplementation",
+    "testRuntimeOnly",
+    "implementation",
+    "runtimeOnly",
+)
+_DEPENDENCY_COORDINATE_RE = re.compile(r"^[\w.\-]+:[\w.\-]+:[\w.\-]+$")
+_DOCKER_IMAGE_RE = re.compile(r"^[\w][\w./\-]*(:[\w][\w.\-]*)?$")
+_DOCKER_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9_\-]*$")
+ALLOWED_DOCKER_IMAGES_RELDIR = os.path.join(
+    "tests", "tck-build-logic", "src", "main", "resources", "allowed-docker-images"
+)
+
+
+def _truncate_preflight_text(value: str | None, max_chars: int) -> str:
+    """Return bounded text for the preflight evidence bundle."""
+    if not value:
+        return ""
+    stripped = value.strip()
+    if len(stripped) <= max_chars:
+        return stripped
+    return stripped[:max_chars] + "\n...[truncated]"
+
+
+def _target_library_for_preflight(claimed_issue: Any) -> str:
+    """Return the library coordinate the workflow will edit or verify."""
+    if claimed_issue.label in {"library-new-request", "library-update-request"}:
+        return claimed_issue.issue_coordinates
+    if claimed_issue.current_coordinates and claimed_issue.new_version:
+        group, artifact, _version = metadata_coordinate_parts(claimed_issue.current_coordinates)
+        return f"{group}:{artifact}:{claimed_issue.new_version}"
+    return claimed_issue.issue_coordinates
+
+
+def _preflight_evidence(name: str, summary: str) -> dict[str, str]:
+    """Build one schema-compatible preflight evidence summary."""
+    return {"name": name, "summary": _truncate_preflight_text(summary, 1000) or "not available"}
+
+
+def _list_all_files(root_dir: str) -> list[str]:
+    """Return all regular files under a directory in stable order."""
+    result: list[str] = []
+    for dirpath, _dirnames, filenames in os.walk(root_dir):
+        for file_name in sorted(filenames):
+            result.append(os.path.join(dirpath, file_name))
+    return result
+
+
+def _list_preflight_test_files(repo_path: str, coordinate: str) -> list[str]:
+    """Return a bounded list of existing test files for a supported coordinate."""
+    try:
+        group, artifact, version = metadata_coordinate_parts(coordinate)
+        if version is None:
+            return []
+        test_dir = resolve_test_dir(repo_path, group, artifact, version)
+    except Exception:
+        return []
+    if not os.path.isdir(test_dir):
+        return []
+    files = []
+    for file_path in _list_all_files(test_dir):
+        if len(files) >= LIBRARY_PREFLIGHT_MAX_TEST_FILES:
+            break
+        files.append(os.path.relpath(file_path, repo_path))
+    return files
+
+
+def build_library_preflight_input_bundle(
+        claimed_issue: Any,
+        issue_body_provider: Callable[[int], str],
+) -> dict[str, Any]:
+    """Collect the small starting context the preflight agent researches from."""
+    issue_number = int(claimed_issue.issue["number"])
+    target_library = _target_library_for_preflight(claimed_issue)
+    issue_body_error = ""
+    try:
+        issue_body = _truncate_preflight_text(
+            issue_body_provider(issue_number),
+            LIBRARY_PREFLIGHT_MAX_ISSUE_BODY_CHARS,
+        )
+    except Exception as exc:
+        issue_body = ""
+        issue_body_error = f"{type(exc).__name__}: {exc}"
+    existing_test_coordinates = [
+        coordinate for coordinate in (
+            claimed_issue.current_coordinates,
+            claimed_issue.issue_coordinates,
+            target_library,
+        )
+        if coordinate
+    ]
+    existing_tests: dict[str, list[str]] = {}
+    for coordinate in dict.fromkeys(existing_test_coordinates):
+        files = _list_preflight_test_files(claimed_issue.worktree_path, coordinate)
+        if files:
+            existing_tests[coordinate] = files
+
+    return {
+        "issue": {
+            "number": issue_number,
+            "title": claimed_issue.issue.get("title") or "",
+            "label": claimed_issue.label,
+            "body": issue_body,
+            "body_error": issue_body_error,
+        },
+        "library": target_library,
+        "current_library": claimed_issue.current_coordinates,
+        "new_version": claimed_issue.new_version,
+        "existing_tests": existing_tests,
+    }
+
+
+def _library_preflight_input_evidence(input_bundle: dict[str, Any]) -> list[dict[str, str]]:
+    """Summarize the preflight bundle for durable metrics."""
+    issue = input_bundle.get("issue") if isinstance(input_bundle.get("issue"), dict) else {}
+    issue_body = str(issue.get("body") or "")
+    issue_body_error = str(issue.get("body_error") or "")
+    existing_tests = input_bundle.get("existing_tests") or {}
+    return [
+        _preflight_evidence(
+            "issue",
+            (
+                f"#{issue.get('number')} {issue.get('title')}; "
+                f"label={issue.get('label')}; body_chars={len(issue_body)}"
+                f"{'; body_error=' + issue_body_error if issue_body_error else ''}"
+            ),
+        ),
+        _preflight_evidence(
+            "existing_tests",
+            f"{sum(len(files) for files in existing_tests.values())} existing test file path(s) included",
+        ),
+    ]
+
+
+def _base_library_preflight_record(
+        claimed_issue: Any,
+        input_bundle: dict[str, Any],
+) -> dict[str, Any]:
+    """Return fields common to completed and degraded preflight records."""
+    record: dict[str, Any] = {
+        "status": "degraded",
+        "action": "no_action",
+        "issue_number": int(claimed_issue.issue["number"]),
+        "issue_label": claimed_issue.label,
+        "library": str(input_bundle.get("library") or _target_library_for_preflight(claimed_issue)),
+        "summary": "",
+        "deterministic_setup": [],
+        "agent_guidance": "",
+        "risks": [],
+        "applied_setup": [],
+        "input_evidence": _library_preflight_input_evidence(input_bundle),
+    }
+    if claimed_issue.current_coordinates:
+        record["current_library"] = claimed_issue.current_coordinates
+    if claimed_issue.new_version:
+        record["new_version"] = claimed_issue.new_version
+    return record
+
+
+def _degraded_library_preflight_record(
+        claimed_issue: Any,
+        input_bundle: dict[str, Any],
+        failure_reason: str,
+        model_name: str | None = None,
+        prompt_path: str | None = None,
+        raw_response_path: str | None = None,
+        session_log_path: str | None = None,
+) -> dict[str, Any]:
+    """Record an unavailable or unusable preflight as no-action advisory output."""
+    record = _base_library_preflight_record(claimed_issue, input_bundle)
+    record["summary"] = "Library preparation preflight did not produce usable advisory setup."
+    record["failure_reason"] = failure_reason
+    if model_name:
+        record["model"] = model_name
+    if prompt_path:
+        record["prompt_path"] = prompt_path
+    if raw_response_path:
+        record["raw_response_path"] = raw_response_path
+    if session_log_path:
+        record["session_log_path"] = session_log_path
+    return record
+
+
+def _extract_preflight_json_response(response_text: str) -> dict[str, Any]:
+    """Extract a JSON object from an LLM response."""
+    try:
+        loaded = json.loads(response_text)
+        if isinstance(loaded, dict):
+            return loaded
+    except json.JSONDecodeError:
+        pass
+
+    start = response_text.find("{")
+    end = response_text.rfind("}")
+    if start < 0 or end <= start:
+        raise ValueError("response did not contain a JSON object")
+    loaded = json.loads(response_text[start:end + 1])
+    if not isinstance(loaded, dict):
+        raise ValueError("response JSON was not an object")
+    return loaded
+
+
+def _preflight_string_list(value: Any, limit: int = 8) -> list[str]:
+    """Normalize a JSON value into a bounded list of non-empty strings."""
+    if isinstance(value, str):
+        values = [value]
+    elif isinstance(value, list):
+        values = value
+    else:
+        values = []
+    normalized = []
+    for item in values:
+        if not isinstance(item, str) or not item.strip():
+            continue
+        normalized.append(_truncate_preflight_text(item, 600))
+        if len(normalized) >= limit:
+            break
+    return normalized
+
+
+def _preflight_contains_unsafe_text(*values: Any) -> bool:
+    """Return True when advisory text asks for unsafe preparation behavior."""
+    combined = "\n".join(str(value).lower() for value in values if value is not None)
+    return any(term in combined for term in LIBRARY_PREFLIGHT_UNSAFE_TERMS)
+
+
+def _parse_deterministic_setup_entry(entry: Any) -> dict[str, str] | None:
+    """Validate one deterministic-setup entry by shape, or drop it (return None)."""
+    if not isinstance(entry, dict):
+        return None
+    kind = str(entry.get("kind") or "").strip()
+    reason = _truncate_preflight_text(str(entry.get("reason") or ""), 300)
+    if kind == "dependency":
+        coordinate = str(entry.get("coordinate") or "").strip()
+        if not _DEPENDENCY_COORDINATE_RE.match(coordinate):
+            return None
+        scope = str(entry.get("scope") or "testImplementation").strip()
+        if scope not in LIBRARY_PREFLIGHT_DEPENDENCY_SCOPES:
+            scope = "testImplementation"
+        return {"kind": kind, "coordinate": coordinate, "scope": scope, "reason": reason}
+    if kind == "docker_image":
+        image = str(entry.get("image") or "").strip()
+        slug = str(entry.get("slug") or "").strip().lower()
+        if not _DOCKER_IMAGE_RE.match(image) or not _DOCKER_SLUG_RE.match(slug):
+            return None
+        return {"kind": kind, "image": image, "slug": slug, "reason": reason}
+    return None
+
+
+def _parse_deterministic_setup(value: Any) -> list[dict[str, str]]:
+    """Normalize the response's deterministic setup into validated, bounded entries."""
+    if not isinstance(value, list):
+        return []
+    parsed: list[dict[str, str]] = []
+    for entry in value:
+        validated = _parse_deterministic_setup_entry(entry)
+        if validated is None:
+            continue
+        parsed.append(validated)
+        if len(parsed) >= LIBRARY_PREFLIGHT_MAX_DETERMINISTIC_SETUP:
+            break
+    return parsed
+
+
+def _completed_library_preflight_record(
+        claimed_issue: Any,
+        input_bundle: dict[str, Any],
+        response_payload: dict[str, Any],
+        model_name: str,
+        agent: Any | None,
+        prompt_path: str | None,
+        raw_response_path: str | None,
+        session_log_path: str | None,
+) -> dict[str, Any]:
+    """Normalize a valid preflight response into the persisted metrics shape."""
+    action = str(response_payload.get("action") or "no_action").strip()
+    if action not in {"no_action", "advisory_preparation"}:
+        raise ValueError(f"unsupported preflight action: {action}")
+    summary = _truncate_preflight_text(str(response_payload.get("summary") or ""), 1000)
+    deterministic_setup = _parse_deterministic_setup(response_payload.get("deterministic_setup"))
+    agent_guidance = _truncate_preflight_text(str(response_payload.get("agent_guidance") or ""), 2000)
+    risks = _preflight_string_list(response_payload.get("risks"))
+    if action == "advisory_preparation" and not (deterministic_setup or agent_guidance):
+        raise ValueError("advisory_preparation response did not include deterministic setup or guidance")
+    # Deterministic entries are validated structurally above; only the free-text
+    # advisory fields can carry prose, so only those are scanned for unsafe terms.
+    if _preflight_contains_unsafe_text(summary, agent_guidance, risks):
+        raise ValueError("preflight response requested unsafe preparation behavior")
+
+    record = _base_library_preflight_record(claimed_issue, input_bundle)
+    record["status"] = "completed"
+    record["action"] = action
+    record["summary"] = summary
+    record["deterministic_setup"] = deterministic_setup
+    record["agent_guidance"] = agent_guidance
+    record["risks"] = risks
+    record["model"] = model_name
+    record["input_tokens_used"] = int(getattr(agent, "total_tokens_sent", 0) or 0)
+    record["output_tokens_used"] = int(getattr(agent, "total_tokens_received", 0) or 0)
+    if prompt_path:
+        record["prompt_path"] = prompt_path
+    if raw_response_path:
+        record["raw_response_path"] = raw_response_path
+    if session_log_path:
+        record["session_log_path"] = session_log_path
+    return record
+
+
+def _library_preflight_prompt(input_bundle: dict[str, Any]) -> str:
+    """Build the LLM prompt instructing the agent to research preparation needs."""
+    return (
+        "You are preparing a Forge workflow for a library issue. Decide whether this "
+        "library needs additional setup beyond the normal generated test scaffold, "
+        "such as optional Maven dependencies, a Docker-backed service and its allowed "
+        "image, or library initialization the test must perform before meaningful "
+        "coverage is reachable.\n\n"
+        "Research the library yourself to make this decision. Investigate the resolved "
+        "artifact and its dependencies, how the library is normally used, and its "
+        "documentation. The JSON context below is only a starting point, not the limit "
+        "of what you may consider. Do not modify the repository or apply any setup "
+        "yourself — return only the decision. The driver applies deterministic setup, "
+        "and local Gradle and Native Image verification remain authoritative.\n\n"
+        "Split any needed setup into two kinds. `deterministic_setup` is a typed list of "
+        "one-time, idempotent edits the driver applies for you; supported kinds:\n"
+        '  - {"kind": "dependency", "coordinate": "group:artifact:version", '
+        '"scope": "testImplementation", "reason": "..."}\n'
+        '  - {"kind": "docker_image", "image": "name:tag", "slug": "short-slug", "reason": "..."}\n'
+        "`agent_guidance` is concise reasoning the workflow agent must apply inside the generated "
+        "test code (for example, exercise a driver against a stood-up service, or set a system "
+        "property before a factory lookup). Do not restate deterministic edits as guidance.\n\n"
+        "Return a single JSON object with this shape:\n"
+        "{\n"
+        '  "action": "no_action" | "advisory_preparation",\n'
+        '  "summary": "short reason",\n'
+        '  "deterministic_setup": [ ... typed entries as above, if any ... ],\n'
+        '  "agent_guidance": "concise guidance for the workflow agent, if any",\n'
+        '  "risks": ["risk notes, if any"]\n'
+        "}\n\n"
+        "Choose no_action unless your research finds concrete evidence that extra setup is needed.\n\n"
+        "Context (starting point):\n"
+        f"{json.dumps(input_bundle, indent=2, ensure_ascii=False)}"
+    )
+
+
+def _relative_or_absolute_path(path: str | None, root: str) -> str | None:
+    """Return a stable metrics path, relative when it is under the metrics root."""
+    if not path:
+        return None
+    try:
+        absolute_path = os.path.abspath(path)
+        absolute_root = os.path.abspath(root)
+        if os.path.commonpath([absolute_path, absolute_root]) == absolute_root:
+            return os.path.relpath(absolute_path, absolute_root)
+    except ValueError:
+        pass
+    return path
+
+
+def _write_text_artifact(root: str, file_name: str, content: str) -> str:
+    """Write a preflight text artifact and return its metrics-root-relative path."""
+    os.makedirs(root, exist_ok=True)
+    path = os.path.join(root, file_name)
+    with open(path, "w", encoding="utf-8") as artifact_file:
+        artifact_file.write(content)
+    return os.path.relpath(path, root)
+
+
+def _fixture_response_text(fixture_response: Any) -> str:
+    """Serialize a configured fixture response like an agent response body."""
+    if isinstance(fixture_response, str):
+        return fixture_response
+    return json.dumps(fixture_response, indent=2, ensure_ascii=False)
+
+
+def _preflight_run_mode(fixture_response: Any | None) -> str:
+    """Describe how the preflight decision is being produced, for logging."""
+    if fixture_response is False:
+        return "live"
+    if fixture_response is None:
+        return "fixture (no response configured)"
+    return "fixture (configured response)"
+
+
+def _write_and_log_preflight(claimed_issue: Any, record: dict[str, Any]) -> str:
+    """Persist the record and log a one-line outcome, covering every decision path."""
+    detail = f"status={record.get('status')} action={record.get('action')}"
+    setup_count = len(record.get("deterministic_setup") or [])
+    if setup_count:
+        detail += f" deterministic_setup={setup_count}"
+    failure_reason = record.get("failure_reason")
+    if failure_reason:
+        detail += f" reason={failure_reason}"
+    log_stage(
+        "library-preflight",
+        f"Preflight decision for issue #{record.get('issue_number')}: {detail}",
+    )
+    return write_library_preparation_preflight(claimed_issue.scratch_metrics_repo_path, record)
+
+
+def run_library_preparation_preflight(
+        claimed_issue: Any,
+        strategy_name: str | None,
+        issue_body_provider: Callable[[int], str],
+        init_agent: Callable[..., Any],
+        default_strategy_name: str,
+        default_model_name: str = DEFAULT_LIBRARY_PREFLIGHT_MODEL_NAME,
+        fixture_response: Any | None = None,
+) -> str:
+    """Run and persist the library-specific preparation preflight before workflow dispatch."""
+    selected_strategy_name = (
+        os.environ.get(DEFAULT_LIBRARY_PREFLIGHT_STRATEGY_ENV)
+        or strategy_name
+        or default_strategy_name
+    )
+    input_bundle = build_library_preflight_input_bundle(
+        claimed_issue,
+        issue_body_provider,
+    )
+    log_stage(
+        "library-preflight",
+        (
+            f"Running preflight for issue #{claimed_issue.issue['number']} "
+            f"({_preflight_run_mode(fixture_response)}) "
+            f"library={input_bundle.get('library')} strategy={selected_strategy_name}"
+        ),
+    )
+    prompt = _library_preflight_prompt(input_bundle)
+    prompt_path = _write_text_artifact(
+        claimed_issue.scratch_metrics_repo_path,
+        "library-preflight-prompt.txt",
+        prompt,
+    )
+    raw_response_path: str | None = None
+    session_log_path: str | None = None
+    model_name = default_model_name
+
+    if fixture_response is None:
+        record = _degraded_library_preflight_record(
+            claimed_issue,
+            input_bundle,
+            "fixture-testing mode did not configure a library preparation preflight response",
+            model_name="fixture-no-response",
+            prompt_path=prompt_path,
+        )
+        return _write_and_log_preflight(claimed_issue, record)
+
+    if fixture_response is not False:
+        try:
+            response_text = _fixture_response_text(fixture_response)
+            raw_response_path = _write_text_artifact(
+                claimed_issue.scratch_metrics_repo_path,
+                "library-preflight-response.txt",
+                response_text,
+            )
+            response_payload = _extract_preflight_json_response(response_text)
+            record = _completed_library_preflight_record(
+                claimed_issue,
+                input_bundle,
+                response_payload,
+                "fixture-configured-response",
+                None,
+                prompt_path,
+                raw_response_path,
+                None,
+            )
+        except Exception as exc:
+            record = _degraded_library_preflight_record(
+                claimed_issue,
+                input_bundle,
+                f"{type(exc).__name__}: {exc}",
+                model_name="fixture-configured-response",
+                prompt_path=prompt_path,
+                raw_response_path=raw_response_path,
+            )
+        return _write_and_log_preflight(claimed_issue, record)
+
+    strategy = load_strategy_by_name(selected_strategy_name)
+    if strategy is None:
+        record = _degraded_library_preflight_record(
+            claimed_issue,
+            input_bundle,
+            f"preflight strategy not found: {selected_strategy_name}",
+            prompt_path=prompt_path,
+        )
+        return _write_and_log_preflight(claimed_issue, record)
+
+    model_name = str(strategy.get("model") or default_model_name)
+    agent: Any | None = None
+    try:
+        agent = init_agent(
+            strategy=strategy,
+            working_dir=claimed_issue.worktree_path,
+            editable_files=[],
+            read_only_files=[],
+            library=str(input_bundle.get("library") or ""),
+            task_type="library-preparation-preflight",
+            verbose=False,
+            model_name=model_name,
+        )
+        response_text = agent.send_prompt(prompt)
+        raw_response_path = _write_text_artifact(
+            claimed_issue.scratch_metrics_repo_path,
+            "library-preflight-response.txt",
+            response_text,
+        )
+        session_log_path = _relative_or_absolute_path(
+            getattr(agent, "_session_log_path", None),
+            claimed_issue.scratch_metrics_repo_path,
+        )
+        response_payload = _extract_preflight_json_response(response_text)
+        record = _completed_library_preflight_record(
+            claimed_issue,
+            input_bundle,
+            response_payload,
+            model_name,
+            agent,
+            prompt_path,
+            raw_response_path,
+            session_log_path,
+        )
+    except Exception as exc:
+        if session_log_path is None and agent is not None:
+            session_log_path = _relative_or_absolute_path(
+                getattr(agent, "_session_log_path", None),
+                claimed_issue.scratch_metrics_repo_path,
+            )
+        record = _degraded_library_preflight_record(
+            claimed_issue,
+            input_bundle,
+            f"{type(exc).__name__}: {exc}",
+            model_name=model_name,
+            prompt_path=prompt_path,
+            raw_response_path=raw_response_path,
+            session_log_path=session_log_path,
+        )
+    return _write_and_log_preflight(claimed_issue, record)
+
+
+def write_library_preparation_preflight(metrics_repo_root: str, preflight: dict[str, Any]) -> str:
+    """Persist the dispatcher's library preparation preflight record."""
+    os.makedirs(metrics_repo_root, exist_ok=True)
+    preflight_path = os.path.join(metrics_repo_root, LIBRARY_PREPARATION_PREFLIGHT_FILENAME)
+    with open(preflight_path, "w", encoding="utf-8") as preflight_file:
+        json.dump(preflight, preflight_file, indent=2, ensure_ascii=False)
+        preflight_file.write("\n")
+    return preflight_path
+
+
+def load_library_preparation_preflight(preflight_path: str | None) -> dict[str, Any] | None:
+    """Load a preflight record passed by the dispatcher."""
+    if not preflight_path:
+        return None
+    if not os.path.isfile(preflight_path):
+        return None
+    with open(preflight_path, "r", encoding="utf-8") as preflight_file:
+        loaded = json.load(preflight_file)
+    return loaded if isinstance(loaded, dict) else None
+
+
+def _insert_into_dependencies_block(text: str, new_line: str) -> str | None:
+    """Insert a dependency line before the close of the `dependencies { }` block."""
+    lines = text.splitlines(keepends=True)
+    start = None
+    for index, line in enumerate(lines):
+        if re.match(r"\s*dependencies\s*\{", line):
+            start = index
+            break
+    if start is None:
+        return None
+    for index in range(start + 1, len(lines)):
+        if lines[index].strip() == "}":
+            lines.insert(index, new_line)
+            return "".join(lines)
+    return None
+
+
+def _apply_dependency_setup(
+        reachability_repo_path: str,
+        library_coordinate: str,
+        entry: dict[str, str],
+) -> dict[str, str]:
+    """Idempotently add a dependency to the target library's test build.gradle."""
+    coordinate = entry["coordinate"]
+    scope = entry.get("scope", "testImplementation")
+    result: dict[str, str] = {"kind": "dependency", "coordinate": coordinate}
+    try:
+        group, artifact, version = metadata_coordinate_parts(library_coordinate)
+    except Exception:
+        return {**result, "result": "skipped", "reason": "unresolved_library_coordinate"}
+    if version is None:
+        return {**result, "result": "skipped", "reason": "missing_library_version"}
+    try:
+        version_dir = resolve_test_dir(reachability_repo_path, group, artifact, version)
+    except Exception as exc:
+        return {**result, "result": "skipped", "reason": f"unresolved_test_dir:{type(exc).__name__}"}
+    build_gradle = os.path.join(version_dir, "build.gradle")
+    if not os.path.isfile(build_gradle):
+        # New-library scaffold does not exist yet; falls back to advisory guidance.
+        return {**result, "result": "skipped", "reason": "build_gradle_absent"}
+    with open(build_gradle, "r", encoding="utf-8") as gradle_file:
+        text = gradle_file.read()
+    dep_group, dep_artifact, _dep_version = metadata_coordinate_parts(coordinate)
+    if re.search(rf"""['"]{re.escape(dep_group)}:{re.escape(dep_artifact)}[:'"]""", text):
+        return {**result, "result": "already_present", "target": os.path.relpath(build_gradle, reachability_repo_path)}
+    updated = _insert_into_dependencies_block(text, f'    {scope} "{coordinate}"\n')
+    if updated is None:
+        return {**result, "result": "skipped", "reason": "no_dependencies_block"}
+    with open(build_gradle, "w", encoding="utf-8") as gradle_file:
+        gradle_file.write(updated)
+    return {**result, "result": "applied", "target": os.path.relpath(build_gradle, reachability_repo_path)}
+
+
+def _apply_docker_image_setup(reachability_repo_path: str, entry: dict[str, str]) -> dict[str, str]:
+    """Idempotently add a Dockerfile pin to the allowed-docker-images directory."""
+    image = entry["image"]
+    slug = entry["slug"]
+    result: dict[str, str] = {"kind": "docker_image", "image": image, "slug": slug}
+    images_dir = os.path.join(reachability_repo_path, ALLOWED_DOCKER_IMAGES_RELDIR)
+    if not os.path.isdir(images_dir):
+        return {**result, "result": "skipped", "reason": "allowed_images_dir_absent"}
+    target = os.path.join(images_dir, f"Dockerfile-{slug}")
+    relative_target = os.path.relpath(target, reachability_repo_path)
+    desired = f"FROM {image}\n"
+    if os.path.isfile(target):
+        with open(target, "r", encoding="utf-8") as image_file:
+            existing = image_file.read()
+        if existing.strip() == desired.strip():
+            return {**result, "result": "already_present", "target": relative_target}
+        # Do not clobber an existing pin that resolves to a different image.
+        return {**result, "result": "skipped", "reason": "slug_conflict", "target": relative_target}
+    with open(target, "w", encoding="utf-8") as image_file:
+        image_file.write(desired)
+    return {**result, "result": "applied", "target": relative_target}
+
+
+def apply_library_preparation_setup(
+        preflight: dict[str, Any] | None,
+        reachability_repo_path: str,
+) -> dict[str, Any] | None:
+    """Apply deterministic preflight setup once and idempotently, recording results.
+
+    Driver-owned step (§ORCH-forge-orchestration-spec.1.1): typed `dependency` and
+    `docker_image` entries are applied as source edits; unappliable entries are
+    left for the advisory guidance fallback. Mutates and returns the record.
+    """
+    if not isinstance(preflight, dict):
+        return preflight
+    if preflight.get("status") != "completed" or preflight.get("action") != "advisory_preparation":
+        preflight.setdefault("applied_setup", [])
+        return preflight
+    library_coordinate = str(preflight.get("library") or "")
+    applied: list[dict[str, str]] = []
+    for entry in preflight.get("deterministic_setup") or []:
+        kind = entry.get("kind") if isinstance(entry, dict) else None
+        try:
+            if kind == "dependency":
+                applied.append(_apply_dependency_setup(reachability_repo_path, library_coordinate, entry))
+            elif kind == "docker_image":
+                applied.append(_apply_docker_image_setup(reachability_repo_path, entry))
+        except Exception as exc:
+            applied.append({"kind": str(kind), "result": "skipped", "reason": f"{type(exc).__name__}: {exc}"})
+    preflight["applied_setup"] = applied
+    return preflight
+
+
+def prepare_library_preparation_preflight(
+        preflight_path: str | None,
+        reachability_repo_path: str,
+) -> tuple[dict[str, Any] | None, str]:
+    """Driver entry point: load the record, apply deterministic setup, render context.
+
+    Returns the (mutated) record for metrics and the advisory-only prompt context.
+    Must run after the reachability repo path is resolved so source edits land in
+    the right worktree (§ORCH-forge-orchestration-spec.1.1).
+    """
+    preflight = load_library_preparation_preflight(preflight_path)
+    apply_library_preparation_setup(preflight, reachability_repo_path)
+    if isinstance(preflight, dict):
+        applied = preflight.get("applied_setup") or []
+        if applied:
+            summary = ", ".join(
+                f"{item.get('kind')}:{item.get('result')}"
+                for item in applied if isinstance(item, dict)
+            )
+            log_stage("library-preflight", f"Applied deterministic setup: {summary}")
+    context = format_library_preparation_preflight_context(preflight)
+    return preflight, context
+
+
+def _format_bullets(values: list[Any]) -> str:
+    lines: list[str] = []
+    for value in values:
+        if isinstance(value, str) and value.strip():
+            lines.append(f"- {value.strip()}")
+    return "\n".join(lines)
+
+
+def _describe_setup_entry(entry: dict[str, str]) -> str:
+    """Render one deterministic-setup entry as agent-facing fallback work."""
+    kind = entry.get("kind")
+    if kind == "dependency":
+        return f"Add {entry.get('scope', 'testImplementation')} dependency {entry.get('coordinate')}"
+    if kind == "docker_image":
+        return f"Use Docker image {entry.get('image')} (allow-list slug {entry.get('slug')})"
+    return str(entry)
+
+
+def _pending_setup_descriptions(preflight: dict[str, Any]) -> list[str]:
+    """Describe deterministic entries the driver did not apply, for agent fallback."""
+    results: dict[tuple[Any, Any], Any] = {}
+    for item in preflight.get("applied_setup") or []:
+        if isinstance(item, dict):
+            results[(item.get("kind"), item.get("coordinate") or item.get("slug"))] = item.get("result")
+    descriptions: list[str] = []
+    for entry in preflight.get("deterministic_setup") or []:
+        if not isinstance(entry, dict):
+            continue
+        key = (entry.get("kind"), entry.get("coordinate") or entry.get("slug"))
+        if results.get(key) in {"applied", "already_present"}:
+            continue
+        descriptions.append(_describe_setup_entry(entry))
+    return descriptions
+
+
+def format_library_preparation_preflight_context(preflight: dict[str, Any] | None) -> str:
+    """Render the advisory portion of a preflight record for workflow prompt context.
+
+    Deterministic setup the driver already applied is intentionally omitted so an
+    iterating workflow does not re-attempt a completed edit; only advisory guidance
+    and unapplied-setup fallback reach the prompt (§ORCH-forge-orchestration-spec.1.1).
+    """
+    if not isinstance(preflight, dict):
+        return NO_LIBRARY_PREPARATION_PREFLIGHT_CONTEXT
+
+    action = str(preflight.get("action") or "no_action")
+    summary = str(preflight.get("summary") or "").strip()
+    if action != "advisory_preparation":
+        reason = str(preflight.get("failure_reason") or "").strip()
+        if reason:
+            return f"{NO_LIBRARY_PREPARATION_PREFLIGHT_CONTEXT} Reason: {reason}"
+        if summary:
+            return f"{NO_LIBRARY_PREPARATION_PREFLIGHT_CONTEXT} Summary: {summary}"
+        return NO_LIBRARY_PREPARATION_PREFLIGHT_CONTEXT
+
+    guidance = str(preflight.get("agent_guidance") or "").strip()
+    pending_setup = _format_bullets(_pending_setup_descriptions(preflight))
+    risks = _format_bullets(preflight.get("risks") or [])
+
+    sections = ["Library preparation preflight produced advisory guidance."]
+    if summary:
+        sections.extend(["", f"Summary: {summary}"])
+    if guidance:
+        sections.extend(["", "Agent guidance:", guidance])
+    if pending_setup:
+        sections.extend(["", "Setup to perform in the generated work:", pending_setup])
+    if risks:
+        sections.extend(["", "Risks:", risks])
+    return "\n".join(sections)

--- a/forge/utility_scripts/metrics_writer.py
+++ b/forge/utility_scripts/metrics_writer.py
@@ -413,6 +413,7 @@ def build_run_metrics_dict(
         stats: dict | None = None,
         previous_library_stats: dict | None = None,
         post_generation_intervention: dict | None = None,
+        library_preparation_preflight: dict | None = None,
 ):
     """Assemble the run_metrics dict."""
     metrics = {
@@ -459,6 +460,8 @@ def build_run_metrics_dict(
         run_metrics["previous_library_stats"] = previous_library_stats
     if post_generation_intervention is not None:
         run_metrics["post_generation_intervention"] = post_generation_intervention
+    if library_preparation_preflight is not None:
+        run_metrics["library_preparation_preflight"] = library_preparation_preflight
     run_metrics["metrics"] = metrics
     run_metrics["artifacts"] = {
         "test_file": test_file,
@@ -535,6 +538,7 @@ def create_run_metrics_output_json(
         starting_commit: str | None = None,
         ending_commit: str | None = None,
         post_generation_intervention: dict | None = None,
+        library_preparation_preflight: dict | None = None,
 ):
     """
     Build a run_metrics dict using collected metrics.
@@ -577,6 +581,7 @@ def create_run_metrics_output_json(
         metadata_file=metadata_file,
         stats=stats,
         post_generation_intervention=post_generation_intervention,
+        library_preparation_preflight=library_preparation_preflight,
     )
 
 
@@ -595,6 +600,7 @@ def create_javac_fix_run_metrics_output_json(
         starting_commit: str | None = None,
         ending_commit: str | None = None,
         post_generation_intervention: dict | None = None,
+        library_preparation_preflight: dict | None = None,
 ):
     """Build run metrics for fix_javac_fail workflow including previous-version metrics."""
     metrics = collect_base_metrics(
@@ -649,6 +655,7 @@ def create_javac_fix_run_metrics_output_json(
         stats=stats,
         previous_library_stats=previous_stats,
         post_generation_intervention=post_generation_intervention,
+        library_preparation_preflight=library_preparation_preflight,
     )
 
 
@@ -666,6 +673,7 @@ def create_failure_run_metrics_output(
         strategy_name,
         starting_commit: str | None = None,
         ending_commit: str | None = None,
+        library_preparation_preflight: dict | None = None,
 ):
     """Builds failure metrics when no valid unit tests were generated."""
     token_metrics = collect_token_usage_metrics(agent, model_name)
@@ -692,6 +700,7 @@ def create_failure_run_metrics_output(
         total_entries=0,
         test_file="None",
         metadata_file="None",
+        library_preparation_preflight=library_preparation_preflight,
     )
 
 

--- a/stats/schemas/run-metrics-output-schema-v1.0.1.json
+++ b/stats/schemas/run-metrics-output-schema-v1.0.1.json
@@ -153,6 +153,212 @@
         }
       }
     },
+    "libraryPreparationPreflightEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "summary"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "libraryPreparationDeterministicSetup": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "dependency",
+            "docker_image"
+          ]
+        },
+        "coordinate": {
+          "type": "string",
+          "pattern": "^[^:]+:[^:]+:[^:]+$"
+        },
+        "scope": {
+          "type": "string",
+          "minLength": 1
+        },
+        "image": {
+          "type": "string",
+          "minLength": 1
+        },
+        "slug": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reason": {
+          "type": "string"
+        }
+      }
+    },
+    "libraryPreparationAppliedSetup": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "result"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "minLength": 1
+        },
+        "result": {
+          "type": "string",
+          "enum": [
+            "applied",
+            "already_present",
+            "skipped"
+          ]
+        },
+        "coordinate": {
+          "type": "string",
+          "minLength": 1
+        },
+        "image": {
+          "type": "string",
+          "minLength": 1
+        },
+        "slug": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "libraryPreparationPreflight": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "action",
+        "issue_number",
+        "issue_label",
+        "library",
+        "summary",
+        "deterministic_setup",
+        "agent_guidance",
+        "risks",
+        "applied_setup",
+        "input_evidence"
+      ],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "completed",
+            "degraded"
+          ]
+        },
+        "action": {
+          "type": "string",
+          "enum": [
+            "no_action",
+            "advisory_preparation"
+          ]
+        },
+        "issue_number": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "issue_label": {
+          "type": "string",
+          "minLength": 1
+        },
+        "library": {
+          "type": "string",
+          "pattern": "^[^:]+:[^:]+:[^:]+$"
+        },
+        "current_library": {
+          "type": "string",
+          "pattern": "^[^:]+:[^:]+:[^:]+$"
+        },
+        "new_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "summary": {
+          "type": "string"
+        },
+        "deterministic_setup": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/libraryPreparationDeterministicSetup"
+          }
+        },
+        "agent_guidance": {
+          "type": "string"
+        },
+        "risks": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "applied_setup": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/libraryPreparationAppliedSetup"
+          }
+        },
+        "input_evidence": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/libraryPreparationPreflightEvidence"
+          }
+        },
+        "failure_reason": {
+          "type": "string",
+          "minLength": 1
+        },
+        "model": {
+          "type": "string",
+          "minLength": 1
+        },
+        "input_tokens_used": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "output_tokens_used": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "prompt_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "raw_response_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "session_log_path": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
     "runMetrics": {
       "type": "object",
       "additionalProperties": false,
@@ -240,6 +446,10 @@
               "description": "Markdown explanation generated for the post-generation failure."
             }
           }
+        },
+        "library_preparation_preflight": {
+          "$ref": "#/definitions/libraryPreparationPreflight",
+          "description": "Dispatcher advisory preflight record collected before workflow-driver dispatch."
         },
         "stats": {
           "$ref": "#/definitions/statsSnapshot",


### PR DESCRIPTION
Closes #7628

## What this does

Adds a **library-specific preparation preflight** to Forge: a bounded, advisory
LLM decision that runs after a supported issue is claimed and its worktree is
set up, but **before** the workflow driver is dispatched
(§ORCH-forge-orchestration-spec.1). It surfaces per-library setup that the issue
label alone cannot express, and records it for maintainers — while **local
CI-equivalent verification remains the sole authority** for accepting or
rejecting work (§FS-local-ci-equivalent-verification). The preflight can never
approve a run, skip verification, or override a failure.

## How the decision is produced

The preflight is given a **small starting context** — issue text and any
existing tests for the coordinate — and is instructed to **research the library
itself** (its resolved artifact, dependencies, usual usage, and documentation)
rather than deciding solely from that context. It investigates but must not
modify the repository; it returns only a structured decision. Every outcome is
persisted as a `.library_preparation_preflight.json` sidecar and embedded in run
metrics; any failure (bad output, unsafe content, agent error) **degrades to a
recorded no-action result** rather than blocking the run.

## Algorithmic vs neural split (§ORCH-forge-orchestration-spec.1.1)

The decision is divided into two kinds, each routed to a different consumer:

- **Deterministic setup** — a typed, structurally-validated list of one-time,
  idempotent source edits the **driver applies itself** before generation:
  - `dependency` → adds a line to the library's test `build.gradle`
  - `docker_image` → adds a `Dockerfile-<slug>` pin to `allowed-docker-images`

  Because the model supplies only typed fields, these are validated by shape
  (not scanned as prose), applied once and idempotently. Any entry that can't be
  applied yet — e.g. a new-library scaffold whose `build.gradle` doesn't exist
  until generation — **falls back into the advisory guidance** so nothing is
  lost. The driver does not pull images or download dependencies from the
  decision; those stay gated by the allow-list and the build.

- **Advisory guidance** — the residual reasoning the agent applies inside the
  generated test code (e.g. exercise a driver against a stood-up service, set a
  system property before a factory lookup). **Only this reaches the prompt**;
  deterministic setup the driver already applied is omitted so an iterating
  workflow does not re-attempt a completed edit, keeping idempotent edits out of
  the iteration loop.

## Metrics, drivers, fixtures, logging

- Run-metrics schema (`run-metrics-output-schema-v1.0.1`) records the decision:
  `deterministic_setup`, `agent_guidance`, `applied_setup` (per-action results),
  `input_evidence`, plus prompt/model/token/log references.
- The four supported drivers (`add_new_library_support`,
  `improve_library_coverage`, `fix_ni_run`, `java_fail_workflow`) load -> apply
  -> render the preflight **after the worktree is resolved**, and inject only
  advisory context into their prompt templates.
- Fixture-backed E2E coverage exercises the preflight evidence path.
- Every preflight path (live / fixture / degraded) and the applied-setup outcome
  are logged under the `library-preflight` stage.
