### PR TITLE
[GenAI] Test fix for org.apache.maven.surefire:surefire-api:3.0.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.maven.surefire/surefire-api/3.0.0/reachability-metadata.json
+++ b/metadata/org.apache.maven.surefire/surefire-api/3.0.0/reachability-metadata.json
@@ -1,0 +1,220 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.api.util.ReflectionUtils"
+      },
+      "type": "org.apache.maven.surefire.api.booter.BaseProviderFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      },
+      "type": "org.apache.maven.surefire.api.booter.BaseProviderFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "setClassLoaders",
+          "parameterTypes": [
+            "java.lang.ClassLoader"
+          ]
+        },
+        {
+          "name": "setProviderProperties",
+          "parameterTypes": [
+            "java.util.Map"
+          ]
+        },
+        {
+          "name": "setTestArtifactInfo",
+          "parameterTypes": [
+            "org.apache.maven.surefire.api.testset.TestArtifactInfo"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      },
+      "type": "org.apache.maven.surefire.api.cli.CommandLineOption"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.api.util.ReflectionUtils"
+      },
+      "type": "org.apache.maven.surefire.api.filter.SpecificTestClassFilter"
+    },
+    {
+      "condition": {
+        "typeReached": "org_apache_maven_surefire.surefire_api.ReflectionUtilsTest"
+      },
+      "type": "org.apache.maven.surefire.api.filter.SpecificTestClassFilter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      },
+      "type": "org.apache.maven.surefire.api.provider.ProviderParameters"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      },
+      "type": "org.apache.maven.surefire.api.report.ReporterConfiguration"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      },
+      "type": "org.apache.maven.surefire.api.report.ReporterFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.api.util.ReflectionUtils"
+      },
+      "type": "org.apache.maven.surefire.api.report.SimpleReportEntry",
+      "methods": [
+        {
+          "name": "getSourceName",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_apache_maven_surefire.surefire_api.ReflectionUtilsTest"
+      },
+      "type": "org.apache.maven.surefire.api.report.SimpleReportEntry",
+      "methods": [
+        {
+          "name": "getName",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      },
+      "type": "org.apache.maven.surefire.api.suite.RunResult"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      },
+      "type": "org.apache.maven.surefire.api.testset.DirectoryScannerParameters"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      },
+      "type": "org.apache.maven.surefire.api.testset.RunOrderParameters"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.api.util.ReflectionUtils"
+      },
+      "type": "org.apache.maven.surefire.api.testset.TestArtifactInfo",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String",
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      },
+      "type": "org.apache.maven.surefire.api.testset.TestArtifactInfo",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String",
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_apache_maven_surefire.surefire_api.ReflectionUtilsTest"
+      },
+      "type": "org.apache.maven.surefire.api.testset.TestArtifactInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      },
+      "type": "org.apache.maven.surefire.api.testset.TestListResolver"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      },
+      "type": "org.apache.maven.surefire.api.testset.TestRequest"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.api.util.DefaultScanResult"
+      },
+      "type": "org.apache.maven.surefire.api.util.DefaultScanResult"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.api.util.DefaultScanResult"
+      },
+      "type": "org.apache.maven.surefire.api.util.TestsToRun"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.api.util.ReflectionUtils"
+      },
+      "type": "org.apache.maven.surefire.shared.utils.io.Java7Support",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.api.util.DefaultDirectoryScanner"
+      },
+      "type": "org_apache_maven_surefire.surefire_api.DefaultDirectoryScannerTest"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org_apache_maven_surefire.surefire_api.DefaultDirectoryScannerTest"
+      },
+      "glob": "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition": {
+        "typeReached": "org_apache_maven_surefire.surefire_api.DefaultDirectoryScannerTest"
+      },
+      "glob": "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/metadata/org.apache.maven.surefire/surefire-api/3.0.0/reachability-metadata.json
+++ b/metadata/org.apache.maven.surefire/surefire-api/3.0.0/reachability-metadata.json
@@ -1,138 +1,112 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.api.util.ReflectionUtils"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.api.util.ReflectionUtils"
       },
-      "type": "org.apache.maven.surefire.api.booter.BaseProviderFactory"
+      "type" : "org.apache.maven.surefire.api.booter.BaseProviderFactory"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.booter.SurefireReflector"
       },
-      "type": "org.apache.maven.surefire.api.booter.BaseProviderFactory",
-      "methods": [
+      "type" : "org.apache.maven.surefire.api.booter.BaseProviderFactory",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "boolean"
           ]
         },
         {
-          "name": "setClassLoaders",
-          "parameterTypes": [
+          "name" : "setClassLoaders",
+          "parameterTypes" : [
             "java.lang.ClassLoader"
           ]
         },
         {
-          "name": "setProviderProperties",
-          "parameterTypes": [
+          "name" : "setProviderProperties",
+          "parameterTypes" : [
             "java.util.Map"
           ]
         },
         {
-          "name": "setTestArtifactInfo",
-          "parameterTypes": [
+          "name" : "setTestArtifactInfo",
+          "parameterTypes" : [
             "org.apache.maven.surefire.api.testset.TestArtifactInfo"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.booter.SurefireReflector"
       },
-      "type": "org.apache.maven.surefire.api.cli.CommandLineOption"
+      "type" : "org.apache.maven.surefire.api.cli.CommandLineOption"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.api.util.ReflectionUtils"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.api.util.ReflectionUtils"
       },
-      "type": "org.apache.maven.surefire.api.filter.SpecificTestClassFilter"
+      "type" : "org.apache.maven.surefire.api.filter.SpecificTestClassFilter"
     },
     {
-      "condition": {
-        "typeReached": "org_apache_maven_surefire.surefire_api.ReflectionUtilsTest"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.booter.SurefireReflector"
       },
-      "type": "org.apache.maven.surefire.api.filter.SpecificTestClassFilter",
-      "methods": [
+      "type" : "org.apache.maven.surefire.api.provider.ProviderParameters"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.booter.SurefireReflector"
+      },
+      "type" : "org.apache.maven.surefire.api.report.ReporterConfiguration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.booter.SurefireReflector"
+      },
+      "type" : "org.apache.maven.surefire.api.report.ReporterFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.api.util.ReflectionUtils"
+      },
+      "type" : "org.apache.maven.surefire.api.report.SimpleReportEntry",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.String[]"
-          ]
+          "name" : "getSourceName",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.booter.SurefireReflector"
       },
-      "type": "org.apache.maven.surefire.api.provider.ProviderParameters"
+      "type" : "org.apache.maven.surefire.api.suite.RunResult"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.booter.SurefireReflector"
       },
-      "type": "org.apache.maven.surefire.api.report.ReporterConfiguration"
+      "type" : "org.apache.maven.surefire.api.testset.DirectoryScannerParameters"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.booter.SurefireReflector"
       },
-      "type": "org.apache.maven.surefire.api.report.ReporterFactory"
+      "type" : "org.apache.maven.surefire.api.testset.RunOrderParameters"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.api.util.ReflectionUtils"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.api.util.ReflectionUtils"
       },
-      "type": "org.apache.maven.surefire.api.report.SimpleReportEntry",
-      "methods": [
+      "type" : "org.apache.maven.surefire.api.testset.TestArtifactInfo",
+      "methods" : [
         {
-          "name": "getSourceName",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_apache_maven_surefire.surefire_api.ReflectionUtilsTest"
-      },
-      "type": "org.apache.maven.surefire.api.report.SimpleReportEntry",
-      "methods": [
-        {
-          "name": "getName",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
-      },
-      "type": "org.apache.maven.surefire.api.suite.RunResult"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
-      },
-      "type": "org.apache.maven.surefire.api.testset.DirectoryScannerParameters"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
-      },
-      "type": "org.apache.maven.surefire.api.testset.RunOrderParameters"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.api.util.ReflectionUtils"
-      },
-      "type": "org.apache.maven.surefire.api.testset.TestArtifactInfo",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.String",
             "java.lang.String"
           ]
@@ -140,14 +114,14 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.booter.SurefireReflector"
       },
-      "type": "org.apache.maven.surefire.api.testset.TestArtifactInfo",
-      "methods": [
+      "type" : "org.apache.maven.surefire.api.testset.TestArtifactInfo",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.String",
             "java.lang.String"
           ]
@@ -155,66 +129,40 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org_apache_maven_surefire.surefire_api.ReflectionUtilsTest"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.booter.SurefireReflector"
       },
-      "type": "org.apache.maven.surefire.api.testset.TestArtifactInfo"
+      "type" : "org.apache.maven.surefire.api.testset.TestListResolver"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.booter.SurefireReflector"
       },
-      "type": "org.apache.maven.surefire.api.testset.TestListResolver"
+      "type" : "org.apache.maven.surefire.api.testset.TestRequest"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.api.util.DefaultScanResult"
       },
-      "type": "org.apache.maven.surefire.api.testset.TestRequest"
+      "type" : "org.apache.maven.surefire.api.util.DefaultScanResult"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.api.util.DefaultScanResult"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.api.util.DefaultScanResult"
       },
-      "type": "org.apache.maven.surefire.api.util.DefaultScanResult"
+      "type" : "org.apache.maven.surefire.api.util.TestsToRun"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.api.util.DefaultScanResult"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.api.util.ReflectionUtils"
       },
-      "type": "org.apache.maven.surefire.api.util.TestsToRun"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.api.util.ReflectionUtils"
-      },
-      "type": "org.apache.maven.surefire.shared.utils.io.Java7Support",
-      "methods": [
+      "type" : "org.apache.maven.surefire.shared.utils.io.Java7Support",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.api.util.DefaultDirectoryScanner"
-      },
-      "type": "org_apache_maven_surefire.surefire_api.DefaultDirectoryScannerTest"
-    }
-  ],
-  "resources": [
-    {
-      "condition": {
-        "typeReached": "org_apache_maven_surefire.surefire_api.DefaultDirectoryScannerTest"
-      },
-      "glob": "META-INF/services/org.assertj.core.configuration.Configuration"
-    },
-    {
-      "condition": {
-        "typeReached": "org_apache_maven_surefire.surefire_api.DefaultDirectoryScannerTest"
-      },
-      "glob": "META-INF/services/org.assertj.core.presentation.Representation"
     }
   ]
 }

--- a/metadata/org.apache.maven.surefire/surefire-api/index.json
+++ b/metadata/org.apache.maven.surefire/surefire-api/index.json
@@ -1,6 +1,16 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.0.0",
+    "tested-versions" : [
+      "3.0.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.maven.plugin.surefire.runorder",
+      "org.apache.maven.surefire"
+    ]
+  },
+  {
     "metadata-version" : "2.22.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/$version$/surefire-api-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/maven-surefire",

--- a/metadata/org.apache.maven.surefire/surefire-api/index.json
+++ b/metadata/org.apache.maven.surefire/surefire-api/index.json
@@ -2,12 +2,18 @@
   {
     "latest" : true,
     "metadata-version" : "3.0.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/$version$/surefire-api-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/maven-surefire",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire/$version$/surefire-$version$-source-release.zip",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/$version$/surefire-api-$version$-javadoc.jar",
+    "description" : "Apache Maven Surefire API provides the shared provider, reporting, booter, scanning, and test-set interfaces used by Maven Surefire and Failsafe components. It supports executing and reporting tests in Maven-based JVM builds by exposing common contracts that Surefire plugins, booters, and test framework providers use.",
     "tested-versions" : [
       "3.0.0"
     ],
     "allowed-packages" : [
       "org.apache.maven.plugin.surefire.runorder",
-      "org.apache.maven.surefire"
+      "org.apache.maven.surefire",
+      "org.apache.maven.surefire.api"
     ]
   },
   {

--- a/stats/org.apache.maven.surefire/surefire-api/3.0.0/execution-metrics.json
+++ b/stats/org.apache.maven.surefire/surefire-api/3.0.0/execution-metrics.json
@@ -1,0 +1,101 @@
+{
+  "fix_javac_fail:2026-06-08": {
+    "timestamp": "2026-06-08T04:34:01.196793Z",
+    "library": "org.apache.maven.surefire:surefire-api:3.0.0",
+    "starting_commit": "0b589e09493e770ffe7b7ac0a86f03adf3f75af5",
+    "ending_commit": "5998bdba65ef30797fbcf665f88211d26ac870cd",
+    "previous_library": "org.apache.maven.surefire:surefire-api:2.22.2",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.0.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 14,
+            "totalCalls": 14
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 14,
+        "totalCalls": 14
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 828,
+          "missed": 10060,
+          "ratio": 0.076047,
+          "total": 10888
+        },
+        "line": {
+          "covered": 200,
+          "missed": 2196,
+          "ratio": 0.083472,
+          "total": 2396
+        },
+        "method": {
+          "covered": 66,
+          "missed": 699,
+          "ratio": 0.086275,
+          "total": 765
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.22.2",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 60,
+            "totalCalls": 60
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 60,
+        "totalCalls": 60
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2372,
+          "missed": 13019,
+          "ratio": 0.154116,
+          "total": 15391
+        },
+        "line": {
+          "covered": 472,
+          "missed": 2797,
+          "ratio": 0.144387,
+          "total": 3269
+        },
+        "method": {
+          "covered": 104,
+          "missed": 662,
+          "ratio": 0.13577,
+          "total": 766
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 166631,
+      "cached_input_tokens_used": 3202048,
+      "output_tokens_used": 20280,
+      "iterations": 3,
+      "cost_usd": 2.2094,
+      "tested_library_loc": 200,
+      "metadata_entries": 26,
+      "test_only_metadata_entries": 9,
+      "previous_library_metadata_entries": 53,
+      "previous_library_test_only_metadata_entries": 1,
+      "code_coverage_percent": 8.35,
+      "previous_library_coverage_percent": 14.44
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/ReflectionUtilsTest.java",
+      "metadata_file": "metadata/org.apache.maven.surefire/surefire-api/3.0.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.maven.surefire/surefire-api/3.0.0/stats.json
+++ b/stats/org.apache.maven.surefire/surefire-api/3.0.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "3.0.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 14,
+          "totalCalls" : 14
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 14,
+      "totalCalls" : 14
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 828,
+        "missed" : 10060,
+        "ratio" : 0.076047,
+        "total" : 10888
+      },
+      "line" : {
+        "covered" : 200,
+        "missed" : 2196,
+        "ratio" : 0.083472,
+        "total" : 2396
+      },
+      "method" : {
+        "covered" : 66,
+        "missed" : 699,
+        "ratio" : 0.086275,
+        "total" : 765
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/.gitignore
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/build.gradle
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.maven.surefire:surefire-api:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/build.gradle
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.apache.maven.surefire:surefire-api:$libraryVersion"
+    testImplementation "org.apache.maven.surefire:surefire-booter:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/gradle.properties
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.maven.surefire:surefire-api:3.0.0
+library.version = 3.0.0
+metadata.dir = org.apache.maven.surefire/surefire-api/3.0.0/

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/settings.gradle
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.maven.surefire.surefire-api_tests'

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/DefaultDirectoryScannerTest.java
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/DefaultDirectoryScannerTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_surefire.surefire_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+
+import org.apache.maven.surefire.util.DefaultDirectoryScanner;
+import org.apache.maven.surefire.util.TestsToRun;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class DefaultDirectoryScannerTest {
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    public void locatesScannedTestClassesThroughTheSuppliedClassLoader() throws IOException {
+        final Path classFile = temporaryDirectory.resolve(
+                DefaultDirectoryScannerTest.class.getName().replace('.', '/') + ".class");
+        Files.createDirectories(classFile.getParent());
+        Files.write(classFile, new byte[0]);
+
+        final DefaultDirectoryScanner scanner = new DefaultDirectoryScanner(
+                temporaryDirectory.toFile(),
+                Collections.singletonList("**/*Test.class"),
+                Collections.singletonList("**/*Ignored.class"),
+                Collections.singletonList("**/DefaultDirectoryScannerTest.java"));
+
+        final TestsToRun tests = scanner.locateTestClasses(
+                DefaultDirectoryScannerTest.class.getClassLoader(),
+                testClass -> testClass == DefaultDirectoryScannerTest.class);
+
+        assertThat(tests.getLocatedClasses()).containsExactly(DefaultDirectoryScannerTest.class);
+    }
+}

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/DefaultDirectoryScannerTest.java
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/DefaultDirectoryScannerTest.java
@@ -13,8 +13,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 
-import org.apache.maven.surefire.util.DefaultDirectoryScanner;
-import org.apache.maven.surefire.util.TestsToRun;
+import org.apache.maven.surefire.api.util.DefaultDirectoryScanner;
+import org.apache.maven.surefire.api.util.TestsToRun;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -24,6 +24,7 @@ public class DefaultDirectoryScannerTest {
     Path temporaryDirectory;
 
     @Test
+    @SuppressWarnings("deprecation")
     public void locatesScannedTestClassesThroughTheSuppliedClassLoader() throws IOException {
         final Path classFile = temporaryDirectory.resolve(
                 DefaultDirectoryScannerTest.class.getName().replace('.', '/') + ".class");

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/DefaultScanResultTest.java
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/DefaultScanResultTest.java
@@ -11,8 +11,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.maven.surefire.util.DefaultScanResult;
-import org.apache.maven.surefire.util.TestsToRun;
+import org.apache.maven.surefire.api.util.DefaultScanResult;
+import org.apache.maven.surefire.api.util.TestsToRun;
 import org.junit.jupiter.api.Test;
 
 public class DefaultScanResultTest {

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/DefaultScanResultTest.java
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/DefaultScanResultTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_surefire.surefire_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.maven.surefire.util.DefaultScanResult;
+import org.apache.maven.surefire.util.TestsToRun;
+import org.junit.jupiter.api.Test;
+
+public class DefaultScanResultTest {
+
+    @Test
+    public void appliesFilterAfterLoadingEachScannedClassByName() {
+        final ClassLoader classLoader = DefaultScanResultTest.class.getClassLoader();
+        final DefaultScanResult scanResult = new DefaultScanResult(Arrays.asList(
+                DefaultScanResult.class.getName(),
+                TestsToRun.class.getName()));
+
+        final TestsToRun acceptedClasses = scanResult.applyFilter(
+                testClass -> testClass == DefaultScanResult.class,
+                classLoader);
+        final List<Class<?>> rejectedClasses = scanResult.getClassesSkippedByValidation(
+                testClass -> testClass == DefaultScanResult.class,
+                classLoader);
+
+        assertThat(acceptedClasses.getLocatedClasses()).containsExactly(DefaultScanResult.class);
+        assertThat(rejectedClasses).containsExactly(TestsToRun.class);
+    }
+}

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/Java7SupportTest.java
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/Java7SupportTest.java
@@ -14,7 +14,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import org.apache.maven.surefire.shade.org.apache.maven.shared.utils.io.Java7Support;
+import org.apache.maven.surefire.shared.utils.io.Java7Support;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/Java7SupportTest.java
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/Java7SupportTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_surefire.surefire_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.maven.surefire.shade.org.apache.maven.shared.utils.io.Java7Support;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class Java7SupportTest {
+
+    @Test
+    public void symbolicLinkLifecycleUsesJava7SupportOperations(@TempDir final Path tempDirectory) throws IOException {
+        final Path target = tempDirectory.resolve("target.txt");
+        final Path link = tempDirectory.resolve("link.txt");
+        Files.write(target, "surefire".getBytes(StandardCharsets.UTF_8));
+
+        final Thread currentThread = Thread.currentThread();
+        final ClassLoader previousClassLoader = currentThread.getContextClassLoader();
+        currentThread.setContextClassLoader(Java7SupportTest.class.getClassLoader());
+        try {
+            assertThat(Java7Support.isAtLeastJava7()).isTrue();
+            assertThat(Java7Support.exists(link.toFile())).isFalse();
+
+            final File createdLink = Java7Support.createSymbolicLink(link.toFile(), target.toFile());
+
+            assertThat(createdLink).isEqualTo(link.toFile());
+            assertThat(Java7Support.exists(createdLink)).isTrue();
+            assertThat(Java7Support.isSymLink(createdLink)).isTrue();
+            assertThat(Java7Support.readSymbolicLink(createdLink)).isEqualTo(target.toFile());
+            assertThat(new String(Files.readAllBytes(link), StandardCharsets.UTF_8)).isEqualTo("surefire");
+
+            Java7Support.delete(createdLink);
+
+            assertThat(Java7Support.exists(createdLink)).isFalse();
+            assertThat(Files.exists(target)).isTrue();
+        } finally {
+            currentThread.setContextClassLoader(previousClassLoader);
+        }
+    }
+}

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/ReflectionUtilsTest.java
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/ReflectionUtilsTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_surefire.surefire_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.apache.maven.surefire.SpecificTestClassFilter;
+import org.apache.maven.surefire.report.SimpleReportEntry;
+import org.apache.maven.surefire.testset.TestArtifactInfo;
+import org.apache.maven.surefire.util.ReflectionUtils;
+import org.junit.jupiter.api.Test;
+
+public class ReflectionUtilsTest {
+
+    @Test
+    public void loadsClassesByNameThroughTheSuppliedClassLoader() {
+        final ClassLoader classLoader = ReflectionUtilsTest.class.getClassLoader();
+
+        assertThat(ReflectionUtils.tryLoadClass(classLoader, SimpleReportEntry.class.getName()))
+                .isEqualTo(SimpleReportEntry.class);
+        assertThat(ReflectionUtils.loadClass(classLoader, TestArtifactInfo.class.getName()))
+                .isEqualTo(TestArtifactInfo.class);
+    }
+
+    @Test
+    public void instantiatesClassesWithSupportedConstructorShapes() {
+        final ClassLoader classLoader = ReflectionUtilsTest.class.getClassLoader();
+
+        final SimpleReportEntry noArgEntry = ReflectionUtils.instantiate(
+                classLoader, SimpleReportEntry.class.getName(), SimpleReportEntry.class);
+        final Object oneArgFilter = ReflectionUtils.instantiateOneArg(
+                classLoader,
+                SpecificTestClassFilter.class.getName(),
+                String[].class,
+                new String[] {ReflectionUtilsTest.class.getName()});
+        final Object twoArgArtifact = ReflectionUtils.instantiateTwoArgs(
+                classLoader,
+                TestArtifactInfo.class.getName(),
+                String.class,
+                "provider-version",
+                String.class,
+                "tests");
+        final Object newInstanceArtifact = ReflectionUtils.instantiateObject(
+                TestArtifactInfo.class.getName(),
+                new Class[] {String.class, String.class},
+                new Object[] {"provider-version", "main"},
+                classLoader);
+
+        assertThat(noArgEntry.getName()).isEqualTo("null");
+        assertThat(oneArgFilter).isInstanceOf(SpecificTestClassFilter.class);
+        assertThat(twoArgArtifact)
+                .isInstanceOfSatisfying(TestArtifactInfo.class, artifact -> {
+                    assertThat(artifact.getVersion()).isEqualTo("provider-version");
+                    assertThat(artifact.getClassifier()).isEqualTo("tests");
+                });
+        assertThat(newInstanceArtifact)
+                .isInstanceOfSatisfying(TestArtifactInfo.class, artifact -> {
+                    assertThat(artifact.getVersion()).isEqualTo("provider-version");
+                    assertThat(artifact.getClassifier()).isEqualTo("main");
+                });
+    }
+
+    @Test
+    public void findsAndInvokesPublicMethods() throws InvocationTargetException {
+        final SimpleReportEntry entry = new SimpleReportEntry("reflection-source", "reflection-name");
+
+        final Method getName = ReflectionUtils.getMethod(entry, "getName");
+        final Method getSourceName = ReflectionUtils.tryGetMethod(SimpleReportEntry.class, "getSourceName");
+
+        assertThat(getSourceName).isNotNull();
+        assertThat(ReflectionUtils.invokeMethodWithArray(entry, getName)).isEqualTo("reflection-name");
+        assertThat(ReflectionUtils.invokeMethodWithArray2(entry, getSourceName)).isEqualTo("reflection-source");
+        assertThat(ReflectionUtils.tryGetMethod(SimpleReportEntry.class, "missingMethod")).isNull();
+    }
+}

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/ReflectionUtilsTest.java
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/ReflectionUtilsTest.java
@@ -8,13 +8,16 @@ package org_apache_maven_surefire.surefire_api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-import org.apache.maven.surefire.SpecificTestClassFilter;
-import org.apache.maven.surefire.report.SimpleReportEntry;
-import org.apache.maven.surefire.testset.TestArtifactInfo;
-import org.apache.maven.surefire.util.ReflectionUtils;
+import org.apache.maven.surefire.api.filter.SpecificTestClassFilter;
+import org.apache.maven.surefire.api.report.RunMode;
+import org.apache.maven.surefire.api.report.SimpleReportEntry;
+import org.apache.maven.surefire.api.testset.TestArtifactInfo;
+import org.apache.maven.surefire.api.util.ReflectionUtils;
+import org.apache.maven.surefire.shared.utils.io.Java7Support;
 import org.junit.jupiter.api.Test;
 
 public class ReflectionUtilsTest {
@@ -33,33 +36,21 @@ public class ReflectionUtilsTest {
     public void instantiatesClassesWithSupportedConstructorShapes() {
         final ClassLoader classLoader = ReflectionUtilsTest.class.getClassLoader();
 
-        final SimpleReportEntry noArgEntry = ReflectionUtils.instantiate(
-                classLoader, SimpleReportEntry.class.getName(), SimpleReportEntry.class);
+        final Java7Support java7Support = ReflectionUtils.instantiate(
+                classLoader, Java7Support.class.getName(), Java7Support.class);
         final Object oneArgFilter = ReflectionUtils.instantiateOneArg(
                 classLoader,
                 SpecificTestClassFilter.class.getName(),
                 String[].class,
                 new String[] {ReflectionUtilsTest.class.getName()});
-        final Object twoArgArtifact = ReflectionUtils.instantiateTwoArgs(
-                classLoader,
-                TestArtifactInfo.class.getName(),
-                String.class,
-                "provider-version",
-                String.class,
-                "tests");
         final Object newInstanceArtifact = ReflectionUtils.instantiateObject(
                 TestArtifactInfo.class.getName(),
-                new Class[] {String.class, String.class},
+                new Class<?>[] {String.class, String.class},
                 new Object[] {"provider-version", "main"},
                 classLoader);
 
-        assertThat(noArgEntry.getName()).isEqualTo("null");
+        assertThat(java7Support).isInstanceOf(Java7Support.class);
         assertThat(oneArgFilter).isInstanceOf(SpecificTestClassFilter.class);
-        assertThat(twoArgArtifact)
-                .isInstanceOfSatisfying(TestArtifactInfo.class, artifact -> {
-                    assertThat(artifact.getVersion()).isEqualTo("provider-version");
-                    assertThat(artifact.getClassifier()).isEqualTo("tests");
-                });
         assertThat(newInstanceArtifact)
                 .isInstanceOfSatisfying(TestArtifactInfo.class, artifact -> {
                     assertThat(artifact.getVersion()).isEqualTo("provider-version");
@@ -68,15 +59,53 @@ public class ReflectionUtilsTest {
     }
 
     @Test
+    public void returnsPublicConstructorsWhenPresent() {
+        final Constructor<SpecificTestClassFilter> constructor = ReflectionUtils.tryGetConstructor(
+                SpecificTestClassFilter.class, String[].class);
+
+        assertThat(constructor).isNotNull();
+
+        final SpecificTestClassFilter filter = ReflectionUtils.newInstance(
+                constructor, (Object) new String[] {ReflectionUtilsTest.class.getName()});
+        assertThat(filter).isInstanceOf(SpecificTestClassFilter.class);
+        assertThat(ReflectionUtils.tryGetConstructor(SpecificTestClassFilter.class, Integer.class)).isNull();
+    }
+
+    @Test
+    public void reloadsTheSourceClassThroughTheSuppliedClassLoader() throws ReflectiveOperationException {
+        final ClassLoader classLoader = ReflectionUtilsTest.class.getClassLoader();
+        final SimpleReportEntry entry = new SimpleReportEntry(
+                RunMode.NORMAL_RUN,
+                2L,
+                "reload-source",
+                "reload-source-text",
+                "reload-name",
+                "reload-name-text");
+
+        final Class<?> reloadedClass = ReflectionUtils.reloadClass(classLoader, entry);
+
+        assertThat(reloadedClass).isEqualTo(SimpleReportEntry.class);
+    }
+
+    @Test
     public void findsAndInvokesPublicMethods() throws InvocationTargetException {
-        final SimpleReportEntry entry = new SimpleReportEntry("reflection-source", "reflection-name");
+        final SimpleReportEntry entry = new SimpleReportEntry(
+                RunMode.NORMAL_RUN,
+                1L,
+                "reflection-source",
+                "reflection-source-text",
+                "reflection-name",
+                "reflection-name-text");
 
         final Method getName = ReflectionUtils.getMethod(entry, "getName");
         final Method getSourceName = ReflectionUtils.tryGetMethod(SimpleReportEntry.class, "getSourceName");
 
+        final String name = ReflectionUtils.invokeMethodWithArray(entry, getName);
+        final String sourceName = ReflectionUtils.invokeMethodWithArray2(entry, getSourceName);
+
         assertThat(getSourceName).isNotNull();
-        assertThat(ReflectionUtils.invokeMethodWithArray(entry, getName)).isEqualTo("reflection-name");
-        assertThat(ReflectionUtils.invokeMethodWithArray2(entry, getSourceName)).isEqualTo("reflection-source");
+        assertThat(name).isEqualTo("reflection-name");
+        assertThat(sourceName).isEqualTo("reflection-source");
         assertThat(ReflectionUtils.tryGetMethod(SimpleReportEntry.class, "missingMethod")).isNull();
     }
 }

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/SurefireReflectorInnerClassLoaderProxyTest.java
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/SurefireReflectorInnerClassLoaderProxyTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_surefire.surefire_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.Arrays;
+
+import org.apache.maven.surefire.booter.SurefireReflector;
+import org.junit.jupiter.api.Test;
+
+public class SurefireReflectorInnerClassLoaderProxyTest {
+
+    @Test
+    public void invocationHandlerDispatchesCallsToDelegateByPublicMethodSignature() throws Exception {
+        final SurefireReflector reflector = new SurefireReflector(getClass().getClassLoader());
+        final InvocationHandler handler = newClassLoaderProxy(reflector, new GreetingDelegate());
+        final GreetingService proxy = (GreetingService) Proxy.newProxyInstance(
+                getClass().getClassLoader(), new Class[] {GreetingService.class}, handler);
+
+        final String greeting = proxy.greet("Maven Surefire");
+
+        assertThat(greeting).isEqualTo("Hello, Maven Surefire");
+    }
+
+    private static InvocationHandler newClassLoaderProxy(final SurefireReflector reflector, final Object delegate)
+            throws Exception {
+        final Class<?> proxyClass = Arrays.stream(SurefireReflector.class.getDeclaredClasses())
+                .filter(candidate -> "ClassLoaderProxy".equals(candidate.getSimpleName()))
+                .findFirst()
+                .orElseThrow(IllegalStateException::new);
+        final Constructor<?> constructor = proxyClass.getDeclaredConstructor(SurefireReflector.class, Object.class);
+        constructor.setAccessible(true);
+        return (InvocationHandler) constructor.newInstance(reflector, delegate);
+    }
+
+    public interface GreetingService {
+        String greet(String name);
+    }
+
+    public static final class GreetingDelegate implements GreetingService {
+        @Override
+        public String greet(final String name) {
+            return "Hello, " + name;
+        }
+    }
+}

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/SurefireReflectorInnerClassLoaderProxyTest.java
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/SurefireReflectorInnerClassLoaderProxyTest.java
@@ -8,37 +8,32 @@ package org_apache_maven_surefire.surefire_api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Proxy;
-import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
 
+import org.apache.maven.surefire.api.booter.BaseProviderFactory;
+import org.apache.maven.surefire.api.testset.TestArtifactInfo;
 import org.apache.maven.surefire.booter.SurefireReflector;
 import org.junit.jupiter.api.Test;
 
 public class SurefireReflectorInnerClassLoaderProxyTest {
 
     @Test
-    public void invocationHandlerDispatchesCallsToDelegateByPublicMethodSignature() throws Exception {
-        final SurefireReflector reflector = new SurefireReflector(getClass().getClassLoader());
-        final InvocationHandler handler = newClassLoaderProxy(reflector, new GreetingDelegate());
-        final GreetingService proxy = (GreetingService) Proxy.newProxyInstance(
-                getClass().getClassLoader(), new Class[] {GreetingService.class}, handler);
+    public void reflectorDispatchesConfigurationThroughSupportedProviderSetters() {
+        final ClassLoader classLoader = getClass().getClassLoader();
+        final SurefireReflector reflector = new SurefireReflector(classLoader);
+        final BaseProviderFactory providerFactory = new BaseProviderFactory(false);
+        final Map<String, String> providerProperties = Collections.singletonMap("tc.0", getClass().getName());
+        final TestArtifactInfo artifactInfo = new TestArtifactInfo("provider-version", "tests");
 
-        final String greeting = proxy.greet("Maven Surefire");
+        reflector.setTestClassLoaderAware(providerFactory, classLoader);
+        reflector.setProviderPropertiesAware(providerFactory, providerProperties);
+        reflector.setTestArtifactInfoAware(providerFactory, artifactInfo);
 
-        assertThat(greeting).isEqualTo("Hello, Maven Surefire");
-    }
-
-    private static InvocationHandler newClassLoaderProxy(final SurefireReflector reflector, final Object delegate)
-            throws Exception {
-        final Class<?> proxyClass = Arrays.stream(SurefireReflector.class.getDeclaredClasses())
-                .filter(candidate -> "ClassLoaderProxy".equals(candidate.getSimpleName()))
-                .findFirst()
-                .orElseThrow(IllegalStateException::new);
-        final Constructor<?> constructor = proxyClass.getDeclaredConstructor(SurefireReflector.class, Object.class);
-        constructor.setAccessible(true);
-        return (InvocationHandler) constructor.newInstance(reflector, delegate);
+        assertThat(providerFactory.getTestClassLoader()).isSameAs(classLoader);
+        assertThat(providerFactory.getProviderProperties()).isEqualTo(providerProperties);
+        assertThat(providerFactory.getTestArtifactInfo().getVersion()).isEqualTo(artifactInfo.getVersion());
+        assertThat(providerFactory.getTestArtifactInfo().getClassifier()).isEqualTo(artifactInfo.getClassifier());
     }
 
     public interface GreetingService {

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/SurefireReflectorTest.java
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/SurefireReflectorTest.java
@@ -8,22 +8,21 @@ package org_apache_maven_surefire.surefire_api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.apache.maven.plugin.surefire.log.api.ConsoleLogger;
-import org.apache.maven.plugin.surefire.log.api.NullConsoleLogger;
+import org.apache.maven.surefire.api.booter.BaseProviderFactory;
 import org.apache.maven.surefire.booter.SurefireReflector;
 import org.junit.jupiter.api.Test;
 
 public class SurefireReflectorTest {
 
     @Test
-    public void constructorLoadsProviderApiTypesAndConsoleLoggerDecorator() {
+    public void constructorLoadsProviderApiTypesAndCreatesBooterConfiguration() {
         final ClassLoader classLoader = SurefireReflectorTest.class.getClassLoader();
         final SurefireReflector reflector = new SurefireReflector(classLoader);
-        final ConsoleLogger logger = new NullConsoleLogger();
 
-        final Object decoratedLogger = reflector.createConsoleLogger(logger);
+        final Object configuration = reflector.createBooterConfiguration(classLoader, false);
 
-        assertThat(decoratedLogger).isInstanceOf(ConsoleLogger.class);
-        assertThat(decoratedLogger).isNotSameAs(logger);
+        assertThat(configuration)
+                .isInstanceOfSatisfying(BaseProviderFactory.class, providerFactory ->
+                        assertThat(providerFactory.isInsideFork()).isFalse());
     }
 }

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/SurefireReflectorTest.java
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/SurefireReflectorTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_surefire.surefire_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.maven.plugin.surefire.log.api.ConsoleLogger;
+import org.apache.maven.plugin.surefire.log.api.NullConsoleLogger;
+import org.apache.maven.surefire.booter.SurefireReflector;
+import org.junit.jupiter.api.Test;
+
+public class SurefireReflectorTest {
+
+    @Test
+    public void constructorLoadsProviderApiTypesAndConsoleLoggerDecorator() {
+        final ClassLoader classLoader = SurefireReflectorTest.class.getClassLoader();
+        final SurefireReflector reflector = new SurefireReflector(classLoader);
+        final ConsoleLogger logger = new NullConsoleLogger();
+
+        final Object decoratedLogger = reflector.createConsoleLogger(logger);
+
+        assertThat(decoratedLogger).isInstanceOf(ConsoleLogger.class);
+        assertThat(decoratedLogger).isNotSameAs(logger);
+    }
+}

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.booter.SurefireReflector$ClassLoaderProxy"
+      },
+      "type" : "org_apache_maven_surefire.surefire_api.SurefireReflectorInnerClassLoaderProxyTest$GreetingDelegate"
+    }
+  ]
+}

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -5,6 +5,58 @@
         "typeReached" : "org.apache.maven.surefire.booter.SurefireReflector$ClassLoaderProxy"
       },
       "type" : "org_apache_maven_surefire.surefire_api.SurefireReflectorInnerClassLoaderProxyTest$GreetingDelegate"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_maven_surefire.surefire_api.ReflectionUtilsTest"
+      },
+      "type" : "org.apache.maven.surefire.api.filter.SpecificTestClassFilter",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_maven_surefire.surefire_api.ReflectionUtilsTest"
+      },
+      "type" : "org.apache.maven.surefire.api.report.SimpleReportEntry",
+      "methods" : [
+        {
+          "name" : "getName",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_maven_surefire.surefire_api.ReflectionUtilsTest"
+      },
+      "type" : "org.apache.maven.surefire.api.testset.TestArtifactInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.api.util.DefaultDirectoryScanner"
+      },
+      "type" : "org_apache_maven_surefire.surefire_api.DefaultDirectoryScannerTest"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org_apache_maven_surefire.surefire_api.DefaultDirectoryScannerTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_maven_surefire.surefire_api.DefaultDirectoryScannerTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
     }
   ]
 }

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/user-code-filter.json
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/user-code-filter.json
@@ -1,0 +1,16 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.maven.plugin.surefire.runorder.**"
+    },
+    {
+      "includeClasses" : "org.apache.maven.surefire.**"
+    },
+    {
+      "includeClasses" : "org_apache_maven_surefire.surefire_api.**"
+    }
+  ]
+}

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/user-code-filter.json
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/user-code-filter.json
@@ -10,6 +10,9 @@
       "includeClasses" : "org.apache.maven.surefire.**"
     },
     {
+      "includeClasses" : "org.apache.maven.surefire.api.**"
+    },
+    {
       "includeClasses" : "org_apache_maven_surefire.surefire_api.**"
     }
   ]


### PR DESCRIPTION
## What does this PR do?

Fixes: #6311

This PR provides test fixes and new metadata for org.apache.maven.surefire:surefire-api:3.0.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 166631
- Cached input tokens: 3202048
- Output tokens: 20280
- Metadata entries: 26
- Test-only metadata entries: 9
- Iterations: 3
- Library coverage percentage: 8.35
- Previous library version metadata entries: 53
- Previous library version test-only metadata entries: 1
- Previous library version coverage percentage: 14.44

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `cc3b6ad5264a8792b4bedea3307e4e6c3e089e41`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.maven.surefire:surefire-api:2.22.2: 60/60 covered calls (100.00%)
- org.apache.maven.surefire:surefire-api:3.0.0: 14/14 covered calls (100.00%)

**Reflection:**
- org.apache.maven.surefire:surefire-api:2.22.2: 60/60 covered calls (100.00%)
- org.apache.maven.surefire:surefire-api:3.0.0: 14/14 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.maven.surefire:surefire-api:2.22.2: 2372/15391 (15.41%)
- org.apache.maven.surefire:surefire-api:3.0.0: 828/10888 (7.60%)

**Line:**
- org.apache.maven.surefire:surefire-api:2.22.2: 472/3269 (14.44%)
- org.apache.maven.surefire:surefire-api:3.0.0: 200/2396 (8.35%)

**Method:**
- org.apache.maven.surefire:surefire-api:2.22.2: 104/766 (13.58%)
- org.apache.maven.surefire:surefire-api:3.0.0: 66/765 (8.63%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/org.apache.maven.surefire/surefire-api/2.22.2/build.gradle b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/build.gradle
index 631fa8c973..2401c57563 100644
--- a/tests/src/org.apache.maven.surefire/surefire-api/2.22.2/build.gradle
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.apache.maven.surefire:surefire-api:$libraryVersion"
+    testImplementation "org.apache.maven.surefire:surefire-booter:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
diff --git a/tests/src/org.apache.maven.surefire/surefire-api/2.22.2/src/test/java/org_apache_maven_surefire/surefire_api/DefaultDirectoryScannerTest.java b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/DefaultDirectoryScannerTest.java
index d9e17b0bb3..bfeb39a604 100644
--- a/tests/src/org.apache.maven.surefire/surefire-api/2.22.2/src/test/java/org_apache_maven_surefire/surefire_api/DefaultDirectoryScannerTest.java
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/DefaultDirectoryScannerTest.java
@@ -13,8 +13,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 
-import org.apache.maven.surefire.util.DefaultDirectoryScanner;
-import org.apache.maven.surefire.util.TestsToRun;
+import org.apache.maven.surefire.api.util.DefaultDirectoryScanner;
+import org.apache.maven.surefire.api.util.TestsToRun;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -24,6 +24,7 @@ public class DefaultDirectoryScannerTest {
     Path temporaryDirectory;
 
     @Test
+    @SuppressWarnings("deprecation")
     public void locatesScannedTestClassesThroughTheSuppliedClassLoader() throws IOException {
         final Path classFile = temporaryDirectory.resolve(
                 DefaultDirectoryScannerTest.class.getName().replace('.', '/') + ".class");
diff --git a/tests/src/org.apache.maven.surefire/surefire-api/2.22.2/src/test/java/org_apache_maven_surefire/surefire_api/DefaultScanResultTest.java b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/DefaultScanResultTest.java
index c7ab12f531..c127e93c19 100644
--- a/tests/src/org.apache.maven.surefire/surefire-api/2.22.2/src/test/java/org_apache_maven_surefire/surefire_api/DefaultScanResultTest.java
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/DefaultScanResultTest.java
@@ -11,8 +11,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.maven.surefire.util.DefaultScanResult;
-import org.apache.maven.surefire.util.TestsToRun;
+import org.apache.maven.surefire.api.util.DefaultScanResult;
+import org.apache.maven.surefire.api.util.TestsToRun;
 import org.junit.jupiter.api.Test;
 
 public class DefaultScanResultTest {
diff --git a/tests/src/org.apache.maven.surefire/surefire-api/2.22.2/src/test/java/org_apache_maven_surefire/surefire_api/Java7SupportTest.java b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/Java7SupportTest.java
index b5909e492c..ee35829f17 100644
--- a/tests/src/org.apache.maven.surefire/surefire-api/2.22.2/src/test/java/org_apache_maven_surefire/surefire_api/Java7SupportTest.java
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/Java7SupportTest.java
@@ -14,7 +14,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import org.apache.maven.surefire.shade.org.apache.maven.shared.utils.io.Java7Support;
+import org.apache.maven.surefire.shared.utils.io.Java7Support;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
diff --git a/tests/src/org.apache.maven.surefire/surefire-api/2.22.2/src/test/java/org_apache_maven_surefire/surefire_api/ReflectionUtilsTest.java b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/ReflectionUtilsTest.java
index 71f0ae8e35..3baffd95b8 100644
--- a/tests/src/org.apache.maven.surefire/surefire-api/2.22.2/src/test/java/org_apache_maven_surefire/surefire_api/ReflectionUtilsTest.java
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/ReflectionUtilsTest.java
@@ -8,13 +8,16 @@ package org_apache_maven_surefire.surefire_api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-import org.apache.maven.surefire.SpecificTestClassFilter;
-import org.apache.maven.surefire.report.SimpleReportEntry;
-import org.apache.maven.surefire.testset.TestArtifactInfo;
-import org.apache.maven.surefire.util.ReflectionUtils;
+import org.apache.maven.surefire.api.filter.SpecificTestClassFilter;
+import org.apache.maven.surefire.api.report.RunMode;
+import org.apache.maven.surefire.api.report.SimpleReportEntry;
+import org.apache.maven.surefire.api.testset.TestArtifactInfo;
+import org.apache.maven.surefire.api.util.ReflectionUtils;
+import org.apache.maven.surefire.shared.utils.io.Java7Support;
 import org.junit.jupiter.api.Test;
 
 public class ReflectionUtilsTest {
@@ -33,33 +36,21 @@ public class ReflectionUtilsTest {
     public void instantiatesClassesWithSupportedConstructorShapes() {
         final ClassLoader classLoader = ReflectionUtilsTest.class.getClassLoader();
 
-        final SimpleReportEntry noArgEntry = ReflectionUtils.instantiate(
-                classLoader, SimpleReportEntry.class.getName(), SimpleReportEntry.class);
+        final Java7Support java7Support = ReflectionUtils.instantiate(
+                classLoader, Java7Support.class.getName(), Java7Support.class);
         final Object oneArgFilter = ReflectionUtils.instantiateOneArg(
                 classLoader,
                 SpecificTestClassFilter.class.getName(),
                 String[].class,
                 new String[] {ReflectionUtilsTest.class.getName()});
-        final Object twoArgArtifact = ReflectionUtils.instantiateTwoArgs(
-                classLoader,
-                TestArtifactInfo.class.getName(),
-                String.class,
-                "provider-version",
-                String.class,
-                "tests");
         final Object newInstanceArtifact = ReflectionUtils.instantiateObject(
                 TestArtifactInfo.class.getName(),
-                new Class[] {String.class, String.class},
+                new Class<?>[] {String.class, String.class},
                 new Object[] {"provider-version", "main"},
                 classLoader);
 
-        assertThat(noArgEntry.getName()).isEqualTo("null");
+        assertThat(java7Support).isInstanceOf(Java7Support.class);
         assertThat(oneArgFilter).isInstanceOf(SpecificTestClassFilter.class);
-        assertThat(twoArgArtifact)
-                .isInstanceOfSatisfying(TestArtifactInfo.class, artifact -> {
-                    assertThat(artifact.getVersion()).isEqualTo("provider-version");
-                    assertThat(artifact.getClassifier()).isEqualTo("tests");
-                });
         assertThat(newInstanceArtifact)
                 .isInstanceOfSatisfying(TestArtifactInfo.class, artifact -> {
                     assertThat(artifact.getVersion()).isEqualTo("provider-version");
@@ -67,16 +58,54 @@ public class ReflectionUtilsTest {
                 });
     }
 
+    @Test
+    public void returnsPublicConstructorsWhenPresent() {
+        final Constructor<SpecificTestClassFilter> constructor = ReflectionUtils.tryGetConstructor(
+                SpecificTestClassFilter.class, String[].class);
+
+        assertThat(constructor).isNotNull();
+
+        final SpecificTestClassFilter filter = ReflectionUtils.newInstance(
+                constructor, (Object) new String[] {ReflectionUtilsTest.class.getName()});
+        assertThat(filter).isInstanceOf(SpecificTestClassFilter.class);
+        assertThat(ReflectionUtils.tryGetConstructor(SpecificTestClassFilter.class, Integer.class)).isNull();
+    }
+
+    @Test
+    public void reloadsTheSourceClassThroughTheSuppliedClassLoader() throws ReflectiveOperationException {
+        final ClassLoader classLoader = ReflectionUtilsTest.class.getClassLoader();
+        final SimpleReportEntry entry = new SimpleReportEntry(
+                RunMode.NORMAL_RUN,
+                2L,
+                "reload-source",
+                "reload-source-text",
+                "reload-name",
+                "reload-name-text");
+
+        final Class<?> reloadedClass = ReflectionUtils.reloadClass(classLoader, entry);
+
+        assertThat(reloadedClass).isEqualTo(SimpleReportEntry.class);
+    }
+
     @Test
     public void findsAndInvokesPublicMethods() throws InvocationTargetException {
-        final SimpleReportEntry entry = new SimpleReportEntry("reflection-source", "reflection-name");
+        final SimpleReportEntry entry = new SimpleReportEntry(
+                RunMode.NORMAL_RUN,
+                1L,
+                "reflection-source",
+                "reflection-source-text",
+                "reflection-name",
+                "reflection-name-text");
 
         final Method getName = ReflectionUtils.getMethod(entry, "getName");
         final Method getSourceName = ReflectionUtils.tryGetMethod(SimpleReportEntry.class, "getSourceName");
 
+        final String name = ReflectionUtils.invokeMethodWithArray(entry, getName);
+        final String sourceName = ReflectionUtils.invokeMethodWithArray2(entry, getSourceName);
+
         assertThat(getSourceName).isNotNull();
-        assertThat(ReflectionUtils.invokeMethodWithArray(entry, getName)).isEqualTo("reflection-name");
-        assertThat(ReflectionUtils.invokeMethodWithArray2(entry, getSourceName)).isEqualTo("reflection-source");
+        assertThat(name).isEqualTo("reflection-name");
+        assertThat(sourceName).isEqualTo("reflection-source");
         assertThat(ReflectionUtils.tryGetMethod(SimpleReportEntry.class, "missingMethod")).isNull();
     }
 }
diff --git a/tests/src/org.apache.maven.surefire/surefire-api/2.22.2/src/test/java/org_apache_maven_surefire/surefire_api/SurefireReflectorInnerClassLoaderProxyTest.java b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/SurefireReflectorInnerClassLoaderProxyTest.java
index c3da611e4d..682873ea9a 100644
--- a/tests/src/org.apache.maven.surefire/surefire-api/2.22.2/src/test/java/org_apache_maven_surefire/surefire_api/SurefireReflectorInnerClassLoaderProxyTest.java
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/SurefireReflectorInnerClassLoaderProxyTest.java
@@ -8,37 +8,32 @@ package org_apache_maven_surefire.surefire_api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Proxy;
-import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
 
+import org.apache.maven.surefire.api.booter.BaseProviderFactory;
+import org.apache.maven.surefire.api.testset.TestArtifactInfo;
 import org.apache.maven.surefire.booter.SurefireReflector;
 import org.junit.jupiter.api.Test;
 
 public class SurefireReflectorInnerClassLoaderProxyTest {
 
     @Test
-    public void invocationHandlerDispatchesCallsToDelegateByPublicMethodSignature() throws Exception {
-        final SurefireReflector reflector = new SurefireReflector(getClass().getClassLoader());
-        final InvocationHandler handler = newClassLoaderProxy(reflector, new GreetingDelegate());
-        final GreetingService proxy = (GreetingService) Proxy.newProxyInstance(
-                getClass().getClassLoader(), new Class[] {GreetingService.class}, handler);
-
-        final String greeting = proxy.greet("Maven Surefire");
-
-        assertThat(greeting).isEqualTo("Hello, Maven Surefire");
-    }
-
-    private static InvocationHandler newClassLoaderProxy(final SurefireReflector reflector, final Object delegate)
-            throws Exception {
-        final Class<?> proxyClass = Arrays.stream(SurefireReflector.class.getDeclaredClasses())
-                .filter(candidate -> "ClassLoaderProxy".equals(candidate.getSimpleName()))
-                .findFirst()
-                .orElseThrow(IllegalStateException::new);
-        final Constructor<?> constructor = proxyClass.getDeclaredConstructor(SurefireReflector.class, Object.class);
-        constructor.setAccessible(true);
-        return (InvocationHandler) constructor.newInstance(reflector, delegate);
+    public void reflectorDispatchesConfigurationThroughSupportedProviderSetters() {
+        final ClassLoader classLoader = getClass().getClassLoader();
+        final SurefireReflector reflector = new SurefireReflector(classLoader);
+        final BaseProviderFactory providerFactory = new BaseProviderFactory(false);
+        final Map<String, String> providerProperties = Collections.singletonMap("tc.0", getClass().getName());
+        final TestArtifactInfo artifactInfo = new TestArtifactInfo("provider-version", "tests");
+
+        reflector.setTestClassLoaderAware(providerFactory, classLoader);
+        reflector.setProviderPropertiesAware(providerFactory, providerProperties);
+        reflector.setTestArtifactInfoAware(providerFactory, artifactInfo);
+
+        assertThat(providerFactory.getTestClassLoader()).isSameAs(classLoader);
+        assertThat(providerFactory.getProviderProperties()).isEqualTo(providerProperties);
+        assertThat(providerFactory.getTestArtifactInfo().getVersion()).isEqualTo(artifactInfo.getVersion());
+        assertThat(providerFactory.getTestArtifactInfo().getClassifier()).isEqualTo(artifactInfo.getClassifier());
     }
 
     public interface GreetingService {
diff --git a/tests/src/org.apache.maven.surefire/surefire-api/2.22.2/src/test/java/org_apache_maven_surefire/surefire_api/SurefireReflectorTest.java b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/SurefireReflectorTest.java
index 6986899d6a..ecc3c8e664 100644
--- a/tests/src/org.apache.maven.surefire/surefire-api/2.22.2/src/test/java/org_apache_maven_surefire/surefire_api/SurefireReflectorTest.java
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/SurefireReflectorTest.java
@@ -8,22 +8,21 @@ package org_apache_maven_surefire.surefire_api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.apache.maven.plugin.surefire.log.api.ConsoleLogger;
-import org.apache.maven.plugin.surefire.log.api.NullConsoleLogger;
+import org.apache.maven.surefire.api.booter.BaseProviderFactory;
 import org.apache.maven.surefire.booter.SurefireReflector;
 import org.junit.jupiter.api.Test;
 
 public class SurefireReflectorTest {
 
     @Test
-    public void constructorLoadsProviderApiTypesAndConsoleLoggerDecorator() {
+    public void constructorLoadsProviderApiTypesAndCreatesBooterConfiguration() {
         final ClassLoader classLoader = SurefireReflectorTest.class.getClassLoader();
         final SurefireReflector reflector = new SurefireReflector(classLoader);
-        final ConsoleLogger logger = new NullConsoleLogger();
 
-        final Object decoratedLogger = reflector.createConsoleLogger(logger);
+        final Object configuration = reflector.createBooterConfiguration(classLoader, false);
 
-        assertThat(decoratedLogger).isInstanceOf(ConsoleLogger.class);
-        assertThat(decoratedLogger).isNotSameAs(logger);
+        assertThat(configuration)
+                .isInstanceOfSatisfying(BaseProviderFactory.class, providerFactory ->
+                        assertThat(providerFactory.isInsideFork()).isFalse());
     }
 }
diff --git a/tests/src/org.apache.maven.surefire/surefire-api/2.22.2/user-code-filter.json b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/user-code-filter.json
index 0d8a97b90a..6fd6b839e4 100644
--- a/tests/src/org.apache.maven.surefire/surefire-api/2.22.2/user-code-filter.json
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/user-code-filter.json
@@ -9,6 +9,9 @@
     {
       "includeClasses" : "org.apache.maven.surefire.**"
     },
+    {
+      "includeClasses" : "org.apache.maven.surefire.api.**"
+    },
     {
       "includeClasses" : "org_apache_maven_surefire.surefire_api.**"
     }

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
