### PR TITLE
[GenAI] Test fix for org.springframework:spring-tx:6.0.2 using gpt-5.5

### DIFF
--- a/metadata/org.springframework/spring-tx/6.0.2/reachability-metadata.json
+++ b/metadata/org.springframework/spring-tx/6.0.2/reachability-metadata.json
@@ -1,0 +1,122 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.interceptor.TransactionInterceptor"
+      },
+      "type" : "org.springframework.transaction.interceptor.TransactionInterceptor",
+      "serializable" : true,
+      "methods" : [
+        {
+          "name" : "readObject",
+          "parameterTypes" : [
+            "java.io.ObjectInputStream"
+          ]
+        },
+        {
+          "name" : "writeObject",
+          "parameterTypes" : [
+            "java.io.ObjectOutputStream"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.interceptor.TransactionInterceptor"
+      },
+      "type" : "java.lang.String",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.interceptor.TransactionInterceptor"
+      },
+      "type" : "org.springframework.transaction.interceptor.TransactionAspectSupport",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.jta.WebLogicJtaTransactionManager"
+      },
+      "type" : "weblogic.transaction.TransactionHelper",
+      "methods" : [
+        {
+          "name" : "getTransactionHelper",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getUserTransaction",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getTransactionManager",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.jta.WebLogicJtaTransactionManager"
+      },
+      "type" : "weblogic.transaction.UserTransaction",
+      "methods" : [
+        {
+          "name" : "begin",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "begin",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.jta.WebLogicJtaTransactionManager"
+      },
+      "type" : "weblogic.transaction.ClientTransactionManager",
+      "methods" : [
+        {
+          "name" : "forceResume",
+          "parameterTypes" : [
+            "javax.transaction.Transaction"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.jta.WebLogicJtaTransactionManager"
+      },
+      "type" : "weblogic.transaction.Transaction",
+      "methods" : [
+        {
+          "name" : "setProperty",
+          "parameterTypes" : [
+            "java.lang.String",
+            "java.io.Serializable"
+          ]
+        }
+      ]
+    }
+  ],
+  "serialization" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.interceptor.TransactionInterceptor"
+      },
+      "type" : "org.springframework.transaction.interceptor.TransactionInterceptor"
+    }
+  ]
+}

--- a/metadata/org.springframework/spring-tx/index.json
+++ b/metadata/org.springframework/spring-tx/index.json
@@ -1,5 +1,15 @@
 [
   {
+    "latest" : true,
+    "metadata-version" : "6.0.2",
+    "tested-versions" : [
+      "6.0.2"
+    ],
+    "allowed-packages" : [
+      "org.springframework"
+    ]
+  },
+  {
     "metadata-version" : "5.3.18",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/spring-tx/$version$/spring-tx-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-framework",
@@ -35,7 +45,6 @@
     ]
   },
   {
-    "latest" : true,
     "metadata-version" : "6.0.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/spring-tx/$version$/spring-tx-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-framework",

--- a/metadata/org.springframework/spring-tx/index.json
+++ b/metadata/org.springframework/spring-tx/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "6.0.2",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/spring-tx/$version$/spring-tx-$version$-sources.jar",
+    "repository-url" : "https://github.com/spring-projects/spring-framework",
+    "test-code-url" : "https://github.com/spring-projects/spring-framework/tree/v$version$/spring-tx/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/springframework/spring-tx/$version$/spring-tx-$version$-javadoc.jar",
+    "description" : "Spring TX provides Spring Framework's transaction abstraction, including declarative and programmatic transaction management APIs for local and global transactions. It defines common transaction annotations, interceptors, synchronization infrastructure, and exception translation types used across Spring data access modules.",
     "tested-versions" : [
       "6.0.2"
     ],

--- a/stats/org.springframework/spring-tx/6.0.2/execution-metrics.json
+++ b/stats/org.springframework/spring-tx/6.0.2/execution-metrics.json
@@ -1,0 +1,99 @@
+{
+  "fix_javac_fail:2026-06-08": {
+    "timestamp": "2026-06-08T10:23:18.049130Z",
+    "library": "org.springframework:spring-tx:6.0.2",
+    "starting_commit": "e728e73f67798947b483d34a0c5df569b408c2dd",
+    "ending_commit": "e7caed4876e2a2bf070eec9cbabb1caae9a19b4d",
+    "previous_library": "org.springframework:spring-tx:6.0.1",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "6.0.2",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 9,
+            "totalCalls": 9
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 9,
+        "totalCalls": 9
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 927,
+          "missed": 12059,
+          "ratio": 0.071385,
+          "total": 12986
+        },
+        "line": {
+          "covered": 275,
+          "missed": 3246,
+          "ratio": 0.078103,
+          "total": 3521
+        },
+        "method": {
+          "covered": 78,
+          "missed": 972,
+          "ratio": 0.074286,
+          "total": 1050
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "6.0.1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 9,
+            "totalCalls": 9
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 9,
+        "totalCalls": 9
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 598,
+          "missed": 12388,
+          "ratio": 0.04605,
+          "total": 12986
+        },
+        "line": {
+          "covered": 183,
+          "missed": 3338,
+          "ratio": 0.051974,
+          "total": 3521
+        },
+        "method": {
+          "covered": 48,
+          "missed": 1002,
+          "ratio": 0.045714,
+          "total": 1050
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 71633,
+      "cached_input_tokens_used": 701440,
+      "output_tokens_used": 8416,
+      "iterations": 3,
+      "cost_usd": 0.6032,
+      "tested_library_loc": 275,
+      "metadata_entries": 19,
+      "previous_library_metadata_entries": 17,
+      "code_coverage_percent": 7.81,
+      "previous_library_coverage_percent": 5.2
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.springframework/spring-tx/6.0.2/src/test/java/weblogic/transaction/ClientTransactionManager.java",
+      "metadata_file": "metadata/org.springframework/spring-tx/6.0.2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.springframework/spring-tx/6.0.2/stats.json
+++ b/stats/org.springframework/spring-tx/6.0.2/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "6.0.2",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 9,
+          "totalCalls" : 9
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 9,
+      "totalCalls" : 9
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 927,
+        "missed" : 12059,
+        "ratio" : 0.071385,
+        "total" : 12986
+      },
+      "line" : {
+        "covered" : 275,
+        "missed" : 3246,
+        "ratio" : 0.078103,
+        "total" : 3521
+      },
+      "method" : {
+        "covered" : 78,
+        "missed" : 972,
+        "ratio" : 0.074286,
+        "total" : 1050
+      }
+    }
+  } ]
+}

--- a/tests/src/org.springframework/spring-tx/6.0.2/.gitignore
+++ b/tests/src/org.springframework/spring-tx/6.0.2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.springframework/spring-tx/6.0.2/build.gradle
+++ b/tests/src/org.springframework/spring-tx/6.0.2/build.gradle
@@ -1,0 +1,30 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.springframework:spring-tx:$libraryVersion"
+    testImplementation "org.springframework:spring-context:$libraryVersion"
+    testImplementation 'jakarta.transaction:jakarta.transaction-api:2.0.1'
+    testImplementation 'javax.transaction:javax.transaction-api:1.3'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-tx/6.0.2/gradle.properties
+++ b/tests/src/org.springframework/spring-tx/6.0.2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.springframework:spring-tx:6.0.2
+library.version = 6.0.2
+metadata.dir = org.springframework/spring-tx/6.0.2/

--- a/tests/src/org.springframework/spring-tx/6.0.2/settings.gradle
+++ b/tests/src/org.springframework/spring-tx/6.0.2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.springframework.spring-tx_tests'

--- a/tests/src/org.springframework/spring-tx/6.0.2/src/test/java/org_springframework/spring_tx/JtaTransactionManagerTest.java
+++ b/tests/src/org.springframework/spring-tx/6.0.2/src/test/java/org_springframework/spring_tx/JtaTransactionManagerTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_tx;
+
+import jakarta.transaction.HeuristicMixedException;
+import jakarta.transaction.HeuristicRollbackException;
+import jakarta.transaction.InvalidTransactionException;
+import jakarta.transaction.NotSupportedException;
+import jakarta.transaction.RollbackException;
+import jakarta.transaction.Status;
+import jakarta.transaction.Synchronization;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.Transaction;
+import jakarta.transaction.TransactionManager;
+import jakarta.transaction.UserTransaction;
+
+import javax.transaction.xa.XAResource;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.jta.JtaTransactionManager;
+import org.springframework.transaction.jta.JtaTransactionObject;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JtaTransactionManagerTest {
+
+    private RecordingUserTransaction userTransaction;
+
+    private RecordingTransactionManager transactionManager;
+
+    @BeforeEach
+    void setUp() {
+        this.userTransaction = new RecordingUserTransaction();
+        this.transactionManager = new RecordingTransactionManager();
+    }
+
+    @Test
+    void constructorConfiguresUserTransactionAndTransactionManager() {
+        ExposedJtaTransactionManager manager = new ExposedJtaTransactionManager(
+                this.userTransaction, this.transactionManager);
+
+        manager.afterPropertiesSet();
+
+        assertThat(manager.getUserTransaction()).isSameAs(this.userTransaction);
+        assertThat(manager.getTransactionManager()).isSameAs(this.transactionManager);
+    }
+
+    @Test
+    void createTransactionUsesTransactionManagerBeginAndTimeout() throws NotSupportedException, SystemException {
+        ExposedJtaTransactionManager manager = new ExposedJtaTransactionManager(
+                this.userTransaction, this.transactionManager);
+
+        Transaction transaction = manager.createTransaction("inventory.update", 7);
+
+        assertThat(transaction).isNotNull();
+        assertThat(this.transactionManager.beginCalls).isEqualTo(1);
+        assertThat(this.transactionManager.lastTimeout).isEqualTo(7);
+    }
+
+    @Test
+    void doJtaBeginAppliesTimeoutAndBeginsUserTransaction() throws NotSupportedException, SystemException {
+        ExposedJtaTransactionManager manager = new ExposedJtaTransactionManager(
+                this.userTransaction, this.transactionManager);
+        DefaultTransactionDefinition definition = new DefaultTransactionDefinition();
+        definition.setTimeout(11);
+
+        manager.begin(new JtaTransactionObject(this.userTransaction), definition);
+
+        assertThat(this.userTransaction.beginCalls).isEqualTo(1);
+        assertThat(this.userTransaction.lastTimeout).isEqualTo(11);
+    }
+
+    @Test
+    void doJtaResumeDelegatesToTransactionManager() throws InvalidTransactionException, SystemException {
+        ExposedJtaTransactionManager manager = new ExposedJtaTransactionManager(
+                this.userTransaction, this.transactionManager);
+
+        manager.resume(this.transactionManager.transaction);
+
+        assertThat(this.transactionManager.resumeCalls).isEqualTo(1);
+        assertThat(this.transactionManager.lastResumedTransaction).isSameAs(this.transactionManager.transaction);
+    }
+
+    private static final class ExposedJtaTransactionManager extends JtaTransactionManager {
+
+        private ExposedJtaTransactionManager(UserTransaction userTransaction, TransactionManager transactionManager) {
+            super(userTransaction, transactionManager);
+        }
+
+        void begin(JtaTransactionObject transactionObject, TransactionDefinition definition)
+                throws NotSupportedException, SystemException {
+            doJtaBegin(transactionObject, definition);
+        }
+
+        void resume(Object suspendedTransaction) throws InvalidTransactionException, SystemException {
+            doJtaResume(null, suspendedTransaction);
+        }
+    }
+
+    private static final class RecordingUserTransaction implements UserTransaction {
+
+        private int beginCalls;
+
+        private int lastTimeout = TransactionDefinition.TIMEOUT_DEFAULT;
+
+        @Override
+        public void begin() {
+            this.beginCalls++;
+        }
+
+        @Override
+        public void commit() {
+        }
+
+        @Override
+        public void rollback() {
+        }
+
+        @Override
+        public void setRollbackOnly() {
+        }
+
+        @Override
+        public int getStatus() {
+            return Status.STATUS_ACTIVE;
+        }
+
+        @Override
+        public void setTransactionTimeout(int seconds) {
+            this.lastTimeout = seconds;
+        }
+    }
+
+    private static final class RecordingTransactionManager implements TransactionManager {
+
+        private final RecordingTransaction transaction = new RecordingTransaction();
+
+        private int beginCalls;
+
+        private int resumeCalls;
+
+        private int lastTimeout = TransactionDefinition.TIMEOUT_DEFAULT;
+
+        private Transaction lastResumedTransaction;
+
+        @Override
+        public void begin() {
+            this.beginCalls++;
+        }
+
+        @Override
+        public void commit() {
+        }
+
+        @Override
+        public void rollback() {
+        }
+
+        @Override
+        public void setRollbackOnly() {
+        }
+
+        @Override
+        public int getStatus() {
+            return Status.STATUS_ACTIVE;
+        }
+
+        @Override
+        public Transaction getTransaction() {
+            return this.transaction;
+        }
+
+        @Override
+        public void setTransactionTimeout(int seconds) {
+            this.lastTimeout = seconds;
+        }
+
+        @Override
+        public Transaction suspend() {
+            return this.transaction;
+        }
+
+        @Override
+        public void resume(Transaction resumedTransaction) {
+            this.resumeCalls++;
+            this.lastResumedTransaction = resumedTransaction;
+        }
+    }
+
+    private static final class RecordingTransaction implements Transaction {
+
+        @Override
+        public void commit()
+                throws RollbackException, HeuristicMixedException, HeuristicRollbackException, SystemException {
+        }
+
+        @Override
+        public boolean delistResource(XAResource xaResource, int flag) {
+            return true;
+        }
+
+        @Override
+        public boolean enlistResource(XAResource xaResource) {
+            return true;
+        }
+
+        @Override
+        public int getStatus() {
+            return Status.STATUS_ACTIVE;
+        }
+
+        @Override
+        public void registerSynchronization(Synchronization synchronization) {
+        }
+
+        @Override
+        public void rollback() {
+        }
+
+        @Override
+        public void setRollbackOnly() {
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-tx/6.0.2/src/test/java/org_springframework/spring_tx/MethodMapTransactionAttributeSourceTest.java
+++ b/tests/src/org.springframework/spring-tx/6.0.2/src/test/java/org_springframework/spring_tx/MethodMapTransactionAttributeSourceTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_tx;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.transaction.interceptor.DefaultTransactionAttribute;
+import org.springframework.transaction.interceptor.MethodMapTransactionAttributeSource;
+import org.springframework.transaction.interceptor.TransactionAttribute;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MethodMapTransactionAttributeSourceTest {
+
+    @Test
+    void addTransactionalMethodWithClassAndPatternRegistersMatchingDeclaredMethods() throws Exception {
+        MethodMapTransactionAttributeSource source = new MethodMapTransactionAttributeSource();
+        TransactionAttribute attribute = new DefaultTransactionAttribute();
+
+        source.addTransactionalMethod(OrderService.class, "create*", attribute);
+
+        assertThat(source.getTransactionAttribute(method("createOrder"), OrderService.class)).isSameAs(attribute);
+        assertThat(source.getTransactionAttribute(method("createInvoice"), OrderService.class)).isSameAs(attribute);
+        assertThat(source.getTransactionAttribute(method("queryOrders"), OrderService.class)).isNull();
+    }
+
+    private static Method method(String name) throws NoSuchMethodException {
+        return OrderService.class.getMethod(name);
+    }
+
+    static class OrderService {
+
+        public void createOrder() {
+        }
+
+        public void createInvoice() {
+        }
+
+        public void queryOrders() {
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-tx/6.0.2/src/test/java/org_springframework/spring_tx/TransactionInterceptorTest.java
+++ b/tests/src/org.springframework/spring-tx/6.0.2/src/test/java/org_springframework/spring_tx/TransactionInterceptorTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_tx;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.transaction.interceptor.TransactionInterceptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TransactionInterceptorTest {
+
+    @Test
+    void serializationRoundTripUsesTransactionInterceptorCustomSerialization() throws Exception {
+        TransactionInterceptor interceptor = new TransactionInterceptor();
+
+        byte[] serialized = serialize(interceptor);
+        Object deserialized = deserialize(serialized);
+
+        assertThat(deserialized).isInstanceOf(TransactionInterceptor.class);
+        TransactionInterceptor restored = (TransactionInterceptor) deserialized;
+        assertThat(restored).isNotSameAs(interceptor);
+        assertThat(restored.getTransactionManager()).isNull();
+        assertThat(restored.getTransactionAttributeSource()).isNull();
+    }
+
+    private static byte[] serialize(TransactionInterceptor interceptor) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream outputStream = new ObjectOutputStream(bytes)) {
+            outputStream.writeObject(interceptor);
+        }
+        return bytes.toByteArray();
+    }
+
+    private static Object deserialize(byte[] bytes) throws Exception {
+        try (ObjectInputStream inputStream = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+            return inputStream.readObject();
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-tx/6.0.2/src/test/java/org_springframework/spring_tx/TransactionInterceptorTest.java
+++ b/tests/src/org.springframework/spring-tx/6.0.2/src/test/java/org_springframework/spring_tx/TransactionInterceptorTest.java
@@ -10,27 +10,64 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.Callable;
 
+import org.aopalliance.intercept.MethodInvocation;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.interceptor.DefaultTransactionAttribute;
+import org.springframework.transaction.interceptor.NameMatchTransactionAttributeSource;
 import org.springframework.transaction.interceptor.TransactionInterceptor;
+import org.springframework.transaction.support.SimpleTransactionStatus;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TransactionInterceptorTest {
 
     @Test
-    void serializationRoundTripUsesTransactionInterceptorCustomSerialization() throws Exception {
+    void serializationWritesTransactionInterceptorCustomState() throws Exception {
         TransactionInterceptor interceptor = new TransactionInterceptor();
+        interceptor.setTransactionManagerBeanName("testTransactionManager");
 
         byte[] serialized = serialize(interceptor);
-        Object deserialized = deserialize(serialized);
 
-        assertThat(deserialized).isInstanceOf(TransactionInterceptor.class);
-        TransactionInterceptor restored = (TransactionInterceptor) deserialized;
-        assertThat(restored).isNotSameAs(interceptor);
-        assertThat(restored.getTransactionManager()).isNull();
-        assertThat(restored.getTransactionAttributeSource()).isNull();
+        assertThat(new String(serialized, StandardCharsets.ISO_8859_1)).contains("testTransactionManager");
+    }
+
+    @Test
+    void deserializationReadsTransactionInterceptorCustomState() throws Exception {
+        TransactionInterceptor interceptor = new TransactionInterceptor();
+        interceptor.setTransactionManagerBeanName("testTransactionManager");
+
+        TransactionInterceptor deserialized = deserialize(serialize(interceptor));
+
+        assertThat(new String(serialize(deserialized), StandardCharsets.ISO_8859_1))
+                .contains("testTransactionManager");
+    }
+
+    @Test
+    void invokeWithTransactionAttributeCommitsAroundInvocation() throws Throwable {
+        TransactionInterceptor interceptor = new TransactionInterceptor();
+        RecordingTransactionManager transactionManager = new RecordingTransactionManager();
+        NameMatchTransactionAttributeSource attributeSource = new NameMatchTransactionAttributeSource();
+        attributeSource.addTransactionalMethod("call", new DefaultTransactionAttribute());
+        interceptor.setTransactionManager(transactionManager);
+        interceptor.setTransactionAttributeSource(attributeSource);
+        CallbackMethodInvocation invocation = new CallbackMethodInvocation(Callable.class.getMethod("call"));
+
+        Object result = interceptor.invoke(invocation);
+
+        assertThat(result).isEqualTo("transactional result");
+        assertThat(invocation.proceeded).isTrue();
+        assertThat(transactionManager.getTransactionCount).isEqualTo(1);
+        assertThat(transactionManager.commitCount).isEqualTo(1);
+        assertThat(transactionManager.rollbackCount).isZero();
     }
 
     private static byte[] serialize(TransactionInterceptor interceptor) throws Exception {
@@ -41,9 +78,66 @@ public class TransactionInterceptorTest {
         return bytes.toByteArray();
     }
 
-    private static Object deserialize(byte[] bytes) throws Exception {
-        try (ObjectInputStream inputStream = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
-            return inputStream.readObject();
+    private static TransactionInterceptor deserialize(byte[] serialized) throws Exception {
+        try (ObjectInputStream inputStream = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            return (TransactionInterceptor) inputStream.readObject();
+        }
+    }
+
+    private static final class CallbackMethodInvocation implements MethodInvocation {
+        private final Method method;
+        private boolean proceeded;
+
+        private CallbackMethodInvocation(Method method) {
+            this.method = method;
+        }
+
+        @Override
+        public Method getMethod() {
+            return this.method;
+        }
+
+        @Override
+        public Object[] getArguments() {
+            return new Object[0];
+        }
+
+        @Override
+        public Object proceed() {
+            this.proceeded = true;
+            return "transactional result";
+        }
+
+        @Override
+        public Object getThis() {
+            return null;
+        }
+
+        @Override
+        public AccessibleObject getStaticPart() {
+            return this.method;
+        }
+    }
+
+    private static final class RecordingTransactionManager implements PlatformTransactionManager {
+        private int getTransactionCount;
+        private int commitCount;
+        private int rollbackCount;
+
+        @Override
+        public TransactionStatus getTransaction(TransactionDefinition definition) {
+            this.getTransactionCount++;
+            return new SimpleTransactionStatus();
+        }
+
+        @Override
+        public void commit(TransactionStatus status) {
+            this.commitCount++;
+        }
+
+        @Override
+        public void rollback(TransactionStatus status) {
+            this.rollbackCount++;
         }
     }
 }

--- a/tests/src/org.springframework/spring-tx/6.0.2/src/test/java/weblogic/transaction/ClientTransactionManager.java
+++ b/tests/src/org.springframework/spring-tx/6.0.2/src/test/java/weblogic/transaction/ClientTransactionManager.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package weblogic.transaction;
+
+import javax.transaction.InvalidTransactionException;
+import javax.transaction.SystemException;
+
+/**
+ * Minimal WebLogic transaction manager contract used by Spring's WebLogic adapter.
+ */
+public interface ClientTransactionManager extends javax.transaction.TransactionManager {
+
+    void forceResume(javax.transaction.Transaction transaction) throws InvalidTransactionException, SystemException;
+}

--- a/tests/src/org.springframework/spring-tx/6.0.2/src/test/java/weblogic/transaction/Transaction.java
+++ b/tests/src/org.springframework/spring-tx/6.0.2/src/test/java/weblogic/transaction/Transaction.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package weblogic.transaction;
+
+import java.io.Serializable;
+
+/**
+ * Minimal WebLogic transaction contract used by Spring's WebLogic adapter.
+ */
+public interface Transaction extends javax.transaction.Transaction {
+
+    void setProperty(String name, Serializable value);
+}

--- a/tests/src/org.springframework/spring-tx/6.0.2/src/test/java/weblogic/transaction/TransactionHelper.java
+++ b/tests/src/org.springframework/spring-tx/6.0.2/src/test/java/weblogic/transaction/TransactionHelper.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package weblogic.transaction;
+
+import java.io.Serializable;
+
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.InvalidTransactionException;
+import javax.transaction.RollbackException;
+import javax.transaction.Status;
+import javax.transaction.Synchronization;
+import javax.transaction.SystemException;
+import javax.transaction.xa.XAResource;
+
+/**
+ * Test double for WebLogic's static transaction helper.
+ */
+public final class TransactionHelper {
+
+    private static final RecordingUserTransaction USER_TRANSACTION = new RecordingUserTransaction();
+
+    private static final RecordingClientTransactionManager TRANSACTION_MANAGER =
+            new RecordingClientTransactionManager();
+
+    private static int getTransactionHelperCalls;
+
+    public static TransactionHelper getTransactionHelper() {
+        getTransactionHelperCalls++;
+        return new TransactionHelper();
+    }
+
+    public static void reset() {
+        getTransactionHelperCalls = 0;
+        USER_TRANSACTION.reset();
+        TRANSACTION_MANAGER.reset();
+    }
+
+    public static int getTransactionHelperCalls() {
+        return getTransactionHelperCalls;
+    }
+
+    public static RecordingUserTransaction userTransaction() {
+        return USER_TRANSACTION;
+    }
+
+    public static RecordingClientTransactionManager transactionManager() {
+        return TRANSACTION_MANAGER;
+    }
+
+    public UserTransaction getUserTransaction() {
+        return USER_TRANSACTION;
+    }
+
+    public ClientTransactionManager getTransactionManager() {
+        return TRANSACTION_MANAGER;
+    }
+
+    public static final class RecordingUserTransaction implements UserTransaction {
+
+        private int beginCalls;
+
+        private int beginWithNameCalls;
+
+        private int beginWithNameAndTimeoutCalls;
+
+        private String lastName;
+
+        private int lastTimeout;
+
+        private void reset() {
+            this.beginCalls = 0;
+            this.beginWithNameCalls = 0;
+            this.beginWithNameAndTimeoutCalls = 0;
+            this.lastName = null;
+            this.lastTimeout = -1;
+        }
+
+        @Override
+        public void begin() {
+            this.beginCalls++;
+        }
+
+        @Override
+        public void begin(String name) {
+            this.beginWithNameCalls++;
+            this.lastName = name;
+        }
+
+        @Override
+        public void begin(String name, int timeout) {
+            this.beginWithNameAndTimeoutCalls++;
+            this.lastName = name;
+            this.lastTimeout = timeout;
+        }
+
+        @Override
+        public void commit() {
+        }
+
+        @Override
+        public void rollback() {
+        }
+
+        @Override
+        public void setRollbackOnly() {
+        }
+
+        @Override
+        public int getStatus() {
+            return Status.STATUS_ACTIVE;
+        }
+
+        @Override
+        public void setTransactionTimeout(int seconds) {
+            this.lastTimeout = seconds;
+        }
+
+        public int beginCalls() {
+            return this.beginCalls;
+        }
+
+        public int beginWithNameCalls() {
+            return this.beginWithNameCalls;
+        }
+
+        public int beginWithNameAndTimeoutCalls() {
+            return this.beginWithNameAndTimeoutCalls;
+        }
+
+        public String lastName() {
+            return this.lastName;
+        }
+
+        public int lastTimeout() {
+            return this.lastTimeout;
+        }
+    }
+
+    public static final class RecordingClientTransactionManager implements ClientTransactionManager {
+
+        private final RecordingTransaction transaction = new RecordingTransaction();
+
+        private int resumeCalls;
+
+        private int forceResumeCalls;
+
+        private boolean failResume;
+
+        private javax.transaction.Transaction lastResumedTransaction;
+
+        private void reset() {
+            this.resumeCalls = 0;
+            this.forceResumeCalls = 0;
+            this.failResume = false;
+            this.lastResumedTransaction = null;
+            this.transaction.reset();
+        }
+
+        @Override
+        public void begin() {
+        }
+
+        @Override
+        public void commit() {
+        }
+
+        @Override
+        public void rollback() {
+        }
+
+        @Override
+        public void setRollbackOnly() {
+        }
+
+        @Override
+        public int getStatus() {
+            return Status.STATUS_ACTIVE;
+        }
+
+        @Override
+        public javax.transaction.Transaction getTransaction() {
+            return this.transaction;
+        }
+
+        @Override
+        public void setTransactionTimeout(int seconds) {
+        }
+
+        @Override
+        public javax.transaction.Transaction suspend() {
+            return this.transaction;
+        }
+
+        @Override
+        public void resume(javax.transaction.Transaction transaction) throws InvalidTransactionException {
+            this.resumeCalls++;
+            this.lastResumedTransaction = transaction;
+            if (this.failResume) {
+                throw new InvalidTransactionException("resume rejected by test double");
+            }
+        }
+
+        @Override
+        public void forceResume(javax.transaction.Transaction transaction) {
+            this.forceResumeCalls++;
+            this.lastResumedTransaction = transaction;
+        }
+
+        public void failResume() {
+            this.failResume = true;
+        }
+
+        public RecordingTransaction transaction() {
+            return this.transaction;
+        }
+
+        public int resumeCalls() {
+            return this.resumeCalls;
+        }
+
+        public int forceResumeCalls() {
+            return this.forceResumeCalls;
+        }
+
+        public javax.transaction.Transaction lastResumedTransaction() {
+            return this.lastResumedTransaction;
+        }
+    }
+
+    public static final class RecordingTransaction implements Transaction {
+
+        private String lastPropertyName;
+
+        private Serializable lastPropertyValue;
+
+        private int setPropertyCalls;
+
+        private void reset() {
+            this.lastPropertyName = null;
+            this.lastPropertyValue = null;
+            this.setPropertyCalls = 0;
+        }
+
+        @Override
+        public void commit()
+                throws RollbackException, HeuristicMixedException, HeuristicRollbackException, SystemException {
+        }
+
+        @Override
+        public boolean delistResource(XAResource xaResource, int flag) {
+            return true;
+        }
+
+        @Override
+        public boolean enlistResource(XAResource xaResource) {
+            return true;
+        }
+
+        @Override
+        public int getStatus() {
+            return Status.STATUS_ACTIVE;
+        }
+
+        @Override
+        public void registerSynchronization(Synchronization synchronization) {
+        }
+
+        @Override
+        public void rollback() {
+        }
+
+        @Override
+        public void setRollbackOnly() {
+        }
+
+        @Override
+        public void setProperty(String name, Serializable value) {
+            this.setPropertyCalls++;
+            this.lastPropertyName = name;
+            this.lastPropertyValue = value;
+        }
+
+        public String lastPropertyName() {
+            return this.lastPropertyName;
+        }
+
+        public Serializable lastPropertyValue() {
+            return this.lastPropertyValue;
+        }
+
+        public int setPropertyCalls() {
+            return this.setPropertyCalls;
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-tx/6.0.2/src/test/java/weblogic/transaction/UserTransaction.java
+++ b/tests/src/org.springframework/spring-tx/6.0.2/src/test/java/weblogic/transaction/UserTransaction.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package weblogic.transaction;
+
+/**
+ * Minimal WebLogic UserTransaction contract used by Spring's WebLogic adapter.
+ */
+public interface UserTransaction extends javax.transaction.UserTransaction {
+
+    void begin(String name);
+
+    void begin(String name, int timeout);
+}

--- a/tests/src/org.springframework/spring-tx/6.0.2/user-code-filter.json
+++ b/tests/src/org.springframework/spring-tx/6.0.2/user-code-filter.json
@@ -1,0 +1,16 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.springframework.**"
+    },
+    {
+      "includeClasses" : "weblogic.transaction.**"
+    },
+    {
+      "includeClasses" : "org_springframework.spring_tx.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #7189

This PR provides test fixes and new metadata for org.springframework:spring-tx:6.0.2, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 71633
- Cached input tokens: 701440
- Output tokens: 8416
- Metadata entries: 19
- Iterations: 3
- Library coverage percentage: 7.81
- Previous library version metadata entries: 17
- Previous library version coverage percentage: 5.2

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `df9fd89d78474c1e8734cdc8c654007bfa78ce2e`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.springframework:spring-tx:6.0.1: 9/9 covered calls (100.00%)
- org.springframework:spring-tx:6.0.2: 9/9 covered calls (100.00%)

**Reflection:**
- org.springframework:spring-tx:6.0.1: 9/9 covered calls (100.00%)
- org.springframework:spring-tx:6.0.2: 9/9 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.springframework:spring-tx:6.0.1: 598/12986 (4.61%)
- org.springframework:spring-tx:6.0.2: 927/12986 (7.14%)

**Line:**
- org.springframework:spring-tx:6.0.1: 183/3521 (5.20%)
- org.springframework:spring-tx:6.0.2: 275/3521 (7.81%)

**Method:**
- org.springframework:spring-tx:6.0.1: 48/1050 (4.57%)
- org.springframework:spring-tx:6.0.2: 78/1050 (7.43%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.springframework/spring-tx/6.0.1/src/test/java/org_springframework/spring_tx/TransactionInterceptorTest.java 2/tests/src/org.springframework/spring-tx/6.0.2/src/test/java/org_springframework/spring_tx/TransactionInterceptorTest.java
index a8a2f08719..991d8458dc 100644
--- 1/tests/src/org.springframework/spring-tx/6.0.1/src/test/java/org_springframework/spring_tx/TransactionInterceptorTest.java
+++ 2/tests/src/org.springframework/spring-tx/6.0.2/src/test/java/org_springframework/spring_tx/TransactionInterceptorTest.java
@@ -10,27 +10,64 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.Callable;
 
+import org.aopalliance.intercept.MethodInvocation;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.interceptor.DefaultTransactionAttribute;
+import org.springframework.transaction.interceptor.NameMatchTransactionAttributeSource;
 import org.springframework.transaction.interceptor.TransactionInterceptor;
+import org.springframework.transaction.support.SimpleTransactionStatus;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TransactionInterceptorTest {
 
     @Test
-    void serializationRoundTripUsesTransactionInterceptorCustomSerialization() throws Exception {
+    void serializationWritesTransactionInterceptorCustomState() throws Exception {
         TransactionInterceptor interceptor = new TransactionInterceptor();
+        interceptor.setTransactionManagerBeanName("testTransactionManager");
 
         byte[] serialized = serialize(interceptor);
-        Object deserialized = deserialize(serialized);
 
-        assertThat(deserialized).isInstanceOf(TransactionInterceptor.class);
-        TransactionInterceptor restored = (TransactionInterceptor) deserialized;
-        assertThat(restored).isNotSameAs(interceptor);
-        assertThat(restored.getTransactionManager()).isNull();
-        assertThat(restored.getTransactionAttributeSource()).isNull();
+        assertThat(new String(serialized, StandardCharsets.ISO_8859_1)).contains("testTransactionManager");
+    }
+
+    @Test
+    void deserializationReadsTransactionInterceptorCustomState() throws Exception {
+        TransactionInterceptor interceptor = new TransactionInterceptor();
+        interceptor.setTransactionManagerBeanName("testTransactionManager");
+
+        TransactionInterceptor deserialized = deserialize(serialize(interceptor));
+
+        assertThat(new String(serialize(deserialized), StandardCharsets.ISO_8859_1))
+                .contains("testTransactionManager");
+    }
+
+    @Test
+    void invokeWithTransactionAttributeCommitsAroundInvocation() throws Throwable {
+        TransactionInterceptor interceptor = new TransactionInterceptor();
+        RecordingTransactionManager transactionManager = new RecordingTransactionManager();
+        NameMatchTransactionAttributeSource attributeSource = new NameMatchTransactionAttributeSource();
+        attributeSource.addTransactionalMethod("call", new DefaultTransactionAttribute());
+        interceptor.setTransactionManager(transactionManager);
+        interceptor.setTransactionAttributeSource(attributeSource);
+        CallbackMethodInvocation invocation = new CallbackMethodInvocation(Callable.class.getMethod("call"));
+
+        Object result = interceptor.invoke(invocation);
+
+        assertThat(result).isEqualTo("transactional result");
+        assertThat(invocation.proceeded).isTrue();
+        assertThat(transactionManager.getTransactionCount).isEqualTo(1);
+        assertThat(transactionManager.commitCount).isEqualTo(1);
+        assertThat(transactionManager.rollbackCount).isZero();
     }
 
     private static byte[] serialize(TransactionInterceptor interceptor) throws Exception {
@@ -41,9 +78,66 @@ public class TransactionInterceptorTest {
         return bytes.toByteArray();
     }
 
-    private static Object deserialize(byte[] bytes) throws Exception {
-        try (ObjectInputStream inputStream = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
-            return inputStream.readObject();
+    private static TransactionInterceptor deserialize(byte[] serialized) throws Exception {
+        try (ObjectInputStream inputStream = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            return (TransactionInterceptor) inputStream.readObject();
+        }
+    }
+
+    private static final class CallbackMethodInvocation implements MethodInvocation {
+        private final Method method;
+        private boolean proceeded;
+
+        private CallbackMethodInvocation(Method method) {
+            this.method = method;
+        }
+
+        @Override
+        public Method getMethod() {
+            return this.method;
+        }
+
+        @Override
+        public Object[] getArguments() {
+            return new Object[0];
+        }
+
+        @Override
+        public Object proceed() {
+            this.proceeded = true;
+            return "transactional result";
+        }
+
+        @Override
+        public Object getThis() {
+            return null;
+        }
+
+        @Override
+        public AccessibleObject getStaticPart() {
+            return this.method;
+        }
+    }
+
+    private static final class RecordingTransactionManager implements PlatformTransactionManager {
+        private int getTransactionCount;
+        private int commitCount;
+        private int rollbackCount;
+
+        @Override
+        public TransactionStatus getTransaction(TransactionDefinition definition) {
+            this.getTransactionCount++;
+            return new SimpleTransactionStatus();
+        }
+
+        @Override
+        public void commit(TransactionStatus status) {
+            this.commitCount++;
+        }
+
+        @Override
+        public void rollback(TransactionStatus status) {
+            this.rollbackCount++;
         }
     }
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
