### PR TITLE
[GenAI] Test fix for org.apache.maven.plugins:maven-compiler-plugin:3.10.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/reachability-metadata.json
+++ b/metadata/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/reachability-metadata.json
@@ -1,0 +1,46 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.plugin.compiler.AbstractCompilerMojo"
+      },
+      "type": "org.apache.maven.execution.MavenSession",
+      "methods": [
+        {
+          "name": "getRequest",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.plugin.compiler.AbstractCompilerMojo"
+      },
+      "type": "org.apache.maven.execution.DefaultMavenExecutionRequest",
+      "methods": [
+        {
+          "name": "getThreadCount",
+          "parameterTypes": []
+        },
+        {
+          "name": "getStartTime",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.plugin.compiler.HelpMojo"
+      },
+      "glob": "META-INF/maven/org.apache.maven.plugins/maven-compiler-plugin/plugin-help.xml"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.plugin.compiler.HelpMojo"
+      },
+      "glob": "META-INF/services/javax.xml.parsers.DocumentBuilderFactory"
+    }
+  ]
+}

--- a/metadata/org.apache.maven.plugins/maven-compiler-plugin/index.json
+++ b/metadata/org.apache.maven.plugins/maven-compiler-plugin/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.10.0",
+    "tested-versions" : [
+      "3.10.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.maven.plugin"
+    ]
+  },
+  {
     "metadata-version" : "3.9.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/$version$/maven-compiler-plugin-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/maven-compiler-plugin",

--- a/metadata/org.apache.maven.plugins/maven-compiler-plugin/index.json
+++ b/metadata/org.apache.maven.plugins/maven-compiler-plugin/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "3.10.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/$version$/maven-compiler-plugin-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/maven-compiler-plugin",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/$version$/maven-compiler-plugin-$version$-source-release.zip",
+    "documentation-url" : "https://github.com/apache/maven-compiler-plugin/blob/maven-compiler-plugin-$version$/src/site/apt/index.apt.vm",
+    "description" : "Apache Maven Compiler Plugin integrates Java compilation into Maven builds. It compiles a project's main and test source trees during the Maven lifecycle and exposes configuration for source and target levels, compiler arguments, annotation processors, and alternate compiler implementations.",
     "tested-versions" : [
       "3.10.0"
     ],

--- a/stats/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/execution-metrics.json
+++ b/stats/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/execution-metrics.json
@@ -1,0 +1,142 @@
+{
+  "fix_javac_fail:2026-06-09": {
+    "timestamp": "2026-06-09T08:59:53.306806Z",
+    "library": "org.apache.maven.plugins:maven-compiler-plugin:3.10.0",
+    "starting_commit": "efedd2e09bf8da1cf4f1b38409d4b50e208bce9c",
+    "ending_commit": "a4acd48cd544029a26397c133dede9fc86cc9e59",
+    "previous_library": "org.apache.maven.plugins:maven-compiler-plugin:3.9.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.10.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 10,
+            "totalCalls": 10
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 11,
+        "totalCalls": 11
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 690,
+          "missed": 4480,
+          "ratio": 0.133462,
+          "total": 5170
+        },
+        "line": {
+          "covered": 133,
+          "missed": 919,
+          "ratio": 0.126426,
+          "total": 1052
+        },
+        "method": {
+          "covered": 19,
+          "missed": 80,
+          "ratio": 0.191919,
+          "total": 99
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.9.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 10,
+            "totalCalls": 10
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 11,
+        "totalCalls": 11
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 687,
+          "missed": 4274,
+          "ratio": 0.13848,
+          "total": 4961
+        },
+        "line": {
+          "covered": 132,
+          "missed": 879,
+          "ratio": 0.130564,
+          "total": 1011
+        },
+        "method": {
+          "covered": 19,
+          "missed": 79,
+          "ratio": 0.193878,
+          "total": 98
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "no_action",
+      "issue_number": 8226,
+      "issue_label": "fails-javac-compile",
+      "library": "org.apache.maven.plugins:maven-compiler-plugin:3.10.0",
+      "summary": "No additional deterministic setup is needed. The artifact is a Maven plugin with Maven/Plexus dependencies already represented by the existing test scaffold; the observed failure is API drift in AbstractCompilerMojo 3.10.0, which adds getDebugFileName(), not a missing service, Docker image, optional dependency, or initialization requirement.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [
+        "Tests that subclass AbstractCompilerMojo must stay source-compatible with the 3.10.0 API by implementing newly added abstract methods.",
+        "Meaningful execution coverage may require constructing MavenSession/MavenProject or plugin-testing harness objects, but that is test-code logic rather than deterministic repository setup."
+      ],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#8226 [Automation] javac compile fails for org.apache.maven.plugins:maven-compiler-plugin:3.10.0; label=fails-javac-compile; body_chars=8015"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "7 existing test file path(s) included"
+        }
+      ],
+      "current_library": "org.apache.maven.plugins:maven-compiler-plugin:3.9.0",
+      "new_version": "3.10.0",
+      "model": "oca/gpt-5.5",
+      "input_tokens_used": 29692,
+      "output_tokens_used": 1366,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.apache.maven.plugins:maven-compiler-plugin:3.10.0/library-preparation-preflight/pi-generation-2026-06-09T08-49-47-190861Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 20362,
+      "cached_input_tokens_used": 161280,
+      "output_tokens_used": 1298,
+      "iterations": 1,
+      "cost_usd": 0.1195,
+      "tested_library_loc": 133,
+      "metadata_entries": 7,
+      "previous_library_metadata_entries": 7,
+      "code_coverage_percent": 12.64,
+      "previous_library_coverage_percent": 13.06
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/src/test/java/org_apache_maven_plugins/maven_compiler_plugin/AbstractCompilerMojoTest.java",
+      "metadata_file": "metadata/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/stats.json
+++ b/stats/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "3.10.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 10,
+          "totalCalls" : 10
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 11,
+      "totalCalls" : 11
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 690,
+        "missed" : 4480,
+        "ratio" : 0.133462,
+        "total" : 5170
+      },
+      "line" : {
+        "covered" : 133,
+        "missed" : 919,
+        "ratio" : 0.126426,
+        "total" : 1052
+      },
+      "method" : {
+        "covered" : 19,
+        "missed" : 80,
+        "ratio" : 0.191919,
+        "total" : 99
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/.gitignore
+++ b/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/build.gradle
+++ b/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/build.gradle
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.maven.plugins:maven-compiler-plugin:$libraryVersion"
+    testImplementation 'org.apache.maven:maven-core:3.2.5'
+    testImplementation 'org.apache.maven:maven-plugin-api:3.2.5'
+    testImplementation 'org.apache.maven.plugin-testing:maven-plugin-testing-harness:3.3.0'
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/gradle.properties
+++ b/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.maven.plugins:maven-compiler-plugin:3.10.0
+library.version = 3.10.0
+metadata.dir = org.apache.maven.plugins/maven-compiler-plugin/3.10.0/

--- a/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/settings.gradle
+++ b/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.maven.plugins.maven-compiler-plugin_tests'

--- a/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/src/test/java/org_apache_maven_plugins/maven_compiler_plugin/AbstractCompilerMojoTest.java
+++ b/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/src/test/java/org_apache_maven_plugins/maven_compiler_plugin/AbstractCompilerMojoTest.java
@@ -165,6 +165,11 @@ public class AbstractCompilerMojoTest {
         protected File getGeneratedSourcesDirectory() {
             return new File("target/generated-sources/annotations");
         }
+
+        @Override
+        protected String getDebugFileName() {
+            return null;
+        }
     }
 
     public static final class TestToolchainManager implements ToolchainManager {

--- a/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/src/test/java/org_apache_maven_plugins/maven_compiler_plugin/AbstractCompilerMojoTest.java
+++ b/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/src/test/java/org_apache_maven_plugins/maven_compiler_plugin/AbstractCompilerMojoTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_plugins.maven_compiler_plugin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.maven.execution.DefaultMavenExecutionRequest;
+import org.apache.maven.execution.DefaultMavenExecutionResult;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.compiler.AbstractCompilerMojo;
+import org.apache.maven.plugin.testing.AbstractMojoTestCase;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.toolchain.Toolchain;
+import org.apache.maven.toolchain.ToolchainManager;
+import org.codehaus.plexus.compiler.util.scan.SourceInclusionScanner;
+import org.codehaus.plexus.languages.java.jpms.JavaModuleDescriptor;
+import org.junit.jupiter.api.Test;
+
+public class AbstractCompilerMojoTest {
+    @Test
+    void requestValuesAreReadThroughMavenCompatibilityReflection() throws Exception {
+        Date startTime = new Date(123456789L);
+        TestExecutionRequest request = new TestExecutionRequest();
+        request.setThreadCount("4");
+        request.setStartTime(startTime);
+
+        TestCompilerMojo mojo = new TestCompilerMojo();
+        MojoFieldInjector injector = new MojoFieldInjector();
+        injector.inject(mojo, "session",
+                new MavenSession(null, request, new DefaultMavenExecutionResult(), new MavenProject()));
+
+        assertEquals(4, mojo.requestThreadCount());
+        assertEquals(startTime, mojo.buildStartTime());
+    }
+
+    @Test
+    void toolchainRequirementsUseNewerToolchainManagerMethodWhenPresent() throws Exception {
+        TestToolchain expectedToolchain = new TestToolchain();
+        TestToolchainManager toolchainManager = new TestToolchainManager(expectedToolchain);
+        Map<String, String> requirements = new HashMap<>();
+        requirements.put("version", "21");
+
+        TestCompilerMojo mojo = new TestCompilerMojo();
+        MojoFieldInjector injector = new MojoFieldInjector();
+        injector.inject(mojo, "session", new MavenSession(null, new DefaultMavenExecutionRequest(),
+                new DefaultMavenExecutionResult(), new MavenProject()));
+        injector.inject(mojo, "toolchainManager", toolchainManager);
+        injector.inject(mojo, "jdkToolchain", requirements);
+
+        assertSame(expectedToolchain, mojo.toolchain());
+        assertEquals("jdk", toolchainManager.requestedType);
+        assertSame(requirements, toolchainManager.requestedRequirements);
+    }
+
+    public static final class TestExecutionRequest extends DefaultMavenExecutionRequest {
+        private String threadCount;
+
+        public void setThreadCount(String threadCount) {
+            this.threadCount = threadCount;
+        }
+
+        public String getThreadCount() {
+            return threadCount;
+        }
+    }
+
+    static final class MojoFieldInjector extends AbstractMojoTestCase {
+        void inject(Object target, String name, Object value) throws IllegalAccessException {
+            setVariableValueToObject(target, name, value);
+        }
+    }
+
+    static final class TestCompilerMojo extends AbstractCompilerMojo {
+        int requestThreadCount() {
+            return getRequestThreadCount();
+        }
+
+        Date buildStartTime() {
+            return getBuildStartTime();
+        }
+
+        Toolchain toolchain() {
+            return getToolchain();
+        }
+
+        @Override
+        protected SourceInclusionScanner getSourceInclusionScanner(int staleMillis) {
+            return null;
+        }
+
+        @Override
+        protected SourceInclusionScanner getSourceInclusionScanner(String inputFileEnding) {
+            return null;
+        }
+
+        @Override
+        protected List<String> getClasspathElements() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        protected List<String> getModulepathElements() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        protected Map<String, JavaModuleDescriptor> getPathElements() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        protected List<String> getCompileSourceRoots() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        protected void preparePaths(Set<File> sourceFiles) {
+        }
+
+        @Override
+        protected File getOutputDirectory() {
+            return new File("target/classes");
+        }
+
+        @Override
+        protected String getSource() {
+            return "1.8";
+        }
+
+        @Override
+        protected String getTarget() {
+            return "1.8";
+        }
+
+        @Override
+        protected String getRelease() {
+            return null;
+        }
+
+        @Override
+        protected String getCompilerArgument() {
+            return null;
+        }
+
+        @Override
+        protected Map<String, String> getCompilerArguments() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        protected File getGeneratedSourcesDirectory() {
+            return new File("target/generated-sources/annotations");
+        }
+    }
+
+    public static final class TestToolchainManager implements ToolchainManager {
+        private final Toolchain toolchain;
+        private String requestedType;
+        private Map<String, String> requestedRequirements;
+
+        TestToolchainManager(Toolchain toolchain) {
+            this.toolchain = toolchain;
+        }
+
+        public List<Toolchain> getToolchains(MavenSession session, String type, Map<String, String> requirements) {
+            requestedType = type;
+            requestedRequirements = requirements;
+            List<Toolchain> toolchains = new ArrayList<>();
+            toolchains.add(toolchain);
+            return toolchains;
+        }
+
+        @Override
+        public Toolchain getToolchainFromBuildContext(String type, MavenSession session) {
+            return null;
+        }
+    }
+
+    static final class TestToolchain implements Toolchain {
+        @Override
+        public String getType() {
+            return "jdk";
+        }
+
+        @Override
+        public String findTool(String toolName) {
+            return toolName;
+        }
+    }
+}

--- a/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/src/test/java/org_apache_maven_plugins/maven_compiler_plugin/HelpMojoTest.java
+++ b/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/src/test/java/org_apache_maven_plugins/maven_compiler_plugin/HelpMojoTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_plugins.maven_compiler_plugin;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.maven.plugin.compiler.HelpMojo;
+import org.apache.maven.plugin.logging.Log;
+import org.junit.jupiter.api.Test;
+
+public class HelpMojoTest {
+    @Test
+    public void executeLoadsBundledPluginHelpResource() throws Exception {
+        CapturingLog log = new CapturingLog();
+        HelpMojo mojo = new HelpMojo();
+        mojo.setLog(log);
+
+        mojo.execute();
+
+        String output = log.info.toString();
+        assertTrue(output.contains("Apache Maven Compiler Plugin"));
+        assertTrue(output.contains("compiler:compile"));
+        assertTrue(output.contains("compiler:testCompile"));
+    }
+
+    static final class CapturingLog implements Log {
+        private final StringBuilder info = new StringBuilder();
+
+        @Override
+        public boolean isDebugEnabled() {
+            return true;
+        }
+
+        @Override
+        public void debug(CharSequence content) {
+        }
+
+        @Override
+        public void debug(CharSequence content, Throwable error) {
+        }
+
+        @Override
+        public void debug(Throwable error) {
+        }
+
+        @Override
+        public boolean isInfoEnabled() {
+            return true;
+        }
+
+        @Override
+        public void info(CharSequence content) {
+            info.append(content);
+        }
+
+        @Override
+        public void info(CharSequence content, Throwable error) {
+            info.append(content);
+        }
+
+        @Override
+        public void info(Throwable error) {
+        }
+
+        @Override
+        public boolean isWarnEnabled() {
+            return true;
+        }
+
+        @Override
+        public void warn(CharSequence content) {
+        }
+
+        @Override
+        public void warn(CharSequence content, Throwable error) {
+        }
+
+        @Override
+        public void warn(Throwable error) {
+        }
+
+        @Override
+        public boolean isErrorEnabled() {
+            return true;
+        }
+
+        @Override
+        public void error(CharSequence content) {
+        }
+
+        @Override
+        public void error(CharSequence content, Throwable error) {
+        }
+
+        @Override
+        public void error(Throwable error) {
+        }
+    }
+}

--- a/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/user-code-filter.json
+++ b/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/user-code-filter.json
@@ -7,6 +7,9 @@
       "includeClasses" : "org.apache.maven.plugin.**"
     },
     {
+      "includeClasses" : "org.apache.maven.plugin.compiler.**"
+    },
+    {
       "includeClasses" : "org_apache_maven_plugins.maven_compiler_plugin.**"
     }
   ]

--- a/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/user-code-filter.json
+++ b/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.maven.plugin.**"
+    },
+    {
+      "includeClasses" : "org_apache_maven_plugins.maven_compiler_plugin.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #8226

This PR provides test fixes and new metadata for org.apache.maven.plugins:maven-compiler-plugin:3.10.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 20362
- Cached input tokens: 161280
- Output tokens: 1298
- Metadata entries: 7
- Iterations: 1
- Library coverage percentage: 12.64
- Previous library version metadata entries: 7
- Previous library version coverage percentage: 13.06

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `b80fd2e16bbceb12246163a014a8331df3802771`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.maven.plugins:maven-compiler-plugin:3.9.0: 11/11 covered calls (100.00%)
- org.apache.maven.plugins:maven-compiler-plugin:3.10.0: 11/11 covered calls (100.00%)

**Reflection:**
- org.apache.maven.plugins:maven-compiler-plugin:3.9.0: 10/10 covered calls (100.00%)
- org.apache.maven.plugins:maven-compiler-plugin:3.10.0: 10/10 covered calls (100.00%)

**Resources:**
- org.apache.maven.plugins:maven-compiler-plugin:3.9.0: 1/1 covered calls (100.00%)
- org.apache.maven.plugins:maven-compiler-plugin:3.10.0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.maven.plugins:maven-compiler-plugin:3.9.0: 687/4961 (13.85%)
- org.apache.maven.plugins:maven-compiler-plugin:3.10.0: 690/5170 (13.35%)

**Line:**
- org.apache.maven.plugins:maven-compiler-plugin:3.9.0: 132/1011 (13.06%)
- org.apache.maven.plugins:maven-compiler-plugin:3.10.0: 133/1052 (12.64%)

**Method:**
- org.apache.maven.plugins:maven-compiler-plugin:3.9.0: 19/98 (19.39%)
- org.apache.maven.plugins:maven-compiler-plugin:3.10.0: 19/99 (19.19%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.9.0/src/test/java/org_apache_maven_plugins/maven_compiler_plugin/AbstractCompilerMojoTest.java 2/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/src/test/java/org_apache_maven_plugins/maven_compiler_plugin/AbstractCompilerMojoTest.java
index 24c1281869..868c3787bd 100644
--- 1/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.9.0/src/test/java/org_apache_maven_plugins/maven_compiler_plugin/AbstractCompilerMojoTest.java
+++ 2/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/src/test/java/org_apache_maven_plugins/maven_compiler_plugin/AbstractCompilerMojoTest.java
@@ -165,6 +165,11 @@ public class AbstractCompilerMojoTest {
         protected File getGeneratedSourcesDirectory() {
             return new File("target/generated-sources/annotations");
         }
+
+        @Override
+        protected String getDebugFileName() {
+            return null;
+        }
     }
 
     public static final class TestToolchainManager implements ToolchainManager {
diff --git 1/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.9.0/user-code-filter.json 2/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/user-code-filter.json
index 768b397608..670da07f10 100644
--- 1/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.9.0/user-code-filter.json
+++ 2/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/user-code-filter.json
@@ -6,6 +6,9 @@
     {
       "includeClasses" : "org.apache.maven.plugin.**"
     },
+    {
+      "includeClasses" : "org.apache.maven.plugin.compiler.**"
+    },
     {
       "includeClasses" : "org_apache_maven_plugins.maven_compiler_plugin.**"
     }

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
