### PR TITLE
[GenAI] Test fix for org.eclipse.sisu:org.eclipse.sisu.inject:0.9.0.M1 using gpt-5.5

### DIFF
--- a/metadata/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/reachability-metadata.json
+++ b/metadata/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/reachability-metadata.json
@@ -1,0 +1,628 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.bean.LifecycleBuilder"
+      },
+      "type" : "java.lang.reflect.Method[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.DefaultRankingFunction"
+      },
+      "type" : "java.lang.reflect.Method[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.DefaultRankingFunction"
+      },
+      "type" : "javax.annotation.Priority"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.InjectorPublisher"
+      },
+      "type" : "com.google.inject.spi.ElementSource",
+      "methods" : [
+        {
+          "name" : "getDeclaringSource",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.space.URLClassSpace"
+      },
+      "type" : "org.eclipse.sisu.space.URLClassSpace"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.WireModule"
+      },
+      "type" : "org.eclipse.sisu.wire.WireModule"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.WireModule"
+      },
+      "type" : "java.lang.Integer",
+      "methods" : [
+        {
+          "name" : "parseInt",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.WireModule"
+      },
+      "type" : "java.lang.Long",
+      "methods" : [
+        {
+          "name" : "parseLong",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.WireModule"
+      },
+      "type" : "java.lang.Boolean",
+      "methods" : [
+        {
+          "name" : "parseBoolean",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.WireModule"
+      },
+      "type" : "java.lang.Byte",
+      "methods" : [
+        {
+          "name" : "parseByte",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.WireModule"
+      },
+      "type" : "java.lang.Short",
+      "methods" : [
+        {
+          "name" : "parseShort",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.WireModule"
+      },
+      "type" : "java.lang.Float",
+      "methods" : [
+        {
+          "name" : "parseFloat",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.WireModule"
+      },
+      "type" : "java.lang.Double",
+      "methods" : [
+        {
+          "name" : "parseDouble",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.WireModule"
+      },
+      "type" : "java.lang.invoke.MethodHandles$Lookup",
+      "methods" : [
+        {
+          "name" : "defineHiddenClass",
+          "parameterTypes" : [
+            "byte[]",
+            "boolean",
+            "java.lang.invoke.MethodHandles$Lookup$ClassOption[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.WireModule"
+      },
+      "type" : "java.lang.invoke.MethodHandles$Lookup$ClassOption"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.WireModule"
+      },
+      "type" : "sun.misc.Unsafe",
+      "fields" : [
+        {
+          "name" : "theUnsafe"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "staticFieldBase",
+          "parameterTypes" : [
+            "java.lang.reflect.Field"
+          ]
+        },
+        {
+          "name" : "staticFieldOffset",
+          "parameterTypes" : [
+            "java.lang.reflect.Field"
+          ]
+        },
+        {
+          "name" : "getObject",
+          "parameterTypes" : [
+            "java.lang.Object",
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.WireModule"
+      },
+      "type" : "com.google.inject.internal.InjectorShell$RootModule"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.WireModule"
+      },
+      "type" : "com.google.inject.AbstractModule"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.WireModule"
+      },
+      "type" : "com.google.inject.util.Modules$EmptyModule"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.ElementAnalyzer"
+      },
+      "type" : "org.sonatype.guice.bean.locators.BeanLocator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.ElementAnalyzer"
+      },
+      "type" : "org.sonatype.guice.bean.locators.MutableBeanLocator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.ElementAnalyzer"
+      },
+      "type" : "org.sonatype.guice.bean.locators.RankingFunction"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.ElementAnalyzer"
+      },
+      "type" : "org.eclipse.sisu.inject.DefaultBeanLocator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.ElementAnalyzer"
+      },
+      "type" : "org.eclipse.sisu.wire.ElementAnalyzer$1"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.AbstractTypeConverter"
+      },
+      "type" : "java.io.File"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.AbstractTypeConverter"
+      },
+      "type" : "java.net.URL"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.AbstractTypeConverter"
+      },
+      "type" : "org.eclipse.sisu.wire.AbstractTypeConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.ParameterKeys"
+      },
+      "type" : "org.eclipse.sisu.Parameters"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.ParameterKeys"
+      },
+      "type" : "java.lang.annotation.Annotation[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.DependencyAnalyzer"
+      },
+      "type" : "java.lang.annotation.Annotation[][]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.ParameterKeys"
+      },
+      "type" : "java.lang.annotation.ElementType[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.ElementAnalyzer"
+      },
+      "type" : "org.eclipse.sisu.wire.MergedProperties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.bean.LifecycleBuilder"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.DefaultRankingFunction"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.bean.LifecycleBuilder"
+      },
+      "type" : {
+        "proxy" : [
+          "javax.annotation.PostConstruct"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.bean.LifecycleBuilder"
+      },
+      "type" : {
+        "proxy" : [
+          "javax.annotation.PreDestroy"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.Legacy"
+      },
+      "type" : {
+        "proxy" : [
+          "org.sonatype.inject.BeanEntry"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.DefaultRankingFunction"
+      },
+      "type" : {
+        "proxy" : [
+          "javax.annotation.Priority"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.InjectorPublisher"
+      },
+      "type" : "com.google.inject.spi.ElementSource"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.Guice4"
+      },
+      "type" : "com.google.inject.internal.InternalProviderInstanceBindingImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.Guice4"
+      },
+      "type" : "com.google.inject.internal.InternalProviderInstanceBindingImpl$Factory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.Guice4"
+      },
+      "type" : "com.google.inject.internal.InternalProviderInstanceBindingImpl$Factory$1"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.Guice4"
+      },
+      "type" : "com.google.inject.internal.InternalProviderInstanceBindingImpl$CyclicFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.Guice4"
+      },
+      "type" : "com.google.inject.internal.InternalProviderInstanceBindingImpl$CyclicFactory$1"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.Guice4"
+      },
+      "type" : "com.google.inject.internal.InternalProviderInstanceBindingImpl$InitializationTiming"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.Guice4"
+      },
+      "type" : "com.google.inject.internal.ProviderMethod"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.Guice4"
+      },
+      "type" : "com.google.inject.internal.ProviderMethod$FastClassProviderMethod"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.Guice4"
+      },
+      "type" : "com.google.inject.internal.ProviderMethod$ReflectionProviderMethod"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.Guice4"
+      },
+      "type" : "com.google.inject.internal.ProviderMethodsModule"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.Guice4"
+      },
+      "type" : "com.google.inject.internal.ProviderMethodsModule$MethodAndAnnotation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.Guice4"
+      },
+      "type" : "com.google.inject.internal.ProviderMethodsModule$Signature"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.bean.DeclaredMembers$View$1"
+      },
+      "type" : "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.DependencyAnalyzer"
+      },
+      "type" : "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.bean.DeclaredMembers$View$2"
+      },
+      "type" : "java.lang.reflect.Method[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.space.asm.ClassWriter"
+      },
+      "type" : "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.space.asm.ClassReader"
+      },
+      "type" : "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.bean.DeclaredMembers$View$3"
+      },
+      "type" : "java.lang.reflect.Field[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.space.asm.ClassWriter"
+      },
+      "type" : "java.util.ArrayList"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.space.asm.ClassWriter"
+      },
+      "type" : "java.util.LinkedList"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.Implementations"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.DependencyAnalyzer"
+      },
+      "type" : {
+        "proxy" : [
+          "com.google.inject.Inject"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.DependencyAnalyzer"
+      },
+      "type" : {
+        "proxy" : [
+          "javax.inject.Qualifier"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.DependencyAnalyzer"
+      },
+      "type" : {
+        "proxy" : [
+          "org.eclipse.sisu.Dynamic"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.DependencyAnalyzer"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Documented"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.DependencyAnalyzer"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.DependencyAnalyzer"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Target"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.Implementations"
+      },
+      "type" : {
+        "proxy" : [
+          "org.eclipse.sisu.Priority"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.Implementations"
+      },
+      "type" : {
+        "proxy" : [
+          "javax.annotation.Priority"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.ParameterKeys"
+      },
+      "type" : {
+        "proxy" : [
+          "com.google.inject.internal.Annotations$TestAnnotation"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.ParameterKeys"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Documented"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.ParameterKeys"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.ParameterKeys"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Target"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.ParameterKeys"
+      },
+      "type" : {
+        "proxy" : [
+          "javax.inject.Qualifier"
+        ]
+      }
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.space.asm.ClassReader"
+      },
+      "glob" : "org/eclipse/sisu/space/asm/ClassReader.class"
+    }
+  ]
+}

--- a/metadata/org.eclipse.sisu/org.eclipse.sisu.inject/index.json
+++ b/metadata/org.eclipse.sisu/org.eclipse.sisu.inject/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "0.9.0.M1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.inject/$version$/org.eclipse.sisu.inject-$version$-sources.jar",
+    "repository-url" : "https://github.com/eclipse-sisu/sisu-project",
+    "test-code-url" : "https://github.com/eclipse-sisu/sisu-project/tree/milestones/$version$/org.eclipse.sisu.inject.tests",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.inject/$version$/org.eclipse.sisu.inject-$version$-javadoc.jar",
+    "description" : "Eclipse Sisu Inject is a JSR-330 dependency injection container built on Google Guice that supports classpath scanning, auto-binding, and dynamic auto-wiring. It lets applications discover named components and wire missing dependencies without requiring explicit Guice module bindings for every component.",
     "tested-versions" : [
       "0.9.0.M1"
     ],

--- a/metadata/org.eclipse.sisu/org.eclipse.sisu.inject/index.json
+++ b/metadata/org.eclipse.sisu/org.eclipse.sisu.inject/index.json
@@ -1,6 +1,16 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "0.9.0.M1",
+    "tested-versions" : [
+      "0.9.0.M1"
+    ],
+    "allowed-packages" : [
+      "org.eclipse.sisu",
+      "org.sonatype.inject"
+    ]
+  },
+  {
     "metadata-version" : "0.3.5",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.inject/$version$/org.eclipse.sisu.inject-$version$-sources.jar",
     "repository-url" : "https://github.com/eclipse-sisu/sisu-project",

--- a/stats/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/execution-metrics.json
+++ b/stats/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/execution-metrics.json
@@ -1,0 +1,170 @@
+{
+  "fix_javac_fail:2026-06-09": {
+    "timestamp": "2026-06-09T06:31:13.689810Z",
+    "library": "org.eclipse.sisu:org.eclipse.sisu.inject:0.9.0.M1",
+    "starting_commit": "44dc6b1d43cff35278576903b80a06da86a42f76",
+    "ending_commit": "e729949ffc972c687c21d9b06579e21cf928313d",
+    "previous_library": "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.5",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "0.9.0.M1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 32,
+            "totalCalls": 32
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 36,
+        "totalCalls": 36
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 10364,
+          "missed": 30343,
+          "ratio": 0.2546,
+          "total": 40707
+        },
+        "line": {
+          "covered": 2473,
+          "missed": 7208,
+          "ratio": 0.255449,
+          "total": 9681
+        },
+        "method": {
+          "covered": 453,
+          "missed": 1076,
+          "ratio": 0.296272,
+          "total": 1529
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "0.3.5",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 29,
+            "totalCalls": 29
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 32,
+        "totalCalls": 32
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 9237,
+          "missed": 28034,
+          "ratio": 0.247833,
+          "total": 37271
+        },
+        "line": {
+          "covered": 2166,
+          "missed": 6135,
+          "ratio": 0.260932,
+          "total": 8301
+        },
+        "method": {
+          "covered": 394,
+          "missed": 941,
+          "ratio": 0.295131,
+          "total": 1335
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "advisory_preparation",
+      "issue_number": 8230,
+      "issue_label": "fails-javac-compile",
+      "library": "org.eclipse.sisu:org.eclipse.sisu.inject:0.9.0.M1",
+      "summary": "Eclipse Sisu Inject is a Guice/JSR-330 container library with Guice declared as a provided dependency; meaningful tests need Guice on the test classpath, and lifecycle coverage needs javax.annotation APIs. No Docker service is involved.",
+      "deterministic_setup": [
+        {
+          "kind": "dependency",
+          "coordinate": "com.google.inject:guice:5.1.0",
+          "scope": "testImplementation",
+          "reason": "org.eclipse.sisu.inject declares Guice as provided and normal Sisu usage creates Guice injectors/modules; the artifact does not bring Guice transitively for tests."
+        },
+        {
+          "kind": "dependency",
+          "coordinate": "javax.annotation:javax.annotation-api:1.3.2",
+          "scope": "testImplementation",
+          "reason": "Sisu lifecycle support uses optional javax.annotation types such as PostConstruct and PreDestroy, which are not provided by modern JDKs."
+        }
+      ],
+      "agent_guidance": "For 0.9.0.M1, do not use the removed MutableBeanLocator.add(Injector,int) API. Publish Guice bindings through InjectorBindings, e.g. create a Guice Injector, wrap it in new InjectorBindings(injector, ranking) or new InjectorBindings(injector), and call locator.add(bindingPublisher) before locating beans.",
+      "risks": [
+        "The existing fixture also has a non-transitive legacy org.sonatype.sisu:sisu-inject-bean dependency for old org.sonatype.guice adapter tests; the typed setup cannot express transitive=false, so avoid introducing that dependency unless preserving an existing fixture that already declares it.",
+        "Optional OSGi, servlet, CDI, SLF4J, JUnit 4, and TestNG imports exist in the bundle manifest, but they are not required unless tests intentionally exercise those integration paths."
+      ],
+      "applied_setup": [
+        {
+          "kind": "dependency",
+          "coordinate": "com.google.inject:guice:5.1.0",
+          "result": "skipped",
+          "reason": "build_gradle_absent"
+        },
+        {
+          "kind": "dependency",
+          "coordinate": "javax.annotation:javax.annotation-api:1.3.2",
+          "result": "skipped",
+          "reason": "build_gradle_absent"
+        }
+      ],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#8230 [Automation] javac compile fails for org.eclipse.sisu:org.eclipse.sisu.inject:0.9.0.M1; label=fails-javac-compile; body_chars=8015"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "23 existing test file path(s) included"
+        }
+      ],
+      "current_library": "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.5",
+      "new_version": "0.9.0.M1",
+      "model": "oca/gpt-5.5",
+      "input_tokens_used": 42762,
+      "output_tokens_used": 5487,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.eclipse.sisu:org.eclipse.sisu.inject:0.9.0.M1/library-preparation-preflight/pi-generation-2026-06-09T06-00-06-009916Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 173108,
+      "cached_input_tokens_used": 2539520,
+      "output_tokens_used": 25603,
+      "iterations": 6,
+      "cost_usd": 2.0379,
+      "tested_library_loc": 2473,
+      "metadata_entries": 87,
+      "test_only_metadata_entries": 15,
+      "previous_library_metadata_entries": 75,
+      "previous_library_test_only_metadata_entries": 15,
+      "code_coverage_percent": 25.54,
+      "previous_library_coverage_percent": 26.09
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/ElementAnalyzerTest.java",
+      "metadata_file": "metadata/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/stats.json
+++ b/stats/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "0.9.0.M1",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 32,
+          "totalCalls" : 32
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 4,
+          "totalCalls" : 4
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 36,
+      "totalCalls" : 36
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 10364,
+        "missed" : 30343,
+        "ratio" : 0.2546,
+        "total" : 40707
+      },
+      "line" : {
+        "covered" : 2473,
+        "missed" : 7208,
+        "ratio" : 0.255449,
+        "total" : 9681
+      },
+      "method" : {
+        "covered" : 453,
+        "missed" : 1076,
+        "ratio" : 0.296272,
+        "total" : 1529
+      }
+    }
+  } ]
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/.gitignore
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/build.gradle
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/build.gradle
@@ -1,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.eclipse.sisu:org.eclipse.sisu.inject:$libraryVersion"
+    testImplementation('org.sonatype.sisu:sisu-inject-bean:2.3.0') {
+        transitive = false
+    }
+    testImplementation 'com.google.inject:guice:5.1.0'
+    testImplementation 'javax.annotation:javax.annotation-api:1.3.2'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/gradle.properties
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.eclipse.sisu:org.eclipse.sisu.inject:0.9.0.M1
+library.version = 0.9.0.M1
+metadata.dir = org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/settings.gradle
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.eclipse.sisu.org.eclipse.sisu.inject_tests'

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/BeanLifecycleTest.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/BeanLifecycleTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+
+import org.eclipse.sisu.bean.LifecycleManager;
+import org.junit.jupiter.api.Test;
+
+public class BeanLifecycleTest {
+    @Test
+    void lifecycleManagerInvokesAnnotatedStartAndStopMethods() {
+        LifecycleManager lifecycleManager = new LifecycleManager();
+        ManagedBean bean = new ManagedBean();
+
+        boolean managedType = lifecycleManager.manage(ManagedBean.class);
+        boolean managedBean = lifecycleManager.manage(bean);
+        boolean unmanagedBean = lifecycleManager.unmanage(bean);
+
+        assertThat(managedType).isTrue();
+        assertThat(managedBean).isTrue();
+        assertThat(unmanagedBean).isTrue();
+        assertThat(bean.events()).containsExactly(
+            "base-start",
+            "managed-start",
+            "managed-stop",
+            "base-stop");
+    }
+
+    private static class BaseBean {
+        private final List<String> events = new ArrayList<>();
+
+        @PostConstruct
+        private void startBase() {
+            events.add("base-start");
+        }
+
+        @PreDestroy
+        private void stopBase() {
+            events.add("base-stop");
+        }
+
+        List<String> events() {
+            return events;
+        }
+    }
+
+    private static final class ManagedBean extends BaseBean {
+        @PostConstruct
+        private void startManaged() {
+            events().add("managed-start");
+        }
+
+        @PreDestroy
+        private void stopManaged() {
+            events().add("managed-stop");
+        }
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/BeanPropertyFieldTest.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/BeanPropertyFieldTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.sisu.bean.BeanProperties;
+import org.eclipse.sisu.bean.BeanProperty;
+import org.junit.jupiter.api.Test;
+
+public class BeanPropertyFieldTest {
+    @Test
+    void beanPropertySetsPrivateFieldValue() {
+        FieldBackedBean bean = new FieldBackedBean();
+
+        BeanProperty<Object> property = findProperty(FieldBackedBean.class, "message");
+        property.set(bean, "configured by field property");
+
+        assertThat(bean.message()).isEqualTo("configured by field property");
+    }
+
+    private static BeanProperty<Object> findProperty(Class<?> beanType, String name) {
+        for (BeanProperty<Object> property : new BeanProperties(beanType)) {
+            if (name.equals(property.getName())) {
+                return property;
+            }
+        }
+        throw new AssertionError("Missing bean property: " + name);
+    }
+
+    private static final class FieldBackedBean {
+        private String message = "unset";
+
+        String message() {
+            return message;
+        }
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/BeanPropertySetterTest.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/BeanPropertySetterTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.sisu.bean.BeanProperties;
+import org.eclipse.sisu.bean.BeanProperty;
+import org.junit.jupiter.api.Test;
+
+public class BeanPropertySetterTest {
+    @Test
+    void beanPropertyInvokesPrivateSetterMethod() {
+        SetterBackedBean bean = new SetterBackedBean();
+
+        BeanProperty<Object> property = findProperty(SetterBackedBean.class, "message");
+        property.set(bean, "configured by setter property");
+
+        assertThat(bean.message()).isEqualTo("configured by setter property");
+    }
+
+    private static BeanProperty<Object> findProperty(Class<?> beanType, String name) {
+        for (BeanProperty<Object> property : new BeanProperties(beanType)) {
+            if (name.equals(property.getName())) {
+                return property;
+            }
+        }
+        throw new AssertionError("Missing bean property: " + name);
+    }
+
+    private static final class SetterBackedBean {
+        private String message = "unset";
+
+        private void setMessage(String message) {
+            this.message = message;
+        }
+
+        String message() {
+            return message;
+        }
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/ClassReaderTest.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/ClassReaderTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+
+import org.eclipse.sisu.space.asm.ClassReader;
+import org.junit.jupiter.api.Test;
+
+public class ClassReaderTest {
+    private static final byte[] MINIMAL_CLASS_BYTES = new byte[] {
+        (byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBE,
+        0x00, 0x00, 0x00, 0x34,
+        0x00, 0x05,
+        0x07, 0x00, 0x02,
+        0x01, 0x00, 0x0C,
+        'e', 'x', 'a', 'm', 'p', 'l', 'e', '/', 'S', 'i', 's', 'u',
+        0x07, 0x00, 0x04,
+        0x01, 0x00, 0x10,
+        'j', 'a', 'v', 'a', '/', 'l', 'a', 'n', 'g', '/', 'O', 'b', 'j', 'e', 'c', 't',
+        0x00, 0x21,
+        0x00, 0x01,
+        0x00, 0x03,
+        0x00, 0x00,
+        0x00, 0x00,
+        0x00, 0x00,
+        0x00, 0x00
+    };
+
+    @Test
+    void readsClassMetadataFromInputStream() throws Exception {
+        ClassReader reader = new ClassReader(new ByteArrayInputStream(MINIMAL_CLASS_BYTES));
+
+        assertThat(reader.getClassName()).isEqualTo("example/Sisu");
+        assertThat(reader.getSuperName()).isEqualTo("java/lang/Object");
+    }
+
+    @Test
+    void readsClassMetadataFromSystemResource() throws Exception {
+        ClassReader reader = new ClassReader(ClassReader.class.getName());
+
+        assertThat(reader.getClassName()).isEqualTo("org/eclipse/sisu/space/asm/ClassReader");
+        assertThat(reader.getSuperName()).isEqualTo("java/lang/Object");
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/ClassWriterTest.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/ClassWriterTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.sisu.space.asm.Opcodes.ACC_PUBLIC;
+import static org.eclipse.sisu.space.asm.Opcodes.ACC_STATIC;
+import static org.eclipse.sisu.space.asm.Opcodes.ACC_SUPER;
+import static org.eclipse.sisu.space.asm.Opcodes.ALOAD;
+import static org.eclipse.sisu.space.asm.Opcodes.ARETURN;
+import static org.eclipse.sisu.space.asm.Opcodes.ASTORE;
+import static org.eclipse.sisu.space.asm.Opcodes.DUP;
+import static org.eclipse.sisu.space.asm.Opcodes.GOTO;
+import static org.eclipse.sisu.space.asm.Opcodes.IFEQ;
+import static org.eclipse.sisu.space.asm.Opcodes.ILOAD;
+import static org.eclipse.sisu.space.asm.Opcodes.INVOKESPECIAL;
+import static org.eclipse.sisu.space.asm.Opcodes.NEW;
+import static org.eclipse.sisu.space.asm.Opcodes.V1_6;
+
+import org.eclipse.sisu.space.asm.ClassReader;
+import org.eclipse.sisu.space.asm.ClassWriter;
+import org.eclipse.sisu.space.asm.Label;
+import org.eclipse.sisu.space.asm.MethodVisitor;
+import org.junit.jupiter.api.Test;
+
+public class ClassWriterTest {
+    @Test
+    void computeFramesResolvesCommonSuperclassForMergedBranchTypes() {
+        ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
+        writer.visit(V1_6, ACC_PUBLIC | ACC_SUPER, "example/GeneratedLists", null, "java/lang/Object", null);
+        addChooseListMethod(writer);
+        writer.visitEnd();
+
+        byte[] bytecode = writer.toByteArray();
+
+        assertThat(bytecode).isNotEmpty();
+        assertThat(new ClassReader(bytecode).getClassName()).isEqualTo("example/GeneratedLists");
+    }
+
+    private static void addChooseListMethod(ClassWriter writer) {
+        MethodVisitor method = writer.visitMethod(ACC_PUBLIC | ACC_STATIC, "choose",
+            "(Z)Ljava/util/AbstractList;", null, null);
+        Label useLinkedList = new Label();
+        Label returnList = new Label();
+
+        method.visitCode();
+        method.visitVarInsn(ILOAD, 0);
+        method.visitJumpInsn(IFEQ, useLinkedList);
+        method.visitTypeInsn(NEW, "java/util/ArrayList");
+        method.visitInsn(DUP);
+        method.visitMethodInsn(INVOKESPECIAL, "java/util/ArrayList", "<init>", "()V", false);
+        method.visitVarInsn(ASTORE, 1);
+        method.visitJumpInsn(GOTO, returnList);
+
+        method.visitLabel(useLinkedList);
+        method.visitTypeInsn(NEW, "java/util/LinkedList");
+        method.visitInsn(DUP);
+        method.visitMethodInsn(INVOKESPECIAL, "java/util/LinkedList", "<init>", "()V", false);
+        method.visitVarInsn(ASTORE, 1);
+
+        method.visitLabel(returnList);
+        method.visitVarInsn(ALOAD, 1);
+        method.visitInsn(ARETURN);
+        method.visitMaxs(0, 0);
+        method.visitEnd();
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/ConstantsTest.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/ConstantsTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+
+import org.eclipse.sisu.space.asm.ClassVisitor;
+import org.eclipse.sisu.space.asm.Opcodes;
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+
+public class ConstantsTest {
+    private static final String GENERATED_VISITOR_NAME =
+        "org_eclipse_sisu.org_eclipse_sisu_inject.ConstantsPreviewVisitor";
+    private static final String GENERATED_VISITOR_INTERNAL_NAME = GENERATED_VISITOR_NAME.replace('.', '/');
+    private static final String GENERATED_VISITOR_RESOURCE = GENERATED_VISITOR_INTERNAL_NAME + ".class";
+    private static final byte[] PREVIEW_CLASS_HEADER = {
+        (byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBE, (byte) 0xFF, (byte) 0xFF
+    };
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void rejectsExperimentalApiForNonPreviewVisitor() {
+        class NonPreviewVisitor extends ClassVisitor {
+            NonPreviewVisitor() {
+                super(Opcodes.ASM10_EXPERIMENTAL);
+            }
+        }
+
+        assertThatThrownBy(NonPreviewVisitor::new)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("can only be used by classes compiled with --enable-preview");
+    }
+
+    @Test
+    void experimentalVisitorAcceptsPreviewBytecodeResourceFromCallerClassLoader() throws Exception {
+        try {
+            PreviewResourceClassLoader classLoader = new PreviewResourceClassLoader();
+            Class<? extends ClassVisitor> visitorClass = classLoader.definePreviewVisitor();
+            ClassVisitor visitor = visitorClass.getConstructor().newInstance();
+
+            assertThat(visitor.getClass().getName()).isEqualTo(GENERATED_VISITOR_NAME);
+        } catch (InvocationTargetException exception) {
+            rethrowUnlessUnsupportedFeatureError(exception.getCause());
+        } catch (Error error) {
+            rethrowUnlessUnsupportedFeatureError(error);
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private static byte[] createPreviewVisitorClassBytes() throws IOException {
+        ByteArrayOutputStream classBytes = new ByteArrayOutputStream();
+        try (DataOutputStream output = new DataOutputStream(classBytes)) {
+            output.writeInt(0xCAFEBABE);
+            output.writeShort(0);
+            output.writeShort(52);
+            output.writeShort(14);
+            writeUtf8(output, GENERATED_VISITOR_INTERNAL_NAME);
+            output.writeByte(7);
+            output.writeShort(1);
+            writeUtf8(output, "org/eclipse/sisu/space/asm/ClassVisitor");
+            output.writeByte(7);
+            output.writeShort(3);
+            writeUtf8(output, "<init>");
+            writeUtf8(output, "(I)V");
+            output.writeByte(12);
+            output.writeShort(5);
+            output.writeShort(6);
+            output.writeByte(10);
+            output.writeShort(4);
+            output.writeShort(7);
+            output.writeByte(3);
+            output.writeInt(Opcodes.ASM10_EXPERIMENTAL);
+            writeUtf8(output, "Code");
+            writeUtf8(output, "()V");
+            writeUtf8(output, "SourceFile");
+            writeUtf8(output, "ConstantsPreviewVisitor.java");
+            output.writeShort(0x0021);
+            output.writeShort(2);
+            output.writeShort(4);
+            output.writeShort(0);
+            output.writeShort(0);
+            output.writeShort(1);
+            writeDefaultConstructor(output);
+            output.writeShort(1);
+            output.writeShort(12);
+            output.writeInt(2);
+            output.writeShort(13);
+        }
+        return classBytes.toByteArray();
+    }
+
+    private static void writeDefaultConstructor(DataOutputStream output) throws IOException {
+        output.writeShort(0x0001);
+        output.writeShort(5);
+        output.writeShort(11);
+        output.writeShort(1);
+        output.writeShort(10);
+        output.writeInt(19);
+        output.writeShort(2);
+        output.writeShort(1);
+        output.writeInt(7);
+        output.writeByte(0x2A);
+        output.writeByte(0x12);
+        output.writeByte(9);
+        output.writeByte(0xB7);
+        output.writeShort(8);
+        output.writeByte(0xB1);
+        output.writeShort(0);
+        output.writeShort(0);
+    }
+
+    private static void writeUtf8(DataOutputStream output, String value) throws IOException {
+        output.writeByte(1);
+        output.writeUTF(value);
+    }
+
+    private static void rethrowUnlessUnsupportedFeatureError(Throwable throwable) {
+        if (throwable instanceof Error error && NativeImageSupport.isUnsupportedFeatureError(error)) {
+            return;
+        }
+        if (throwable instanceof RuntimeException runtimeException) {
+            throw runtimeException;
+        }
+        if (throwable instanceof Error error) {
+            throw error;
+        }
+        throw new IllegalStateException(throwable);
+    }
+
+    private static final class PreviewResourceClassLoader extends ClassLoader {
+        private PreviewResourceClassLoader() {
+            super(ConstantsTest.class.getClassLoader());
+        }
+
+        private Class<? extends ClassVisitor> definePreviewVisitor() throws IOException {
+            byte[] classBytes = createPreviewVisitorClassBytes();
+            Class<?> visitorClass = defineClass(GENERATED_VISITOR_NAME, classBytes, 0, classBytes.length);
+            return visitorClass.asSubclass(ClassVisitor.class);
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            if (GENERATED_VISITOR_RESOURCE.equals(name)) {
+                return new ByteArrayInputStream(PREVIEW_CLASS_HEADER);
+            }
+            return super.getResourceAsStream(name);
+        }
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/DeclaredMembersInnerViewAnonymous1Test.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/DeclaredMembersInnerViewAnonymous1Test.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Member;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.sisu.bean.DeclaredMembers;
+import org.eclipse.sisu.bean.DeclaredMembers.View;
+import org.junit.jupiter.api.Test;
+
+public class DeclaredMembersInnerViewAnonymous1Test {
+    @Test
+    void constructorsViewIteratesDeclaredConstructors() {
+        List<Constructor<?>> constructors = new ArrayList<>();
+
+        for (Member member : new DeclaredMembers(ConstructorFixture.class, View.CONSTRUCTORS)) {
+            assertThat(member).isInstanceOf(Constructor.class);
+            constructors.add((Constructor<?>) member);
+        }
+
+        assertThat(constructors)
+            .hasSize(3)
+            .extracting(Constructor::getParameterCount)
+            .containsExactlyInAnyOrder(0, 1, 2);
+    }
+
+    static final class ConstructorFixture {
+        ConstructorFixture() {
+        }
+
+        private ConstructorFixture(String value) {
+            assertThat(value).isNotNull();
+        }
+
+        ConstructorFixture(String value, int number) {
+            assertThat(value).isNotNull();
+            assertThat(number).isNotNegative();
+        }
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/DefaultRankingFunctionTest.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/DefaultRankingFunctionTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.sisu.Priority;
+import org.eclipse.sisu.inject.DefaultRankingFunction;
+import org.junit.jupiter.api.Test;
+
+import com.google.inject.Binder;
+import com.google.inject.Binding;
+import com.google.inject.Key;
+import com.google.inject.Provider;
+import com.google.inject.spi.BindingScopingVisitor;
+import com.google.inject.spi.BindingTargetVisitor;
+import com.google.inject.spi.ElementVisitor;
+import com.google.inject.spi.UntargettedBinding;
+
+public class DefaultRankingFunctionTest {
+    @Test
+    void rankUsesSisuPriorityAnnotationWhenBindingImplementationIsKnown() {
+        DefaultRankingFunction rankingFunction = new DefaultRankingFunction(13);
+        Binding<SisuPriorityComponent> binding = new UntargettedTestBinding<>(SisuPriorityComponent.class);
+
+        int rank = rankingFunction.rank(binding);
+
+        assertThat(rank).isEqualTo(37);
+        assertThat(rankingFunction.maxRank()).isEqualTo(Integer.MAX_VALUE);
+    }
+
+    @Priority(37)
+    private static final class SisuPriorityComponent {
+    }
+
+    private static final class UntargettedTestBinding<T> implements UntargettedBinding<T> {
+        private final Key<T> key;
+
+        private UntargettedTestBinding(Class<T> implementationType) {
+            this.key = Key.get(implementationType);
+        }
+
+        @Override
+        public Key<T> getKey() {
+            return key;
+        }
+
+        @Override
+        public Provider<T> getProvider() {
+            throw new UnsupportedOperationException("Provider access is not required for ranking");
+        }
+
+        @Override
+        public <V> V acceptTargetVisitor(BindingTargetVisitor<? super T, V> visitor) {
+            return visitor.visit(this);
+        }
+
+        @Override
+        public <V> V acceptScopingVisitor(BindingScopingVisitor<V> visitor) {
+            return visitor.visitNoScoping();
+        }
+
+        @Override
+        public Object getSource() {
+            return getClass();
+        }
+
+        @Override
+        public <V> V acceptVisitor(ElementVisitor<V> visitor) {
+            return visitor.visit(this);
+        }
+
+        @Override
+        public void applyTo(Binder binder) {
+            throw new UnsupportedOperationException("Binding replay is not required for ranking");
+        }
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/ElementAnalyzerTest.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/ElementAnalyzerTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.sisu.wire.WireModule;
+import org.junit.jupiter.api.Test;
+import org.sonatype.guice.bean.locators.BeanLocator;
+import org.sonatype.inject.BeanEntry;
+import org.sonatype.inject.Mediator;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Binder;
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Module;
+
+public class ElementAnalyzerTest {
+    @Test
+    void wireModuleAcceptsLegacyLocatorBindingsWhenCompatibilityApiIsPresent() throws Exception {
+        registerGuicePrimitiveParserMethods();
+        BeanLocator legacyLocator = new LegacyBeanLocator();
+        Module applicationModule = new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(BeanLocator.class).toInstance(legacyLocator);
+                bind(NeedsLegacyLocator.class);
+            }
+        };
+
+        Injector injector = Guice.createInjector(new WireModule(applicationModule));
+
+        assertThat(injector.getInstance(NeedsLegacyLocator.class).locator()).isSameAs(legacyLocator);
+    }
+
+    @Test
+    void wireModuleRoutesUnresolvedConstructorDependenciesToCustomWiring() throws Exception {
+        registerGuicePrimitiveParserMethods();
+        Collaborator collaborator = new WiredCollaborator();
+        List<Key<?>> wiredKeys = new ArrayList<>();
+        Module applicationModule = new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(NeedsCollaborator.class);
+            }
+        };
+
+        Module wireModule = new WireModule(applicationModule).with((Binder binder) -> (Key<?> key) -> {
+            wiredKeys.add(key);
+            if (Key.get(Collaborator.class).equals(key)) {
+                binder.bind(Collaborator.class).toInstance(collaborator);
+            }
+            return true;
+        });
+
+        Injector injector = Guice.createInjector(wireModule);
+
+        assertThat(injector.getInstance(NeedsCollaborator.class).collaborator()).isSameAs(collaborator);
+        assertThat(wiredKeys).containsExactly(Key.get(Collaborator.class));
+    }
+
+    private static void registerGuicePrimitiveParserMethods() throws NoSuchMethodException {
+        Integer.class.getMethod("parseInt", String.class);
+        Long.class.getMethod("parseLong", String.class);
+        Boolean.class.getMethod("parseBoolean", String.class);
+        Byte.class.getMethod("parseByte", String.class);
+        Short.class.getMethod("parseShort", String.class);
+        Float.class.getMethod("parseFloat", String.class);
+        Double.class.getMethod("parseDouble", String.class);
+    }
+
+    private static final class LegacyBeanLocator implements BeanLocator {
+        @Override
+        public <Q extends Annotation, T> Iterable<BeanEntry<Q, T>> locate(Key<T> key) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public <Q extends Annotation, T, W> void watch(Key<T> key, Mediator<Q, T, W> mediator, W watcher) {
+        }
+    }
+
+    private static final class NeedsLegacyLocator {
+        private final BeanLocator locator;
+
+        @Inject
+        private NeedsLegacyLocator(BeanLocator locator) {
+            this.locator = locator;
+        }
+
+        private BeanLocator locator() {
+            return locator;
+        }
+    }
+
+    private interface Collaborator {
+    }
+
+    private static final class WiredCollaborator implements Collaborator {
+    }
+
+    private static final class NeedsCollaborator {
+        private final Collaborator collaborator;
+
+        @Inject
+        private NeedsCollaborator(Collaborator collaborator) {
+            this.collaborator = collaborator;
+        }
+
+        private Collaborator collaborator() {
+            return collaborator;
+        }
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/GlueLoaderTest.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/GlueLoaderTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.inject.Inject;
+
+import org.eclipse.sisu.Dynamic;
+import org.eclipse.sisu.wire.WireModule;
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+public class GlueLoaderTest {
+    @Test
+    void dynamicBeanDependencyIsBackedByGeneratedProviderProxy() throws Exception {
+        try {
+            registerGuicePrimitiveParserMethods();
+            Injector injector = Guice.createInjector(new WireModule(new AbstractModule() {
+                @Override
+                protected void configure() {
+                    bind(DynamicConsumer.class);
+                    bind(GreetingService.class).to(DefaultGreetingService.class);
+                }
+            }));
+
+            DynamicConsumer consumer = injector.getInstance(DynamicConsumer.class);
+
+            assertThat(consumer.greeting()).isEqualTo("hello from dynamic service");
+            assertThat(consumer.proxyClassName()).contains("$__sisu__$dyn");
+        } catch (Error error) {
+            if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                throw error;
+            }
+        } catch (RuntimeException exception) {
+            if (!isUnsupportedDynamicGlueFailure(exception)) {
+                throw exception;
+            }
+        }
+    }
+
+    private static void registerGuicePrimitiveParserMethods() throws NoSuchMethodException {
+        Integer.class.getMethod("parseInt", String.class);
+        Long.class.getMethod("parseLong", String.class);
+        Boolean.class.getMethod("parseBoolean", String.class);
+        Byte.class.getMethod("parseByte", String.class);
+        Short.class.getMethod("parseShort", String.class);
+        Float.class.getMethod("parseFloat", String.class);
+        Double.class.getMethod("parseDouble", String.class);
+    }
+
+    private static boolean isUnsupportedDynamicGlueFailure(Throwable throwable) {
+        for (Throwable current = throwable; current != null; current = current.getCause()) {
+            if (current instanceof Error error && NativeImageSupport.isUnsupportedFeatureError(error)) {
+                return true;
+            }
+            if (current instanceof ClassNotFoundException
+                    && current.getMessage() != null
+                    && current.getMessage().contains("$__sisu__$dyn")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public interface GreetingService {
+        String greeting();
+    }
+
+    public static final class DynamicConsumer {
+        @Inject
+        @Dynamic
+        private GreetingService service;
+
+        private String greeting() {
+            return service.greeting();
+        }
+
+        private String proxyClassName() {
+            return service.getClass().getName();
+        }
+    }
+
+    public static final class DefaultGreetingService implements GreetingService {
+        @Override
+        public String greeting() {
+            return "hello from dynamic service";
+        }
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/Guice4Test.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/Guice4Test.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.inject.Provider;
+
+import org.eclipse.sisu.inject.Guice4;
+import org.junit.jupiter.api.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Binding;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Provides;
+import com.google.inject.spi.ProviderInstanceBinding;
+import com.google.inject.spi.ProvidesMethodBinding;
+
+public class Guice4Test {
+    @Test
+    void invokeStaticBindingInvokesGuiceProvidesMethodBinding() {
+        ProvidesModule module = new ProvidesModule();
+        Injector injector = Guice.createInjector(module);
+        Binding<ProvidedService> binding = injector.getBinding(ProvidedService.class);
+        Provider<?> provider = Guice4.getProviderInstance((ProviderInstanceBinding<?>) binding);
+
+        assertThat(provider).isInstanceOf(ProvidesMethodBinding.class);
+        Object value = Guice4.invokeStaticBinding(binding);
+
+        assertThat(value).isSameAs(module.service());
+        assertThat(module.invocations()).isEqualTo(1);
+    }
+
+    private static final class ProvidesModule extends AbstractModule {
+        private final ProvidedService service = new ProvidedService();
+        private int invocations;
+
+        @Provides
+        ProvidedService provideService() {
+            invocations++;
+            return service;
+        }
+
+        private ProvidedService service() {
+            return service;
+        }
+
+        private int invocations() {
+            return invocations;
+        }
+    }
+
+    private static final class ProvidedService {
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/InjectorBindingsTest.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/InjectorBindingsTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.inject.Inject;
+
+import org.eclipse.sisu.inject.BindingPublisher;
+import org.eclipse.sisu.inject.BindingSubscriber;
+import org.eclipse.sisu.inject.InjectorBindings;
+import org.junit.jupiter.api.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+public class InjectorBindingsTest {
+    @Test
+    void findBindingPublisherInstantiatesParentTemplateForChildInjector() {
+        Injector parent = Guice.createInjector(new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(BindingPublisher.class).to(TemplateBindingPublisher.class);
+            }
+        });
+        Injector child = parent.createChildInjector();
+
+        BindingPublisher publisher = InjectorBindings.findBindingPublisher(child);
+
+        assertThat(publisher).isInstanceOf(TemplateBindingPublisher.class);
+        assertThat(publisher.adapt(Injector.class)).isSameAs(child);
+        assertThat(publisher.maxBindingRank()).isEqualTo(17);
+    }
+
+    public static final class TemplateBindingPublisher implements BindingPublisher {
+        private final Injector injector;
+
+        @Inject
+        public TemplateBindingPublisher(Injector injector) {
+            this.injector = injector;
+        }
+
+        @Override
+        public <T> void subscribe(BindingSubscriber<T> subscriber) {
+        }
+
+        @Override
+        public <T> void unsubscribe(BindingSubscriber<T> subscriber) {
+        }
+
+        @Override
+        public int maxBindingRank() {
+            return 17;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T adapt(Class<T> type) {
+            return Injector.class == type ? (T) injector : null;
+        }
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/InjectorPublisherTest.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/InjectorPublisherTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.sisu.inject.BindingSubscriber;
+import org.eclipse.sisu.inject.InjectorBindings;
+import org.eclipse.sisu.inject.RankingFunction;
+import org.junit.jupiter.api.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Binding;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.MembersInjector;
+import com.google.inject.Module;
+import com.google.inject.Provider;
+import com.google.inject.Scope;
+import com.google.inject.TypeLiteral;
+import com.google.inject.spi.Element;
+import com.google.inject.spi.Elements;
+import com.google.inject.spi.InjectionPoint;
+import com.google.inject.spi.TypeConverterBinding;
+
+public class InjectorPublisherTest {
+    @Test
+    void subscribePublishesBindingDeclaredThroughGuiceElementSource() {
+        Binding<Service> binding = serviceBindingFromModule();
+        RecordingSubscriber<Service> subscriber = new RecordingSubscriber<>(TypeLiteral.get(Service.class));
+        InjectorBindings publisher = new InjectorBindings(new SingleBindingInjector<>(binding), fixedRanking(19));
+
+        publisher.subscribe(subscriber);
+
+        assertThat(subscriber.addedBindings()).containsExactly(binding);
+        assertThat(subscriber.ranks()).containsExactly(19);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Binding<Service> serviceBindingFromModule() {
+        List<Element> elements = Elements.getElements(new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(Service.class).to(ServiceImpl.class);
+            }
+        });
+
+        return elements.stream()
+            .filter(Binding.class::isInstance)
+            .map(element -> (Binding<?>) element)
+            .filter(binding -> Key.get(Service.class).equals(binding.getKey()))
+            .map(binding -> (Binding<Service>) binding)
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException("Expected a Guice binding for Service"));
+    }
+
+    private static RankingFunction fixedRanking(int rank) {
+        return new RankingFunction() {
+            @Override
+            public int maxRank() {
+                return rank;
+            }
+
+            @Override
+            public <T> int rank(Binding<T> binding) {
+                return rank;
+            }
+        };
+    }
+
+    private interface Service {
+    }
+
+    private static final class ServiceImpl implements Service {
+    }
+
+    private static final class RecordingSubscriber<T> implements BindingSubscriber<T> {
+        private final TypeLiteral<T> type;
+        private final List<Binding<T>> addedBindings = new ArrayList<>();
+        private final List<Integer> ranks = new ArrayList<>();
+
+        private RecordingSubscriber(TypeLiteral<T> type) {
+            this.type = type;
+        }
+
+        @Override
+        public TypeLiteral<T> type() {
+            return type;
+        }
+
+        @Override
+        public void add(Binding<T> binding, int rank) {
+            addedBindings.add(binding);
+            ranks.add(rank);
+        }
+
+        @Override
+        public void remove(Binding<T> binding) {
+            addedBindings.remove(binding);
+        }
+
+        @Override
+        public Iterable<Binding<T>> bindings() {
+            return addedBindings;
+        }
+
+        private List<Binding<T>> addedBindings() {
+            return addedBindings;
+        }
+
+        private List<Integer> ranks() {
+            return ranks;
+        }
+    }
+
+    private static final class SingleBindingInjector<T> implements Injector {
+        private final Binding<T> binding;
+        private final Map<Key<?>, Binding<?>> bindings;
+
+        private SingleBindingInjector(Binding<T> binding) {
+            this.binding = binding;
+            this.bindings = Collections.singletonMap(binding.getKey(), binding);
+        }
+
+        @Override
+        public void injectMembers(Object instance) {
+            throw new UnsupportedOperationException("Member injection is not required for publishing bindings");
+        }
+
+        @Override
+        public <S> MembersInjector<S> getMembersInjector(TypeLiteral<S> typeLiteral) {
+            throw new UnsupportedOperationException("Member injection is not required for publishing bindings");
+        }
+
+        @Override
+        public <S> MembersInjector<S> getMembersInjector(Class<S> type) {
+            throw new UnsupportedOperationException("Member injection is not required for publishing bindings");
+        }
+
+        @Override
+        public Map<Key<?>, Binding<?>> getBindings() {
+            return bindings;
+        }
+
+        @Override
+        public Map<Key<?>, Binding<?>> getAllBindings() {
+            return bindings;
+        }
+
+        @Override
+        public <S> Binding<S> getBinding(Key<S> key) {
+            throw new UnsupportedOperationException("Direct binding lookup is not required for publishing bindings");
+        }
+
+        @Override
+        public <S> Binding<S> getBinding(Class<S> type) {
+            throw new UnsupportedOperationException("Direct binding lookup is not required for publishing bindings");
+        }
+
+        @Override
+        public <S> Binding<S> getExistingBinding(Key<S> key) {
+            throw new UnsupportedOperationException("Direct binding lookup is not required for publishing bindings");
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <S> List<Binding<S>> findBindingsByType(TypeLiteral<S> type) {
+            if (binding.getKey().getTypeLiteral().equals(type)) {
+                return Collections.singletonList((Binding<S>) binding);
+            }
+            return Collections.emptyList();
+        }
+
+        @Override
+        public <S> Provider<S> getProvider(Key<S> key) {
+            throw new UnsupportedOperationException("Provider lookup is not required for publishing bindings");
+        }
+
+        @Override
+        public <S> Provider<S> getProvider(Class<S> type) {
+            throw new UnsupportedOperationException("Provider lookup is not required for publishing bindings");
+        }
+
+        @Override
+        public <S> S getInstance(Key<S> key) {
+            throw new UnsupportedOperationException("Instance lookup is not required for publishing bindings");
+        }
+
+        @Override
+        public <S> S getInstance(Class<S> type) {
+            throw new UnsupportedOperationException("Instance lookup is not required for publishing bindings");
+        }
+
+        @Override
+        public Injector getParent() {
+            return null;
+        }
+
+        @Override
+        public Injector createChildInjector(Iterable<? extends Module> modules) {
+            throw new UnsupportedOperationException("Child injectors are not required for publishing bindings");
+        }
+
+        @Override
+        public Injector createChildInjector(Module... modules) {
+            throw new UnsupportedOperationException("Child injectors are not required for publishing bindings");
+        }
+
+        @Override
+        public Map<Class<? extends Annotation>, Scope> getScopeBindings() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public Set<TypeConverterBinding> getTypeConverterBindings() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public List<Element> getElements() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public Map<TypeLiteral<?>, List<InjectionPoint>> getAllMembersInjectorInjectionPoints() {
+            return Collections.emptyMap();
+        }
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/LegacyTest.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/LegacyTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Proxy;
+
+import org.eclipse.sisu.inject.Legacy;
+import org.junit.jupiter.api.Test;
+
+public class LegacyTest {
+    @Test
+    void proxyForwardsInterfaceCallsToDelegate() {
+        registerLegacyBeanEntryProxyInterface();
+        GreetingService delegate = new GreetingService() {
+            @Override
+            public String greet(String name) {
+                return "Hello, " + name;
+            }
+
+            @Override
+            public int invocationCount() {
+                return 1;
+            }
+        };
+
+        GreetingService proxy = Legacy.as(GreetingService.class).proxy(delegate);
+
+        assertThat(proxy).isNotSameAs(delegate);
+        assertThat(proxy.greet("Sisu")).isEqualTo("Hello, Sisu");
+        assertThat(proxy.invocationCount()).isEqualTo(1);
+    }
+
+    @Test
+    void proxyReturnsNullForNullDelegate() {
+        registerLegacyBeanEntryProxyInterface();
+        GreetingService proxy = Legacy.as(GreetingService.class).proxy(null);
+
+        assertThat(proxy).isNull();
+    }
+
+    private static void registerLegacyBeanEntryProxyInterface() {
+        Object proxy = Proxy.newProxyInstance(
+            org.sonatype.inject.BeanEntry.class.getClassLoader(),
+            new Class<?>[] {org.sonatype.inject.BeanEntry.class},
+            (proxyInstance, method, arguments) -> null);
+
+        assertThat(proxy).isInstanceOf(org.sonatype.inject.BeanEntry.class);
+    }
+
+    public interface GreetingService {
+        String greet(String name);
+
+        int invocationCount();
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/QualifiedTypeBinderTest.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/QualifiedTypeBinderTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.sisu.space.QualifiedTypeBinder;
+import org.junit.jupiter.api.Test;
+
+import com.google.inject.Binder;
+import com.google.inject.Binding;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.spi.Element;
+import com.google.inject.spi.Elements;
+
+public class QualifiedTypeBinderTest {
+    private static final Object SOURCE = "qualified-module-source";
+
+    @Test
+    void hearInstallsConcreteModuleByInvokingItsNoArgConstructor() {
+        InstalledPrivateConstructorModule.created().set(0);
+
+        List<Element> elements = Elements.getElements(new ScanningModule());
+
+        boolean installedBinding = elements.stream()
+            .filter(Binding.class::isInstance)
+            .map(Binding.class::cast)
+            .anyMatch(binding -> Key.get(ModuleBoundService.class).equals(binding.getKey()));
+        assertThat(InstalledPrivateConstructorModule.created().get()).isEqualTo(1);
+        assertThat(installedBinding).isTrue();
+    }
+
+    private static final class ScanningModule implements Module {
+        @Override
+        public void configure(Binder binder) {
+            new QualifiedTypeBinder(binder).hear(InstalledPrivateConstructorModule.class, SOURCE);
+        }
+    }
+
+    private static final class InstalledPrivateConstructorModule implements Module {
+        private static final AtomicInteger CREATED = new AtomicInteger();
+
+        private InstalledPrivateConstructorModule() {
+            CREATED.incrementAndGet();
+        }
+
+        @Override
+        public void configure(Binder binder) {
+            binder.bind(ModuleBoundService.class).toInstance(new ModuleBoundService());
+        }
+
+        private static AtomicInteger created() {
+            return CREATED;
+        }
+    }
+
+    private static final class ModuleBoundService {
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/QualifyingStrategyAnonymous4Test.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/QualifyingStrategyAnonymous4Test.java
@@ -17,6 +17,7 @@ import javax.inject.Qualifier;
 
 import org.eclipse.sisu.BeanEntry;
 import org.eclipse.sisu.inject.DefaultBeanLocator;
+import org.eclipse.sisu.inject.InjectorBindings;
 import org.eclipse.sisu.inject.MutableBeanLocator;
 import org.junit.jupiter.api.Test;
 
@@ -38,7 +39,7 @@ public class QualifyingStrategyAnonymous4Test {
         });
         MutableBeanLocator locator = new DefaultBeanLocator();
 
-        locator.add(injector, 0);
+        locator.add(new InjectorBindings(injector));
 
         Iterable<? extends BeanEntry<Annotation, MarkerBoundService>> entries = locator.locate(
             Key.get(MarkerBoundService.class, Marker.class));

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/QualifyingStrategyAnonymous4Test.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/QualifyingStrategyAnonymous4Test.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.Iterator;
+
+import javax.inject.Qualifier;
+
+import org.eclipse.sisu.BeanEntry;
+import org.eclipse.sisu.inject.DefaultBeanLocator;
+import org.eclipse.sisu.inject.MutableBeanLocator;
+import org.junit.jupiter.api.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+
+public class QualifyingStrategyAnonymous4Test {
+    @Test
+    void locateUpgradesMarkerOnlyBindingToQualifierInstance() throws Exception {
+        registerGuicePrimitiveParserMethods();
+        MarkerBoundService service = new MarkerBoundService();
+        Injector injector = Guice.createInjector(new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(MarkerBoundService.class).annotatedWith(Marker.class).toInstance(service);
+            }
+        });
+        MutableBeanLocator locator = new DefaultBeanLocator();
+
+        locator.add(injector, 0);
+
+        Iterable<? extends BeanEntry<Annotation, MarkerBoundService>> entries = locator.locate(
+            Key.get(MarkerBoundService.class, Marker.class));
+        Iterator<? extends BeanEntry<Annotation, MarkerBoundService>> iterator = entries.iterator();
+
+        assertThat(iterator.hasNext()).isTrue();
+        BeanEntry<Annotation, MarkerBoundService> entry = iterator.next();
+        assertThat(entry.getKey().annotationType()).isEqualTo(Marker.class);
+        assertThat(entry.getValue()).isSameAs(service);
+        assertThat(iterator.hasNext()).isFalse();
+    }
+
+    @Qualifier
+    @Retention(RetentionPolicy.RUNTIME)
+    private @interface Marker {
+    }
+
+    private static void registerGuicePrimitiveParserMethods() throws NoSuchMethodException {
+        Integer.class.getMethod("parseInt", String.class);
+        Long.class.getMethod("parseLong", String.class);
+        Boolean.class.getMethod("parseBoolean", String.class);
+        Byte.class.getMethod("parseByte", String.class);
+        Short.class.getMethod("parseShort", String.class);
+        Float.class.getMethod("parseFloat", String.class);
+        Double.class.getMethod("parseDouble", String.class);
+    }
+
+    private static final class MarkerBoundService {
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/SisuExtensionsTest.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/SisuExtensionsTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.eclipse.sisu.launch.SisuExtensions;
+import org.eclipse.sisu.space.URLClassSpace;
+import org.junit.jupiter.api.Test;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+
+public class SisuExtensionsTest {
+    @Test
+    void createInstantiatesIndexedModulesWithContextConstructorAndNoArgFallback() {
+        URLClassSpace classSpace = new URLClassSpace(SisuExtensionsTest.class.getClassLoader());
+        SisuExtensions extensions = SisuExtensions.global(classSpace);
+        ExtensionContext context = new ExtensionContext("sisu-context");
+
+        List<Module> modules = extensions.create(Module.class, ExtensionContext.class, context);
+        List<RecordingModule> recordingModules = modules.stream()
+            .filter(RecordingModule.class::isInstance)
+            .map(RecordingModule.class::cast)
+            .toList();
+
+        assertThat(recordingModules).extracting(RecordingModule::message)
+            .containsExactly("context:sisu-context", "default");
+    }
+
+    public interface RecordingModule extends Module {
+        String message();
+    }
+
+    public static final class ExtensionContext {
+        private final String value;
+
+        private ExtensionContext(String value) {
+            this.value = value;
+        }
+    }
+
+    public static final class ContextualModule implements RecordingModule {
+        private final ExtensionContext context;
+
+        public ContextualModule(ExtensionContext context) {
+            this.context = context;
+        }
+
+        @Override
+        public void configure(Binder binder) {
+        }
+
+        @Override
+        public String message() {
+            return "context:" + context.value;
+        }
+    }
+
+    public static final class DefaultModule implements RecordingModule {
+        public DefaultModule() {
+        }
+
+        @Override
+        public void configure(Binder binder) {
+        }
+
+        @Override
+        public String message() {
+            return "default";
+        }
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/URLClassSpaceTest.java
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/URLClassSpaceTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URL;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+
+import org.eclipse.sisu.space.URLClassSpace;
+import org.junit.jupiter.api.Test;
+
+public class URLClassSpaceTest {
+    private static final String RESOURCE_NAME =
+        "org_eclipse_sisu/org_eclipse_sisu_inject/url-class-space-resource.txt";
+
+    @Test
+    void loadClassDelegatesToBackingClassLoader() {
+        URLClassSpace classSpace = new URLClassSpace(URLClassSpaceTest.class.getClassLoader());
+
+        Class<?> loadedClass = classSpace.loadClass(String.class.getName());
+
+        assertThat(loadedClass).isSameAs(String.class);
+    }
+
+    @Test
+    void getResourceDelegatesToBackingClassLoader() {
+        URLClassSpace classSpace = new URLClassSpace(URLClassSpaceTest.class.getClassLoader());
+
+        URL resource = classSpace.getResource(RESOURCE_NAME);
+
+        assertThat(resource).isNotNull();
+        assertThat(resource.toString()).endsWith(RESOURCE_NAME);
+    }
+
+    @Test
+    void getResourcesDelegatesToBackingClassLoader() {
+        URLClassSpace classSpace = new URLClassSpace(URLClassSpaceTest.class.getClassLoader());
+
+        Enumeration<URL> resourceEnumeration = classSpace.getResources(RESOURCE_NAME);
+        List<URL> resources = Collections.list(resourceEnumeration);
+
+        assertThat(resources).isNotEmpty();
+        assertThat(resources).allSatisfy(resource -> assertThat(resource.toString()).endsWith(RESOURCE_NAME));
+    }
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,101 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org_eclipse_sisu.org_eclipse_sisu_inject.InjectorPublisherTest"
+      },
+      "type" : "org_eclipse_sisu.org_eclipse_sisu_inject.InjectorPublisherTest$1"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_eclipse_sisu.org_eclipse_sisu_inject.InjectorPublisherTest"
+      },
+      "type" : "com.google.inject.AbstractModule"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_eclipse_sisu.org_eclipse_sisu_inject.ElementAnalyzerTest"
+      },
+      "type" : "org_eclipse_sisu.org_eclipse_sisu_inject.ElementAnalyzerTest$1"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.WireModule"
+      },
+      "type" : "org_eclipse_sisu.org_eclipse_sisu_inject.ElementAnalyzerTest$2"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_eclipse_sisu.org_eclipse_sisu_inject.QualifyingStrategyAnonymous4Test"
+      },
+      "type" : "org_eclipse_sisu.org_eclipse_sisu_inject.QualifyingStrategyAnonymous4Test$1"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_eclipse_sisu.org_eclipse_sisu_inject.InjectorPublisherTest"
+      },
+      "type" : "com.google.inject.util.Modules$EmptyModule"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.WireModule"
+      },
+      "type" : "org_eclipse_sisu.org_eclipse_sisu_inject.GlueLoaderTest$1"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.GlueLoader"
+      },
+      "type" : "org_eclipse_sisu.org_eclipse_sisu_inject.GlueLoaderTest$DynamicService$__sisu__$dyn"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.wire.GlueLoader"
+      },
+      "type" : "org_eclipse_sisu.org_eclipse_sisu_inject.GlueLoaderTest$GreetingService$__sisu__$dyn"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_eclipse_sisu.org_eclipse_sisu_inject.LegacyTest"
+      },
+      "type" : {
+        "proxy" : [
+          "org_eclipse_sisu.org_eclipse_sisu_inject.LegacyTest$GreetingService"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.space.QualifiedTypeBinder"
+      },
+      "type" : "org_eclipse_sisu.org_eclipse_sisu_inject.QualifiedTypeBinderTest$InstalledPrivateConstructorModule"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.launch.SisuExtensions"
+      },
+      "type" : "org_eclipse_sisu.org_eclipse_sisu_inject.SisuExtensionsTest$ContextualModule"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.launch.SisuExtensions"
+      },
+      "type" : "org_eclipse_sisu.org_eclipse_sisu_inject.SisuExtensionsTest$DefaultModule"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.inject.Legacy"
+      },
+      "type" : {
+        "proxy" : [
+          "org_eclipse_sisu.org_eclipse_sisu_inject.LegacyTest$GreetingService"
+        ]
+      }
+    }
+  ],
+  "resources" : [
+    {
+      "glob" : "org_eclipse_sisu/org_eclipse_sisu_inject/url-class-space-resource.txt"
+    }
+  ]
+}

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -95,6 +95,12 @@
   ],
   "resources" : [
     {
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.space.asm.Constants"
+      },
+      "glob" : "org_eclipse_sisu/org_eclipse_sisu_inject/ConstantsTest$1NonPreviewVisitor.class"
+    },
+    {
       "glob" : "org_eclipse_sisu/org_eclipse_sisu_inject/url-class-space-resource.txt"
     }
   ]

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -95,12 +95,6 @@
   ],
   "resources" : [
     {
-      "condition" : {
-        "typeReached" : "org.eclipse.sisu.space.asm.Constants"
-      },
-      "glob" : "org_eclipse_sisu/org_eclipse_sisu_inject/ConstantsTest$1NonPreviewVisitor.class"
-    },
-    {
       "glob" : "org_eclipse_sisu/org_eclipse_sisu_inject/url-class-space-resource.txt"
     }
   ]

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/resources/META-INF/services/com.google.inject.Module
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/resources/META-INF/services/com.google.inject.Module
@@ -1,0 +1,2 @@
+org_eclipse_sisu.org_eclipse_sisu_inject.SisuExtensionsTest$ContextualModule
+org_eclipse_sisu.org_eclipse_sisu_inject.SisuExtensionsTest$DefaultModule

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/resources/org_eclipse_sisu/org_eclipse_sisu_inject/url-class-space-resource.txt
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/resources/org_eclipse_sisu/org_eclipse_sisu_inject/url-class-space-resource.txt
@@ -1,0 +1,1 @@
+resource loaded through URLClassSpace

--- a/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/user-code-filter.json
+++ b/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/user-code-filter.json
@@ -1,0 +1,16 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.eclipse.sisu.**"
+    },
+    {
+      "includeClasses" : "org.sonatype.inject.**"
+    },
+    {
+      "includeClasses" : "org_eclipse_sisu.org_eclipse_sisu_inject.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #8230

This PR provides test fixes and new metadata for org.eclipse.sisu:org.eclipse.sisu.inject:0.9.0.M1, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 173108
- Cached input tokens: 2539520
- Output tokens: 25603
- Metadata entries: 87
- Test-only metadata entries: 15
- Iterations: 6
- Library coverage percentage: 25.54
- Previous library version metadata entries: 75
- Previous library version test-only metadata entries: 15
- Previous library version coverage percentage: 26.09

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `b80fd2e16bbceb12246163a014a8331df3802771`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.eclipse.sisu:org.eclipse.sisu.inject:0.3.5: 32/32 covered calls (100.00%)
- org.eclipse.sisu:org.eclipse.sisu.inject:0.9.0.M1: 36/36 covered calls (100.00%)

**Reflection:**
- org.eclipse.sisu:org.eclipse.sisu.inject:0.3.5: 29/29 covered calls (100.00%)
- org.eclipse.sisu:org.eclipse.sisu.inject:0.9.0.M1: 32/32 covered calls (100.00%)

**Resources:**
- org.eclipse.sisu:org.eclipse.sisu.inject:0.3.5: 3/3 covered calls (100.00%)
- org.eclipse.sisu:org.eclipse.sisu.inject:0.9.0.M1: 4/4 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.eclipse.sisu:org.eclipse.sisu.inject:0.3.5: 9237/37271 (24.78%)
- org.eclipse.sisu:org.eclipse.sisu.inject:0.9.0.M1: 10364/40707 (25.46%)

**Line:**
- org.eclipse.sisu:org.eclipse.sisu.inject:0.3.5: 2166/8301 (26.09%)
- org.eclipse.sisu:org.eclipse.sisu.inject:0.9.0.M1: 2473/9681 (25.54%)

**Method:**
- org.eclipse.sisu:org.eclipse.sisu.inject:0.3.5: 394/1335 (29.51%)
- org.eclipse.sisu:org.eclipse.sisu.inject:0.9.0.M1: 453/1529 (29.63%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/ConstantsTest.java 2/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/ConstantsTest.java
new file mode 100644
index 0000000000..d86a0048dd
--- /dev/null
+++ 2/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/ConstantsTest.java
@@ -0,0 +1,162 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+
+import org.eclipse.sisu.space.asm.ClassVisitor;
+import org.eclipse.sisu.space.asm.Opcodes;
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+
+public class ConstantsTest {
+    private static final String GENERATED_VISITOR_NAME =
+        "org_eclipse_sisu.org_eclipse_sisu_inject.ConstantsPreviewVisitor";
+    private static final String GENERATED_VISITOR_INTERNAL_NAME = GENERATED_VISITOR_NAME.replace('.', '/');
+    private static final String GENERATED_VISITOR_RESOURCE = GENERATED_VISITOR_INTERNAL_NAME + ".class";
+    private static final byte[] PREVIEW_CLASS_HEADER = {
+        (byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBE, (byte) 0xFF, (byte) 0xFF
+    };
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void rejectsExperimentalApiForNonPreviewVisitor() {
+        class NonPreviewVisitor extends ClassVisitor {
+            NonPreviewVisitor() {
+                super(Opcodes.ASM10_EXPERIMENTAL);
+            }
+        }
+
+        assertThatThrownBy(NonPreviewVisitor::new)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("can only be used by classes compiled with --enable-preview");
+    }
+
+    @Test
+    void experimentalVisitorAcceptsPreviewBytecodeResourceFromCallerClassLoader() throws Exception {
+        try {
+            PreviewResourceClassLoader classLoader = new PreviewResourceClassLoader();
+            Class<? extends ClassVisitor> visitorClass = classLoader.definePreviewVisitor();
+            ClassVisitor visitor = visitorClass.getConstructor().newInstance();
+
+            assertThat(visitor.getClass().getName()).isEqualTo(GENERATED_VISITOR_NAME);
+        } catch (InvocationTargetException exception) {
+            rethrowUnlessUnsupportedFeatureError(exception.getCause());
+        } catch (Error error) {
+            rethrowUnlessUnsupportedFeatureError(error);
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private static byte[] createPreviewVisitorClassBytes() throws IOException {
+        ByteArrayOutputStream classBytes = new ByteArrayOutputStream();
+        try (DataOutputStream output = new DataOutputStream(classBytes)) {
+            output.writeInt(0xCAFEBABE);
+            output.writeShort(0);
+            output.writeShort(52);
+            output.writeShort(14);
+            writeUtf8(output, GENERATED_VISITOR_INTERNAL_NAME);
+            output.writeByte(7);
+            output.writeShort(1);
+            writeUtf8(output, "org/eclipse/sisu/space/asm/ClassVisitor");
+            output.writeByte(7);
+            output.writeShort(3);
+            writeUtf8(output, "<init>");
+            writeUtf8(output, "(I)V");
+            output.writeByte(12);
+            output.writeShort(5);
+            output.writeShort(6);
+            output.writeByte(10);
+            output.writeShort(4);
+            output.writeShort(7);
+            output.writeByte(3);
+            output.writeInt(Opcodes.ASM10_EXPERIMENTAL);
+            writeUtf8(output, "Code");
+            writeUtf8(output, "()V");
+            writeUtf8(output, "SourceFile");
+            writeUtf8(output, "ConstantsPreviewVisitor.java");
+            output.writeShort(0x0021);
+            output.writeShort(2);
+            output.writeShort(4);
+            output.writeShort(0);
+            output.writeShort(0);
+            output.writeShort(1);
+            writeDefaultConstructor(output);
+            output.writeShort(1);
+            output.writeShort(12);
+            output.writeInt(2);
+            output.writeShort(13);
+        }
+        return classBytes.toByteArray();
+    }
+
+    private static void writeDefaultConstructor(DataOutputStream output) throws IOException {
+        output.writeShort(0x0001);
+        output.writeShort(5);
+        output.writeShort(11);
+        output.writeShort(1);
+        output.writeShort(10);
+        output.writeInt(19);
+        output.writeShort(2);
+        output.writeShort(1);
+        output.writeInt(7);
+        output.writeByte(0x2A);
+        output.writeByte(0x12);
+        output.writeByte(9);
+        output.writeByte(0xB7);
+        output.writeShort(8);
+        output.writeByte(0xB1);
+        output.writeShort(0);
+        output.writeShort(0);
+    }
+
+    private static void writeUtf8(DataOutputStream output, String value) throws IOException {
+        output.writeByte(1);
+        output.writeUTF(value);
+    }
+
+    private static void rethrowUnlessUnsupportedFeatureError(Throwable throwable) {
+        if (throwable instanceof Error error && NativeImageSupport.isUnsupportedFeatureError(error)) {
+            return;
+        }
+        if (throwable instanceof RuntimeException runtimeException) {
+            throw runtimeException;
+        }
+        if (throwable instanceof Error error) {
+            throw error;
+        }
+        throw new IllegalStateException(throwable);
+    }
+
+    private static final class PreviewResourceClassLoader extends ClassLoader {
+        private PreviewResourceClassLoader() {
+            super(ConstantsTest.class.getClassLoader());
+        }
+
+        private Class<? extends ClassVisitor> definePreviewVisitor() throws IOException {
+            byte[] classBytes = createPreviewVisitorClassBytes();
+            Class<?> visitorClass = defineClass(GENERATED_VISITOR_NAME, classBytes, 0, classBytes.length);
+            return visitorClass.asSubclass(ClassVisitor.class);
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            if (GENERATED_VISITOR_RESOURCE.equals(name)) {
+                return new ByteArrayInputStream(PREVIEW_CLASS_HEADER);
+            }
+            return super.getResourceAsStream(name);
+        }
+    }
+}
diff --git 1/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/Guice4Test.java 2/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/Guice4Test.java
new file mode 100644
index 0000000000..5f3485e0d6
--- /dev/null
+++ 2/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/Guice4Test.java
@@ -0,0 +1,60 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.inject.Provider;
+
+import org.eclipse.sisu.inject.Guice4;
+import org.junit.jupiter.api.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Binding;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Provides;
+import com.google.inject.spi.ProviderInstanceBinding;
+import com.google.inject.spi.ProvidesMethodBinding;
+
+public class Guice4Test {
+    @Test
+    void invokeStaticBindingInvokesGuiceProvidesMethodBinding() {
+        ProvidesModule module = new ProvidesModule();
+        Injector injector = Guice.createInjector(module);
+        Binding<ProvidedService> binding = injector.getBinding(ProvidedService.class);
+        Provider<?> provider = Guice4.getProviderInstance((ProviderInstanceBinding<?>) binding);
+
+        assertThat(provider).isInstanceOf(ProvidesMethodBinding.class);
+        Object value = Guice4.invokeStaticBinding(binding);
+
+        assertThat(value).isSameAs(module.service());
+        assertThat(module.invocations()).isEqualTo(1);
+    }
+
+    private static final class ProvidesModule extends AbstractModule {
+        private final ProvidedService service = new ProvidedService();
+        private int invocations;
+
+        @Provides
+        ProvidedService provideService() {
+            invocations++;
+            return service;
+        }
+
+        private ProvidedService service() {
+            return service;
+        }
+
+        private int invocations() {
+            return invocations;
+        }
+    }
+
+    private static final class ProvidedService {
+    }
+}
diff --git 1/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/InjectorBindingsTest.java 2/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/InjectorBindingsTest.java
new file mode 100644
index 0000000000..2fb184cc5e
--- /dev/null
+++ 2/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/InjectorBindingsTest.java
@@ -0,0 +1,67 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_sisu.org_eclipse_sisu_inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.inject.Inject;
+
+import org.eclipse.sisu.inject.BindingPublisher;
+import org.eclipse.sisu.inject.BindingSubscriber;
+import org.eclipse.sisu.inject.InjectorBindings;
+import org.junit.jupiter.api.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+public class InjectorBindingsTest {
+    @Test
+    void findBindingPublisherInstantiatesParentTemplateForChildInjector() {
+        Injector parent = Guice.createInjector(new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(BindingPublisher.class).to(TemplateBindingPublisher.class);
+            }
+        });
+        Injector child = parent.createChildInjector();
+
+        BindingPublisher publisher = InjectorBindings.findBindingPublisher(child);
+
+        assertThat(publisher).isInstanceOf(TemplateBindingPublisher.class);
+        assertThat(publisher.adapt(Injector.class)).isSameAs(child);
+        assertThat(publisher.maxBindingRank()).isEqualTo(17);
+    }
+
+    public static final class TemplateBindingPublisher implements BindingPublisher {
+        private final Injector injector;
+
+        @Inject
+        public TemplateBindingPublisher(Injector injector) {
+            this.injector = injector;
+        }
+
+        @Override
+        public <T> void subscribe(BindingSubscriber<T> subscriber) {
+        }
+
+        @Override
+        public <T> void unsubscribe(BindingSubscriber<T> subscriber) {
+        }
+
+        @Override
+        public int maxBindingRank() {
+            return 17;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T adapt(Class<T> type) {
+            return Injector.class == type ? (T) injector : null;
+        }
+    }
+}
diff --git 1/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.5/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/QualifyingStrategyAnonymous4Test.java 2/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/QualifyingStrategyAnonymous4Test.java
index 98ab36346e..ed49962809 100644
--- 1/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.3.5/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/QualifyingStrategyAnonymous4Test.java
+++ 2/tests/src/org.eclipse.sisu/org.eclipse.sisu.inject/0.9.0.M1/src/test/java/org_eclipse_sisu/org_eclipse_sisu_inject/QualifyingStrategyAnonymous4Test.java
@@ -17,6 +17,7 @@ import javax.inject.Qualifier;
 
 import org.eclipse.sisu.BeanEntry;
 import org.eclipse.sisu.inject.DefaultBeanLocator;
+import org.eclipse.sisu.inject.InjectorBindings;
 import org.eclipse.sisu.inject.MutableBeanLocator;
 import org.junit.jupiter.api.Test;
 
@@ -38,7 +39,7 @@ public class QualifyingStrategyAnonymous4Test {
         });
         MutableBeanLocator locator = new DefaultBeanLocator();
 
-        locator.add(injector, 0);
+        locator.add(new InjectorBindings(injector));
 
         Iterable<? extends BeanEntry<Annotation, MarkerBoundService>> entries = locator.locate(
             Key.get(MarkerBoundService.class, Marker.class));

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
