### PR TITLE
[GenAI] Test fix for com.thoughtworks.qdox:qdox:2.0-M1 using gpt-5.5

### DIFF
--- a/metadata/com.thoughtworks.qdox/qdox/2.0-M1/reachability-metadata.json
+++ b/metadata/com.thoughtworks.qdox/qdox/2.0-M1/reachability-metadata.json
@@ -1,0 +1,314 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "com.thoughtworks.qdox.library.AbstractClassLibrary",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "com.thoughtworks.qdox.library.ClassLoaderLibrary",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "com.thoughtworks.qdox.library.ClassNameLibrary",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "com.thoughtworks.qdox.library.JavaClassContext",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "com.thoughtworks.qdox.library.SortedClassLibraryBuilder",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "com.thoughtworks.qdox.library.SourceFolderLibrary",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "com.thoughtworks.qdox.library.SourceLibrary",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "com.thoughtworks.qdox.model.impl.AbstractBaseJavaEntity",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "com.thoughtworks.qdox.model.impl.AbstractBaseMethod",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "com.thoughtworks.qdox.model.impl.AbstractInheritableJavaEntity",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "com.thoughtworks.qdox.model.impl.AbstractJavaEntity",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "com.thoughtworks.qdox.model.impl.AbstractJavaModel",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "com.thoughtworks.qdox.model.impl.DefaultJavaClass",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "com.thoughtworks.qdox.model.impl.DefaultJavaField",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "com.thoughtworks.qdox.model.impl.DefaultJavaMethod",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "com.thoughtworks.qdox.model.impl.DefaultJavaPackage",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "com.thoughtworks.qdox.model.impl.DefaultJavaParameterizedType",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "com.thoughtworks.qdox.model.impl.DefaultJavaSource",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "com.thoughtworks.qdox.model.impl.DefaultJavaType",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.library.ClassLoaderLibrary"
+      },
+      "type": "java$lang$String"
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "java.io.ObjectStreamClass$MemberSignature[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.library.ClassLoaderLibrary"
+      },
+      "type": "java.lang$String"
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.parser.impl.JFlexLexer"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "java.lang.String",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.parser.impl.BinaryClassParser"
+      },
+      "type": "java.lang.String$CaseInsensitiveComparator"
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.parser.impl.BinaryClassParser"
+      },
+      "type": "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.parser.impl.BinaryClassParser"
+      },
+      "type": "java.lang.reflect.Field[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.parser.impl.BinaryClassParser"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "java.util.AbstractCollection"
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "java.util.AbstractList"
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "java.util.AbstractMap"
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "java.util.AbstractSequentialList"
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "java.util.AbstractSet"
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "java.util.Collections$EmptyList",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "java.util.HashMap",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "java.util.HashSet",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "java.util.LinkedHashMap",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "java.util.LinkedHashSet",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.JavaProjectBuilder"
+      },
+      "type": "java.util.LinkedList",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.library.ClassLoaderLibrary"
+      },
+      "type": "sample$java$lang$String"
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.library.ClassLoaderLibrary"
+      },
+      "type": "sample.java$lang$String"
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.library.ClassLoaderLibrary"
+      },
+      "type": "sample.java.lang$String"
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.library.ClassLoaderLibrary"
+      },
+      "type": "sample.java.lang.String"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.library.ClassLoaderLibrary"
+      },
+      "glob": "com_thoughtworks_qdox/qdox/JavaDocBuilderTest$BinarySample.java"
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.library.ClassLoaderLibrary"
+      },
+      "glob": "java/lang/String.java"
+    },
+    {
+      "condition": {
+        "typeReached": "com.thoughtworks.qdox.parser.impl.JFlexLexer"
+      },
+      "glob": "qdox.properties"
+    }
+  ]
+}

--- a/metadata/com.thoughtworks.qdox/qdox/index.json
+++ b/metadata/com.thoughtworks.qdox/qdox/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.0-M1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/thoughtworks/qdox/qdox/$version$/qdox-$version$-sources.jar",
+    "repository-url" : "https://github.com/codehaus/qdox",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/com/thoughtworks/qdox/qdox/$version$/qdox-$version$-project.tar.gz",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/thoughtworks/qdox/qdox/$version$/qdox-$version$-javadoc.jar",
+    "description" : "QDox is a high-speed, small-footprint parser for extracting Java class, interface, method, and Javadoc tag information from source files. It is intended for tools such as active code generators and documentation generators that need a lightweight source model.",
     "tested-versions" : [
       "2.0-M1"
     ],

--- a/metadata/com.thoughtworks.qdox/qdox/index.json
+++ b/metadata/com.thoughtworks.qdox/qdox/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.0-M1",
+    "tested-versions" : [
+      "2.0-M1"
+    ],
+    "allowed-packages" : [
+      "com.thoughtworks.qdox"
+    ]
+  },
+  {
     "metadata-version" : "1.12.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/com/thoughtworks/qdox/qdox/$version$/qdox-$version$-sources.jar",
     "repository-url" : "https://github.com/codehaus/qdox",

--- a/stats/com.thoughtworks.qdox/qdox/2.0-M1/execution-metrics.json
+++ b/stats/com.thoughtworks.qdox/qdox/2.0-M1/execution-metrics.json
@@ -1,0 +1,104 @@
+{
+  "fix_javac_fail:2026-06-08": {
+    "timestamp": "2026-06-08T18:06:29.723672Z",
+    "library": "com.thoughtworks.qdox:qdox:2.0-M1",
+    "starting_commit": "256713878d2a57c2ed2d4c652cfc7600c3b40078",
+    "ending_commit": "22504abdef3d97b2b0646d4f27c53edf53da2a47",
+    "previous_library": "com.thoughtworks.qdox:qdox:1.12.1",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.0-M1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 9,
+            "totalCalls": 9
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 11,
+        "totalCalls": 11
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 47215,
+          "missed": 17704,
+          "ratio": 0.727291,
+          "total": 64919
+        },
+        "line": {
+          "covered": 1793,
+          "missed": 3809,
+          "ratio": 0.320064,
+          "total": 5602
+        },
+        "method": {
+          "covered": 396,
+          "missed": 956,
+          "ratio": 0.292899,
+          "total": 1352
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.12.1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 8,
+            "totalCalls": 8
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 8,
+        "totalCalls": 8
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 23854,
+          "missed": 15188,
+          "ratio": 0.610983,
+          "total": 39042
+        },
+        "line": {
+          "covered": 1273,
+          "missed": 2968,
+          "ratio": 0.300165,
+          "total": 4241
+        },
+        "method": {
+          "covered": 229,
+          "missed": 634,
+          "ratio": 0.265353,
+          "total": 863
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 176754,
+      "cached_input_tokens_used": 1012736,
+      "output_tokens_used": 8820,
+      "iterations": 3,
+      "cost_usd": 0.771,
+      "tested_library_loc": 1793,
+      "metadata_entries": 73,
+      "previous_library_metadata_entries": 60,
+      "code_coverage_percent": 32.01,
+      "previous_library_coverage_percent": 30.02
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.thoughtworks.qdox/qdox/2.0-M1/src/test/java/com_thoughtworks_qdox/qdox/QDoxTesterTest.java",
+      "metadata_file": "metadata/com.thoughtworks.qdox/qdox/2.0-M1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.thoughtworks.qdox/qdox/2.0-M1/stats.json
+++ b/stats/com.thoughtworks.qdox/qdox/2.0-M1/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "2.0-M1",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 9,
+          "totalCalls" : 9
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 11,
+      "totalCalls" : 11
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 47215,
+        "missed" : 17704,
+        "ratio" : 0.727291,
+        "total" : 64919
+      },
+      "line" : {
+        "covered" : 1793,
+        "missed" : 3809,
+        "ratio" : 0.320064,
+        "total" : 5602
+      },
+      "method" : {
+        "covered" : 396,
+        "missed" : 956,
+        "ratio" : 0.292899,
+        "total" : 1352
+      }
+    }
+  } ]
+}

--- a/tests/src/com.thoughtworks.qdox/qdox/2.0-M1/.gitignore
+++ b/tests/src/com.thoughtworks.qdox/qdox/2.0-M1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.thoughtworks.qdox/qdox/2.0-M1/build.gradle
+++ b/tests/src/com.thoughtworks.qdox/qdox/2.0-M1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.thoughtworks.qdox:qdox:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.thoughtworks.qdox/qdox/2.0-M1/gradle.properties
+++ b/tests/src/com.thoughtworks.qdox/qdox/2.0-M1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.thoughtworks.qdox:qdox:2.0-M1
+library.version = 2.0-M1
+metadata.dir = com.thoughtworks.qdox/qdox/2.0-M1/

--- a/tests/src/com.thoughtworks.qdox/qdox/2.0-M1/settings.gradle
+++ b/tests/src/com.thoughtworks.qdox/qdox/2.0-M1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.thoughtworks.qdox.qdox_tests'

--- a/tests/src/com.thoughtworks.qdox/qdox/2.0-M1/src/test/java/com_thoughtworks_qdox/qdox/EvaluatingVisitorTest.java
+++ b/tests/src/com.thoughtworks.qdox/qdox/2.0-M1/src/test/java/com_thoughtworks_qdox/qdox/EvaluatingVisitorTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_thoughtworks_qdox.qdox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.thoughtworks.qdox.JavaDocBuilder;
+import com.thoughtworks.qdox.model.Annotation;
+import com.thoughtworks.qdox.model.JavaClass;
+import com.thoughtworks.qdox.model.JavaField;
+import com.thoughtworks.qdox.model.annotation.EvaluatingVisitor;
+import java.io.StringReader;
+import org.junit.jupiter.api.Test;
+
+public class EvaluatingVisitorTest {
+    @Test
+    void evaluatesParsedAnnotationExpressions() {
+        JavaDocBuilder builder = new JavaDocBuilder();
+        builder.addSource(new StringReader("""
+                package sample;
+
+                @interface Values {
+                    int total();
+                    String label();
+                    int[] numbers();
+                }
+
+                @Values(total = 1 + 2 * 3, label = "q" + "dox", numbers = {1, 2, 3})
+                public class AnnotatedSample {
+                }
+                """));
+        JavaClass javaClassAnnotationAccess = builder.getClassByName("sample.AnnotatedSample");
+        Annotation annotation = javaClassAnnotationAccess.getAnnotations()[0];
+        EvaluatingVisitor visitor = new ConstantOnlyEvaluatingVisitor();
+
+        assertThat(visitor.getValue(annotation, "total")).isEqualTo(7);
+        assertThat(visitor.getValue(annotation, "label")).isEqualTo("qdox");
+        assertThat(visitor.getListValue(annotation, "numbers")).containsExactly(1, 2, 3);
+    }
+
+    private static final class ConstantOnlyEvaluatingVisitor extends EvaluatingVisitor {
+        @Override
+        protected Object getFieldReferenceValue(JavaField javaField) {
+            throw new UnsupportedOperationException("Field references are not used by this test.");
+        }
+    }
+}

--- a/tests/src/com.thoughtworks.qdox/qdox/2.0-M1/src/test/java/com_thoughtworks_qdox/qdox/EvaluatingVisitorTest.java
+++ b/tests/src/com.thoughtworks.qdox/qdox/2.0-M1/src/test/java/com_thoughtworks_qdox/qdox/EvaluatingVisitorTest.java
@@ -8,18 +8,19 @@ package com_thoughtworks_qdox.qdox;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.thoughtworks.qdox.JavaDocBuilder;
-import com.thoughtworks.qdox.model.Annotation;
+import com.thoughtworks.qdox.JavaProjectBuilder;
+import com.thoughtworks.qdox.builder.impl.EvaluatingVisitor;
+import com.thoughtworks.qdox.model.JavaAnnotation;
 import com.thoughtworks.qdox.model.JavaClass;
 import com.thoughtworks.qdox.model.JavaField;
-import com.thoughtworks.qdox.model.annotation.EvaluatingVisitor;
 import java.io.StringReader;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class EvaluatingVisitorTest {
     @Test
     void evaluatesParsedAnnotationExpressions() {
-        JavaDocBuilder builder = new JavaDocBuilder();
+        JavaProjectBuilder builder = new JavaProjectBuilder();
         builder.addSource(new StringReader("""
                 package sample;
 
@@ -34,12 +35,33 @@ public class EvaluatingVisitorTest {
                 }
                 """));
         JavaClass javaClassAnnotationAccess = builder.getClassByName("sample.AnnotatedSample");
-        Annotation annotation = javaClassAnnotationAccess.getAnnotations()[0];
+        JavaAnnotation annotation = javaClassAnnotationAccess.getAnnotations().get(0);
         EvaluatingVisitor visitor = new ConstantOnlyEvaluatingVisitor();
 
         assertThat(visitor.getValue(annotation, "total")).isEqualTo(7);
         assertThat(visitor.getValue(annotation, "label")).isEqualTo("qdox");
-        assertThat(visitor.getListValue(annotation, "numbers")).containsExactly(1, 2, 3);
+        assertThat(visitor.getListValue(annotation, "numbers")).isEqualTo(List.of(1, 2, 3));
+    }
+
+    @Test
+    void evaluatesParsedAnnotationReferenceTypeCasts() {
+        JavaProjectBuilder builder = new JavaProjectBuilder();
+        builder.addSource(new StringReader("""
+                package sample;
+
+                @interface Values {
+                    String label();
+                }
+
+                @Values(label = (java.lang.String) "qdox")
+                public class AnnotatedReferenceCast {
+                }
+                """));
+        JavaClass javaClassAnnotationAccess = builder.getClassByName("sample.AnnotatedReferenceCast");
+        JavaAnnotation annotation = javaClassAnnotationAccess.getAnnotations().get(0);
+        EvaluatingVisitor visitor = new ConstantOnlyEvaluatingVisitor();
+
+        assertThat(visitor.getValue(annotation, "label")).isEqualTo("qdox");
     }
 
     private static final class ConstantOnlyEvaluatingVisitor extends EvaluatingVisitor {

--- a/tests/src/com.thoughtworks.qdox/qdox/2.0-M1/src/test/java/com_thoughtworks_qdox/qdox/JavaDocBuilderTest.java
+++ b/tests/src/com.thoughtworks.qdox/qdox/2.0-M1/src/test/java/com_thoughtworks_qdox/qdox/JavaDocBuilderTest.java
@@ -8,19 +8,18 @@ package com_thoughtworks_qdox.qdox;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.thoughtworks.qdox.JavaDocBuilder;
+import com.thoughtworks.qdox.JavaProjectBuilder;
 import com.thoughtworks.qdox.model.JavaClass;
 import com.thoughtworks.qdox.model.JavaMethod;
 import java.io.File;
 import java.io.StringReader;
 import java.nio.file.Files;
-import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 public class JavaDocBuilderTest {
     @Test
     void resolvesBinaryClassMembersThroughBuilderClassLookup() {
-        JavaDocBuilder builder = new JavaDocBuilder();
+        JavaProjectBuilder builder = new JavaProjectBuilder();
 
         JavaClass javaClass = builder.getClassByName(BinarySample.class.getName());
 
@@ -34,7 +33,7 @@ public class JavaDocBuilderTest {
 
     @Test
     void savesAndLoadsParsedSources() throws Exception {
-        JavaDocBuilder builder = new JavaDocBuilder();
+        JavaProjectBuilder builder = new JavaProjectBuilder();
         builder.addSource(new StringReader("""
                 package sample;
 
@@ -51,7 +50,7 @@ public class JavaDocBuilderTest {
         try {
             builder.save(file);
 
-            JavaDocBuilder loadedBuilder = JavaDocBuilder.load(file);
+            JavaProjectBuilder loadedBuilder = JavaProjectBuilder.load(file);
             JavaClass loadedClass = loadedBuilder.getClassByName("sample.ParsedSample");
 
             assertThat(loadedClass.getFieldByName("value")).isNotNull();
@@ -62,12 +61,11 @@ public class JavaDocBuilderTest {
     }
 
     private static boolean hasConstructor(JavaClass javaClass) {
-        return Arrays.stream(javaClass.getMethods()).anyMatch(JavaMethod::isConstructor);
+        return !javaClass.getConstructors().isEmpty();
     }
 
     private static JavaMethod methodNamed(JavaClass javaClass, String name) {
-        return Arrays.stream(javaClass.getMethods())
-                .filter(method -> !method.isConstructor())
+        return javaClass.getMethods().stream()
                 .filter(method -> name.equals(method.getName()))
                 .findFirst()
                 .orElse(null);

--- a/tests/src/com.thoughtworks.qdox/qdox/2.0-M1/src/test/java/com_thoughtworks_qdox/qdox/JavaDocBuilderTest.java
+++ b/tests/src/com.thoughtworks.qdox/qdox/2.0-M1/src/test/java/com_thoughtworks_qdox/qdox/JavaDocBuilderTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_thoughtworks_qdox.qdox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.thoughtworks.qdox.JavaDocBuilder;
+import com.thoughtworks.qdox.model.JavaClass;
+import com.thoughtworks.qdox.model.JavaMethod;
+import java.io.File;
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+public class JavaDocBuilderTest {
+    @Test
+    void resolvesBinaryClassMembersThroughBuilderClassLookup() {
+        JavaDocBuilder builder = new JavaDocBuilder();
+
+        JavaClass javaClass = builder.getClassByName(BinarySample.class.getName());
+
+        assertThat(javaClass.getFullyQualifiedName()).isEqualTo(BinarySample.class.getName());
+        assertThat(javaClass.getFieldByName("label")).isNotNull();
+        assertThat(javaClass.getFieldByName("count")).isNotNull();
+        assertThat(hasConstructor(javaClass)).isTrue();
+        assertThat(methodNamed(javaClass, "describe")).isNotNull();
+        assertThat(methodNamed(javaClass, "reset")).isNotNull();
+    }
+
+    @Test
+    void savesAndLoadsParsedSources() throws Exception {
+        JavaDocBuilder builder = new JavaDocBuilder();
+        builder.addSource(new StringReader("""
+                package sample;
+
+                /** A parsed source used to verify persistence. */
+                public class ParsedSample {
+                    private int value;
+
+                    public String describe() {
+                        return String.valueOf(value);
+                    }
+                }
+                """));
+        File file = Files.createTempFile("qdox-builder", ".ser").toFile();
+        try {
+            builder.save(file);
+
+            JavaDocBuilder loadedBuilder = JavaDocBuilder.load(file);
+            JavaClass loadedClass = loadedBuilder.getClassByName("sample.ParsedSample");
+
+            assertThat(loadedClass.getFieldByName("value")).isNotNull();
+            assertThat(methodNamed(loadedClass, "describe")).isNotNull();
+        } finally {
+            Files.deleteIfExists(file.toPath());
+        }
+    }
+
+    private static boolean hasConstructor(JavaClass javaClass) {
+        return Arrays.stream(javaClass.getMethods()).anyMatch(JavaMethod::isConstructor);
+    }
+
+    private static JavaMethod methodNamed(JavaClass javaClass, String name) {
+        return Arrays.stream(javaClass.getMethods())
+                .filter(method -> !method.isConstructor())
+                .filter(method -> name.equals(method.getName()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    public static class BinarySample {
+        public String label;
+        private int count;
+
+        public BinarySample() {
+        }
+
+        public BinarySample(String label, int count) {
+            this.label = label;
+            this.count = count;
+        }
+
+        public String describe(String prefix) {
+            return prefix + label + count;
+        }
+
+        public void reset() {
+            label = null;
+            count = 0;
+        }
+    }
+}

--- a/tests/src/com.thoughtworks.qdox/qdox/2.0-M1/src/test/java/com_thoughtworks_qdox/qdox/QDoxTesterTest.java
+++ b/tests/src/com.thoughtworks.qdox/qdox/2.0-M1/src/test/java/com_thoughtworks_qdox/qdox/QDoxTesterTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_thoughtworks_qdox.qdox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import com.thoughtworks.qdox.tools.QDoxTester;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class QDoxTesterTest {
+    @Test
+    void mainWithoutSourcesPrintsUsageWithTesterClassName() {
+        PrintStream originalErr = System.err;
+        UsageCapturingPrintStream capture = new UsageCapturingPrintStream();
+        try {
+            System.setErr(capture);
+
+            Throwable thrown = catchThrowable(() -> QDoxTester.main(new String[0]));
+
+            assertThat(thrown).isInstanceOf(UsageCapturedException.class);
+        } finally {
+            System.setErr(originalErr);
+            capture.close();
+        }
+
+        assertThat(capture.lines())
+                .contains("Tool that verifies that QDox can parse some Java source.")
+                .contains("Usage: java com.thoughtworks.qdox.tools.QDoxTester src1 [src2] [src3]...");
+    }
+
+    private static final class UsageCapturingPrintStream extends PrintStream {
+        private final List<String> lines = new ArrayList<>();
+
+        private UsageCapturingPrintStream() {
+            super(new ByteArrayOutputStream(), true, StandardCharsets.UTF_8);
+        }
+
+        @Override
+        public void println(String line) {
+            lines.add(line);
+            if (line.startsWith("Usage: java ")) {
+                throw new UsageCapturedException();
+            }
+        }
+
+        private List<String> lines() {
+            return Collections.unmodifiableList(lines);
+        }
+    }
+
+    private static final class UsageCapturedException extends RuntimeException {
+    }
+}

--- a/tests/src/com.thoughtworks.qdox/qdox/2.0-M1/user-code-filter.json
+++ b/tests/src/com.thoughtworks.qdox/qdox/2.0-M1/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.thoughtworks.qdox.**"
+    },
+    {
+      "includeClasses" : "com_thoughtworks_qdox.qdox.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #8203

This PR provides test fixes and new metadata for com.thoughtworks.qdox:qdox:2.0-M1, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 176754
- Cached input tokens: 1012736
- Output tokens: 8820
- Metadata entries: 73
- Iterations: 3
- Library coverage percentage: 32.01
- Previous library version metadata entries: 60
- Previous library version coverage percentage: 30.02

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `99a13ea22bbb5a03e1edb74ffa2c671e7bd68ffb`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.thoughtworks.qdox:qdox:1.12.1: 8/8 covered calls (100.00%)
- com.thoughtworks.qdox:qdox:2.0-M1: 11/11 covered calls (100.00%)

**Reflection:**
- com.thoughtworks.qdox:qdox:1.12.1: 8/8 covered calls (100.00%)
- com.thoughtworks.qdox:qdox:2.0-M1: 9/9 covered calls (100.00%)

**Resources:**
- com.thoughtworks.qdox:qdox:1.12.1: N/A
- com.thoughtworks.qdox:qdox:2.0-M1: 2/2 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.thoughtworks.qdox:qdox:1.12.1: 23854/39042 (61.10%)
- com.thoughtworks.qdox:qdox:2.0-M1: 47215/64919 (72.73%)

**Line:**
- com.thoughtworks.qdox:qdox:1.12.1: 1273/4241 (30.02%)
- com.thoughtworks.qdox:qdox:2.0-M1: 1793/5602 (32.01%)

**Method:**
- com.thoughtworks.qdox:qdox:1.12.1: 229/863 (26.54%)
- com.thoughtworks.qdox:qdox:2.0-M1: 396/1352 (29.29%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/com.thoughtworks.qdox/qdox/1.12.1/src/test/java/com_thoughtworks_qdox/qdox/EvaluatingVisitorTest.java 2/tests/src/com.thoughtworks.qdox/qdox/2.0-M1/src/test/java/com_thoughtworks_qdox/qdox/EvaluatingVisitorTest.java
index 5aede18457..3ad5364c0c 100644
--- 1/tests/src/com.thoughtworks.qdox/qdox/1.12.1/src/test/java/com_thoughtworks_qdox/qdox/EvaluatingVisitorTest.java
+++ 2/tests/src/com.thoughtworks.qdox/qdox/2.0-M1/src/test/java/com_thoughtworks_qdox/qdox/EvaluatingVisitorTest.java
@@ -8,18 +8,19 @@ package com_thoughtworks_qdox.qdox;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.thoughtworks.qdox.JavaDocBuilder;
-import com.thoughtworks.qdox.model.Annotation;
+import com.thoughtworks.qdox.JavaProjectBuilder;
+import com.thoughtworks.qdox.builder.impl.EvaluatingVisitor;
+import com.thoughtworks.qdox.model.JavaAnnotation;
 import com.thoughtworks.qdox.model.JavaClass;
 import com.thoughtworks.qdox.model.JavaField;
-import com.thoughtworks.qdox.model.annotation.EvaluatingVisitor;
 import java.io.StringReader;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class EvaluatingVisitorTest {
     @Test
     void evaluatesParsedAnnotationExpressions() {
-        JavaDocBuilder builder = new JavaDocBuilder();
+        JavaProjectBuilder builder = new JavaProjectBuilder();
         builder.addSource(new StringReader("""
                 package sample;
 
@@ -34,12 +35,33 @@ public class EvaluatingVisitorTest {
                 }
                 """));
         JavaClass javaClassAnnotationAccess = builder.getClassByName("sample.AnnotatedSample");
-        Annotation annotation = javaClassAnnotationAccess.getAnnotations()[0];
+        JavaAnnotation annotation = javaClassAnnotationAccess.getAnnotations().get(0);
         EvaluatingVisitor visitor = new ConstantOnlyEvaluatingVisitor();
 
         assertThat(visitor.getValue(annotation, "total")).isEqualTo(7);
         assertThat(visitor.getValue(annotation, "label")).isEqualTo("qdox");
-        assertThat(visitor.getListValue(annotation, "numbers")).containsExactly(1, 2, 3);
+        assertThat(visitor.getListValue(annotation, "numbers")).isEqualTo(List.of(1, 2, 3));
+    }
+
+    @Test
+    void evaluatesParsedAnnotationReferenceTypeCasts() {
+        JavaProjectBuilder builder = new JavaProjectBuilder();
+        builder.addSource(new StringReader("""
+                package sample;
+
+                @interface Values {
+                    String label();
+                }
+
+                @Values(label = (java.lang.String) "qdox")
+                public class AnnotatedReferenceCast {
+                }
+                """));
+        JavaClass javaClassAnnotationAccess = builder.getClassByName("sample.AnnotatedReferenceCast");
+        JavaAnnotation annotation = javaClassAnnotationAccess.getAnnotations().get(0);
+        EvaluatingVisitor visitor = new ConstantOnlyEvaluatingVisitor();
+
+        assertThat(visitor.getValue(annotation, "label")).isEqualTo("qdox");
     }
 
     private static final class ConstantOnlyEvaluatingVisitor extends EvaluatingVisitor {
diff --git 1/tests/src/com.thoughtworks.qdox/qdox/1.12.1/src/test/java/com_thoughtworks_qdox/qdox/JavaDocBuilderTest.java 2/tests/src/com.thoughtworks.qdox/qdox/2.0-M1/src/test/java/com_thoughtworks_qdox/qdox/JavaDocBuilderTest.java
index 5ac73375b4..041033ad8c 100644
--- 1/tests/src/com.thoughtworks.qdox/qdox/1.12.1/src/test/java/com_thoughtworks_qdox/qdox/JavaDocBuilderTest.java
+++ 2/tests/src/com.thoughtworks.qdox/qdox/2.0-M1/src/test/java/com_thoughtworks_qdox/qdox/JavaDocBuilderTest.java
@@ -8,19 +8,18 @@ package com_thoughtworks_qdox.qdox;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.thoughtworks.qdox.JavaDocBuilder;
+import com.thoughtworks.qdox.JavaProjectBuilder;
 import com.thoughtworks.qdox.model.JavaClass;
 import com.thoughtworks.qdox.model.JavaMethod;
 import java.io.File;
 import java.io.StringReader;
 import java.nio.file.Files;
-import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 public class JavaDocBuilderTest {
     @Test
     void resolvesBinaryClassMembersThroughBuilderClassLookup() {
-        JavaDocBuilder builder = new JavaDocBuilder();
+        JavaProjectBuilder builder = new JavaProjectBuilder();
 
         JavaClass javaClass = builder.getClassByName(BinarySample.class.getName());
 
@@ -34,7 +33,7 @@ public class JavaDocBuilderTest {
 
     @Test
     void savesAndLoadsParsedSources() throws Exception {
-        JavaDocBuilder builder = new JavaDocBuilder();
+        JavaProjectBuilder builder = new JavaProjectBuilder();
         builder.addSource(new StringReader("""
                 package sample;
 
@@ -51,7 +50,7 @@ public class JavaDocBuilderTest {
         try {
             builder.save(file);
 
-            JavaDocBuilder loadedBuilder = JavaDocBuilder.load(file);
+            JavaProjectBuilder loadedBuilder = JavaProjectBuilder.load(file);
             JavaClass loadedClass = loadedBuilder.getClassByName("sample.ParsedSample");
 
             assertThat(loadedClass.getFieldByName("value")).isNotNull();
@@ -62,12 +61,11 @@ public class JavaDocBuilderTest {
     }
 
     private static boolean hasConstructor(JavaClass javaClass) {
-        return Arrays.stream(javaClass.getMethods()).anyMatch(JavaMethod::isConstructor);
+        return !javaClass.getConstructors().isEmpty();
     }
 
     private static JavaMethod methodNamed(JavaClass javaClass, String name) {
-        return Arrays.stream(javaClass.getMethods())
-                .filter(method -> !method.isConstructor())
+        return javaClass.getMethods().stream()
                 .filter(method -> name.equals(method.getName()))
                 .findFirst()
                 .orElse(null);

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
