### PR TITLE
[GenAI] Test fix for org.apache.maven.plugins:maven-compiler-plugin:3.11.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/reachability-metadata.json
+++ b/metadata/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/reachability-metadata.json
@@ -1,0 +1,47 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.maven.plugins.maven_compiler_plugin.HelpMojo"
+      },
+      "type" : "com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.maven.plugin.testing.AbstractMojoTestCase"
+      },
+      "type" : "org.apache.maven.plugin.compiler.AbstractCompilerMojo",
+      "fields" : [
+        {
+          "name" : "session"
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.maven.plugins.maven_compiler_plugin.HelpMojo"
+      },
+      "glob" : "META-INF/maven/org.apache.maven.plugins/maven-compiler-plugin/plugin-help.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.maven.plugin.testing.AbstractMojoTestCase"
+      },
+      "glob" : "META-INF/maven/org.apache.maven/maven-core/pom.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.maven.plugins.maven_compiler_plugin.HelpMojo"
+      },
+      "glob" : "META-INF/services/javax.xml.parsers.DocumentBuilderFactory"
+    }
+  ]
+}

--- a/metadata/org.apache.maven.plugins/maven-compiler-plugin/index.json
+++ b/metadata/org.apache.maven.plugins/maven-compiler-plugin/index.json
@@ -11,7 +11,9 @@
       "3.11.0"
     ],
     "allowed-packages" : [
-      "org.apache.maven.plugin"
+      "org.apache.maven.plugin",
+      "org.apache.maven.plugin.compiler",
+      "org.apache.maven.plugins.maven_compiler_plugin"
     ]
   },
   {

--- a/metadata/org.apache.maven.plugins/maven-compiler-plugin/index.json
+++ b/metadata/org.apache.maven.plugins/maven-compiler-plugin/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.11.0",
+    "tested-versions" : [
+      "3.11.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.maven.plugin"
+    ]
+  },
+  {
     "metadata-version" : "3.10.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/$version$/maven-compiler-plugin-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/maven-compiler-plugin",

--- a/metadata/org.apache.maven.plugins/maven-compiler-plugin/index.json
+++ b/metadata/org.apache.maven.plugins/maven-compiler-plugin/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "3.11.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/$version$/maven-compiler-plugin-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/maven-compiler-plugin",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/$version$/maven-compiler-plugin-$version$-source-release.zip",
+    "documentation-url" : "https://maven.apache.org/plugins-archives/maven-compiler-plugin-$version$/plugin-info.html",
+    "description" : "Apache Maven Compiler Plugin integrates Java compilation into Maven builds. It compiles a project's main and test source trees during the Maven lifecycle and exposes configuration for source and target levels, compiler arguments, annotation processors, and alternate compiler implementations.",
     "tested-versions" : [
       "3.11.0"
     ],

--- a/stats/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/execution-metrics.json
+++ b/stats/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/execution-metrics.json
@@ -1,0 +1,181 @@
+{
+  "fix_javac_fail:2026-06-09": {
+    "timestamp": "2026-06-09T14:06:27.267066Z",
+    "library": "org.apache.maven.plugins:maven-compiler-plugin:3.11.0",
+    "starting_commit": "1d7ed3f28a69a46be1f83cb04b2fb08e296024d1",
+    "ending_commit": "28930530ed3b83c65116fd1e4d56d5b5d1135d65",
+    "previous_library": "org.apache.maven.plugins:maven-compiler-plugin:3.10.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.11.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 3,
+        "totalCalls": 3
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 643,
+          "missed": 4879,
+          "ratio": 0.116443,
+          "total": 5522
+        },
+        "line": {
+          "covered": 127,
+          "missed": 980,
+          "ratio": 0.114724,
+          "total": 1107
+        },
+        "method": {
+          "covered": 19,
+          "missed": 103,
+          "ratio": 0.155738,
+          "total": 122
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.10.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 10,
+            "totalCalls": 10
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 11,
+        "totalCalls": 11
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 690,
+          "missed": 4480,
+          "ratio": 0.133462,
+          "total": 5170
+        },
+        "line": {
+          "covered": 133,
+          "missed": 919,
+          "ratio": 0.126426,
+          "total": 1052
+        },
+        "method": {
+          "covered": 19,
+          "missed": 80,
+          "ratio": 0.191919,
+          "total": 99
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "advisory_preparation",
+      "issue_number": 8254,
+      "issue_label": "fails-javac-compile",
+      "library": "org.apache.maven.plugins:maven-compiler-plugin:3.11.0",
+      "summary": "maven-compiler-plugin is a Maven plugin whose useful APIs depend on Maven's provided runtime/test infrastructure; no Docker service is needed.",
+      "deterministic_setup": [
+        {
+          "kind": "dependency",
+          "coordinate": "org.apache.maven:maven-core:3.2.5",
+          "scope": "testImplementation",
+          "reason": "The plugin declares Maven core as provided, but tests that instantiate mojos or MavenSession/MavenProject need it on the test classpath."
+        },
+        {
+          "kind": "dependency",
+          "coordinate": "org.apache.maven:maven-plugin-api:3.2.5",
+          "scope": "testImplementation",
+          "reason": "Mojo classes extend Maven plugin API types such as AbstractMojo and use plugin logging/exceptions that are provided by Maven at runtime."
+        },
+        {
+          "kind": "dependency",
+          "coordinate": "org.apache.maven.plugin-testing:maven-plugin-testing-harness:3.3.0",
+          "scope": "testImplementation",
+          "reason": "Meaningful unit coverage commonly requires Maven plugin-test utilities for injecting private mojo fields and constructing plugin test state."
+        }
+      ],
+      "agent_guidance": "Treat this as a Maven plugin, not a standalone library. For 3.11.0 the generated help mojo class is `org.apache.maven.plugins.maven_compiler_plugin.HelpMojo`; do not import the old `org.apache.maven.plugin.compiler.HelpMojo`. If subclassing `AbstractCompilerMojo`, implement the 3.11.0 abstract methods including `getIncludes()` and `getExcludes()`, and seed required Maven session/project/toolchain fields before exercising behavior.",
+      "risks": [
+        "The reported javac failure is primarily API/package drift between 3.10.0 and 3.11.0, so dependencies alone will not fix the tests.",
+        "Calling full `execute()` paths can require a realistic MavenProject and compiler manager setup; focused helper/resource tests are less brittle."
+      ],
+      "applied_setup": [
+        {
+          "kind": "dependency",
+          "coordinate": "org.apache.maven:maven-core:3.2.5",
+          "result": "skipped",
+          "reason": "build_gradle_absent"
+        },
+        {
+          "kind": "dependency",
+          "coordinate": "org.apache.maven:maven-plugin-api:3.2.5",
+          "result": "skipped",
+          "reason": "build_gradle_absent"
+        },
+        {
+          "kind": "dependency",
+          "coordinate": "org.apache.maven.plugin-testing:maven-plugin-testing-harness:3.3.0",
+          "result": "skipped",
+          "reason": "build_gradle_absent"
+        }
+      ],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#8254 [Automation] javac compile fails for org.apache.maven.plugins:maven-compiler-plugin:3.11.0; label=fails-javac-compile; body_chars=8015"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "7 existing test file path(s) included"
+        }
+      ],
+      "current_library": "org.apache.maven.plugins:maven-compiler-plugin:3.10.0",
+      "new_version": "3.11.0",
+      "model": "oca/gpt-5.5",
+      "input_tokens_used": 42225,
+      "output_tokens_used": 3992,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.apache.maven.plugins:maven-compiler-plugin:3.11.0/library-preparation-preflight/pi-generation-2026-06-09T13-51-37-456596Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 62863,
+      "cached_input_tokens_used": 329728,
+      "output_tokens_used": 2752,
+      "iterations": 2,
+      "cost_usd": 0.2475,
+      "tested_library_loc": 127,
+      "metadata_entries": 7,
+      "test_only_metadata_entries": 6,
+      "previous_library_metadata_entries": 7,
+      "code_coverage_percent": 11.47,
+      "previous_library_coverage_percent": 12.64
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/src/test/java/org_apache_maven_plugins/maven_compiler_plugin/HelpMojoTest.java",
+      "metadata_file": "metadata/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/stats.json
+++ b/stats/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "3.11.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 3,
+      "totalCalls" : 3
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 643,
+        "missed" : 4879,
+        "ratio" : 0.116443,
+        "total" : 5522
+      },
+      "line" : {
+        "covered" : 127,
+        "missed" : 980,
+        "ratio" : 0.114724,
+        "total" : 1107
+      },
+      "method" : {
+        "covered" : 19,
+        "missed" : 103,
+        "ratio" : 0.155738,
+        "total" : 122
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/.gitignore
+++ b/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/build.gradle
+++ b/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/build.gradle
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.maven.plugins:maven-compiler-plugin:$libraryVersion"
+    testImplementation 'org.apache.maven:maven-core:3.2.5'
+    testImplementation 'org.apache.maven:maven-plugin-api:3.2.5'
+    testImplementation 'org.apache.maven.plugin-testing:maven-plugin-testing-harness:3.3.0'
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/gradle.properties
+++ b/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.maven.plugins:maven-compiler-plugin:3.11.0
+library.version = 3.11.0
+metadata.dir = org.apache.maven.plugins/maven-compiler-plugin/3.11.0/

--- a/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/settings.gradle
+++ b/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.maven.plugins.maven-compiler-plugin_tests'

--- a/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/src/test/java/org_apache_maven_plugins/maven_compiler_plugin/AbstractCompilerMojoTest.java
+++ b/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/src/test/java/org_apache_maven_plugins/maven_compiler_plugin/AbstractCompilerMojoTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_plugins.maven_compiler_plugin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.maven.execution.DefaultMavenExecutionRequest;
+import org.apache.maven.execution.DefaultMavenExecutionResult;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.compiler.AbstractCompilerMojo;
+import org.apache.maven.plugin.testing.AbstractMojoTestCase;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.toolchain.Toolchain;
+import org.apache.maven.toolchain.ToolchainManager;
+import org.codehaus.plexus.compiler.util.scan.SourceInclusionScanner;
+import org.codehaus.plexus.languages.java.jpms.JavaModuleDescriptor;
+import org.junit.jupiter.api.Test;
+
+public class AbstractCompilerMojoTest {
+    @Test
+    void requestValuesAreReadThroughMavenCompatibilityReflection() throws Exception {
+        Date startTime = new Date(123456789L);
+        TestExecutionRequest request = new TestExecutionRequest();
+        request.setThreadCount("4");
+        request.setStartTime(startTime);
+
+        TestCompilerMojo mojo = new TestCompilerMojo();
+        MojoFieldInjector injector = new MojoFieldInjector();
+        injector.inject(mojo, "session",
+                new MavenSession(null, request, new DefaultMavenExecutionResult(), new MavenProject()));
+
+        assertEquals(4, mojo.requestThreadCount());
+        assertEquals(startTime, mojo.buildStartTime());
+    }
+
+    @Test
+    void toolchainRequirementsUseNewerToolchainManagerMethodWhenPresent() throws Exception {
+        TestToolchain expectedToolchain = new TestToolchain();
+        TestToolchainManager toolchainManager = new TestToolchainManager(expectedToolchain);
+        Map<String, String> requirements = new HashMap<>();
+        requirements.put("version", "21");
+
+        TestCompilerMojo mojo = new TestCompilerMojo();
+        MojoFieldInjector injector = new MojoFieldInjector();
+        injector.inject(mojo, "session", new MavenSession(null, new DefaultMavenExecutionRequest(),
+                new DefaultMavenExecutionResult(), new MavenProject()));
+        injector.inject(mojo, "toolchainManager", toolchainManager);
+        injector.inject(mojo, "jdkToolchain", requirements);
+
+        assertSame(expectedToolchain, mojo.toolchain());
+        assertEquals("jdk", toolchainManager.requestedType);
+        assertSame(requirements, toolchainManager.requestedRequirements);
+    }
+
+    public static final class TestExecutionRequest extends DefaultMavenExecutionRequest {
+        private String threadCount;
+
+        public void setThreadCount(String threadCount) {
+            this.threadCount = threadCount;
+        }
+
+        public String getThreadCount() {
+            return threadCount;
+        }
+    }
+
+    static final class MojoFieldInjector extends AbstractMojoTestCase {
+        void inject(Object target, String name, Object value) throws IllegalAccessException {
+            setVariableValueToObject(target, name, value);
+        }
+    }
+
+    static final class TestCompilerMojo extends AbstractCompilerMojo {
+        int requestThreadCount() {
+            return getRequestThreadCount();
+        }
+
+        Date buildStartTime() {
+            return getBuildStartTime();
+        }
+
+        Toolchain toolchain() {
+            return getToolchain();
+        }
+
+        @Override
+        protected SourceInclusionScanner getSourceInclusionScanner(int staleMillis) {
+            return null;
+        }
+
+        @Override
+        protected SourceInclusionScanner getSourceInclusionScanner(String inputFileEnding) {
+            return null;
+        }
+
+        @Override
+        protected List<String> getClasspathElements() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        protected List<String> getModulepathElements() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        protected Map<String, JavaModuleDescriptor> getPathElements() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        protected List<String> getCompileSourceRoots() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        protected void preparePaths(Set<File> sourceFiles) {
+        }
+
+        @Override
+        protected File getOutputDirectory() {
+            return new File("target/classes");
+        }
+
+        @Override
+        protected String getSource() {
+            return "1.8";
+        }
+
+        @Override
+        protected String getTarget() {
+            return "1.8";
+        }
+
+        @Override
+        protected String getRelease() {
+            return null;
+        }
+
+        @Override
+        protected String getCompilerArgument() {
+            return null;
+        }
+
+        @Override
+        protected Map<String, String> getCompilerArguments() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        protected File getGeneratedSourcesDirectory() {
+            return new File("target/generated-sources/annotations");
+        }
+
+        @Override
+        protected String getDebugFileName() {
+            return null;
+        }
+    }
+
+    public static final class TestToolchainManager implements ToolchainManager {
+        private final Toolchain toolchain;
+        private String requestedType;
+        private Map<String, String> requestedRequirements;
+
+        TestToolchainManager(Toolchain toolchain) {
+            this.toolchain = toolchain;
+        }
+
+        public List<Toolchain> getToolchains(MavenSession session, String type, Map<String, String> requirements) {
+            requestedType = type;
+            requestedRequirements = requirements;
+            List<Toolchain> toolchains = new ArrayList<>();
+            toolchains.add(toolchain);
+            return toolchains;
+        }
+
+        @Override
+        public Toolchain getToolchainFromBuildContext(String type, MavenSession session) {
+            return null;
+        }
+    }
+
+    static final class TestToolchain implements Toolchain {
+        @Override
+        public String getType() {
+            return "jdk";
+        }
+
+        @Override
+        public String findTool(String toolName) {
+            return toolName;
+        }
+    }
+}

--- a/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/src/test/java/org_apache_maven_plugins/maven_compiler_plugin/AbstractCompilerMojoTest.java
+++ b/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/src/test/java/org_apache_maven_plugins/maven_compiler_plugin/AbstractCompilerMojoTest.java
@@ -32,10 +32,10 @@ import org.junit.jupiter.api.Test;
 
 public class AbstractCompilerMojoTest {
     @Test
-    void requestValuesAreReadThroughMavenCompatibilityReflection() throws Exception {
+    void requestValuesAreReadFromMavenExecutionRequest() throws Exception {
         Date startTime = new Date(123456789L);
-        TestExecutionRequest request = new TestExecutionRequest();
-        request.setThreadCount("4");
+        DefaultMavenExecutionRequest request = new DefaultMavenExecutionRequest();
+        request.setDegreeOfConcurrency(4);
         request.setStartTime(startTime);
 
         TestCompilerMojo mojo = new TestCompilerMojo();
@@ -64,18 +64,6 @@ public class AbstractCompilerMojoTest {
         assertSame(expectedToolchain, mojo.toolchain());
         assertEquals("jdk", toolchainManager.requestedType);
         assertSame(requirements, toolchainManager.requestedRequirements);
-    }
-
-    public static final class TestExecutionRequest extends DefaultMavenExecutionRequest {
-        private String threadCount;
-
-        public void setThreadCount(String threadCount) {
-            this.threadCount = threadCount;
-        }
-
-        public String getThreadCount() {
-            return threadCount;
-        }
     }
 
     static final class MojoFieldInjector extends AbstractMojoTestCase {
@@ -169,6 +157,16 @@ public class AbstractCompilerMojoTest {
         @Override
         protected String getDebugFileName() {
             return null;
+        }
+
+        @Override
+        protected Set<String> getIncludes() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        protected Set<String> getExcludes() {
+            return Collections.emptySet();
         }
     }
 

--- a/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/src/test/java/org_apache_maven_plugins/maven_compiler_plugin/HelpMojoTest.java
+++ b/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/src/test/java/org_apache_maven_plugins/maven_compiler_plugin/HelpMojoTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_plugins.maven_compiler_plugin;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.maven.plugin.compiler.HelpMojo;
+import org.apache.maven.plugin.logging.Log;
+import org.junit.jupiter.api.Test;
+
+public class HelpMojoTest {
+    @Test
+    public void executeLoadsBundledPluginHelpResource() throws Exception {
+        CapturingLog log = new CapturingLog();
+        HelpMojo mojo = new HelpMojo();
+        mojo.setLog(log);
+
+        mojo.execute();
+
+        String output = log.info.toString();
+        assertTrue(output.contains("Apache Maven Compiler Plugin"));
+        assertTrue(output.contains("compiler:compile"));
+        assertTrue(output.contains("compiler:testCompile"));
+    }
+
+    static final class CapturingLog implements Log {
+        private final StringBuilder info = new StringBuilder();
+
+        @Override
+        public boolean isDebugEnabled() {
+            return true;
+        }
+
+        @Override
+        public void debug(CharSequence content) {
+        }
+
+        @Override
+        public void debug(CharSequence content, Throwable error) {
+        }
+
+        @Override
+        public void debug(Throwable error) {
+        }
+
+        @Override
+        public boolean isInfoEnabled() {
+            return true;
+        }
+
+        @Override
+        public void info(CharSequence content) {
+            info.append(content);
+        }
+
+        @Override
+        public void info(CharSequence content, Throwable error) {
+            info.append(content);
+        }
+
+        @Override
+        public void info(Throwable error) {
+        }
+
+        @Override
+        public boolean isWarnEnabled() {
+            return true;
+        }
+
+        @Override
+        public void warn(CharSequence content) {
+        }
+
+        @Override
+        public void warn(CharSequence content, Throwable error) {
+        }
+
+        @Override
+        public void warn(Throwable error) {
+        }
+
+        @Override
+        public boolean isErrorEnabled() {
+            return true;
+        }
+
+        @Override
+        public void error(CharSequence content) {
+        }
+
+        @Override
+        public void error(CharSequence content, Throwable error) {
+        }
+
+        @Override
+        public void error(Throwable error) {
+        }
+    }
+}

--- a/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/src/test/java/org_apache_maven_plugins/maven_compiler_plugin/HelpMojoTest.java
+++ b/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/src/test/java/org_apache_maven_plugins/maven_compiler_plugin/HelpMojoTest.java
@@ -8,7 +8,7 @@ package org_apache_maven_plugins.maven_compiler_plugin;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.apache.maven.plugin.compiler.HelpMojo;
+import org.apache.maven.plugins.maven_compiler_plugin.HelpMojo;
 import org.apache.maven.plugin.logging.Log;
 import org.junit.jupiter.api.Test;
 

--- a/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,40 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org_apache_maven_plugins.maven_compiler_plugin.AbstractCompilerMojoTest"
+      },
+      "type" : "org.apache.maven.plugin.compiler.AbstractCompilerMojo",
+      "fields" : [
+        {
+          "name" : "jdkToolchain"
+        },
+        {
+          "name" : "toolchainManager"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.maven.plugin.testing.AbstractMojoTestCase"
+      },
+      "type" : "org_apache_maven_plugins.maven_compiler_plugin.AbstractCompilerMojoTest$TestCompilerMojo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.maven.plugin.compiler.AbstractCompilerMojo"
+      },
+      "type" : "org_apache_maven_plugins.maven_compiler_plugin.AbstractCompilerMojoTest$TestToolchainManager",
+      "methods" : [
+        {
+          "name" : "getToolchains",
+          "parameterTypes" : [
+            "org.apache.maven.execution.MavenSession",
+            "java.lang.String",
+            "java.util.Map"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/user-code-filter.json
+++ b/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/user-code-filter.json
@@ -10,6 +10,9 @@
       "includeClasses" : "org.apache.maven.plugin.compiler.**"
     },
     {
+      "includeClasses" : "org.apache.maven.plugins.maven_compiler_plugin.**"
+    },
+    {
       "includeClasses" : "org_apache_maven_plugins.maven_compiler_plugin.**"
     }
   ]

--- a/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/user-code-filter.json
+++ b/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/user-code-filter.json
@@ -1,0 +1,16 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.maven.plugin.**"
+    },
+    {
+      "includeClasses" : "org.apache.maven.plugin.compiler.**"
+    },
+    {
+      "includeClasses" : "org_apache_maven_plugins.maven_compiler_plugin.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #8254

This PR provides test fixes and new metadata for org.apache.maven.plugins:maven-compiler-plugin:3.11.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 62863
- Cached input tokens: 329728
- Output tokens: 2752
- Metadata entries: 7
- Test-only metadata entries: 6
- Iterations: 2
- Library coverage percentage: 11.47
- Previous library version metadata entries: 7
- Previous library version coverage percentage: 12.64

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `9db49a6fa052e4b35c82f0ff9798e41179e07b42`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.maven.plugins:maven-compiler-plugin:3.10.0: 11/11 covered calls (100.00%)
- org.apache.maven.plugins:maven-compiler-plugin:3.11.0: 3/3 covered calls (100.00%)

**Reflection:**
- org.apache.maven.plugins:maven-compiler-plugin:3.10.0: 10/10 covered calls (100.00%)
- org.apache.maven.plugins:maven-compiler-plugin:3.11.0: 2/2 covered calls (100.00%)

**Resources:**
- org.apache.maven.plugins:maven-compiler-plugin:3.10.0: 1/1 covered calls (100.00%)
- org.apache.maven.plugins:maven-compiler-plugin:3.11.0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.maven.plugins:maven-compiler-plugin:3.10.0: 690/5170 (13.35%)
- org.apache.maven.plugins:maven-compiler-plugin:3.11.0: 643/5522 (11.64%)

**Line:**
- org.apache.maven.plugins:maven-compiler-plugin:3.10.0: 133/1052 (12.64%)
- org.apache.maven.plugins:maven-compiler-plugin:3.11.0: 127/1107 (11.47%)

**Method:**
- org.apache.maven.plugins:maven-compiler-plugin:3.10.0: 19/99 (19.19%)
- org.apache.maven.plugins:maven-compiler-plugin:3.11.0: 19/122 (15.57%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/src/test/java/org_apache_maven_plugins/maven_compiler_plugin/AbstractCompilerMojoTest.java b/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/src/test/java/org_apache_maven_plugins/maven_compiler_plugin/AbstractCompilerMojoTest.java
index 868c3787bd..549be5efa6 100644
--- a/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/src/test/java/org_apache_maven_plugins/maven_compiler_plugin/AbstractCompilerMojoTest.java
+++ b/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/src/test/java/org_apache_maven_plugins/maven_compiler_plugin/AbstractCompilerMojoTest.java
@@ -32,10 +32,10 @@ import org.junit.jupiter.api.Test;
 
 public class AbstractCompilerMojoTest {
     @Test
-    void requestValuesAreReadThroughMavenCompatibilityReflection() throws Exception {
+    void requestValuesAreReadFromMavenExecutionRequest() throws Exception {
         Date startTime = new Date(123456789L);
-        TestExecutionRequest request = new TestExecutionRequest();
-        request.setThreadCount("4");
+        DefaultMavenExecutionRequest request = new DefaultMavenExecutionRequest();
+        request.setDegreeOfConcurrency(4);
         request.setStartTime(startTime);
 
         TestCompilerMojo mojo = new TestCompilerMojo();
@@ -66,18 +66,6 @@ public class AbstractCompilerMojoTest {
         assertSame(requirements, toolchainManager.requestedRequirements);
     }
 
-    public static final class TestExecutionRequest extends DefaultMavenExecutionRequest {
-        private String threadCount;
-
-        public void setThreadCount(String threadCount) {
-            this.threadCount = threadCount;
-        }
-
-        public String getThreadCount() {
-            return threadCount;
-        }
-    }
-
     static final class MojoFieldInjector extends AbstractMojoTestCase {
         void inject(Object target, String name, Object value) throws IllegalAccessException {
             setVariableValueToObject(target, name, value);
@@ -170,6 +158,16 @@ public class AbstractCompilerMojoTest {
         protected String getDebugFileName() {
             return null;
         }
+
+        @Override
+        protected Set<String> getIncludes() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        protected Set<String> getExcludes() {
+            return Collections.emptySet();
+        }
     }
 
     public static final class TestToolchainManager implements ToolchainManager {
diff --git a/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/src/test/java/org_apache_maven_plugins/maven_compiler_plugin/HelpMojoTest.java b/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/src/test/java/org_apache_maven_plugins/maven_compiler_plugin/HelpMojoTest.java
index e2a1ac8692..d1518b4b84 100644
--- a/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/src/test/java/org_apache_maven_plugins/maven_compiler_plugin/HelpMojoTest.java
+++ b/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/src/test/java/org_apache_maven_plugins/maven_compiler_plugin/HelpMojoTest.java
@@ -8,7 +8,7 @@ package org_apache_maven_plugins.maven_compiler_plugin;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.apache.maven.plugin.compiler.HelpMojo;
+import org.apache.maven.plugins.maven_compiler_plugin.HelpMojo;
 import org.apache.maven.plugin.logging.Log;
 import org.junit.jupiter.api.Test;
 
diff --git a/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/user-code-filter.json b/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/user-code-filter.json
index 670da07f10..ee9476619c 100644
--- a/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/user-code-filter.json
+++ b/tests/src/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/user-code-filter.json
@@ -9,6 +9,9 @@
     {
       "includeClasses" : "org.apache.maven.plugin.compiler.**"
     },
+    {
+      "includeClasses" : "org.apache.maven.plugins.maven_compiler_plugin.**"
+    },
     {
       "includeClasses" : "org_apache_maven_plugins.maven_compiler_plugin.**"
     }

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
