### PR TITLE
[GenAI] Test fix for org.specs2:specs2-core_3:5.5.0 using gpt-5.5

### DIFF
--- a/metadata/org.specs2/specs2-core_3/5.5.0/reachability-metadata.json
+++ b/metadata/org.specs2/specs2-core_3/5.5.0/reachability-metadata.json
@@ -1,0 +1,70 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.specs2.execute.Failure$"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.specs2.specification.core.StacktraceLocation$"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.specs2.collection.Seqx"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.specs2.reporter.BufferedPrinterLogger"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.specs2.specification.create.S2StringContext$"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.specs2.text.TextTable"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.specs2.control.producer.Producers"
+      },
+      "type": "org.specs2.specification.core.Fragment[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.specs2.specification.core.EnvDefault$"
+      },
+      "type": "scala.collection.concurrent.CNodeBase"
+    },
+    {
+      "condition": {
+        "typeReached": "org.specs2.specification.core.EnvDefault$"
+      },
+      "type": "scala.collection.concurrent.INodeBase"
+    },
+    {
+      "condition": {
+        "typeReached": "org.specs2.specification.core.EnvDefault$"
+      },
+      "type": "scala.collection.concurrent.MainNode"
+    },
+    {
+      "condition": {
+        "typeReached": "org.specs2.specification.core.EnvDefault$"
+      },
+      "type": "scala.collection.concurrent.TrieMap"
+    }
+  ]
+}

--- a/metadata/org.specs2/specs2-core_3/index.json
+++ b/metadata/org.specs2/specs2-core_3/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "5.5.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/specs2/specs2-core_3/$version$/specs2-core_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/etorreborre/specs2",
+    "test-code-url" : "https://github.com/etorreborre/specs2/tree/SPECS2-$version$/core/jvm/src/test/scala/org/specs2",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/specs2/specs2-core_3/$version$/specs2-core_3-$version$-javadoc.jar",
+    "description" : "specs2-core provides the core implementation of the specs2 testing framework for Scala 3, including specification structure, execution, reporting, and runner support. It is used to define and run acceptance and unit specifications with matchers and integrations supplied by the broader specs2 modules.",
     "language" : {
       "name" : "scala",
       "version" : "3"

--- a/metadata/org.specs2/specs2-core_3/index.json
+++ b/metadata/org.specs2/specs2-core_3/index.json
@@ -1,6 +1,20 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "5.5.0",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "5.5.0"
+    ],
+    "allowed-packages" : [
+      "org.specs2",
+      "specs2"
+    ]
+  },
+  {
     "metadata-version" : "5.0.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/specs2/specs2-core_3/$version$/specs2-core_3-$version$-sources.jar",
     "repository-url" : "https://github.com/etorreborre/specs2",

--- a/stats/org.specs2/specs2-core_3/5.5.0/execution-metrics.json
+++ b/stats/org.specs2/specs2-core_3/5.5.0/execution-metrics.json
@@ -1,0 +1,115 @@
+{
+  "fix_java_run_fail:2026-06-09": {
+    "timestamp": "2026-06-09T02:57:29.924468Z",
+    "library": "org.specs2:specs2-core_3:5.5.0",
+    "starting_commit": "9cb97cd200b79e46bc6d23dc377063f24b2ac38d",
+    "ending_commit": "f187c924c8742e751de5657dfc221fa7d713e3d2",
+    "previous_library": "org.specs2:specs2-core_3:5.0.0",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "5.5.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5693,
+          "missed": 72115,
+          "ratio": 0.073167,
+          "total": 77808
+        },
+        "line": {
+          "covered": 463,
+          "missed": 2353,
+          "ratio": 0.164418,
+          "total": 2816
+        },
+        "method": {
+          "covered": 531,
+          "missed": 4966,
+          "ratio": 0.096598,
+          "total": 5497
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "5.0.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4792,
+          "missed": 63298,
+          "ratio": 0.070377,
+          "total": 68090
+        },
+        "line": {
+          "covered": 464,
+          "missed": 2307,
+          "ratio": 0.167449,
+          "total": 2771
+        },
+        "method": {
+          "covered": 525,
+          "missed": 4699,
+          "ratio": 0.100498,
+          "total": 5224
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "degraded",
+      "action": "no_action",
+      "issue_number": 8231,
+      "issue_label": "fails-java-run",
+      "library": "org.specs2:specs2-core_3:5.5.0",
+      "summary": "Library preparation preflight did not produce usable advisory setup.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#8231 [Automation] java run fails for org.specs2:specs2-core_3:5.5.0; label=fails-java-run; body_chars=8015"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "6 existing test file path(s) included"
+        }
+      ],
+      "current_library": "org.specs2:specs2-core_3:5.0.0",
+      "new_version": "5.5.0",
+      "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
+      "model": "oca/gpt-5.5",
+      "prompt_path": "library-preflight-prompt.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.specs2:specs2-core_3:5.5.0/library-preparation-preflight/pi-generation-2026-06-09T02-50-59-430356Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 20605,
+      "cached_input_tokens_used": 123904,
+      "output_tokens_used": 947,
+      "iterations": 1,
+      "cost_usd": 0.0904,
+      "tested_library_loc": 463,
+      "metadata_entries": 11,
+      "previous_library_metadata_entries": 81,
+      "code_coverage_percent": 16.44,
+      "previous_library_coverage_percent": 16.74
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.specs2/specs2-core_3/5.5.0/src/test/scala/org_specs2/specs2_core_3/Specs2_core_3Test.scala",
+      "metadata_file": "metadata/org.specs2/specs2-core_3/5.5.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.specs2/specs2-core_3/5.5.0/stats.json
+++ b/stats/org.specs2/specs2-core_3/5.5.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "5.5.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 5693,
+        "missed" : 72115,
+        "ratio" : 0.073167,
+        "total" : 77808
+      },
+      "line" : {
+        "covered" : 463,
+        "missed" : 2353,
+        "ratio" : 0.164418,
+        "total" : 2816
+      },
+      "method" : {
+        "covered" : 531,
+        "missed" : 4966,
+        "ratio" : 0.096598,
+        "total" : 5497
+      }
+    }
+  } ]
+}

--- a/tests/src/org.specs2/specs2-core_3/5.5.0/.gitignore
+++ b/tests/src/org.specs2/specs2-core_3/5.5.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.specs2/specs2-core_3/5.5.0/build.gradle
+++ b/tests/src/org.specs2/specs2-core_3/5.5.0/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.specs2:specs2-core_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.specs2/specs2-core_3/5.5.0/gradle.properties
+++ b/tests/src/org.specs2/specs2-core_3/5.5.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.specs2:specs2-core_3:5.5.0
+library.version = 5.5.0
+metadata.dir = org.specs2/specs2-core_3/5.5.0/

--- a/tests/src/org.specs2/specs2-core_3/5.5.0/settings.gradle
+++ b/tests/src/org.specs2/specs2-core_3/5.5.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.specs2.specs2-core_3_tests'

--- a/tests/src/org.specs2/specs2-core_3/5.5.0/src/test/scala/org_specs2/specs2_core_3/Specs2_core_3Test.scala
+++ b/tests/src/org.specs2/specs2-core_3/5.5.0/src/test/scala/org_specs2/specs2_core_3/Specs2_core_3Test.scala
@@ -7,7 +7,6 @@
 package org_specs2.specs2_core_3
 
 import scala.collection.mutable.ArrayBuffer
-import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 import scala.util.Failure as TryFailure
 import scala.util.Success as TrySuccess
@@ -230,7 +229,7 @@ class Specs2_core_3Test {
   private def withEnv[A](f: Env => A): A = {
     val env: Env = Env()
     try f(env)
-    finally Await.result(env.shutdown, 10.seconds)
+    finally env.shutdown(10.seconds)
   }
 }
 

--- a/tests/src/org.specs2/specs2-core_3/5.5.0/src/test/scala/org_specs2/specs2_core_3/Specs2_core_3Test.scala
+++ b/tests/src/org.specs2/specs2-core_3/5.5.0/src/test/scala/org_specs2/specs2_core_3/Specs2_core_3Test.scala
@@ -1,0 +1,307 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_specs2.specs2_core_3
+
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+import scala.util.Failure as TryFailure
+import scala.util.Success as TrySuccess
+import scala.util.Try
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.specs2.Spec
+import org.specs2.execute.DecoratedResult
+import org.specs2.execute.Failure
+import org.specs2.execute.PendingUntilFixed
+import org.specs2.execute.Result
+import org.specs2.execute.ResultLogicalCombinators.combineResult
+import org.specs2.execute.Skipped
+import org.specs2.execute.Success
+import org.specs2.matcher.DataTable
+import org.specs2.matcher.MustMatchers
+import org.specs2.reporter.PrinterLogger
+import org.specs2.specification.After
+import org.specs2.specification.Before
+import org.specs2.specification.BeforeAfter
+import org.specs2.specification.Tables
+import org.specs2.specification.core.Env
+import org.specs2.specification.core.Execution
+import org.specs2.specification.core.Fragment
+import org.specs2.specification.core.Fragments
+import org.specs2.specification.core.SpecificationStructure as CoreSpecificationStructure
+import org.specs2.specification.core.SpecStructure
+import org.specs2.specification.core.Text
+import org.specs2.specification.process.DefaultExecutor
+import org.specs2.specification.process.Stats
+
+class Specs2_core_3Test {
+  @Test
+  def buildsAndExecutesImmutableSpecificationsFromTheAcceptanceDsl(): Unit = {
+    val specification: CalculatorAcceptanceSpecification = new CalculatorAcceptanceSpecification
+
+    withEnv { env =>
+      val fragments: List[Fragment] = specification.structure.fragmentsList(env.specs2ExecutionEnv)
+      val renderedText: String = fragments.map(_.description.show).mkString("\n")
+      val examples: List[Fragment] = fragments.filter(Fragment.isExample)
+
+      assertTrue(renderedText.contains("Calculator acceptance"))
+      assertTrue(examples.exists(_.description.show.contains("adds positive integers")))
+      assertTrue(examples.exists(_.description.show.contains("finds a maximum")))
+    }
+
+    val results: List[Result] = executeExamples(specification)
+
+    assertEquals(2, results.size)
+    results.foreach { result =>
+      assertTrue(result.isSuccess, result.message)
+      assertEquals("success", result.statusName)
+    }
+  }
+
+  @Test
+  def buildsAndExecutesMutableSpecificationsWithNestedBlocks(): Unit = {
+    val specification: MutableCollectionSpecification = new MutableCollectionSpecification
+
+    withEnv { env =>
+      val fragments: List[Fragment] = specification.structure.fragmentsList(env.specs2ExecutionEnv)
+      val renderedText: String = fragments.map(_.description.show).mkString("\n")
+
+      assertTrue(renderedText.contains("A mutable collection specification"))
+      assertTrue(renderedText.contains("preserve insertion order"))
+      assertEquals(2, fragments.count(Fragment.isExample))
+    }
+
+    val results: List[Result] = executeExamples(specification)
+
+    assertEquals(2, results.size)
+    assertTrue(results.forall(_.isSuccess), results.map(_.message).mkString("; "))
+  }
+
+  @Test
+  def evaluatesCoreMatchersAndReportsFailuresWithoutThrowing(): Unit = {
+    val combinedSuccess: Result = Specs2CoreExpectations.combinedCollectionAndStringExpectation
+    val failingResult: Result = Specs2CoreExpectations.failingStringExpectation
+    val trySuccess: Result = Specs2CoreExpectations.tryExpectation(TrySuccess(7))
+    val tryFailure: Result = Specs2CoreExpectations.tryFailureExpectation(TryFailure(new IllegalArgumentException("boom")))
+
+    assertTrue(combinedSuccess.isSuccess)
+    assertTrue(trySuccess.isSuccess)
+    assertTrue(tryFailure.isSuccess)
+    assertTrue(failingResult.isFailure)
+    assertTrue(failingResult.message.contains("gamma"), failingResult.message)
+  }
+
+  @Test
+  def composesResultsWithBooleanResultAlgebra(): Unit = {
+    val allSuccessful: Result = Success("validated first condition").and(Success("validated second condition"))
+    val failedConjunction: Result = Success("validated first condition").and(Failure("second condition was not met"))
+    val recoveredDisjunction: Result =
+      Failure("primary condition was not met").or(Success("fallback condition was met"))
+    val failedDisjunction: Result =
+      Failure("primary condition was not met").or(Failure("fallback condition was not met"))
+
+    assertTrue(allSuccessful.isSuccess, allSuccessful.message)
+    assertEquals("success", allSuccessful.statusName)
+    assertTrue(failedConjunction.isFailure)
+    assertEquals("failure", failedConjunction.statusName)
+    assertTrue(recoveredDisjunction.isSuccess, recoveredDisjunction.message)
+    assertTrue(failedDisjunction.isFailure)
+  }
+
+  @Test
+  def executesDataTablesAndDecoratesAggregatedResults(): Unit = {
+    val decorated: DecoratedResult[DataTable] = Specs2CoreExpectations.multiplicationTableResult
+    val dataTable: DataTable = decorated.decorator
+
+    assertTrue(decorated.isSuccess, decorated.message)
+    assertEquals(Seq("value", "double"), dataTable.titles)
+    assertEquals(3, dataTable.rows.size)
+    assertTrue(dataTable.isSuccess)
+    assertTrue(dataTable.show.contains("double"))
+  }
+
+  @Test
+  def composesContextsAndAlwaysRunsAfterActions(): Unit = {
+    val events: ArrayBuffer[String] = ArrayBuffer.empty[String]
+    val before: Before = Before.create(events += "before")
+    val after: After = After.create(events += "after")
+    val beforeAfter: BeforeAfter = BeforeAfter.create(events += "setup", events += "cleanup")
+
+    val successful: Result = before.andThen(Before.create(events += "second-before"))(Success("body"))
+    val cleaned: Result = beforeAfter.andThen(BeforeAfter.create(events += "inner-setup", events += "inner-cleanup")) {
+      Specs2CoreExpectations.equalExpectation(4, 4)
+    }
+    val afterFailure: Result = after(Failure("checked failure", "expected success"))
+
+    assertTrue(successful.isSuccess)
+    assertTrue(cleaned.isSuccess)
+    assertTrue(afterFailure.isFailure)
+    assertEquals(
+      Seq("before", "second-before", "setup", "inner-setup", "cleanup", "inner-cleanup", "after"),
+      events.toSeq
+    )
+  }
+
+  @Test
+  def manipulatesFragmentsExecutionsAndStatistics(): Unit = {
+    withEnv { env =>
+      val firstText: Fragment = Fragment(Text("| first line\n"))
+      val secondText: Fragment = Fragment(Text("| second line"))
+      val successFragment: Fragment = Fragment(Text("successful example"), Execution.result(Success("done"))).setTimeout(2.seconds)
+      val failureFragment: Fragment = Fragment(Text("failing example"), Execution.result(Failure("not done")))
+      val fragments: Fragments = Fragments(firstText, secondText, successFragment, failureFragment).stripMargin.compact
+      val fragmentList: List[Fragment] = fragments.fragmentsList(env.specs2ExecutionEnv)
+      val successResult: Result = successFragment.startExecution(env).executionResult.run(env.specs2ExecutionEnv)
+      val skippedResult: Result = successFragment.skip.executionResult.run(env.specs2ExecutionEnv)
+      val aggregatedStats: Stats = Stats.StatsMonoid.append(Stats(successResult), Stats(Failure("not done")))
+      val trendedStats: Stats = aggregatedStats.updateFrom(Stats(successes = 2, expectations = 2))
+
+      assertEquals(3, fragmentList.size)
+      assertEquals(" first line\n second line", fragmentList.head.description.show)
+      assertTrue(successResult.isSuccess)
+      assertTrue(skippedResult.isSkipped)
+      assertTrue(successFragment.stopOnFail.mustStopOn(Failure("stop")))
+      assertFalse(successFragment.stopOnFail.mustStopOn(Success("continue")))
+      assertEquals(2, aggregatedStats.examples)
+      assertEquals(1, aggregatedStats.successes)
+      assertEquals(1, aggregatedStats.failures)
+      assertTrue(aggregatedStats.hasFailures)
+      assertTrue(trendedStats.trend.exists(_.successes == -1))
+    }
+  }
+
+  @Test
+  def tracksPendingUntilFixedExpectations(): Unit = {
+    val pendingResult: Result = executeExecution(Specs2CoreExpectations.pendingUntilFixedForUnmetExpectation)
+    val fixedResult: Result = executeExecution(Specs2CoreExpectations.pendingUntilFixedForMetExpectation)
+
+    assertEquals("pending", pendingResult.statusName)
+    assertTrue(pendingResult.message.contains("Pending until fixed"), pendingResult.message)
+    assertTrue(fixedResult.isFailure)
+    assertTrue(fixedResult.message.contains("Fixed now"), fixedResult.message)
+  }
+
+  @Test
+  def buffersReporterLinesAndClassifiesResultStatistics(): Unit = {
+    val logger = PrinterLogger.stringPrinterLogger
+    logger.infoLog("starting specs2")
+    logger.infoLog(" core\n")
+    logger.warnLog("watch this")
+    logger.newline()
+    logger.failureLog("expectation failed")
+    logger.newline()
+    logger.errorLog("unexpected error")
+    logger.newline()
+    logger.close()
+
+    val pendingStats: Stats = Stats(Skipped("not selected"))
+    val failureStats: Stats = Stats(Failure("bad value"))
+    val errorStats: Stats = Stats(org.specs2.execute.Error("boom"))
+
+    assertTrue(logger.output.contains("[info] starting specs2 core"), logger.output)
+    assertTrue(logger.output.contains("[warn] watch this"), logger.output)
+    assertTrue(logger.output.contains("[error] expectation failed"), logger.output)
+    assertTrue(pendingStats.hasSuspended)
+    assertTrue(failureStats.hasIssues)
+    assertTrue(errorStats.hasErrors)
+    assertEquals("failure", failureStats.result.statusName)
+  }
+
+  private def executeExamples(specification: CoreSpecificationStructure): List[Result] = {
+    withEnv { env =>
+      val fragments: List[Fragment] = DefaultExecutor.runSpecificationAction(specification, env).run(env.specs2ExecutionEnv)
+      fragments.filter(Fragment.isExample).map(_.executionResult.run(env.specs2ExecutionEnv))
+    }
+  }
+
+  private def executeExecution(execution: Execution): Result =
+    withEnv { env =>
+      execution.startExecution(env).executionResult.run(env.specs2ExecutionEnv)
+    }
+
+  private def withEnv[A](f: Env => A): A = {
+    val env: Env = Env()
+    try f(env)
+    finally Await.result(env.shutdown, 10.seconds)
+  }
+}
+
+final class CalculatorAcceptanceSpecification extends Spec {
+  def is: SpecStructure = s2"""
+ Calculator acceptance
+   adds positive integers $addsPositiveIntegers
+   finds a maximum       $findsAMaximum
+  """
+
+  def addsPositiveIntegers: Result =
+    (2 + 3) === 5
+
+  def findsAMaximum: Result =
+    List(1, 9, 4).max === 9
+}
+
+final class MutableCollectionSpecification extends org.specs2.mutable.Specification with MustMatchers {
+  "A mutable collection specification" should {
+    "preserve insertion order" in {
+      val values: Vector[String] = Vector("first", "second", "third")
+
+      values.mkString(",") === "first,second,third"
+    }
+
+    "support option expectations" in {
+      val maybeValue: Option[Int] = Some(42)
+
+      maybeValue must beSome(42)
+    }
+  }
+}
+
+object Specs2CoreExpectations extends MustMatchers with Tables with PendingUntilFixed {
+  def combinedCollectionAndStringExpectation: Result = {
+    (List("alpha", "beta", "gamma") must contain("beta")) and
+      ("specs2-core" must startWith("specs2")) and
+      (Option("metadata") must beSome("metadata")) and
+      (Right(42) must beRight(42))
+  }
+
+  def failingStringExpectation: Result =
+    "alpha beta" must contain("gamma")
+
+  def tryExpectation(value: Try[Int]): Result =
+    value must beSuccessfulTry(7)
+
+  def tryFailureExpectation(value: Try[Int]): Result =
+    value must beFailedTry.like { case e: IllegalArgumentException => e.getMessage === "boom" }
+
+  def equalExpectation(actual: Int, expected: Int): Result =
+    actual === expected
+
+  def pendingUntilFixedForUnmetExpectation: Execution =
+    pendingUntilFixed("feature is intentionally pending") {
+      "accepted" === "implemented"
+    }
+
+  def pendingUntilFixedForMetExpectation: Execution =
+    pendingUntilFixed("feature is ready") {
+      1 + 1 === 2
+    }
+
+  def multiplicationTableResult: DecoratedResult[DataTable] = {
+    val firstRow: DataRow2[Int, Int] = DataRow2(1, 2)
+    val secondRow: DataRow2[Int, Int] = DataRow2(4, 8)
+    val thirdRow: DataRow2[Int, Int] = DataRow2(7, 14)
+    val table: Table2[Int, Int] = TableHeader(List("value")).|("double").|>(firstRow).|(secondRow).|(thirdRow)
+
+    table.|> { (value: Int, double: Int) =>
+      value * 2 === double
+    }
+  }
+}

--- a/tests/src/org.specs2/specs2-core_3/5.5.0/user-code-filter.json
+++ b/tests/src/org.specs2/specs2-core_3/5.5.0/user-code-filter.json
@@ -1,0 +1,16 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.specs2.**"
+    },
+    {
+      "includeClasses" : "specs2.**"
+    },
+    {
+      "includeClasses" : "org_specs2.specs2_core_3.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #8231

This PR provides test fixes and new metadata for org.specs2:specs2-core_3:5.5.0, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 20605
- Cached input tokens: 123904
- Output tokens: 947
- Metadata entries: 11
- Iterations: 1
- Library coverage percentage: 16.44
- Previous library version metadata entries: 81
- Previous library version coverage percentage: 16.74

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `f19db3614bc8644ff70614572168bfec05dd19eb`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.specs2:specs2-core_3:5.0.0: 0/0 covered calls (100.00%)
- org.specs2:specs2-core_3:5.5.0: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.specs2:specs2-core_3:5.0.0: 4792/68090 (7.04%)
- org.specs2:specs2-core_3:5.5.0: 5693/77808 (7.32%)

**Line:**
- org.specs2:specs2-core_3:5.0.0: 464/2771 (16.74%)
- org.specs2:specs2-core_3:5.5.0: 463/2816 (16.44%)

**Method:**
- org.specs2:specs2-core_3:5.0.0: 525/5224 (10.05%)
- org.specs2:specs2-core_3:5.5.0: 531/5497 (9.66%)

**Comparison between existing test version and AI-Generated update**

```diff

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
