### PR TITLE
[GenAI] Test fix for org.springframework:spring-test:6.0.0 using gpt-5.5

### DIFF
--- a/metadata/org.springframework/spring-test/6.0.0/reachability-metadata.json
+++ b/metadata/org.springframework/spring-test/6.0.0/reachability-metadata.json
@@ -1,0 +1,389 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.LocalVariableTableParameterNameDiscoverer"
+      },
+      "type" : "java.lang.Thread",
+      "methods" : [
+        {
+          "name" : "getContextClassLoader",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.annotation.AnnotationTypeMapping"
+      },
+      "type" : "java.lang.Thread",
+      "methods" : [
+        {
+          "name" : "getContextClassLoader",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.env.AbstractEnvironment"
+      },
+      "type" : "java.lang.Thread",
+      "methods" : [
+        {
+          "name" : "getContextClassLoader",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.env.AbstractPropertyResolver"
+      },
+      "type" : "java.lang.Thread",
+      "methods" : [
+        {
+          "name" : "getContextClassLoader",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.env.PropertySource"
+      },
+      "type" : "java.lang.Thread",
+      "methods" : [
+        {
+          "name" : "getContextClassLoader",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.io.support.SpringFactoriesLoader"
+      },
+      "type" : "java.lang.Thread",
+      "methods" : [
+        {
+          "name" : "getContextClassLoader",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.test.annotation.ProfileValueUtils"
+      },
+      "type" : "java.lang.Thread",
+      "methods" : [
+        {
+          "name" : "getContextClassLoader",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.test.context.BootstrapUtils"
+      },
+      "type" : "java.lang.Thread",
+      "methods" : [
+        {
+          "name" : "getContextClassLoader",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.test.context.TestContextManager"
+      },
+      "type" : "java.lang.Thread",
+      "methods" : [
+        {
+          "name" : "getContextClassLoader",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.test.context.aot.AotTestContextInitializersCodeGenerator"
+      },
+      "type" : "java.lang.Thread",
+      "methods" : [
+        {
+          "name" : "getContextClassLoader",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.test.context.aot.TestContextAotGenerator"
+      },
+      "type" : "java.lang.Thread",
+      "methods" : [
+        {
+          "name" : "getContextClassLoader",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate"
+      },
+      "type" : "java.lang.Thread",
+      "methods" : [
+        {
+          "name" : "getContextClassLoader",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.test.context.cache.DefaultContextCache"
+      },
+      "type" : "java.lang.Thread",
+      "methods" : [
+        {
+          "name" : "getContextClassLoader",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.test.context.junit4.SpringJUnit4ClassRunner"
+      },
+      "type" : "java.lang.Thread",
+      "methods" : [
+        {
+          "name" : "getContextClassLoader",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.test.context.util.TestContextFailureHandler"
+      },
+      "type" : "java.lang.Thread",
+      "methods" : [
+        {
+          "name" : "getContextClassLoader",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.test.context.util.TestContextSpringFactoriesUtils"
+      },
+      "type" : "java.lang.Thread",
+      "methods" : [
+        {
+          "name" : "getContextClassLoader",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.util.PropertyPlaceholderHelper"
+      },
+      "type" : "java.lang.Thread",
+      "methods" : [
+        {
+          "name" : "getContextClassLoader",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.test.context.aot.TestContextAotGenerator"
+      },
+      "type" : "org.apache.commons.logging.LogFactoryService"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.test.context.aot.TestContextAotGenerator"
+      },
+      "type" : "org.apache.commons.logging.impl.WeakHashtable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.test.context.junit4.SpringJUnit4ClassRunner"
+      },
+      "type" : "org.junit.internal.Throwables"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.test.context.junit4.SpringJUnit4ClassRunner"
+      },
+      "type" : "org.junit.runners.BlockJUnit4ClassRunner",
+      "methods" : [
+        {
+          "name" : "withRules",
+          "parameterTypes" : [
+            "org.junit.runners.model.FrameworkMethod",
+            "java.lang.Object",
+            "org.junit.runners.model.Statement"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.test.context.aot.GeneratedMapUtils"
+      },
+      "type" : "org.springframework.test.context.aot.AotTestContextInitializers__Generated",
+      "methods" : [
+        {
+          "name" : "getContextInitializers",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getContextInitializerClasses",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.test.context.BootstrapUtils"
+      },
+      "type" : "org.springframework.test.context.support.DefaultBootstrapContext",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Class",
+            "org.springframework.test.context.CacheAwareContextLoaderDelegate"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.test.context.BootstrapUtils"
+      },
+      "type" : "org.springframework.test.context.support.DefaultTestContextBootstrapper",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.test.context.BootstrapUtils"
+      },
+      "type" : "org.springframework.test.context.web.WebTestContextBootstrapper",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.test.context.support.AbstractTestContextBootstrapper"
+      },
+      "type" : "org.springframework.test.context.support.DelegatingSmartContextLoader",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.test.context.support.AbstractTestContextBootstrapper"
+      },
+      "type" : "org.springframework.test.context.web.WebDelegatingSmartContextLoader",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.beans.BeanUtils"
+      },
+      "type" : "org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.test.context.aot.MergedContextConfigurationRuntimeHints"
+      },
+      "type" : "org.springframework.test.context.web.WebMergedContextConfiguration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.annotation.AnnotationsScanner"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Documented"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.annotation.AnnotationsScanner"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Inherited"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.annotation.AnnotationsScanner"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.annotation.AnnotationsScanner"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Target"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.core.annotation.AnnotationsScanner"
+      },
+      "type" : {
+        "proxy" : [
+          "org.springframework.test.annotation.ProfileValueSourceConfiguration"
+        ]
+      }
+    }
+  ]
+}

--- a/metadata/org.springframework/spring-test/6.0.0/reachability-metadata.json
+++ b/metadata/org.springframework/spring-test/6.0.0/reachability-metadata.json
@@ -319,7 +319,7 @@
     },
     {
       "condition" : {
-        "typeReached" : "org.springframework.beans.BeanUtils"
+        "typeReached" : "org.springframework.test.context.BootstrapUtils"
       },
       "type" : "org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate",
       "methods" : [

--- a/metadata/org.springframework/spring-test/index.json
+++ b/metadata/org.springframework/spring-test/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "6.0.0",
+    "tested-versions" : [
+      "6.0.0"
+    ],
+    "allowed-packages" : [
+      "org.springframework"
+    ]
+  },
+  {
     "metadata-version" : "3.0.5.RELEASE",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/spring-test/$version$/spring-test-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-framework",

--- a/metadata/org.springframework/spring-test/index.json
+++ b/metadata/org.springframework/spring-test/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "6.0.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/spring-test/$version$/spring-test-$version$-sources.jar",
+    "repository-url" : "https://github.com/spring-projects/spring-framework",
+    "test-code-url" : "https://github.com/spring-projects/spring-framework/tree/v$version$/spring-test/src/test/java",
+    "documentation-url" : "https://docs.spring.io/spring-framework/docs/$version$/reference/html/testing.html",
+    "description" : "Spring Test provides testing support for Spring applications, including mock objects, testing utilities, and integration testing through the Spring TestContext Framework. It helps developers write unit and integration tests that load and manage Spring application contexts across common Java testing frameworks.",
     "tested-versions" : [
       "6.0.0"
     ],

--- a/stats/org.springframework/spring-test/6.0.0/execution-metrics.json
+++ b/stats/org.springframework/spring-test/6.0.0/execution-metrics.json
@@ -1,0 +1,101 @@
+{
+  "fix_javac_fail:2026-06-08": {
+    "timestamp": "2026-06-08T20:32:24.092575Z",
+    "library": "org.springframework:spring-test:6.0.0",
+    "starting_commit": "51cd2a816f98d83b233c75fb0c38f879c4bb3841",
+    "ending_commit": "36db530b4cff4f82fd22c9642a7f6bb06877ea67",
+    "previous_library": "org.springframework:spring-test:3.0.5.RELEASE",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "6.0.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 7,
+            "totalCalls": 7
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 7,
+        "totalCalls": 7
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3632,
+          "missed": 42414,
+          "ratio": 0.078878,
+          "total": 46046
+        },
+        "line": {
+          "covered": 920,
+          "missed": 9801,
+          "ratio": 0.085813,
+          "total": 10721
+        },
+        "method": {
+          "covered": 250,
+          "missed": 3360,
+          "ratio": 0.069252,
+          "total": 3610
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.0.5.RELEASE",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 54,
+          "missed": 15918,
+          "ratio": 0.003381,
+          "total": 15972
+        },
+        "line": {
+          "covered": 16,
+          "missed": 3916,
+          "ratio": 0.004069,
+          "total": 3932
+        },
+        "method": {
+          "covered": 4,
+          "missed": 1188,
+          "ratio": 0.003356,
+          "total": 1192
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 238152,
+      "cached_input_tokens_used": 2547200,
+      "output_tokens_used": 30508,
+      "iterations": 5,
+      "cost_usd": 2.1888,
+      "tested_library_loc": 920,
+      "metadata_entries": 60,
+      "test_only_metadata_entries": 2,
+      "previous_library_metadata_entries": 19,
+      "previous_library_test_only_metadata_entries": 1,
+      "code_coverage_percent": 8.58,
+      "previous_library_coverage_percent": 0.41
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.springframework/spring-test/6.0.0/src/test/java/org/springframework/test/context/aot/AotTestContextInitializers__Generated.java",
+      "metadata_file": "metadata/org.springframework/spring-test/6.0.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.springframework/spring-test/6.0.0/stats.json
+++ b/stats/org.springframework/spring-test/6.0.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "6.0.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 7,
+          "totalCalls" : 7
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 7,
+      "totalCalls" : 7
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3632,
+        "missed" : 42414,
+        "ratio" : 0.078878,
+        "total" : 46046
+      },
+      "line" : {
+        "covered" : 920,
+        "missed" : 9801,
+        "ratio" : 0.085813,
+        "total" : 10721
+      },
+      "method" : {
+        "covered" : 250,
+        "missed" : 3360,
+        "ratio" : 0.069252,
+        "total" : 3610
+      }
+    }
+  } ]
+}

--- a/tests/src/org.springframework/spring-test/6.0.0/.gitignore
+++ b/tests/src/org.springframework/spring-test/6.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.springframework/spring-test/6.0.0/build.gradle
+++ b/tests/src/org.springframework/spring-test/6.0.0/build.gradle
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.springframework:spring-test:$libraryVersion"
+    testImplementation 'commons-logging:commons-logging:1.1.1'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-test/6.0.0/build.gradle
+++ b/tests/src/org.springframework/spring-test/6.0.0/build.gradle
@@ -13,6 +13,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.springframework:spring-test:$libraryVersion"
     testImplementation "org.springframework:spring-context:$libraryVersion"
+    testImplementation 'junit:junit:4.13.2'
     testImplementation 'commons-logging:commons-logging:1.1.1'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }

--- a/tests/src/org.springframework/spring-test/6.0.0/build.gradle
+++ b/tests/src/org.springframework/spring-test/6.0.0/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.springframework:spring-test:$libraryVersion"
+    testImplementation "org.springframework:spring-context:$libraryVersion"
     testImplementation 'commons-logging:commons-logging:1.1.1'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }

--- a/tests/src/org.springframework/spring-test/6.0.0/gradle.properties
+++ b/tests/src/org.springframework/spring-test/6.0.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.springframework:spring-test:6.0.0
+library.version = 6.0.0
+metadata.dir = org.springframework/spring-test/6.0.0/

--- a/tests/src/org.springframework/spring-test/6.0.0/settings.gradle
+++ b/tests/src/org.springframework/spring-test/6.0.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.springframework.spring-test_tests'

--- a/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org/springframework/test/context/aot/AotTestContextInitializers__Generated.java
+++ b/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org/springframework/test/context/aot/AotTestContextInitializers__Generated.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.springframework.test.context.aot;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+
+public final class AotTestContextInitializers__Generated {
+    private AotTestContextInitializers__Generated() {
+    }
+
+    public static Map<String, Supplier<ApplicationContextInitializer<ConfigurableApplicationContext>>> getContextInitializers() {
+        return Map.of();
+    }
+
+    public static Map<String, Class<ApplicationContextInitializer<?>>> getContextInitializerClasses() {
+        return Map.of();
+    }
+}

--- a/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org_springframework/spring_test/MergedContextConfigurationRuntimeHintsTest.java
+++ b/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org_springframework/spring_test/MergedContextConfigurationRuntimeHintsTest.java
@@ -49,8 +49,7 @@ public class MergedContextConfigurationRuntimeHintsTest {
                     .flatMap(Collection::stream)
                     .anyMatch(hint -> WEB_RESOURCE_PATTERN.equals(hint.getPattern())))
                     .isTrue();
-        }
-        catch (IllegalStateException ex) {
+        } catch (IllegalStateException ex) {
             assertThat(ex)
                     .hasMessage("Cannot perform AOT processing during AOT run-time execution");
         }

--- a/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org_springframework/spring_test/MergedContextConfigurationRuntimeHintsTest.java
+++ b/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org_springframework/spring_test/MergedContextConfigurationRuntimeHintsTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_test;
+
+import java.util.Collection;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aot.generate.InMemoryGeneratedFiles;
+import org.springframework.aot.hint.ResourcePatternHints;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextConfigurationAttributes;
+import org.springframework.test.context.MergedContextConfiguration;
+import org.springframework.test.context.aot.AotContextLoader;
+import org.springframework.test.context.aot.TestContextAotGenerator;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MergedContextConfigurationRuntimeHintsTest {
+    private static final String WEB_RESOURCE_BASE_PATH =
+            "classpath:/org_springframework/spring_test/webapp";
+
+    private static final String WEB_RESOURCE_PATTERN =
+            "org_springframework/spring_test/webapp/*";
+
+    @Test
+    void registersRuntimeHintsForWebMergedContextConfigurationResourceBasePath() {
+        RuntimeHints runtimeHints = new RuntimeHints();
+        InMemoryGeneratedFiles generatedFiles = new InMemoryGeneratedFiles();
+        TestContextAotGenerator generator =
+                new TestContextAotGenerator(generatedFiles, runtimeHints);
+
+        try {
+            generator.processAheadOfTime(Stream.of(WebApplicationTestCase.class));
+
+            assertThat(runtimeHints.resources().resourcePatternHints()
+                    .map(ResourcePatternHints::getIncludes)
+                    .flatMap(Collection::stream)
+                    .anyMatch(hint -> WEB_RESOURCE_PATTERN.equals(hint.getPattern())))
+                    .isTrue();
+        }
+        catch (IllegalStateException ex) {
+            assertThat(ex)
+                    .hasMessage("Cannot perform AOT processing during AOT run-time execution");
+        }
+    }
+
+    @WebAppConfiguration(WEB_RESOURCE_BASE_PATH)
+    @ContextConfiguration(classes = TestConfiguration.class, loader = TestAotContextLoader.class)
+    static class WebApplicationTestCase {
+    }
+
+    static class TestConfiguration {
+    }
+
+    public static class TestAotContextLoader implements AotContextLoader {
+        @Override
+        public void processContextConfiguration(ContextConfigurationAttributes configAttributes) {
+        }
+
+        @Override
+        public ApplicationContext loadContext(MergedContextConfiguration mergedConfig) {
+            GenericApplicationContext context = new GenericApplicationContext();
+            context.refresh();
+            return context;
+        }
+
+        @Override
+        public ApplicationContext loadContextForAotProcessing(
+                MergedContextConfiguration mergedConfig) {
+
+            return new GenericApplicationContext();
+        }
+
+        @Override
+        public ApplicationContext loadContextForAotRuntime(MergedContextConfiguration mergedConfig,
+                ApplicationContextInitializer<ConfigurableApplicationContext> initializer) {
+
+            GenericApplicationContext context = new GenericApplicationContext();
+            initializer.initialize(context);
+            context.refresh();
+            return context;
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org_springframework/spring_test/ProfileValueUtilsTest.java
+++ b/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org_springframework/spring_test/ProfileValueUtilsTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_test;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.test.annotation.ProfileValueSource;
+import org.springframework.test.annotation.ProfileValueSourceConfiguration;
+import org.springframework.test.annotation.ProfileValueUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProfileValueUtilsTest {
+    @Test
+    void retrievesConfiguredProfileValueSource() {
+        ProfileValueSource profileValueSource =
+                ProfileValueUtils.retrieveProfileValueSource(ProfileConfiguredTestCase.class);
+
+        assertThat(profileValueSource).isInstanceOf(TestProfileValueSource.class);
+        assertThat(profileValueSource.get("spring.profile")).isEqualTo("configured");
+    }
+
+    @ProfileValueSourceConfiguration(TestProfileValueSource.class)
+    static class ProfileConfiguredTestCase {
+    }
+
+    public static class TestProfileValueSource implements ProfileValueSource {
+        @Override
+        public String get(String key) {
+            if ("spring.profile".equals(key)) {
+                return "configured";
+            }
+            return null;
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org_springframework/spring_test/SimpleNamingContextBuilderTest.java
+++ b/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org_springframework/spring_test/SimpleNamingContextBuilderTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_test;
+
+import java.util.Hashtable;
+import java.util.Properties;
+
+import javax.naming.Context;
+import javax.naming.NamingException;
+import javax.naming.spi.InitialContextFactory;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.mock.jndi.SimpleNamingContextBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SimpleNamingContextBuilderTest {
+    @Test
+    void createsInitialContextFactoryFromEnvironmentClass() {
+        SimpleNamingContextBuilder builder = new SimpleNamingContextBuilder();
+        builder.deactivate();
+        TestInitialContextFactory.createdInstances = 0;
+
+        Properties environment = new Properties();
+        environment.put(Context.INITIAL_CONTEXT_FACTORY, TestInitialContextFactory.class);
+
+        InitialContextFactory factory = builder.createInitialContextFactory(environment);
+
+        assertThat(factory).isInstanceOf(TestInitialContextFactory.class);
+        assertThat(TestInitialContextFactory.createdInstances).isEqualTo(1);
+    }
+
+    public static class TestInitialContextFactory implements InitialContextFactory {
+        static int createdInstances;
+
+        public TestInitialContextFactory() {
+            createdInstances++;
+        }
+
+        @Override
+        public Context getInitialContext(Hashtable<?, ?> environment) throws NamingException {
+            return null;
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org_springframework/spring_test/SimpleNamingContextBuilderTest.java
+++ b/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org_springframework/spring_test/SimpleNamingContextBuilderTest.java
@@ -7,7 +7,6 @@
 package org_springframework.spring_test;
 
 import java.util.Hashtable;
-import java.util.Properties;
 
 import javax.naming.Context;
 import javax.naming.NamingException;
@@ -15,33 +14,32 @@ import javax.naming.spi.InitialContextFactory;
 
 import org.junit.jupiter.api.Test;
 
-import org.springframework.mock.jndi.SimpleNamingContextBuilder;
+import org.springframework.core.env.Profiles;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.mock.env.MockPropertySource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SimpleNamingContextBuilderTest {
     @Test
-    void createsInitialContextFactoryFromEnvironmentClass() {
-        SimpleNamingContextBuilder builder = new SimpleNamingContextBuilder();
-        builder.deactivate();
-        TestInitialContextFactory.createdInstances = 0;
+    void resolvesClassValuedPropertiesAndProfilesFromMockPropertySources() {
+        MockPropertySource propertySource = new MockPropertySource("testProperties")
+                .withProperty(Context.INITIAL_CONTEXT_FACTORY, TestInitialContextFactory.class)
+                .withProperty("application.name", "reachability-metadata")
+                .withProperty("application.retries", "3");
 
-        Properties environment = new Properties();
-        environment.put(Context.INITIAL_CONTEXT_FACTORY, TestInitialContextFactory.class);
+        MockEnvironment environment = new MockEnvironment();
+        environment.getPropertySources().addFirst(propertySource);
+        environment.setActiveProfiles("native", "test");
 
-        InitialContextFactory factory = builder.createInitialContextFactory(environment);
-
-        assertThat(factory).isInstanceOf(TestInitialContextFactory.class);
-        assertThat(TestInitialContextFactory.createdInstances).isEqualTo(1);
+        assertThat(environment.getProperty(Context.INITIAL_CONTEXT_FACTORY, Object.class))
+                .isSameAs(TestInitialContextFactory.class);
+        assertThat(environment.getRequiredProperty("application.name")).isEqualTo("reachability-metadata");
+        assertThat(environment.getProperty("application.retries", Integer.class)).isEqualTo(3);
+        assertThat(environment.acceptsProfiles(Profiles.of("native & test"))).isTrue();
     }
 
     public static class TestInitialContextFactory implements InitialContextFactory {
-        static int createdInstances;
-
-        public TestInitialContextFactory() {
-            createdInstances++;
-        }
-
         @Override
         public Context getInitialContext(Hashtable<?, ?> environment) throws NamingException {
             return null;

--- a/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org_springframework/spring_test/SpringJUnit4ClassRunnerTest.java
+++ b/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org_springframework/spring_test/SpringJUnit4ClassRunnerTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_test;
+
+import org.junit.jupiter.api.Test;
+import org.junit.runner.Description;
+import org.junit.runners.model.InitializationError;
+
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SpringJUnit4ClassRunnerTest {
+    @Test
+    void createsRunnerForJUnit4TestClass() throws InitializationError {
+        SpringJUnit4ClassRunner runner = new SpringJUnit4ClassRunner(PlainJUnit4TestCase.class);
+
+        Description description = runner.getDescription();
+
+        assertThat(description.getTestClass()).isEqualTo(PlainJUnit4TestCase.class);
+        assertThat(description.getChildren()).hasSize(1);
+        assertThat(description.getChildren().get(0).getMethodName()).isEqualTo("sampleTest");
+    }
+
+    public static class PlainJUnit4TestCase {
+        @org.junit.Test
+        public void sampleTest() {
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org_springframework/spring_test/TestContextManagerTest.java
+++ b/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org_springframework/spring_test/TestContextManagerTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_test;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.AttributeAccessorSupport;
+import org.springframework.test.annotation.DirtiesContext.HierarchyMode;
+import org.springframework.test.context.BootstrapContext;
+import org.springframework.test.context.MergedContextConfiguration;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.TestContextBootstrapper;
+import org.springframework.test.context.TestContextManager;
+import org.springframework.test.context.TestExecutionListener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestContextManagerTest {
+    @Test
+    void usesTestContextCopyConstructorForThreadLocalContext() {
+        CopyableTestContext.resetCopyCount();
+        CopyableTestContext original = new CopyableTestContext(ManagedTestCase.class);
+        TestContextManager manager = new TestContextManager(new CopyableBootstrapper(original));
+
+        TestContext testContext = manager.getTestContext();
+
+        assertThat(testContext).isInstanceOf(CopyableTestContext.class);
+        CopyableTestContext copy = (CopyableTestContext) testContext;
+        assertThat(copy).isNotSameAs(original);
+        assertThat(copy.getSource()).isSameAs(original);
+        assertThat(copy.getTestClass()).isEqualTo(ManagedTestCase.class);
+        assertThat(CopyableTestContext.getCopyCount()).isEqualTo(1);
+        assertThat(manager.getTestContext()).isSameAs(copy);
+        assertThat(CopyableTestContext.getCopyCount()).isEqualTo(1);
+    }
+
+    static class ManagedTestCase {
+    }
+
+    static class CopyableBootstrapper implements TestContextBootstrapper {
+        private final TestContext testContext;
+
+        private BootstrapContext bootstrapContext;
+
+        CopyableBootstrapper(TestContext testContext) {
+            this.testContext = testContext;
+        }
+
+        @Override
+        public void setBootstrapContext(BootstrapContext bootstrapContext) {
+            this.bootstrapContext = bootstrapContext;
+        }
+
+        @Override
+        public BootstrapContext getBootstrapContext() {
+            return this.bootstrapContext;
+        }
+
+        @Override
+        public TestContext buildTestContext() {
+            return this.testContext;
+        }
+
+        @Override
+        public MergedContextConfiguration buildMergedContextConfiguration() {
+            throw new UnsupportedOperationException("Merged context configuration is not needed");
+        }
+
+        @Override
+        public List<TestExecutionListener> getTestExecutionListeners() {
+            return Collections.emptyList();
+        }
+    }
+
+    public static class CopyableTestContext extends AttributeAccessorSupport implements TestContext {
+        private static int copyCount;
+
+        private final Class<?> testClass;
+
+        private final CopyableTestContext source;
+
+        private Object testInstance;
+
+        private Method testMethod;
+
+        private Throwable testException;
+
+        CopyableTestContext(Class<?> testClass) {
+            this.testClass = testClass;
+            this.source = null;
+        }
+
+        public CopyableTestContext(CopyableTestContext source) {
+            copyCount++;
+            this.testClass = source.testClass;
+            this.source = source;
+            copyAttributesFrom(source);
+        }
+
+        static void resetCopyCount() {
+            copyCount = 0;
+        }
+
+        static int getCopyCount() {
+            return copyCount;
+        }
+
+        CopyableTestContext getSource() {
+            return this.source;
+        }
+
+        @Override
+        public ApplicationContext getApplicationContext() {
+            throw new IllegalStateException("No application context is configured");
+        }
+
+        @Override
+        public Class<?> getTestClass() {
+            return this.testClass;
+        }
+
+        @Override
+        public Object getTestInstance() {
+            return this.testInstance;
+        }
+
+        @Override
+        public Method getTestMethod() {
+            return this.testMethod;
+        }
+
+        @Override
+        public Throwable getTestException() {
+            return this.testException;
+        }
+
+        @Override
+        public void markApplicationContextDirty(HierarchyMode hierarchyMode) {
+        }
+
+        @Override
+        public void updateState(Object testInstance, Method testMethod, Throwable testException) {
+            this.testInstance = testInstance;
+            this.testMethod = testMethod;
+            this.testException = testException;
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-test/6.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.springframework/spring-test/6.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.mock.jndi.SimpleNamingContextBuilder"
+      },
+      "type" : "org_springframework.spring_test.SimpleNamingContextBuilderTest$TestInitialContextFactory"
+    }
+  ]
+}

--- a/tests/src/org.springframework/spring-test/6.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.springframework/spring-test/6.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -5,6 +5,12 @@
         "typeReached" : "org.springframework.mock.jndi.SimpleNamingContextBuilder"
       },
       "type" : "org_springframework.spring_test.SimpleNamingContextBuilderTest$TestInitialContextFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.util.ReflectionUtils"
+      },
+      "type" : "org_springframework.spring_test.ProfileValueUtilsTest$TestProfileValueSource"
     }
   ]
 }

--- a/tests/src/org.springframework/spring-test/6.0.0/user-code-filter.json
+++ b/tests/src/org.springframework/spring-test/6.0.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.springframework.**"
+    },
+    {
+      "includeClasses" : "org_springframework.spring_test.**"
+    }
+  ]
+}

--- a/tests/src/org.springframework/spring-test/6.0.0/user-code-filter.json
+++ b/tests/src/org.springframework/spring-test/6.0.0/user-code-filter.json
@@ -7,6 +7,9 @@
       "includeClasses" : "org.springframework.**"
     },
     {
+      "includeClasses" : "org.springframework.test.context.aot.**"
+    },
+    {
       "includeClasses" : "org_springframework.spring_test.**"
     }
   ]


### PR DESCRIPTION
## What does this PR do?

Fixes: #7615

This PR provides test fixes and new metadata for org.springframework:spring-test:6.0.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 238152
- Cached input tokens: 2547200
- Output tokens: 30508
- Metadata entries: 60
- Test-only metadata entries: 2
- Iterations: 5
- Library coverage percentage: 8.58
- Previous library version metadata entries: 19
- Previous library version test-only metadata entries: 1
- Previous library version coverage percentage: 0.41

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `0688aab9203961a15dc8b10bf26f1d0362ab4356`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.springframework:spring-test:3.0.5.RELEASE: 1/1 covered calls (100.00%)
- org.springframework:spring-test:6.0.0: 7/7 covered calls (100.00%)

**Reflection:**
- org.springframework:spring-test:3.0.5.RELEASE: 1/1 covered calls (100.00%)
- org.springframework:spring-test:6.0.0: 7/7 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.springframework:spring-test:3.0.5.RELEASE: 54/15972 (0.34%)
- org.springframework:spring-test:6.0.0: 3632/46046 (7.89%)

**Line:**
- org.springframework:spring-test:3.0.5.RELEASE: 16/3932 (0.41%)
- org.springframework:spring-test:6.0.0: 920/10721 (8.58%)

**Method:**
- org.springframework:spring-test:3.0.5.RELEASE: 4/1192 (0.34%)
- org.springframework:spring-test:6.0.0: 250/3610 (6.93%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.springframework/spring-test/3.0.5.RELEASE/build.gradle 2/tests/src/org.springframework/spring-test/6.0.0/build.gradle
index d00c1cb3ec..3cc476a7c4 100644
--- 1/tests/src/org.springframework/spring-test/3.0.5.RELEASE/build.gradle
+++ 2/tests/src/org.springframework/spring-test/6.0.0/build.gradle
@@ -12,6 +12,8 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.springframework:spring-test:$libraryVersion"
+    testImplementation "org.springframework:spring-context:$libraryVersion"
+    testImplementation 'junit:junit:4.13.2'
     testImplementation 'commons-logging:commons-logging:1.1.1'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
diff --git 1/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org/springframework/test/context/aot/AotTestContextInitializers__Generated.java 2/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org/springframework/test/context/aot/AotTestContextInitializers__Generated.java
new file mode 100644
index 0000000000..17d04e089e
--- /dev/null
+++ 2/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org/springframework/test/context/aot/AotTestContextInitializers__Generated.java
@@ -0,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.springframework.test.context.aot;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+
+public final class AotTestContextInitializers__Generated {
+    private AotTestContextInitializers__Generated() {
+    }
+
+    public static Map<String, Supplier<ApplicationContextInitializer<ConfigurableApplicationContext>>> getContextInitializers() {
+        return Map.of();
+    }
+
+    public static Map<String, Class<ApplicationContextInitializer<?>>> getContextInitializerClasses() {
+        return Map.of();
+    }
+}
diff --git 1/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org_springframework/spring_test/MergedContextConfigurationRuntimeHintsTest.java 2/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org_springframework/spring_test/MergedContextConfigurationRuntimeHintsTest.java
new file mode 100644
index 0000000000..6912d14422
--- /dev/null
+++ 2/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org_springframework/spring_test/MergedContextConfigurationRuntimeHintsTest.java
@@ -0,0 +1,95 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_test;
+
+import java.util.Collection;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aot.generate.InMemoryGeneratedFiles;
+import org.springframework.aot.hint.ResourcePatternHints;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextConfigurationAttributes;
+import org.springframework.test.context.MergedContextConfiguration;
+import org.springframework.test.context.aot.AotContextLoader;
+import org.springframework.test.context.aot.TestContextAotGenerator;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MergedContextConfigurationRuntimeHintsTest {
+    private static final String WEB_RESOURCE_BASE_PATH =
+            "classpath:/org_springframework/spring_test/webapp";
+
+    private static final String WEB_RESOURCE_PATTERN =
+            "org_springframework/spring_test/webapp/*";
+
+    @Test
+    void registersRuntimeHintsForWebMergedContextConfigurationResourceBasePath() {
+        RuntimeHints runtimeHints = new RuntimeHints();
+        InMemoryGeneratedFiles generatedFiles = new InMemoryGeneratedFiles();
+        TestContextAotGenerator generator =
+                new TestContextAotGenerator(generatedFiles, runtimeHints);
+
+        try {
+            generator.processAheadOfTime(Stream.of(WebApplicationTestCase.class));
+
+            assertThat(runtimeHints.resources().resourcePatternHints()
+                    .map(ResourcePatternHints::getIncludes)
+                    .flatMap(Collection::stream)
+                    .anyMatch(hint -> WEB_RESOURCE_PATTERN.equals(hint.getPattern())))
+                    .isTrue();
+        } catch (IllegalStateException ex) {
+            assertThat(ex)
+                    .hasMessage("Cannot perform AOT processing during AOT run-time execution");
+        }
+    }
+
+    @WebAppConfiguration(WEB_RESOURCE_BASE_PATH)
+    @ContextConfiguration(classes = TestConfiguration.class, loader = TestAotContextLoader.class)
+    static class WebApplicationTestCase {
+    }
+
+    static class TestConfiguration {
+    }
+
+    public static class TestAotContextLoader implements AotContextLoader {
+        @Override
+        public void processContextConfiguration(ContextConfigurationAttributes configAttributes) {
+        }
+
+        @Override
+        public ApplicationContext loadContext(MergedContextConfiguration mergedConfig) {
+            GenericApplicationContext context = new GenericApplicationContext();
+            context.refresh();
+            return context;
+        }
+
+        @Override
+        public ApplicationContext loadContextForAotProcessing(
+                MergedContextConfiguration mergedConfig) {
+
+            return new GenericApplicationContext();
+        }
+
+        @Override
+        public ApplicationContext loadContextForAotRuntime(MergedContextConfiguration mergedConfig,
+                ApplicationContextInitializer<ConfigurableApplicationContext> initializer) {
+
+            GenericApplicationContext context = new GenericApplicationContext();
+            initializer.initialize(context);
+            context.refresh();
+            return context;
+        }
+    }
+}
diff --git 1/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org_springframework/spring_test/ProfileValueUtilsTest.java 2/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org_springframework/spring_test/ProfileValueUtilsTest.java
new file mode 100644
index 0000000000..93bd1e908f
--- /dev/null
+++ 2/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org_springframework/spring_test/ProfileValueUtilsTest.java
@@ -0,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_test;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.test.annotation.ProfileValueSource;
+import org.springframework.test.annotation.ProfileValueSourceConfiguration;
+import org.springframework.test.annotation.ProfileValueUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProfileValueUtilsTest {
+    @Test
+    void retrievesConfiguredProfileValueSource() {
+        ProfileValueSource profileValueSource =
+                ProfileValueUtils.retrieveProfileValueSource(ProfileConfiguredTestCase.class);
+
+        assertThat(profileValueSource).isInstanceOf(TestProfileValueSource.class);
+        assertThat(profileValueSource.get("spring.profile")).isEqualTo("configured");
+    }
+
+    @ProfileValueSourceConfiguration(TestProfileValueSource.class)
+    static class ProfileConfiguredTestCase {
+    }
+
+    public static class TestProfileValueSource implements ProfileValueSource {
+        @Override
+        public String get(String key) {
+            if ("spring.profile".equals(key)) {
+                return "configured";
+            }
+            return null;
+        }
+    }
+}
diff --git 1/tests/src/org.springframework/spring-test/3.0.5.RELEASE/src/test/java/org_springframework/spring_test/SimpleNamingContextBuilderTest.java 2/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org_springframework/spring_test/SimpleNamingContextBuilderTest.java
index b6e5980ee5..d9eb469288 100644
--- 1/tests/src/org.springframework/spring-test/3.0.5.RELEASE/src/test/java/org_springframework/spring_test/SimpleNamingContextBuilderTest.java
+++ 2/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org_springframework/spring_test/SimpleNamingContextBuilderTest.java
@@ -7,7 +7,6 @@
 package org_springframework.spring_test;
 
 import java.util.Hashtable;
-import java.util.Properties;
 
 import javax.naming.Context;
 import javax.naming.NamingException;
@@ -15,33 +14,32 @@ import javax.naming.spi.InitialContextFactory;
 
 import org.junit.jupiter.api.Test;
 
-import org.springframework.mock.jndi.SimpleNamingContextBuilder;
+import org.springframework.core.env.Profiles;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.mock.env.MockPropertySource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SimpleNamingContextBuilderTest {
     @Test
-    void createsInitialContextFactoryFromEnvironmentClass() {
-        SimpleNamingContextBuilder builder = new SimpleNamingContextBuilder();
-        builder.deactivate();
-        TestInitialContextFactory.createdInstances = 0;
-
-        Properties environment = new Properties();
-        environment.put(Context.INITIAL_CONTEXT_FACTORY, TestInitialContextFactory.class);
-
-        InitialContextFactory factory = builder.createInitialContextFactory(environment);
-
-        assertThat(factory).isInstanceOf(TestInitialContextFactory.class);
-        assertThat(TestInitialContextFactory.createdInstances).isEqualTo(1);
+    void resolvesClassValuedPropertiesAndProfilesFromMockPropertySources() {
+        MockPropertySource propertySource = new MockPropertySource("testProperties")
+                .withProperty(Context.INITIAL_CONTEXT_FACTORY, TestInitialContextFactory.class)
+                .withProperty("application.name", "reachability-metadata")
+                .withProperty("application.retries", "3");
+
+        MockEnvironment environment = new MockEnvironment();
+        environment.getPropertySources().addFirst(propertySource);
+        environment.setActiveProfiles("native", "test");
+
+        assertThat(environment.getProperty(Context.INITIAL_CONTEXT_FACTORY, Object.class))
+                .isSameAs(TestInitialContextFactory.class);
+        assertThat(environment.getRequiredProperty("application.name")).isEqualTo("reachability-metadata");
+        assertThat(environment.getProperty("application.retries", Integer.class)).isEqualTo(3);
+        assertThat(environment.acceptsProfiles(Profiles.of("native & test"))).isTrue();
     }
 
     public static class TestInitialContextFactory implements InitialContextFactory {
-        static int createdInstances;
-
-        public TestInitialContextFactory() {
-            createdInstances++;
-        }
-
         @Override
         public Context getInitialContext(Hashtable<?, ?> environment) throws NamingException {
             return null;
diff --git 1/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org_springframework/spring_test/SpringJUnit4ClassRunnerTest.java 2/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org_springframework/spring_test/SpringJUnit4ClassRunnerTest.java
new file mode 100644
index 0000000000..4c16621477
--- /dev/null
+++ 2/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org_springframework/spring_test/SpringJUnit4ClassRunnerTest.java
@@ -0,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_test;
+
+import org.junit.jupiter.api.Test;
+import org.junit.runner.Description;
+import org.junit.runners.model.InitializationError;
+
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SpringJUnit4ClassRunnerTest {
+    @Test
+    void createsRunnerForJUnit4TestClass() throws InitializationError {
+        SpringJUnit4ClassRunner runner = new SpringJUnit4ClassRunner(PlainJUnit4TestCase.class);
+
+        Description description = runner.getDescription();
+
+        assertThat(description.getTestClass()).isEqualTo(PlainJUnit4TestCase.class);
+        assertThat(description.getChildren()).hasSize(1);
+        assertThat(description.getChildren().get(0).getMethodName()).isEqualTo("sampleTest");
+    }
+
+    public static class PlainJUnit4TestCase {
+        @org.junit.Test
+        public void sampleTest() {
+        }
+    }
+}
diff --git 1/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org_springframework/spring_test/TestContextManagerTest.java 2/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org_springframework/spring_test/TestContextManagerTest.java
new file mode 100644
index 0000000000..71e1e34a67
--- /dev/null
+++ 2/tests/src/org.springframework/spring-test/6.0.0/src/test/java/org_springframework/spring_test/TestContextManagerTest.java
@@ -0,0 +1,157 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_test;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.AttributeAccessorSupport;
+import org.springframework.test.annotation.DirtiesContext.HierarchyMode;
+import org.springframework.test.context.BootstrapContext;
+import org.springframework.test.context.MergedContextConfiguration;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.TestContextBootstrapper;
+import org.springframework.test.context.TestContextManager;
+import org.springframework.test.context.TestExecutionListener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestContextManagerTest {
+    @Test
+    void usesTestContextCopyConstructorForThreadLocalContext() {
+        CopyableTestContext.resetCopyCount();
+        CopyableTestContext original = new CopyableTestContext(ManagedTestCase.class);
+        TestContextManager manager = new TestContextManager(new CopyableBootstrapper(original));
+
+        TestContext testContext = manager.getTestContext();
+
+        assertThat(testContext).isInstanceOf(CopyableTestContext.class);
+        CopyableTestContext copy = (CopyableTestContext) testContext;
+        assertThat(copy).isNotSameAs(original);
+        assertThat(copy.getSource()).isSameAs(original);
+        assertThat(copy.getTestClass()).isEqualTo(ManagedTestCase.class);
+        assertThat(CopyableTestContext.getCopyCount()).isEqualTo(1);
+        assertThat(manager.getTestContext()).isSameAs(copy);
+        assertThat(CopyableTestContext.getCopyCount()).isEqualTo(1);
+    }
+
+    static class ManagedTestCase {
+    }
+
+    static class CopyableBootstrapper implements TestContextBootstrapper {
+        private final TestContext testContext;
+
+        private BootstrapContext bootstrapContext;
+
+        CopyableBootstrapper(TestContext testContext) {
+            this.testContext = testContext;
+        }
+
+        @Override
+        public void setBootstrapContext(BootstrapContext bootstrapContext) {
+            this.bootstrapContext = bootstrapContext;
+        }
+
+        @Override
+        public BootstrapContext getBootstrapContext() {
+            return this.bootstrapContext;
+        }
+
+        @Override
+        public TestContext buildTestContext() {
+            return this.testContext;
+        }
+
+        @Override
+        public MergedContextConfiguration buildMergedContextConfiguration() {
+            throw new UnsupportedOperationException("Merged context configuration is not needed");
+        }
+
+        @Override
+        public List<TestExecutionListener> getTestExecutionListeners() {
+            return Collections.emptyList();
+        }
+    }
+
+    public static class CopyableTestContext extends AttributeAccessorSupport implements TestContext {
+        private static int copyCount;
+
+        private final Class<?> testClass;
+
+        private final CopyableTestContext source;
+
+        private Object testInstance;
+
+        private Method testMethod;
+
+        private Throwable testException;
+
+        CopyableTestContext(Class<?> testClass) {
+            this.testClass = testClass;
+            this.source = null;
+        }
+
+        public CopyableTestContext(CopyableTestContext source) {
+            copyCount++;
+            this.testClass = source.testClass;
+            this.source = source;
+            copyAttributesFrom(source);
+        }
+
+        static void resetCopyCount() {
+            copyCount = 0;
+        }
+
+        static int getCopyCount() {
+            return copyCount;
+        }
+
+        CopyableTestContext getSource() {
+            return this.source;
+        }
+
+        @Override
+        public ApplicationContext getApplicationContext() {
+            throw new IllegalStateException("No application context is configured");
+        }
+
+        @Override
+        public Class<?> getTestClass() {
+            return this.testClass;
+        }
+
+        @Override
+        public Object getTestInstance() {
+            return this.testInstance;
+        }
+
+        @Override
+        public Method getTestMethod() {
+            return this.testMethod;
+        }
+
+        @Override
+        public Throwable getTestException() {
+            return this.testException;
+        }
+
+        @Override
+        public void markApplicationContextDirty(HierarchyMode hierarchyMode) {
+        }
+
+        @Override
+        public void updateState(Object testInstance, Method testMethod, Throwable testException) {
+            this.testInstance = testInstance;
+            this.testMethod = testMethod;
+            this.testException = testException;
+        }
+    }
+}
diff --git 1/tests/src/org.springframework/spring-test/3.0.5.RELEASE/user-code-filter.json 2/tests/src/org.springframework/spring-test/6.0.0/user-code-filter.json
index f270613a92..edd3b67705 100644
--- 1/tests/src/org.springframework/spring-test/3.0.5.RELEASE/user-code-filter.json
+++ 2/tests/src/org.springframework/spring-test/6.0.0/user-code-filter.json
@@ -6,6 +6,9 @@
     {
       "includeClasses" : "org.springframework.**"
     },
+    {
+      "includeClasses" : "org.springframework.test.context.aot.**"
+    },
     {
       "includeClasses" : "org_springframework.spring_test.**"
     }

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
