### PR TITLE
[GenAI] Test fix for org.springframework:spring-webflux:6.0.0 using gpt-5.5

### DIFF
--- a/metadata/org.springframework/spring-webflux/6.0.0/reachability-metadata.json
+++ b/metadata/org.springframework/spring-webflux/6.0.0/reachability-metadata.json
@@ -1,0 +1,473 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.http.codec.support.BaseDefaultCodecs"
+      },
+      "type" : "com.fasterxml.jackson.databind$ObjectMapper"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.http.codec.support.BaseDefaultCodecs"
+      },
+      "type" : "com.fasterxml.jackson.databind.ObjectMapper"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.http.codec.support.BaseDefaultCodecs"
+      },
+      "type" : "com.fasterxml.jackson.dataformat.smile$SmileFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.http.codec.support.BaseDefaultCodecs"
+      },
+      "type" : "com.fasterxml.jackson.dataformat.smile.SmileFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.http.codec.support.BaseDefaultCodecs"
+      },
+      "type" : "com.google.protobuf$Message"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.http.codec.support.BaseDefaultCodecs"
+      },
+      "type" : "com.google.protobuf.Message"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.http.codec.support.BaseDefaultCodecs"
+      },
+      "type" : "io.netty.buffer$ByteBuf"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.http.codec.support.BaseDefaultCodecs"
+      },
+      "type" : "io.netty.buffer.ByteBuf"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.http.codec.support.BaseDefaultCodecs"
+      },
+      "type" : "io.netty5.buffer$Buffer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.http.codec.support.BaseDefaultCodecs"
+      },
+      "type" : "io.netty5.buffer.Buffer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.ReactiveAdapterRegistry"
+      },
+      "type" : "io.reactivex.rxjava3.core$Flowable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.ReactiveAdapterRegistry"
+      },
+      "type" : "io.reactivex.rxjava3.core.Flowable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.ReactiveAdapterRegistry"
+      },
+      "type" : "io.smallrye.mutiny$Multi"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.ReactiveAdapterRegistry"
+      },
+      "type" : "io.smallrye.mutiny.Multi"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.web.reactive.socket.server.support.HandshakeWebSocketService"
+      },
+      "type" : "io.undertow.websockets$WebSocketProtocolHandshakeHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.web.reactive.socket.server.support.HandshakeWebSocketService"
+      },
+      "type" : "io.undertow.websockets.WebSocketProtocolHandshakeHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.http.codec.support.BaseDefaultCodecs"
+      },
+      "type" : "jakarta.xml.bind$Binder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.http.codec.support.BaseDefaultCodecs"
+      },
+      "type" : "jakarta.xml.bind.Binder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.web.reactive.socket.client.JettyWebSocketClient"
+      },
+      "type" : "java.lang.Boolean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.web.reactive.socket.client.JettyWebSocketClient"
+      },
+      "type" : "java.lang.Byte"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.web.reactive.socket.client.JettyWebSocketClient"
+      },
+      "type" : "java.lang.Double"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.web.reactive.socket.client.JettyWebSocketClient"
+      },
+      "type" : "java.lang.Float"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.web.reactive.socket.client.JettyWebSocketClient"
+      },
+      "type" : "java.lang.Integer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.web.reactive.socket.client.JettyWebSocketClient"
+      },
+      "type" : "java.lang.Long"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.web.reactive.socket.client.JettyWebSocketClient"
+      },
+      "type" : "java.lang.Short"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.KotlinDetector"
+      },
+      "type" : "kotlin$Metadata"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.KotlinDetector"
+      },
+      "type" : "kotlin.Metadata"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.KotlinDetector"
+      },
+      "type" : "kotlin.reflect.full$KClasses"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.KotlinDetector"
+      },
+      "type" : "kotlin.reflect.full.KClasses"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.ReactiveAdapterRegistry"
+      },
+      "type" : "kotlinx.coroutines.reactor$MonoKt"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.ReactiveAdapterRegistry"
+      },
+      "type" : "kotlinx.coroutines.reactor.MonoKt"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.http.codec.support.BaseDefaultCodecs"
+      },
+      "type" : "kotlinx.serialization.cbor$Cbor"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.http.codec.support.BaseDefaultCodecs"
+      },
+      "type" : "kotlinx.serialization.cbor.Cbor"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.http.codec.support.BaseDefaultCodecs"
+      },
+      "type" : "kotlinx.serialization.json$Json"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.http.codec.support.BaseDefaultCodecs"
+      },
+      "type" : "kotlinx.serialization.json.Json"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.http.codec.support.BaseDefaultCodecs"
+      },
+      "type" : "kotlinx.serialization.protobuf$ProtoBuf"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.http.codec.support.BaseDefaultCodecs"
+      },
+      "type" : "kotlinx.serialization.protobuf.ProtoBuf"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.web.reactive.socket.server.support.HandshakeWebSocketService"
+      },
+      "type" : "org.apache.logging.log4j.spi.ExtendedLogger"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.web.reactive.socket.server.support.HandshakeWebSocketService"
+      },
+      "type" : "org.apache.tomcat.websocket.server$WsHttpUpgradeHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.web.reactive.socket.server.support.HandshakeWebSocketService"
+      },
+      "type" : "org.apache.tomcat.websocket.server.WsHttpUpgradeHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.web.reactive.socket.client.JettyWebSocketClient"
+      },
+      "type" : "org.eclipse.jetty.util.TypeUtil",
+      "methods" : [
+        {
+          "name" : "getClassLoaderLocation",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name" : "getCodeSourceLocation",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name" : "getModuleLocation",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name" : "getSystemClassLoaderLocation",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.web.reactive.socket.client.JettyWebSocketClient"
+      },
+      "type" : "org.eclipse.jetty.websocket.core.internal.FragmentExtension"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.web.reactive.socket.client.JettyWebSocketClient"
+      },
+      "type" : "org.eclipse.jetty.websocket.core.internal.FrameCaptureExtension"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.web.reactive.socket.client.JettyWebSocketClient"
+      },
+      "type" : "org.eclipse.jetty.websocket.core.internal.IdentityExtension"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.web.reactive.socket.client.JettyWebSocketClient"
+      },
+      "type" : "org.eclipse.jetty.websocket.core.internal.PerMessageDeflateExtension"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.web.reactive.socket.client.JettyWebSocketClient"
+      },
+      "type" : "org.eclipse.jetty.websocket.core.internal.ValidationExtension"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.web.reactive.socket.server.support.HandshakeWebSocketService"
+      },
+      "type" : "org.eclipse.jetty.websocket.server.JettyWebSocketServerContainer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.web.reactive.socket.server.support.HandshakeWebSocketService"
+      },
+      "type" : "org.slf4j.spi.LocationAwareLogger"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.http.codec.CodecConfigurerFactory"
+      },
+      "type" : "org.springframework.http.codec.ClientCodecConfigurer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.http.codec.CodecConfigurerFactory"
+      },
+      "type" : "org.springframework.http.codec.ServerCodecConfigurer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.http.codec.CodecConfigurerFactory"
+      },
+      "type" : "org.springframework.http.codec.support.DefaultClientCodecConfigurer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.beans.BeanUtils"
+      },
+      "type" : "org.springframework.http.codec.support.DefaultServerCodecConfigurer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.http.codec.CodecConfigurerFactory"
+      },
+      "type" : "org.springframework.http.codec.support.DefaultServerCodecConfigurer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.util.ConcurrentReferenceHashMap"
+      },
+      "type" : "org.springframework.util.ConcurrentReferenceHashMap$Segment[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.http.codec.support.BaseDefaultCodecs"
+      },
+      "type" : "org.synchronoss.cloud.nio.multipart$NioMultipartParser"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.http.codec.support.BaseDefaultCodecs"
+      },
+      "type" : "org.synchronoss.cloud.nio.multipart.NioMultipartParser"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.ReactiveAdapterRegistry"
+      },
+      "type" : "reactor.core.publisher.Flux"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.web.server.adapter.DefaultServerWebExchange"
+      },
+      "type" : "reactor.core.publisher.MonoCacheTime"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.web.reactive.socket.server.support.HandshakeWebSocketService"
+      },
+      "type" : "reactor.netty.http.server$HttpServerResponse"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.web.reactive.socket.server.support.HandshakeWebSocketService"
+      },
+      "type" : "reactor.netty.http.server.HttpServerResponse"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.web.reactive.socket.server.support.HandshakeWebSocketService"
+      },
+      "type" : "reactor.netty5.http.server$HttpServerResponse"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.web.reactive.socket.server.support.HandshakeWebSocketService"
+      },
+      "type" : "reactor.netty5.http.server.HttpServerResponse"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.mock.web.MockHttpServletResponse"
+      },
+      "glob" : "META-INF/services/java.util.spi.ResourceBundleControlProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.web.reactive.socket.client.JettyWebSocketClient"
+      },
+      "glob" : "META-INF/services/org.eclipse.jetty.websocket.core.Extension"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.web.reactive.socket.server.support.HandshakeWebSocketService"
+      },
+      "glob" : "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.mock.web.MockHttpServletResponse"
+      },
+      "glob" : "jakarta/servlet/LocalStrings.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.mock.web.MockHttpServletResponse"
+      },
+      "glob" : "jakarta/servlet/LocalStrings_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.mock.web.MockHttpServletResponse"
+      },
+      "glob" : "jakarta/servlet/LocalStrings_en_US.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.web.reactive.socket.client.JettyWebSocketClient"
+      },
+      "glob" : "jetty-websocket-httpclient.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.web.reactive.socket.client.JettyWebSocketClient"
+      },
+      "glob" : "org/eclipse/jetty/version/build.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.web.reactive.socket.server.support.HandshakeWebSocketService"
+      },
+      "glob" : "org/slf4j/impl/StaticLoggerBinder.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.io.ClassPathResource"
+      },
+      "glob" : "org/springframework/http/codec/CodecConfigurer.properties"
+    },
+    {
+      "bundle" : "jakarta.servlet.LocalStrings"
+    }
+  ]
+}

--- a/metadata/org.springframework/spring-webflux/index.json
+++ b/metadata/org.springframework/spring-webflux/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "6.0.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/spring-webflux/$version$/spring-webflux-$version$-sources.jar",
+    "repository-url" : "https://github.com/spring-projects/spring-framework",
+    "test-code-url" : "https://github.com/spring-projects/spring-framework/tree/v$version$/spring-webflux/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/springframework/spring-webflux/$version$/spring-webflux-$version$-javadoc.jar",
+    "description" : "Spring WebFlux is Spring Framework's reactive web module for building asynchronous HTTP applications with annotated controllers or functional endpoints. It provides reactive server-side web support and a reactive WebClient built on Project Reactor and Reactive Streams.",
     "tested-versions" : [
       "6.0.0"
     ],

--- a/metadata/org.springframework/spring-webflux/index.json
+++ b/metadata/org.springframework/spring-webflux/index.json
@@ -1,6 +1,23 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "6.0.0",
+    "tested-versions" : [
+      "6.0.0"
+    ],
+    "allowed-packages" : [
+      "org.springframework.web.reactive",
+      "org.springframework.beans",
+      "org.springframework.core",
+      "org.springframework.core.io",
+      "org.springframework.http",
+      "org.springframework.http.codec.multipart",
+      "org.springframework.mock.web",
+      "org.springframework.util",
+      "org.springframework.web.server.adapter"
+    ]
+  },
+  {
     "metadata-version" : "5.3.31",
     "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/spring-webflux/$version$/spring-webflux-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-framework",

--- a/stats/org.springframework/spring-webflux/6.0.0/execution-metrics.json
+++ b/stats/org.springframework/spring-webflux/6.0.0/execution-metrics.json
@@ -1,0 +1,100 @@
+{
+  "fix_javac_fail:2026-06-08": {
+    "timestamp": "2026-06-08T06:34:19.651540Z",
+    "library": "org.springframework:spring-webflux:6.0.0",
+    "starting_commit": "4aacd41c2a641542de18bd2982fb30dab8741a4c",
+    "ending_commit": "9f5d05101bf92c3720437712454d99530c6fe9c9",
+    "previous_library": "org.springframework:spring-webflux:5.3.31",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "6.0.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 394,
+          "missed": 42170,
+          "ratio": 0.009257,
+          "total": 42564
+        },
+        "line": {
+          "covered": 117,
+          "missed": 9323,
+          "ratio": 0.012394,
+          "total": 9440
+        },
+        "method": {
+          "covered": 32,
+          "missed": 3340,
+          "ratio": 0.00949,
+          "total": 3372
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "5.3.31",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 10,
+            "totalCalls": 10
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 10,
+        "totalCalls": 10
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 524,
+          "missed": 43150,
+          "ratio": 0.011998,
+          "total": 43674
+        },
+        "line": {
+          "covered": 140,
+          "missed": 9162,
+          "ratio": 0.015051,
+          "total": 9302
+        },
+        "method": {
+          "covered": 34,
+          "missed": 3236,
+          "ratio": 0.010398,
+          "total": 3270
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 72852,
+      "cached_input_tokens_used": 586752,
+      "output_tokens_used": 6636,
+      "iterations": 1,
+      "cost_usd": 0.4925,
+      "tested_library_loc": 117,
+      "metadata_entries": 78,
+      "test_only_metadata_entries": 8,
+      "previous_library_metadata_entries": 92,
+      "code_coverage_percent": 1.24,
+      "previous_library_coverage_percent": 1.51
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.springframework/spring-webflux/6.0.0/src/test/java/org_springframework/spring_webflux/HandshakeWebSocketServiceTest.java",
+      "metadata_file": "metadata/org.springframework/spring-webflux/6.0.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.springframework/spring-webflux/6.0.0/stats.json
+++ b/stats/org.springframework/spring-webflux/6.0.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "6.0.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 1,
+      "totalCalls" : 1
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 394,
+        "missed" : 42170,
+        "ratio" : 0.009257,
+        "total" : 42564
+      },
+      "line" : {
+        "covered" : 117,
+        "missed" : 9323,
+        "ratio" : 0.012394,
+        "total" : 9440
+      },
+      "method" : {
+        "covered" : 32,
+        "missed" : 3340,
+        "ratio" : 0.00949,
+        "total" : 3372
+      }
+    }
+  } ]
+}

--- a/tests/src/org.springframework/spring-webflux/6.0.0/.gitignore
+++ b/tests/src/org.springframework/spring-webflux/6.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.springframework/spring-webflux/6.0.0/build.gradle
+++ b/tests/src/org.springframework/spring-webflux/6.0.0/build.gradle
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.springframework:spring-webflux:$libraryVersion"
+    testImplementation "org.springframework:spring-context:$libraryVersion"
+    testImplementation "org.springframework:spring-test:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.eclipse.jetty.websocket:websocket-jetty-server:10.0.18'
+    testImplementation 'org.eclipse.jetty.websocket:websocket-jetty-client:10.0.18'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-webflux/6.0.0/build.gradle
+++ b/tests/src/org.springframework/spring-webflux/6.0.0/build.gradle
@@ -14,9 +14,10 @@ dependencies {
     testImplementation "org.springframework:spring-webflux:$libraryVersion"
     testImplementation "org.springframework:spring-context:$libraryVersion"
     testImplementation "org.springframework:spring-test:$libraryVersion"
+    testImplementation 'jakarta.servlet:jakarta.servlet-api:6.0.0'
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.eclipse.jetty.websocket:websocket-jetty-server:10.0.18'
-    testImplementation 'org.eclipse.jetty.websocket:websocket-jetty-client:10.0.18'
+    testImplementation 'org.eclipse.jetty.websocket:websocket-jetty-server:11.0.18'
+    testImplementation 'org.eclipse.jetty.websocket:websocket-jetty-client:11.0.18'
 }
 
 graalvmNative {

--- a/tests/src/org.springframework/spring-webflux/6.0.0/gradle.properties
+++ b/tests/src/org.springframework/spring-webflux/6.0.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.springframework:spring-webflux:6.0.0
+library.version = 6.0.0
+metadata.dir = org.springframework/spring-webflux/6.0.0/

--- a/tests/src/org.springframework/spring-webflux/6.0.0/settings.gradle
+++ b/tests/src/org.springframework/spring-webflux/6.0.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.springframework.spring-webflux_tests'

--- a/tests/src/org.springframework/spring-webflux/6.0.0/src/test/java/org_springframework/spring_webflux/HandshakeWebSocketServiceTest.java
+++ b/tests/src/org.springframework/spring-webflux/6.0.0/src/test/java/org_springframework/spring_webflux/HandshakeWebSocketServiceTest.java
@@ -11,14 +11,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.web.reactive.socket.server.support.HandshakeWebSocketService;
-import org.springframework.web.reactive.socket.server.upgrade.Jetty10RequestUpgradeStrategy;
+import org.springframework.web.reactive.socket.server.upgrade.JettyRequestUpgradeStrategy;
 
 public class HandshakeWebSocketServiceTest {
     @Test
     void defaultConstructorInstantiatesDetectedUpgradeStrategy() {
         HandshakeWebSocketService service = new HandshakeWebSocketService();
 
-        assertThat(service.getUpgradeStrategy()).isInstanceOf(Jetty10RequestUpgradeStrategy.class);
+        assertThat(service.getUpgradeStrategy()).isInstanceOf(JettyRequestUpgradeStrategy.class);
         assertThat(service.isRunning()).isFalse();
     }
 }

--- a/tests/src/org.springframework/spring-webflux/6.0.0/src/test/java/org_springframework/spring_webflux/HandshakeWebSocketServiceTest.java
+++ b/tests/src/org.springframework/spring-webflux/6.0.0/src/test/java/org_springframework/spring_webflux/HandshakeWebSocketServiceTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_webflux;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.web.reactive.socket.server.support.HandshakeWebSocketService;
+import org.springframework.web.reactive.socket.server.upgrade.Jetty10RequestUpgradeStrategy;
+
+public class HandshakeWebSocketServiceTest {
+    @Test
+    void defaultConstructorInstantiatesDetectedUpgradeStrategy() {
+        HandshakeWebSocketService service = new HandshakeWebSocketService();
+
+        assertThat(service.getUpgradeStrategy()).isInstanceOf(Jetty10RequestUpgradeStrategy.class);
+        assertThat(service.isRunning()).isFalse();
+    }
+}

--- a/tests/src/org.springframework/spring-webflux/6.0.0/src/test/java/org_springframework/spring_webflux/InvocableHandlerMethodTest.java
+++ b/tests/src/org.springframework/spring-webflux/6.0.0/src/test/java/org_springframework/spring_webflux/InvocableHandlerMethodTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_webflux;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.reactive.BindingContext;
+import org.springframework.web.reactive.HandlerResult;
+import org.springframework.web.reactive.result.method.InvocableHandlerMethod;
+import org.springframework.web.server.ServerWebExchange;
+
+public class InvocableHandlerMethodTest {
+    @Test
+    void invokeCallsUnderlyingHandlerMethod() throws Exception {
+        GreetingHandler handler = new GreetingHandler();
+        Method method = GreetingHandler.class.getMethod("greeting");
+        InvocableHandlerMethod invocableMethod = new InvocableHandlerMethod(handler, method);
+        ServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/greeting"));
+
+        HandlerResult result = invocableMethod.invoke(exchange, new BindingContext()).block(Duration.ofSeconds(5));
+
+        assertThat(result).isNotNull();
+        assertThat(result.getHandler()).isSameAs(invocableMethod);
+        assertThat(result.getReturnValue()).isEqualTo("hello from handler");
+    }
+
+    public static final class GreetingHandler {
+        public String greeting() {
+            return "hello from handler";
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-webflux/6.0.0/src/test/java/org_springframework/spring_webflux/Jetty10RequestUpgradeStrategyTest.java
+++ b/tests/src/org.springframework/spring-webflux/6.0.0/src/test/java/org_springframework/spring_webflux/Jetty10RequestUpgradeStrategyTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_webflux;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URI;
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.HttpCookie;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.codec.ServerCodecConfigurer;
+import org.springframework.http.server.reactive.AbstractServerHttpRequest;
+import org.springframework.http.server.reactive.AbstractServerHttpResponse;
+import org.springframework.http.server.reactive.SslInfo;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.socket.HandshakeInfo;
+import org.springframework.web.reactive.socket.server.RequestUpgradeStrategy;
+import org.springframework.web.reactive.socket.server.upgrade.Jetty10RequestUpgradeStrategy;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.adapter.DefaultServerWebExchange;
+import org.springframework.web.server.i18n.AcceptHeaderLocaleContextResolver;
+import org.springframework.web.server.session.DefaultWebSessionManager;
+
+public class Jetty10RequestUpgradeStrategyTest {
+    private static final URI REQUEST_URI = URI.create("http://localhost/ws");
+
+    @Test
+    void constructsStrategyWhenJetty10WebSocketServerApiIsAvailable() {
+        RequestUpgradeStrategy strategy = new Jetty10RequestUpgradeStrategy();
+
+        assertThat(strategy).isInstanceOf(Jetty10RequestUpgradeStrategy.class);
+    }
+
+    @Test
+    void upgradeCreatesJettyWebSocketCreatorProxyBeforeLookingUpContainer() {
+        RequestUpgradeStrategy strategy = new Jetty10RequestUpgradeStrategy();
+        MockServletContext servletContext = new MockServletContext();
+        MockHttpServletRequest servletRequest = new MockHttpServletRequest(servletContext, "GET", "/ws");
+        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+        ServerWebExchange exchange = createExchange(servletRequest, servletResponse);
+        HandshakeInfo handshakeInfo = new HandshakeInfo(REQUEST_URI, new HttpHeaders(), Mono.empty(), "chat");
+
+        // The mock servlet context intentionally has no Jetty container; by the time this fails,
+        // the strategy has already created the JettyWebSocketCreator proxy.
+        assertThatThrownBy(() -> strategy.upgrade(exchange, session -> Mono.empty(), "chat", () -> handshakeInfo)
+                .block(Duration.ofSeconds(5)))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    private static ServerWebExchange createExchange(
+            MockHttpServletRequest servletRequest, MockHttpServletResponse servletResponse) {
+
+        return new DefaultServerWebExchange(
+                new NativeServerHttpRequest(servletRequest),
+                new NativeServerHttpResponse(servletResponse),
+                new DefaultWebSessionManager(),
+                ServerCodecConfigurer.create(),
+                new AcceptHeaderLocaleContextResolver());
+    }
+
+    private static final class NativeServerHttpRequest extends AbstractServerHttpRequest {
+        private final MockHttpServletRequest servletRequest;
+
+        private NativeServerHttpRequest(MockHttpServletRequest servletRequest) {
+            super(REQUEST_URI, "", new HttpHeaders());
+            this.servletRequest = servletRequest;
+        }
+
+        @Override
+        public String getMethodValue() {
+            return this.servletRequest.getMethod();
+        }
+
+        @Override
+        public Flux<DataBuffer> getBody() {
+            return Flux.empty();
+        }
+
+        @Override
+        protected MultiValueMap<String, HttpCookie> initCookies() {
+            return new LinkedMultiValueMap<>();
+        }
+
+        @Override
+        protected SslInfo initSslInfo() {
+            return null;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getNativeRequest() {
+            return (T) this.servletRequest;
+        }
+    }
+
+    private static final class NativeServerHttpResponse extends AbstractServerHttpResponse {
+        private final MockHttpServletResponse servletResponse;
+
+        private NativeServerHttpResponse(MockHttpServletResponse servletResponse) {
+            super(DefaultDataBufferFactory.sharedInstance);
+            this.servletResponse = servletResponse;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getNativeResponse() {
+            return (T) this.servletResponse;
+        }
+
+        @Override
+        protected Mono<Void> writeWithInternal(Publisher<? extends DataBuffer> body) {
+            return Mono.empty();
+        }
+
+        @Override
+        protected Mono<Void> writeAndFlushWithInternal(Publisher<? extends Publisher<? extends DataBuffer>> body) {
+            return Mono.empty();
+        }
+
+        @Override
+        protected void applyStatusCode() {
+            // No underlying response state is needed for this upgrade-path test.
+        }
+
+        @Override
+        protected void applyHeaders() {
+            // No underlying response state is needed for this upgrade-path test.
+        }
+
+        @Override
+        protected void applyCookies() {
+            // No underlying response state is needed for this upgrade-path test.
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-webflux/6.0.0/src/test/java/org_springframework/spring_webflux/JettyRequestUpgradeStrategyTest.java
+++ b/tests/src/org.springframework/spring-webflux/6.0.0/src/test/java/org_springframework/spring_webflux/JettyRequestUpgradeStrategyTest.java
@@ -21,6 +21,7 @@ import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DefaultDataBufferFactory;
 import org.springframework.http.HttpCookie;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.codec.ServerCodecConfigurer;
 import org.springframework.http.server.reactive.AbstractServerHttpRequest;
 import org.springframework.http.server.reactive.AbstractServerHttpResponse;
@@ -32,25 +33,25 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.socket.HandshakeInfo;
 import org.springframework.web.reactive.socket.server.RequestUpgradeStrategy;
-import org.springframework.web.reactive.socket.server.upgrade.Jetty10RequestUpgradeStrategy;
+import org.springframework.web.reactive.socket.server.upgrade.JettyRequestUpgradeStrategy;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.adapter.DefaultServerWebExchange;
 import org.springframework.web.server.i18n.AcceptHeaderLocaleContextResolver;
 import org.springframework.web.server.session.DefaultWebSessionManager;
 
-public class Jetty10RequestUpgradeStrategyTest {
+public class JettyRequestUpgradeStrategyTest {
     private static final URI REQUEST_URI = URI.create("http://localhost/ws");
 
     @Test
-    void constructsStrategyWhenJetty10WebSocketServerApiIsAvailable() {
-        RequestUpgradeStrategy strategy = new Jetty10RequestUpgradeStrategy();
+    void constructsStrategyWhenJettyWebSocketServerApiIsAvailable() {
+        RequestUpgradeStrategy strategy = new JettyRequestUpgradeStrategy();
 
-        assertThat(strategy).isInstanceOf(Jetty10RequestUpgradeStrategy.class);
+        assertThat(strategy).isInstanceOf(JettyRequestUpgradeStrategy.class);
     }
 
     @Test
     void upgradeCreatesJettyWebSocketCreatorProxyBeforeLookingUpContainer() {
-        RequestUpgradeStrategy strategy = new Jetty10RequestUpgradeStrategy();
+        RequestUpgradeStrategy strategy = new JettyRequestUpgradeStrategy();
         MockServletContext servletContext = new MockServletContext();
         MockHttpServletRequest servletRequest = new MockHttpServletRequest(servletContext, "GET", "/ws");
         MockHttpServletResponse servletResponse = new MockHttpServletResponse();
@@ -84,8 +85,8 @@ public class Jetty10RequestUpgradeStrategyTest {
         }
 
         @Override
-        public String getMethodValue() {
-            return this.servletRequest.getMethod();
+        public HttpMethod getMethod() {
+            return HttpMethod.valueOf(this.servletRequest.getMethod());
         }
 
         @Override

--- a/tests/src/org.springframework/spring-webflux/6.0.0/src/test/java/org_springframework/spring_webflux/JettyWebSocketClientInnerJetty10UpgradeHelperTest.java
+++ b/tests/src/org.springframework/spring-webflux/6.0.0/src/test/java/org_springframework/spring_webflux/JettyWebSocketClientInnerJetty10UpgradeHelperTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_webflux;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.web.reactive.socket.client.JettyWebSocketClient;
+
+public class JettyWebSocketClientInnerJetty10UpgradeHelperTest {
+    @Test
+    void constructionInitializesJetty10UpgradeHelper() {
+        JettyWebSocketClient client = new JettyWebSocketClient();
+        try {
+            assertThat(client.getJettyClient()).isNotNull();
+            assertThat(client.isRunning()).isFalse();
+        } finally {
+            client.stop();
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-webflux/6.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.springframework/spring-webflux/6.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,54 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.web.reactive.result.method.InvocableHandlerMethod"
+      },
+      "type" : "org_springframework.spring_webflux.InvocableHandlerMethodTest$GreetingHandler",
+      "methods" : [
+        {
+          "name" : "greeting",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework.spring_webflux.InvocableHandlerMethodTest"
+      },
+      "type" : "org_springframework.spring_webflux.InvocableHandlerMethodTest$GreetingHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework.spring_webflux.JettyRequestUpgradeStrategyTest"
+      },
+      "type" : "reactor.core.publisher.FluxConcatArray$ConcatArraySubscriber"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework.spring_webflux.JettyRequestUpgradeStrategyTest"
+      },
+      "type" : "reactor.core.publisher.MonoIgnoreThen$ThenIgnoreMain"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework.spring_webflux.InvocableHandlerMethodTest"
+      },
+      "type" : "reactor.core.publisher.Operators$ScalarSubscription"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org_springframework.spring_webflux.HandshakeWebSocketServiceTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework.spring_webflux.HandshakeWebSocketServiceTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/tests/src/org.springframework/spring-webflux/6.0.0/user-code-filter.json
+++ b/tests/src/org.springframework/spring-webflux/6.0.0/user-code-filter.json
@@ -7,6 +7,30 @@
       "includeClasses" : "org.springframework.web.reactive.**"
     },
     {
+      "includeClasses" : "org.springframework.beans.**"
+    },
+    {
+      "includeClasses" : "org.springframework.core.**"
+    },
+    {
+      "includeClasses" : "org.springframework.core.io.**"
+    },
+    {
+      "includeClasses" : "org.springframework.http.**"
+    },
+    {
+      "includeClasses" : "org.springframework.http.codec.multipart.**"
+    },
+    {
+      "includeClasses" : "org.springframework.mock.web.**"
+    },
+    {
+      "includeClasses" : "org.springframework.util.**"
+    },
+    {
+      "includeClasses" : "org.springframework.web.server.adapter.**"
+    },
+    {
       "includeClasses" : "org_springframework.spring_webflux.**"
     }
   ]

--- a/tests/src/org.springframework/spring-webflux/6.0.0/user-code-filter.json
+++ b/tests/src/org.springframework/spring-webflux/6.0.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.springframework.web.reactive.**"
+    },
+    {
+      "includeClasses" : "org_springframework.spring_webflux.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6974

This PR provides test fixes and new metadata for org.springframework:spring-webflux:6.0.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 72852
- Cached input tokens: 586752
- Output tokens: 6636
- Metadata entries: 78
- Test-only metadata entries: 8
- Iterations: 1
- Library coverage percentage: 1.24
- Previous library version metadata entries: 92
- Previous library version coverage percentage: 1.51

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `c111364c5bbdcbc311b72b04d596c7cbe053f3a4`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.springframework:spring-webflux:5.3.31: 10/10 covered calls (100.00%)
- org.springframework:spring-webflux:6.0.0: 1/1 covered calls (100.00%)

**Reflection:**
- org.springframework:spring-webflux:5.3.31: 10/10 covered calls (100.00%)
- org.springframework:spring-webflux:6.0.0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.springframework:spring-webflux:5.3.31: 524/43674 (1.20%)
- org.springframework:spring-webflux:6.0.0: 394/42564 (0.93%)

**Line:**
- org.springframework:spring-webflux:5.3.31: 140/9302 (1.51%)
- org.springframework:spring-webflux:6.0.0: 117/9440 (1.24%)

**Method:**
- org.springframework:spring-webflux:5.3.31: 34/3270 (1.04%)
- org.springframework:spring-webflux:6.0.0: 32/3372 (0.95%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/org.springframework/spring-webflux/5.3.31/build.gradle b/tests/src/org.springframework/spring-webflux/6.0.0/build.gradle
index 12f05cf009..40faf5d43c 100644
--- a/tests/src/org.springframework/spring-webflux/5.3.31/build.gradle
+++ b/tests/src/org.springframework/spring-webflux/6.0.0/build.gradle
@@ -14,9 +14,10 @@ dependencies {
     testImplementation "org.springframework:spring-webflux:$libraryVersion"
     testImplementation "org.springframework:spring-context:$libraryVersion"
     testImplementation "org.springframework:spring-test:$libraryVersion"
+    testImplementation 'jakarta.servlet:jakarta.servlet-api:6.0.0'
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.eclipse.jetty.websocket:websocket-jetty-server:10.0.18'
-    testImplementation 'org.eclipse.jetty.websocket:websocket-jetty-client:10.0.18'
+    testImplementation 'org.eclipse.jetty.websocket:websocket-jetty-server:11.0.18'
+    testImplementation 'org.eclipse.jetty.websocket:websocket-jetty-client:11.0.18'
 }
 
 graalvmNative {
diff --git a/tests/src/org.springframework/spring-webflux/5.3.31/src/test/java/org_springframework/spring_webflux/HandshakeWebSocketServiceTest.java b/tests/src/org.springframework/spring-webflux/6.0.0/src/test/java/org_springframework/spring_webflux/HandshakeWebSocketServiceTest.java
index 2d81e493f9..29a74ba42f 100644
--- a/tests/src/org.springframework/spring-webflux/5.3.31/src/test/java/org_springframework/spring_webflux/HandshakeWebSocketServiceTest.java
+++ b/tests/src/org.springframework/spring-webflux/6.0.0/src/test/java/org_springframework/spring_webflux/HandshakeWebSocketServiceTest.java
@@ -11,14 +11,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.web.reactive.socket.server.support.HandshakeWebSocketService;
-import org.springframework.web.reactive.socket.server.upgrade.Jetty10RequestUpgradeStrategy;
+import org.springframework.web.reactive.socket.server.upgrade.JettyRequestUpgradeStrategy;
 
 public class HandshakeWebSocketServiceTest {
     @Test
     void defaultConstructorInstantiatesDetectedUpgradeStrategy() {
         HandshakeWebSocketService service = new HandshakeWebSocketService();
 
-        assertThat(service.getUpgradeStrategy()).isInstanceOf(Jetty10RequestUpgradeStrategy.class);
+        assertThat(service.getUpgradeStrategy()).isInstanceOf(JettyRequestUpgradeStrategy.class);
         assertThat(service.isRunning()).isFalse();
     }
 }
diff --git a/tests/src/org.springframework/spring-webflux/5.3.31/src/test/java/org_springframework/spring_webflux/Jetty10RequestUpgradeStrategyTest.java b/tests/src/org.springframework/spring-webflux/6.0.0/src/test/java/org_springframework/spring_webflux/JettyRequestUpgradeStrategyTest.java
similarity index 91%
rename from /tests/src/org.springframework/spring-webflux/5.3.31/src/test/java/org_springframework/spring_webflux/Jetty10RequestUpgradeStrategyTest.java
rename to /tests/src/org.springframework/spring-webflux/6.0.0/src/test/java/org_springframework/spring_webflux/JettyRequestUpgradeStrategyTest.java
index dd360dacb0..c819861493 100644
--- a/tests/src/org.springframework/spring-webflux/5.3.31/src/test/java/org_springframework/spring_webflux/Jetty10RequestUpgradeStrategyTest.java
+++ b/tests/src/org.springframework/spring-webflux/6.0.0/src/test/java/org_springframework/spring_webflux/JettyRequestUpgradeStrategyTest.java
@@ -21,6 +21,7 @@ import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DefaultDataBufferFactory;
 import org.springframework.http.HttpCookie;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.codec.ServerCodecConfigurer;
 import org.springframework.http.server.reactive.AbstractServerHttpRequest;
 import org.springframework.http.server.reactive.AbstractServerHttpResponse;
@@ -32,25 +33,25 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.socket.HandshakeInfo;
 import org.springframework.web.reactive.socket.server.RequestUpgradeStrategy;
-import org.springframework.web.reactive.socket.server.upgrade.Jetty10RequestUpgradeStrategy;
+import org.springframework.web.reactive.socket.server.upgrade.JettyRequestUpgradeStrategy;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.adapter.DefaultServerWebExchange;
 import org.springframework.web.server.i18n.AcceptHeaderLocaleContextResolver;
 import org.springframework.web.server.session.DefaultWebSessionManager;
 
-public class Jetty10RequestUpgradeStrategyTest {
+public class JettyRequestUpgradeStrategyTest {
     private static final URI REQUEST_URI = URI.create("http://localhost/ws");
 
     @Test
-    void constructsStrategyWhenJetty10WebSocketServerApiIsAvailable() {
-        RequestUpgradeStrategy strategy = new Jetty10RequestUpgradeStrategy();
+    void constructsStrategyWhenJettyWebSocketServerApiIsAvailable() {
+        RequestUpgradeStrategy strategy = new JettyRequestUpgradeStrategy();
 
-        assertThat(strategy).isInstanceOf(Jetty10RequestUpgradeStrategy.class);
+        assertThat(strategy).isInstanceOf(JettyRequestUpgradeStrategy.class);
     }
 
     @Test
     void upgradeCreatesJettyWebSocketCreatorProxyBeforeLookingUpContainer() {
-        RequestUpgradeStrategy strategy = new Jetty10RequestUpgradeStrategy();
+        RequestUpgradeStrategy strategy = new JettyRequestUpgradeStrategy();
         MockServletContext servletContext = new MockServletContext();
         MockHttpServletRequest servletRequest = new MockHttpServletRequest(servletContext, "GET", "/ws");
         MockHttpServletResponse servletResponse = new MockHttpServletResponse();
@@ -84,8 +85,8 @@ public class Jetty10RequestUpgradeStrategyTest {
         }
 
         @Override
-        public String getMethodValue() {
-            return this.servletRequest.getMethod();
+        public HttpMethod getMethod() {
+            return HttpMethod.valueOf(this.servletRequest.getMethod());
         }
 
         @Override
diff --git a/tests/src/org.springframework/spring-webflux/5.3.31/user-code-filter.json b/tests/src/org.springframework/spring-webflux/6.0.0/user-code-filter.json
index 002df36b88..0a8b081c13 100644
--- a/tests/src/org.springframework/spring-webflux/5.3.31/user-code-filter.json
+++ b/tests/src/org.springframework/spring-webflux/6.0.0/user-code-filter.json
@@ -6,6 +6,30 @@
     {
       "includeClasses" : "org.springframework.web.reactive.**"
     },
+    {
+      "includeClasses" : "org.springframework.beans.**"
+    },
+    {
+      "includeClasses" : "org.springframework.core.**"
+    },
+    {
+      "includeClasses" : "org.springframework.core.io.**"
+    },
+    {
+      "includeClasses" : "org.springframework.http.**"
+    },
+    {
+      "includeClasses" : "org.springframework.http.codec.multipart.**"
+    },
+    {
+      "includeClasses" : "org.springframework.mock.web.**"
+    },
+    {
+      "includeClasses" : "org.springframework.util.**"
+    },
+    {
+      "includeClasses" : "org.springframework.web.server.adapter.**"
+    },
     {
       "includeClasses" : "org_springframework.spring_webflux.**"
     }

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
