### PR TITLE
[GenAI] Test fix for com.clickhouse:jdbc-v2:0.9.7 using gpt-5.5

### DIFF
--- a/metadata/com.clickhouse/jdbc-v2/0.9.7/reachability-metadata.json
+++ b/metadata/com.clickhouse/jdbc-v2/0.9.7/reachability-metadata.json
@@ -1,0 +1,132 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.clickhouse.client.api.Client"
+      },
+      "type": "byte[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.clickhouse.jdbc.internal.JdbcConfiguration"
+      },
+      "type": "java.lang.Object[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.clickhouse.jdbc.internal.JdbcUtils"
+      },
+      "type": "java.lang.String[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.clickhouse.client.api.internal.HttpAPIClientHelper"
+      },
+      "type": "java.net.InetAddress[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.clickhouse.jdbc.Driver"
+      },
+      "type": "java.sql.DriverPropertyInfo[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.clickhouse.jdbc.StatementImpl"
+      },
+      "type": "java.sql.SQLException"
+    },
+    {
+      "condition": {
+        "typeReached": "com.clickhouse.client.api.DataTypeUtils"
+      },
+      "type": "java.time.format.DateTimeFormatterBuilder$DateTimePrinterParser[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.clickhouse.jdbc.internal.JdbcUtils"
+      },
+      "type": "java.util.Map$Entry[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.clickhouse.client.api.internal.HttpAPIClientHelper"
+      },
+      "type": "jdk.net.LinuxSocketOptions"
+    },
+    {
+      "condition": {
+        "typeReached": "com.clickhouse.client.api.Client"
+      },
+      "type": "net.jpountz.lz4.LZ4HCJNICompressor"
+    },
+    {
+      "condition": {
+        "typeReached": "com.clickhouse.client.api.Client"
+      },
+      "type": "net.jpountz.lz4.LZ4JNICompressor"
+    },
+    {
+      "condition": {
+        "typeReached": "com.clickhouse.client.api.Client"
+      },
+      "type": "net.jpountz.lz4.LZ4JNISafeDecompressor"
+    },
+    {
+      "condition": {
+        "typeReached": "com.clickhouse.client.api.internal.HttpAPIClientHelper"
+      },
+      "type": "org.apache.hc.core5.http.Header[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.clickhouse.client.api.Client"
+      },
+      "type": "sun.security.provider.NativePRNG"
+    },
+    {
+      "condition": {
+        "typeReached": "com.clickhouse.client.api.Client"
+      },
+      "type": "sun.security.provider.SHA"
+    },
+    {
+      "condition": {
+        "typeReached": "com.clickhouse.jdbc.ConnectionImpl"
+      },
+      "type": "sun.util.resources.cldr.CalendarData"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "com.clickhouse.logging.LoggerFactory"
+      },
+      "glob": "META-INF/services/com.clickhouse.logging.LoggerFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "com.clickhouse.jdbc.StatementImpl"
+      },
+      "glob": "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "com.clickhouse.client.config.ClickHouseClientOption"
+      },
+      "glob": "client-v2-version.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "com.clickhouse.client.config.ClickHouseClientOption"
+      },
+      "glob": "jdbc-v2-version.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "com.clickhouse.client.api.internal.HttpAPIClientHelper"
+      },
+      "glob": "org/apache/hc/client5/version.properties"
+    }
+  ]
+}

--- a/metadata/com.clickhouse/jdbc-v2/0.9.7/reachability-metadata.json
+++ b/metadata/com.clickhouse/jdbc-v2/0.9.7/reachability-metadata.json
@@ -1,132 +1,132 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "com.clickhouse.client.api.Client"
+      "condition" : {
+        "typeReached" : "com.clickhouse.client.api.Client"
       },
-      "type": "byte[][]"
+      "type" : "byte[][]"
     },
     {
-      "condition": {
-        "typeReached": "com.clickhouse.jdbc.internal.JdbcConfiguration"
+      "condition" : {
+        "typeReached" : "com.clickhouse.jdbc.internal.JdbcConfiguration"
       },
-      "type": "java.lang.Object[]"
+      "type" : "java.lang.Object[]"
     },
     {
-      "condition": {
-        "typeReached": "com.clickhouse.jdbc.internal.JdbcUtils"
+      "condition" : {
+        "typeReached" : "com.clickhouse.jdbc.internal.JdbcUtils"
       },
-      "type": "java.lang.String[][]"
+      "type" : "java.lang.String[][]"
     },
     {
-      "condition": {
-        "typeReached": "com.clickhouse.client.api.internal.HttpAPIClientHelper"
+      "condition" : {
+        "typeReached" : "com.clickhouse.client.api.internal.HttpAPIClientHelper"
       },
-      "type": "java.net.InetAddress[]"
+      "type" : "java.net.InetAddress[]"
     },
     {
-      "condition": {
-        "typeReached": "com.clickhouse.jdbc.Driver"
+      "condition" : {
+        "typeReached" : "com.clickhouse.jdbc.Driver"
       },
-      "type": "java.sql.DriverPropertyInfo[]"
+      "type" : "java.sql.DriverPropertyInfo[]"
     },
     {
-      "condition": {
-        "typeReached": "com.clickhouse.jdbc.StatementImpl"
+      "condition" : {
+        "typeReached" : "com.clickhouse.jdbc.StatementImpl"
       },
-      "type": "java.sql.SQLException"
+      "type" : "java.sql.SQLException"
     },
     {
-      "condition": {
-        "typeReached": "com.clickhouse.client.api.DataTypeUtils"
+      "condition" : {
+        "typeReached" : "com.clickhouse.client.api.DataTypeUtils"
       },
-      "type": "java.time.format.DateTimeFormatterBuilder$DateTimePrinterParser[]"
+      "type" : "java.time.format.DateTimeFormatterBuilder$DateTimePrinterParser[]"
     },
     {
-      "condition": {
-        "typeReached": "com.clickhouse.jdbc.internal.JdbcUtils"
+      "condition" : {
+        "typeReached" : "com.clickhouse.jdbc.internal.JdbcUtils"
       },
-      "type": "java.util.Map$Entry[]"
+      "type" : "java.util.Map$Entry[]"
     },
     {
-      "condition": {
-        "typeReached": "com.clickhouse.client.api.internal.HttpAPIClientHelper"
+      "condition" : {
+        "typeReached" : "com.clickhouse.client.api.internal.HttpAPIClientHelper"
       },
-      "type": "jdk.net.LinuxSocketOptions"
+      "type" : "jdk.net.LinuxSocketOptions"
     },
     {
-      "condition": {
-        "typeReached": "com.clickhouse.client.api.Client"
+      "condition" : {
+        "typeReached" : "com.clickhouse.client.api.Client"
       },
-      "type": "net.jpountz.lz4.LZ4HCJNICompressor"
+      "type" : "net.jpountz.lz4.LZ4HCJNICompressor"
     },
     {
-      "condition": {
-        "typeReached": "com.clickhouse.client.api.Client"
+      "condition" : {
+        "typeReached" : "com.clickhouse.client.api.Client"
       },
-      "type": "net.jpountz.lz4.LZ4JNICompressor"
+      "type" : "net.jpountz.lz4.LZ4JNICompressor"
     },
     {
-      "condition": {
-        "typeReached": "com.clickhouse.client.api.Client"
+      "condition" : {
+        "typeReached" : "com.clickhouse.client.api.Client"
       },
-      "type": "net.jpountz.lz4.LZ4JNISafeDecompressor"
+      "type" : "net.jpountz.lz4.LZ4JNISafeDecompressor"
     },
     {
-      "condition": {
-        "typeReached": "com.clickhouse.client.api.internal.HttpAPIClientHelper"
+      "condition" : {
+        "typeReached" : "com.clickhouse.client.api.internal.HttpAPIClientHelper"
       },
-      "type": "org.apache.hc.core5.http.Header[]"
+      "type" : "org.apache.hc.core5.http.Header[]"
     },
     {
-      "condition": {
-        "typeReached": "com.clickhouse.client.api.Client"
+      "condition" : {
+        "typeReached" : "com.clickhouse.client.api.Client"
       },
-      "type": "sun.security.provider.NativePRNG"
+      "type" : "sun.security.provider.NativePRNG"
     },
     {
-      "condition": {
-        "typeReached": "com.clickhouse.client.api.Client"
+      "condition" : {
+        "typeReached" : "com.clickhouse.client.api.Client"
       },
-      "type": "sun.security.provider.SHA"
+      "type" : "sun.security.provider.SHA"
     },
     {
-      "condition": {
-        "typeReached": "com.clickhouse.jdbc.ConnectionImpl"
+      "condition" : {
+        "typeReached" : "com.clickhouse.jdbc.ConnectionImpl"
       },
-      "type": "sun.util.resources.cldr.CalendarData"
+      "type" : "sun.util.resources.cldr.CalendarData"
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "com.clickhouse.logging.LoggerFactory"
+      "condition" : {
+        "typeReached" : "com.clickhouse.logging.LoggerFactory"
       },
-      "glob": "META-INF/services/com.clickhouse.logging.LoggerFactory"
+      "glob" : "META-INF/services/com.clickhouse.logging.LoggerFactory"
     },
     {
-      "condition": {
-        "typeReached": "com.clickhouse.jdbc.StatementImpl"
+      "condition" : {
+        "typeReached" : "com.clickhouse.jdbc.StatementImpl"
       },
-      "glob": "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
+      "glob" : "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
     },
     {
-      "condition": {
-        "typeReached": "com.clickhouse.client.config.ClickHouseClientOption"
+      "condition" : {
+        "typeReached" : "com.clickhouse.client.config.ClickHouseClientOption"
       },
-      "glob": "client-v2-version.properties"
+      "glob" : "client-v2-version.properties"
     },
     {
-      "condition": {
-        "typeReached": "com.clickhouse.client.config.ClickHouseClientOption"
+      "condition" : {
+        "typeReached" : "com.clickhouse.client.config.ClickHouseClientOption"
       },
-      "glob": "jdbc-v2-version.properties"
+      "glob" : "jdbc-v2-version.properties"
     },
     {
-      "condition": {
-        "typeReached": "com.clickhouse.client.api.internal.HttpAPIClientHelper"
+      "condition" : {
+        "typeReached" : "com.clickhouse.client.api.internal.HttpAPIClientHelper"
       },
-      "glob": "org/apache/hc/client5/version.properties"
+      "glob" : "org/apache/hc/client5/version.properties"
     }
   ]
 }

--- a/metadata/com.clickhouse/jdbc-v2/index.json
+++ b/metadata/com.clickhouse/jdbc-v2/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "0.9.7",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/clickhouse/jdbc-v2/$version$/jdbc-v2-$version$-sources.jar",
+    "repository-url" : "https://github.com/ClickHouse/clickhouse-java",
+    "test-code-url" : "https://github.com/ClickHouse/clickhouse-java/tree/v$version$/jdbc-v2/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/clickhouse/jdbc-v2/$version$/jdbc-v2-$version$-javadoc.jar",
+    "description" : "ClickHouse JDBC Driver V2 implements the standard Java Database Connectivity API for connecting JVM applications to ClickHouse databases. It builds on the ClickHouse Java client to execute SQL statements, read result sets, handle metadata, and support JDBC DataSource and Driver integrations.",
     "tested-versions" : [
       "0.9.7"
     ],

--- a/metadata/com.clickhouse/jdbc-v2/index.json
+++ b/metadata/com.clickhouse/jdbc-v2/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "0.9.7",
+    "tested-versions" : [
+      "0.9.7"
+    ],
+    "allowed-packages" : [
+      "com.clickhouse"
+    ]
+  },
+  {
     "metadata-version" : "0.9.5",
     "source-code-url" : "https://repo.maven.apache.org/maven2/com/clickhouse/jdbc-v2/$version$/jdbc-v2-$version$-sources.jar",
     "repository-url" : "https://github.com/ClickHouse/clickhouse-java",

--- a/stats/com.clickhouse/jdbc-v2/0.9.7/execution-metrics.json
+++ b/stats/com.clickhouse/jdbc-v2/0.9.7/execution-metrics.json
@@ -1,0 +1,101 @@
+{
+  "fix_java_run_fail:2026-06-08": {
+    "timestamp": "2026-06-08T02:20:30.424757Z",
+    "library": "com.clickhouse:jdbc-v2:0.9.7",
+    "starting_commit": "d70f22852b59c7eb8783ccbc45fd636ace86111b",
+    "ending_commit": "003e82d9f6ffab7742034115eb4e4c2e7d780be6",
+    "previous_library": "com.clickhouse:jdbc-v2:0.9.5",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "0.9.7",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 4,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 16547,
+          "missed": 110294,
+          "ratio": 0.130455,
+          "total": 126841
+        },
+        "line": {
+          "covered": 2801,
+          "missed": 23898,
+          "ratio": 0.10491,
+          "total": 26699
+        },
+        "method": {
+          "covered": 550,
+          "missed": 5995,
+          "ratio": 0.084034,
+          "total": 6545
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "0.9.5",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 4,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 14305,
+          "missed": 107842,
+          "ratio": 0.117113,
+          "total": 122147
+        },
+        "line": {
+          "covered": 2746,
+          "missed": 23546,
+          "ratio": 0.104442,
+          "total": 26292
+        },
+        "method": {
+          "covered": 539,
+          "missed": 5630,
+          "ratio": 0.087372,
+          "total": 6169
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 48836,
+      "cached_input_tokens_used": 516608,
+      "output_tokens_used": 2457,
+      "iterations": 2,
+      "cost_usd": 0.332,
+      "tested_library_loc": 2801,
+      "metadata_entries": 21,
+      "test_only_metadata_entries": 19,
+      "previous_library_metadata_entries": 23,
+      "previous_library_test_only_metadata_entries": 19,
+      "code_coverage_percent": 10.49,
+      "previous_library_coverage_percent": 10.44
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.clickhouse/jdbc-v2/0.9.7/src/test/java/com_clickhouse/jdbc_v2/JdbcUtilsTest.java",
+      "metadata_file": "metadata/com.clickhouse/jdbc-v2/0.9.7/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.clickhouse/jdbc-v2/0.9.7/stats.json
+++ b/stats/com.clickhouse/jdbc-v2/0.9.7/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "0.9.7",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 4,
+          "totalCalls" : 4
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 4,
+      "totalCalls" : 4
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 16547,
+        "missed" : 110294,
+        "ratio" : 0.130455,
+        "total" : 126841
+      },
+      "line" : {
+        "covered" : 2801,
+        "missed" : 23898,
+        "ratio" : 0.10491,
+        "total" : 26699
+      },
+      "method" : {
+        "covered" : 550,
+        "missed" : 5995,
+        "ratio" : 0.084034,
+        "total" : 6545
+      }
+    }
+  } ]
+}

--- a/tests/src/com.clickhouse/jdbc-v2/0.9.7/.gitignore
+++ b/tests/src/com.clickhouse/jdbc-v2/0.9.7/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.clickhouse/jdbc-v2/0.9.7/build.gradle
+++ b/tests/src/com.clickhouse/jdbc-v2/0.9.7/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.clickhouse:jdbc-v2:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.clickhouse/jdbc-v2/0.9.7/gradle.properties
+++ b/tests/src/com.clickhouse/jdbc-v2/0.9.7/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.clickhouse:jdbc-v2:0.9.7
+library.version = 0.9.7
+metadata.dir = com.clickhouse/jdbc-v2/0.9.7/

--- a/tests/src/com.clickhouse/jdbc-v2/0.9.7/settings.gradle
+++ b/tests/src/com.clickhouse/jdbc-v2/0.9.7/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.clickhouse.jdbc-v2_tests'

--- a/tests/src/com.clickhouse/jdbc-v2/0.9.7/src/test/java/com_clickhouse/jdbc_v2/JdbcUtilsTest.java
+++ b/tests/src/com.clickhouse/jdbc-v2/0.9.7/src/test/java/com_clickhouse/jdbc_v2/JdbcUtilsTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_clickhouse.jdbc_v2;
+
+import com.clickhouse.jdbc.internal.JdbcUtils;
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JdbcUtilsTest {
+    @Test
+    void convertListCreatesNestedTypedArrays() throws SQLException {
+        List<?> values = List.of(
+                List.of(1, 2),
+                List.of(3, 4));
+
+        Object converted = JdbcUtils.convertList(values, String.class, 2);
+
+        assertThat(converted).isInstanceOf(String[][].class);
+        String[][] actual = (String[][]) converted;
+        assertThat(actual[0]).containsExactly("1", "2");
+        assertThat(actual[1]).containsExactly("3", "4");
+    }
+
+    @Test
+    void convertArrayCreatesNestedTypedArrays() throws SQLException {
+        Object values = new Object[] {
+                new Object[] {1, 2},
+                new Object[] {3, 4}
+        };
+
+        Object converted = JdbcUtils.convertArray(values, String.class, 2);
+
+        assertThat(converted).isInstanceOf(String[][].class);
+        String[][] actual = (String[][]) converted;
+        assertThat(actual[0]).containsExactly("1", "2");
+        assertThat(actual[1]).containsExactly("3", "4");
+    }
+}

--- a/tests/src/com.clickhouse/jdbc-v2/0.9.7/src/test/java/com_clickhouse/jdbc_v2/Jdbc_v2Test.java
+++ b/tests/src/com.clickhouse/jdbc-v2/0.9.7/src/test/java/com_clickhouse/jdbc_v2/Jdbc_v2Test.java
@@ -1,0 +1,381 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_clickhouse.jdbc_v2;
+
+import com.clickhouse.data.ClickHouseColumn;
+import com.clickhouse.data.ClickHouseDataType;
+import com.clickhouse.data.Tuple;
+import com.clickhouse.jdbc.DataSourceImpl;
+import com.clickhouse.jdbc.Driver;
+import com.clickhouse.jdbc.PreparedStatementImpl;
+import com.clickhouse.jdbc.metadata.ResultSetMetaDataImpl;
+import com.clickhouse.jdbc.types.Array;
+import org.junit.jupiter.api.Test;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.math.BigDecimal;
+import java.net.InetAddress;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.DriverPropertyInfo;
+import java.sql.JDBCType;
+import java.sql.ParameterMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.Statement;
+import java.sql.Types;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.TimeZone;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class Jdbc_v2Test {
+    private static final String URL = "jdbc:clickhouse://localhost:8123/default";
+
+    @Test
+    void driverRecognizesClickHouseUrlsAndExposesConfiguration() throws Exception {
+        Driver driver = new Driver();
+        Properties properties = offlineProperties();
+        properties.setProperty("user", "property-user");
+
+        assertThat(driver.acceptsURL("jdbc:clickhouse://localhost:8123/default")).isTrue();
+        assertThat(driver.acceptsURL("jdbc:ch://localhost:8123/default")).isTrue();
+        assertThat(driver.acceptsURL("jdbc:postgresql://localhost:5432/postgres")).isFalse();
+        assertThat(driver.connect("jdbc:postgresql://localhost:5432/postgres", properties)).isNull();
+        assertThat(driver.jdbcCompliant()).isFalse();
+        assertThat(driver.getMajorVersion()).isEqualTo(Driver.getDriverMajorVersion());
+        assertThat(driver.getMinorVersion()).isEqualTo(Driver.getDriverMinorVersion());
+        assertThat(Driver.chSettingKey("max_threads")).isEqualTo("clickhouse_setting_max_threads");
+        assertThatThrownBy(driver::getParentLogger).isInstanceOf(SQLFeatureNotSupportedException.class);
+
+        DriverPropertyInfo[] propertyInfos = driver.getPropertyInfo(
+                "jdbc:clickhouse://localhost:8123/analytics?user=url-user&socket_timeout=250", properties);
+        Map<String, String> valuesByName = new LinkedHashMap<>();
+        for (DriverPropertyInfo propertyInfo : propertyInfos) {
+            valuesByName.put(propertyInfo.name, propertyInfo.value);
+        }
+
+        assertThat(valuesByName)
+                .containsEntry("database", "analytics")
+                .containsEntry("user", "url-user")
+                .containsEntry("socket_timeout", "250")
+                .containsKey("server_time_zone");
+    }
+
+    @Test
+    void dataSourceProvidesJdbcWrapperSemanticsAndConnections() throws Exception {
+        DataSourceImpl dataSource = new DataSourceImpl(URL, offlineProperties());
+        StringWriter sink = new StringWriter();
+        PrintWriter logWriter = new PrintWriter(sink);
+
+        dataSource.setLogWriter(logWriter);
+
+        assertThat(dataSource.getLogWriter()).isSameAs(logWriter);
+        assertThat(dataSource.isWrapperFor(DataSourceImpl.class)).isTrue();
+        assertThat(dataSource.unwrap(DataSourceImpl.class)).isSameAs(dataSource);
+        assertThatThrownBy(() -> dataSource.unwrap(String.class)).isInstanceOf(SQLException.class);
+        assertThatThrownBy(() -> dataSource.setLoginTimeout(1)).isInstanceOf(SQLFeatureNotSupportedException.class);
+        assertThatThrownBy(dataSource::getLoginTimeout).isInstanceOf(SQLFeatureNotSupportedException.class);
+        assertThatThrownBy(dataSource::getParentLogger).isInstanceOf(SQLFeatureNotSupportedException.class);
+
+        try (Connection connection = dataSource.getConnection("user-from-call", "secret")) {
+            assertThat(connection).isNotNull();
+            assertThat(connection.isClosed()).isFalse();
+        }
+    }
+
+    @Test
+    void connectionExposesOfflineJdbcStateAndUnsupportedOperations() throws Exception {
+        try (Connection connection = openConnection()) {
+            assertThat(connection.getAutoCommit()).isTrue();
+            assertThat(connection.isReadOnly()).isFalse();
+            assertThat(connection.getTransactionIsolation()).isEqualTo(Connection.TRANSACTION_NONE);
+            assertThat(connection.isValid(0)).isFalse();
+            assertThat(connection.getSchema()).isEqualTo("default");
+            assertThat(connection.getCatalog()).isNull();
+            assertThat(connection.getWarnings() == null).isTrue();
+            assertThat(connection.getHoldability()).isEqualTo(ResultSet.HOLD_CURSORS_OVER_COMMIT);
+            assertThat(connection.isWrapperFor(Connection.class)).isTrue();
+            assertThat(connection.unwrap(Connection.class)).isSameAs(connection);
+
+            connection.setSchema("analytics");
+            connection.setClientInfo("ApplicationName", "metadata-test");
+            assertThat(connection.getSchema()).isEqualTo("analytics");
+            assertThat(connection.getClientInfo("ApplicationName")).isEqualTo("metadata-test");
+            assertThat(connection.getClientInfo()).containsEntry("ApplicationName", "metadata-test");
+
+            DatabaseMetaData metadata = connection.getMetaData();
+            assertThat(metadata.getDatabaseProductName()).isEqualTo("ClickHouse");
+            assertThat(metadata.getDriverName()).isEqualTo("ClickHouse JDBC Driver");
+            assertThat(metadata.supportsTransactions()).isFalse();
+            assertThat(metadata.supportsMultipleResultSets()).isFalse();
+            assertThat(metadata.supportsColumnAliasing()).isTrue();
+
+            assertThatThrownBy(() -> connection.setAutoCommit(false))
+                    .isInstanceOf(SQLFeatureNotSupportedException.class);
+            assertThatThrownBy(connection::commit).isInstanceOf(SQLFeatureNotSupportedException.class);
+            assertThatThrownBy(connection::rollback).isInstanceOf(SQLFeatureNotSupportedException.class);
+            connection.setReadOnly(true);
+            assertThat(connection.isReadOnly()).isTrue();
+            assertThatThrownBy(() -> connection.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED))
+                    .isInstanceOf(SQLFeatureNotSupportedException.class);
+        }
+    }
+
+    @Test
+    void statementMaintainsJdbcStateWithoutExecutingQueries() throws Exception {
+        try (Connection connection = openConnection(); Statement statement = connection.createStatement()) {
+            assertThat(statement.getConnection()).isSameAs(connection);
+            assertThat(statement.getResultSet()).isNull();
+            assertThat(statement.getUpdateCount()).isEqualTo(-1);
+            assertThat(statement.getMoreResults()).isFalse();
+            assertThat(statement.getWarnings() == null).isTrue();
+            assertThat(statement.getFetchDirection()).isEqualTo(ResultSet.FETCH_FORWARD);
+            assertThat(statement.getFetchSize()).isPositive();
+            assertThat(statement.getResultSetConcurrency()).isEqualTo(ResultSet.CONCUR_READ_ONLY);
+            assertThat(statement.getResultSetType()).isEqualTo(ResultSet.TYPE_FORWARD_ONLY);
+            assertThat(statement.getResultSetHoldability()).isEqualTo(ResultSet.HOLD_CURSORS_OVER_COMMIT);
+            assertThat(statement.isPoolable()).isFalse();
+            assertThat(statement.isCloseOnCompletion()).isFalse();
+            assertThat(statement.getGeneratedKeys()).isNull();
+            assertThat(statement.getLargeUpdateCount()).isEqualTo(-1L);
+
+            statement.setMaxRows(42);
+            statement.setQueryTimeout(3);
+            statement.setFetchSize(128);
+            statement.setPoolable(true);
+            statement.addBatch("INSERT INTO t VALUES (1)");
+            statement.clearBatch();
+            statement.clearWarnings();
+            statement.closeOnCompletion();
+
+            assertThat(statement.getMaxRows()).isEqualTo(42);
+            assertThat(statement.getLargeMaxRows()).isEqualTo(42L);
+            assertThat(statement.getQueryTimeout()).isEqualTo(3);
+            assertThat(statement.getFetchSize()).isEqualTo(128);
+            assertThat(statement.isPoolable()).isTrue();
+            assertThat(statement.isWrapperFor(Statement.class)).isTrue();
+            assertThat(statement.unwrap(Statement.class)).isSameAs(statement);
+
+            statement.setFetchDirection(ResultSet.FETCH_REVERSE);
+            statement.setMaxFieldSize(100);
+            assertThat(statement.getFetchDirection()).isEqualTo(ResultSet.FETCH_FORWARD);
+            assertThat(statement.getMaxFieldSize()).isEqualTo(100);
+            assertThatThrownBy(() -> statement.setFetchDirection(-1)).isInstanceOf(SQLException.class);
+        }
+    }
+
+    @Test
+    void preparedStatementReportsParametersAndRejectsStatementSqlOverloads() throws Exception {
+        try (Connection connection = openConnection();
+                PreparedStatement statement = connection.prepareStatement("SELECT ? AS first, ? AS second")) {
+            ParameterMetaData parameterMetaData = statement.getParameterMetaData();
+
+            assertThat(parameterMetaData.getParameterCount()).isEqualTo(2);
+            assertThat(parameterMetaData.isNullable(1)).isEqualTo(ParameterMetaData.parameterNullableUnknown);
+            assertThat(parameterMetaData.isSigned(1)).isFalse();
+            assertThat(parameterMetaData.getPrecision(1)).isZero();
+            assertThat(parameterMetaData.getScale(1)).isZero();
+            assertThat(parameterMetaData.getParameterType(1)).isEqualTo(Types.OTHER);
+            assertThat(parameterMetaData.getParameterTypeName(1)).isEqualTo("UNKNOWN");
+            assertThat(parameterMetaData.getParameterClassName(1)).isEqualTo(Object.class.getName());
+            assertThat(parameterMetaData.getParameterMode(1)).isEqualTo(ParameterMetaData.parameterModeIn);
+            assertThatThrownBy(() -> parameterMetaData.getParameterType(0)).isInstanceOf(SQLException.class);
+            assertThatThrownBy(() -> parameterMetaData.getParameterType(3)).isInstanceOf(SQLException.class);
+
+            statement.setInt(1, 7);
+            statement.setString(2, "ClickHouse's JDBC");
+            statement.clearParameters();
+            statement.setObject(1, LocalDate.of(2024, 1, 2), JDBCType.DATE);
+            statement.setObject(2, Arrays.asList("alpha", "beta"));
+            assertThatThrownBy(() -> statement.setObject(2, Arrays.asList("gamma", "delta"), JDBCType.ARRAY))
+                    .isInstanceOf(SQLException.class)
+                    .hasMessageContaining("requires a parameter");
+            assertThat(statement.isPoolable()).isTrue();
+            assertThat(statement.isWrapperFor(PreparedStatement.class)).isTrue();
+            assertThat(statement.unwrap(PreparedStatement.class)).isSameAs(statement);
+
+            assertThatThrownBy(() -> statement.executeQuery("SELECT 1")).isInstanceOf(SQLException.class);
+            assertThatThrownBy(() -> statement.executeUpdate("SELECT 1")).isInstanceOf(SQLException.class);
+            assertThatThrownBy(() -> statement.execute("SELECT 1")).isInstanceOf(SQLException.class);
+            assertThatThrownBy(() -> statement.addBatch("SELECT 1")).isInstanceOf(SQLException.class);
+            assertThatThrownBy(() -> statement.setRowId(1, null)).isInstanceOf(SQLException.class);
+            assertThatThrownBy(() -> statement.setRef(1, null)).isInstanceOf(SQLFeatureNotSupportedException.class);
+        }
+    }
+
+    @Test
+    void preparedStatementAcceptsCommonJavaValueTypes() throws Exception {
+        try (Connection connection = openConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "INSERT INTO t VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
+            Map<String, Integer> map = new LinkedHashMap<>();
+            map.put("one", 1);
+            map.put("two", 2);
+
+            statement.setBoolean(1, true);
+            statement.setBigDecimal(2, new BigDecimal("123.45"));
+            statement.setBytes(3, new byte[] {1, 2, 3});
+            statement.setDate(4, java.sql.Date.valueOf(LocalDate.of(2024, 2, 3)));
+            statement.setTime(5, java.sql.Time.valueOf(LocalTime.of(4, 5, 6)));
+            statement.setTimestamp(6, java.sql.Timestamp.valueOf(LocalDateTime.of(2024, 2, 3, 4, 5, 6, 7)));
+            statement.setObject(7, OffsetDateTime.parse("2024-02-03T04:05:06Z"));
+            statement.setObject(8, Instant.parse("2024-02-03T04:05:06Z"));
+            statement.setObject(9, InetAddress.getByName("127.0.0.1"));
+            statement.setArray(10, stringArray("x", "y"));
+            statement.setObject(11, map);
+            statement.setNull(12, Types.NULL);
+            statement.addBatch();
+        }
+    }
+
+    @Test
+    void connectionCreatesJdbcArraysFromClickHouseTypeNames() throws Exception {
+        try (Connection connection = openConnection()) {
+            java.sql.Array stringArray = connection.createArrayOf("String", new Object[] {"alpha", "beta"});
+            java.sql.Array integerArray = connection.createArrayOf("Int32", new Object[] {1, 2, 3});
+            java.sql.Array emptyArray = connection.createArrayOf("Bool", new Object[0]);
+            try {
+                assertThat(stringArray.getBaseTypeName()).isEqualTo("String");
+                assertThat(stringArray.getBaseType()).isEqualTo(Types.VARCHAR);
+                assertThat((Object[]) stringArray.getArray()).containsExactly("alpha", "beta");
+
+                assertThat(integerArray.getBaseTypeName()).isEqualTo("Int32");
+                assertThat(integerArray.getBaseType()).isEqualTo(Types.INTEGER);
+                assertThat((Object[]) integerArray.getArray()).containsExactly(1, 2, 3);
+
+                assertThat(emptyArray.getBaseTypeName()).isEqualTo("Bool");
+                assertThat(emptyArray.getBaseType()).isEqualTo(Types.BOOLEAN);
+                assertThat((Object[]) emptyArray.getArray()).isEmpty();
+
+                assertThatThrownBy(() -> connection.createArrayOf("NotAClickHouseType", new Object[] {"value"}))
+                        .isInstanceOf(IllegalArgumentException.class);
+            } finally {
+                stringArray.free();
+                integerArray.free();
+                emptyArray.free();
+            }
+        }
+    }
+
+    @Test
+    void resultSetMetadataDescribesClickHouseColumnsAsJdbcColumns() throws Exception {
+        List<ClickHouseColumn> columns = List.of(
+                ClickHouseColumn.of("id", "Int32"),
+                ClickHouseColumn.of("amount", "Nullable(Decimal(12, 2))"),
+                ClickHouseColumn.of("tags", "Array(String)"));
+        Map<ClickHouseDataType, Class<?>> typeClassMap = new LinkedHashMap<>();
+        typeClassMap.put(ClickHouseDataType.Int32, Integer.class);
+        typeClassMap.put(ClickHouseDataType.Decimal, BigDecimal.class);
+        typeClassMap.put(ClickHouseDataType.Array, Object[].class);
+
+        ResultSetMetaData metadata = new ResultSetMetaDataImpl(
+                columns, "analytics", "local", "events", typeClassMap);
+
+        assertThat(metadata.getColumnCount()).isEqualTo(3);
+        assertThat(metadata.getColumnName(1)).isEqualTo("id");
+        assertThat(metadata.getColumnLabel(1)).isEqualTo("id");
+        assertThat(metadata.getColumnType(1)).isEqualTo(Types.INTEGER);
+        assertThat(metadata.getColumnTypeName(1)).isEqualTo("Int32");
+        assertThat(metadata.isSigned(1)).isTrue();
+        assertThat(metadata.isNullable(1)).isEqualTo(ResultSetMetaData.columnNoNulls);
+        assertThat(metadata.getColumnClassName(1)).isEqualTo(Integer.class.getName());
+
+        assertThat(metadata.getSchemaName(2)).isEqualTo("analytics");
+        assertThat(metadata.getCatalogName(2)).isEqualTo("local");
+        assertThat(metadata.getTableName(2)).isEqualTo("events");
+        assertThat(metadata.getColumnType(2)).isEqualTo(Types.DECIMAL);
+        assertThat(metadata.getColumnTypeName(2)).contains("Decimal");
+        assertThat(metadata.getPrecision(2)).isEqualTo(12);
+        assertThat(metadata.getScale(2)).isEqualTo(2);
+        assertThat(metadata.isNullable(2)).isEqualTo(ResultSetMetaData.columnNullable);
+        assertThat(metadata.getColumnClassName(2)).isEqualTo(BigDecimal.class.getName());
+
+        assertThat(metadata.getColumnType(3)).isEqualTo(Types.ARRAY);
+        assertThat(metadata.getColumnTypeName(3)).isEqualTo("Array(String)");
+        assertThat(metadata.getColumnClassName(3)).isEqualTo(Object[].class.getName());
+        assertThat(metadata.isAutoIncrement(3)).isFalse();
+        assertThat(metadata.isReadOnly(3)).isTrue();
+        assertThat(metadata.isWritable(3)).isFalse();
+        assertThatThrownBy(() -> metadata.getColumnName(0)).isInstanceOf(SQLException.class);
+    }
+
+    @Test
+    void clickHouseArrayAndTupleExposeValueObjects() throws Exception {
+        Array array = stringArray("one", "two", "three");
+        Tuple tuple = new Tuple("name", 42, true);
+
+        assertThat(array.getBaseTypeName()).isEqualTo("String");
+        assertThat(array.getBaseType()).isEqualTo(Types.VARCHAR);
+        assertThat((Object[]) array.getArray()).containsExactly("one", "two", "three");
+        assertThat((Object[]) array.getArray(1, 2)).containsExactly("two", "three");
+        try (ResultSet resultSet = array.getResultSet()) {
+            ResultSetMetaData metadata = resultSet.getMetaData();
+
+            assertThat(metadata.getColumnCount()).isEqualTo(2);
+            assertThat(metadata.getColumnName(1)).isEqualTo("INDEX");
+            assertThat(metadata.getColumnName(2)).isEqualTo("VALUE");
+            assertThat(resultSet.isBeforeFirst()).isTrue();
+            assertThat(resultSet.next()).isTrue();
+            assertThat(resultSet.getInt("INDEX")).isEqualTo(1);
+            assertThat(resultSet.getString("VALUE")).isEqualTo("one");
+            assertThat(resultSet.next()).isTrue();
+            assertThat(resultSet.getObject(1)).isEqualTo(2);
+            assertThat(resultSet.getObject(2, String.class)).isEqualTo("two");
+        }
+        assertThatThrownBy(() -> array.getArray(Map.of())).isInstanceOf(SQLFeatureNotSupportedException.class);
+        assertThatThrownBy(() -> array.getResultSet(Map.of())).isInstanceOf(SQLFeatureNotSupportedException.class);
+        assertThatThrownBy(() -> array.getArray(-1, 1)).isInstanceOf(SQLException.class);
+        array.free();
+        assertThatThrownBy(array::getArray).isInstanceOf(SQLException.class);
+
+        assertThat(tuple.size()).isEqualTo(3);
+        assertThat(tuple.getValue(0)).isEqualTo("name");
+        assertThat(tuple.getValues()).containsExactly("name", 42, true);
+        assertThat(tuple).hasToString("(name, 42, true)");
+    }
+
+    @Test
+    void preparedStatementUtilityReplacesOnlyUnquotedQuestionMarks() {
+        String sql = "SELECT ?, '?', \"?\", `?`, col FROM table WHERE id = ?";
+
+        assertThat(PreparedStatementImpl.replaceQuestionMarks(sql, "NULL"))
+                .isEqualTo("SELECT NULL, '?', \"?\", `?`, col FROM table WHERE id = NULL");
+    }
+
+    private static Connection openConnection() throws SQLException {
+        return new Driver().connect(URL, offlineProperties());
+    }
+
+    private static Array stringArray(Object... elements) throws SQLException {
+        return new Array(ClickHouseColumn.of("values", "Array(String)"), elements);
+    }
+
+    private static Properties offlineProperties() {
+        Properties properties = new Properties();
+        properties.setProperty("server_time_zone", TimeZone.getTimeZone("UTC").getID());
+        properties.setProperty("disable_frameworks_detection", "true");
+        properties.setProperty("connection_pool_enabled", "false");
+        properties.setProperty("user", "default");
+        properties.setProperty("password", "");
+        return properties;
+    }
+}

--- a/tests/src/com.clickhouse/jdbc-v2/0.9.7/src/test/java/com_clickhouse/jdbc_v2/Jdbc_v2Test.java
+++ b/tests/src/com.clickhouse/jdbc-v2/0.9.7/src/test/java/com_clickhouse/jdbc_v2/Jdbc_v2Test.java
@@ -45,6 +45,7 @@ import java.util.Properties;
 import java.util.TimeZone;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class Jdbc_v2Test {
@@ -206,9 +207,8 @@ public class Jdbc_v2Test {
             statement.clearParameters();
             statement.setObject(1, LocalDate.of(2024, 1, 2), JDBCType.DATE);
             statement.setObject(2, Arrays.asList("alpha", "beta"));
-            assertThatThrownBy(() -> statement.setObject(2, Arrays.asList("gamma", "delta"), JDBCType.ARRAY))
-                    .isInstanceOf(SQLException.class)
-                    .hasMessageContaining("requires a parameter");
+            assertThatCode(() -> statement.setObject(2, Arrays.asList("gamma", "delta"), JDBCType.ARRAY))
+                    .doesNotThrowAnyException();
             assertThat(statement.isPoolable()).isTrue();
             assertThat(statement.isWrapperFor(PreparedStatement.class)).isTrue();
             assertThat(statement.unwrap(PreparedStatement.class)).isSameAs(statement);
@@ -372,7 +372,6 @@ public class Jdbc_v2Test {
     private static Properties offlineProperties() {
         Properties properties = new Properties();
         properties.setProperty("server_time_zone", TimeZone.getTimeZone("UTC").getID());
-        properties.setProperty("disable_frameworks_detection", "true");
         properties.setProperty("connection_pool_enabled", "false");
         properties.setProperty("user", "default");
         properties.setProperty("password", "");

--- a/tests/src/com.clickhouse/jdbc-v2/0.9.7/src/test/resources/META-INF/native-image/com.clickhouse/jdbc-v2-tests/native-image.properties
+++ b/tests/src/com.clickhouse/jdbc-v2/0.9.7/src/test/resources/META-INF/native-image/com.clickhouse/jdbc-v2-tests/native-image.properties
@@ -1,0 +1,1 @@
+Args = --enable-url-protocols=http

--- a/tests/src/com.clickhouse/jdbc-v2/0.9.7/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.clickhouse/jdbc-v2/0.9.7/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,115 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com_clickhouse.jdbc_v2.Jdbc_v2Test"
+      },
+      "type" : "java.lang.OutOfMemoryError",
+      "jniAccessible" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_clickhouse.jdbc_v2.Jdbc_v2Test"
+      },
+      "type" : "net.jpountz.lz4.LZ4HCJNICompressor",
+      "fields" : [
+        {
+          "name" : "INSTANCE"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_clickhouse.jdbc_v2.Jdbc_v2Test"
+      },
+      "type" : "net.jpountz.lz4.LZ4JNICompressor",
+      "fields" : [
+        {
+          "name" : "INSTANCE"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_clickhouse.jdbc_v2.Jdbc_v2Test"
+      },
+      "type" : "net.jpountz.lz4.LZ4JNIFastDecompressor",
+      "fields" : [
+        {
+          "name" : "INSTANCE"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_clickhouse.jdbc_v2.Jdbc_v2Test"
+      },
+      "type" : "net.jpountz.lz4.LZ4JNISafeDecompressor",
+      "fields" : [
+        {
+          "name" : "INSTANCE"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_clickhouse.jdbc_v2.Jdbc_v2Test"
+      },
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_clickhouse.jdbc_v2.Jdbc_v2Test"
+      },
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com_clickhouse.jdbc_v2.Jdbc_v2Test"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_clickhouse.jdbc_v2.Jdbc_v2Test"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_clickhouse.jdbc_v2.Jdbc_v2Test"
+      },
+      "glob" : "net/jpountz/util/linux/amd64/liblz4-java.so"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_clickhouse.jdbc_v2.Jdbc_v2Test"
+      },
+      "glob" : "org/publicsuffix/list/effective_tld_names.dat"
+    }
+  ]
+}

--- a/tests/src/com.clickhouse/jdbc-v2/0.9.7/user-code-filter.json
+++ b/tests/src/com.clickhouse/jdbc-v2/0.9.7/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.clickhouse.**"
+    },
+    {
+      "includeClasses" : "com_clickhouse.jdbc_v2.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #8170

This PR provides test fixes and new metadata for com.clickhouse:jdbc-v2:0.9.7, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 48836
- Cached input tokens: 516608
- Output tokens: 2457
- Metadata entries: 21
- Test-only metadata entries: 19
- Iterations: 2
- Library coverage percentage: 10.49
- Previous library version metadata entries: 23
- Previous library version test-only metadata entries: 19
- Previous library version coverage percentage: 10.44

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `eece5f4c4d04e88b1b154b86fa6532f07e3f836b`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.clickhouse:jdbc-v2:0.9.5: 4/4 covered calls (100.00%)
- com.clickhouse:jdbc-v2:0.9.7: 4/4 covered calls (100.00%)

**Reflection:**
- com.clickhouse:jdbc-v2:0.9.5: 4/4 covered calls (100.00%)
- com.clickhouse:jdbc-v2:0.9.7: 4/4 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.clickhouse:jdbc-v2:0.9.5: 14305/122147 (11.71%)
- com.clickhouse:jdbc-v2:0.9.7: 16547/126841 (13.05%)

**Line:**
- com.clickhouse:jdbc-v2:0.9.5: 2746/26292 (10.44%)
- com.clickhouse:jdbc-v2:0.9.7: 2801/26699 (10.49%)

**Method:**
- com.clickhouse:jdbc-v2:0.9.5: 539/6169 (8.74%)
- com.clickhouse:jdbc-v2:0.9.7: 550/6545 (8.40%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/com.clickhouse/jdbc-v2/0.9.5/src/test/java/com_clickhouse/jdbc_v2/Jdbc_v2Test.java 2/tests/src/com.clickhouse/jdbc-v2/0.9.7/src/test/java/com_clickhouse/jdbc_v2/Jdbc_v2Test.java
index ef3da64472..f32649b3ad 100644
--- 1/tests/src/com.clickhouse/jdbc-v2/0.9.5/src/test/java/com_clickhouse/jdbc_v2/Jdbc_v2Test.java
+++ 2/tests/src/com.clickhouse/jdbc-v2/0.9.7/src/test/java/com_clickhouse/jdbc_v2/Jdbc_v2Test.java
@@ -45,6 +45,7 @@ import java.util.Properties;
 import java.util.TimeZone;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class Jdbc_v2Test {
@@ -206,9 +207,8 @@ public class Jdbc_v2Test {
             statement.clearParameters();
             statement.setObject(1, LocalDate.of(2024, 1, 2), JDBCType.DATE);
             statement.setObject(2, Arrays.asList("alpha", "beta"));
-            assertThatThrownBy(() -> statement.setObject(2, Arrays.asList("gamma", "delta"), JDBCType.ARRAY))
-                    .isInstanceOf(SQLException.class)
-                    .hasMessageContaining("requires a parameter");
+            assertThatCode(() -> statement.setObject(2, Arrays.asList("gamma", "delta"), JDBCType.ARRAY))
+                    .doesNotThrowAnyException();
             assertThat(statement.isPoolable()).isTrue();
             assertThat(statement.isWrapperFor(PreparedStatement.class)).isTrue();
             assertThat(statement.unwrap(PreparedStatement.class)).isSameAs(statement);
@@ -372,7 +372,6 @@ public class Jdbc_v2Test {
     private static Properties offlineProperties() {
         Properties properties = new Properties();
         properties.setProperty("server_time_zone", TimeZone.getTimeZone("UTC").getID());
-        properties.setProperty("disable_frameworks_detection", "true");
         properties.setProperty("connection_pool_enabled", "false");
         properties.setProperty("user", "default");
         properties.setProperty("password", "");

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
