### PR TITLE
Refine grund specification

### DIFF
--- a/.agents/grund.toml
+++ b/.agents/grund.toml
@@ -1,5 +1,6 @@
 grund_config_version = 1
 project_name = "root"
+project_description = "Repository for shared GraalVM reachability metadata, tests, and release infrastructure"
 
 [workspace]
 members = ["forge"]
@@ -89,3 +90,36 @@ relative_paths = true
 [fmt.cross_refs]
 enabled = false
 anchor_format = "github" # github | gitlab | mkdocs | pandoc | none
+
+[citations]
+default = "may"
+
+[citations.GOAL]
+should = ["GRUND|GOAL"]
+
+[citations.FS]
+should = ["GOAL|FS"]
+
+[citations.AR]
+should = ["FS|GOAL"]
+
+[citations.TCK]
+should = ["FS|AR|GOAL"]
+
+[citations.E2E]
+should = ["FS|TCK|AR"]
+
+[citations.CI]
+should = ["FS|TCK|METADATA|TESTS|E2E|GOAL"]
+
+[citations.METADATA]
+should = ["FS|GOAL"]
+
+[citations.TESTS]
+should = ["FS|METADATA|GOAL"]
+
+[citations.SKILL]
+should = ["FS|CI|METADATA|TESTS"]
+
+[citations.code]
+should = ["FS|AR|TCK|E2E|CI|METADATA|TESTS"]

--- a/.github/workflows/test-affected-spring-aot-main.yml
+++ b/.github/workflows/test-affected-spring-aot-main.yml
@@ -1,6 +1,6 @@
-# Spring AOT smoke gate: when a PR's metadata change affects a Spring AOT project, runs the
-# triaged native tests (run-spring-aot-triaged-test.sh, §CI-shared-scripts) for the impacted
-# projects. §CI-test-affected-spring-aot; conditional gate of §FS-repository-functional-spec.5.3.
+# Spring AOT smoke gate for metadata changes affecting Spring projects.
+# Runs triaged native tests via §CI-shared-scripts for §CI-test-affected-spring-aot.
+# Enforces §FS-repository-functional-spec.5.2.1, scoped by §FS-repository-functional-spec.5.3.
 name: "Test affected Spring AOT smoke tests (4.1.x)"
 
 on:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,9 +86,9 @@
   source of truth instead of mock-only or direct-driver tests. Live GitHub Forge
   E2E still requires an explicit user request.
 
-## Grounding with grund (v2)
+## Grounding with grund (v3)
 
-This project uses [`grund`](https://github.com/vjovanov/grund): every spec, goal, decision, and end-to-end test has a stable ID `<KIND>-<slug>[.<section>]`, cited with the marker `§`. Root repository IDs use `KIND ∈ {GRUND, GOAL, FS, AR, TCK, E2E, CI, METADATA, TESTS, SKILL}`; Forge has its own `forge` namespace with `KIND ∈ {GRUND, GOAL, AR, FS, DW, STRAT, ORCH, GIT, WF, E2E, BENCH, ROADMAP}`. For example, `FS-user-login.3.1` is only a shape illustration, not a real ID in this repo. Type `$$` in a grund-aware editor and it becomes `§`. Bare ID-shaped tokens are ignored — `[reference] strict = true` is set in `.agents/grund.toml`, so only `§`-prefixed citations are checked.
+This project uses [`grund`](https://github.com/vjovanov/grund): every spec, goal, decision, and end-to-end test has a stable ID `<KIND>-<slug>[.<section>]` (`KIND ∈ {GRUND, GOAL, FS, AR, TCK, E2E, CI, METADATA, TESTS, SKILL}`), cited with the marker `§` — for example, `FS-user-login.3.1` is only a shape illustration, not a real ID in this repo. Type `$$` in a grund-aware editor and it becomes `§`. Bare ID-shaped tokens are ignored — `[reference] strict = true` is set in `.agents/grund.toml`, so only `§`-prefixed citations are checked.
 
 ### Grounding from a citation
 
@@ -100,26 +100,34 @@ A `§<ID>` is a pointer to a fact, not a file path. Resolve it with `grund` and 
 - `grund <ID> --brief` — heading + first paragraph only.
 - `grund refs <ID>` — every site that cites the ID; add `--summary` for one line per file. Run before renaming or moving a declaration.
 - `grund list` / `grund list --kind FS,AR` — discover IDs if you get lost
-- Cross-namespace citations use `§forge/<ID>`; for example, root repository docs cite Forge goals as `§forge/GOAL-forge-direction`.
 
 ### Project map
 
 - [GRUND](docs/grund.md): Why: repository motivation
-- [GOAL](docs/goals.md): Where: repository outcome goals
+- [GOAL](docs/goals.md): Where: repository direction and outcomes
 - [FS](docs): Repository functional behavior and contributor-facing requirements
 - [AR](docs): Repository architecture and build infrastructure
-- [TCK](docs/tck.md): Test harness task groups
+- [TCK](docs/tck.md): Test harness (TCK): task groups
 - [E2E](docs/e2e.md): Infrastructure end-to-end tests (testInfra/testAllInfra)
 - [CI](docs/ci.md): Recurring CI workflows and composite actions
-- [METADATA](docs/metadata.md): The shipped `metadata/` suite
-- [TESTS](docs/tests.md): The `tests/` suite that justifies the metadata
+- [METADATA](docs/metadata.md): The metadata/ suite: shipped reachability metadata
+- [TESTS](docs/tests.md): The tests/ suite: tests that justify the metadata
 - [SKILL](skills): Agent review and automation skills
 
-Start from [docs/README.md](docs/README.md) for the documentation index.
+### Project namespaces
 
-Workspace members:
+A namespace is a project boundary, not a docs folder. The current project is the local namespace: cite its IDs as `§<ID>`.
 
-- `forge` → [forge/AGENTS.md](forge/AGENTS.md): Forge namespace. Local Forge citations use `§<ID>` inside `forge/`; repository docs cite Forge facts with `§forge/<ID>`.
+Create or use a separate namespace when work introduces an independently checked app, package, service, or subproject. Give that project its own `.agents/grund.toml`, add it to the workspace root's `[workspace] members`, run `grund init` there, and set a stable `project_name`.
+
+Do not create a namespace for a regular module or component that still belongs to this project. Cite across namespaces as `§alias/<ID>` and run `grund check` from the workspace root.
+
+### Workspace members
+
+Cross-project citations use §alias/<ID>.
+
+- [`forge`](forge/AGENTS.md): Automation subproject that turns labeled issues into reviewed metadata pull requests
+- [`root`](AGENTS.md): Repository for shared GraalVM reachability metadata, tests, and release infrastructure
 
 ### Declarations and citations
 
@@ -128,10 +136,20 @@ Declarations are heading lines `# FS-user-login: …` in markdown. In a code doc
 ### Rules
 
 - **Spec first.** For behavior or design changes, write or update the most-specific spec point before code.
-- **Document by component when complexity warrants it.** A complex component, such as a module, service, workflow family, script family, or large behavior-owning file, may have its own functional spec and architecture following the same behavior/requirements vs how split.
-- **Do not over-nest simple components.** If a component only needs one architecture explanation and has no separate behavioral contract, keep it as a single architecture declaration/file rather than creating a subdirectory.
-- **Grund and goals are namespace-local top-level docs.** Repository motivation and direction live in `docs/grund.md` and `docs/goals.md`; Forge motivation and direction live in `forge/docs/grund.md` and `forge/docs/goals.md`.
 - **Cite as you write.** Place `§<ID>` at the point a claim or behavior is made — on the doc-comment for a whole behavior, inline beside the clause it enforces.
 - **Inline citation style.** Inline notes: ≤ 1 line preferred, hard cap 3 lines; ≤ 100 columns.
 - **Always cite the most-specific point.**
-- **Citations climb to reasons (grund.md).** Goals cite reasons, specs cite goals; architecture cites specs; code and executable tests cite specs.
+
+### Citation directions
+
+- **GOAL** should cite GRUND or GOAL.
+- **FS** should cite GOAL or FS.
+- **AR** should cite FS or GOAL.
+- **TCK** should cite FS or AR or GOAL.
+- **E2E** should cite FS or TCK or AR.
+- **CI** should cite FS or TCK or METADATA or TESTS or E2E or GOAL.
+- **METADATA** should cite FS or GOAL.
+- **TESTS** should cite FS or METADATA or GOAL.
+- **SKILL** should cite FS or CI or METADATA or TESTS.
+- **code** (any file outside a kind home) should cite FS or AR or TCK or E2E or CI or METADATA or TESTS.
+Unlisted kinds and pairs are fine.

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,7 +47,7 @@ all of its IDs in that one file.
 ### Files at a glance
 
 - [grund.md](grund.md) — `GRUND-repository-motivation`: why this repository exists.
-- [goals.md](goals.md) — the outcome goals: tested metadata, broad version coverage, fresh releases, and no regressions.
+- [goals.md](goals.md) — the outcome goals: tested metadata, framework-owned inference, broad version coverage, fresh releases, and no regressions.
 - [functional-spec.md](functional-spec.md) — `FS-repository-functional-spec`: the system's behavior, requirements, the native-build-tools interface contract, library-version compatibility automation, and how each audience uses the repository.
 - [architecture.md](architecture.md) — `AR-repository-architecture`: the component map and high-level implementation overview.
 - [build-infra.md](build-infra.md) — `AR-build-infrastructure`: the two-layer Gradle build, convention plugins, and scaffolding.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -58,7 +58,9 @@ tests (§E2E-infrastructure-tests).
 Triggers on PRs touching `metadata/`. Runs `generateAffectedSpringTestMatrix` to
 compute impacted Spring AOT projects, then runs triaged native tests via
 `run-spring-aot-triaged-test.sh` (§CI-shared-scripts). Only runs when metadata
-changes actually affect a Spring AOT project (§FS-repository-functional-spec.5.3).
+changes actually affect a Spring AOT project; this is the concrete Spring gate
+for framework-aware compatibility (§FS-repository-functional-spec.5.2.1,
+§FS-repository-functional-spec.5.3).
 
 ### CI-index-file-validation: Validate index.json files
 
@@ -205,7 +207,8 @@ Helpers under `.github/workflows/scripts/` used by the workflows above (these ar
   version and stopping the chain. Drives §CI-verify-new-library-version-compatibility.
 - **Spring AOT triage** — `run-spring-aot-triaged-test.sh` runs the triaged
   native Spring AOT smoke tests for the projects computed by
-  §CI-test-affected-spring-aot.
+  §CI-test-affected-spring-aot, enforcing framework-aware compatibility when
+  changed metadata can affect Spring AOT (§FS-repository-functional-spec.5.2.1).
 - **Dependency issue linking** — `open-dependency-issues-and-link-blockers.js`
   opens/reuses issues for unsupported transitive dependencies and links them as
   blockers, used by §CI-triage-new-issues.

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -1,7 +1,8 @@
 # FS-repository-functional-spec: Repository functional specification
 
 This document describes what the **GraalVM Reachability Metadata Repository** does for its users, who those users are, and the requirements that the repository, its build infrastructure, and its automation (Forge) must meet. For the structural and implementation overview that organizes these behaviors into components, see §AR-repository-architecture.
-§GOAL-tested-metadata §GOAL-broad-version-coverage §GOAL-fresh-metadata §GOAL-protect-shipped-metadata
+§GOAL-tested-metadata §GOAL-framework-owned §GOAL-broad-version-coverage
+§GOAL-fresh-metadata §GOAL-protect-shipped-metadata
 
 It is intended for agents, contributors, and downstream tooling owners who need a single, behavior-focused description of the system. The repository's moving parts are documented as modules that this spec cites at the point each behavior is stated: the test harness (§TCK-test-harness), the CI workflows (§CI-repository-ci), and the metadata and tests suites (§METADATA-suite, §TESTS-suite). Forge automation has its own functional spec in its namespace (§forge/FS-forge-functional-spec) and owns the derived metrics under `stats/` (§forge/FS-forge-run-metrics). For the task-oriented "what do I run, and when" view rather than the requirements, see [§8 How this repository is used](#8-how-this-repository-is-used).
 
@@ -34,6 +35,7 @@ Two properties make this achievable: the reachability-metadata schema is itself 
 - **No library patching.** No substitutions, bytecode rewrites, or shaded forks of upstream libraries. Patching ships a different version than the one the user resolved through Maven Central, is invisible at the dependency-resolution layer, and is unstable across upstream releases.
 - **No `Feature` classes.** Metadata bundles must not ship `org.graalvm.nativeimage.hosted.Feature` implementations or any other artifact that runs arbitrary Java inside the image builder. `Feature`s are a security concern (full filesystem / network / reflective access at build time) and break additivity because their effect is whatever code the author wrote.
 - **No untested metadata.** Metadata that has not passed the test gates defined in [§5.2 Tests](#52-tests) and [§5.3 CI gates](#53-ci-gates) is not published from this repository, regardless of provenance (human or Forge).
+- **No framework-inferred metadata.** Metadata whose correctness depends on a framework dynamically analyzing a user's application, annotations, configuration, generated code, or classpath is not publishable from this repository. It must be generated, maintained, and tested by the framework that performs that inference (§GOAL-framework-owned).
 
 These constraints apply uniformly to human-authored PRs and to Forge output, and are enforced by `checkMetadataFiles` plus the reviewer skills.
 
@@ -217,6 +219,7 @@ All four elements are versioned through the schema `$id` URLs and the GitHub Rel
 - **Conditional registration.** Every metadata entry must use [Conditional Configuration](https://www.graalvm.org/latest/reference-manual/native-image/metadata/#specifying-reflection-metadata-in-json): a `condition` whose only key is `typeReached`, so registration is gated on actual reachability. `typeReached` is the sole condition form the vendored schema accepts; the older `typeReachable` is not valid and is rejected by `checkMetadataFiles`.
 - **Allowed-package conditions.** Every metadata entry's `typeReached` condition must reference a class inside the artifact's `allowed-packages`.
 - **No test-only shipped entries.** No metadata entry may target a class or resource that exists only for testing.
+- **Framework-owned dynamic inference.** Metadata whose required registrations are discovered from a framework's analysis of application code, configuration, generated sources, or classpath composition must not ship from this repository. Coordinate tests cannot prove such metadata correct for arbitrary user applications; it belongs in the framework itself. This repository may ship only entries that a coordinate-level public API test can justify, while testing compatibility with framework metadata mechanisms separately (§GOAL-framework-owned).
 - **Index coverage.** Each `metadata/<group>/<artifact>/` directory must include a valid `index.json` enumerating its metadata versions and tested library versions.
 - **Single latest entry.** Exactly one entry in a non-empty `index.json` must carry `latest: true`. If a library version is not in `tested-versions`, the harness selects an entry by matching the optional `default-for` regex.
 - **Dependency and test-only split.** Metadata can declare dependencies on other artifacts via `requires`. Metadata needed only by the tests — entries whose type or `typeReached` names a test package, or whose resource is a test resource — must not ship to consumers; `splitTestOnlyMetadata` moves them out of the library's `reachability-metadata.json` into the test project's `src/test/resources/META-INF/native-image/reachability-metadata.json`, keeping the shipped metadata free of test-only types (§METADATA-suite).
@@ -231,12 +234,23 @@ All four elements are versioned through the schema `$id` URLs and the GitHub Rel
 - **Recorded passing versions.** Newly added `tested-versions` entries are recorded in `index.json` only after they pass on **every** required environment (enforced by `verify-new-library-version-compatibility`).
 - **Coverage non-regression.** Dynamic-access coverage between consecutive tested versions of a library must not regress (enforced by reviewer skills `review-fixes-javac-fail`, `review-fixes-native-image-run-fail`, `review-fixes-java-run-fail`).
 
+#### 5.2.1 Framework-aware compatibility
+
+When repository metadata changes can affect a framework integration, the
+repository must test the affected framework behavior when an automatable suite
+exists. A gate may run an upstream smoke suite, such as Spring AOT smoke tests,
+or a repo-local equivalent that exercises the framework as a consumer would.
+This coverage demonstrates that shipped library metadata does not break
+framework metadata generation or native-image integration; it does not authorize
+shipping metadata that only the framework can dynamically infer
+(§FS-repository-functional-spec.5.1, §GOAL-framework-owned).
+
 ### 5.3 CI gates
 
 - **PR gates.** Every PR is gated on the relevant subset of: `checkstyle`, `spotlessCheck`, `validateIndexFiles`, `checkMetadataFiles`, `validateLibraryStats`, `library-and-framework-list-validation`, and the appropriate `test-*` workflow.
 - **Docker isolation.** Docker images used in tests are pre-pulled from `allowed-docker-images`, after which the runner disables Docker networking for deterministic, isolated test runs.
 - **Release style gate.** The release workflow runs `spotlessCheck` before packaging.
-- **Spring AOT scope.** The Spring AOT smoke matrix runs only when `metadata/` changes affect a Spring AOT project.
+- **Spring AOT scope.** The Spring AOT smoke matrix runs only when `metadata/` changes affect a Spring AOT project, as a framework-aware compatibility gate (§FS-repository-functional-spec.5.2.1).
 - **Compatibility budget.** `verify-new-library-version-compatibility` caps each scheduled run at a fixed library budget and at most 30 newer versions per library, expanding across the configured GraalVM JDK/OS combinations, and creates one aggregated GitHub issue per failed `(library, version)` pair.
 - **Docker tag sync.** Dependabot updates to `allowed-docker-images` trigger `sync-docker-tags.yml`, which back-commits the synchronized tags into the Dependabot PR.
 - **Full sweep.** `test-all-metadata` runs only on schedule or manual dispatch in the main repository, uses 85 batches, creates one aggregated GitHub issue per failed `(library, version)` pair across configured GraalVM JDK/OS combinations and native-image modes, and is release-blocking when failures are found.

--- a/docs/goals.md
+++ b/docs/goals.md
@@ -7,6 +7,17 @@ that would fail without it passes the harness gates, so the additive contract is
 demonstrated rather than asserted.
 §GRUND-repository-motivation
 
+# GOAL-framework-owned: Framework-inferred metadata stays with frameworks
+
+Frameworks that infer reachability metadata from application structure,
+configuration, annotations, generated code, or classpath composition own that
+metadata. The repository cannot reliably test metadata whose correctness depends
+on a framework's dynamic analysis of a user's application, so it should not ship
+such entries. Instead, this repository should stay compatible with framework
+metadata generation while providing only statically testable library metadata;
+framework-owned inference belongs in the framework release and its tests.
+§GRUND-repository-motivation
+
 # GOAL-broad-version-coverage: As many tested versions as practical
 
 Supported artifacts should have as many tested library versions as practical, so

--- a/docs/tck.md
+++ b/docs/tck.md
@@ -102,7 +102,7 @@ These emit the GitHub Actions matrices the workflows consume, all driven by
 | `generateMatrixMatchingCoordinates`, `generateMatrixBatchedCoordinates` | Full and batched matrices (the latter powers §CI-test-all-metadata). |
 | `generateChangedCoordinatesMatrix`, `generateChangedMetadataTestMatrix`, `generateChangedCoordinatesOnlyMatrix`, `generateChangedIndexFileCoordinatesList` | PR-scoped matrices for changed metadata and index files. |
 | `generateInfrastructureChangedCoordinatesMatrix` | Matrix for build-logic changes; also selects the coordinate for §E2E-infrastructure-tests. |
-| `generateAffectedSpringTestMatrix` | Impacted Spring AOT projects. |
+| `generateAffectedSpringTestMatrix` | Impacted Spring AOT projects (§FS-repository-functional-spec.5.2.1). |
 | `fetchExistingLibrariesWithNewerVersions`, `generateNewLibraryVersionCompatibilityMatrix` | Discover newer upstream versions and build the compatibility matrix (§GOAL-broad-version-coverage). |
 
 ## 8. Reporting, stats, coverage, and packaging

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -77,3 +77,10 @@ coverage between consecutive versions must not regress
 (§FS-repository-functional-spec.5.2, §GOAL-protect-shipped-metadata). New test
 projects are created from the scaffold templates by the authoring tasks
 (§TCK-test-harness.5), by a human or by Forge (§forge/FS-forge-functional-spec).
+
+Framework-aware compatibility is separate from per-coordinate metadata
+justification. When a metadata change affects an automatable framework smoke
+suite, CI runs that affected suite, or a repo-local equivalent, to prove the
+change does not break framework metadata generation or native-image integration
+(§FS-repository-functional-spec.5.2.1). Such tests do not justify shipping
+framework-inferred metadata from this repository (§GOAL-framework-owned).

--- a/forge/.agents/grund.toml
+++ b/forge/.agents/grund.toml
@@ -1,5 +1,6 @@
 grund_config_version = 1
 project_name = "forge"
+project_description = "Automation subproject that turns labeled issues into reviewed metadata pull requests"
 
 [reference]
 marker = "§"
@@ -95,3 +96,42 @@ relative_paths = true
 [fmt.cross_refs]
 enabled = false
 anchor_format = "github" # github | gitlab | mkdocs | pandoc | none
+
+[citations]
+default = "may"
+
+[citations.GOAL]
+should = ["GRUND|GOAL"]
+
+[citations.FS]
+should = ["GOAL|FS"]
+
+[citations.AR]
+should = ["FS|GOAL"]
+
+[citations.DW]
+should = ["FS|AR"]
+
+[citations.STRAT]
+should = ["FS|AR|GOAL"]
+
+[citations.ORCH]
+should = ["FS|AR|STRAT"]
+
+[citations.GIT]
+should = ["FS|AR"]
+
+[citations.WF]
+should = ["FS|STRAT|ORCH|GIT"]
+
+[citations.E2E]
+should = ["FS|WF|ORCH"]
+
+[citations.BENCH]
+should = ["FS|AR|GOAL"]
+
+[citations.ROADMAP]
+should = ["GOAL|FS|AR"]
+
+[citations.code]
+should = ["FS|AR|DW|STRAT|ORCH|GIT|WF"]

--- a/forge/AGENTS.md
+++ b/forge/AGENTS.md
@@ -60,9 +60,9 @@ Agents MUST read and strictly adhere to the following before making any changes:
 - Summarize each open question briefly and concretely so a reviewer can understand the decision point without re-reading the whole conversation.
 - If there are no open questions or user-requested notes for reviewers, omit the section instead of adding an empty heading.
 
-## Grounding with grund (v2)
+## Grounding with grund (v3)
 
-This project uses [`grund`](https://github.com/vjovanov/grund): every spec, goal, decision, and end-to-end test has a stable ID `<KIND>-<slug>[.<section>]` (`KIND ∈ {GRUND, GOAL, AR, FS, DW, STRAT, ORCH, GIT, WF, E2E, BENCH, ROADMAP}`), cited with the marker `§` — e.g. `FS-user-login.3.1` (the `FS-user-login` here is a shape illustration, not a real ID in this repo). Type `$$` in a grund-aware editor and it becomes `§`. Bare ID-shaped tokens are ignored — `[reference] strict = true` is set in `.agents/grund.toml`, so only `§`-prefixed citations are checked.
+This project uses [`grund`](https://github.com/vjovanov/grund): every spec, goal, decision, and end-to-end test has a stable ID `<KIND>-<slug>[.<section>]` (`KIND ∈ {GRUND, GOAL, AR, FS, DW, STRAT, ORCH, GIT, WF, E2E, BENCH, ROADMAP}`), cited with the marker `§` — for example, `FS-user-login.3.1` is only a shape illustration, not a real ID in this repo. Type `$$` in a grund-aware editor and it becomes `§`. Bare ID-shaped tokens are ignored — `[reference] strict = true` is set in `.agents/grund.toml`, so only `§`-prefixed citations are checked.
 
 ### Grounding from a citation
 
@@ -81,13 +81,14 @@ A `§<ID>` is a pointer to a fact, not a file path. Resolve it with `grund` and 
 - [GOAL](docs/goals.md): Where: Forge direction and outcomes
 - [AR](docs): Forge architecture and technical structure
 - [FS](docs): Forge functional behavior and requirements
-- [DW](docs/do-work.md): Forge do-work loop architecture
-- [STRAT](docs/strategies.md): Forge strategy configuration architecture
-- [ORCH](docs/orchestration-scripts.md): Forge orchestration scripts behavior and architecture
-- [GIT](docs/git-scripts.md): Forge git scripts publication behavior and architecture
+- [DW](docs): Forge do-work loop architecture
+- [STRAT](docs): Forge strategy configuration architecture
+- [ORCH](docs): Forge orchestration scripts behavior and architecture
+- [GIT](docs): Forge git scripts publication behavior and architecture
 - [WF](docs/workflows): Forge workflow specifications and operating rules
-- [BENCH](docs/benchmarking.md): Forge benchmark specifications
-- [ROADMAP](docs/roadmap.md): Forge implementation roadmap
+- [E2E](docs): Forge end-to-end test specifications
+- [BENCH](docs): Forge benchmark specifications
+- [ROADMAP](docs): Forge implementation roadmap
 
 ### Project namespaces
 
@@ -101,8 +102,8 @@ Do not create a namespace for a regular module or component that still belongs t
 
 Cross-project citations use §alias/<ID>.
 
-- `forge` → [AGENTS.md](AGENTS.md)
-- `root` → [../AGENTS.md](../AGENTS.md)
+- [`forge`](AGENTS.md): Automation subproject that turns labeled issues into reviewed metadata pull requests
+- [`root`](../AGENTS.md): Repository for shared GraalVM reachability metadata, tests, and release infrastructure
 
 ### Declarations and citations
 
@@ -114,4 +115,19 @@ Declarations are heading lines `# FS-user-login: …` in markdown. In a code doc
 - **Cite as you write.** Place `§<ID>` at the point a claim or behavior is made — on the doc-comment for a whole behavior, inline beside the clause it enforces.
 - **Inline citation style.** Inline notes: ≤ 1 line preferred, hard cap 3 lines; ≤ 100 columns.
 - **Always cite the most-specific point.**
-- **Citations climb to reasons (grund.md).** Goals cite reasons, specs cite goals; architecture cites specs; code and executable tests cite specs.
+
+### Citation directions
+
+- **GOAL** should cite GRUND or GOAL.
+- **AR** should cite FS or GOAL.
+- **FS** should cite GOAL or FS.
+- **DW** should cite FS or AR.
+- **STRAT** should cite FS or AR or GOAL.
+- **ORCH** should cite FS or AR or STRAT.
+- **GIT** should cite FS or AR.
+- **WF** should cite FS or STRAT or ORCH or GIT.
+- **E2E** should cite FS or WF or ORCH.
+- **BENCH** should cite FS or AR or GOAL.
+- **ROADMAP** should cite GOAL or FS or AR.
+- **code** (any file outside a kind home) should cite FS or AR or DW or STRAT or ORCH or GIT or WF.
+Unlisted kinds and pairs are fine.

--- a/tests/tck-build-logic/scripts/spring-aot-impact-scan.gradle
+++ b/tests/tck-build-logic/scripts/spring-aot-impact-scan.gradle
@@ -11,7 +11,9 @@ import org.gradle.api.Project
  * by changes in a library's Reachability Metadata. It ensures that any
  * modification to the library's metadata triggers
  * the specific native verification suites that rely on it.
- * §CI-test-affected-spring-aot; matrix task is specified in §TCK-test-harness.7.
+ * §CI-test-affected-spring-aot; framework-aware requirement is
+ * §FS-repository-functional-spec.5.2.1; matrix task is specified in
+ * §TCK-test-harness.7.
  *
  * How it works:
  * 1. Scope: Only targets projects containing 'nativeTest' or 'nativeAppTest' tasks.

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
@@ -868,7 +868,9 @@ tasks.register("extractLibraryTestParams", DefaultTask) { task ->
     }
 }
 
-// gradle generateAffectedSpringTestMatrix -PbaseCommit=<base> -PnewCommit=<head> -PspringAotBranch=<branch> -PspringAotPath=/path/to/spring-aot-smoke-tests  §TCK-test-harness.7
+// gradle generateAffectedSpringTestMatrix -PbaseCommit=<base> -PnewCommit=<head>
+//     -PspringAotBranch=<branch> -PspringAotPath=/path/to/spring-aot-smoke-tests
+// §TCK-test-harness.7 §FS-repository-functional-spec.5.2.1
 //
 // Generates a GitHub Actions matrix for 'spring-aot-smoke-tests' impacted by metadata changes:
 // 1. Identifies changed Group:Artifacts via git diff between commits.


### PR DESCRIPTION
## Summary

- add a goal that framework-inferred reachability metadata belongs with the framework
- add a citable framework-aware compatibility requirement
- cite the Spring AOT smoke-test gate as the current exercise of that requirement

## Validation

- `grund check`
- `git diff --check`

Closes #8240