### PR TITLE
[GenAI] Add support for com.squareup.retrofit2:retrofit:2.5.0 using gpt-5.5

### DIFF
--- a/metadata/com.squareup.retrofit2/retrofit/2.5.0/reachability-metadata.json
+++ b/metadata/com.squareup.retrofit2/retrofit/2.5.0/reachability-metadata.json
@@ -1,0 +1,108 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "retrofit2.Platform"
+      },
+      "type" : "android.os.Build"
+    },
+    {
+      "condition" : {
+        "typeReached" : "retrofit2.Retrofit$1"
+      },
+      "type" : "java.lang.Object",
+      "methods" : [
+        {
+          "name" : "toString",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "retrofit2.Retrofit$Builder"
+      },
+      "type" : "java.lang.Throwable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "retrofit2.Utils"
+      },
+      "type" : "java.util.List[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "retrofit2.Platform"
+      },
+      "type" : "java.util.Optional"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "type" : {
+        "proxy" : [
+          "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test$ProxyObjectMethodService"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitTest"
+      },
+      "type" : "com_squareup_retrofit2.retrofit.RetrofitTest$EagerService"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitTest"
+      },
+      "type" : {
+        "proxy" : [
+          "com_squareup_retrofit2.retrofit.RetrofitTest$EagerService"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitTest"
+      },
+      "type" : {
+        "proxy" : [
+          "com_squareup_retrofit2.retrofit.RetrofitTest$SimpleService"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.UtilsTest"
+      },
+      "type" : "com_squareup_retrofit2.retrofit.UtilsTest$GenericArrayQueryService"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.UtilsTest"
+      },
+      "type" : {
+        "proxy" : [
+          "com_squareup_retrofit2.retrofit.UtilsTest$GenericArrayQueryService"
+        ]
+      }
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "retrofit2.Retrofit$Builder"
+      },
+      "module" : "java.base",
+      "glob" : "jdk/internal/icu/impl/data/icudt76b/uprops.icu"
+    },
+    {
+      "condition" : {
+        "typeReached" : "retrofit2.Retrofit$Builder"
+      },
+      "module" : "java.base",
+      "glob" : "sun/net/idn/uidna.spp"
+    }
+  ]
+}

--- a/metadata/com.squareup.retrofit2/retrofit/2.5.0/reachability-metadata.json
+++ b/metadata/com.squareup.retrofit2/retrofit/2.5.0/reachability-metadata.json
@@ -38,55 +38,41 @@
     },
     {
       "condition" : {
-        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+        "typeReached" : "retrofit2.Retrofit$Builder"
       },
-      "type" : {
-        "proxy" : [
-          "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test$ProxyObjectMethodService"
-        ]
-      }
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
     },
     {
       "condition" : {
-        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitTest"
+        "typeReached" : "retrofit2.Retrofit$Builder"
       },
-      "type" : "com_squareup_retrofit2.retrofit.RetrofitTest$EagerService"
+      "type" : "sun.security.ssl.SSLContextImpl$TLSContext",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
     },
     {
       "condition" : {
-        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitTest"
+        "typeReached" : "retrofit2.Retrofit$Builder"
       },
-      "type" : {
-        "proxy" : [
-          "com_squareup_retrofit2.retrofit.RetrofitTest$EagerService"
-        ]
-      }
-    },
-    {
-      "condition" : {
-        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitTest"
-      },
-      "type" : {
-        "proxy" : [
-          "com_squareup_retrofit2.retrofit.RetrofitTest$SimpleService"
-        ]
-      }
-    },
-    {
-      "condition" : {
-        "typeReached" : "com_squareup_retrofit2.retrofit.UtilsTest"
-      },
-      "type" : "com_squareup_retrofit2.retrofit.UtilsTest$GenericArrayQueryService"
-    },
-    {
-      "condition" : {
-        "typeReached" : "com_squareup_retrofit2.retrofit.UtilsTest"
-      },
-      "type" : {
-        "proxy" : [
-          "com_squareup_retrofit2.retrofit.UtilsTest$GenericArrayQueryService"
-        ]
-      }
+      "type" : "sun.security.ssl.TrustManagerFactoryImpl$PKIXFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
     }
   ],
   "resources" : [

--- a/metadata/com.squareup.retrofit2/retrofit/index.json
+++ b/metadata/com.squareup.retrofit2/retrofit/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.5.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/squareup/retrofit2/retrofit/$version$/retrofit-$version$-sources.jar",
+    "repository-url" : "https://github.com/square/retrofit",
+    "test-code-url" : "https://github.com/square/retrofit/tree/parent-$version$/retrofit/src/test/java",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/squareup/retrofit2/retrofit/$version$/retrofit-$version$-javadoc.jar",
+    "description" : "Retrofit is a type-safe HTTP client for Java and Android that turns annotated interfaces into network API clients. It integrates with OkHttp and pluggable converters/adapters to execute requests and marshal request and response bodies.",
+    "tested-versions" : [
+      "2.5.0"
+    ],
+    "allowed-packages" : [
+      "retrofit2"
+    ]
+  }
+]

--- a/stats/com.squareup.retrofit2/retrofit/2.5.0/execution-metrics.json
+++ b/stats/com.squareup.retrofit2/retrofit/2.5.0/execution-metrics.json
@@ -1,0 +1,63 @@
+{
+  "add_new_library_support:2026-06-08": {
+    "timestamp": "2026-06-08T06:05:36.943256Z",
+    "library": "com.squareup.retrofit2:retrofit:2.5.0",
+    "starting_commit": "f0075919dcd4a4b2c74b713ccc5997c50ac8d763",
+    "ending_commit": "16538dacd72939916b7567de2aa8ab5d220c1307",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.5.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 4,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1138,
+          "missed": 6093,
+          "ratio": 0.157378,
+          "total": 7231
+        },
+        "line": {
+          "covered": 286,
+          "missed": 1266,
+          "ratio": 0.184278,
+          "total": 1552
+        },
+        "method": {
+          "covered": 77,
+          "missed": 228,
+          "ratio": 0.252459,
+          "total": 305
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 65793,
+      "cached_input_tokens_used": 398848,
+      "output_tokens_used": 5902,
+      "iterations": 3,
+      "cost_usd": 0.3765,
+      "generated_loc": 97,
+      "tested_library_loc": 286,
+      "metadata_entries": 16,
+      "test_only_metadata_entries": 59,
+      "code_coverage_percent": 18.43
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.squareup.retrofit2/retrofit/2.5.0/src/test/java/com_squareup_retrofit2/retrofit/RetrofitTest.java",
+      "metadata_file": "metadata/com.squareup.retrofit2/retrofit/2.5.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.squareup.retrofit2/retrofit/2.5.0/stats.json
+++ b/stats/com.squareup.retrofit2/retrofit/2.5.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "2.5.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 4,
+          "totalCalls" : 4
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 4,
+      "totalCalls" : 4
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1138,
+        "missed" : 6093,
+        "ratio" : 0.157378,
+        "total" : 7231
+      },
+      "line" : {
+        "covered" : 286,
+        "missed" : 1266,
+        "ratio" : 0.184278,
+        "total" : 1552
+      },
+      "method" : {
+        "covered" : 77,
+        "missed" : 228,
+        "ratio" : 0.252459,
+        "total" : 305
+      }
+    }
+  } ]
+}

--- a/tests/src/com.squareup.retrofit2/retrofit/2.5.0/.gitignore
+++ b/tests/src/com.squareup.retrofit2/retrofit/2.5.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.squareup.retrofit2/retrofit/2.5.0/build.gradle
+++ b/tests/src/com.squareup.retrofit2/retrofit/2.5.0/build.gradle
@@ -16,6 +16,12 @@ dependencies {
 }
 
 graalvmNative {
+    binaries {
+        test {
+            // okhttp3.internal.Util eagerly resolves UTF-32 charsets during static init.
+            buildArgs.add("-H:+AddAllCharsets")
+        }
+    }
     agent {
         defaultMode = "conditional"
         modes {

--- a/tests/src/com.squareup.retrofit2/retrofit/2.5.0/build.gradle
+++ b/tests/src/com.squareup.retrofit2/retrofit/2.5.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.squareup.retrofit2:retrofit:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.squareup.retrofit2/retrofit/2.5.0/gradle.properties
+++ b/tests/src/com.squareup.retrofit2/retrofit/2.5.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.squareup.retrofit2:retrofit:2.5.0
+library.version = 2.5.0
+metadata.dir = com.squareup.retrofit2/retrofit/2.5.0/

--- a/tests/src/com.squareup.retrofit2/retrofit/2.5.0/settings.gradle
+++ b/tests/src/com.squareup.retrofit2/retrofit/2.5.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.squareup.retrofit2.retrofit_tests'

--- a/tests/src/com.squareup.retrofit2/retrofit/2.5.0/src/test/java/com_squareup_retrofit2/retrofit/RetrofitAnonymous1Test.java
+++ b/tests/src/com.squareup.retrofit2/retrofit/2.5.0/src/test/java/com_squareup_retrofit2/retrofit/RetrofitAnonymous1Test.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_squareup_retrofit2.retrofit;
+
+import okhttp3.ResponseBody;
+import org.junit.jupiter.api.Test;
+import retrofit2.Call;
+import retrofit2.Retrofit;
+import retrofit2.http.GET;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RetrofitAnonymous1Test {
+    @Test
+    void delegatesObjectMethodsOnServiceProxyToInvocationHandler() {
+        Retrofit retrofit = new Retrofit.Builder()
+                .baseUrl("https://example.com/")
+                .build();
+
+        ProxyObjectMethodService service = retrofit.create(ProxyObjectMethodService.class);
+
+        assertThat(service.toString()).isNotBlank();
+    }
+
+    public interface ProxyObjectMethodService {
+        @GET("messages")
+        Call<ResponseBody> messages();
+    }
+}

--- a/tests/src/com.squareup.retrofit2/retrofit/2.5.0/src/test/java/com_squareup_retrofit2/retrofit/RetrofitTest.java
+++ b/tests/src/com.squareup.retrofit2/retrofit/2.5.0/src/test/java/com_squareup_retrofit2/retrofit/RetrofitTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_squareup_retrofit2.retrofit;
+
+import org.junit.jupiter.api.Test;
+
+class RetrofitTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/com.squareup.retrofit2/retrofit/2.5.0/src/test/java/com_squareup_retrofit2/retrofit/RetrofitTest.java
+++ b/tests/src/com.squareup.retrofit2/retrofit/2.5.0/src/test/java/com_squareup_retrofit2/retrofit/RetrofitTest.java
@@ -6,11 +6,45 @@
  */
 package com_squareup_retrofit2.retrofit;
 
+import okhttp3.ResponseBody;
 import org.junit.jupiter.api.Test;
+import retrofit2.Call;
+import retrofit2.Retrofit;
+import retrofit2.http.GET;
 
-class RetrofitTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RetrofitTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void createsProxyForAnnotatedServiceInterface() {
+        Retrofit retrofit = new Retrofit.Builder()
+                .baseUrl("https://example.com/")
+                .build();
+
+        SimpleService service = retrofit.create(SimpleService.class);
+
+        assertThat(service).isInstanceOf(SimpleService.class);
+    }
+
+    @Test
+    void eagerlyValidatesDeclaredServiceMethods() {
+        Retrofit retrofit = new Retrofit.Builder()
+                .baseUrl("https://example.com/")
+                .validateEagerly(true)
+                .build();
+
+        EagerService service = retrofit.create(EagerService.class);
+
+        assertThat(service).isInstanceOf(EagerService.class);
+    }
+
+    public interface SimpleService {
+        @GET("messages")
+        Call<ResponseBody> messages();
+    }
+
+    public interface EagerService {
+        @GET("users")
+        Call<ResponseBody> users();
     }
 }

--- a/tests/src/com.squareup.retrofit2/retrofit/2.5.0/src/test/java/com_squareup_retrofit2/retrofit/UtilsTest.java
+++ b/tests/src/com.squareup.retrofit2/retrofit/2.5.0/src/test/java/com_squareup_retrofit2/retrofit/UtilsTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_squareup_retrofit2.retrofit;
+
+import java.util.List;
+import okhttp3.ResponseBody;
+import org.junit.jupiter.api.Test;
+import retrofit2.Call;
+import retrofit2.Retrofit;
+import retrofit2.http.GET;
+import retrofit2.http.Query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UtilsTest {
+    @Test
+    void validatesGenericArrayParameterType() {
+        Retrofit retrofit = new Retrofit.Builder()
+                .baseUrl("https://example.com/")
+                .validateEagerly(true)
+                .build();
+
+        GenericArrayQueryService service = retrofit.create(GenericArrayQueryService.class);
+
+        assertThat(service).isInstanceOf(GenericArrayQueryService.class);
+    }
+
+    public interface GenericArrayQueryService {
+        @GET("messages")
+        Call<ResponseBody> messages(@Query("tag") List<String>[] tags);
+    }
+}

--- a/tests/src/com.squareup.retrofit2/retrofit/2.5.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.squareup.retrofit2/retrofit/2.5.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,401 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "type" : "com.android.org.conscrypt.SSLParametersImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "type" : "com.sun.crypto.provider.AESCipher$General",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "type" : "com.sun.crypto.provider.ARCFOURCipher",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "type" : "com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Poly1305",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "type" : "com.sun.crypto.provider.DESCipher",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "type" : "com.sun.crypto.provider.DESedeCipher",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "type" : "com.sun.crypto.provider.GaloisCounterMode$AESGCM",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitTest"
+      },
+      "type" : "com_squareup_retrofit2.retrofit.RetrofitTest$EagerService"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.UtilsTest"
+      },
+      "type" : "com_squareup_retrofit2.retrofit.UtilsTest$GenericArrayQueryService"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "type" : "java.security.AlgorithmParametersSpi"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "type" : "java.security.KeyStoreSpi"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "type" : "javax.net.ssl.SSLParameters"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "type" : "javax.net.ssl.SSLSocket"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "type" : "org.apache.harmony.xnet.provider.jsse.SSLParametersImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "type" : "sun.security.pkcs12.PKCS12KeyStore",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "type" : "sun.security.pkcs12.PKCS12KeyStore$DualFormatPKCS12",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "type" : "sun.security.provider.X509Factory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "type" : "sun.security.rsa.RSAKeyFactory$Legacy",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "type" : "sun.security.x509.AuthorityInfoAccessExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "type" : "sun.security.x509.AuthorityKeyIdentifierExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "type" : "sun.security.x509.BasicConstraintsExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "type" : "sun.security.x509.CRLDistributionPointsExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "type" : "sun.security.x509.CertificatePoliciesExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "type" : "sun.security.x509.ExtendedKeyUsageExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "type" : "sun.security.x509.KeyUsageExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "type" : "sun.security.x509.NetscapeCertTypeExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "type" : "sun.security.x509.PrivateKeyUsageExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "type" : "sun.security.x509.SubjectKeyIdentifierExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "type" : {
+        "proxy" : [
+          "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test$ProxyObjectMethodService"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitTest"
+      },
+      "type" : {
+        "proxy" : [
+          "com_squareup_retrofit2.retrofit.RetrofitTest$EagerService"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitTest"
+      },
+      "type" : {
+        "proxy" : [
+          "com_squareup_retrofit2.retrofit.RetrofitTest$SimpleService"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.UtilsTest"
+      },
+      "type" : {
+        "proxy" : [
+          "com_squareup_retrofit2.retrofit.UtilsTest$GenericArrayQueryService"
+        ]
+      }
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "glob" : "META-INF/services/java.net.spi.URLStreamHandlerProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_retrofit2.retrofit.RetrofitAnonymous1Test"
+      },
+      "module" : "java.base",
+      "glob" : "jdk/internal/icu/impl/data/icudt76b/nfkc.nrm"
+    }
+  ]
+}

--- a/tests/src/com.squareup.retrofit2/retrofit/2.5.0/user-code-filter.json
+++ b/tests/src/com.squareup.retrofit2/retrofit/2.5.0/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "retrofit2.**"
+      "includeClasses" : "retrofit2.**"
+    },
+    {
+      "includeClasses" : "com_squareup_retrofit2.retrofit.**"
     }
   ]
 }

--- a/tests/src/com.squareup.retrofit2/retrofit/2.5.0/user-code-filter.json
+++ b/tests/src/com.squareup.retrofit2/retrofit/2.5.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "retrofit2.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #2200

This PR introduces tests and metadata for com.squareup.retrofit2:retrofit:2.5.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 65793
- Cached input tokens: 398848
- Output tokens: 5902
- Metadata entries: 16
- Test-only metadata entries: 59
- Iterations: 3
- Library coverage percentage: 18.43
- Generated lines of code: 97
- Tested library lines of code: 286

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `cc3b6ad5264a8792b4bedea3307e4e6c3e089e41`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 4/4 covered calls (100.00%)
- Reflection: 4/4 covered calls (100.00%)

Library coverage:
- Instruction: 1138/7231 (15.74%)
- Line: 286/1552 (18.43%)
- Method: 77/305 (25.25%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
