### PR TITLE
[GenAI] Test fix for org.codehaus.plexus:plexus-classworlds:2.10.0 using gpt-5.5

### DIFF
--- a/metadata/org.codehaus.plexus/plexus-classworlds/2.10.0/reachability-metadata.json
+++ b/metadata/org.codehaus.plexus/plexus-classworlds/2.10.0/reachability-metadata.json
@@ -1,34 +1,10 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org.codehaus.plexus.classworlds.launcher.Launcher"
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.launcher.Launcher"
       },
-      "type": "java.lang.reflect.Method[]"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.plexus.classworlds.launcher.Launcher"
-      },
-      "type": "org_codehaus_plexus.plexus_classworlds.LauncherTest$EnhancedMain"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.plexus.classworlds.launcher.Launcher"
-      },
-      "type": "org_codehaus_plexus.plexus_classworlds.LauncherTest$EnhancedResourceMain"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.plexus.classworlds.launcher.Launcher"
-      },
-      "type": "org_codehaus_plexus.plexus_classworlds.LauncherTest$StandardMain"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.plexus.classworlds.launcher.Launcher"
-      },
-      "type": "org_codehaus_plexus.plexus_classworlds.LauncherTest$StandardResourceMain"
+      "type" : "java.lang.reflect.Method[]"
     }
   ]
 }

--- a/metadata/org.codehaus.plexus/plexus-classworlds/2.10.0/reachability-metadata.json
+++ b/metadata/org.codehaus.plexus/plexus-classworlds/2.10.0/reachability-metadata.json
@@ -1,0 +1,34 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type": "org_codehaus_plexus.plexus_classworlds.LauncherTest$EnhancedMain"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type": "org_codehaus_plexus.plexus_classworlds.LauncherTest$EnhancedResourceMain"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type": "org_codehaus_plexus.plexus_classworlds.LauncherTest$StandardMain"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type": "org_codehaus_plexus.plexus_classworlds.LauncherTest$StandardResourceMain"
+    }
+  ]
+}

--- a/metadata/org.codehaus.plexus/plexus-classworlds/index.json
+++ b/metadata/org.codehaus.plexus/plexus-classworlds/index.json
@@ -1,6 +1,16 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.10.0",
+    "tested-versions" : [
+      "2.10.0"
+    ],
+    "allowed-packages" : [
+      "org.codehaus.classworlds",
+      "org.codehaus.plexus.classworlds"
+    ]
+  },
+  {
     "metadata-version" : "2.4.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/$version$/plexus-classworlds-$version$-sources.jar",
     "repository-url" : "https://github.com/codehaus-plexus/plexus-classworlds",

--- a/metadata/org.codehaus.plexus/plexus-classworlds/index.json
+++ b/metadata/org.codehaus.plexus/plexus-classworlds/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.10.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/$version$/plexus-classworlds-$version$-sources.jar",
+    "repository-url" : "https://github.com/codehaus-plexus/plexus-classworlds",
+    "test-code-url" : "https://github.com/codehaus-plexus/plexus-classworlds/tree/plexus-classworlds-$version$/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/$version$/plexus-classworlds-$version$-javadoc.jar",
+    "description" : "Plexus Classworlds is a framework for creating and managing isolated Java class loader realms. It lets container-style applications and build tools load components with controlled classpath separation and package imports between realms.",
     "tested-versions" : [
       "2.10.0"
     ],

--- a/stats/org.codehaus.plexus/plexus-classworlds/2.10.0/execution-metrics.json
+++ b/stats/org.codehaus.plexus/plexus-classworlds/2.10.0/execution-metrics.json
@@ -1,0 +1,144 @@
+{
+  "fix_javac_fail:2026-06-09": {
+    "timestamp": "2026-06-09T05:23:21.433786Z",
+    "library": "org.codehaus.plexus:plexus-classworlds:2.10.0",
+    "starting_commit": "332f997ea8159b1d8011054dde99e0b3e127db38",
+    "ending_commit": "9ac9fb74cbd4aa13657ea131a1133d172572b011",
+    "previous_library": "org.codehaus.plexus:plexus-classworlds:2.4.2",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.10.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 7,
+            "totalCalls": 7
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 8,
+            "totalCalls": 8
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 15,
+        "totalCalls": 15
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1020,
+          "missed": 1612,
+          "ratio": 0.387538,
+          "total": 2632
+        },
+        "line": {
+          "covered": 278,
+          "missed": 383,
+          "ratio": 0.420575,
+          "total": 661
+        },
+        "method": {
+          "covered": 72,
+          "missed": 63,
+          "ratio": 0.533333,
+          "total": 135
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.4.2",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 7,
+            "totalCalls": 7
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 7,
+            "totalCalls": 7
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 14,
+        "totalCalls": 14
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 982,
+          "missed": 2457,
+          "ratio": 0.285548,
+          "total": 3439
+        },
+        "line": {
+          "covered": 274,
+          "missed": 607,
+          "ratio": 0.31101,
+          "total": 881
+        },
+        "method": {
+          "covered": 74,
+          "missed": 160,
+          "ratio": 0.316239,
+          "total": 234
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "advisory_preparation",
+      "issue_number": 8229,
+      "issue_label": "fails-javac-compile",
+      "library": "org.codehaus.plexus:plexus-classworlds:2.10.0",
+      "summary": "No deterministic setup is needed: plexus-classworlds 2.10.0 has no runtime Maven dependencies and does not require Docker or external services. The compile failure comes from tests using the removed legacy org.codehaus.classworlds package instead of the current org.codehaus.plexus.classworlds API.",
+      "deterministic_setup": [],
+      "agent_guidance": "Use the 2.10.0 public API packages: org.codehaus.plexus.classworlds.ClassWorld and org.codehaus.plexus.classworlds.realm.ClassRealm. Exercise coverage by creating ClassWorld/ClassRealm instances, adding/importing URLs or resources, and optionally configuring Launcher with classworlds.conf; do not add or rely on legacy org.codehaus.classworlds classes.",
+      "risks": [
+        "Latest upstream documentation mentions restored legacy compatibility in later versions, but the resolved 2.10.0 artifact itself does not contain org.codehaus.classworlds classes.",
+        "Tests that add old classworlds artifacts as extra dependencies may mask the actual 2.10.0 API surface and provide misleading coverage."
+      ],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#8229 [Automation] javac compile fails for org.codehaus.plexus:plexus-classworlds:2.10.0; label=fails-javac-compile; body_chars=8015"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "13 existing test file path(s) included"
+        }
+      ],
+      "current_library": "org.codehaus.plexus:plexus-classworlds:2.4.2",
+      "new_version": "2.10.0",
+      "model": "oca/gpt-5.5",
+      "input_tokens_used": 28995,
+      "output_tokens_used": 3267,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.codehaus.plexus:plexus-classworlds:2.10.0/library-preparation-preflight/pi-generation-2026-06-09T05-14-43-192493Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 40735,
+      "cached_input_tokens_used": 376832,
+      "output_tokens_used": 3097,
+      "iterations": 2,
+      "cost_usd": 0.2813,
+      "tested_library_loc": 278,
+      "metadata_entries": 1,
+      "test_only_metadata_entries": 23,
+      "previous_library_metadata_entries": 1,
+      "previous_library_test_only_metadata_entries": 23,
+      "code_coverage_percent": 42.06,
+      "previous_library_coverage_percent": 31.1
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/src/test/java/org_codehaus_plexus/plexus_classworlds/DefaultStrategyTest.java",
+      "metadata_file": "metadata/org.codehaus.plexus/plexus-classworlds/2.10.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.codehaus.plexus/plexus-classworlds/2.10.0/stats.json
+++ b/stats/org.codehaus.plexus/plexus-classworlds/2.10.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "2.10.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 7,
+          "totalCalls" : 7
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 8,
+          "totalCalls" : 8
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 15,
+      "totalCalls" : 15
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1020,
+        "missed" : 1612,
+        "ratio" : 0.387538,
+        "total" : 2632
+      },
+      "line" : {
+        "covered" : 278,
+        "missed" : 383,
+        "ratio" : 0.420575,
+        "total" : 661
+      },
+      "method" : {
+        "covered" : 72,
+        "missed" : 63,
+        "ratio" : 0.533333,
+        "total" : 135
+      }
+    }
+  } ]
+}

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/.gitignore
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/build.gradle
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.codehaus.plexus:plexus-classworlds:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/gradle.properties
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.codehaus.plexus:plexus-classworlds:2.10.0
+library.version = 2.10.0
+metadata.dir = org.codehaus.plexus/plexus-classworlds/2.10.0/

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/settings.gradle
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.codehaus.plexus.plexus-classworlds_tests'

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmAdapterTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmAdapterTest.java
@@ -10,15 +10,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URL;
 
-import org.codehaus.classworlds.ClassRealm;
-import org.codehaus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
 import org.junit.jupiter.api.Test;
 
 public class ClassRealmAdapterTest {
     @Test
-    void getResourceDelegatesThroughLegacyRealmAdapter() throws Exception {
+    void getResourceDelegatesThroughRealmClassLoader() throws Exception {
         ClassWorld world = new ClassWorld();
-        ClassRealm realm = world.newRealm("legacy-adapter-realm", ClassRealmAdapterTest.class.getClassLoader());
+        ClassRealm realm = world.newRealm("adapter-realm", ClassRealmAdapterTest.class.getClassLoader());
 
         URL resource = realm.getResource("classworlds.conf");
 

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmAdapterTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmAdapterTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_classworlds;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URL;
+
+import org.codehaus.classworlds.ClassRealm;
+import org.codehaus.classworlds.ClassWorld;
+import org.junit.jupiter.api.Test;
+
+public class ClassRealmAdapterTest {
+    @Test
+    void getResourceDelegatesThroughLegacyRealmAdapter() throws Exception {
+        ClassWorld world = new ClassWorld();
+        ClassRealm realm = world.newRealm("legacy-adapter-realm", ClassRealmAdapterTest.class.getClassLoader());
+
+        URL resource = realm.getResource("classworlds.conf");
+
+        assertThat(resource).isNotNull();
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java
@@ -37,6 +37,16 @@ public class ClassRealmTest {
     }
 
     @Test
+    void getResourcesLoadsResourcesThroughRealmClassLoader() throws Exception {
+        ClassRealm realm = newRealm();
+
+        Enumeration<URL> resources = realm.getResources("classworlds.conf");
+
+        assertThat(resources).isNotNull();
+        assertThat(resources.hasMoreElements()).isTrue();
+    }
+
+    @Test
     void loadClassUsesParentClassLoaderWhenRealmHasNoMatchingClass() throws Exception {
         ClassRealm realm = new ClassWorld().newRealm("parent-class-loader-realm", null);
         realm.setParentClassLoader(ClassRealmTest.class.getClassLoader());

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_classworlds;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URL;
+import java.util.Enumeration;
+
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.junit.jupiter.api.Test;
+
+public class ClassRealmTest {
+    private static final String REALM_ID = "direct-realm";
+
+    @Test
+    void loadClassLoadsClassThroughRealmClassLoader() throws Exception {
+        ClassRealm realm = newRealm();
+
+        Class<?> loadedClass = realm.loadClass(ClassRealmTest.class.getName());
+
+        assertThat(loadedClass).isSameAs(ClassRealmTest.class);
+    }
+
+    @Test
+    void getResourceLoadsResourceThroughRealmClassLoader() throws Exception {
+        ClassRealm realm = newRealm();
+
+        URL resource = realm.getResource("classworlds.conf");
+
+        assertThat(resource).isNotNull();
+    }
+
+    @Test
+    void loadClassUsesParentClassLoaderWhenRealmHasNoMatchingClass() throws Exception {
+        ClassRealm realm = new ClassWorld().newRealm("parent-class-loader-realm", null);
+        realm.setParentClassLoader(ClassRealmTest.class.getClassLoader());
+
+        Class<?> loadedClass = realm.loadClass(ClassRealmTest.class.getName());
+
+        assertThat(loadedClass).isSameAs(ClassRealmTest.class);
+    }
+
+    @Test
+    void loadResourceFromParentUsesForeignClassLoader() throws Exception {
+        ClassRealm realm = newRealmWithParentClassLoader();
+
+        URL resource = realm.loadResourceFromParent("classworlds.conf");
+
+        assertThat(resource).isNotNull();
+    }
+
+    @Test
+    void loadResourcesFromParentUsesForeignClassLoader() throws Exception {
+        ClassRealm realm = newRealmWithParentClassLoader();
+
+        Enumeration<?> resources = realm.loadResourcesFromParent("classworlds.conf");
+
+        assertThat(resources).isNotNull();
+        assertThat(resources.hasMoreElements()).isTrue();
+    }
+
+    private static ClassRealm newRealm() throws Exception {
+        ClassWorld world = new ClassWorld();
+        return world.newRealm(REALM_ID, ClassRealmTest.class.getClassLoader());
+    }
+
+    private static ClassRealm newRealmWithParentClassLoader() throws Exception {
+        ClassRealm realm = newRealm();
+        realm.setParentClassLoader(ClassRealmTest.class.getClassLoader());
+        return realm;
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/src/test/java/org_codehaus_plexus/plexus_classworlds/DefaultStrategyTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/src/test/java/org_codehaus_plexus/plexus_classworlds/DefaultStrategyTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_classworlds;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy;
+import org.junit.jupiter.api.Test;
+
+public class DefaultStrategyTest {
+    private static final String REALM_ID = "default-realm";
+
+    @Test
+    void loadClassDelegatesClassworldsClassesToClassworldsClassLoader() throws Exception {
+        ClassRealm realm = new ClassWorld().newRealm(REALM_ID);
+
+        Class<?> loadedClass = realm.loadClass(ClassWorld.class.getName());
+
+        assertThat(realm.getStrategy()).isInstanceOf(SelfFirstStrategy.class);
+        assertThat(loadedClass).isSameAs(ClassWorld.class);
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ForeignStrategyTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ForeignStrategyTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_classworlds;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy;
+import org.junit.jupiter.api.Test;
+
+public class ForeignStrategyTest {
+    private static final String CLASS_NAME = ForeignLoadTarget.class.getName();
+    private static final String REALM_ID = "foreign-realm";
+    private static final String RESOURCE_NAME = "foreign/resource.txt";
+
+    @Test
+    void loadClassConsultsImportedClassLoaderFirst() throws Exception {
+        ClassLoader foreignClassLoader = new ClassLoader(
+                ForeignStrategyTest.class.getClassLoader()) {
+        };
+        SelfFirstStrategy strategy = newSelfFirstStrategy(
+                foreignClassLoader, ForeignLoadTarget.class.getPackageName());
+
+        Class<?> loadedClass = strategy.loadClass(CLASS_NAME);
+
+        assertThat(loadedClass).isEqualTo(ForeignLoadTarget.class);
+    }
+
+    @Test
+    void getResourceConsultsImportedClassLoaderFirst() throws Exception {
+        RecordingClassLoader foreignClassLoader = new RecordingClassLoader();
+        SelfFirstStrategy strategy = newSelfFirstStrategy(foreignClassLoader, "foreign");
+
+        URL resource = strategy.getResource(RESOURCE_NAME);
+
+        assertThat(resource).isEqualTo(foreignClassLoader.resource);
+        assertThat(foreignClassLoader.resourceLookups).containsExactly(RESOURCE_NAME);
+    }
+
+    @Test
+    void getResourcesIncludesResourcesFromImportedClassLoader() throws Exception {
+        RecordingClassLoader foreignClassLoader = new RecordingClassLoader();
+        SelfFirstStrategy strategy = newSelfFirstStrategy(foreignClassLoader, "foreign");
+
+        List<URL> resources = resources(strategy.getResources(RESOURCE_NAME));
+
+        assertThat(resources).containsExactly(foreignClassLoader.enumeratedResource);
+        assertThat(foreignClassLoader.resourcesLookups).containsExactly(RESOURCE_NAME);
+    }
+
+    private static SelfFirstStrategy newSelfFirstStrategy(
+            ClassLoader foreignClassLoader, String importedPackage) throws Exception {
+        ClassWorld world = new ClassWorld();
+        ClassRealm realm = world.newRealm(REALM_ID);
+        realm.importFrom(foreignClassLoader, importedPackage);
+        return new SelfFirstStrategy(realm);
+    }
+
+    private static List<URL> resources(Enumeration<?> enumeration) {
+        List<URL> resources = new ArrayList<>();
+        while (enumeration.hasMoreElements()) {
+            resources.add((URL) enumeration.nextElement());
+        }
+        return resources;
+    }
+
+    private static URL fileUrl(String path) {
+        try {
+            return Path.of(path).toUri().toURL();
+        } catch (MalformedURLException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public static final class ForeignLoadTarget {
+    }
+
+    private static final class RecordingClassLoader extends ClassLoader {
+        private final URL resource = fileUrl("/foreign-resource.txt");
+        private final URL enumeratedResource = fileUrl("/foreign-enumerated-resource.txt");
+        private final List<String> resourceLookups = new ArrayList<>();
+        private final List<String> resourcesLookups = new ArrayList<>();
+
+        private RecordingClassLoader() {
+            super(null);
+        }
+
+        @Override
+        public URL getResource(String name) {
+            resourceLookups.add(name);
+            if (RESOURCE_NAME.equals(name)) {
+                return resource;
+            }
+            return null;
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            resourcesLookups.add(name);
+            if (RESOURCE_NAME.equals(name)) {
+                return Collections.enumeration(Collections.singletonList(enumeratedResource));
+            }
+            return Collections.emptyEnumeration();
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/src/test/java/org_codehaus_plexus/plexus_classworlds/LauncherTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/src/test/java/org_codehaus_plexus/plexus_classworlds/LauncherTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_classworlds;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.launcher.Launcher;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.junit.jupiter.api.Test;
+
+public class LauncherTest {
+    private static final String REALM_ID = "test";
+    private static final String CLASSWORLDS_CONF_PROPERTY = "classworlds.conf";
+    private static final String BOOTSTRAPPED_PROPERTY = "classworlds.bootstrapped";
+
+    @Test
+    void launchInvokesEnhancedMainMethodFromConfiguredRealm() throws Exception {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        EnhancedMain.reset();
+        Launcher launcher = configuredLauncher(EnhancedMain.class);
+        try {
+            launcher.launch(new String[] {"alpha", "beta"});
+
+            assertThat(EnhancedMain.args).containsExactly("alpha", "beta");
+            assertThat(EnhancedMain.world).isSameAs(launcher.getWorld());
+            assertThat(EnhancedMain.contextClassLoader).isSameAs(launcher.getMainRealm());
+            assertThat(Thread.currentThread().getContextClassLoader()).isSameAs(originalClassLoader);
+            assertThat(launcher.getExitCode()).isEqualTo(21);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    @Test
+    void launchFallsBackToStandardMainMethodFromConfiguredRealm() throws Exception {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        StandardMain.reset();
+        Launcher launcher = configuredLauncher(StandardMain.class);
+        try {
+            launcher.launch(new String[] {"gamma"});
+
+            assertThat(StandardMain.args).containsExactly("gamma");
+            assertThat(StandardMain.contextClassLoader).isSameAs(launcher.getMainRealm());
+            assertThat(Thread.currentThread().getContextClassLoader()).isSameAs(originalClassLoader);
+            assertThat(launcher.getExitCode()).isEqualTo(34);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    @Test
+    void mainWithExitCodeLoadsClasspathConfigurationResource() throws Exception {
+        StandardResourceMain.reset();
+        withLauncherResourceLookup(false, () -> {
+            int exitCode = Launcher.mainWithExitCode(new String[] {"from-classpath"});
+
+            assertThat(exitCode).isEqualTo(55);
+            assertThat(StandardResourceMain.args).containsExactly("from-classpath");
+        });
+    }
+
+    @Test
+    void mainWithExitCodeLoadsBootstrappedUberjarConfigurationResource() throws Exception {
+        EnhancedResourceMain.reset();
+        withLauncherResourceLookup(true, () -> {
+            int exitCode = Launcher.mainWithExitCode(new String[] {"from-uberjar"});
+
+            assertThat(exitCode).isEqualTo(89);
+            assertThat(EnhancedResourceMain.args).containsExactly("from-uberjar");
+            assertThat(EnhancedResourceMain.world).isNotNull();
+        });
+    }
+
+    private static Launcher configuredLauncher(Class<?> mainClass) throws Exception {
+        ClassLoader applicationClassLoader = LauncherTest.class.getClassLoader();
+        ClassLoader systemClassLoader = Thread.currentThread().getContextClassLoader();
+        ClassWorld world = new ClassWorld();
+        ClassRealm realm = world.newRealm(REALM_ID, applicationClassLoader);
+        Launcher launcher = new Launcher();
+        launcher.setSystemClassLoader(systemClassLoader);
+        launcher.setWorld(world);
+        launcher.setAppMain(mainClass.getName(), realm.getId());
+        return launcher;
+    }
+
+    private static void withLauncherResourceLookup(boolean bootstrapped, ThrowingRunnable runnable) throws Exception {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        String originalConf = System.getProperty(CLASSWORLDS_CONF_PROPERTY);
+        String originalBootstrapped = System.getProperty(BOOTSTRAPPED_PROPERTY);
+        try {
+            Thread.currentThread().setContextClassLoader(LauncherTest.class.getClassLoader());
+            System.clearProperty(CLASSWORLDS_CONF_PROPERTY);
+            if (bootstrapped) {
+                System.setProperty(BOOTSTRAPPED_PROPERTY, "true");
+            } else {
+                System.clearProperty(BOOTSTRAPPED_PROPERTY);
+            }
+            runnable.run();
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+            restoreProperty(CLASSWORLDS_CONF_PROPERTY, originalConf);
+            restoreProperty(BOOTSTRAPPED_PROPERTY, originalBootstrapped);
+        }
+    }
+
+    private static void restoreProperty(String property, String value) {
+        if (value == null) {
+            System.clearProperty(property);
+        } else {
+            System.setProperty(property, value);
+        }
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+
+    public static class EnhancedMain {
+        private static String[] args;
+        private static ClassWorld world;
+        private static ClassLoader contextClassLoader;
+
+        public static int main(String[] arguments, ClassWorld classWorld) {
+            args = arguments.clone();
+            world = classWorld;
+            contextClassLoader = Thread.currentThread().getContextClassLoader();
+            return 21;
+        }
+
+        private static void reset() {
+            args = null;
+            world = null;
+            contextClassLoader = null;
+        }
+    }
+
+    public static class StandardMain {
+        private static String[] args;
+        private static ClassLoader contextClassLoader;
+
+        public static int main(String[] arguments) {
+            args = arguments.clone();
+            contextClassLoader = Thread.currentThread().getContextClassLoader();
+            return 34;
+        }
+
+        private static void reset() {
+            args = null;
+            contextClassLoader = null;
+        }
+    }
+
+    public static class StandardResourceMain {
+        private static String[] args;
+
+        public static int main(String[] arguments) {
+            args = arguments.clone();
+            return 55;
+        }
+
+        private static void reset() {
+            args = null;
+        }
+    }
+
+    public static class EnhancedResourceMain {
+        private static String[] args;
+        private static ClassWorld world;
+
+        public static int main(String[] arguments, ClassWorld classWorld) {
+            args = arguments.clone();
+            world = classWorld;
+            return 89;
+        }
+
+        private static void reset() {
+            args = null;
+            world = null;
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,154 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type" : "org_codehaus_plexus.plexus_classworlds.LauncherTest$EnhancedMain"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type" : "org_codehaus_plexus.plexus_classworlds.LauncherTest$EnhancedResourceMain"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type" : "org_codehaus_plexus.plexus_classworlds.LauncherTest$StandardMain"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "type" : "org_codehaus_plexus.plexus_classworlds.LauncherTest$StandardResourceMain"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.DefaultStrategyTest"
+      },
+      "type" : "org.codehaus.plexus.classworlds.ClassWorld"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.ClassRealmTest"
+      },
+      "type" : "org_codehaus_plexus.plexus_classworlds.ClassRealmTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.LauncherTest"
+      },
+      "type" : "org_codehaus_plexus.plexus_classworlds.LauncherTest$EnhancedMain",
+      "methods" : [
+        {
+          "name" : "main",
+          "parameterTypes" : [
+            "java.lang.String[]",
+            "org.codehaus.plexus.classworlds.ClassWorld"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.LauncherTest"
+      },
+      "type" : "org_codehaus_plexus.plexus_classworlds.LauncherTest$EnhancedResourceMain",
+      "methods" : [
+        {
+          "name" : "main",
+          "parameterTypes" : [
+            "java.lang.String[]",
+            "org.codehaus.plexus.classworlds.ClassWorld"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.LauncherTest"
+      },
+      "type" : "org_codehaus_plexus.plexus_classworlds.LauncherTest$StandardMain",
+      "methods" : [
+        {
+          "name" : "main",
+          "parameterTypes" : [
+            "java.lang.String[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.LauncherTest"
+      },
+      "type" : "org_codehaus_plexus.plexus_classworlds.LauncherTest$StandardResourceMain",
+      "methods" : [
+        {
+          "name" : "main",
+          "parameterTypes" : [
+            "java.lang.String[]"
+          ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.launcher.Launcher"
+      },
+      "glob" : "WORLDS-INF/conf/classworlds.conf"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.classworlds.realm.ClassRealm"
+      },
+      "glob" : "classworlds.conf"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.ClassRealmTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.ClassRealmTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.LauncherTest"
+      },
+      "glob" : "WORLDS-INF/conf/classworlds.conf"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.ClassRealmTest"
+      },
+      "glob" : "classworlds.conf"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.ClassRealmAdapterTest"
+      },
+      "glob" : "classworlds.conf"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_plexus.plexus_classworlds.LauncherTest"
+      },
+      "glob" : "classworlds.conf"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.classworlds.ClassRealmAdapter"
+      },
+      "glob" : "classworlds.conf"
+    }
+  ]
+}

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/src/test/resources/WORLDS-INF/conf/classworlds.conf
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/src/test/resources/WORLDS-INF/conf/classworlds.conf
@@ -1,0 +1,3 @@
+main is org_codehaus_plexus.plexus_classworlds.LauncherTest$EnhancedResourceMain from test
+
+[test]

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/src/test/resources/classworlds.conf
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/src/test/resources/classworlds.conf
@@ -1,0 +1,3 @@
+main is org_codehaus_plexus.plexus_classworlds.LauncherTest$StandardResourceMain from test
+
+[test]

--- a/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/user-code-filter.json
+++ b/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/user-code-filter.json
@@ -1,0 +1,16 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.codehaus.classworlds.**"
+    },
+    {
+      "includeClasses" : "org.codehaus.plexus.classworlds.**"
+    },
+    {
+      "includeClasses" : "org_codehaus_plexus.plexus_classworlds.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #8229

This PR provides test fixes and new metadata for org.codehaus.plexus:plexus-classworlds:2.10.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 40735
- Cached input tokens: 376832
- Output tokens: 3097
- Metadata entries: 1
- Test-only metadata entries: 23
- Iterations: 2
- Library coverage percentage: 42.06
- Previous library version metadata entries: 1
- Previous library version test-only metadata entries: 23
- Previous library version coverage percentage: 31.1

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `d0e6d8fc6dcc1e5ca2605d934b485933ec40cc63`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.codehaus.plexus:plexus-classworlds:2.4.2: 14/14 covered calls (100.00%)
- org.codehaus.plexus:plexus-classworlds:2.10.0: 15/15 covered calls (100.00%)

**Reflection:**
- org.codehaus.plexus:plexus-classworlds:2.4.2: 7/7 covered calls (100.00%)
- org.codehaus.plexus:plexus-classworlds:2.10.0: 7/7 covered calls (100.00%)

**Resources:**
- org.codehaus.plexus:plexus-classworlds:2.4.2: 7/7 covered calls (100.00%)
- org.codehaus.plexus:plexus-classworlds:2.10.0: 8/8 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.codehaus.plexus:plexus-classworlds:2.4.2: 982/3439 (28.55%)
- org.codehaus.plexus:plexus-classworlds:2.10.0: 1020/2632 (38.75%)

**Line:**
- org.codehaus.plexus:plexus-classworlds:2.4.2: 274/881 (31.10%)
- org.codehaus.plexus:plexus-classworlds:2.10.0: 278/661 (42.06%)

**Method:**
- org.codehaus.plexus:plexus-classworlds:2.4.2: 74/234 (31.62%)
- org.codehaus.plexus:plexus-classworlds:2.10.0: 72/135 (53.33%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.codehaus.plexus/plexus-classworlds/2.4.2/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmAdapterTest.java 2/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmAdapterTest.java
index b4ebce1894..c2d2c60621 100644
--- 1/tests/src/org.codehaus.plexus/plexus-classworlds/2.4.2/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmAdapterTest.java
+++ 2/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmAdapterTest.java
@@ -10,15 +10,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URL;
 
-import org.codehaus.classworlds.ClassRealm;
-import org.codehaus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
 import org.junit.jupiter.api.Test;
 
 public class ClassRealmAdapterTest {
     @Test
-    void getResourceDelegatesThroughLegacyRealmAdapter() throws Exception {
+    void getResourceDelegatesThroughRealmClassLoader() throws Exception {
         ClassWorld world = new ClassWorld();
-        ClassRealm realm = world.newRealm("legacy-adapter-realm", ClassRealmAdapterTest.class.getClassLoader());
+        ClassRealm realm = world.newRealm("adapter-realm", ClassRealmAdapterTest.class.getClassLoader());
 
         URL resource = realm.getResource("classworlds.conf");
 
diff --git 1/tests/src/org.codehaus.plexus/plexus-classworlds/2.4.2/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java 2/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java
index 0336424446..d9be0b6ee2 100644
--- 1/tests/src/org.codehaus.plexus/plexus-classworlds/2.4.2/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java
+++ 2/tests/src/org.codehaus.plexus/plexus-classworlds/2.10.0/src/test/java/org_codehaus_plexus/plexus_classworlds/ClassRealmTest.java
@@ -36,6 +36,16 @@ public class ClassRealmTest {
         assertThat(resource).isNotNull();
     }
 
+    @Test
+    void getResourcesLoadsResourcesThroughRealmClassLoader() throws Exception {
+        ClassRealm realm = newRealm();
+
+        Enumeration<URL> resources = realm.getResources("classworlds.conf");
+
+        assertThat(resources).isNotNull();
+        assertThat(resources.hasMoreElements()).isTrue();
+    }
+
     @Test
     void loadClassUsesParentClassLoaderWhenRealmHasNoMatchingClass() throws Exception {
         ClassRealm realm = new ClassWorld().newRealm("parent-class-loader-realm", null);

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
