### PR TITLE
[GenAI] Mark org.springframework.boot:spring-boot-starter-security as not for Native Image

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-starter-security/index.json
+++ b/metadata/org.springframework.boot/spring-boot-starter-security/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published JAR for org.springframework.boot:spring-boot-starter-security:2.7.18 contains only META-INF files and no JVM class files; it is a dependency starter whose runtime classes are supplied by its dependencies.",
+    "replacement": "Use class-bearing dependencies such as org.springframework:spring-aop:5.3.31, org.springframework.security:spring-security-config:5.7.11, org.springframework.security:spring-security-web:5.7.11, org.springframework.boot:spring-boot:2.7.18, and org.springframework.boot:spring-boot-autoconfigure:2.7.18."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #2656

This PR records `org.springframework.boot:spring-boot-starter-security` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published JAR for org.springframework.boot:spring-boot-starter-security:2.7.18 contains only META-INF files and no JVM class files; it is a dependency starter whose runtime classes are supplied by its dependencies.

Replacement guidance:
- Use class-bearing dependencies such as org.springframework:spring-aop:5.3.31, org.springframework.security:spring-security-config:5.7.11, org.springframework.security:spring-security-web:5.7.11, org.springframework.boot:spring-boot:2.7.18, and org.springframework.boot:spring-boot-autoconfigure:2.7.18.

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `99a13ea22bbb5a03e1edb74ffa2c671e7bd68ffb`

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
