### PR TITLE
[GenAI] Add support for com.alibaba.fastjson2:fastjson2:2.0.53 using gpt-5.5

### DIFF
--- a/metadata/com.alibaba.fastjson2/fastjson2/2.0.53/reachability-metadata.json
+++ b/metadata/com.alibaba.fastjson2/fastjson2/2.0.53/reachability-metadata.json
@@ -1,0 +1,261 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.util.TypeUtils"
+      },
+      "type" : "com.alibaba.fastjson.JSONArray"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.util.TypeUtils"
+      },
+      "type" : "com.alibaba.fastjson.JSONObject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.JSONFactory"
+      },
+      "type" : "com.alibaba.fastjson2.JSONFactory$CacheItem"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.util.BeanUtils"
+      },
+      "type" : "com.alibaba.fastjson2.JSONObject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.util.TypeUtils"
+      },
+      "type" : "com.alibaba.fastjson2.util.TypeUtils$Cache"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.writer.FieldWriter"
+      },
+      "type" : "com.alibaba.fastjson2.writer.FieldWriter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.writer.FieldWriterObject"
+      },
+      "type" : "com.alibaba.fastjson2.writer.FieldWriterObject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.util.JDKUtils"
+      },
+      "type" : "java.beans.Transient"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.util.JDKUtils"
+      },
+      "type" : "java.lang.String",
+      "fields" : [
+        {
+          "name" : "coder"
+        },
+        {
+          "name" : "value"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "byte[]",
+            "byte"
+          ]
+        },
+        {
+          "name" : "coder",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "isASCII",
+          "parameterTypes" : [
+            "byte[]"
+          ]
+        },
+        {
+          "name" : "value",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.util.JDKUtils"
+      },
+      "type" : "java.lang.StringCoding",
+      "methods" : [
+        {
+          "name" : "hasNegatives",
+          "parameterTypes" : [
+            "byte[]",
+            "int",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.util.JDKUtils"
+      },
+      "type" : "java.lang.invoke.MethodHandles$Lookup",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Class",
+            "java.lang.Class",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.util.JDKUtils"
+      },
+      "type" : "java.lang.management.ManagementFactory",
+      "methods" : [
+        {
+          "name" : "getRuntimeMXBean",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.util.JDKUtils"
+      },
+      "type" : "java.lang.management.RuntimeMXBean",
+      "methods" : [
+        {
+          "name" : "getInputArguments",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.util.JDKUtils"
+      },
+      "type" : "java.math.BigDecimal",
+      "fields" : [
+        {
+          "name" : "intCompact"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.util.JDKUtils"
+      },
+      "type" : "java.math.BigInteger",
+      "fields" : [
+        {
+          "name" : "mag"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.util.JdbcSupport"
+      },
+      "type" : "java.sql.Clob"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.util.JdbcSupport"
+      },
+      "type" : "java.sql.Struct"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.util.TypeUtils"
+      },
+      "type" : "java.util.Collections$UnmodifiableCollection"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.util.TypeUtils"
+      },
+      "type" : "java.util.Collections$UnmodifiableMap"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.util.JDKUtils"
+      },
+      "type" : "javax.sql.DataSource"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.util.JDKUtils"
+      },
+      "type" : "javax.sql.RowSet"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.util.JDKUtils"
+      },
+      "type" : "sun.management.VMManagementImpl",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "compTimeMonitoringSupport"
+        },
+        {
+          "name" : "currentThreadCpuTimeSupport"
+        },
+        {
+          "name" : "objectMonitorUsageSupport"
+        },
+        {
+          "name" : "otherThreadCpuTimeSupport"
+        },
+        {
+          "name" : "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name" : "synchronizerUsageSupport"
+        },
+        {
+          "name" : "threadAllocatedMemorySupport"
+        },
+        {
+          "name" : "threadContentionMonitoringSupport"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.util.JDKUtils"
+      },
+      "type" : "sun.misc.Unsafe",
+      "fields" : [
+        {
+          "name" : "theUnsafe"
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.JSONWriter$Context"
+      },
+      "glob" : "META-INF/services/java.time.zone.ZoneRulesProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.JSONFactory"
+      },
+      "glob" : "fastjson2.properties"
+    }
+  ]
+}

--- a/metadata/com.alibaba.fastjson2/fastjson2/index.json
+++ b/metadata/com.alibaba.fastjson2/fastjson2/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.0.53",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/alibaba/fastjson2/fastjson2/$version$/fastjson2-$version$-sources.jar",
+    "repository-url" : "https://github.com/alibaba/fastjson2",
+    "test-code-url" : "https://github.com/alibaba/fastjson2/tree/$version$/core/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/alibaba/fastjson2/fastjson2/$version$/fastjson2-$version$-javadoc.jar",
+    "description" : "Fastjson2 is a Java JSON processor from Alibaba for parsing, generating, serializing, and deserializing JSON. It provides APIs for mapping JSON to Java objects and includes utilities for JSONPath queries, JSONB binary JSON, and CSV handling.",
+    "tested-versions" : [
+      "2.0.53"
+    ],
+    "allowed-packages" : [
+      "com.alibaba.fastjson2"
+    ]
+  }
+]

--- a/stats/com.alibaba.fastjson2/fastjson2/2.0.53/execution-metrics.json
+++ b/stats/com.alibaba.fastjson2/fastjson2/2.0.53/execution-metrics.json
@@ -1,0 +1,68 @@
+{
+  "add_new_library_support:2026-06-08": {
+    "timestamp": "2026-06-08T02:48:32.428419Z",
+    "library": "com.alibaba.fastjson2:fastjson2:2.0.53",
+    "starting_commit": "fc22276577aac3f2cc4952163e8674d78f7bf0d7",
+    "ending_commit": "1195b119fad1d84713e318a4922484b427701b90",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.0.53",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.055238,
+            "coveredCalls": 29,
+            "totalCalls": 525
+          },
+          "resources": {
+            "coverageRatio": 0.25,
+            "coveredCalls": 1,
+            "totalCalls": 4
+          }
+        },
+        "coverageRatio": 0.056711,
+        "coveredCalls": 30,
+        "totalCalls": 529
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 48898,
+          "missed": 346078,
+          "ratio": 0.1238,
+          "total": 394976
+        },
+        "line": {
+          "covered": 9950,
+          "missed": 70839,
+          "ratio": 0.12316,
+          "total": 80789
+        },
+        "method": {
+          "covered": 830,
+          "missed": 5020,
+          "ratio": 0.14188,
+          "total": 5850
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 268672,
+      "cached_input_tokens_used": 3245056,
+      "output_tokens_used": 23356,
+      "iterations": 9,
+      "cost_usd": 2.3232,
+      "generated_loc": 302,
+      "tested_library_loc": 9950,
+      "metadata_entries": 47,
+      "test_only_metadata_entries": 60,
+      "code_coverage_percent": 12.32
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.alibaba.fastjson2/fastjson2/2.0.53/src/test/java/com_alibaba_fastjson2/fastjson2/Fastjson2Test.java",
+      "metadata_file": "metadata/com.alibaba.fastjson2/fastjson2/2.0.53/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.alibaba.fastjson2/fastjson2/2.0.53/stats.json
+++ b/stats/com.alibaba.fastjson2/fastjson2/2.0.53/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "2.0.53",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.055238,
+          "coveredCalls" : 29,
+          "totalCalls" : 525
+        },
+        "resources" : {
+          "coverageRatio" : 0.25,
+          "coveredCalls" : 1,
+          "totalCalls" : 4
+        }
+      },
+      "coverageRatio" : 0.056711,
+      "coveredCalls" : 30,
+      "totalCalls" : 529
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 48898,
+        "missed" : 346078,
+        "ratio" : 0.1238,
+        "total" : 394976
+      },
+      "line" : {
+        "covered" : 9950,
+        "missed" : 70839,
+        "ratio" : 0.12316,
+        "total" : 80789
+      },
+      "method" : {
+        "covered" : 830,
+        "missed" : 5020,
+        "ratio" : 0.14188,
+        "total" : 5850
+      }
+    }
+  } ]
+}

--- a/tests/src/com.alibaba.fastjson2/fastjson2/2.0.53/.gitignore
+++ b/tests/src/com.alibaba.fastjson2/fastjson2/2.0.53/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.alibaba.fastjson2/fastjson2/2.0.53/build.gradle
+++ b/tests/src/com.alibaba.fastjson2/fastjson2/2.0.53/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.alibaba.fastjson2:fastjson2:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.alibaba.fastjson2/fastjson2/2.0.53/build.gradle
+++ b/tests/src/com.alibaba.fastjson2/fastjson2/2.0.53/build.gradle
@@ -16,6 +16,12 @@ dependencies {
 }
 
 graalvmNative {
+    binaries {
+        test {
+            buildArgs.add('--initialize-at-build-time=com.alibaba.fastjson2')
+        }
+    }
+
     agent {
         defaultMode = "conditional"
         modes {

--- a/tests/src/com.alibaba.fastjson2/fastjson2/2.0.53/build.gradle
+++ b/tests/src/com.alibaba.fastjson2/fastjson2/2.0.53/build.gradle
@@ -18,7 +18,9 @@ dependencies {
 graalvmNative {
     binaries {
         test {
-            buildArgs.add('--initialize-at-build-time=com.alibaba.fastjson2')
+            excludeConfig.put("com.alibaba.fastjson2:fastjson2", [
+                    ".*/com\\.alibaba\\.fastjson2/fastjson2/native-image\\.properties"
+            ])
         }
     }
 

--- a/tests/src/com.alibaba.fastjson2/fastjson2/2.0.53/gradle.properties
+++ b/tests/src/com.alibaba.fastjson2/fastjson2/2.0.53/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.alibaba.fastjson2:fastjson2:2.0.53
+library.version = 2.0.53
+metadata.dir = com.alibaba.fastjson2/fastjson2/2.0.53/

--- a/tests/src/com.alibaba.fastjson2/fastjson2/2.0.53/settings.gradle
+++ b/tests/src/com.alibaba.fastjson2/fastjson2/2.0.53/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.alibaba.fastjson2.fastjson2_tests'

--- a/tests/src/com.alibaba.fastjson2/fastjson2/2.0.53/src/test/java/com_alibaba_fastjson2/fastjson2/Fastjson2Test.java
+++ b/tests/src/com.alibaba.fastjson2/fastjson2/2.0.53/src/test/java/com_alibaba_fastjson2/fastjson2/Fastjson2Test.java
@@ -21,10 +21,14 @@ import com.alibaba.fastjson2.annotation.JSONField;
 import com.alibaba.fastjson2.filter.ValueFilter;
 import com.alibaba.fastjson2.schema.JSONSchema;
 import com.alibaba.fastjson2.schema.ValidateResult;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 public class Fastjson2Test {
@@ -153,6 +157,39 @@ public class Fastjson2Test {
         JSONObject object = JSON.parseObject(filtered);
         assertThat(object.getString("summary")).isEqualTo("unknown");
         assertThat(object.getString("title")).isEqualTo(book.getTitle());
+    }
+
+    @Test
+    void streamsJsonThroughReaderAndWriterApis() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (JSONWriter writer = JSONWriter.ofUTF8()) {
+            writer.startObject();
+            writer.writeName("name");
+            writer.writeColon();
+            writer.writeString("streaming");
+            writer.writeName("quantities");
+            writer.writeColon();
+            writer.startArray();
+            writer.writeInt32(3);
+            writer.writeComma();
+            writer.writeInt32(5);
+            writer.endArray();
+            writer.writeName("active");
+            writer.writeColon();
+            writer.writeBool(true);
+            writer.endObject();
+
+            assertThat(writer.flushTo(output)).isPositive();
+        }
+
+        try (JSONReader reader = JSONReader.of(
+                new ByteArrayInputStream(output.toByteArray()), StandardCharsets.UTF_8)) {
+            Map<String, Object> document = reader.readObject();
+
+            assertThat(document.get("name")).isEqualTo("streaming");
+            assertThat(document.get("quantities")).isEqualTo(List.of(3, 5));
+            assertThat(document.get("active")).isEqualTo(Boolean.TRUE);
+        }
     }
 
     @Test

--- a/tests/src/com.alibaba.fastjson2/fastjson2/2.0.53/src/test/java/com_alibaba_fastjson2/fastjson2/Fastjson2Test.java
+++ b/tests/src/com.alibaba.fastjson2/fastjson2/2.0.53/src/test/java/com_alibaba_fastjson2/fastjson2/Fastjson2Test.java
@@ -6,11 +6,266 @@
  */
 package com_alibaba_fastjson2.fastjson2;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONB;
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
+import com.alibaba.fastjson2.JSONPath;
+import com.alibaba.fastjson2.JSONReader;
+import com.alibaba.fastjson2.JSONValidator;
+import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson2.TypeReference;
+import com.alibaba.fastjson2.annotation.JSONField;
+import com.alibaba.fastjson2.filter.ValueFilter;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
-class Fastjson2Test {
+public class Fastjson2Test {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void parsesAndWritesAnnotatedBeanGraph() {
+        String json = """
+                {
+                  "id": 101,
+                  "book_title": "Native Java",
+                  "price": 39.99,
+                  "published_at": "2024-06-01",
+                  "available": true,
+                  "tags": ["json", "graalvm"],
+                  "author": {"name": "Ada", "active": true}
+                }
+                """;
+
+        Book book = JSON.parseObject(json, Book.class, JSONReader.Feature.SupportSmartMatch);
+
+        assertThat(book.getId()).isEqualTo(101L);
+        assertThat(book.getTitle()).isEqualTo("Native Java");
+        assertThat(book.getPrice()).isEqualByComparingTo(new BigDecimal("39.99"));
+        assertThat(book.getPublishedAt()).isEqualTo(LocalDate.of(2024, 6, 1));
+        assertThat(book.isAvailable()).isTrue();
+        assertThat(book.getTags()).containsExactly("json", "graalvm");
+        assertThat(book.getAuthor().getName()).isEqualTo("Ada");
+
+        String serialized = JSON.toJSONString(
+                book,
+                JSONWriter.Feature.WriteNulls,
+                JSONWriter.Feature.SortMapEntriesByKeys);
+        JSONObject object = JSON.parseObject(serialized);
+        assertThat(object.getLongValue("id")).isEqualTo(101L);
+        assertThat(object.getString("title")).isEqualTo("Native Java");
+        assertThat(object.getString("published_at")).isEqualTo("2024-06-01");
+        assertThat(object.getJSONObject("author").getBooleanValue("active")).isTrue();
+    }
+
+    @Test
+    void convertsGenericCollectionsAndJSONObjectAccessors() {
+        String json = """
+                [
+                  {"id":1,"title":"A","price":12.50,"published_at":"2024-01-10","tags":["fast"]},
+                  {"id":2,"title":"B","price":15.75,"published_at":"2024-02-20","tags":["json","binary"]}
+                ]
+                """;
+        TypeReference<List<Book>> booksType = new TypeReference<List<Book>>() {
+        };
+
+        List<Book> books = JSON.parseObject(json, booksType);
+
+        assertThat(books).hasSize(2);
+        assertThat(books.get(0).getPublishedAt()).isEqualTo(LocalDate.of(2024, 1, 10));
+        assertThat(books.get(1).getTags()).containsExactly("json", "binary");
+
+        JSONObject catalog = JSONObject.of("name", "samples");
+        JSONArray items = catalog.putArray("items");
+        items.add(JSONObject.from(books.get(0)));
+        items.add(JSONObject.from(books.get(1)));
+
+        assertThat(catalog.getString("name")).isEqualTo("samples");
+        assertThat(catalog.getJSONArray("items").getJSONObject(1).getString("title")).isEqualTo("B");
+        assertThat(catalog.getJSONArray("items").getJSONObject(0).getBigDecimal("price"))
+                .isEqualByComparingTo(new BigDecimal("12.50"));
+    }
+
+    @Test
+    void evaluatesMutatesAndRemovesValuesWithJSONPath() {
+        JSONObject document = JSON.parseObject("""
+                {
+                  "store": {
+                    "books": [
+                      {"title":"A","price":10},
+                      {"title":"B","price":20}
+                    ],
+                    "open": true
+                  }
+                }
+                """);
+
+        assertThat(JSONPath.eval(document, "$.store.books[1].title")).isEqualTo("B");
+        assertThat(JSONPath.contains(document, "$.store.open")).isTrue();
+
+        JSONPath.set(document, "$.store.books[0].price", 11);
+        JSONPath.remove(document, "$.store.open");
+
+        assertThat(JSONPath.eval(document, "$.store.books[0].price")).isEqualTo(11);
+        assertThat(JSONPath.contains(document, "$.store.open")).isFalse();
+    }
+
+    @Test
+    void roundTripsJsonbForBeanAndContainerValues() {
+        Book book = sampleBook();
+        byte[] bytes = JSONB.toBytes(book, JSONWriter.Feature.WriteNulls);
+
+        Book restored = JSONB.parseObject(bytes, Book.class);
+
+        assertThat(restored.getTitle()).isEqualTo(book.getTitle());
+        assertThat(restored.getAuthor().getName()).isEqualTo(book.getAuthor().getName());
+        assertThat(restored.getPublishedAt()).isEqualTo(book.getPublishedAt());
+        assertThat(restored.getTags()).containsExactlyElementsOf(book.getTags());
+
+        byte[] arrayBytes = JSONB.toBytes(JSONArray.of("alpha", 7, true));
+        JSONArray restoredArray = JSONB.parseArray(arrayBytes);
+        assertThat(restoredArray.getString(0)).isEqualTo("alpha");
+        assertThat(restoredArray.getIntValue(1)).isEqualTo(7);
+        assertThat(restoredArray.getBooleanValue(2)).isTrue();
+    }
+
+    @Test
+    void validatesInputAndAppliesWriterFilters() {
+        byte[] validJson = "{\"name\":\"fastjson2\",\"features\":[\"json\",\"jsonb\"]}"
+                .getBytes(StandardCharsets.UTF_8);
+        JSONValidator validator = JSONValidator.fromUtf8(validJson);
+
+        assertThat(validator.validate()).isTrue();
+        assertThat(validator.getType()).isEqualTo(JSONValidator.Type.Object);
+        assertThat(JSON.isValidArray("[1,2,3]")).isTrue();
+        assertThat(JSON.isValidObject("[1,2,3]")).isFalse();
+
+        Book book = sampleBook();
+        book.setSummary(null);
+        ValueFilter nullTextFilter = (object, name, value) -> value == null ? "unknown" : value;
+
+        String filtered = JSON.toJSONString(book, nullTextFilter, JSONWriter.Feature.WriteNulls);
+        JSONObject object = JSON.parseObject(filtered);
+        assertThat(object.getString("summary")).isEqualTo("unknown");
+        assertThat(object.getString("title")).isEqualTo(book.getTitle());
+    }
+
+    private static Book sampleBook() {
+        Author author = new Author();
+        author.setName("Grace");
+        author.setActive(true);
+
+        Book book = new Book();
+        book.setId(7L);
+        book.setTitle("Fast JSON");
+        book.setPrice(new BigDecimal("28.25"));
+        book.setPublishedAt(LocalDate.of(2024, 3, 5));
+        book.setAvailable(true);
+        book.setTags(List.of("json", "native-image"));
+        book.setAuthor(author);
+        book.setSummary("Integration coverage");
+        return book;
+    }
+
+    public static class Book {
+        private long id;
+        private String title;
+        private BigDecimal price;
+        private LocalDate publishedAt;
+        private boolean available;
+        private List<String> tags;
+        private Author author;
+        private String summary;
+
+        public long getId() {
+            return id;
+        }
+
+        public void setId(long id) {
+            this.id = id;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        @JSONField(name = "title", alternateNames = {"book_title"})
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
+        public BigDecimal getPrice() {
+            return price;
+        }
+
+        public void setPrice(BigDecimal price) {
+            this.price = price;
+        }
+
+        @JSONField(name = "published_at", format = "yyyy-MM-dd")
+        public LocalDate getPublishedAt() {
+            return publishedAt;
+        }
+
+        @JSONField(name = "published_at", format = "yyyy-MM-dd")
+        public void setPublishedAt(LocalDate publishedAt) {
+            this.publishedAt = publishedAt;
+        }
+
+        public boolean isAvailable() {
+            return available;
+        }
+
+        public void setAvailable(boolean available) {
+            this.available = available;
+        }
+
+        public List<String> getTags() {
+            return tags;
+        }
+
+        public void setTags(List<String> tags) {
+            this.tags = tags;
+        }
+
+        public Author getAuthor() {
+            return author;
+        }
+
+        public void setAuthor(Author author) {
+            this.author = author;
+        }
+
+        public String getSummary() {
+            return summary;
+        }
+
+        public void setSummary(String summary) {
+            this.summary = summary;
+        }
+    }
+
+    public static class Author {
+        private String name;
+        private boolean active;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public boolean isActive() {
+            return active;
+        }
+
+        public void setActive(boolean active) {
+            this.active = active;
+        }
     }
 }

--- a/tests/src/com.alibaba.fastjson2/fastjson2/2.0.53/src/test/java/com_alibaba_fastjson2/fastjson2/Fastjson2Test.java
+++ b/tests/src/com.alibaba.fastjson2/fastjson2/2.0.53/src/test/java/com_alibaba_fastjson2/fastjson2/Fastjson2Test.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_alibaba_fastjson2.fastjson2;
+
+import org.junit.jupiter.api.Test;
+
+class Fastjson2Test {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/com.alibaba.fastjson2/fastjson2/2.0.53/src/test/java/com_alibaba_fastjson2/fastjson2/Fastjson2Test.java
+++ b/tests/src/com.alibaba.fastjson2/fastjson2/2.0.53/src/test/java/com_alibaba_fastjson2/fastjson2/Fastjson2Test.java
@@ -19,6 +19,8 @@ import com.alibaba.fastjson2.JSONWriter;
 import com.alibaba.fastjson2.TypeReference;
 import com.alibaba.fastjson2.annotation.JSONField;
 import com.alibaba.fastjson2.filter.ValueFilter;
+import com.alibaba.fastjson2.schema.JSONSchema;
+import com.alibaba.fastjson2.schema.ValidateResult;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
@@ -151,6 +153,53 @@ public class Fastjson2Test {
         JSONObject object = JSON.parseObject(filtered);
         assertThat(object.getString("summary")).isEqualTo("unknown");
         assertThat(object.getString("title")).isEqualTo(book.getTitle());
+    }
+
+    @Test
+    void validatesDocumentsAgainstJsonSchemaConstraints() {
+        JSONSchema schema = JSONSchema.parseSchema("""
+                {
+                  "type": "object",
+                  "required": ["sku", "quantity", "status", "tags"],
+                  "properties": {
+                    "sku": {"type": "string", "minLength": 3, "pattern": "^[A-Z]{3}-\\\\d{3}$"},
+                    "quantity": {"type": "integer", "minimum": 1, "maximum": 99},
+                    "status": {"type": "string", "enum": ["draft", "active", "archived"]},
+                    "tags": {
+                      "type": "array",
+                      "minItems": 1,
+                      "uniqueItems": true,
+                      "items": {"type": "string", "minLength": 2}
+                    }
+                  }
+                }
+                """);
+
+        JSONObject validInventoryItem = JSON.parseObject("""
+                {
+                  "sku": "ABC-123",
+                  "quantity": 12,
+                  "status": "active",
+                  "tags": ["warehouse", "fragile"]
+                }
+                """);
+        JSONObject invalidInventoryItem = JSON.parseObject("""
+                {
+                  "sku": "bad",
+                  "quantity": 0,
+                  "status": "retired",
+                  "tags": ["x", "x"]
+                }
+                """);
+
+        ValidateResult validResult = schema.validate(validInventoryItem);
+        ValidateResult invalidResult = schema.validate(invalidInventoryItem);
+
+        assertThat(schema.getType()).isEqualTo(JSONSchema.Type.Object);
+        assertThat(validResult.isSuccess()).isTrue();
+        assertThat(schema.isValid(validInventoryItem)).isTrue();
+        assertThat(invalidResult.isSuccess()).isFalse();
+        assertThat(schema.isValid(invalidInventoryItem)).isFalse();
     }
 
     private static Book sampleBook() {

--- a/tests/src/com.alibaba.fastjson2/fastjson2/2.0.53/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.alibaba.fastjson2/fastjson2/2.0.53/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,335 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.JSON"
+      },
+      "type" : "com_alibaba_fastjson2.fastjson2.Fastjson2Test$Author"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.JSONWriter"
+      },
+      "type" : "com_alibaba_fastjson2.fastjson2.Fastjson2Test$Author",
+      "fields" : [
+        {
+          "name" : "active"
+        },
+        {
+          "name" : "name"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getName",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "isActive",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.reader.FieldReaderStringMethod"
+      },
+      "type" : "com_alibaba_fastjson2.fastjson2.Fastjson2Test$Author",
+      "methods" : [
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.reader.ObjectReader2"
+      },
+      "type" : "com_alibaba_fastjson2.fastjson2.Fastjson2Test$Author",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setActive",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        },
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.JSON"
+      },
+      "type" : "com_alibaba_fastjson2.fastjson2.Fastjson2Test$Book",
+      "methods" : [
+        {
+          "name" : "setAvailable",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.JSONWriter$Context"
+      },
+      "type" : "com_alibaba_fastjson2.fastjson2.Fastjson2Test$Book",
+      "fields" : [
+        {
+          "name" : "author"
+        },
+        {
+          "name" : "available"
+        },
+        {
+          "name" : "id"
+        },
+        {
+          "name" : "publishedAt"
+        },
+        {
+          "name" : "summary"
+        },
+        {
+          "name" : "title"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getAuthor",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getId",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getPrice",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getPublishedAt",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getSummary",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getTags",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getTitle",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "isAvailable",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.reader.FieldReader"
+      },
+      "type" : "com_alibaba_fastjson2.fastjson2.Fastjson2Test$Book",
+      "fields" : [
+        {
+          "name" : "tags"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.reader.FieldReaderBigDecimalMethod"
+      },
+      "type" : "com_alibaba_fastjson2.fastjson2.Fastjson2Test$Book",
+      "methods" : [
+        {
+          "name" : "setPrice",
+          "parameterTypes" : [
+            "java.math.BigDecimal"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.reader.FieldReaderInt64ValueMethod"
+      },
+      "type" : "com_alibaba_fastjson2.fastjson2.Fastjson2Test$Book",
+      "methods" : [
+        {
+          "name" : "setId",
+          "parameterTypes" : [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.reader.FieldReaderList"
+      },
+      "type" : "com_alibaba_fastjson2.fastjson2.Fastjson2Test$Book",
+      "methods" : [
+        {
+          "name" : "setTags",
+          "parameterTypes" : [
+            "java.util.List"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.reader.FieldReaderLocalDate"
+      },
+      "type" : "com_alibaba_fastjson2.fastjson2.Fastjson2Test$Book",
+      "methods" : [
+        {
+          "name" : "setPublishedAt",
+          "parameterTypes" : [
+            "java.time.LocalDate"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.reader.FieldReaderObject"
+      },
+      "type" : "com_alibaba_fastjson2.fastjson2.Fastjson2Test$Book",
+      "methods" : [
+        {
+          "name" : "setAuthor",
+          "parameterTypes" : [
+            "com_alibaba_fastjson2.fastjson2.Fastjson2Test$Author"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.reader.ObjectReaderAdapter"
+      },
+      "type" : "com_alibaba_fastjson2.fastjson2.Fastjson2Test$Book",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setAvailable",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        },
+        {
+          "name" : "setSummary",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setTitle",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.reader.ObjectReaderBean"
+      },
+      "type" : "com_alibaba_fastjson2.fastjson2.Fastjson2Test$Book",
+      "methods" : [
+        {
+          "name" : "setTitle",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.reader.ObjectReaderImplList"
+      },
+      "type" : "com_alibaba_fastjson2.fastjson2.Fastjson2Test$Book"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.writer.FieldWriterInt64"
+      },
+      "type" : "com_alibaba_fastjson2.fastjson2.Fastjson2Test$Book",
+      "fields" : [
+        {
+          "name" : "id"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.writer.FieldWriterListStrFunc"
+      },
+      "type" : "com_alibaba_fastjson2.fastjson2.Fastjson2Test$Book",
+      "fields" : [
+        {
+          "name" : "tags"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.writer.FieldWriterObject"
+      },
+      "type" : "com_alibaba_fastjson2.fastjson2.Fastjson2Test$Book"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.writer.FieldWriterObjectFinal"
+      },
+      "type" : "com_alibaba_fastjson2.fastjson2.Fastjson2Test$Book",
+      "fields" : [
+        {
+          "name" : "publishedAt"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.alibaba.fastjson2.writer.FieldWriterObjectFunc"
+      },
+      "type" : "com_alibaba_fastjson2.fastjson2.Fastjson2Test$Book",
+      "fields" : [
+        {
+          "name" : "author"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/com.alibaba.fastjson2/fastjson2/2.0.53/user-code-filter.json
+++ b/tests/src/com.alibaba.fastjson2/fastjson2/2.0.53/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.alibaba.fastjson2.**"
+      "includeClasses" : "com.alibaba.fastjson2.**"
+    },
+    {
+      "includeClasses" : "com_alibaba_fastjson2.fastjson2.**"
     }
   ]
 }

--- a/tests/src/com.alibaba.fastjson2/fastjson2/2.0.53/user-code-filter.json
+++ b/tests/src/com.alibaba.fastjson2/fastjson2/2.0.53/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.alibaba.fastjson2.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #2192

This PR introduces tests and metadata for com.alibaba.fastjson2:fastjson2:2.0.53, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 268672
- Cached input tokens: 3245056
- Output tokens: 23356
- Metadata entries: 47
- Test-only metadata entries: 60
- Iterations: 9
- Library coverage percentage: 12.32
- Generated lines of code: 302
- Tested library lines of code: 9950

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `eece5f4c4d04e88b1b154b86fa6532f07e3f836b`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 30/529 covered calls (5.67%)
- Reflection: 29/525 covered calls (5.52%)
- Resources: 1/4 covered calls (25.00%)

Library coverage:
- Instruction: 48898/394976 (12.38%)
- Line: 9950/80789 (12.32%)
- Method: 830/5850 (14.19%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
