### PR TITLE
[GenAI] Mark org.apache.hadoop:hadoop-client as not for Native Image

### DIFF
--- a/metadata/org.apache.hadoop/hadoop-client/index.json
+++ b/metadata/org.apache.hadoop/hadoop-client/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The hadoop-client 2.7.3 Maven JAR contains only META-INF license, notice, and Maven metadata files and no JVM .class files.",
+    "replacement": "Use the class-bearing Hadoop module artifacts declared by this client aggregate, such as org.apache.hadoop:hadoop-common:2.7.3, org.apache.hadoop:hadoop-hdfs:2.7.3, org.apache.hadoop:hadoop-mapreduce-client-core:2.7.3, org.apache.hadoop:hadoop-mapreduce-client-jobclient:2.7.3, and org.apache.hadoop:hadoop-yarn-api:2.7.3."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #2664

This PR records `org.apache.hadoop:hadoop-client` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The hadoop-client 2.7.3 Maven JAR contains only META-INF license, notice, and Maven metadata files and no JVM .class files.

Replacement guidance:
- Use the class-bearing Hadoop module artifacts declared by this client aggregate, such as org.apache.hadoop:hadoop-common:2.7.3, org.apache.hadoop:hadoop-hdfs:2.7.3, org.apache.hadoop:hadoop-mapreduce-client-core:2.7.3, org.apache.hadoop:hadoop-mapreduce-client-jobclient:2.7.3, and org.apache.hadoop:hadoop-yarn-api:2.7.3.

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `0688aab9203961a15dc8b10bf26f1d0362ab4356`

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
