### PR TITLE
[GenAI] Mark org.apache.groovy:groovy-all as not for Native Image

### DIFF
--- a/metadata/org.apache.groovy/groovy-all/index.json
+++ b/metadata/org.apache.groovy/groovy-all/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published artifact is a POM-only aggregate with no primary JVM class-file jar; Native Image metadata should target the Groovy JVM modules it depends on.",
+    "replacement": "org.apache.groovy:groovy:4.0.24"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #2213

This PR records `org.apache.groovy:groovy-all` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published artifact is a POM-only aggregate with no primary JVM class-file jar; Native Image metadata should target the Groovy JVM modules it depends on.

Replacement guidance:
- org.apache.groovy:groovy:4.0.24

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `684206317038b03cf790d0e19201fa0640a38604`

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
