### PR TITLE
Maintain latest metadata release and weekly cadence

### DIFF
--- a/.github/workflows/create-latest-release.yml
+++ b/.github/workflows/create-latest-release.yml
@@ -1,3 +1,5 @@
+# Latest release: packages metadata after master updates and publishes it on the
+# floating latest tag. §CI-create-latest-release; §FS-repository-functional-spec.4.4.
 name: "Create latest release"
 
 on:

--- a/.github/workflows/create-latest-release.yml
+++ b/.github/workflows/create-latest-release.yml
@@ -105,4 +105,4 @@ jobs:
 
       - name: "📝 Publish a release"
         run: |
-          gh release create latest build/graalvm-reachability-metadata-*.zip --title "Latest"
+          gh release create latest build/graalvm-reachability-metadata-*.zip --title "SNAPSHOT" --latest=false

--- a/.github/workflows/create-latest-release.yml
+++ b/.github/workflows/create-latest-release.yml
@@ -1,0 +1,106 @@
+name: "Create latest release"
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  get-changed-metadata:
+    name: "📋 Get a list of changed metadata"
+    if: github.repository == 'oracle/graalvm-reachability-metadata'
+    runs-on: "ubuntu-22.04"
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      none-found: ${{ steps.set-matrix.outputs.none-found }}
+      latest-release-exists: ${{ steps.get-base-ref.outputs.latest-release-exists }}
+    steps:
+      - name: "☁️ Checkout repository"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: "🔧 Setup java"
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          distribution: 'graalvm'
+          java-version: '21'
+
+      - name: "🔎 Determine diff base"
+        id: get-base-ref
+        run: |
+          if git rev-parse --verify latest >/dev/null 2>&1; then
+            echo "Using existing latest tag as base"
+            echo "BASE_COMMIT=$(git rev-parse latest)" >> ${GITHUB_ENV}
+            echo "latest-release-exists=true" >> ${GITHUB_OUTPUT}
+            exit 0
+          fi
+
+          LATEST_VERSION_TAG=$(git tag --list | grep -v '^latest$' | sort -V | tail -1)
+          if [[ -z "${LATEST_VERSION_TAG}" ]]; then
+            echo "No existing version tag found to bootstrap the latest release"
+            exit 1
+          fi
+
+          echo "Bootstrapping latest release from ${LATEST_VERSION_TAG}"
+          echo "BASE_COMMIT=$(git rev-parse ${LATEST_VERSION_TAG})" >> ${GITHUB_ENV}
+          echo "latest-release-exists=false" >> ${GITHUB_OUTPUT}
+
+      - name: "🕸️ Get changed metadata matrix"
+        id: set-matrix
+        run: |
+          ./gradlew generateChangedCoordinatesMatrix -PbaseCommit=${BASE_COMMIT} -PnewCommit=$(git rev-parse HEAD)
+
+  release:
+    needs: get-changed-metadata
+    if: needs.get-changed-metadata.result == 'success' && needs.get-changed-metadata.outputs.none-found != 'true'
+    name: "🚀 Create latest release"
+    runs-on: "ubuntu-22.04"
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: "☁️ Checkout repository"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: "🔧 Setup java"
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          distribution: 'graalvm'
+          java-version: '21'
+
+      - name: "⬆️ Update version"
+        run: |
+          sed -i "s/project.version(\"1.0.0-SNAPSHOT\")/project.version(\"latest\")/g" build.gradle
+
+      - name: "🔍 Run spotless check"
+        run: |
+          ./gradlew spotlessCheck
+
+      - name: "🏭 Generate release artifacts"
+        run: |
+          ./gradlew package
+
+      - name: "🧹 Delete previous latest release and tag"
+        if: needs.get-changed-metadata.outputs.latest-release-exists == 'true'
+        run: |
+          gh release delete latest --cleanup-tag -y
+
+      - name: "📄 Commit changes"
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "Github Actions"
+          git add .
+          git commit -m "Update latest release"
+          git tag -f latest
+          git push origin refs/tags/latest --force
+
+      - name: "📝 Publish a release"
+        run: |
+          gh release create latest build/graalvm-reachability-metadata-*.zip --title "Latest"

--- a/.github/workflows/create-scheduled-release.yml
+++ b/.github/workflows/create-scheduled-release.yml
@@ -84,7 +84,7 @@ jobs:
       - name: "🕸️ Get changed metadata matrix"
         id: set-matrix
         run: |
-          LATEST_TAG=$(git tag --list | sort -V | tail -1)
+          LATEST_TAG=$(git tag --list | grep -v '^latest$' | sort -V | tail -1)
           # Keep the expanded matrix out of job outputs; the release job only needs none-found.
           GRADLE_OUTPUT=$(mktemp)
           GITHUB_OUTPUT="$GRADLE_OUTPUT" ./gradlew generateChangedCoordinatesMatrix -PbaseCommit="$(git show-ref -s "$LATEST_TAG")" -PnewCommit="$(git rev-parse HEAD)"
@@ -111,7 +111,7 @@ jobs:
 
       - name: "Get tags"
         run: |
-          PREVIOUS_RELEASE_TAG=$(git tag --list | sort -V | tail -1)
+          PREVIOUS_RELEASE_TAG=$(git tag --list | grep -v '^latest$' | sort -V | tail -1)
           if [[ ! "$PREVIOUS_RELEASE_TAG" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
             echo "Unexpected release tag format: $PREVIOUS_RELEASE_TAG" >&2
             exit 1

--- a/.github/workflows/create-scheduled-release.yml
+++ b/.github/workflows/create-scheduled-release.yml
@@ -83,7 +83,7 @@ jobs:
       - name: "🕸️ Get changed metadata matrix"
         id: set-matrix
         run: |
-          LATEST_TAG=$(git tag --list | grep -v '^latest$' | sort -V | tail -1)
+          LATEST_TAG=$(git tag --list | grep -E '^[0-9]+[.][0-9]+[.][0-9]+$' | sort -V | tail -1)
           # Keep the expanded matrix out of job outputs; the release job only needs none-found.
           GRADLE_OUTPUT=$(mktemp)
           GITHUB_OUTPUT="$GRADLE_OUTPUT" ./gradlew generateChangedCoordinatesMatrix -PbaseCommit="$(git show-ref -s "$LATEST_TAG")" -PnewCommit="$(git rev-parse HEAD)"
@@ -110,7 +110,7 @@ jobs:
 
       - name: "Get tags"
         run: |
-          PREVIOUS_RELEASE_TAG=$(git tag --list | grep -v '^latest$' | sort -V | tail -1)
+          PREVIOUS_RELEASE_TAG=$(git tag --list | grep -E '^[0-9]+[.][0-9]+[.][0-9]+$' | sort -V | tail -1)
           if [[ ! "$PREVIOUS_RELEASE_TAG" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
             echo "Unexpected release tag format: $PREVIOUS_RELEASE_TAG" >&2
             exit 1

--- a/.github/workflows/create-scheduled-release.yml
+++ b/.github/workflows/create-scheduled-release.yml
@@ -1,12 +1,11 @@
-# Scheduled release (1st & 15th): runs spotlessCheck and packages metadata when it changed and the
-# latest test-all-metadata passed. §CI-create-scheduled-release; gated on §CI-test-all-metadata,
-# produces the artifact native-build-tools consumes (§FS-repository-functional-spec.4).
+# Scheduled release (weekly Monday): packages changed metadata after spotlessCheck.
+# §CI-create-scheduled-release; gated on §CI-test-all-metadata.
+# Produces the native-build-tools artifact (§FS-repository-functional-spec.4).
 name: "Create scheduled release"
 
 on:
   schedule:
-    - cron: "0 3 1 * *"
-    - cron: "0 3 15 * *"
+    - cron: "0 3 * * 1"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/create-snapshot-release.yml
+++ b/.github/workflows/create-snapshot-release.yml
@@ -73,7 +73,7 @@ jobs:
 
   release:
     needs: get-changed-metadata
-    if: needs.get-changed-metadata.result == 'success' && needs.get-changed-metadata.outputs.none-found != 'true'
+    if: needs.get-changed-metadata.result == 'success' && (needs.get-changed-metadata.outputs.none-found != 'true' || (needs.get-changed-metadata.outputs.snapshot-tag-exists == 'true' && needs.get-changed-metadata.outputs.snapshot-release-exists != 'true'))
     name: "🚀 Create snapshot release"
     runs-on: "ubuntu-22.04"
     env:

--- a/.github/workflows/create-snapshot-release.yml
+++ b/.github/workflows/create-snapshot-release.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: create-snapshot-release
+  cancel-in-progress: true
+
 jobs:
   get-changed-metadata:
     name: "📋 Get a list of changed metadata"

--- a/.github/workflows/create-snapshot-release.yml
+++ b/.github/workflows/create-snapshot-release.yml
@@ -1,6 +1,6 @@
-# Latest release: packages metadata after master updates and publishes it on the
-# floating latest tag. §CI-create-latest-release; §FS-repository-functional-spec.4.4.
-name: "Create latest release"
+# Snapshot release: packages metadata after master updates and publishes it on the
+# floating latest tag. §CI-create-snapshot-release; §FS-repository-functional-spec.4.4.
+name: "Create snapshot release"
 
 on:
   push:
@@ -20,7 +20,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       none-found: ${{ steps.set-matrix.outputs.none-found }}
-      latest-release-exists: ${{ steps.get-base-ref.outputs.latest-release-exists }}
+      snapshot-release-exists: ${{ steps.get-base-ref.outputs.snapshot-release-exists }}
     steps:
       - name: "☁️ Checkout repository"
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -39,19 +39,19 @@ jobs:
           if git rev-parse --verify latest >/dev/null 2>&1; then
             echo "Using existing latest tag as base"
             echo "BASE_COMMIT=$(git rev-parse latest)" >> ${GITHUB_ENV}
-            echo "latest-release-exists=true" >> ${GITHUB_OUTPUT}
+            echo "snapshot-release-exists=true" >> ${GITHUB_OUTPUT}
             exit 0
           fi
 
-          LATEST_VERSION_TAG=$(git tag --list | grep -v '^latest$' | sort -V | tail -1)
+          LATEST_VERSION_TAG=$(git tag --list | grep -E '^[0-9]+[.][0-9]+[.][0-9]+$' | sort -V | tail -1)
           if [[ -z "${LATEST_VERSION_TAG}" ]]; then
-            echo "No existing version tag found to bootstrap the latest release"
+            echo "No existing numbered version tag found to bootstrap the snapshot release"
             exit 1
           fi
 
-          echo "Bootstrapping latest release from ${LATEST_VERSION_TAG}"
+          echo "Bootstrapping snapshot release from ${LATEST_VERSION_TAG}"
           echo "BASE_COMMIT=$(git rev-parse ${LATEST_VERSION_TAG})" >> ${GITHUB_ENV}
-          echo "latest-release-exists=false" >> ${GITHUB_OUTPUT}
+          echo "snapshot-release-exists=false" >> ${GITHUB_OUTPUT}
 
       - name: "🕸️ Get changed metadata matrix"
         id: set-matrix
@@ -61,7 +61,7 @@ jobs:
   release:
     needs: get-changed-metadata
     if: needs.get-changed-metadata.result == 'success' && needs.get-changed-metadata.outputs.none-found != 'true'
-    name: "🚀 Create latest release"
+    name: "🚀 Create snapshot release"
     runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ github.token }}
@@ -89,8 +89,8 @@ jobs:
         run: |
           ./gradlew package
 
-      - name: "🧹 Delete previous latest release and tag"
-        if: needs.get-changed-metadata.outputs.latest-release-exists == 'true'
+      - name: "🧹 Delete previous snapshot release and tag"
+        if: needs.get-changed-metadata.outputs.snapshot-release-exists == 'true'
         run: |
           gh release delete latest --cleanup-tag -y
 
@@ -99,7 +99,7 @@ jobs:
           git config --local user.email "actions@github.com"
           git config --local user.name "Github Actions"
           git add .
-          git commit -m "Update latest release"
+          git commit -m "Update snapshot release"
           git tag -f latest
           git push origin refs/tags/latest --force
 

--- a/.github/workflows/create-snapshot-release.yml
+++ b/.github/workflows/create-snapshot-release.yml
@@ -1,5 +1,5 @@
 # Snapshot release: packages metadata after master updates and publishes it on the
-# floating latest tag. §CI-create-snapshot-release; §FS-repository-functional-spec.4.4.
+# floating SNAPSHOT tag. §CI-create-snapshot-release; §FS-repository-functional-spec.4.4.
 name: "Create snapshot release"
 
 on:
@@ -36,9 +36,9 @@ jobs:
       - name: "🔎 Determine diff base"
         id: get-base-ref
         run: |
-          if git rev-parse --verify latest >/dev/null 2>&1; then
-            echo "Using existing latest tag as base"
-            echo "BASE_COMMIT=$(git rev-parse latest)" >> ${GITHUB_ENV}
+          if git rev-parse --verify SNAPSHOT >/dev/null 2>&1; then
+            echo "Using existing SNAPSHOT tag as base"
+            echo "BASE_COMMIT=$(git rev-parse SNAPSHOT)" >> ${GITHUB_ENV}
             echo "snapshot-release-exists=true" >> ${GITHUB_OUTPUT}
             exit 0
           fi
@@ -79,7 +79,7 @@ jobs:
 
       - name: "⬆️ Update version"
         run: |
-          sed -i "s/project.version(\"1.0.0-SNAPSHOT\")/project.version(\"latest\")/g" build.gradle
+          sed -i "s/project.version(\"1.0.0-SNAPSHOT\")/project.version(\"SNAPSHOT\")/g" build.gradle
 
       - name: "🔍 Run spotless check"
         run: |
@@ -92,7 +92,7 @@ jobs:
       - name: "🧹 Delete previous snapshot release and tag"
         if: needs.get-changed-metadata.outputs.snapshot-release-exists == 'true'
         run: |
-          gh release delete latest --cleanup-tag -y
+          gh release delete SNAPSHOT --cleanup-tag -y
 
       - name: "📄 Commit changes"
         run: |
@@ -100,9 +100,9 @@ jobs:
           git config --local user.name "Github Actions"
           git add .
           git commit -m "Update snapshot release"
-          git tag -f latest
-          git push origin refs/tags/latest --force
+          git tag -f SNAPSHOT
+          git push origin refs/tags/SNAPSHOT --force
 
       - name: "📝 Publish a release"
         run: |
-          gh release create latest build/graalvm-reachability-metadata-*.zip --title "SNAPSHOT" --latest=false
+          gh release create SNAPSHOT build/graalvm-reachability-metadata-*.zip --title "SNAPSHOT" --latest=false

--- a/.github/workflows/create-snapshot-release.yml
+++ b/.github/workflows/create-snapshot-release.yml
@@ -24,7 +24,10 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       none-found: ${{ steps.set-matrix.outputs.none-found }}
+      snapshot-tag-exists: ${{ steps.get-base-ref.outputs.snapshot-tag-exists }}
       snapshot-release-exists: ${{ steps.get-base-ref.outputs.snapshot-release-exists }}
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - name: "☁️ Checkout repository"
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -43,19 +46,25 @@ jobs:
           if git rev-parse --verify SNAPSHOT >/dev/null 2>&1; then
             echo "Using existing SNAPSHOT tag as base"
             echo "BASE_COMMIT=$(git rev-parse SNAPSHOT)" >> ${GITHUB_ENV}
+            echo "snapshot-tag-exists=true" >> ${GITHUB_OUTPUT}
+          else
+            echo "snapshot-tag-exists=false" >> ${GITHUB_OUTPUT}
+
+            LATEST_VERSION_TAG=$(git tag --list | grep -E '^[0-9]+[.][0-9]+[.][0-9]+$' | sort -V | tail -1)
+            if [[ -z "${LATEST_VERSION_TAG}" ]]; then
+              echo "No existing numbered version tag found to bootstrap the snapshot release"
+              exit 1
+            fi
+
+            echo "Bootstrapping snapshot release from ${LATEST_VERSION_TAG}"
+            echo "BASE_COMMIT=$(git rev-parse ${LATEST_VERSION_TAG})" >> ${GITHUB_ENV}
+          fi
+
+          if gh release view SNAPSHOT >/dev/null 2>&1; then
             echo "snapshot-release-exists=true" >> ${GITHUB_OUTPUT}
-            exit 0
+          else
+            echo "snapshot-release-exists=false" >> ${GITHUB_OUTPUT}
           fi
-
-          LATEST_VERSION_TAG=$(git tag --list | grep -E '^[0-9]+[.][0-9]+[.][0-9]+$' | sort -V | tail -1)
-          if [[ -z "${LATEST_VERSION_TAG}" ]]; then
-            echo "No existing numbered version tag found to bootstrap the snapshot release"
-            exit 1
-          fi
-
-          echo "Bootstrapping snapshot release from ${LATEST_VERSION_TAG}"
-          echo "BASE_COMMIT=$(git rev-parse ${LATEST_VERSION_TAG})" >> ${GITHUB_ENV}
-          echo "snapshot-release-exists=false" >> ${GITHUB_OUTPUT}
 
       - name: "🕸️ Get changed metadata matrix"
         id: set-matrix
@@ -97,6 +106,11 @@ jobs:
         if: needs.get-changed-metadata.outputs.snapshot-release-exists == 'true'
         run: |
           gh release delete SNAPSHOT --cleanup-tag -y
+
+      - name: "🧹 Delete orphan snapshot tag"
+        if: needs.get-changed-metadata.outputs.snapshot-tag-exists == 'true' && needs.get-changed-metadata.outputs.snapshot-release-exists != 'true'
+        run: |
+          git push origin :refs/tags/SNAPSHOT
 
       - name: "📄 Commit changes"
         run: |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,9 +49,10 @@ leaves as released metadata:
 4. **Recording coverage.** Newly passing versions are recorded into `index.json`
    and mirrored into `stats/`; the coverage dashboard is regenerated and
    published (§forge/FS-forge-run-metrics, §CI-repository-ci).
-5. **Release.** On `master` pushes and on a weekly cadence the metadata
-   directory is packaged and attached as a GitHub Release, which
-   native-build-tools resolves at build time
+5. **Release.** On a weekly cadence the metadata directory is packaged and
+   attached as a numbered GitHub Release; metadata-changing `master` pushes can
+   also refresh the floating `SNAPSHOT` release, which native-build-tools
+   resolves at build time
    (§FS-repository-functional-spec.4, §GOAL-fresh-metadata).
 
 Two scheduled loops keep this self-sustaining: the full metadata sweep guards

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,8 +49,9 @@ leaves as released metadata:
 4. **Recording coverage.** Newly passing versions are recorded into `index.json`
    and mirrored into `stats/`; the coverage dashboard is regenerated and
    published (§forge/FS-forge-run-metrics, §CI-repository-ci).
-5. **Release.** On a fixed cadence the metadata directory is packaged and attached as
-   a GitHub Release, which native-build-tools resolves at build time
+5. **Release.** On `master` pushes and on a weekly cadence the metadata
+   directory is packaged and attached as a GitHub Release, which
+   native-build-tools resolves at build time
    (§FS-repository-functional-spec.4, §GOAL-fresh-metadata).
 
 Two scheduled loops keep this self-sustaining: the full metadata sweep guards

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -147,12 +147,24 @@ to the `stats/coverage` branch. The published branch keeps only `COVERAGE.md`,
 
 ### CI-create-scheduled-release: Create scheduled release
 
-On the 1st and 15th of each month (`0 3 1 * *`, `0 3 15 * *`) and on manual
-dispatch. Packages metadata only if it changed and the latest completed
-test-all-metadata workflow passed (§CI-test-all-metadata); runs `spotlessCheck`
-before packaging (§FS-repository-functional-spec.5.3). Manual dispatches bypass
-the test-all gate. The packaged ZIP is the artifact native-build-tools consumes
+Every Monday (`0 3 * * 1`) and on manual dispatch. Packages metadata only if it
+changed and the latest completed test-all-metadata workflow passed
+(§CI-test-all-metadata); runs `spotlessCheck` before packaging
+(§FS-repository-functional-spec.5.3). Manual dispatches bypass the test-all gate.
+The workflow ignores the floating `latest` tag when choosing the previous
+numbered release tag, then creates the next `<major>.<minor>.<patch>` release.
+The packaged ZIP is the numbered artifact native-build-tools consumes
 (§FS-repository-functional-spec.4, §GOAL-fresh-metadata).
+
+### CI-create-latest-release: Create latest release
+
+On pushes to `master` and on manual dispatch. Publishes a floating `latest`
+GitHub Release when metadata changed since the previous `latest` tag; if that
+tag does not exist yet, it bootstraps the diff from the latest numbered release
+tag. The workflow packages metadata with repository version `latest`, deletes
+the previous `latest` release/tag when present, and force-pushes a fresh
+`latest` tag for consumers that need a continuously updated snapshot-style
+bundle (§FS-repository-functional-spec.4.4, §GOAL-fresh-metadata).
 
 ## Event-triggered automation
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -152,7 +152,7 @@ changed and the latest completed test-all-metadata workflow passed
 (§CI-test-all-metadata); runs `spotlessCheck` before packaging
 (§FS-repository-functional-spec.5.3). Manual dispatches bypass the test-all gate.
 The workflow considers only semantic version tags when choosing the previous
-numbered release tag, so floating snapshot tags such as `latest` are ignored.
+numbered release tag, so floating snapshot tags such as `SNAPSHOT` are ignored.
 It then creates the next `<major>.<minor>.<patch>` release. The packaged ZIP is
 the numbered artifact native-build-tools consumes (§FS-repository-functional-spec.4,
 §GOAL-fresh-metadata).
@@ -160,11 +160,11 @@ the numbered artifact native-build-tools consumes (§FS-repository-functional-sp
 ### CI-create-snapshot-release: Create snapshot release
 
 On pushes to `master` and on manual dispatch. Publishes a floating `SNAPSHOT`
-GitHub Release on the `latest` tag when metadata changed since the previous
-`latest` tag; if that tag does not exist yet, it bootstraps the diff from the
+GitHub Release on the `SNAPSHOT` tag when metadata changed since the previous
+`SNAPSHOT` tag; if that tag does not exist yet, it bootstraps the diff from the
 latest numbered release tag. The workflow packages metadata with repository
-version `latest`, deletes the previous snapshot release/tag when present,
-force-pushes a fresh `latest` tag, and marks the release as not GitHub's
+version `SNAPSHOT`, deletes the previous snapshot release/tag when present,
+force-pushes a fresh `SNAPSHOT` tag, and marks the release as not GitHub's
 Latest release (§FS-repository-functional-spec.4.4, §GOAL-fresh-metadata).
 
 ## Event-triggered automation

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -151,20 +151,21 @@ Every Monday (`0 3 * * 1`) and on manual dispatch. Packages metadata only if it
 changed and the latest completed test-all-metadata workflow passed
 (§CI-test-all-metadata); runs `spotlessCheck` before packaging
 (§FS-repository-functional-spec.5.3). Manual dispatches bypass the test-all gate.
-The workflow ignores the floating `latest` tag when choosing the previous
-numbered release tag, then creates the next `<major>.<minor>.<patch>` release.
-The packaged ZIP is the numbered artifact native-build-tools consumes
-(§FS-repository-functional-spec.4, §GOAL-fresh-metadata).
+The workflow considers only semantic version tags when choosing the previous
+numbered release tag, so floating snapshot tags such as `latest` are ignored.
+It then creates the next `<major>.<minor>.<patch>` release. The packaged ZIP is
+the numbered artifact native-build-tools consumes (§FS-repository-functional-spec.4,
+§GOAL-fresh-metadata).
 
-### CI-create-latest-release: Create latest release
+### CI-create-snapshot-release: Create snapshot release
 
-On pushes to `master` and on manual dispatch. Publishes a floating `latest`
-GitHub Release when metadata changed since the previous `latest` tag; if that
-tag does not exist yet, it bootstraps the diff from the latest numbered release
-tag. The workflow packages metadata with repository version `latest`, deletes
-the previous `latest` release/tag when present, and force-pushes a fresh
-`latest` tag for consumers that need a continuously updated snapshot-style
-bundle (§FS-repository-functional-spec.4.4, §GOAL-fresh-metadata).
+On pushes to `master` and on manual dispatch. Publishes a floating `SNAPSHOT`
+GitHub Release on the `latest` tag when metadata changed since the previous
+`latest` tag; if that tag does not exist yet, it bootstraps the diff from the
+latest numbered release tag. The workflow packages metadata with repository
+version `latest`, deletes the previous snapshot release/tag when present,
+force-pushes a fresh `latest` tag, and marks the release as not GitHub's
+Latest release (§FS-repository-functional-spec.4.4, §GOAL-fresh-metadata).
 
 ## Event-triggered automation
 

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -66,15 +66,15 @@ The harness uses a single coordinates filter `-Pcoordinates=` accepting `all`, `
 GitHub Actions, configured by [`ci.json`](../ci.json) as the single source of truth for OS/JDK matrix, run the workflows enumerated in [ci.md](ci.md):
 - PR-scoped: changed-metadata, changed-infrastructure, new-library-version, Spring AOT smoke, library-stats validation, library-and-framework-list validation, checkstyle.
 - Schedule-driven: full metadata sweep every three days to prevent incomplete or breaking metadata from shipping in releases, new-library-version compatibility (every six hours), Docker image vulnerability scans, scheduled release every Monday, scheduled coverage publication.
-- Event-driven release publication: every push to `master` may refresh the floating `latest` release when metadata changed since the previous `latest` tag.
+- Event-driven snapshot publication: every push to `master` may refresh the floating `SNAPSHOT` release when metadata changed since the previous `latest` tag.
 
 CI must pass before any merge, and is the authoritative gate — local runs are best-effort.
 
 ### 4.4 Releases
 
-Every Monday the `create-scheduled-release` workflow packages metadata into the next numbered release if it has changed and the latest completed test-all metadata workflow passed (§CI-create-scheduled-release). Manual release dispatches bypass this test-all gate. Numbered releases ignore the floating `latest` tag when computing the previous version tag, so the permanent release cadence advances only from semantic-version tags.
+Every Monday the `create-scheduled-release` workflow packages metadata into the next numbered release if it has changed and the latest completed test-all metadata workflow passed (§CI-create-scheduled-release). Manual release dispatches bypass this test-all gate. Numbered releases consider only semantic version tags when computing the previous version tag, so floating snapshot tags such as `latest` cannot affect the permanent release cadence.
 
-The `create-latest-release` workflow refreshes a floating `latest` GitHub Release on `master` pushes when metadata changed since the previous `latest` tag, or since the latest numbered release when bootstrapping (§CI-create-latest-release). It packages the repository with version `latest`, replaces the previous `latest` release/tag, and provides a continuously updated snapshot-style metadata bundle between numbered releases. The packaged artifacts are what the GraalVM Gradle/Maven plugins consume.
+The `create-snapshot-release` workflow refreshes a floating `SNAPSHOT` GitHub Release on the `latest` tag after `master` pushes when metadata changed since the previous `latest` tag, or since the latest numbered release when bootstrapping (§CI-create-snapshot-release). It packages the repository with version `latest`, replaces the previous snapshot release/tag, and provides a continuously updated snapshot-style metadata bundle between numbered releases without taking GitHub's Latest marker from the newest numbered release. The packaged artifacts are what the GraalVM Gradle/Maven plugins consume.
 
 ### 4.5 Coverage and metrics dashboard
 
@@ -143,7 +143,7 @@ sequenceDiagram
     participant App as Application build
     participant NI as native-image
 
-    Note over Repo: Push-triggered latest release<br/>Weekly create-scheduled-release
+    Note over Repo: Push-triggered snapshot release<br/>Weekly create-scheduled-release
     Repo->>Artifact: package metadata/** + index.json files
 
     Note over App: nativeCompile / native:compile
@@ -159,7 +159,7 @@ sequenceDiagram
 
 native-build-tools consumes this repository through exactly four observable elements. Changes to any of them are breaking changes for plugin users.
 
-**1. Distribution artifact.** The `package` Gradle task produces `graalvm-reachability-metadata-<repo-version>.zip`, which the scheduled release workflow attaches as a GitHub Release asset on a `<repo-version>` tag every Monday, and which the latest-release workflow attaches on the floating `latest` tag after metadata-changing pushes to `master`. The ZIP is a verbatim copy of the repository's `metadata/` directory — there is no separate top-level manifest. Its contents at the ZIP root are exactly:
+**1. Distribution artifact.** The `package` Gradle task produces `graalvm-reachability-metadata-<repo-version>.zip`, which the scheduled release workflow attaches as a GitHub Release asset on a `<repo-version>` tag every Monday, and which the snapshot-release workflow attaches as `SNAPSHOT` on the floating `latest` tag after metadata-changing pushes to `master`. The ZIP is a verbatim copy of the repository's `metadata/` directory — there is no separate top-level manifest. Its contents at the ZIP root are exactly:
 
 ```text
 library-and-framework-list.json                          # the master list of supported libraries (schema-validated)
@@ -210,7 +210,7 @@ flowchart TD
 
 Auxiliary contracts: `requires` triggers the plugin to also load metadata for the listed `group:artifact` pair; `override: true` instructs the plugin to suppress any built-in metadata that ships inside `native-image` itself for the matched versions.
 
-All four elements are versioned through the schema `$id` URLs and the GitHub Release tag. Newer plugins keep reading older repository releases, and older plugins keep reading newer **minor and patch** schema versions, which only add optional fields or non-plugin formats. A **major** schema bump (e.g. `reachability-metadata` 1.2.0 → 2.0.0, or `metadata-library-index` 2.x → 3.0.0) represents a change native-build-tools must adopt and is released together with a coordinated plugin update — it is not something older plugins absorb. Schema fidelity (§6), the weekly numbered release cadence, and the floating `latest` release (§4.4) keep this contract live.
+All four elements are versioned through the schema `$id` URLs and the GitHub Release tag. Newer plugins keep reading older repository releases, and older plugins keep reading newer **minor and patch** schema versions, which only add optional fields or non-plugin formats. A **major** schema bump (e.g. `reachability-metadata` 1.2.0 → 2.0.0, or `metadata-library-index` 2.x → 3.0.0) represents a change native-build-tools must adopt and is released together with a coordinated plugin update — it is not something older plugins absorb. Schema fidelity (§6), the weekly numbered release cadence, and the floating `SNAPSHOT` release (§4.4) keep this contract live.
 
 ## 5. Repository Requirements
 
@@ -279,7 +279,7 @@ Forge's requirements are specified in [forge/docs/functional-spec.md](../forge/d
 
 - Validated metadata + tests + index.json under `metadata/` and `tests/src/`.
 - Mirrored stats under `stats/`, a generated root `COVERAGE.md`, and aggregated coverage artifacts on `stats/coverage`.
-- Weekly numbered release artifacts and floating `latest` release artifacts consumed by the GraalVM Gradle/Maven plugins.
+- Weekly numbered release artifacts and floating `SNAPSHOT` release artifacts consumed by the GraalVM Gradle/Maven plugins.
 - Forge run metrics committed under `stats/<group>/<artifact>/<version>/execution-metrics.json`.
 - GitHub PRs (only when initiated through Forge `git_scripts/`).
 - GitHub issues for new-version compatibility failures, one per `(library, version)`.

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -65,13 +65,16 @@ The harness uses a single coordinates filter `-Pcoordinates=` accepting `all`, `
 
 GitHub Actions, configured by [`ci.json`](../ci.json) as the single source of truth for OS/JDK matrix, run the workflows enumerated in [ci.md](ci.md):
 - PR-scoped: changed-metadata, changed-infrastructure, new-library-version, Spring AOT smoke, library-stats validation, library-and-framework-list validation, checkstyle.
-- Schedule-driven: weekly full metadata sweep to prevent incomplete or breaking metadata from shipping in releases, new-library-version compatibility (every six hours), Docker image vulnerability scans, scheduled release every two weeks, scheduled coverage publication.
+- Schedule-driven: full metadata sweep every three days to prevent incomplete or breaking metadata from shipping in releases, new-library-version compatibility (every six hours), Docker image vulnerability scans, scheduled release every Monday, scheduled coverage publication.
+- Event-driven release publication: every push to `master` may refresh the floating `latest` release when metadata changed since the previous `latest` tag.
 
 CI must pass before any merge, and is the authoritative gate — local runs are best-effort.
 
 ### 4.4 Releases
 
-Every two weeks the `create-scheduled-release` workflow packages metadata if it has changed and the latest completed test-all metadata workflow passed. Manual release dispatches bypass this test-all gate. The packaged artifact is what the GraalVM Gradle/Maven plugins consume.
+Every Monday the `create-scheduled-release` workflow packages metadata into the next numbered release if it has changed and the latest completed test-all metadata workflow passed (§CI-create-scheduled-release). Manual release dispatches bypass this test-all gate. Numbered releases ignore the floating `latest` tag when computing the previous version tag, so the permanent release cadence advances only from semantic-version tags.
+
+The `create-latest-release` workflow refreshes a floating `latest` GitHub Release on `master` pushes when metadata changed since the previous `latest` tag, or since the latest numbered release when bootstrapping (§CI-create-latest-release). It packages the repository with version `latest`, replaces the previous `latest` release/tag, and provides a continuously updated snapshot-style metadata bundle between numbered releases. The packaged artifacts are what the GraalVM Gradle/Maven plugins consume.
 
 ### 4.5 Coverage and metrics dashboard
 
@@ -140,7 +143,7 @@ sequenceDiagram
     participant App as Application build
     participant NI as native-image
 
-    Note over Repo: Bi-weekly create-scheduled-release
+    Note over Repo: Push-triggered latest release<br/>Weekly create-scheduled-release
     Repo->>Artifact: package metadata/** + index.json files
 
     Note over App: nativeCompile / native:compile
@@ -156,7 +159,7 @@ sequenceDiagram
 
 native-build-tools consumes this repository through exactly four observable elements. Changes to any of them are breaking changes for plugin users.
 
-**1. Distribution artifact.** The `package` Gradle task produces `graalvm-reachability-metadata-<repo-version>.zip`, which the scheduled release workflow attaches as a GitHub Release asset on a `<repo-version>` tag every two weeks. The ZIP is a verbatim copy of the repository's `metadata/` directory — there is no separate top-level manifest. Its contents at the ZIP root are exactly:
+**1. Distribution artifact.** The `package` Gradle task produces `graalvm-reachability-metadata-<repo-version>.zip`, which the scheduled release workflow attaches as a GitHub Release asset on a `<repo-version>` tag every Monday, and which the latest-release workflow attaches on the floating `latest` tag after metadata-changing pushes to `master`. The ZIP is a verbatim copy of the repository's `metadata/` directory — there is no separate top-level manifest. Its contents at the ZIP root are exactly:
 
 ```text
 library-and-framework-list.json                          # the master list of supported libraries (schema-validated)
@@ -207,7 +210,7 @@ flowchart TD
 
 Auxiliary contracts: `requires` triggers the plugin to also load metadata for the listed `group:artifact` pair; `override: true` instructs the plugin to suppress any built-in metadata that ships inside `native-image` itself for the matched versions.
 
-All four elements are versioned through the schema `$id` URLs and the GitHub Release tag. Newer plugins keep reading older repository releases, and older plugins keep reading newer **minor and patch** schema versions, which only add optional fields or non-plugin formats. A **major** schema bump (e.g. `reachability-metadata` 1.2.0 → 2.0.0, or `metadata-library-index` 2.x → 3.0.0) represents a change native-build-tools must adopt and is released together with a coordinated plugin update — it is not something older plugins absorb. Schema fidelity (§6) and the bi-weekly release cadence (§4.4) keep this contract live.
+All four elements are versioned through the schema `$id` URLs and the GitHub Release tag. Newer plugins keep reading older repository releases, and older plugins keep reading newer **minor and patch** schema versions, which only add optional fields or non-plugin formats. A **major** schema bump (e.g. `reachability-metadata` 1.2.0 → 2.0.0, or `metadata-library-index` 2.x → 3.0.0) represents a change native-build-tools must adopt and is released together with a coordinated plugin update — it is not something older plugins absorb. Schema fidelity (§6), the weekly numbered release cadence, and the floating `latest` release (§4.4) keep this contract live.
 
 ## 5. Repository Requirements
 
@@ -276,7 +279,7 @@ Forge's requirements are specified in [forge/docs/functional-spec.md](../forge/d
 
 - Validated metadata + tests + index.json under `metadata/` and `tests/src/`.
 - Mirrored stats under `stats/`, a generated root `COVERAGE.md`, and aggregated coverage artifacts on `stats/coverage`.
-- Bi-weekly release artifacts consumed by the GraalVM Gradle/Maven plugins.
+- Weekly numbered release artifacts and floating `latest` release artifacts consumed by the GraalVM Gradle/Maven plugins.
 - Forge run metrics committed under `stats/<group>/<artifact>/<version>/execution-metrics.json`.
 - GitHub PRs (only when initiated through Forge `git_scripts/`).
 - GitHub issues for new-version compatibility failures, one per `(library, version)`.

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -66,15 +66,15 @@ The harness uses a single coordinates filter `-Pcoordinates=` accepting `all`, `
 GitHub Actions, configured by [`ci.json`](../ci.json) as the single source of truth for OS/JDK matrix, run the workflows enumerated in [ci.md](ci.md):
 - PR-scoped: changed-metadata, changed-infrastructure, new-library-version, Spring AOT smoke, library-stats validation, library-and-framework-list validation, checkstyle.
 - Schedule-driven: full metadata sweep every three days to prevent incomplete or breaking metadata from shipping in releases, new-library-version compatibility (every six hours), Docker image vulnerability scans, scheduled release every Monday, scheduled coverage publication.
-- Event-driven snapshot publication: every push to `master` may refresh the floating `SNAPSHOT` release when metadata changed since the previous `latest` tag.
+- Event-driven snapshot publication: every push to `master` may refresh the floating `SNAPSHOT` release when metadata changed since the previous `SNAPSHOT` tag.
 
 CI must pass before any merge, and is the authoritative gate — local runs are best-effort.
 
 ### 4.4 Releases
 
-Every Monday the `create-scheduled-release` workflow packages metadata into the next numbered release if it has changed and the latest completed test-all metadata workflow passed (§CI-create-scheduled-release). Manual release dispatches bypass this test-all gate. Numbered releases consider only semantic version tags when computing the previous version tag, so floating snapshot tags such as `latest` cannot affect the permanent release cadence.
+Every Monday the `create-scheduled-release` workflow packages metadata into the next numbered release if it has changed and the latest completed test-all metadata workflow passed (§CI-create-scheduled-release). Manual release dispatches bypass this test-all gate. Numbered releases consider only semantic version tags when computing the previous version tag, so floating snapshot tags such as `SNAPSHOT` cannot affect the permanent release cadence.
 
-The `create-snapshot-release` workflow refreshes a floating `SNAPSHOT` GitHub Release on the `latest` tag after `master` pushes when metadata changed since the previous `latest` tag, or since the latest numbered release when bootstrapping (§CI-create-snapshot-release). It packages the repository with version `latest`, replaces the previous snapshot release/tag, and provides a continuously updated snapshot-style metadata bundle between numbered releases without taking GitHub's Latest marker from the newest numbered release. The packaged artifacts are what the GraalVM Gradle/Maven plugins consume.
+The `create-snapshot-release` workflow refreshes a floating `SNAPSHOT` GitHub Release on the `SNAPSHOT` tag after `master` pushes when metadata changed since the previous `SNAPSHOT` tag, or since the latest numbered release when bootstrapping (§CI-create-snapshot-release). It packages the repository with version `SNAPSHOT`, replaces the previous snapshot release/tag, and provides a continuously updated snapshot-style metadata bundle between numbered releases without taking GitHub's Latest marker from the newest numbered release. The packaged artifacts are what the GraalVM Gradle/Maven plugins consume.
 
 ### 4.5 Coverage and metrics dashboard
 
@@ -159,7 +159,7 @@ sequenceDiagram
 
 native-build-tools consumes this repository through exactly four observable elements. Changes to any of them are breaking changes for plugin users.
 
-**1. Distribution artifact.** The `package` Gradle task produces `graalvm-reachability-metadata-<repo-version>.zip`, which the scheduled release workflow attaches as a GitHub Release asset on a `<repo-version>` tag every Monday, and which the snapshot-release workflow attaches as `SNAPSHOT` on the floating `latest` tag after metadata-changing pushes to `master`. The ZIP is a verbatim copy of the repository's `metadata/` directory — there is no separate top-level manifest. Its contents at the ZIP root are exactly:
+**1. Distribution artifact.** The `package` Gradle task produces `graalvm-reachability-metadata-<repo-version>.zip`, which the scheduled release workflow attaches as a GitHub Release asset on a `<repo-version>` tag every Monday, and which the snapshot-release workflow attaches on the floating `SNAPSHOT` tag after metadata-changing pushes to `master`. The ZIP is a verbatim copy of the repository's `metadata/` directory — there is no separate top-level manifest. Its contents at the ZIP root are exactly:
 
 ```text
 library-and-framework-list.json                          # the master list of supported libraries (schema-validated)


### PR DESCRIPTION
Fixes #2109.

## Summary
- Add a `create-snapshot-release.yml` workflow that publishes a floating `SNAPSHOT` GitHub Release on the `SNAPSHOT` tag after `master` pushes when metadata changed since the previous `SNAPSHOT` tag.
- Bootstrap the first snapshot release from the most recent numbered release tag, then use the existing `SNAPSHOT` tag as the diff base for subsequent refreshes.
- Keep scheduled numbered releases independent from floating snapshot tags by selecting only semantic-version tags when diffing and computing the next numbered release.
- Change the numbered scheduled release cadence from twice per month to every Monday at 03:00 UTC so it can align with downstream repository release automation.
- Add/update Grund-backed CI and functional specs, plus the architecture overview, to document both the floating `SNAPSHOT` release and weekly numbered release cadence.

## Notes
- The snapshot release packages the repository with version `SNAPSHOT`, replaces the previous `SNAPSHOT` release/tag, publishes with title `SNAPSHOT`, and uses `--latest=false` so the newest numbered release keeps GitHub's Latest marker.
- Numbered releases continue to run `spotlessCheck`, package metadata, and require the latest completed `test-all-metadata` run to have passed unless manually dispatched.

## Verification
- `grund check`
- `git diff --check`
- Checked for stale twice-monthly/bi-weekly scheduled-release wording in the touched docs and workflows.