### PR TITLE
[GenAI] Test fix for org.apache.maven.plugins:maven-jar-plugin:3.4.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.maven.plugins/maven-jar-plugin/3.4.0/reachability-metadata.json
+++ b/metadata/org.apache.maven.plugins/maven-jar-plugin/3.4.0/reachability-metadata.json
@@ -1,0 +1,42 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.plugins.maven_jar_plugin.HelpMojo"
+      },
+      "type": "com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.plugins.maven_jar_plugin.HelpMojo"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.plugins.maven_jar_plugin.HelpMojo"
+      },
+      "type": "short[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.plugins.maven_jar_plugin.HelpMojo"
+      },
+      "type": "short[][]"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.plugins.maven_jar_plugin.HelpMojo"
+      },
+      "glob": "META-INF/maven/org.apache.maven.plugins/maven-jar-plugin/plugin-help.xml"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.plugins.maven_jar_plugin.HelpMojo"
+      },
+      "glob": "META-INF/services/javax.xml.parsers.DocumentBuilderFactory"
+    }
+  ]
+}

--- a/metadata/org.apache.maven.plugins/maven-jar-plugin/index.json
+++ b/metadata/org.apache.maven.plugins/maven-jar-plugin/index.json
@@ -11,7 +11,7 @@
       "3.4.0"
     ],
     "allowed-packages" : [
-      "org.apache.maven.plugins.jar"
+      "org.apache.maven.plugins.maven_jar_plugin"
     ]
   },
   {

--- a/metadata/org.apache.maven.plugins/maven-jar-plugin/index.json
+++ b/metadata/org.apache.maven.plugins/maven-jar-plugin/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "3.4.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/$version$/maven-jar-plugin-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/maven-jar-plugin",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/$version$/maven-jar-plugin-$version$-source-release.zip",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/$version$/maven-jar-plugin-$version$-javadoc.jar",
+    "description" : "Apache Maven JAR Plugin builds Java Archive (JAR) files from a Maven project's compiled classes and resources. It also provides goals for packaging the main artifact and attaching a test JAR containing test classes.",
     "tested-versions" : [
       "3.4.0"
     ],

--- a/metadata/org.apache.maven.plugins/maven-jar-plugin/index.json
+++ b/metadata/org.apache.maven.plugins/maven-jar-plugin/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.4.0",
+    "tested-versions" : [
+      "3.4.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.maven.plugins.jar"
+    ]
+  },
+  {
     "metadata-version" : "3.3.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/$version$/maven-jar-plugin-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/maven-jar-plugin",

--- a/stats/org.apache.maven.plugins/maven-jar-plugin/3.4.0/execution-metrics.json
+++ b/stats/org.apache.maven.plugins/maven-jar-plugin/3.4.0/execution-metrics.json
@@ -1,0 +1,131 @@
+{
+  "fix_javac_fail:2026-06-09": {
+    "timestamp": "2026-06-09T07:48:12.558577Z",
+    "library": "org.apache.maven.plugins:maven-jar-plugin:3.4.0",
+    "starting_commit": "726bc13f0674109f239787c6d30069912b02b895",
+    "ending_commit": "eb54d82513bdeecaa09a7906daaa61209355f2b1",
+    "previous_library": "org.apache.maven.plugins:maven-jar-plugin:3.3.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.4.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 538,
+          "missed": 922,
+          "ratio": 0.368493,
+          "total": 1460
+        },
+        "line": {
+          "covered": 103,
+          "missed": 175,
+          "ratio": 0.370504,
+          "total": 278
+        },
+        "method": {
+          "covered": 14,
+          "missed": 33,
+          "ratio": 0.297872,
+          "total": 47
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.3.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 538,
+          "missed": 671,
+          "ratio": 0.444996,
+          "total": 1209
+        },
+        "line": {
+          "covered": 102,
+          "missed": 125,
+          "ratio": 0.449339,
+          "total": 227
+        },
+        "method": {
+          "covered": 14,
+          "missed": 21,
+          "ratio": 0.4,
+          "total": 35
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "no_action",
+      "issue_number": 8227,
+      "issue_label": "fails-javac-compile",
+      "library": "org.apache.maven.plugins:maven-jar-plugin:3.4.0",
+      "summary": "No extra deterministic setup is needed. The 3.4.0 artifact contains the plugin implementation and its normal transitive runtime dependencies; the javac failure is caused by the generated HelpMojo class moving from org.apache.maven.plugins.jar.HelpMojo in 3.3.0 to org.apache.maven.plugins.maven_jar_plugin.HelpMojo in 3.4.0, not by a missing dependency, service, or initialization step.",
+      "deterministic_setup": [],
+      "agent_guidance": "Do not assume the generated help mojo stays in org.apache.maven.plugins.jar; for 3.4.0 use org.apache.maven.plugins.maven_jar_plugin.HelpMojo or exercise stable plugin classes such as org.apache.maven.plugins.jar.JarMojo/TestJarMojo with local temporary files only if additional coverage is needed.",
+      "risks": [
+        "Directly executing the real jar/test-jar mojos is more involved than executing the help mojo because Maven normally injects project/session/output-directory fields; avoid adding broad Maven harness setup unless the generated test intentionally covers archive creation."
+      ],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#8227 [Automation] javac compile fails for org.apache.maven.plugins:maven-jar-plugin:3.4.0; label=fails-javac-compile; body_chars=8015"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "6 existing test file path(s) included"
+        }
+      ],
+      "current_library": "org.apache.maven.plugins:maven-jar-plugin:3.3.0",
+      "new_version": "3.4.0",
+      "model": "oca/gpt-5.5",
+      "input_tokens_used": 25372,
+      "output_tokens_used": 2755,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.apache.maven.plugins:maven-jar-plugin:3.4.0/library-preparation-preflight/pi-generation-2026-06-09T07-38-15-865991Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 10899,
+      "cached_input_tokens_used": 90112,
+      "output_tokens_used": 900,
+      "iterations": 1,
+      "cost_usd": 0.0721,
+      "tested_library_loc": 103,
+      "metadata_entries": 6,
+      "previous_library_metadata_entries": 6,
+      "code_coverage_percent": 37.05,
+      "previous_library_coverage_percent": 44.93
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.maven.plugins/maven-jar-plugin/3.4.0/src/test/java/org_apache_maven_plugins/maven_jar_plugin/HelpMojoTest.java",
+      "metadata_file": "metadata/org.apache.maven.plugins/maven-jar-plugin/3.4.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.maven.plugins/maven-jar-plugin/3.4.0/stats.json
+++ b/stats/org.apache.maven.plugins/maven-jar-plugin/3.4.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "3.4.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 1,
+      "totalCalls" : 1
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 538,
+        "missed" : 922,
+        "ratio" : 0.368493,
+        "total" : 1460
+      },
+      "line" : {
+        "covered" : 103,
+        "missed" : 175,
+        "ratio" : 0.370504,
+        "total" : 278
+      },
+      "method" : {
+        "covered" : 14,
+        "missed" : 33,
+        "ratio" : 0.297872,
+        "total" : 47
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.4.0/.gitignore
+++ b/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.4.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.4.0/build.gradle
+++ b/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.4.0/build.gradle
@@ -1,0 +1,30 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation("org.apache.maven.plugins:maven-jar-plugin:$libraryVersion") {
+        exclude group: "org.sonatype.sisu", module: "sisu-guice"
+    }
+    testImplementation 'org.apache.maven:maven-plugin-api:3.2.5'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.4.0/gradle.properties
+++ b/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.4.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.maven.plugins:maven-jar-plugin:3.4.0
+library.version = 3.4.0
+metadata.dir = org.apache.maven.plugins/maven-jar-plugin/3.4.0/

--- a/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.4.0/settings.gradle
+++ b/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.4.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.maven.plugins.maven-jar-plugin_tests'

--- a/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.4.0/src/test/java/org_apache_maven_plugins/maven_jar_plugin/HelpMojoTest.java
+++ b/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.4.0/src/test/java/org_apache_maven_plugins/maven_jar_plugin/HelpMojoTest.java
@@ -8,7 +8,7 @@ package org_apache_maven_plugins.maven_jar_plugin;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-import org.apache.maven.plugins.jar.HelpMojo;
+import org.apache.maven.plugins.maven_jar_plugin.HelpMojo;
 import org.junit.jupiter.api.Test;
 
 public class HelpMojoTest {

--- a/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.4.0/src/test/java/org_apache_maven_plugins/maven_jar_plugin/HelpMojoTest.java
+++ b/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.4.0/src/test/java/org_apache_maven_plugins/maven_jar_plugin/HelpMojoTest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_plugins.maven_jar_plugin;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.apache.maven.plugins.jar.HelpMojo;
+import org.junit.jupiter.api.Test;
+
+public class HelpMojoTest {
+    @Test
+    void executeLoadsPluginHelpResource() {
+        HelpMojo mojo = new HelpMojo();
+
+        assertThatCode(mojo::execute).doesNotThrowAnyException();
+    }
+}

--- a/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.4.0/user-code-filter.json
+++ b/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.4.0/user-code-filter.json
@@ -7,6 +7,9 @@
       "includeClasses" : "org.apache.maven.plugins.jar.**"
     },
     {
+      "includeClasses" : "org.apache.maven.plugins.**"
+    },
+    {
       "includeClasses" : "org_apache_maven_plugins.maven_jar_plugin.**"
     }
   ]

--- a/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.4.0/user-code-filter.json
+++ b/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.4.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.maven.plugins.jar.**"
+    },
+    {
+      "includeClasses" : "org_apache_maven_plugins.maven_jar_plugin.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #8227

This PR provides test fixes and new metadata for org.apache.maven.plugins:maven-jar-plugin:3.4.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 10899
- Cached input tokens: 90112
- Output tokens: 900
- Metadata entries: 6
- Iterations: 1
- Library coverage percentage: 37.05
- Previous library version metadata entries: 6
- Previous library version coverage percentage: 44.93

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `b80fd2e16bbceb12246163a014a8331df3802771`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.maven.plugins:maven-jar-plugin:3.3.0: 1/1 covered calls (100.00%)
- org.apache.maven.plugins:maven-jar-plugin:3.4.0: 1/1 covered calls (100.00%)

**Resources:**
- org.apache.maven.plugins:maven-jar-plugin:3.3.0: 1/1 covered calls (100.00%)
- org.apache.maven.plugins:maven-jar-plugin:3.4.0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.maven.plugins:maven-jar-plugin:3.3.0: 538/1209 (44.50%)
- org.apache.maven.plugins:maven-jar-plugin:3.4.0: 538/1460 (36.85%)

**Line:**
- org.apache.maven.plugins:maven-jar-plugin:3.3.0: 102/227 (44.93%)
- org.apache.maven.plugins:maven-jar-plugin:3.4.0: 103/278 (37.05%)

**Method:**
- org.apache.maven.plugins:maven-jar-plugin:3.3.0: 14/35 (40.00%)
- org.apache.maven.plugins:maven-jar-plugin:3.4.0: 14/47 (29.79%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.3.0/src/test/java/org_apache_maven_plugins/maven_jar_plugin/HelpMojoTest.java 2/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.4.0/src/test/java/org_apache_maven_plugins/maven_jar_plugin/HelpMojoTest.java
index e85df3ab4c..4252dfd3bf 100644
--- 1/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.3.0/src/test/java/org_apache_maven_plugins/maven_jar_plugin/HelpMojoTest.java
+++ 2/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.4.0/src/test/java/org_apache_maven_plugins/maven_jar_plugin/HelpMojoTest.java
@@ -8,7 +8,7 @@ package org_apache_maven_plugins.maven_jar_plugin;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-import org.apache.maven.plugins.jar.HelpMojo;
+import org.apache.maven.plugins.maven_jar_plugin.HelpMojo;
 import org.junit.jupiter.api.Test;
 
 public class HelpMojoTest {
diff --git 1/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.3.0/user-code-filter.json 2/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.4.0/user-code-filter.json
index de4da96588..1755ef9170 100644
--- 1/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.3.0/user-code-filter.json
+++ 2/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.4.0/user-code-filter.json
@@ -6,6 +6,9 @@
     {
       "includeClasses" : "org.apache.maven.plugins.jar.**"
     },
+    {
+      "includeClasses" : "org.apache.maven.plugins.**"
+    },
     {
       "includeClasses" : "org_apache_maven_plugins.maven_jar_plugin.**"
     }

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
