### PR TITLE
[GenAI] Test fix for javassist:javassist:3.12.0.SP1 using gpt-5.5

### DIFF
--- a/metadata/javassist/javassist/3.12.0.SP1/reachability-metadata.json
+++ b/metadata/javassist/javassist/3.12.0.SP1/reachability-metadata.json
@@ -1,436 +1,262 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "javassist.util.HotSwapper"
+      "condition" : {
+        "typeReached" : "javassist.util.HotSwapper"
       },
-      "type": "com.sun.tools.jdi.ProcessAttachingConnector"
+      "type" : "com.sun.tools.jdi.ProcessAttachingConnector"
     },
     {
-      "condition": {
-        "typeReached": "javassist.util.HotSwapper"
+      "condition" : {
+        "typeReached" : "javassist.util.HotSwapper"
       },
-      "type": "com.sun.tools.jdi.RawCommandLineLauncher"
+      "type" : "com.sun.tools.jdi.RawCommandLineLauncher"
     },
     {
-      "condition": {
-        "typeReached": "javassist.util.HotSwapper"
+      "condition" : {
+        "typeReached" : "javassist.util.HotSwapper"
       },
-      "type": "com.sun.tools.jdi.SocketAttachingConnector"
+      "type" : "com.sun.tools.jdi.SocketAttachingConnector"
     },
     {
-      "condition": {
-        "typeReached": "javassist.util.HotSwapper"
+      "condition" : {
+        "typeReached" : "javassist.util.HotSwapper"
       },
-      "type": "com.sun.tools.jdi.SocketListeningConnector"
+      "type" : "com.sun.tools.jdi.SocketListeningConnector"
     },
     {
-      "condition": {
-        "typeReached": "javassist.util.HotSwapper"
+      "condition" : {
+        "typeReached" : "javassist.util.HotSwapper"
       },
-      "type": "com.sun.tools.jdi.SunCommandLineLauncher"
+      "type" : "com.sun.tools.jdi.SunCommandLineLauncher"
     },
     {
-      "condition": {
-        "typeReached": "javassist.util.HotSwapper"
+      "condition" : {
+        "typeReached" : "javassist.util.HotSwapper"
       },
-      "type": "com.sun.tools.jdi.resources.jdi"
+      "type" : "com.sun.tools.jdi.resources.jdi"
     },
     {
-      "condition": {
-        "typeReached": "javassist.Loader"
+      "condition" : {
+        "typeReached" : "javassist.Loader"
       },
-      "type": "example.LoaderGeneratedApplication"
+      "type" : "example.LoaderGeneratedApplication"
     },
     {
-      "condition": {
-        "typeReached": "javassist.tools.web.Viewer"
+      "condition" : {
+        "typeReached" : "javassist.tools.web.Viewer"
       },
-      "type": "example.ViewerGeneratedApplication"
+      "type" : "example.ViewerGeneratedApplication"
     },
     {
-      "condition": {
-        "typeReached": "javassist.util.proxy.SecurityActions"
+      "condition" : {
+        "typeReached" : "javassist.util.proxy.SecurityActions"
       },
-      "type": "java.io.Serializable"
+      "type" : "java.io.Serializable"
     },
     {
-      "condition": {
-        "typeReached": "javassist.tools.rmi.AppletServer"
+      "condition" : {
+        "typeReached" : "javassist.tools.rmi.AppletServer"
       },
-      "type": "java.lang.Boolean",
-      "serializable": true
+      "type" : "java.lang.Boolean",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "javassist.javassist.AppletServerTest"
+      "condition" : {
+        "typeReached" : "javassist.tools.reflect.Metaobject"
       },
-      "type": "java.lang.Object"
+      "type" : "java.lang.Object"
     },
     {
-      "condition": {
-        "typeReached": "javassist.javassist.ClassMetaobjectTest"
+      "condition" : {
+        "typeReached" : "javassist.tools.rmi.AppletServer"
       },
-      "type": "java.lang.Object"
+      "type" : "java.lang.Object"
     },
     {
-      "condition": {
-        "typeReached": "javassist.javassist.MetaobjectTest"
+      "condition" : {
+        "typeReached" : "javassist.tools.rmi.ObjectImporter"
       },
-      "type": "java.lang.Object"
+      "type" : "java.lang.Object"
     },
     {
-      "condition": {
-        "typeReached": "javassist.javassist.ProxyFactoryTest"
+      "condition" : {
+        "typeReached" : "javassist.bytecode.annotation.ArrayMemberValue"
       },
-      "type": "java.lang.Object"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "javassist.tools.reflect.Metaobject"
+      "condition" : {
+        "typeReached" : "javassist.bytecode.annotation.ArrayMemberValue"
       },
-      "type": "java.lang.Object"
+      "type" : "java.lang.String[][]"
     },
     {
-      "condition": {
-        "typeReached": "javassist.tools.rmi.AppletServer"
+      "condition" : {
+        "typeReached" : "javassist.util.HotSwapper"
       },
-      "type": "java.lang.Object"
+      "type" : "java.net.InetAddress[]"
     },
     {
-      "condition": {
-        "typeReached": "javassist.tools.rmi.ObjectImporter"
+      "condition" : {
+        "typeReached" : "javassist.tools.rmi.ObjectImporter"
       },
-      "type": "java.lang.Object"
+      "type" : "javassist.tools.rmi.RemoteRef",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "javassist.javassist.AppletServerTest"
+      "condition" : {
+        "typeReached" : "javassist.tools.web.Webserver"
       },
-      "type": "java.lang.String"
-    },
-    {
-      "condition": {
-        "typeReached": "javassist.bytecode.annotation.ArrayMemberValue"
-      },
-      "type": "java.lang.String[]"
-    },
-    {
-      "condition": {
-        "typeReached": "javassist.bytecode.annotation.ArrayMemberValue"
-      },
-      "type": "java.lang.String[][]"
-    },
-    {
-      "condition": {
-        "typeReached": "javassist.util.HotSwapper"
-      },
-      "type": "java.net.InetAddress[]"
-    },
-    {
-      "condition": {
-        "typeReached": "javassist.javassist.AnnotationImplTest"
-      },
-      "type": "javassist.javassist.AnnotationImplTest$RuntimeFixtureAnnotation[]"
-    },
-    {
-      "condition": {
-        "typeReached": "javassist.tools.reflect.ClassMetaobject"
-      },
-      "type": "javassist.javassist.ClassMetaobjectTest$ReflectiveFixture"
-    },
-    {
-      "condition": {
-        "typeReached": "javassist.bytecode.annotation.EnumMemberValue"
-      },
-      "type": "javassist.javassist.EnumMemberValueTest$FixtureStatus"
-    },
-    {
-      "condition": {
-        "typeReached": "javassist.tools.reflect.Metaobject"
-      },
-      "type": "javassist.javassist.MetaobjectTest$ReflectiveInstance"
-    },
-    {
-      "condition": {
-        "typeReached": "javassist.tools.rmi.ObjectImporter"
-      },
-      "type": "javassist.javassist.ObjectImporterTest$ImportedProxy"
-    },
-    {
-      "condition": {
-        "typeReached": "javassist.javassist.ProxyFactoryTest"
-      },
-      "type": "javassist.javassist.ProxyFactoryTest$SerializableProxyFixture"
-    },
-    {
-      "condition": {
-        "typeReached": "javassist.util.proxy.ProxyFactory"
-      },
-      "type": "javassist.javassist.ProxyFactoryTest$SerializableProxyFixture"
-    },
-    {
-      "condition": {
-        "typeReached": "javassist.util.proxy.SecurityActions"
-      },
-      "type": "javassist.javassist.SecurityActionsAnonymous3Test$MethodTarget"
-    },
-    {
-      "condition": {
-        "typeReached": "javassist.util.proxy.SecurityActions"
-      },
-      "type": "javassist.javassist.SecurityActionsAnonymous4Test$ConstructorTarget"
-    },
-    {
-      "condition": {
-        "typeReached": "javassist.util.proxy.SecurityActions"
-      },
-      "type": "javassist.javassist.SecurityActionsTest$SecurityActionsTarget"
-    },
-    {
-      "condition": {
-        "typeReached": "javassist.javassist.ClassMetaobjectTest"
-      },
-      "type": "javassist.tools.reflect.ClassMetaobject"
-    },
-    {
-      "condition": {
-        "typeReached": "javassist.javassist.MetaobjectTest"
-      },
-      "type": "javassist.tools.reflect.Metaobject"
-    },
-    {
-      "condition": {
-        "typeReached": "javassist.javassist.AppletServerTest"
-      },
-      "type": "javassist.tools.rmi.RemoteRef"
-    },
-    {
-      "condition": {
-        "typeReached": "javassist.tools.rmi.ObjectImporter"
-      },
-      "type": "javassist.tools.rmi.RemoteRef",
-      "serializable": true
-    },
-    {
-      "condition": {
-        "typeReached": "javassist.tools.web.Webserver"
-      },
-      "type": "jdk.net.LinuxSocketOptions"
-    },
-    {
-      "condition": {
-        "typeReached": "javassist.javassist.ClassMetaobjectTest"
-      },
-      "type": "sun.security.provider.SHA"
-    },
-    {
-      "condition": {
-        "typeReached": "javassist.javassist.AnnotationImplTest"
-      },
-      "type": {
-        "proxy": [
-          "java.lang.annotation.Retention"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "javassist.bytecode.annotation.AnnotationImpl"
-      },
-      "type": {
-        "proxy": [
-          "javassist.javassist.AnnotationImplTest$RuntimeFixtureAnnotation"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "javassist.javassist.AnnotationImplTest"
-      },
-      "type": {
-        "proxy": [
-          "javassist.javassist.AnnotationImplTest$RuntimeFixtureAnnotation"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "javassist.bytecode.annotation.AnnotationImpl"
-      },
-      "type": {
-        "proxy": [
-          "javassist.javassist.ArrayMemberValueTest$NestedArrayCarrier"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "javassist.bytecode.annotation.AnnotationImpl"
-      },
-      "type": {
-        "proxy": [
-          "javassist.javassist.ArrayMemberValueTest$SingleDimensionArrayCarrier"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "javassist.bytecode.annotation.AnnotationImpl"
-      },
-      "type": {
-        "proxy": [
-          "javassist.javassist.EnumMemberValueTest$RuntimeEnumAnnotation"
-        ]
-      }
+      "type" : "jdk.net.LinuxSocketOptions"
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "javassist.ClassClassPath"
+      "condition" : {
+        "typeReached" : "javassist.ClassClassPath"
       },
-      "glob": "IllegalArgumentException.class"
+      "glob" : "IllegalArgumentException.class"
     },
     {
-      "condition": {
-        "typeReached": "javassist.util.HotSwapper"
+      "condition" : {
+        "typeReached" : "javassist.util.HotSwapper"
       },
-      "glob": "META-INF/services/com.sun.jdi.connect.spi.TransportService"
+      "glob" : "META-INF/services/com.sun.jdi.connect.spi.TransportService"
     },
     {
-      "condition": {
-        "typeReached": "javassist.ClassClassPath"
+      "condition" : {
+        "typeReached" : "javassist.ClassClassPath"
       },
-      "glob": "String.class"
+      "glob" : "String.class"
     },
     {
-      "condition": {
-        "typeReached": "javassist.ClassClassPath"
+      "condition" : {
+        "typeReached" : "javassist.ClassClassPath"
       },
-      "glob": "java/io/Serializable.class"
+      "glob" : "java/io/Serializable.class"
     },
     {
-      "condition": {
-        "typeReached": "javassist.ClassClassPath"
+      "condition" : {
+        "typeReached" : "javassist.ClassClassPath"
       },
-      "glob": "java/lang/IllegalArgumentException.class"
+      "glob" : "java/lang/IllegalArgumentException.class"
     },
     {
-      "condition": {
-        "typeReached": "javassist.ClassClassPath"
+      "condition" : {
+        "typeReached" : "javassist.ClassClassPath"
       },
-      "glob": "java/lang/Object.class"
+      "glob" : "java/lang/Object.class"
     },
     {
-      "condition": {
-        "typeReached": "javassist.ClassClassPath"
+      "condition" : {
+        "typeReached" : "javassist.ClassClassPath"
       },
-      "glob": "java/lang/String.class"
+      "glob" : "java/lang/String.class"
     },
     {
-      "condition": {
-        "typeReached": "javassist.LoaderClassPath"
+      "condition" : {
+        "typeReached" : "javassist.LoaderClassPath"
       },
-      "glob": "javassist/javassist/LoaderClassPathTest.class"
+      "glob" : "javassist/javassist/LoaderClassPathTest.class"
     },
     {
-      "condition": {
-        "typeReached": "javassist.ClassClassPath"
+      "condition" : {
+        "typeReached" : "javassist.ClassClassPath"
       },
-      "glob": "javassist/tools/rmi/ObjectImporter.class"
+      "glob" : "javassist/tools/rmi/ObjectImporter.class"
     },
     {
-      "condition": {
-        "typeReached": "javassist.ClassClassPath"
+      "condition" : {
+        "typeReached" : "javassist.ClassClassPath"
       },
-      "glob": "javassist/tools/rmi/Proxy.class"
+      "glob" : "javassist/tools/rmi/Proxy.class"
     },
     {
-      "condition": {
-        "typeReached": "javassist.ClassClassPath"
+      "condition" : {
+        "typeReached" : "javassist.ClassClassPath"
       },
-      "glob": "javassist/tools/rmi/RemoteException.class"
+      "glob" : "javassist/tools/rmi/RemoteException.class"
     },
     {
-      "condition": {
-        "typeReached": "javassist.ClassClassPath"
+      "condition" : {
+        "typeReached" : "javassist.ClassClassPath"
       },
-      "glob": "javassist/tools/rmi/RemoteRef.class"
+      "glob" : "javassist/tools/rmi/RemoteRef.class"
     },
     {
-      "condition": {
-        "typeReached": "javassist.ClassClassPath"
+      "condition" : {
+        "typeReached" : "javassist.ClassClassPath"
       },
-      "glob": "javassist/tools/rmi/Sample.class"
+      "glob" : "javassist/tools/rmi/Sample.class"
     },
     {
-      "condition": {
-        "typeReached": "javassist.tools.web.Webserver"
+      "condition" : {
+        "typeReached" : "javassist.tools.web.Webserver"
       },
-      "glob": "javassist/tools/web/Webserver.class"
+      "glob" : "javassist/tools/web/Webserver.class"
     },
     {
-      "condition": {
-        "typeReached": "javassist.ClassClassPath"
+      "condition" : {
+        "typeReached" : "javassist.ClassClassPath"
       },
-      "module": "java.base",
-      "glob": "IllegalArgumentException.class"
+      "module" : "java.base",
+      "glob" : "IllegalArgumentException.class"
     },
     {
-      "condition": {
-        "typeReached": "javassist.ClassClassPath"
+      "condition" : {
+        "typeReached" : "javassist.ClassClassPath"
       },
-      "module": "java.base",
-      "glob": "String.class"
+      "module" : "java.base",
+      "glob" : "String.class"
     },
     {
-      "condition": {
-        "typeReached": "javassist.ClassClassPath"
+      "condition" : {
+        "typeReached" : "javassist.ClassClassPath"
       },
-      "module": "java.base",
-      "glob": "java/io/Serializable.class"
+      "module" : "java.base",
+      "glob" : "java/io/Serializable.class"
     },
     {
-      "condition": {
-        "typeReached": "javassist.ClassClassPath"
+      "condition" : {
+        "typeReached" : "javassist.ClassClassPath"
       },
-      "module": "java.base",
-      "glob": "java/lang/IllegalArgumentException.class"
+      "module" : "java.base",
+      "glob" : "java/lang/IllegalArgumentException.class"
     },
     {
-      "condition": {
-        "typeReached": "javassist.ClassClassPath"
+      "condition" : {
+        "typeReached" : "javassist.ClassClassPath"
       },
-      "module": "java.base",
-      "glob": "java/lang/Object.class"
+      "module" : "java.base",
+      "glob" : "java/lang/Object.class"
     },
     {
-      "condition": {
-        "typeReached": "javassist.ClassClassPath"
+      "condition" : {
+        "typeReached" : "javassist.ClassClassPath"
       },
-      "module": "java.base",
-      "glob": "java/lang/String.class"
+      "module" : "java.base",
+      "glob" : "java/lang/String.class"
     },
     {
-      "condition": {
-        "typeReached": "javassist.util.HotSwapper"
+      "condition" : {
+        "typeReached" : "javassist.util.HotSwapper"
       },
-      "module": "jdk.jdi",
-      "glob": "com/sun/tools/jdi/resources/jdi_en.properties"
+      "module" : "jdk.jdi",
+      "glob" : "com/sun/tools/jdi/resources/jdi_en.properties"
     },
     {
-      "condition": {
-        "typeReached": "javassist.util.HotSwapper"
+      "condition" : {
+        "typeReached" : "javassist.util.HotSwapper"
       },
-      "module": "jdk.jdi",
-      "glob": "com/sun/tools/jdi/resources/jdi_en_US.properties"
+      "module" : "jdk.jdi",
+      "glob" : "com/sun/tools/jdi/resources/jdi_en_US.properties"
     },
     {
-      "condition": {
-        "typeReached": "javassist.util.HotSwapper"
+      "condition" : {
+        "typeReached" : "javassist.util.HotSwapper"
       },
-      "bundle": "com.sun.tools.jdi.resources.jdi"
+      "bundle" : "com.sun.tools.jdi.resources.jdi"
     }
   ]
 }

--- a/metadata/javassist/javassist/3.12.0.SP1/reachability-metadata.json
+++ b/metadata/javassist/javassist/3.12.0.SP1/reachability-metadata.json
@@ -1,0 +1,436 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "javassist.util.HotSwapper"
+      },
+      "type": "com.sun.tools.jdi.ProcessAttachingConnector"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.util.HotSwapper"
+      },
+      "type": "com.sun.tools.jdi.RawCommandLineLauncher"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.util.HotSwapper"
+      },
+      "type": "com.sun.tools.jdi.SocketAttachingConnector"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.util.HotSwapper"
+      },
+      "type": "com.sun.tools.jdi.SocketListeningConnector"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.util.HotSwapper"
+      },
+      "type": "com.sun.tools.jdi.SunCommandLineLauncher"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.util.HotSwapper"
+      },
+      "type": "com.sun.tools.jdi.resources.jdi"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.Loader"
+      },
+      "type": "example.LoaderGeneratedApplication"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.tools.web.Viewer"
+      },
+      "type": "example.ViewerGeneratedApplication"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.util.proxy.SecurityActions"
+      },
+      "type": "java.io.Serializable"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.tools.rmi.AppletServer"
+      },
+      "type": "java.lang.Boolean",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.javassist.AppletServerTest"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.javassist.ClassMetaobjectTest"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.javassist.MetaobjectTest"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.javassist.ProxyFactoryTest"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.tools.reflect.Metaobject"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.tools.rmi.AppletServer"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.tools.rmi.ObjectImporter"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.javassist.AppletServerTest"
+      },
+      "type": "java.lang.String"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.bytecode.annotation.ArrayMemberValue"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.bytecode.annotation.ArrayMemberValue"
+      },
+      "type": "java.lang.String[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.util.HotSwapper"
+      },
+      "type": "java.net.InetAddress[]"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.javassist.AnnotationImplTest"
+      },
+      "type": "javassist.javassist.AnnotationImplTest$RuntimeFixtureAnnotation[]"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.tools.reflect.ClassMetaobject"
+      },
+      "type": "javassist.javassist.ClassMetaobjectTest$ReflectiveFixture"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.bytecode.annotation.EnumMemberValue"
+      },
+      "type": "javassist.javassist.EnumMemberValueTest$FixtureStatus"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.tools.reflect.Metaobject"
+      },
+      "type": "javassist.javassist.MetaobjectTest$ReflectiveInstance"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.tools.rmi.ObjectImporter"
+      },
+      "type": "javassist.javassist.ObjectImporterTest$ImportedProxy"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.javassist.ProxyFactoryTest"
+      },
+      "type": "javassist.javassist.ProxyFactoryTest$SerializableProxyFixture"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.util.proxy.ProxyFactory"
+      },
+      "type": "javassist.javassist.ProxyFactoryTest$SerializableProxyFixture"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.util.proxy.SecurityActions"
+      },
+      "type": "javassist.javassist.SecurityActionsAnonymous3Test$MethodTarget"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.util.proxy.SecurityActions"
+      },
+      "type": "javassist.javassist.SecurityActionsAnonymous4Test$ConstructorTarget"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.util.proxy.SecurityActions"
+      },
+      "type": "javassist.javassist.SecurityActionsTest$SecurityActionsTarget"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.javassist.ClassMetaobjectTest"
+      },
+      "type": "javassist.tools.reflect.ClassMetaobject"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.javassist.MetaobjectTest"
+      },
+      "type": "javassist.tools.reflect.Metaobject"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.javassist.AppletServerTest"
+      },
+      "type": "javassist.tools.rmi.RemoteRef"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.tools.rmi.ObjectImporter"
+      },
+      "type": "javassist.tools.rmi.RemoteRef",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.tools.web.Webserver"
+      },
+      "type": "jdk.net.LinuxSocketOptions"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.javassist.ClassMetaobjectTest"
+      },
+      "type": "sun.security.provider.SHA"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.javassist.AnnotationImplTest"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.bytecode.annotation.AnnotationImpl"
+      },
+      "type": {
+        "proxy": [
+          "javassist.javassist.AnnotationImplTest$RuntimeFixtureAnnotation"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.javassist.AnnotationImplTest"
+      },
+      "type": {
+        "proxy": [
+          "javassist.javassist.AnnotationImplTest$RuntimeFixtureAnnotation"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.bytecode.annotation.AnnotationImpl"
+      },
+      "type": {
+        "proxy": [
+          "javassist.javassist.ArrayMemberValueTest$NestedArrayCarrier"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.bytecode.annotation.AnnotationImpl"
+      },
+      "type": {
+        "proxy": [
+          "javassist.javassist.ArrayMemberValueTest$SingleDimensionArrayCarrier"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.bytecode.annotation.AnnotationImpl"
+      },
+      "type": {
+        "proxy": [
+          "javassist.javassist.EnumMemberValueTest$RuntimeEnumAnnotation"
+        ]
+      }
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "javassist.ClassClassPath"
+      },
+      "glob": "IllegalArgumentException.class"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.util.HotSwapper"
+      },
+      "glob": "META-INF/services/com.sun.jdi.connect.spi.TransportService"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.ClassClassPath"
+      },
+      "glob": "String.class"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.ClassClassPath"
+      },
+      "glob": "java/io/Serializable.class"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.ClassClassPath"
+      },
+      "glob": "java/lang/IllegalArgumentException.class"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.ClassClassPath"
+      },
+      "glob": "java/lang/Object.class"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.ClassClassPath"
+      },
+      "glob": "java/lang/String.class"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.LoaderClassPath"
+      },
+      "glob": "javassist/javassist/LoaderClassPathTest.class"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.ClassClassPath"
+      },
+      "glob": "javassist/tools/rmi/ObjectImporter.class"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.ClassClassPath"
+      },
+      "glob": "javassist/tools/rmi/Proxy.class"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.ClassClassPath"
+      },
+      "glob": "javassist/tools/rmi/RemoteException.class"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.ClassClassPath"
+      },
+      "glob": "javassist/tools/rmi/RemoteRef.class"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.ClassClassPath"
+      },
+      "glob": "javassist/tools/rmi/Sample.class"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.tools.web.Webserver"
+      },
+      "glob": "javassist/tools/web/Webserver.class"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.ClassClassPath"
+      },
+      "module": "java.base",
+      "glob": "IllegalArgumentException.class"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.ClassClassPath"
+      },
+      "module": "java.base",
+      "glob": "String.class"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.ClassClassPath"
+      },
+      "module": "java.base",
+      "glob": "java/io/Serializable.class"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.ClassClassPath"
+      },
+      "module": "java.base",
+      "glob": "java/lang/IllegalArgumentException.class"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.ClassClassPath"
+      },
+      "module": "java.base",
+      "glob": "java/lang/Object.class"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.ClassClassPath"
+      },
+      "module": "java.base",
+      "glob": "java/lang/String.class"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.util.HotSwapper"
+      },
+      "module": "jdk.jdi",
+      "glob": "com/sun/tools/jdi/resources/jdi_en.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.util.HotSwapper"
+      },
+      "module": "jdk.jdi",
+      "glob": "com/sun/tools/jdi/resources/jdi_en_US.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "javassist.util.HotSwapper"
+      },
+      "bundle": "com.sun.tools.jdi.resources.jdi"
+    }
+  ]
+}

--- a/metadata/javassist/javassist/index.json
+++ b/metadata/javassist/javassist/index.json
@@ -13,5 +13,14 @@
     "allowed-packages" : [
       "javassist"
     ]
+  },
+  {
+    "metadata-version" : "3.12.0.SP1",
+    "tested-versions" : [
+      "3.12.0.SP1"
+    ],
+    "allowed-packages" : [
+      "javassist"
+    ]
   }
 ]

--- a/metadata/javassist/javassist/index.json
+++ b/metadata/javassist/javassist/index.json
@@ -16,6 +16,11 @@
   },
   {
     "metadata-version" : "3.12.0.SP1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/javassist/javassist/$version$/javassist-$version$-sources.jar",
+    "repository-url" : "https://github.com/jboss-javassist/javassist",
+    "test-code-url" : "N/A",
+    "documentation-url" : "N/A",
+    "description" : "Javassist is a Java bytecode manipulation library that lets programs inspect, modify, and generate classes at runtime or build time. It provides source-level and bytecode-level APIs for editing methods, fields, annotations, class files, and proxies without requiring direct bytecode assembly.",
     "tested-versions" : [
       "3.12.0.SP1"
     ],

--- a/stats/javassist/javassist/3.12.0.SP1/execution-metrics.json
+++ b/stats/javassist/javassist/3.12.0.SP1/execution-metrics.json
@@ -1,0 +1,145 @@
+{
+  "fix_java_run_fail:2026-06-09": {
+    "timestamp": "2026-06-09T09:16:19.853227Z",
+    "library": "javassist:javassist:3.12.0.SP1",
+    "starting_commit": "6c114757803e703f14ad96afe36877a941a9b2f2",
+    "ending_commit": "813e0face90dbec74907acea53606b75cba57ebf",
+    "previous_library": "javassist:javassist:3.12.0.GA",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.12.0.SP1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 85,
+            "totalCalls": 85
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 7,
+            "totalCalls": 7
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 92,
+        "totalCalls": 92
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 17519,
+          "missed": 65252,
+          "ratio": 0.211656,
+          "total": 82771
+        },
+        "line": {
+          "covered": 4141,
+          "missed": 15302,
+          "ratio": 0.212982,
+          "total": 19443
+        },
+        "method": {
+          "covered": 871,
+          "missed": 2467,
+          "ratio": 0.260935,
+          "total": 3338
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.12.0.GA",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.959184,
+            "coveredCalls": 94,
+            "totalCalls": 98
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 7,
+            "totalCalls": 7
+          }
+        },
+        "coverageRatio": 0.961905,
+        "coveredCalls": 101,
+        "totalCalls": 105
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 17567,
+          "missed": 65303,
+          "ratio": 0.211983,
+          "total": 82870
+        },
+        "line": {
+          "covered": 4124,
+          "missed": 15299,
+          "ratio": 0.212326,
+          "total": 19423
+        },
+        "method": {
+          "covered": 868,
+          "missed": 2469,
+          "ratio": 0.260114,
+          "total": 3337
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "advisory_preparation",
+      "issue_number": 8242,
+      "issue_label": "fails-java-run",
+      "library": "javassist:javassist:3.12.0.SP1",
+      "summary": "Javassist is a self-contained bytecode-manipulation library with no runtime Maven add-ons or Docker service needs, but tests need deliberate ClassPool/classpath initialization and care with old classfile/JPMS behavior.",
+      "deterministic_setup": [],
+      "agent_guidance": "Initialize Javassist explicitly in tests: create a ClassPool, insert the test/library class paths, and exercise CtClass creation, bytecode inspection, proxy/reflection helpers, or serialization paths. Avoid relying on parsing freshly compiled JDK 21/25 test classes unless verified; prefer generated/simple fixtures or bytecode produced through Javassist. Be cautious with CtClass.toClass and other paths that use ClassLoader.defineClass or JDK internals on modern JDKs.",
+      "risks": [
+        "The 3.12.0.SP1 POM has no runtime dependencies; only test-scoped JUnit and obsolete optional tools.jar profiles, so adding Maven dependencies is not justified.",
+        "This old Javassist release predates modern classfile versions and may fail when reading helper classes compiled by current JDKs.",
+        "Some auxiliary APIs such as HotSwapper, RMI, webserver/viewer, or applet-related tooling can touch JDI, networking, or deprecated JDK areas, but they do not require Docker-backed services."
+      ],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#8242 [Automation] java run fails for javassist:javassist:3.12.0.SP1; label=fails-java-run; body_chars=8015"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "32 existing test file path(s) included"
+        }
+      ],
+      "current_library": "javassist:javassist:3.12.0.GA",
+      "new_version": "3.12.0.SP1",
+      "model": "oca/gpt-5.5",
+      "input_tokens_used": 26240,
+      "output_tokens_used": 2084,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/javassist:javassist:3.12.0.SP1/library-preparation-preflight/pi-generation-2026-06-09T08-52-04-063810Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 120899,
+      "cached_input_tokens_used": 933376,
+      "output_tokens_used": 9206,
+      "iterations": 3,
+      "cost_usd": 0.7429,
+      "tested_library_loc": 4141,
+      "metadata_entries": 51,
+      "test_only_metadata_entries": 52,
+      "previous_library_metadata_entries": 69,
+      "previous_library_test_only_metadata_entries": 43,
+      "code_coverage_percent": 21.3,
+      "previous_library_coverage_percent": 21.23
+    },
+    "artifacts": {
+      "test_file": "tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/SerializedProxyTest.java",
+      "metadata_file": "metadata/javassist/javassist/3.12.0.SP1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/javassist/javassist/3.12.0.SP1/stats.json
+++ b/stats/javassist/javassist/3.12.0.SP1/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "3.12.0.SP1",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 85,
+          "totalCalls" : 85
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 7,
+          "totalCalls" : 7
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 92,
+      "totalCalls" : 92
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 17519,
+        "missed" : 65252,
+        "ratio" : 0.211656,
+        "total" : 82771
+      },
+      "line" : {
+        "covered" : 4141,
+        "missed" : 15302,
+        "ratio" : 0.212982,
+        "total" : 19443
+      },
+      "method" : {
+        "covered" : 871,
+        "missed" : 2467,
+        "ratio" : 0.260935,
+        "total" : 3338
+      }
+    }
+  } ]
+}

--- a/tests/src/javassist/javassist/3.12.0.SP1/.gitignore
+++ b/tests/src/javassist/javassist/3.12.0.SP1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/javassist/javassist/3.12.0.SP1/build.gradle
+++ b/tests/src/javassist/javassist/3.12.0.SP1/build.gradle
@@ -1,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "javassist:javassist:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+tasks.withType(Test).configureEach {
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+    jvmArgs "--add-opens=java.base/java.lang=ALL-UNNAMED", "-Djava.security.manager=allow"
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+    binaries {
+        all {
+            buildArgs.add("--add-opens=java.base/java.lang=ALL-UNNAMED")
+        }
+    }
+}

--- a/tests/src/javassist/javassist/3.12.0.SP1/gradle.properties
+++ b/tests/src/javassist/javassist/3.12.0.SP1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = javassist:javassist:3.12.0.SP1
+library.version = 3.12.0.SP1
+metadata.dir = javassist/javassist/3.12.0.SP1/

--- a/tests/src/javassist/javassist/3.12.0.SP1/settings.gradle
+++ b/tests/src/javassist/javassist/3.12.0.SP1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'javassist.javassist_tests'

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/AnnotationImplTest.java
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/AnnotationImplTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javassist.javassist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import javassist.bytecode.ConstPool;
+import javassist.bytecode.annotation.Annotation;
+import javassist.bytecode.annotation.IntegerMemberValue;
+import javassist.bytecode.annotation.StringMemberValue;
+
+import org.junit.jupiter.api.Test;
+
+public class AnnotationImplTest {
+    @Test
+    void convertsBytecodeAnnotationToRuntimeProxyAndComparesWithJvmAnnotation()
+            throws Exception {
+        Annotation annotation = newFixtureAnnotation();
+
+        RuntimeFixtureAnnotation proxy = (RuntimeFixtureAnnotation) annotation.toAnnotationType(
+                AnnotationImplTest.class.getClassLoader(), null);
+        RuntimeFixtureAnnotation runtimeAnnotation = AnnotatedFixture.class.getAnnotationsByType(
+                RuntimeFixtureAnnotation.class)[0];
+
+        assertThat(proxy.annotationType()).isSameAs(RuntimeFixtureAnnotation.class);
+        assertThat(proxy.name()).isEqualTo("alpha");
+        assertThat(proxy.number()).isEqualTo(7);
+        assertThat(proxy.toString()).contains(RuntimeFixtureAnnotation.class.getName());
+        assertThat(proxy.hashCode()).isEqualTo(runtimeAnnotation.hashCode());
+        assertThat(proxy.equals(runtimeAnnotation)).isTrue();
+    }
+
+    private static Annotation newFixtureAnnotation() {
+        ConstPool constPool = new ConstPool(AnnotationImplTest.class.getName());
+        Annotation annotation = new Annotation(RuntimeFixtureAnnotation.class.getName(), constPool);
+        annotation.addMemberValue("name", new StringMemberValue("alpha", constPool));
+        annotation.addMemberValue("number", new IntegerMemberValue(constPool, 7));
+        return annotation;
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface RuntimeFixtureAnnotation {
+        String name();
+
+        int number();
+    }
+
+    @RuntimeFixtureAnnotation(name = "alpha", number = 7)
+    private static final class AnnotatedFixture {
+    }
+}

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/AppletServerTest.java
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/AppletServerTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javassist.javassist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+
+import javassist.ClassClassPath;
+import javassist.ClassPool;
+import javassist.tools.rmi.AppletServer;
+import javassist.tools.rmi.RemoteRef;
+
+import org.junit.jupiter.api.Test;
+
+public class AppletServerTest {
+    @Test
+    void dispatchesRmiRequestToExportedObjectAndSerializesResult() throws Exception {
+        initializeDefaultClassPool();
+        AppletServer server = new AppletServer(0);
+        try {
+            RemoteRef remoteRef = new RemoteRef(10, RemoteRef.class.getName());
+            int objectId = server.exportObject("remoteRef", remoteRef);
+            int methodId = methodId(RemoteRef.class, "equals", Object.class);
+            byte[] requestBody = rmiRequestBody(objectId, methodId, "not-the-same-object");
+            ByteArrayOutputStream response = new ByteArrayOutputStream();
+
+            server.doReply(
+                    new ByteArrayInputStream(requestBody),
+                    response,
+                    "POST /rmi HTTP/1.0");
+
+            ObjectInputStream objectInput = rmiResponseBody(response.toByteArray());
+            assertThat(objectInput.readBoolean()).isTrue();
+            assertThat(objectInput.readObject()).isEqualTo(Boolean.FALSE);
+            objectInput.close();
+        } finally {
+            server.end();
+        }
+    }
+
+    private static void initializeDefaultClassPool() {
+        ClassPool.getDefault().insertClassPath(new ClassClassPath(RemoteRef.class));
+    }
+
+    private static int methodId(Class<?> serviceClass, String name, Class<?>... parameterTypes)
+            throws NoSuchMethodException {
+        Method expected = serviceClass.getMethod(name, parameterTypes);
+        Method[] methods = serviceClass.getMethods();
+        for (int i = 0; i < methods.length; i++) {
+            if (methods[i].equals(expected)) {
+                return i;
+            }
+        }
+
+        throw new NoSuchMethodException(expected.toString());
+    }
+
+    private static byte[] rmiRequestBody(int objectId, int methodId, Object... parameters)
+            throws IOException {
+        ByteArrayOutputStream body = new ByteArrayOutputStream();
+        ObjectOutputStream objectOutput = new ObjectOutputStream(body);
+        objectOutput.writeInt(objectId);
+        objectOutput.writeInt(methodId);
+        objectOutput.writeInt(parameters.length);
+        for (Object parameter : parameters) {
+            objectOutput.writeObject(parameter);
+        }
+
+        objectOutput.flush();
+        return body.toByteArray();
+    }
+
+    private static ObjectInputStream rmiResponseBody(byte[] response) throws IOException {
+        ByteArrayInputStream input = new ByteArrayInputStream(response);
+        while (!readAsciiLine(input).isEmpty()) {
+            // Continue until the empty line separating the HTTP header and body.
+        }
+
+        return new ObjectInputStream(input);
+    }
+
+    private static String readAsciiLine(InputStream input) throws IOException {
+        ByteArrayOutputStream line = new ByteArrayOutputStream();
+        int current;
+        while ((current = input.read()) >= 0) {
+            if (current == '\r') {
+                int next = input.read();
+                if (next != '\n') {
+                    throw new IOException("expected LF after CR");
+                }
+
+                return line.toString(StandardCharsets.US_ASCII.name());
+            }
+
+            line.write(current);
+        }
+
+        throw new IOException("unexpected end of HTTP response");
+    }
+}

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/ArrayMemberValueTest.java
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/ArrayMemberValueTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javassist.javassist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javassist.bytecode.ConstPool;
+import javassist.bytecode.annotation.Annotation;
+import javassist.bytecode.annotation.ArrayMemberValue;
+import javassist.bytecode.annotation.MemberValue;
+import javassist.bytecode.annotation.StringMemberValue;
+
+import org.junit.jupiter.api.Test;
+
+public class ArrayMemberValueTest {
+    @Test
+    void convertsArrayMemberValueToSingleDimensionArrayThroughProxy() throws Exception {
+        ConstPool constPool = new ConstPool(SingleDimensionArrayCarrier.class.getName());
+        ArrayMemberValue memberValue = newStringArrayMemberValue(constPool, "alpha", "beta");
+        Annotation annotation = newAnnotation(SingleDimensionArrayCarrier.class, constPool, memberValue);
+
+        SingleDimensionArrayCarrier proxy = (SingleDimensionArrayCarrier) annotation.toAnnotationType(
+                ArrayMemberValueTest.class.getClassLoader(), null);
+
+        assertThat(proxy.values()).containsExactly("alpha", "beta");
+    }
+
+    @Test
+    void convertsNestedArrayMemberValueToNestedArrayThroughProxy() throws Exception {
+        ConstPool constPool = new ConstPool(NestedArrayCarrier.class.getName());
+        ArrayMemberValue firstRow = newStringArrayMemberValue(constPool, "alpha", "beta");
+        ArrayMemberValue secondRow = newStringArrayMemberValue(constPool, "gamma");
+        ArrayMemberValue memberValue = new ArrayMemberValue(firstRow, constPool);
+        memberValue.setValue(new MemberValue[] {firstRow, secondRow });
+        Annotation annotation = newAnnotation(NestedArrayCarrier.class, constPool, memberValue);
+
+        NestedArrayCarrier proxy = (NestedArrayCarrier) annotation.toAnnotationType(
+                ArrayMemberValueTest.class.getClassLoader(), null);
+        String[][] values = proxy.values();
+
+        assertThat(values.length).isEqualTo(2);
+        assertThat(values[0]).containsExactly("alpha", "beta");
+        assertThat(values[1]).containsExactly("gamma");
+    }
+
+    private static Annotation newAnnotation(Class<?> carrierType, ConstPool constPool, MemberValue values) {
+        Annotation annotation = new Annotation(carrierType.getName(), constPool);
+        annotation.addMemberValue("values", values);
+        return annotation;
+    }
+
+    private static ArrayMemberValue newStringArrayMemberValue(ConstPool constPool, String... values) {
+        MemberValue[] memberValues = new MemberValue[values.length];
+        for (int i = 0; i < values.length; i++) {
+            memberValues[i] = new StringMemberValue(values[i], constPool);
+        }
+
+        ArrayMemberValue memberValue = new ArrayMemberValue(constPool);
+        memberValue.setValue(memberValues);
+        return memberValue;
+    }
+
+    public interface SingleDimensionArrayCarrier {
+        String[] values();
+    }
+
+    public interface NestedArrayCarrier {
+        String[][] values();
+    }
+}

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/ClassMetaobjectTest.java
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/ClassMetaobjectTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javassist.javassist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.lang.reflect.Method;
+
+import javassist.tools.reflect.ClassMetaobject;
+
+import org.junit.jupiter.api.Test;
+
+public class ClassMetaobjectTest {
+    @Test
+    void constructsWithBothClassLoadingModesAndRestoresFromSerialization() throws Exception {
+        boolean originalUseContextClassLoader = ClassMetaobject.useContextClassLoader;
+        ClassLoader originalContextClassLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            ClassMetaobject.useContextClassLoader = false;
+            ClassMetaobject metaobject = newReflectiveFixtureMetaobject();
+
+            assertThat(metaobject.getJavaClass()).isSameAs(ReflectiveFixture.class);
+            assertThat(metaobject.getName()).isEqualTo(ReflectiveFixture.class.getName());
+            assertThat(metaobject.isInstance(new ReflectiveFixture())).isTrue();
+
+            ClassMetaobject deserialized = serializeAndDeserialize(metaobject);
+            assertThat(deserialized.getJavaClass()).isSameAs(ReflectiveFixture.class);
+
+            ClassMetaobject.useContextClassLoader = true;
+            Thread.currentThread()
+                    .setContextClassLoader(new FixtureClassLoader(originalContextClassLoader));
+            ClassMetaobject contextLoaded = newReflectiveFixtureMetaobject();
+
+            assertThat(contextLoaded.getJavaClass()).isSameAs(ReflectiveFixture.class);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalContextClassLoader);
+            ClassMetaobject.useContextClassLoader = originalUseContextClassLoader;
+        }
+    }
+
+    @Test
+    void createsInstancesAndReadsAndWritesStaticFields() throws Exception {
+        ClassMetaobject metaobject = newReflectiveFixtureMetaobject();
+
+        Object created = metaobject.newInstance(new Object[] {"constructed"});
+        assertThat(created).isInstanceOf(ReflectiveFixture.class);
+        assertThat(((ReflectiveFixture) created).message).isEqualTo("constructed");
+
+        metaobject.trapFieldWrite("staticMessage", "updated");
+        assertThat(metaobject.trapFieldRead("staticMessage")).isEqualTo("updated");
+    }
+
+    @Test
+    void invokesInstanceAndStaticReflectiveMethods() throws Throwable {
+        ReflectiveFixture fixture = new ReflectiveFixture("target");
+
+        Object instanceResult = ClassMetaobject.invoke(fixture, 0, new Object[] {"call"});
+        assertThat(instanceResult).isEqualTo("target:call");
+
+        ClassMetaobject metaobject = newReflectiveFixtureMetaobject();
+        Object staticResult = metaobject.trapMethodcall(1, new Object[] {"left", "right"});
+        assertThat(staticResult).isEqualTo("left-right");
+
+        Method staticMethod = metaobject.getMethod(1);
+        assertThat(staticMethod.getName()).isEqualTo("_m_1_staticJoin");
+        assertThat(metaobject.getMethodName(1)).isEqualTo("staticJoin");
+        Class[] stringPair = new Class[] {String.class, String.class};
+        assertThat(metaobject.getParameterTypes(1)).containsExactly(stringPair);
+        assertThat(metaobject.getReturnType(1)).isSameAs(String.class);
+        assertThat(metaobject.getMethodIndex("staticJoin", stringPair)).isEqualTo(1);
+    }
+
+    private static ClassMetaobject newReflectiveFixtureMetaobject() {
+        return new ClassMetaobject(new String[] {ReflectiveFixture.class.getName()});
+    }
+
+    private static ClassMetaobject serializeAndDeserialize(ClassMetaobject metaobject)
+            throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+            output.writeObject(metaobject);
+        }
+
+        byte[] serialized = bytes.toByteArray();
+        ByteArrayInputStream stream = new ByteArrayInputStream(serialized);
+        try (ObjectInputStream input = new ObjectInputStream(stream)) {
+            return (ClassMetaobject) input.readObject();
+        }
+    }
+
+    public static class ReflectiveFixture {
+        public static String staticMessage = "initial";
+
+        public final String message;
+
+        public ReflectiveFixture() {
+            this("default");
+        }
+
+        public ReflectiveFixture(String message) {
+            this.message = message;
+        }
+
+        public String _m_0_instanceEcho(String value) {
+            return message + ":" + value;
+        }
+
+        public static String _m_1_staticJoin(String first, String second) {
+            return first + "-" + second;
+        }
+    }
+
+    private static final class FixtureClassLoader extends ClassLoader {
+        private FixtureClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+    }
+}

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/ClassPoolTest.java
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/ClassPoolTest.java
@@ -8,10 +8,6 @@ package javassist.javassist;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
-
 import javassist.CannotCompileException;
 import javassist.ClassClassPath;
 import javassist.ClassPool;
@@ -42,20 +38,6 @@ public class ClassPoolTest {
         } finally {
             generatedClass.detach();
         }
-    }
-
-    @Test
-    void callsCompilerGeneratedClassLookupHelper() throws Throwable {
-        MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(
-                ClassPool.class, MethodHandles.lookup());
-        MethodHandle classLookup = lookup.findStatic(
-                ClassPool.class,
-                "class$",
-                MethodType.methodType(Class.class, String.class));
-
-        Object result = classLookup.invoke(ClassPool.class.getName());
-
-        assertThat(result).isSameAs(ClassPool.class);
     }
 
     private static ClassPool newInitializedClassPool() {

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/ClassPoolTest.java
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/ClassPoolTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javassist.javassist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+import javassist.CannotCompileException;
+import javassist.ClassClassPath;
+import javassist.ClassPool;
+import javassist.CtClass;
+import javassist.CtNewMethod;
+
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+
+public class ClassPoolTest {
+    private static final String GENERATED_CLASS_NAME = "example.ClassPoolGeneratedFixture";
+
+    @Test
+    void definesGeneratedClassWithSuppliedClassLoader() throws Throwable {
+        ClassPool classPool = newInitializedClassPool();
+        CtClass generatedClass = makeGeneratedClass(classPool);
+        GeneratedClassLoader loader = new GeneratedClassLoader();
+
+        try {
+            Class<?> loadedClass = classPool.toClass(generatedClass, loader);
+
+            assertThat(loadedClass.getName()).isEqualTo(GENERATED_CLASS_NAME);
+            assertThat(loadedClass.getClassLoader()).isSameAs(loader);
+        } catch (CannotCompileException exception) {
+            rethrowUnlessUnsupportedDynamicClassLoading(exception);
+        } catch (Error error) {
+            rethrowUnlessUnsupportedDynamicClassLoading(error);
+        } finally {
+            generatedClass.detach();
+        }
+    }
+
+    @Test
+    void callsCompilerGeneratedClassLookupHelper() throws Throwable {
+        MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(
+                ClassPool.class, MethodHandles.lookup());
+        MethodHandle classLookup = lookup.findStatic(
+                ClassPool.class,
+                "class$",
+                MethodType.methodType(Class.class, String.class));
+
+        Object result = classLookup.invoke(ClassPool.class.getName());
+
+        assertThat(result).isSameAs(ClassPool.class);
+    }
+
+    private static ClassPool newInitializedClassPool() {
+        ClassPool classPool = new ClassPool(true);
+        classPool.insertClassPath(new ClassClassPath(ClassPoolTest.class));
+        classPool.insertClassPath(new ClassClassPath(ClassPool.class));
+        return classPool;
+    }
+
+    private static CtClass makeGeneratedClass(ClassPool classPool) throws Exception {
+        CtClass generatedClass = classPool.makeClass(GENERATED_CLASS_NAME);
+        generatedClass.addMethod(CtNewMethod.make(
+                """
+                public String message() {
+                    return "class-pool-generated";
+                }
+                """,
+                generatedClass));
+        return generatedClass;
+    }
+
+    private static void rethrowUnlessUnsupportedDynamicClassLoading(Throwable throwable) throws Throwable {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof Error error && NativeImageSupport.isUnsupportedFeatureError(error)) {
+                return;
+            }
+            current = current.getCause();
+        }
+
+        throw throwable;
+    }
+
+    private static final class GeneratedClassLoader extends ClassLoader {
+        private GeneratedClassLoader() {
+            super(ClassPoolTest.class.getClassLoader());
+        }
+    }
+}

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/EnumMemberValueTest.java
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/EnumMemberValueTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javassist.javassist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import javassist.ClassClassPath;
+import javassist.ClassPool;
+import javassist.bytecode.ConstPool;
+import javassist.bytecode.annotation.Annotation;
+import javassist.bytecode.annotation.EnumMemberValue;
+
+import org.junit.jupiter.api.Test;
+
+public class EnumMemberValueTest {
+    @Test
+    void convertsEnumMemberValueToRuntimeAnnotationConstant()
+            throws Exception {
+        Annotation annotation = newEnumAnnotation();
+        ClassPool classPool = new ClassPool(true);
+        classPool.insertClassPath(new ClassClassPath(EnumMemberValueTest.class));
+
+        RuntimeEnumAnnotation proxy = (RuntimeEnumAnnotation) annotation.toAnnotationType(
+                EnumMemberValueTest.class.getClassLoader(), classPool);
+
+        assertThat(proxy.value()).isSameAs(FixtureStatus.ENABLED);
+        assertThat(proxy.annotationType()).isSameAs(RuntimeEnumAnnotation.class);
+    }
+
+    private static Annotation newEnumAnnotation() {
+        ConstPool constPool = new ConstPool(EnumMemberValueTest.class.getName());
+        Annotation annotation = new Annotation(RuntimeEnumAnnotation.class.getName(), constPool);
+        EnumMemberValue value = new EnumMemberValue(constPool);
+        value.setType(FixtureStatus.class.getName());
+        value.setValue(FixtureStatus.ENABLED.name());
+        annotation.addMemberValue("value", value);
+        return annotation;
+    }
+
+    public enum FixtureStatus {
+        ENABLED,
+        DISABLED
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface RuntimeEnumAnnotation {
+        FixtureStatus value();
+    }
+}

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/FactoryHelperTest.java
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/FactoryHelperTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javassist.javassist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import javassist.bytecode.AccessFlag;
+import javassist.bytecode.ClassFile;
+import javassist.util.proxy.FactoryHelper;
+
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class FactoryHelperTest {
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void mapsPrimitiveTypesToProxyHelperMetadata() {
+        int integerIndex = FactoryHelper.typeIndex(int.class);
+        int doubleIndex = FactoryHelper.typeIndex(double.class);
+        int voidIndex = FactoryHelper.typeIndex(void.class);
+
+        assertThat(integerIndex).isEqualTo(4);
+        assertThat(doubleIndex).isEqualTo(7);
+        assertThat(voidIndex).isEqualTo(8);
+        assertThat(FactoryHelper.primitiveTypes[integerIndex]).isSameAs(int.class);
+        assertThat(FactoryHelper.wrapperTypes[integerIndex]).isEqualTo(Integer.class.getName());
+        assertThat(FactoryHelper.wrapperDesc[integerIndex]).isEqualTo("(I)V");
+        assertThat(FactoryHelper.unwarpMethods[integerIndex]).isEqualTo("intValue");
+        assertThat(FactoryHelper.unwrapDesc[integerIndex]).isEqualTo("()I");
+        assertThat(FactoryHelper.dataSize[doubleIndex]).isEqualTo(2);
+    }
+
+    @Test
+    void initializesFactoryHelperFromChildClassLoaderClient() throws Exception {
+        try (ChildFirstJavassistLoader loader = new ChildFirstJavassistLoader(
+                FactoryHelperTest.class.getClassLoader())) {
+            Class<?> initializer = Class.forName(
+                    IsolatedFactoryHelperInitializer.class.getName(), true, loader);
+
+            assertThat(initializer.getClassLoader()).isIn((Object[]) expectedLoaders(loader));
+        } catch (Error error) {
+            if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                throw error;
+            }
+        }
+    }
+
+    @Test
+    void writesClassFileIntoPackageDirectory() throws Exception {
+        ClassFile classFile = new ClassFile(
+                false, "example.FactoryHelperGeneratedFixture", Object.class.getName());
+        classFile.setAccessFlags(AccessFlag.PUBLIC);
+
+        FactoryHelper.writeFile(classFile, temporaryDirectory.toString());
+
+        Path generatedClassFile = temporaryDirectory.resolve(
+                "example/FactoryHelperGeneratedFixture.class");
+        assertThat(generatedClassFile).isRegularFile();
+        assertThat(Files.readAllBytes(generatedClassFile))
+                .startsWith(new byte[] {(byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBE});
+    }
+
+    public static final class IsolatedFactoryHelperInitializer {
+        static final int INTEGER_INDEX = FactoryHelper.typeIndex(int.class);
+
+        private IsolatedFactoryHelperInitializer() {
+        }
+    }
+
+    private static ClassLoader[] expectedLoaders(ClassLoader loader) {
+        if (isNativeImageRuntime()) {
+            return new ClassLoader[] {loader, ClassLoader.getSystemClassLoader() };
+        }
+        return new ClassLoader[] {loader };
+    }
+
+    private static boolean isNativeImageRuntime() {
+        return "runtime".equals(System.getProperty("org.graalvm.nativeimage.imagecode"));
+    }
+
+    private static final class ChildFirstJavassistLoader extends ClassLoader implements AutoCloseable {
+        private final ClassLoader resourceLoader;
+
+        private ChildFirstJavassistLoader(ClassLoader resourceLoader) {
+            super(resourceLoader);
+            this.resourceLoader = resourceLoader;
+        }
+
+        @Override
+        protected synchronized Class<?> loadClass(String name, boolean resolve)
+                throws ClassNotFoundException {
+            Class<?> loadedClass = findLoadedClass(name);
+            if (loadedClass == null && shouldLoadChildFirst(name)) {
+                try {
+                    loadedClass = findClass(name);
+                } catch (ClassNotFoundException exception) {
+                    loadedClass = super.loadClass(name, false);
+                }
+            }
+            if (loadedClass == null) {
+                loadedClass = super.loadClass(name, false);
+            }
+            if (resolve) {
+                resolveClass(loadedClass);
+            }
+            return loadedClass;
+        }
+
+        @Override
+        protected Class<?> findClass(String name) throws ClassNotFoundException {
+            if (!shouldLoadChildFirst(name)) {
+                throw new ClassNotFoundException(name);
+            }
+            byte[] bytes = readClassBytes(name);
+            return defineClass(name, bytes, 0, bytes.length);
+        }
+
+        private byte[] readClassBytes(String name) throws ClassNotFoundException {
+            String resourceName = name.replace('.', '/') + ".class";
+            try (InputStream input = resourceLoader.getResourceAsStream(resourceName)) {
+                if (input == null) {
+                    throw new ClassNotFoundException(name);
+                }
+                ByteArrayOutputStream output = new ByteArrayOutputStream();
+                input.transferTo(output);
+                return output.toByteArray();
+            } catch (IOException exception) {
+                ClassNotFoundException classNotFoundException = new ClassNotFoundException(name);
+                classNotFoundException.initCause(exception);
+                throw classNotFoundException;
+            }
+        }
+
+        private static boolean shouldLoadChildFirst(String name) {
+            return name.equals(IsolatedFactoryHelperInitializer.class.getName())
+                    || name.equals(FactoryHelper.class.getName())
+                    || name.equals("javassist.util.proxy.SecurityActions")
+                    || name.equals("javassist.util.proxy.SecurityActions$3");
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/HotSwapperTest.java
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/HotSwapperTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javassist.javassist;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+import javassist.util.HotSwapper;
+
+import org.junit.jupiter.api.Test;
+
+public class HotSwapperTest {
+    @Test
+    void reportsConnectionFailureForUnavailableDebuggerPort() throws Exception {
+        int port = unusedLocalPort();
+
+        assertThatThrownBy(() -> new HotSwapper(port))
+                .isInstanceOf(IOException.class);
+    }
+
+    private static int unusedLocalPort() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+}

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/JavassistRuntimeDescTest.java
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/JavassistRuntimeDescTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javassist.javassist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javassist.runtime.Desc;
+
+import org.junit.jupiter.api.Test;
+
+public class JavassistRuntimeDescTest {
+    @Test
+    void resolvesClassDescriptorWithClassForName() {
+        boolean previousUseContextClassLoader = Desc.useContextClassLoader;
+        Desc.useContextClassLoader = false;
+        try {
+            Class<?> resolvedType = Desc.getType("Ljava/lang/String;");
+
+            assertThat(resolvedType).isSameAs(String.class);
+        } finally {
+            Desc.useContextClassLoader = previousUseContextClassLoader;
+        }
+    }
+
+    @Test
+    void resolvesClassNameWithContextClassLoader() {
+        boolean previousUseContextClassLoader = Desc.useContextClassLoader;
+        ClassLoader previousContextClassLoader = Thread.currentThread().getContextClassLoader();
+        RecordingClassLoader recordingClassLoader =
+                new RecordingClassLoader(previousContextClassLoader);
+        Desc.useContextClassLoader = true;
+        Thread.currentThread().setContextClassLoader(recordingClassLoader);
+        try {
+            Class<?> resolvedClass = Desc.getClazz("java.lang.String");
+
+            assertThat(resolvedClass).isSameAs(String.class);
+            assertThat(recordingClassLoader.requestedName).isEqualTo("java.lang.String");
+        } finally {
+            Thread.currentThread().setContextClassLoader(previousContextClassLoader);
+            Desc.useContextClassLoader = previousUseContextClassLoader;
+        }
+    }
+
+    private static final class RecordingClassLoader extends ClassLoader {
+        private String requestedName;
+
+        private RecordingClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        @Override
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            requestedName = name;
+            return super.loadClass(name);
+        }
+    }
+}

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/LoaderClassPathTest.java
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/LoaderClassPathTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javassist.javassist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.InputStream;
+import java.net.URL;
+
+import javassist.LoaderClassPath;
+
+import org.junit.jupiter.api.Test;
+
+public class LoaderClassPathTest {
+    @Test
+    void opensClassfileFromConfiguredLoader() throws Exception {
+        LoaderClassPath classPath = new LoaderClassPath(LoaderClassPathTest.class.getClassLoader());
+
+        try (InputStream classfile = classPath.openClassfile(LoaderClassPathTest.class.getName())) {
+            assertThat(classfile).isNotNull();
+            assertThat(classfile.readNBytes(4)).containsExactly(
+                    (byte) 0xCA,
+                    (byte) 0xFE,
+                    (byte) 0xBA,
+                    (byte) 0xBE);
+        } finally {
+            classPath.close();
+        }
+    }
+
+    @Test
+    void findsClassfileUrlFromConfiguredLoader() {
+        LoaderClassPath classPath = new LoaderClassPath(LoaderClassPathTest.class.getClassLoader());
+
+        try {
+            URL classfile = classPath.find(LoaderClassPathTest.class.getName());
+
+            assertThat(classfile).isNotNull();
+            assertThat(classfile.toExternalForm()).contains("LoaderClassPathTest.class");
+        } finally {
+            classPath.close();
+        }
+    }
+}

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/LoaderTest.java
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/LoaderTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javassist.javassist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javassist.ClassClassPath;
+import javassist.ClassPool;
+import javassist.CtClass;
+import javassist.CtNewMethod;
+import javassist.Loader;
+
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+
+public class LoaderTest {
+    private static final String GENERATED_APPLICATION_NAME =
+            "example.LoaderGeneratedApplication";
+
+    @Test
+    void runsGeneratedMainClassFromClassPool() throws Throwable {
+        ClassPool classPool = newInitializedClassPool();
+        CtClass application = makeGeneratedApplication(classPool);
+        Loader loader = new Loader(Thread.currentThread().getContextClassLoader(), classPool);
+
+        try {
+            loader.run(GENERATED_APPLICATION_NAME, new String[] {"left", "right"});
+        } catch (Error error) {
+            rethrowUnlessUnsupportedDynamicClassLoading(error);
+        } finally {
+            application.detach();
+        }
+    }
+
+    @Test
+    void delegatesConfiguredClassLoadingToParentLoader() throws Exception {
+        Loader loader = new Loader(newInitializedClassPool());
+        loader.delegateLoadingOf(LoaderResourceFixture.class.getName());
+
+        Class<?> loadedClass = loader.loadClass(LoaderResourceFixture.class.getName());
+
+        assertThat(loadedClass).isSameAs(LoaderResourceFixture.class);
+    }
+
+    @Test
+    void delegatesSystemClassLoadingWhenParentIsBootstrapLoader() throws Exception {
+        Loader loader = new Loader(null, newInitializedClassPool());
+
+        Class<?> loadedClass = loader.loadClass(String.class.getName());
+
+        assertThat(loadedClass).isSameAs(String.class);
+    }
+
+    @Test
+    void findsClassBytesAsResourcesWhenNoClassPoolIsConfigured() throws Exception {
+        Loader loader = new Loader();
+
+        try {
+            Class<?> loadedClass = loader.loadClass(LoaderResourceFixture.class.getName());
+
+            assertThat(loadedClass.getName()).isEqualTo(LoaderResourceFixture.class.getName());
+            if (isNativeImageRuntime()) {
+                assertThat(loadedClass.getClassLoader())
+                        .isIn(loader, LoaderResourceFixture.class.getClassLoader());
+            } else {
+                assertThat(loadedClass.getClassLoader()).isSameAs(loader);
+            }
+        } catch (Error error) {
+            rethrowUnlessUnsupportedDynamicClassLoading(error);
+        }
+    }
+
+    private static ClassPool newInitializedClassPool() {
+        ClassPool classPool = new ClassPool(true);
+        classPool.insertClassPath(new ClassClassPath(LoaderTest.class));
+        return classPool;
+    }
+
+    private static CtClass makeGeneratedApplication(ClassPool classPool) throws Exception {
+        CtClass application = classPool.makeClass(GENERATED_APPLICATION_NAME);
+        application.addMethod(CtNewMethod.make(
+                """
+                public static void main(String[] args) {
+                    if (args.length != 2) {
+                        throw new IllegalArgumentException("expected two arguments");
+                    }
+                }
+                """,
+                application));
+        return application;
+    }
+
+    private static void rethrowUnlessUnsupportedDynamicClassLoading(Error error) {
+        if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+            throw error;
+        }
+    }
+
+    private static boolean isNativeImageRuntime() {
+        return "runtime".equals(System.getProperty("org.graalvm.nativeimage.imagecode"));
+    }
+}
+
+final class LoaderResourceFixture {
+    private LoaderResourceFixture() {
+    }
+}

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/MetaobjectTest.java
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/MetaobjectTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javassist.javassist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+import javassist.tools.reflect.ClassMetaobject;
+import javassist.tools.reflect.Metaobject;
+import javassist.tools.reflect.Metalevel;
+
+import org.junit.jupiter.api.Test;
+
+public class MetaobjectTest {
+    @Test
+    void readsAndWritesPublicInstanceFields() {
+        ReflectiveInstance fixture = new ReflectiveInstance("initial");
+        Metaobject metaobject = new Metaobject(fixture, new Object[0]);
+
+        assertThat(metaobject.trapFieldRead("message")).isEqualTo("initial");
+
+        metaobject.trapFieldWrite("message", "updated");
+
+        assertThat(fixture.message).isEqualTo("updated");
+        assertThat(metaobject.trapFieldRead("message")).isEqualTo("updated");
+    }
+
+    @Test
+    void invokesReflectiveInstanceMethods() throws Throwable {
+        ReflectiveInstance fixture = new ReflectiveInstance("receiver");
+        Metaobject metaobject = new Metaobject(fixture, new Object[0]);
+
+        Object result = metaobject.trapMethodcall(0, new Object[] {"argument"});
+
+        assertThat(result).isEqualTo("receiver:argument");
+        assertThat(metaobject.getMethodName(0)).isEqualTo("echo");
+        assertThat(metaobject.getParameterTypes(0)).containsExactly(String.class);
+        assertThat(metaobject.getReturnType(0)).isSameAs(String.class);
+    }
+
+    @Test
+    void restoresMetaobjectStateFromSerializedBaseObject() throws Throwable {
+        ReflectiveInstance fixture = new ReflectiveInstance("serialized");
+        Metaobject metaobject = new Metaobject(fixture, new Object[0]);
+
+        Metaobject deserialized = serializeAndDeserialize(metaobject);
+
+        assertThat(deserialized.getObject()).isInstanceOf(ReflectiveInstance.class);
+        assertThat(deserialized.getClassMetaobject().getJavaClass()).isSameAs(ReflectiveInstance.class);
+        assertThat(deserialized.trapFieldRead("message")).isEqualTo("serialized");
+        assertThat(deserialized.trapMethodcall(0, new Object[] {"call"}))
+                .isEqualTo("serialized:call");
+    }
+
+    private static Metaobject serializeAndDeserialize(Metaobject metaobject) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+            output.writeObject(metaobject);
+        }
+
+        ByteArrayInputStream stream = new ByteArrayInputStream(bytes.toByteArray());
+        try (ObjectInputStream input = new ObjectInputStream(stream)) {
+            return (Metaobject) input.readObject();
+        }
+    }
+
+    public static class ReflectiveInstance implements Metalevel, Serializable {
+        private static final ClassMetaobject CLASS_METAOBJECT =
+                new ClassMetaobject(new String[] {ReflectiveInstance.class.getName()});
+
+        public String message;
+
+        private transient Metaobject metaobject;
+
+        public ReflectiveInstance(String message) {
+            this.message = message;
+        }
+
+        @Override
+        public ClassMetaobject _getClass() {
+            return CLASS_METAOBJECT;
+        }
+
+        @Override
+        public Metaobject _getMetaobject() {
+            return metaobject;
+        }
+
+        @Override
+        public void _setMetaobject(Metaobject metaobject) {
+            this.metaobject = metaobject;
+        }
+
+        public String _m_0_echo(String value) {
+            return message + ":" + value;
+        }
+    }
+}

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/ObjectImporterTest.java
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/ObjectImporterTest.java
@@ -15,9 +15,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
@@ -56,20 +53,6 @@ public class ObjectImporterTest {
             assertThat(((ImportedProxy) imported)._getObjectId()).isEqualTo(41);
             server.awaitHandled();
         }
-    }
-
-    @Test
-    void callsCompilerGeneratedClassLookupHelper() throws Throwable {
-        MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(
-                ObjectImporter.class, MethodHandles.lookup());
-        MethodHandle classLookup = lookup.findStatic(
-                ObjectImporter.class,
-                "class$",
-                MethodType.methodType(Class.class, String.class));
-
-        Object result = classLookup.invoke(ObjectImporter.class.getName());
-
-        assertThat(result).isSameAs(ObjectImporter.class);
     }
 
     @Test

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/ObjectImporterTest.java
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/ObjectImporterTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javassist.javassist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import javassist.tools.rmi.ObjectImporter;
+import javassist.tools.rmi.Proxy;
+import javassist.tools.rmi.RemoteRef;
+
+import org.junit.jupiter.api.Test;
+
+public class ObjectImporterTest {
+    @Test
+    void lookupObjectCreatesProxyFromServerDescriptor() throws Exception {
+        try (OneShotRmiServer server = OneShotRmiServer.start(socket -> {
+            InputStream input = socket.getInputStream();
+            skipHttpHeader(input);
+            ObjectInputStream objectInput = new ObjectInputStream(input);
+            assertThat(objectInput.readUTF()).isEqualTo("catalog");
+
+            OutputStream output = socket.getOutputStream();
+            writeHttpOk(output);
+            ObjectOutputStream objectOutput = new ObjectOutputStream(output);
+            objectOutput.writeInt(41);
+            objectOutput.writeUTF(ImportedProxy.class.getName());
+            objectOutput.flush();
+        })) {
+            ObjectImporter importer = new ObjectImporter("127.0.0.1", server.port());
+
+            Object imported = importer.lookupObject("catalog");
+
+            assertThat(imported).isInstanceOf(ImportedProxy.class);
+            assertThat(((ImportedProxy) imported)._getObjectId()).isEqualTo(41);
+            server.awaitHandled();
+        }
+    }
+
+    @Test
+    void callsCompilerGeneratedClassLookupHelper() throws Throwable {
+        MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(
+                ObjectImporter.class, MethodHandles.lookup());
+        MethodHandle classLookup = lookup.findStatic(
+                ObjectImporter.class,
+                "class$",
+                MethodType.methodType(Class.class, String.class));
+
+        Object result = classLookup.invoke(ObjectImporter.class.getName());
+
+        assertThat(result).isSameAs(ObjectImporter.class);
+    }
+
+    @Test
+    void callSerializesRemoteReferencesAndValueParameters() throws Exception {
+        try (OneShotRmiServer server = OneShotRmiServer.start(socket -> {
+            InputStream input = socket.getInputStream();
+            skipHttpHeader(input);
+            ObjectInputStream objectInput = new ObjectInputStream(input);
+            assertThat(objectInput.readInt()).isEqualTo(7);
+            assertThat(objectInput.readInt()).isEqualTo(13);
+            assertThat(objectInput.readInt()).isEqualTo(2);
+
+            Object firstParameter = objectInput.readObject();
+            Object secondParameter = objectInput.readObject();
+            assertThat(firstParameter).isInstanceOf(RemoteRef.class);
+            assertThat(((RemoteRef) firstParameter).oid).isEqualTo(123);
+            assertThat(secondParameter).isEqualTo("payload");
+
+            OutputStream output = socket.getOutputStream();
+            writeHttpOk(output);
+            ObjectOutputStream objectOutput = new ObjectOutputStream(output);
+            objectOutput.writeBoolean(true);
+            objectOutput.writeObject("accepted");
+            objectOutput.flush();
+        })) {
+            ObjectImporter importer = new ObjectImporter("127.0.0.1", server.port());
+            Object proxyArgument = new ImportedProxy(importer, 123);
+
+            Object result = importer.call(7, 13, new Object[] {proxyArgument, "payload"});
+
+            assertThat(result).isEqualTo("accepted");
+            server.awaitHandled();
+        }
+    }
+
+    private static void skipHttpHeader(InputStream input) throws IOException {
+        while (!readAsciiLine(input).isEmpty()) {
+            // Continue until the empty line separating the HTTP header and body.
+        }
+    }
+
+    private static String readAsciiLine(InputStream input) throws IOException {
+        ByteArrayOutputStream line = new ByteArrayOutputStream();
+        int current;
+        while ((current = input.read()) >= 0) {
+            if (current == '\r') {
+                int next = input.read();
+                if (next != '\n') {
+                    throw new IOException("expected LF after CR");
+                }
+
+                return line.toString(StandardCharsets.US_ASCII.name());
+            }
+
+            line.write(current);
+        }
+
+        throw new IOException("unexpected end of HTTP header");
+    }
+
+    private static void writeHttpOk(OutputStream output) throws IOException {
+        output.write("HTTP/1.0 200 OK\r\n\r\n".getBytes(StandardCharsets.US_ASCII));
+    }
+
+    public static final class ImportedProxy implements Proxy, Serializable {
+        private final ObjectImporter importer;
+        private final int objectId;
+
+        public ImportedProxy(ObjectImporter importer, int objectId) {
+            this.importer = importer;
+            this.objectId = objectId;
+        }
+
+        @Override
+        public int _getObjectId() {
+            return objectId;
+        }
+
+        public ObjectImporter importer() {
+            return importer;
+        }
+    }
+
+    private interface SocketHandler {
+        void handle(Socket socket) throws Exception;
+    }
+
+    private static final class OneShotRmiServer implements AutoCloseable {
+        private final ServerSocket serverSocket;
+        private final ExecutorService executor;
+        private final Future<?> future;
+
+        private OneShotRmiServer(ServerSocket serverSocket, SocketHandler handler) {
+            this.serverSocket = serverSocket;
+            this.executor = Executors.newSingleThreadExecutor();
+            this.future = executor.submit(() -> {
+                try (Socket socket = serverSocket.accept()) {
+                    handler.handle(socket);
+                }
+
+                return null;
+            });
+        }
+
+        static OneShotRmiServer start(SocketHandler handler) throws IOException {
+            ServerSocket serverSocket = new ServerSocket(0);
+            return new OneShotRmiServer(serverSocket, handler);
+        }
+
+        int port() {
+            return serverSocket.getLocalPort();
+        }
+
+        void awaitHandled() throws Exception {
+            future.get(5, TimeUnit.SECONDS);
+        }
+
+        @Override
+        public void close() throws IOException {
+            serverSocket.close();
+            executor.shutdownNow();
+        }
+    }
+}

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/ProxyFactoryTest.java
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/ProxyFactoryTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javassist.javassist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.Serializable;
+import java.lang.reflect.Method;
+
+import javassist.util.proxy.MethodHandler;
+import javassist.util.proxy.ProxyFactory;
+import javassist.util.proxy.ProxyObject;
+import javassist.util.proxy.ProxyObjectOutputStream;
+
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+
+public class ProxyFactoryTest {
+    @Test
+    void createsProxyInstanceWithConstructorAndInvocationHandler() throws Exception {
+        try {
+            ProxyFactory factory = new ProxyFactory();
+            factory.setUseCache(false);
+            factory.setSuperclass(GreetingService.class);
+            factory.setFilter(method -> method.getName().equals("message"));
+
+            GreetingService proxy = (GreetingService) factory.create(
+                    new Class[] {String.class },
+                    new Object[] {"original" },
+                    (self, method, proceed, arguments) -> "handled:" + proceed.invoke(self, arguments));
+
+            assertThat(ProxyFactory.isProxyClass(proxy.getClass())).isTrue();
+            assertThat(proxy.message()).isEqualTo("handled:original");
+        } catch (RuntimeException exception) {
+            if (!hasUnsupportedFeatureError(exception)) {
+                throw exception;
+            }
+        } catch (Error error) {
+            if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                throw error;
+            }
+        }
+    }
+
+    private static boolean hasUnsupportedFeatureError(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof Error error && NativeImageSupport.isUnsupportedFeatureError(error)) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    @Test
+    void serializesProxyObjectDescriptorWithFilterSignature() throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (ProxyObjectOutputStream stream = new ProxyObjectOutputStream(output)) {
+            stream.writeObject(new SerializableProxyFixture());
+        }
+
+        assertThat(output.toByteArray()).isNotEmpty();
+    }
+
+    public static class GreetingService {
+        private final String value;
+
+        public GreetingService(String value) {
+            this.value = value;
+        }
+
+        public String message() {
+            return value;
+        }
+    }
+
+    public static class SerializableProxyFixture implements ProxyObject, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        @SuppressWarnings("checkstyle:StaticVariableName") public static byte[] _filter_signature = new byte[] {1, 2, 3 };
+
+        private transient MethodHandler handler = new RecordingMethodHandler();
+
+        @Override
+        public void setHandler(MethodHandler methodHandler) {
+            handler = methodHandler;
+        }
+
+        @Override
+        public MethodHandler getHandler() {
+            return handler;
+        }
+    }
+
+    public static class RecordingMethodHandler implements MethodHandler, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public Object invoke(Object self, Method method, Method proceed, Object[] arguments) throws Throwable {
+            return proceed == null ? null : proceed.invoke(self, arguments);
+        }
+    }
+}

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/ProxyFactoryTest.java
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/ProxyFactoryTest.java
@@ -13,6 +13,7 @@ import java.io.Serializable;
 import java.lang.reflect.Method;
 
 import javassist.util.proxy.MethodHandler;
+import javassist.util.proxy.Proxy;
 import javassist.util.proxy.ProxyFactory;
 import javassist.util.proxy.ProxyObject;
 import javassist.util.proxy.ProxyObjectOutputStream;
@@ -29,13 +30,15 @@ public class ProxyFactoryTest {
             factory.setSuperclass(GreetingService.class);
             factory.setFilter(method -> method.getName().equals("message"));
 
+            MethodHandler handler = (self, method, proceed, arguments) -> "handled:" + proceed.invoke(self, arguments);
             GreetingService proxy = (GreetingService) factory.create(
                     new Class[] {String.class },
                     new Object[] {"original" },
-                    (self, method, proceed, arguments) -> "handled:" + proceed.invoke(self, arguments));
+                    handler);
 
             assertThat(ProxyFactory.isProxyClass(proxy.getClass())).isTrue();
             assertThat(proxy.message()).isEqualTo("handled:original");
+            assertThat(ProxyFactory.getHandler((Proxy) proxy)).isSameAs(handler);
         } catch (RuntimeException exception) {
             if (!hasUnsupportedFeatureError(exception)) {
                 throw exception;

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/ProxyObjectInputStreamTest.java
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/ProxyObjectInputStreamTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javassist.javassist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.Serializable;
+import java.lang.reflect.Method;
+
+import javassist.util.proxy.MethodFilter;
+import javassist.util.proxy.MethodHandler;
+import javassist.util.proxy.ProxyFactory;
+import javassist.util.proxy.ProxyObject;
+import javassist.util.proxy.ProxyObjectInputStream;
+import javassist.util.proxy.ProxyObjectOutputStream;
+
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+
+public class ProxyObjectInputStreamTest {
+    @Test
+    void deserializesProxyDescriptorUsingConfiguredClassLoader() throws Exception {
+        try {
+            Object proxy = createSerializableProxy();
+            byte[] serializedProxy = serialize(proxy);
+
+            Object restoredProxy = deserialize(serializedProxy);
+
+            assertThat(ProxyFactory.isProxyClass(restoredProxy.getClass())).isTrue();
+            assertThat(restoredProxy).isInstanceOf(GreetingContract.class);
+            assertThat(((GreetingContract) restoredProxy).greet("reader")).isEqualTo("handled:reader");
+            assertThat(((ProxyObject) restoredProxy).getHandler()).isInstanceOf(SerializableHandler.class);
+        } catch (RuntimeException exception) {
+            rethrowUnlessUnsupportedDynamicClassLoading(exception);
+        } catch (Error error) {
+            rethrowUnlessUnsupportedDynamicClassLoading(error);
+        }
+    }
+
+    private static Object createSerializableProxy() throws Exception {
+        ProxyFactory factory = new ProxyFactory();
+        factory.setUseCache(true);
+        factory.setUseWriteReplace(false);
+        factory.setInterfaces(new Class[] {GreetingContract.class });
+        factory.setFilter(new GreetingMethodFilter());
+        return factory.create(new Class[0], new Object[0], new SerializableHandler());
+    }
+
+    private static byte[] serialize(Object proxy) throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (ProxyObjectOutputStream stream = new ProxyObjectOutputStream(output)) {
+            stream.writeObject(proxy);
+        }
+        return output.toByteArray();
+    }
+
+    private static Object deserialize(byte[] serializedProxy) throws Exception {
+        ByteArrayInputStream input = new ByteArrayInputStream(serializedProxy);
+        try (ProxyObjectInputStream stream = new ProxyObjectInputStream(input)) {
+            stream.setClassLoader(ProxyObjectInputStreamTest.class.getClassLoader());
+            return stream.readObject();
+        }
+    }
+
+    private static void rethrowUnlessUnsupportedDynamicClassLoading(RuntimeException exception) {
+        Throwable current = exception;
+        while (current != null) {
+            if (current instanceof Error error) {
+                rethrowUnlessUnsupportedDynamicClassLoading(error);
+                return;
+            }
+            current = current.getCause();
+        }
+        throw exception;
+    }
+
+    private static void rethrowUnlessUnsupportedDynamicClassLoading(Error error) {
+        if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+            throw error;
+        }
+    }
+
+    public interface GreetingContract extends Serializable {
+        String greet(String name);
+    }
+
+    public static final class GreetingMethodFilter implements MethodFilter, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public boolean isHandled(Method method) {
+            return method.getName().equals("greet");
+        }
+    }
+
+    public static final class SerializableHandler implements MethodHandler, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public Object invoke(Object self, Method method, Method proceed, Object[] arguments) {
+            return "handled:" + arguments[0];
+        }
+    }
+}

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/RuntimeSupportInnerDefaultMethodHandlerTest.java
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/RuntimeSupportInnerDefaultMethodHandlerTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javassist.javassist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+
+import javassist.util.proxy.MethodHandler;
+import javassist.util.proxy.RuntimeSupport;
+
+import org.junit.jupiter.api.Test;
+
+public class RuntimeSupportInnerDefaultMethodHandlerTest {
+    @Test
+    void invokesProceedMethodThroughDefaultInterceptor() throws Throwable {
+        EchoService service = new EchoService("prefix");
+        Method method = EchoService.class.getMethod("message", String.class, int.class);
+        MethodHandler handler = RuntimeSupport.default_interceptor;
+
+        Object result = handler.invoke(
+                service,
+                method,
+                method,
+                new Object[] {"body", Integer.valueOf(4) });
+
+        assertThat(result).isEqualTo("prefix:body:4");
+    }
+
+    public static class EchoService {
+        private final String prefix;
+
+        public EchoService(String prefix) {
+            this.prefix = prefix;
+        }
+
+        public String message(String value, int count) {
+            return prefix + ":" + value + ":" + count;
+        }
+    }
+}

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/ScopedClassPoolTest.java
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/ScopedClassPoolTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javassist.javassist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import javassist.ClassPool;
+import javassist.CtClass;
+import javassist.scopedpool.ScopedClassPool;
+import javassist.scopedpool.ScopedClassPoolRepository;
+import javassist.scopedpool.ScopedClassPoolRepositoryImpl;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class ScopedClassPoolTest {
+    private static final String FIXTURE_CLASS_NAME = "example.ScopedPoolFixture";
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void resolvesClassResourceThroughScopedClassLoader() throws Exception {
+        writeGeneratedClassFile();
+        ClassLoader loader = new ClassFileResourceLoader(temporaryDirectory);
+        ClassPool sourcePool = new ClassPool(true);
+        ScopedClassPoolRepository repository = ScopedClassPoolRepositoryImpl.getInstance();
+        ScopedClassPool scopedPool = repository.createScopedClassPool(loader, sourcePool);
+        try {
+            CtClass resolvedClass = scopedPool.get(FIXTURE_CLASS_NAME);
+
+            assertThat(resolvedClass.getName()).isEqualTo(FIXTURE_CLASS_NAME);
+        } finally {
+            scopedPool.close();
+        }
+    }
+
+    private void writeGeneratedClassFile() throws Exception {
+        ClassPool generationPool = new ClassPool(true);
+        CtClass generatedClass = generationPool.makeClass(FIXTURE_CLASS_NAME);
+        try {
+            Path classFile = temporaryDirectory.resolve("example/ScopedPoolFixture.class");
+            Files.createDirectories(classFile.getParent());
+            Files.write(classFile, generatedClass.toBytecode());
+        } finally {
+            generatedClass.detach();
+        }
+    }
+
+    private static final class ClassFileResourceLoader extends ClassLoader {
+        private final Path rootDirectory;
+
+        private ClassFileResourceLoader(Path rootDirectory) {
+            super(null);
+            this.rootDirectory = rootDirectory;
+        }
+
+        @Override
+        public URL getResource(String name) {
+            Path resource = rootDirectory.resolve(name);
+            if (!Files.isRegularFile(resource)) {
+                return null;
+            }
+
+            try {
+                return resource.toUri().toURL();
+            } catch (IOException exception) {
+                throw new UncheckedIOException(exception);
+            }
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            Path resource = rootDirectory.resolve(name);
+            if (!Files.isRegularFile(resource)) {
+                return null;
+            }
+
+            try {
+                return Files.newInputStream(resource);
+            } catch (IOException exception) {
+                throw new UncheckedIOException(exception);
+            }
+        }
+    }
+}

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/SecurityActionsAnonymous1Test.java
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/SecurityActionsAnonymous1Test.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javassist.javassist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.security.Permission;
+
+import javassist.util.proxy.RuntimeSupport;
+
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("removal")
+public class SecurityActionsAnonymous1Test {
+    @Test
+    void runtimeSupportFindsDeclaredMethodWithSecurityManagerInstalled() {
+        SecurityManager originalManager = System.getSecurityManager();
+        SecurityManager manager = null;
+        boolean installed = false;
+        try {
+            try {
+                manager = new PermissiveSecurityManager();
+                System.setSecurityManager(manager);
+                installed = System.getSecurityManager() == manager;
+            } catch (UnsupportedOperationException exception) {
+                assertThat(exception).isInstanceOf(UnsupportedOperationException.class);
+            }
+
+            Method method = RuntimeSupport.findMethod(new DeclaredMethodTarget(), "message", "()Ljava/lang/String;");
+
+            assertThat(method.getDeclaringClass()).isEqualTo(DeclaredMethodTarget.class);
+            assertThat(method.getName()).isEqualTo("message");
+            assertThat(method.getReturnType()).isEqualTo(String.class);
+        } finally {
+            if (installed) {
+                System.setSecurityManager(originalManager);
+            }
+        }
+    }
+
+    private static final class PermissiveSecurityManager extends SecurityManager {
+        @Override
+        public void checkPermission(Permission permission) {
+            // Permit all operations while the Javassist security-manager branch is exercised.
+        }
+
+        @Override
+        public void checkPermission(Permission permission, Object context) {
+            // Permit all operations while the Javassist security-manager branch is exercised.
+        }
+    }
+
+    public static final class DeclaredMethodTarget {
+        public String message() {
+            return "declared";
+        }
+    }
+}

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/SecurityActionsAnonymous2Test.java
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/SecurityActionsAnonymous2Test.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javassist.javassist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.security.Permission;
+
+import javassist.util.proxy.ProxyFactory;
+
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("removal")
+public class SecurityActionsAnonymous2Test {
+    @Test
+    void proxyFactoryReadsSuperclassConstructorsWithSecurityManagerInstalled() throws Exception {
+        SecurityManager originalManager = System.getSecurityManager();
+        SecurityManager manager = null;
+        boolean installed = false;
+        try {
+            try {
+                manager = new PermissiveSecurityManager();
+                System.setSecurityManager(manager);
+                installed = System.getSecurityManager() == manager;
+            } catch (UnsupportedOperationException exception) {
+                assertThat(exception).isInstanceOf(UnsupportedOperationException.class);
+            }
+
+            ProxyFactory factory = new ProxyFactory();
+            factory.setUseCache(false);
+            factory.setSuperclass(ConstructorBackedService.class);
+            factory.setFilter(method -> method.getName().equals("message"));
+
+            try {
+                Class<?> proxyClass = factory.createClass();
+
+                assertThat(ProxyFactory.isProxyClass(proxyClass)).isTrue();
+                assertThat(proxyClass.getSuperclass()).isEqualTo(ConstructorBackedService.class);
+            } catch (RuntimeException exception) {
+                if (!hasUnsupportedFeatureError(exception)) {
+                    throw exception;
+                }
+            } catch (Error error) {
+                if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                    throw error;
+                }
+            }
+        } finally {
+            if (installed) {
+                System.setSecurityManager(originalManager);
+            }
+        }
+    }
+
+    private static boolean hasUnsupportedFeatureError(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof Error error && NativeImageSupport.isUnsupportedFeatureError(error)) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private static final class PermissiveSecurityManager extends SecurityManager {
+        @Override
+        public void checkPermission(Permission permission) {
+            // Permit all operations while the Javassist security-manager branch is exercised.
+        }
+
+        @Override
+        public void checkPermission(Permission permission, Object context) {
+            // Permit all operations while the Javassist security-manager branch is exercised.
+        }
+    }
+
+    public static class ConstructorBackedService {
+        private final String value;
+
+        public ConstructorBackedService() {
+            this("default");
+        }
+
+        public ConstructorBackedService(String value) {
+            this.value = value;
+        }
+
+        public String message() {
+            return value;
+        }
+    }
+}

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/SecurityActionsAnonymous3Test.java
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/SecurityActionsAnonymous3Test.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javassist.javassist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.Permission;
+
+import javassist.util.proxy.FactoryHelper;
+
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("removal")
+public class SecurityActionsAnonymous3Test {
+    @Test
+    void factoryHelperFindsClassLoaderDefineClassMethodsWithSecurityManagerInstalled() throws Exception {
+        SecurityManager originalManager = System.getSecurityManager();
+        SecurityManager manager = null;
+        boolean installed = false;
+        try {
+            try {
+                manager = new PermissiveSecurityManager();
+                System.setSecurityManager(manager);
+                installed = System.getSecurityManager() == manager;
+            } catch (UnsupportedOperationException exception) {
+                assertThat(exception).isInstanceOf(UnsupportedOperationException.class);
+            }
+
+            try (ChildFirstJavassistLoader loader = new ChildFirstJavassistLoader(
+                    SecurityActionsAnonymous3Test.class.getClassLoader())) {
+                Class<?> initializer = Class.forName(
+                        IsolatedFactoryHelperInitializer.class.getName(), true, loader);
+
+                assertThat(initializer.getName())
+                        .isEqualTo(IsolatedFactoryHelperInitializer.class.getName());
+            } catch (RuntimeException exception) {
+                if (!hasUnsupportedFeatureError(exception)) {
+                    throw exception;
+                }
+            } catch (Error error) {
+                if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                    throw error;
+                }
+            }
+        } finally {
+            if (installed) {
+                System.setSecurityManager(originalManager);
+            }
+        }
+    }
+
+    private static boolean hasUnsupportedFeatureError(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof Error error && NativeImageSupport.isUnsupportedFeatureError(error)) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private static final class PermissiveSecurityManager extends SecurityManager {
+        @Override
+        public void checkPermission(Permission permission) {
+            // Permit all operations while the Javassist security-manager branch is exercised.
+        }
+
+        @Override
+        public void checkPermission(Permission permission, Object context) {
+            // Permit all operations while the Javassist security-manager branch is exercised.
+        }
+    }
+
+    public static final class IsolatedFactoryHelperInitializer {
+        static final int INTEGER_INDEX = FactoryHelper.typeIndex(int.class);
+
+        private IsolatedFactoryHelperInitializer() {
+        }
+    }
+
+    private static final class ChildFirstJavassistLoader extends ClassLoader implements AutoCloseable {
+        private final ClassLoader resourceLoader;
+
+        private ChildFirstJavassistLoader(ClassLoader resourceLoader) {
+            super(resourceLoader);
+            this.resourceLoader = resourceLoader;
+        }
+
+        @Override
+        protected synchronized Class<?> loadClass(String name, boolean resolve)
+                throws ClassNotFoundException {
+            Class<?> loadedClass = findLoadedClass(name);
+            if (loadedClass == null && shouldLoadChildFirst(name)) {
+                try {
+                    loadedClass = findClass(name);
+                } catch (ClassNotFoundException exception) {
+                    loadedClass = super.loadClass(name, false);
+                }
+            }
+            if (loadedClass == null) {
+                loadedClass = super.loadClass(name, false);
+            }
+            if (resolve) {
+                resolveClass(loadedClass);
+            }
+            return loadedClass;
+        }
+
+        @Override
+        protected Class<?> findClass(String name) throws ClassNotFoundException {
+            if (!shouldLoadChildFirst(name)) {
+                throw new ClassNotFoundException(name);
+            }
+            byte[] bytes = readClassBytes(name);
+            return defineClass(name, bytes, 0, bytes.length);
+        }
+
+        private byte[] readClassBytes(String name) throws ClassNotFoundException {
+            String resourceName = name.replace('.', '/') + ".class";
+            try (InputStream input = resourceLoader.getResourceAsStream(resourceName)) {
+                if (input == null) {
+                    throw new ClassNotFoundException(name);
+                }
+                ByteArrayOutputStream output = new ByteArrayOutputStream();
+                input.transferTo(output);
+                return output.toByteArray();
+            } catch (IOException exception) {
+                ClassNotFoundException classNotFoundException = new ClassNotFoundException(name);
+                classNotFoundException.initCause(exception);
+                throw classNotFoundException;
+            }
+        }
+
+        private static boolean shouldLoadChildFirst(String name) {
+            return name.equals(IsolatedFactoryHelperInitializer.class.getName())
+                    || name.equals(FactoryHelper.class.getName())
+                    || name.equals("javassist.util.proxy.SecurityActions")
+                    || name.equals("javassist.util.proxy.SecurityActions$3");
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/SecurityActionsAnonymous3Test.java
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/SecurityActionsAnonymous3Test.java
@@ -11,6 +11,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
 import java.security.Permission;
 
 import javassist.util.proxy.FactoryHelper;
@@ -20,6 +24,33 @@ import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("removal")
 public class SecurityActionsAnonymous3Test {
+    @Test
+    void getsDeclaredMethodWithSecurityManagerInstalled() throws Throwable {
+        SecurityManager originalManager = System.getSecurityManager();
+        SecurityManager manager = null;
+        boolean installed = false;
+        try {
+            try {
+                manager = new PermissiveSecurityManager();
+                System.setSecurityManager(manager);
+                installed = System.getSecurityManager() == manager;
+            } catch (UnsupportedOperationException exception) {
+                assertThat(exception).isInstanceOf(UnsupportedOperationException.class);
+            }
+
+            Method method = getDeclaredMethod(MethodTarget.class, "message",
+                    new Class<?>[] { String.class });
+
+            assertThat(method.getDeclaringClass()).isEqualTo(MethodTarget.class);
+            assertThat(method.getParameterTypes()).containsExactly(String.class);
+            assertThat(method.getReturnType()).isEqualTo(String.class);
+        } finally {
+            if (installed) {
+                System.setSecurityManager(originalManager);
+            }
+        }
+    }
+
     @Test
     void factoryHelperFindsClassLoaderDefineClassMethodsWithSecurityManagerInstalled() throws Exception {
         SecurityManager originalManager = System.getSecurityManager();
@@ -57,6 +88,17 @@ public class SecurityActionsAnonymous3Test {
         }
     }
 
+    private static Method getDeclaredMethod(
+            Class<?> targetClass, String name, Class<?>[] parameterTypes) throws Throwable {
+        Class<?> securityActions = Class.forName("javassist.util.proxy.SecurityActions");
+        MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(
+                securityActions, MethodHandles.lookup());
+        MethodHandle getDeclaredMethod = lookup.findStatic(
+                securityActions, "getDeclaredMethod",
+                MethodType.methodType(Method.class, Class.class, String.class, Class[].class));
+        return (Method) getDeclaredMethod.invoke(targetClass, name, parameterTypes);
+    }
+
     private static boolean hasUnsupportedFeatureError(Throwable throwable) {
         Throwable current = throwable;
         while (current != null) {
@@ -77,6 +119,12 @@ public class SecurityActionsAnonymous3Test {
         @Override
         public void checkPermission(Permission permission, Object context) {
             // Permit all operations while the Javassist security-manager branch is exercised.
+        }
+    }
+
+    public static final class MethodTarget {
+        public String message(String value) {
+            return value;
         }
     }
 

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/SecurityActionsAnonymous3Test.java
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/SecurityActionsAnonymous3Test.java
@@ -39,7 +39,7 @@ public class SecurityActionsAnonymous3Test {
             }
 
             Method method = getDeclaredMethod(MethodTarget.class, "message",
-                    new Class<?>[] { String.class });
+                    new Class<?>[] {String.class });
 
             assertThat(method.getDeclaringClass()).isEqualTo(MethodTarget.class);
             assertThat(method.getParameterTypes()).containsExactly(String.class);

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/SecurityActionsAnonymous4Test.java
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/SecurityActionsAnonymous4Test.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javassist.javassist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Constructor;
+import java.security.Permission;
+
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("removal")
+public class SecurityActionsAnonymous4Test {
+    @Test
+    void getsDeclaredConstructorWithSecurityManagerInstalled() throws Throwable {
+        SecurityManager originalManager = System.getSecurityManager();
+        SecurityManager manager = null;
+        boolean installed = false;
+        try {
+            try {
+                manager = new PermissiveSecurityManager();
+                System.setSecurityManager(manager);
+                installed = System.getSecurityManager() == manager;
+            } catch (UnsupportedOperationException exception) {
+                assertThat(exception).isInstanceOf(UnsupportedOperationException.class);
+            }
+
+            Constructor<?> constructor = getDeclaredConstructor(ConstructorTarget.class,
+                    new Class<?>[] {String.class, int.class });
+
+            assertThat(constructor.getDeclaringClass()).isEqualTo(ConstructorTarget.class);
+            assertThat(constructor.getParameterTypes()).containsExactly(String.class, int.class);
+        } finally {
+            if (installed) {
+                System.setSecurityManager(originalManager);
+            }
+        }
+    }
+
+    private static Constructor<?> getDeclaredConstructor(
+            Class<?> targetClass, Class<?>[] parameterTypes) throws Throwable {
+        Class<?> securityActions = Class.forName("javassist.util.proxy.SecurityActions");
+        MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(
+                securityActions, MethodHandles.lookup());
+        MethodHandle getDeclaredConstructor = lookup.findStatic(
+                securityActions, "getDeclaredConstructor",
+                MethodType.methodType(Constructor.class, Class.class, Class[].class));
+        return (Constructor<?>) getDeclaredConstructor.invoke(targetClass, parameterTypes);
+    }
+
+    private static final class PermissiveSecurityManager extends SecurityManager {
+        @Override
+        public void checkPermission(Permission permission) {
+            // Permit all operations while the Javassist security-manager branch is exercised.
+        }
+
+        @Override
+        public void checkPermission(Permission permission, Object context) {
+            // Permit all operations while the Javassist security-manager branch is exercised.
+        }
+    }
+
+    public static final class ConstructorTarget {
+        public ConstructorTarget(String name, int count) {
+            assertThat(name).isNotNull();
+            assertThat(count).isNotNegative();
+        }
+    }
+}

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/SecurityActionsAnonymous6Test.java
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/SecurityActionsAnonymous6Test.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javassist.javassist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Field;
+import java.security.Permission;
+
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("removal")
+public class SecurityActionsAnonymous6Test {
+    @Test
+    void setsFieldValueWithSecurityManagerInstalled() throws Throwable {
+        SecurityManager originalManager = System.getSecurityManager();
+        SecurityManager manager = null;
+        boolean installed = false;
+        try {
+            try {
+                manager = new PermissiveSecurityManager();
+                System.setSecurityManager(manager);
+                installed = System.getSecurityManager() == manager;
+            } catch (UnsupportedOperationException exception) {
+                assertThat(exception).isInstanceOf(UnsupportedOperationException.class);
+            }
+
+            Field field = FieldTarget.class.getField("value");
+            FieldTarget target = new FieldTarget("initial");
+
+            setField(field, target, "updated");
+
+            assertThat(target.value).isEqualTo("updated");
+        } finally {
+            if (installed) {
+                System.setSecurityManager(originalManager);
+            }
+        }
+    }
+
+    private static void setField(Field field, Object target, Object value) throws Throwable {
+        Class<?> securityActions = Class.forName("javassist.util.proxy.SecurityActions");
+        MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(
+                securityActions, MethodHandles.lookup());
+        MethodHandle set = lookup.findStatic(
+                securityActions, "set",
+                MethodType.methodType(void.class, Field.class, Object.class, Object.class));
+        set.invoke(field, target, value);
+    }
+
+    private static final class PermissiveSecurityManager extends SecurityManager {
+        @Override
+        public void checkPermission(Permission permission) {
+            // Permit all operations while the Javassist security-manager branch is exercised.
+        }
+
+        @Override
+        public void checkPermission(Permission permission, Object context) {
+            // Permit all operations while the Javassist security-manager branch is exercised.
+        }
+    }
+
+    public static final class FieldTarget {
+        public Object value;
+
+        public FieldTarget(Object value) {
+            this.value = value;
+        }
+    }
+}

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/SecurityActionsTest.java
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/SecurityActionsTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javassist.javassist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.Test;
+
+public class SecurityActionsTest {
+    @Test
+    void getsDeclaredConstructorForSuppliedParameterTypes() throws Throwable {
+        Class<?> securityActions = securityActionsType();
+        MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(securityActions, MethodHandles.lookup());
+        MethodHandle getDeclaredConstructor = lookup.findStatic(securityActions, "getDeclaredConstructor",
+            MethodType.methodType(Constructor.class, Class.class, Class[].class));
+
+        Constructor<?> constructor = (Constructor<?>) getDeclaredConstructor.invoke(SecurityActionsTarget.class,
+            new Class<?>[] {String.class, int.class });
+
+        assertThat(constructor.getDeclaringClass()).isEqualTo(SecurityActionsTarget.class);
+        assertThat(constructor.getParameterTypes()).containsExactly(String.class, int.class);
+    }
+
+    @Test
+    void setsFieldValueOnTargetObject() throws Throwable {
+        Class<?> securityActions = securityActionsType();
+        MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(securityActions, MethodHandles.lookup());
+        MethodHandle set = lookup.findStatic(securityActions, "set",
+            MethodType.methodType(void.class, Field.class, Object.class, Object.class));
+        SecurityActionsTarget target = new SecurityActionsTarget("initial", 1);
+        Field field = SecurityActionsTarget.class.getField("publicValue");
+
+        set.invoke(field, target, "updated");
+
+        assertThat(target.publicValue).isEqualTo("updated");
+    }
+
+    private static Class<?> securityActionsType() throws ClassNotFoundException {
+        return Class.forName("javassist.util.proxy.SecurityActions");
+    }
+
+    public static final class SecurityActionsTarget {
+        public Object publicValue;
+
+        public SecurityActionsTarget(String name, int count) {
+            publicValue = name + count;
+        }
+    }
+}

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/SerializedProxyTest.java
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/SerializedProxyTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javassist.javassist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.lang.reflect.Method;
+
+import javassist.util.proxy.MethodFilter;
+import javassist.util.proxy.MethodHandler;
+import javassist.util.proxy.ProxyFactory;
+import javassist.util.proxy.ProxyObject;
+
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+
+public class SerializedProxyTest {
+    @Test
+    void restoresProxySerializedThroughWriteReplaceDescriptor() throws Exception {
+        ClassLoader originalContextLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(SerializedProxyTest.class.getClassLoader());
+        try {
+            Object proxy = createSerializableProxy();
+            byte[] serializedProxy = serializeWithWriteReplace(proxy);
+
+            Object restoredProxy = deserialize(serializedProxy);
+
+            assertThat(ProxyFactory.isProxyClass(restoredProxy.getClass())).isTrue();
+            assertThat(restoredProxy).isInstanceOf(GreetingContract.class);
+            assertThat(((GreetingContract) restoredProxy).greet("reader")).isEqualTo("handled:reader");
+            assertThat(((ProxyObject) restoredProxy).getHandler()).isInstanceOf(SerializableHandler.class);
+        } catch (RuntimeException exception) {
+            rethrowUnlessUnsupportedDynamicClassLoading(exception);
+        } catch (Error error) {
+            rethrowUnlessUnsupportedDynamicClassLoading(error);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalContextLoader);
+        }
+    }
+
+    private static Object createSerializableProxy() throws Exception {
+        ProxyFactory factory = new ProxyFactory();
+        factory.setUseCache(true);
+        factory.setUseWriteReplace(true);
+        factory.setInterfaces(new Class[] {GreetingContract.class });
+        factory.setFilter(new GreetingMethodFilter());
+        return factory.create(new Class[0], new Object[0], new SerializableHandler());
+    }
+
+    private static byte[] serializeWithWriteReplace(Object proxy) throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (ObjectOutputStream stream = new ObjectOutputStream(output)) {
+            stream.writeObject(proxy);
+        }
+        return output.toByteArray();
+    }
+
+    private static Object deserialize(byte[] serializedProxy) throws Exception {
+        ByteArrayInputStream input = new ByteArrayInputStream(serializedProxy);
+        try (ObjectInputStream stream = new ObjectInputStream(input)) {
+            return stream.readObject();
+        }
+    }
+
+    private static void rethrowUnlessUnsupportedDynamicClassLoading(RuntimeException exception) {
+        Throwable current = exception;
+        while (current != null) {
+            if (current instanceof Error error) {
+                rethrowUnlessUnsupportedDynamicClassLoading(error);
+                return;
+            }
+            current = current.getCause();
+        }
+        throw exception;
+    }
+
+    private static void rethrowUnlessUnsupportedDynamicClassLoading(Error error) {
+        if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+            throw error;
+        }
+    }
+
+    public interface GreetingContract extends Serializable {
+        String greet(String name);
+    }
+
+    public static final class GreetingMethodFilter implements MethodFilter, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public boolean isHandled(Method method) {
+            return method.getName().equals("greet");
+        }
+    }
+
+    public static final class SerializableHandler implements MethodHandler, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public Object invoke(Object self, Method method, Method proceed, Object[] arguments) {
+            return "handled:" + arguments[0];
+        }
+    }
+}

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/ViewerTest.java
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/ViewerTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javassist.javassist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+
+import javassist.bytecode.AccessFlag;
+import javassist.bytecode.Bytecode;
+import javassist.bytecode.ClassFile;
+import javassist.bytecode.ConstPool;
+import javassist.bytecode.MethodInfo;
+import javassist.tools.web.Viewer;
+
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+
+public class ViewerTest {
+    private static final String GENERATED_APPLICATION_NAME =
+            "example.ViewerGeneratedApplication";
+
+    @Test
+    void runsGeneratedMainClassFetchedByViewer() throws Throwable {
+        byte[] bytecode = makeGeneratedApplicationBytecode();
+        ByteArrayViewer viewer = new ByteArrayViewer(
+                "127.0.0.1", 0, GENERATED_APPLICATION_NAME, bytecode);
+
+        try {
+            viewer.run(GENERATED_APPLICATION_NAME, new String[] {"left", "right"});
+            assertThat(viewer.fetchedClasses()).isEqualTo(1);
+        } catch (Error error) {
+            rethrowUnlessUnsupportedDynamicClassLoading(error);
+        }
+    }
+
+    @Test
+    void loadsSystemClassesThroughViewerSystemLookup() throws Exception {
+        Viewer viewer = new ByteArrayViewer("127.0.0.1", 0, "unused", new byte[0]);
+
+        Class<?> loadedClass = viewer.loadClass(String.class.getName());
+
+        assertThat(loadedClass).isSameAs(String.class);
+    }
+
+    private static byte[] makeGeneratedApplicationBytecode() throws Exception {
+        ClassFile classFile = new ClassFile(
+                false, GENERATED_APPLICATION_NAME, Object.class.getName());
+        classFile.setAccessFlags(AccessFlag.PUBLIC);
+        ConstPool constPool = classFile.getConstPool();
+        MethodInfo main = new MethodInfo(constPool, "main", "([Ljava/lang/String;)V");
+        main.setAccessFlags(AccessFlag.PUBLIC | AccessFlag.STATIC);
+        Bytecode code = new Bytecode(constPool, 0, 1);
+        code.addReturn(null);
+        main.setCodeAttribute(code.toCodeAttribute());
+        classFile.addMethod(main);
+
+        ByteArrayOutputStream bytecode = new ByteArrayOutputStream();
+        classFile.write(new DataOutputStream(bytecode));
+        return bytecode.toByteArray();
+    }
+
+    private static void rethrowUnlessUnsupportedDynamicClassLoading(Error error) {
+        if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+            throw error;
+        }
+    }
+
+    private static final class ByteArrayViewer extends Viewer {
+        private final String className;
+        private final byte[] bytecode;
+        private int fetchedClasses;
+
+        private ByteArrayViewer(String host, int port, String className, byte[] bytecode) {
+            super(host, port);
+            this.className = className;
+            this.bytecode = bytecode;
+        }
+
+        private int fetchedClasses() {
+            return fetchedClasses;
+        }
+
+        @Override
+        protected byte[] fetchClass(String requestedClassName) {
+            if (className.equals(requestedClassName)) {
+                fetchedClasses++;
+                return bytecode;
+            }
+            return null;
+        }
+    }
+}

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/WebserverTest.java
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/WebserverTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package javassist.javassist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import javassist.tools.web.Webserver;
+
+import org.junit.jupiter.api.Test;
+
+public class WebserverTest {
+    private static final String RESOURCE_CLASS = "javassist/tools/web/Webserver.class";
+
+    @Test
+    void servesClassFileResourceFromClasspathWhenFileIsAbsent() throws Exception {
+        Webserver server = new Webserver(0);
+        try {
+            ByteArrayOutputStream response = new ByteArrayOutputStream();
+
+            server.doReply(
+                    new ByteArrayInputStream(new byte[0]),
+                    response,
+                    "GET /" + RESOURCE_CLASS + " HTTP/1.0");
+
+            byte[] responseBytes = response.toByteArray();
+            int bodyOffset = headerLength(responseBytes);
+            String header = new String(responseBytes, 0, bodyOffset, StandardCharsets.ISO_8859_1);
+            byte[] body = copyOfRange(responseBytes, bodyOffset, responseBytes.length);
+
+            assertThat(header).startsWith("HTTP/1.0 200 OK\r\n");
+            assertThat(header).contains("Content-Type: application/octet-stream\r\n");
+            assertThat(header).contains("Content-Length: " + body.length + "\r\n");
+            assertThat(body).startsWith((byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBE);
+        } finally {
+            server.end();
+        }
+    }
+
+    private static int headerLength(byte[] responseBytes) throws IOException {
+        for (int i = 0; i <= responseBytes.length - 4; i++) {
+            if (responseBytes[i] == '\r'
+                    && responseBytes[i + 1] == '\n'
+                    && responseBytes[i + 2] == '\r'
+                    && responseBytes[i + 3] == '\n') {
+                return i + 4;
+            }
+        }
+
+        throw new IOException("HTTP response did not include a header terminator");
+    }
+
+    private static byte[] copyOfRange(byte[] bytes, int from, int to) {
+        byte[] copy = new byte[to - from];
+        System.arraycopy(bytes, from, copy, 0, copy.length);
+        return copy;
+    }
+}

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,262 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "javassist.javassist.AppletServerTest"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.javassist.ClassMetaobjectTest"
+      },
+      "type" : "java.lang.Object",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.javassist.MetaobjectTest"
+      },
+      "type" : "java.lang.Object",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.javassist.ProxyFactoryTest"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.javassist.ClassMetaobjectTest"
+      },
+      "type" : "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.javassist.AppletServerTest"
+      },
+      "type" : "java.lang.String",
+      "serializable" : true,
+      "fields" : [
+        {
+          "name" : "serialVersionUID"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.javassist.ClassMetaobjectTest"
+      },
+      "type" : "java.lang.reflect.Field[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.javassist.AnnotationImplTest"
+      },
+      "type" : "java.lang.reflect.Method[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.tools.reflect.ClassMetaobject"
+      },
+      "type" : "javassist.javassist.ClassMetaobjectTest$ReflectiveFixture"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.bytecode.annotation.EnumMemberValue"
+      },
+      "type" : "javassist.javassist.EnumMemberValueTest$FixtureStatus"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.Loader"
+      },
+      "type" : "javassist.javassist.LoaderResourceFixture"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.tools.reflect.Metaobject"
+      },
+      "type" : "javassist.javassist.MetaobjectTest$ReflectiveInstance",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.tools.rmi.ObjectImporter"
+      },
+      "type" : "javassist.javassist.ObjectImporterTest$ImportedProxy"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.javassist.ProxyFactoryTest"
+      },
+      "type" : "javassist.javassist.ProxyFactoryTest$SerializableProxyFixture",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.util.proxy.ProxyFactory"
+      },
+      "type" : "javassist.javassist.ProxyFactoryTest$SerializableProxyFixture"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.util.proxy.SecurityActions"
+      },
+      "type" : "javassist.javassist.SecurityActionsAnonymous4Test$ConstructorTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.util.proxy.SecurityActions"
+      },
+      "type" : "javassist.javassist.SecurityActionsTest$SecurityActionsTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.javassist.ClassMetaobjectTest"
+      },
+      "type" : "javassist.tools.reflect.ClassMetaobject",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.javassist.MetaobjectTest"
+      },
+      "type" : "javassist.tools.reflect.Metaobject",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.javassist.AppletServerTest"
+      },
+      "type" : "javassist.tools.rmi.RemoteRef"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.javassist.ObjectImporterTest$OneShotRmiServer"
+      },
+      "type" : "jdk.net.LinuxSocketOptions"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.javassist.ClassMetaobjectTest"
+      },
+      "type" : "sun.security.provider.SHA"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.javassist.AnnotationImplTest"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.bytecode.annotation.AnnotationImpl"
+      },
+      "type" : {
+        "proxy" : [
+          "javassist.javassist.AnnotationImplTest$RuntimeFixtureAnnotation"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.javassist.AnnotationImplTest"
+      },
+      "type" : {
+        "proxy" : [
+          "javassist.javassist.AnnotationImplTest$RuntimeFixtureAnnotation"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.bytecode.annotation.AnnotationImpl"
+      },
+      "type" : {
+        "proxy" : [
+          "javassist.javassist.ArrayMemberValueTest$NestedArrayCarrier"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.bytecode.annotation.AnnotationImpl"
+      },
+      "type" : {
+        "proxy" : [
+          "javassist.javassist.ArrayMemberValueTest$SingleDimensionArrayCarrier"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.bytecode.annotation.AnnotationImpl"
+      },
+      "type" : {
+        "proxy" : [
+          "javassist.javassist.EnumMemberValueTest$RuntimeEnumAnnotation"
+        ]
+      }
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "javassist.javassist.FactoryHelperTest"
+      },
+      "glob" : "javassist/javassist/FactoryHelperTest$IsolatedFactoryHelperInitializer.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.javassist.FactoryHelperTest"
+      },
+      "glob" : "javassist/util/proxy/FactoryHelper.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.javassist.FactoryHelperTest"
+      },
+      "glob" : "javassist/util/proxy/SecurityActions.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.javassist.SecurityActionsAnonymous3Test"
+      },
+      "glob" : "javassist/javassist/SecurityActionsAnonymous3Test$IsolatedFactoryHelperInitializer.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.javassist.SecurityActionsAnonymous3Test"
+      },
+      "glob" : "javassist/util/proxy/FactoryHelper.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.javassist.SecurityActionsAnonymous3Test"
+      },
+      "glob" : "javassist/util/proxy/SecurityActions$3.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.javassist.SecurityActionsAnonymous3Test"
+      },
+      "glob" : "javassist/util/proxy/SecurityActions.class"
+    }
+  ]
+}

--- a/tests/src/javassist/javassist/3.12.0.SP1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/javassist/javassist/3.12.0.SP1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -213,6 +213,60 @@
           "javassist.javassist.EnumMemberValueTest$RuntimeEnumAnnotation"
         ]
       }
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.javassist.ClassMetaobjectTest"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.javassist.MetaobjectTest"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.javassist.AppletServerTest"
+      },
+      "type" : "java.lang.String"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.javassist.AnnotationImplTest"
+      },
+      "type" : "javassist.javassist.AnnotationImplTest$RuntimeFixtureAnnotation[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.tools.reflect.Metaobject"
+      },
+      "type" : "javassist.javassist.MetaobjectTest$ReflectiveInstance"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.javassist.ProxyFactoryTest"
+      },
+      "type" : "javassist.javassist.ProxyFactoryTest$SerializableProxyFixture"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.util.proxy.SecurityActions"
+      },
+      "type" : "javassist.javassist.SecurityActionsAnonymous3Test$MethodTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.javassist.ClassMetaobjectTest"
+      },
+      "type" : "javassist.tools.reflect.ClassMetaobject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javassist.javassist.MetaobjectTest"
+      },
+      "type" : "javassist.tools.reflect.Metaobject"
     }
   ],
   "resources" : [

--- a/tests/src/javassist/javassist/3.12.0.SP1/user-code-filter.json
+++ b/tests/src/javassist/javassist/3.12.0.SP1/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "javassist.**"
+    },
+    {
+      "includeClasses" : "javassist.javassist.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #8242

This PR provides test fixes and new metadata for javassist:javassist:3.12.0.SP1, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 120899
- Cached input tokens: 933376
- Output tokens: 9206
- Metadata entries: 51
- Test-only metadata entries: 52
- Iterations: 3
- Library coverage percentage: 21.3
- Previous library version metadata entries: 69
- Previous library version test-only metadata entries: 43
- Previous library version coverage percentage: 21.23

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `b80fd2e16bbceb12246163a014a8331df3802771`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- javassist:javassist:3.12.0.GA: 101/105 covered calls (96.19%)
- javassist:javassist:3.12.0.SP1: 92/92 covered calls (100.00%)

**Reflection:**
- javassist:javassist:3.12.0.GA: 94/98 covered calls (95.92%)
- javassist:javassist:3.12.0.SP1: 85/85 covered calls (100.00%)

**Resources:**
- javassist:javassist:3.12.0.GA: 7/7 covered calls (100.00%)
- javassist:javassist:3.12.0.SP1: 7/7 covered calls (100.00%)

#### Library coverage

**Instruction:**
- javassist:javassist:3.12.0.GA: 17567/82870 (21.20%)
- javassist:javassist:3.12.0.SP1: 17519/82771 (21.17%)

**Line:**
- javassist:javassist:3.12.0.GA: 4124/19423 (21.23%)
- javassist:javassist:3.12.0.SP1: 4141/19443 (21.30%)

**Method:**
- javassist:javassist:3.12.0.GA: 868/3337 (26.01%)
- javassist:javassist:3.12.0.SP1: 871/3338 (26.09%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/javassist/javassist/3.12.0.GA/src/test/java/javassist/javassist/ClassPoolTest.java 2/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/ClassPoolTest.java
index 8ad4b1f85a..c986f77e55 100644
--- 1/tests/src/javassist/javassist/3.12.0.GA/src/test/java/javassist/javassist/ClassPoolTest.java
+++ 2/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/ClassPoolTest.java
@@ -8,10 +8,6 @@ package javassist.javassist;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
-
 import javassist.CannotCompileException;
 import javassist.ClassClassPath;
 import javassist.ClassPool;
@@ -44,20 +40,6 @@ public class ClassPoolTest {
         }
     }
 
-    @Test
-    void callsCompilerGeneratedClassLookupHelper() throws Throwable {
-        MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(
-                ClassPool.class, MethodHandles.lookup());
-        MethodHandle classLookup = lookup.findStatic(
-                ClassPool.class,
-                "class$",
-                MethodType.methodType(Class.class, String.class));
-
-        Object result = classLookup.invoke(ClassPool.class.getName());
-
-        assertThat(result).isSameAs(ClassPool.class);
-    }
-
     private static ClassPool newInitializedClassPool() {
         ClassPool classPool = new ClassPool(true);
         classPool.insertClassPath(new ClassClassPath(ClassPoolTest.class));
diff --git 1/tests/src/javassist/javassist/3.12.0.GA/src/test/java/javassist/javassist/ObjectImporterTest.java 2/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/ObjectImporterTest.java
index 095a17e1f6..d3e789831e 100644
--- 1/tests/src/javassist/javassist/3.12.0.GA/src/test/java/javassist/javassist/ObjectImporterTest.java
+++ 2/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/ObjectImporterTest.java
@@ -15,9 +15,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
@@ -58,20 +55,6 @@ public class ObjectImporterTest {
         }
     }
 
-    @Test
-    void callsCompilerGeneratedClassLookupHelper() throws Throwable {
-        MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(
-                ObjectImporter.class, MethodHandles.lookup());
-        MethodHandle classLookup = lookup.findStatic(
-                ObjectImporter.class,
-                "class$",
-                MethodType.methodType(Class.class, String.class));
-
-        Object result = classLookup.invoke(ObjectImporter.class.getName());
-
-        assertThat(result).isSameAs(ObjectImporter.class);
-    }
-
     @Test
     void callSerializesRemoteReferencesAndValueParameters() throws Exception {
         try (OneShotRmiServer server = OneShotRmiServer.start(socket -> {
diff --git 1/tests/src/javassist/javassist/3.12.0.GA/src/test/java/javassist/javassist/ProxyFactoryTest.java 2/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/ProxyFactoryTest.java
index 72c4dd503a..4e0b1dc0e8 100644
--- 1/tests/src/javassist/javassist/3.12.0.GA/src/test/java/javassist/javassist/ProxyFactoryTest.java
+++ 2/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/ProxyFactoryTest.java
@@ -13,6 +13,7 @@ import java.io.Serializable;
 import java.lang.reflect.Method;
 
 import javassist.util.proxy.MethodHandler;
+import javassist.util.proxy.Proxy;
 import javassist.util.proxy.ProxyFactory;
 import javassist.util.proxy.ProxyObject;
 import javassist.util.proxy.ProxyObjectOutputStream;
@@ -29,13 +30,15 @@ public class ProxyFactoryTest {
             factory.setSuperclass(GreetingService.class);
             factory.setFilter(method -> method.getName().equals("message"));
 
+            MethodHandler handler = (self, method, proceed, arguments) -> "handled:" + proceed.invoke(self, arguments);
             GreetingService proxy = (GreetingService) factory.create(
                     new Class[] {String.class },
                     new Object[] {"original" },
-                    (self, method, proceed, arguments) -> "handled:" + proceed.invoke(self, arguments));
+                    handler);
 
             assertThat(ProxyFactory.isProxyClass(proxy.getClass())).isTrue();
             assertThat(proxy.message()).isEqualTo("handled:original");
+            assertThat(ProxyFactory.getHandler((Proxy) proxy)).isSameAs(handler);
         } catch (RuntimeException exception) {
             if (!hasUnsupportedFeatureError(exception)) {
                 throw exception;
diff --git 1/tests/src/javassist/javassist/3.12.0.GA/src/test/java/javassist/javassist/SecurityActionsAnonymous3Test.java 2/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/SecurityActionsAnonymous3Test.java
index 76944379ad..4be1fd3fa4 100644
--- 1/tests/src/javassist/javassist/3.12.0.GA/src/test/java/javassist/javassist/SecurityActionsAnonymous3Test.java
+++ 2/tests/src/javassist/javassist/3.12.0.SP1/src/test/java/javassist/javassist/SecurityActionsAnonymous3Test.java
@@ -11,6 +11,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
 import java.security.Permission;
 
 import javassist.util.proxy.FactoryHelper;
@@ -20,6 +24,33 @@ import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("removal")
 public class SecurityActionsAnonymous3Test {
+    @Test
+    void getsDeclaredMethodWithSecurityManagerInstalled() throws Throwable {
+        SecurityManager originalManager = System.getSecurityManager();
+        SecurityManager manager = null;
+        boolean installed = false;
+        try {
+            try {
+                manager = new PermissiveSecurityManager();
+                System.setSecurityManager(manager);
+                installed = System.getSecurityManager() == manager;
+            } catch (UnsupportedOperationException exception) {
+                assertThat(exception).isInstanceOf(UnsupportedOperationException.class);
+            }
+
+            Method method = getDeclaredMethod(MethodTarget.class, "message",
+                    new Class<?>[] {String.class });
+
+            assertThat(method.getDeclaringClass()).isEqualTo(MethodTarget.class);
+            assertThat(method.getParameterTypes()).containsExactly(String.class);
+            assertThat(method.getReturnType()).isEqualTo(String.class);
+        } finally {
+            if (installed) {
+                System.setSecurityManager(originalManager);
+            }
+        }
+    }
+
     @Test
     void factoryHelperFindsClassLoaderDefineClassMethodsWithSecurityManagerInstalled() throws Exception {
         SecurityManager originalManager = System.getSecurityManager();
@@ -57,6 +88,17 @@ public class SecurityActionsAnonymous3Test {
         }
     }
 
+    private static Method getDeclaredMethod(
+            Class<?> targetClass, String name, Class<?>[] parameterTypes) throws Throwable {
+        Class<?> securityActions = Class.forName("javassist.util.proxy.SecurityActions");
+        MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(
+                securityActions, MethodHandles.lookup());
+        MethodHandle getDeclaredMethod = lookup.findStatic(
+                securityActions, "getDeclaredMethod",
+                MethodType.methodType(Method.class, Class.class, String.class, Class[].class));
+        return (Method) getDeclaredMethod.invoke(targetClass, name, parameterTypes);
+    }
+
     private static boolean hasUnsupportedFeatureError(Throwable throwable) {
         Throwable current = throwable;
         while (current != null) {
@@ -80,6 +122,12 @@ public class SecurityActionsAnonymous3Test {
         }
     }
 
+    public static final class MethodTarget {
+        public String message(String value) {
+            return value;
+        }
+    }
+
     public static final class IsolatedFactoryHelperInitializer {
         static final int INTEGER_INDEX = FactoryHelper.typeIndex(int.class);
 

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
