### PR TITLE
[GenAI] Test fix for org.apache.maven.plugins:maven-source-plugin:4.0.0-beta-1 using gpt-5.5

### DIFF
--- a/metadata/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/reachability-metadata.json
+++ b/metadata/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/reachability-metadata.json
@@ -1,0 +1,30 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.maven.plugins.maven_source_plugin.HelpMojo"
+      },
+      "type" : "com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.maven.plugins.maven_source_plugin.HelpMojo"
+      },
+      "glob" : "META-INF/maven/org.apache.maven.plugins/maven-source-plugin/plugin-help.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.maven.plugins.maven_source_plugin.HelpMojo"
+      },
+      "glob" : "META-INF/services/javax.xml.parsers.DocumentBuilderFactory"
+    }
+  ]
+}

--- a/metadata/org.apache.maven.plugins/maven-source-plugin/index.json
+++ b/metadata/org.apache.maven.plugins/maven-source-plugin/index.json
@@ -12,7 +12,8 @@
     ],
     "allowed-packages" : [
       "org.apache.maven.plugins.source",
-      "org.apache.maven.plugins.maven_source_plugin"
+      "org.apache.maven.plugins.maven_source_plugin",
+      "org.apache.maven.plugins"
     ]
   },
   {

--- a/metadata/org.apache.maven.plugins/maven-source-plugin/index.json
+++ b/metadata/org.apache.maven.plugins/maven-source-plugin/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "4.0.0-beta-1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-source-plugin/$version$/maven-source-plugin-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/maven-source-plugin",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-source-plugin/$version$/maven-source-plugin-$version$-source-release.zip",
+    "documentation-url" : "https://maven.apache.org/plugins-archives/maven-source-plugin-$version$/",
+    "description" : "Apache Maven Source Plugin creates source and test-source archive artifacts for Maven projects. It provides goals to package project sources into JARs and attach them to the build for installation or deployment.",
     "tested-versions" : [
       "4.0.0-beta-1"
     ],

--- a/metadata/org.apache.maven.plugins/maven-source-plugin/index.json
+++ b/metadata/org.apache.maven.plugins/maven-source-plugin/index.json
@@ -1,6 +1,16 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "4.0.0-beta-1",
+    "tested-versions" : [
+      "4.0.0-beta-1"
+    ],
+    "allowed-packages" : [
+      "org.apache.maven.plugins.source",
+      "org.apache.maven.plugins.maven_source_plugin"
+    ]
+  },
+  {
     "metadata-version" : "3.3.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-source-plugin/$version$/maven-source-plugin-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/maven-source-plugin",

--- a/stats/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/execution-metrics.json
+++ b/stats/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/execution-metrics.json
@@ -1,0 +1,100 @@
+{
+  "fix_javac_fail:2026-06-08": {
+    "timestamp": "2026-06-08T02:30:28.752175Z",
+    "library": "org.apache.maven.plugins:maven-source-plugin:4.0.0-beta-1",
+    "starting_commit": "0e442a297c2700de4bdb3c919855408ccb570366",
+    "ending_commit": "f5df6474775ad2bd42c45dc47592ef95736533b4",
+    "previous_library": "org.apache.maven.plugins:maven-source-plugin:3.3.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.0.0-beta-1",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 502,
+          "missed": 1058,
+          "ratio": 0.321795,
+          "total": 1560
+        },
+        "line": {
+          "covered": 103,
+          "missed": 243,
+          "ratio": 0.297688,
+          "total": 346
+        },
+        "method": {
+          "covered": 14,
+          "missed": 38,
+          "ratio": 0.269231,
+          "total": 52
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.3.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 538,
+          "missed": 1024,
+          "ratio": 0.34443,
+          "total": 1562
+        },
+        "line": {
+          "covered": 103,
+          "missed": 204,
+          "ratio": 0.335505,
+          "total": 307
+        },
+        "method": {
+          "covered": 14,
+          "missed": 32,
+          "ratio": 0.304348,
+          "total": 46
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 105814,
+      "cached_input_tokens_used": 1681408,
+      "output_tokens_used": 11372,
+      "iterations": 3,
+      "cost_usd": 1.1819,
+      "tested_library_loc": 103,
+      "metadata_entries": 4,
+      "test_only_metadata_entries": 4,
+      "previous_library_metadata_entries": 1,
+      "code_coverage_percent": 29.77,
+      "previous_library_coverage_percent": 33.55
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/src/test/java/org_apache_maven_plugins/maven_source_plugin/HelpMojoTest.java",
+      "metadata_file": "metadata/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/stats.json
+++ b/stats/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "4.0.0-beta-1",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 1,
+      "totalCalls" : 1
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 502,
+        "missed" : 1058,
+        "ratio" : 0.321795,
+        "total" : 1560
+      },
+      "line" : {
+        "covered" : 103,
+        "missed" : 243,
+        "ratio" : 0.297688,
+        "total" : 346
+      },
+      "method" : {
+        "covered" : 14,
+        "missed" : 38,
+        "ratio" : 0.269231,
+        "total" : 52
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/.gitignore
+++ b/tests/src/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/build.gradle
+++ b/tests/src/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/build.gradle
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.maven.plugins:maven-source-plugin:$libraryVersion"
+    testImplementation 'org.apache.maven:maven-plugin-api:3.2.5'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/build.gradle
+++ b/tests/src/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/build.gradle
@@ -12,7 +12,10 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.apache.maven.plugins:maven-source-plugin:$libraryVersion"
-    testImplementation 'org.apache.maven:maven-plugin-api:3.2.5'
+    testImplementation 'org.apache.maven:maven-api-core:4.0.0-beta-3'
+    testImplementation 'org.apache.maven:maven-api-impl:4.0.0-beta-3'
+    testImplementation 'org.apache.maven.plugin-testing:maven-plugin-testing-harness:4.0.0-beta-1'
+    testImplementation 'org.codehaus.plexus:plexus-xml:4.0.3'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/gradle.properties
+++ b/tests/src/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.maven.plugins:maven-source-plugin:4.0.0-beta-1
+library.version = 4.0.0-beta-1
+metadata.dir = org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/

--- a/tests/src/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/settings.gradle
+++ b/tests/src/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.maven.plugins.maven-source-plugin_tests'

--- a/tests/src/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/src/test/java/org_apache_maven_plugins/maven_source_plugin/HelpMojoTest.java
+++ b/tests/src/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/src/test/java/org_apache_maven_plugins/maven_source_plugin/HelpMojoTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_plugins.maven_source_plugin;
+
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.maven_source_plugin.HelpMojo;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HelpMojoTest {
+    @Test
+    public void executeReadsBundledPluginHelpResource() throws Exception {
+        HelpMojo mojo = new HelpMojo();
+        CapturingLog log = new CapturingLog();
+        mojo.setLog(log);
+
+        mojo.execute();
+
+        assertThat(log.debugMessages()).contains("plugin-help.xml");
+        assertThat(log.infoMessages())
+                .contains("Maven Source Plugin")
+                .contains("source:jar")
+                .contains("source:test-jar");
+    }
+
+    private static final class CapturingLog implements Log {
+        private final StringBuilder debugMessages = new StringBuilder();
+        private final StringBuilder infoMessages = new StringBuilder();
+        private final StringBuilder warnMessages = new StringBuilder();
+        private final StringBuilder errorMessages = new StringBuilder();
+
+        String debugMessages() {
+            return debugMessages.toString();
+        }
+
+        String infoMessages() {
+            return infoMessages.toString();
+        }
+
+        @Override
+        public boolean isDebugEnabled() {
+            return true;
+        }
+
+        @Override
+        public void debug(CharSequence content) {
+            append(debugMessages, content);
+        }
+
+        @Override
+        public void debug(CharSequence content, Throwable error) {
+            append(debugMessages, content);
+            append(debugMessages, error);
+        }
+
+        @Override
+        public void debug(Throwable error) {
+            append(debugMessages, error);
+        }
+
+        @Override
+        public boolean isInfoEnabled() {
+            return true;
+        }
+
+        @Override
+        public void info(CharSequence content) {
+            append(infoMessages, content);
+        }
+
+        @Override
+        public void info(CharSequence content, Throwable error) {
+            append(infoMessages, content);
+            append(infoMessages, error);
+        }
+
+        @Override
+        public void info(Throwable error) {
+            append(infoMessages, error);
+        }
+
+        @Override
+        public boolean isWarnEnabled() {
+            return true;
+        }
+
+        @Override
+        public void warn(CharSequence content) {
+            append(warnMessages, content);
+        }
+
+        @Override
+        public void warn(CharSequence content, Throwable error) {
+            append(warnMessages, content);
+            append(warnMessages, error);
+        }
+
+        @Override
+        public void warn(Throwable error) {
+            append(warnMessages, error);
+        }
+
+        @Override
+        public boolean isErrorEnabled() {
+            return true;
+        }
+
+        @Override
+        public void error(CharSequence content) {
+            append(errorMessages, content);
+        }
+
+        @Override
+        public void error(CharSequence content, Throwable error) {
+            append(errorMessages, content);
+            append(errorMessages, error);
+        }
+
+        @Override
+        public void error(Throwable error) {
+            append(errorMessages, error);
+        }
+
+        private static void append(StringBuilder messages, CharSequence content) {
+            messages.append(content).append('\n');
+        }
+
+        private static void append(StringBuilder messages, Throwable error) {
+            messages.append(error.getClass().getName()).append(": ").append(error.getMessage()).append('\n');
+        }
+    }
+}

--- a/tests/src/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/src/test/java/org_apache_maven_plugins/maven_source_plugin/HelpMojoTest.java
+++ b/tests/src/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/src/test/java/org_apache_maven_plugins/maven_source_plugin/HelpMojoTest.java
@@ -6,7 +6,10 @@
  */
 package org_apache_maven_plugins.maven_source_plugin;
 
-import org.apache.maven.plugin.logging.Log;
+import java.util.function.Supplier;
+
+import org.apache.maven.api.plugin.Log;
+import org.apache.maven.api.plugin.testing.MojoExtension;
 import org.apache.maven.plugins.maven_source_plugin.HelpMojo;
 import org.junit.jupiter.api.Test;
 
@@ -17,7 +20,7 @@ public class HelpMojoTest {
     public void executeReadsBundledPluginHelpResource() throws Exception {
         HelpMojo mojo = new HelpMojo();
         CapturingLog log = new CapturingLog();
-        mojo.setLog(log);
+        MojoExtension.setVariableValueToObject(mojo, "logger", log);
 
         mojo.execute();
 
@@ -64,6 +67,17 @@ public class HelpMojoTest {
         }
 
         @Override
+        public void debug(Supplier<String> content) {
+            append(debugMessages, content.get());
+        }
+
+        @Override
+        public void debug(Supplier<String> content, Throwable error) {
+            append(debugMessages, content.get());
+            append(debugMessages, error);
+        }
+
+        @Override
         public boolean isInfoEnabled() {
             return true;
         }
@@ -81,6 +95,17 @@ public class HelpMojoTest {
 
         @Override
         public void info(Throwable error) {
+            append(infoMessages, error);
+        }
+
+        @Override
+        public void info(Supplier<String> content) {
+            append(infoMessages, content.get());
+        }
+
+        @Override
+        public void info(Supplier<String> content, Throwable error) {
+            append(infoMessages, content.get());
             append(infoMessages, error);
         }
 
@@ -106,6 +131,17 @@ public class HelpMojoTest {
         }
 
         @Override
+        public void warn(Supplier<String> content) {
+            append(warnMessages, content.get());
+        }
+
+        @Override
+        public void warn(Supplier<String> content, Throwable error) {
+            append(warnMessages, content.get());
+            append(warnMessages, error);
+        }
+
+        @Override
         public boolean isErrorEnabled() {
             return true;
         }
@@ -123,6 +159,17 @@ public class HelpMojoTest {
 
         @Override
         public void error(Throwable error) {
+            append(errorMessages, error);
+        }
+
+        @Override
+        public void error(Supplier<String> content) {
+            append(errorMessages, content.get());
+        }
+
+        @Override
+        public void error(Supplier<String> content, Throwable error) {
+            append(errorMessages, content.get());
             append(errorMessages, error);
         }
 

--- a/tests/src/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,29 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org_apache_maven_plugins.maven_source_plugin.HelpMojoTest"
+      },
+      "type" : "org.apache.maven.plugins.maven_source_plugin.HelpMojo",
+      "fields" : [
+        {
+          "name" : "logger"
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org_apache_maven_plugins.maven_source_plugin.HelpMojoTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_maven_plugins.maven_source_plugin.HelpMojoTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/tests/src/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/user-code-filter.json
+++ b/tests/src/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/user-code-filter.json
@@ -7,6 +7,9 @@
       "includeClasses" : "org.apache.maven.plugins.source.**"
     },
     {
+      "includeClasses" : "org.apache.maven.plugins.maven_source_plugin.**"
+    },
+    {
       "includeClasses" : "org.apache.maven.plugins.**"
     },
     {

--- a/tests/src/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/user-code-filter.json
+++ b/tests/src/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/user-code-filter.json
@@ -1,0 +1,16 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.maven.plugins.source.**"
+    },
+    {
+      "includeClasses" : "org.apache.maven.plugins.**"
+    },
+    {
+      "includeClasses" : "org_apache_maven_plugins.maven_source_plugin.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #8172

This PR provides test fixes and new metadata for org.apache.maven.plugins:maven-source-plugin:4.0.0-beta-1, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 105814
- Cached input tokens: 1681408
- Output tokens: 11372
- Metadata entries: 4
- Test-only metadata entries: 4
- Iterations: 3
- Library coverage percentage: 29.77
- Previous library version metadata entries: 1
- Previous library version coverage percentage: 33.55

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `eece5f4c4d04e88b1b154b86fa6532f07e3f836b`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.maven.plugins:maven-source-plugin:3.3.0: 1/1 covered calls (100.00%)
- org.apache.maven.plugins:maven-source-plugin:4.0.0-beta-1: 1/1 covered calls (100.00%)

**Resources:**
- org.apache.maven.plugins:maven-source-plugin:3.3.0: 1/1 covered calls (100.00%)
- org.apache.maven.plugins:maven-source-plugin:4.0.0-beta-1: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.maven.plugins:maven-source-plugin:3.3.0: 538/1562 (34.44%)
- org.apache.maven.plugins:maven-source-plugin:4.0.0-beta-1: 502/1560 (32.18%)

**Line:**
- org.apache.maven.plugins:maven-source-plugin:3.3.0: 103/307 (33.55%)
- org.apache.maven.plugins:maven-source-plugin:4.0.0-beta-1: 103/346 (29.77%)

**Method:**
- org.apache.maven.plugins:maven-source-plugin:3.3.0: 14/46 (30.43%)
- org.apache.maven.plugins:maven-source-plugin:4.0.0-beta-1: 14/52 (26.92%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/org.apache.maven.plugins/maven-source-plugin/3.3.0/build.gradle b/tests/src/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/build.gradle
index 578831a074..f954793b76 100644
--- a/tests/src/org.apache.maven.plugins/maven-source-plugin/3.3.0/build.gradle
+++ b/tests/src/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/build.gradle
@@ -12,7 +12,10 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.apache.maven.plugins:maven-source-plugin:$libraryVersion"
-    testImplementation 'org.apache.maven:maven-plugin-api:3.2.5'
+    testImplementation 'org.apache.maven:maven-api-core:4.0.0-beta-3'
+    testImplementation 'org.apache.maven:maven-api-impl:4.0.0-beta-3'
+    testImplementation 'org.apache.maven.plugin-testing:maven-plugin-testing-harness:4.0.0-beta-1'
+    testImplementation 'org.codehaus.plexus:plexus-xml:4.0.3'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
diff --git a/tests/src/org.apache.maven.plugins/maven-source-plugin/3.3.0/src/test/java/org_apache_maven_plugins/maven_source_plugin/HelpMojoTest.java b/tests/src/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/src/test/java/org_apache_maven_plugins/maven_source_plugin/HelpMojoTest.java
index a8535a8ecf..26671752e0 100644
--- a/tests/src/org.apache.maven.plugins/maven-source-plugin/3.3.0/src/test/java/org_apache_maven_plugins/maven_source_plugin/HelpMojoTest.java
+++ b/tests/src/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/src/test/java/org_apache_maven_plugins/maven_source_plugin/HelpMojoTest.java
@@ -6,7 +6,10 @@
  */
 package org_apache_maven_plugins.maven_source_plugin;
 
-import org.apache.maven.plugin.logging.Log;
+import java.util.function.Supplier;
+
+import org.apache.maven.api.plugin.Log;
+import org.apache.maven.api.plugin.testing.MojoExtension;
 import org.apache.maven.plugins.maven_source_plugin.HelpMojo;
 import org.junit.jupiter.api.Test;
 
@@ -17,7 +20,7 @@ public class HelpMojoTest {
     public void executeReadsBundledPluginHelpResource() throws Exception {
         HelpMojo mojo = new HelpMojo();
         CapturingLog log = new CapturingLog();
-        mojo.setLog(log);
+        MojoExtension.setVariableValueToObject(mojo, "logger", log);
 
         mojo.execute();
 
@@ -63,6 +66,17 @@ public class HelpMojoTest {
             append(debugMessages, error);
         }
 
+        @Override
+        public void debug(Supplier<String> content) {
+            append(debugMessages, content.get());
+        }
+
+        @Override
+        public void debug(Supplier<String> content, Throwable error) {
+            append(debugMessages, content.get());
+            append(debugMessages, error);
+        }
+
         @Override
         public boolean isInfoEnabled() {
             return true;
@@ -84,6 +98,17 @@ public class HelpMojoTest {
             append(infoMessages, error);
         }
 
+        @Override
+        public void info(Supplier<String> content) {
+            append(infoMessages, content.get());
+        }
+
+        @Override
+        public void info(Supplier<String> content, Throwable error) {
+            append(infoMessages, content.get());
+            append(infoMessages, error);
+        }
+
         @Override
         public boolean isWarnEnabled() {
             return true;
@@ -105,6 +130,17 @@ public class HelpMojoTest {
             append(warnMessages, error);
         }
 
+        @Override
+        public void warn(Supplier<String> content) {
+            append(warnMessages, content.get());
+        }
+
+        @Override
+        public void warn(Supplier<String> content, Throwable error) {
+            append(warnMessages, content.get());
+            append(warnMessages, error);
+        }
+
         @Override
         public boolean isErrorEnabled() {
             return true;
@@ -126,6 +162,17 @@ public class HelpMojoTest {
             append(errorMessages, error);
         }
 
+        @Override
+        public void error(Supplier<String> content) {
+            append(errorMessages, content.get());
+        }
+
+        @Override
+        public void error(Supplier<String> content, Throwable error) {
+            append(errorMessages, content.get());
+            append(errorMessages, error);
+        }
+
         private static void append(StringBuilder messages, CharSequence content) {
             messages.append(content).append('\n');
         }
diff --git a/tests/src/org.apache.maven.plugins/maven-source-plugin/3.3.0/user-code-filter.json b/tests/src/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/user-code-filter.json
index e3ab0f09de..95ffd6913d 100644
--- a/tests/src/org.apache.maven.plugins/maven-source-plugin/3.3.0/user-code-filter.json
+++ b/tests/src/org.apache.maven.plugins/maven-source-plugin/4.0.0-beta-1/user-code-filter.json
@@ -6,6 +6,9 @@
     {
       "includeClasses" : "org.apache.maven.plugins.source.**"
     },
+    {
+      "includeClasses" : "org.apache.maven.plugins.maven_source_plugin.**"
+    },
     {
       "includeClasses" : "org.apache.maven.plugins.**"
     },

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
