### PR TITLE
[GenAI] Test fix for org.apache.maven.plugins:maven-jar-plugin:4.0.0-beta-1 using gpt-5.5

### DIFF
--- a/metadata/org.apache.maven.plugins/maven-jar-plugin/4.0.0-beta-1/reachability-metadata.json
+++ b/metadata/org.apache.maven.plugins/maven-jar-plugin/4.0.0-beta-1/reachability-metadata.json
@@ -1,0 +1,42 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.plugins.maven_jar_plugin.HelpMojo"
+      },
+      "type": "com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.plugins.maven_jar_plugin.HelpMojo"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.plugins.maven_jar_plugin.HelpMojo"
+      },
+      "type": "short[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.plugins.maven_jar_plugin.HelpMojo"
+      },
+      "type": "short[][]"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.plugins.maven_jar_plugin.HelpMojo"
+      },
+      "glob": "META-INF/maven/org.apache.maven.plugins/maven-jar-plugin/plugin-help.xml"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.plugins.maven_jar_plugin.HelpMojo"
+      },
+      "glob": "META-INF/services/javax.xml.parsers.DocumentBuilderFactory"
+    }
+  ]
+}

--- a/metadata/org.apache.maven.plugins/maven-jar-plugin/index.json
+++ b/metadata/org.apache.maven.plugins/maven-jar-plugin/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "4.0.0-beta-1",
+    "tested-versions" : [
+      "4.0.0-beta-1"
+    ],
+    "allowed-packages" : [
+      "org.apache.maven.plugins.maven_jar_plugin"
+    ]
+  },
+  {
     "metadata-version" : "3.4.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/$version$/maven-jar-plugin-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/maven-jar-plugin",

--- a/metadata/org.apache.maven.plugins/maven-jar-plugin/index.json
+++ b/metadata/org.apache.maven.plugins/maven-jar-plugin/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "4.0.0-beta-1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/$version$/maven-jar-plugin-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/maven-jar-plugin",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/$version$/maven-jar-plugin-$version$-source-release.zip",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/$version$/maven-jar-plugin-$version$-javadoc.jar",
+    "description" : "Apache Maven JAR Plugin builds Java Archive (JAR) files from a Maven project's compiled classes and resources. It also provides goals for packaging the main artifact and attaching a test JAR containing test classes.",
     "tested-versions" : [
       "4.0.0-beta-1"
     ],

--- a/stats/org.apache.maven.plugins/maven-jar-plugin/4.0.0-beta-1/execution-metrics.json
+++ b/stats/org.apache.maven.plugins/maven-jar-plugin/4.0.0-beta-1/execution-metrics.json
@@ -1,0 +1,146 @@
+{
+  "fix_java_run_fail:2026-06-09": {
+    "timestamp": "2026-06-09T14:36:14.227291Z",
+    "library": "org.apache.maven.plugins:maven-jar-plugin:4.0.0-beta-1",
+    "starting_commit": "551411e6bfead1c75d3e00686a5779c38c73dabf",
+    "ending_commit": "571a4a1ff8ffb440cfff6afcf0bff030d8a4c860",
+    "previous_library": "org.apache.maven.plugins:maven-jar-plugin:3.4.0",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.0.0-beta-1",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 502,
+          "missed": 703,
+          "ratio": 0.416598,
+          "total": 1205
+        },
+        "line": {
+          "covered": 103,
+          "missed": 151,
+          "ratio": 0.405512,
+          "total": 254
+        },
+        "method": {
+          "covered": 14,
+          "missed": 30,
+          "ratio": 0.318182,
+          "total": 44
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.4.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 538,
+          "missed": 922,
+          "ratio": 0.368493,
+          "total": 1460
+        },
+        "line": {
+          "covered": 103,
+          "missed": 175,
+          "ratio": 0.370504,
+          "total": 278
+        },
+        "method": {
+          "covered": 14,
+          "missed": 33,
+          "ratio": 0.297872,
+          "total": 47
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "advisory_preparation",
+      "issue_number": 8255,
+      "issue_label": "fails-java-run",
+      "library": "org.apache.maven.plugins:maven-jar-plugin:4.0.0-beta-1",
+      "summary": "maven-jar-plugin 4.x is a Maven 4 plugin whose mojos are normally created by Maven/plugin-testing infrastructure; direct instantiation leaves DI fields such as HelpMojo.logger unset, causing the observed Java-run NPE.",
+      "deterministic_setup": [
+        {
+          "kind": "dependency",
+          "coordinate": "org.apache.maven.plugin-testing:maven-plugin-testing-harness:4.0.0-beta-1",
+          "scope": "testImplementation",
+          "reason": "The plugin's own test setup uses Maven Plugin Testing Harness, and Maven 4 mojos require Maven/container-style injection for fields such as org.apache.maven.api.plugin.Log."
+        }
+      ],
+      "agent_guidance": "Do not call Maven mojos as plain new objects unless all Maven-injected fields are initialized. Prefer Maven Plugin Testing Harness to look up/configure the mojo, or for the narrow HelpMojo resource test inject a no-op org.apache.maven.api.plugin.Log before execute(); keep any temp project/archive work isolated in test temp directories.",
+      "risks": [
+        "The testing harness is beta-aligned with Maven 4 and may require Maven-style test descriptors/configuration; for a minimal HelpMojo-only test, reflective Log injection may be simpler.",
+        "Main jar/test-jar mojos require additional Maven project/session/archive configuration; coverage should avoid relying on a real external Maven build or network service."
+      ],
+      "applied_setup": [
+        {
+          "kind": "dependency",
+          "coordinate": "org.apache.maven.plugin-testing:maven-plugin-testing-harness:4.0.0-beta-1",
+          "result": "skipped",
+          "reason": "build_gradle_absent"
+        }
+      ],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#8255 [Automation] java run fails for org.apache.maven.plugins:maven-jar-plugin:4.0.0-beta-1; label=fails-java-run; body_chars=8015"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "6 existing test file path(s) included"
+        }
+      ],
+      "current_library": "org.apache.maven.plugins:maven-jar-plugin:3.4.0",
+      "new_version": "4.0.0-beta-1",
+      "model": "oca/gpt-5.5",
+      "input_tokens_used": 19420,
+      "output_tokens_used": 2848,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.apache.maven.plugins:maven-jar-plugin:4.0.0-beta-1/library-preparation-preflight/pi-generation-2026-06-09T14-25-33-963128Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 76175,
+      "cached_input_tokens_used": 708096,
+      "output_tokens_used": 5943,
+      "iterations": 1,
+      "cost_usd": 0.5323,
+      "tested_library_loc": 103,
+      "metadata_entries": 6,
+      "previous_library_metadata_entries": 6,
+      "code_coverage_percent": 40.55,
+      "previous_library_coverage_percent": 37.05
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.maven.plugins/maven-jar-plugin/4.0.0-beta-1/src/test/java/org_apache_maven_plugins/maven_jar_plugin/HelpMojoTest.java",
+      "metadata_file": "metadata/org.apache.maven.plugins/maven-jar-plugin/4.0.0-beta-1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.maven.plugins/maven-jar-plugin/4.0.0-beta-1/stats.json
+++ b/stats/org.apache.maven.plugins/maven-jar-plugin/4.0.0-beta-1/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "4.0.0-beta-1",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 1,
+      "totalCalls" : 1
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 502,
+        "missed" : 703,
+        "ratio" : 0.416598,
+        "total" : 1205
+      },
+      "line" : {
+        "covered" : 103,
+        "missed" : 151,
+        "ratio" : 0.405512,
+        "total" : 254
+      },
+      "method" : {
+        "covered" : 14,
+        "missed" : 30,
+        "ratio" : 0.318182,
+        "total" : 44
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.maven.plugins/maven-jar-plugin/4.0.0-beta-1/.gitignore
+++ b/tests/src/org.apache.maven.plugins/maven-jar-plugin/4.0.0-beta-1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.maven.plugins/maven-jar-plugin/4.0.0-beta-1/build.gradle
+++ b/tests/src/org.apache.maven.plugins/maven-jar-plugin/4.0.0-beta-1/build.gradle
@@ -1,0 +1,30 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation("org.apache.maven.plugins:maven-jar-plugin:$libraryVersion") {
+        exclude group: "org.sonatype.sisu", module: "sisu-guice"
+    }
+    testImplementation 'org.apache.maven:maven-plugin-api:3.2.5'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.maven.plugins/maven-jar-plugin/4.0.0-beta-1/gradle.properties
+++ b/tests/src/org.apache.maven.plugins/maven-jar-plugin/4.0.0-beta-1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.maven.plugins:maven-jar-plugin:4.0.0-beta-1
+library.version = 4.0.0-beta-1
+metadata.dir = org.apache.maven.plugins/maven-jar-plugin/4.0.0-beta-1/

--- a/tests/src/org.apache.maven.plugins/maven-jar-plugin/4.0.0-beta-1/settings.gradle
+++ b/tests/src/org.apache.maven.plugins/maven-jar-plugin/4.0.0-beta-1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.maven.plugins.maven-jar-plugin_tests'

--- a/tests/src/org.apache.maven.plugins/maven-jar-plugin/4.0.0-beta-1/src/test/java/org_apache_maven_plugins/maven_jar_plugin/HelpMojoTest.java
+++ b/tests/src/org.apache.maven.plugins/maven-jar-plugin/4.0.0-beta-1/src/test/java/org_apache_maven_plugins/maven_jar_plugin/HelpMojoTest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_plugins.maven_jar_plugin;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.apache.maven.plugins.maven_jar_plugin.HelpMojo;
+import org.junit.jupiter.api.Test;
+
+public class HelpMojoTest {
+    @Test
+    void executeLoadsPluginHelpResource() {
+        HelpMojo mojo = new HelpMojo();
+
+        assertThatCode(mojo::execute).doesNotThrowAnyException();
+    }
+}

--- a/tests/src/org.apache.maven.plugins/maven-jar-plugin/4.0.0-beta-1/src/test/java/org_apache_maven_plugins/maven_jar_plugin/HelpMojoTest.java
+++ b/tests/src/org.apache.maven.plugins/maven-jar-plugin/4.0.0-beta-1/src/test/java/org_apache_maven_plugins/maven_jar_plugin/HelpMojoTest.java
@@ -6,16 +6,147 @@
  */
 package org_apache_maven_plugins.maven_jar_plugin;
 
-import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.apache.maven.api.plugin.Log;
 import org.apache.maven.plugins.maven_jar_plugin.HelpMojo;
 import org.junit.jupiter.api.Test;
 
 public class HelpMojoTest {
     @Test
-    void executeLoadsPluginHelpResource() {
-        HelpMojo mojo = new HelpMojo();
+    void executeLoadsPluginHelpResource() throws ReflectiveOperationException {
+        CapturingLog log = new CapturingLog();
+        HelpMojo mojo = configuredHelpMojo(log);
 
-        assertThatCode(mojo::execute).doesNotThrowAnyException();
+        mojo.execute();
+
+        assertThat(log.infoMessages())
+                .singleElement()
+                .satisfies(message -> assertThat(message).contains("jar:jar"));
+    }
+
+    private static HelpMojo configuredHelpMojo(Log log) throws ReflectiveOperationException {
+        HelpMojo mojo = new HelpMojo();
+        Field loggerField = HelpMojo.class.getDeclaredField("logger");
+        loggerField.setAccessible(true);
+        loggerField.set(mojo, log);
+        return mojo;
+    }
+
+    private static final class CapturingLog implements Log {
+        private final List<String> infoMessages = new ArrayList<>();
+
+        private List<String> infoMessages() {
+            return infoMessages;
+        }
+
+        @Override
+        public boolean isDebugEnabled() {
+            return false;
+        }
+
+        @Override
+        public void debug(CharSequence content) {
+        }
+
+        @Override
+        public void debug(CharSequence content, Throwable error) {
+        }
+
+        @Override
+        public void debug(Throwable error) {
+        }
+
+        @Override
+        public void debug(Supplier<String> content) {
+        }
+
+        @Override
+        public void debug(Supplier<String> content, Throwable error) {
+        }
+
+        @Override
+        public boolean isInfoEnabled() {
+            return true;
+        }
+
+        @Override
+        public void info(CharSequence content) {
+            infoMessages.add(content.toString());
+        }
+
+        @Override
+        public void info(CharSequence content, Throwable error) {
+            info(content);
+        }
+
+        @Override
+        public void info(Throwable error) {
+        }
+
+        @Override
+        public void info(Supplier<String> content) {
+            info(content.get());
+        }
+
+        @Override
+        public void info(Supplier<String> content, Throwable error) {
+            info(content);
+        }
+
+        @Override
+        public boolean isWarnEnabled() {
+            return false;
+        }
+
+        @Override
+        public void warn(CharSequence content) {
+        }
+
+        @Override
+        public void warn(CharSequence content, Throwable error) {
+        }
+
+        @Override
+        public void warn(Throwable error) {
+        }
+
+        @Override
+        public void warn(Supplier<String> content) {
+        }
+
+        @Override
+        public void warn(Supplier<String> content, Throwable error) {
+        }
+
+        @Override
+        public boolean isErrorEnabled() {
+            return false;
+        }
+
+        @Override
+        public void error(CharSequence content) {
+        }
+
+        @Override
+        public void error(CharSequence content, Throwable error) {
+        }
+
+        @Override
+        public void error(Throwable error) {
+        }
+
+        @Override
+        public void error(Supplier<String> content) {
+        }
+
+        @Override
+        public void error(Supplier<String> content, Throwable error) {
+        }
     }
 }

--- a/tests/src/org.apache.maven.plugins/maven-jar-plugin/4.0.0-beta-1/user-code-filter.json
+++ b/tests/src/org.apache.maven.plugins/maven-jar-plugin/4.0.0-beta-1/user-code-filter.json
@@ -1,0 +1,16 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.maven.plugins.jar.**"
+    },
+    {
+      "includeClasses" : "org.apache.maven.plugins.**"
+    },
+    {
+      "includeClasses" : "org_apache_maven_plugins.maven_jar_plugin.**"
+    }
+  ]
+}

--- a/tests/src/org.apache.maven.plugins/maven-jar-plugin/4.0.0-beta-1/user-code-filter.json
+++ b/tests/src/org.apache.maven.plugins/maven-jar-plugin/4.0.0-beta-1/user-code-filter.json
@@ -4,7 +4,7 @@
       "excludeClasses" : "**"
     },
     {
-      "includeClasses" : "org.apache.maven.plugins.jar.**"
+      "includeClasses" : "org.apache.maven.plugins.maven_jar_plugin.**"
     },
     {
       "includeClasses" : "org.apache.maven.plugins.**"


### PR DESCRIPTION
## What does this PR do?

Fixes: #8255

This PR provides test fixes and new metadata for org.apache.maven.plugins:maven-jar-plugin:4.0.0-beta-1, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 76175
- Cached input tokens: 708096
- Output tokens: 5943
- Metadata entries: 6
- Iterations: 1
- Library coverage percentage: 40.55
- Previous library version metadata entries: 6
- Previous library version coverage percentage: 37.05

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `db30d67522f79b4989bb316525d11d93f91cb3d5`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.maven.plugins:maven-jar-plugin:3.4.0: 1/1 covered calls (100.00%)
- org.apache.maven.plugins:maven-jar-plugin:4.0.0-beta-1: 1/1 covered calls (100.00%)

**Resources:**
- org.apache.maven.plugins:maven-jar-plugin:3.4.0: 1/1 covered calls (100.00%)
- org.apache.maven.plugins:maven-jar-plugin:4.0.0-beta-1: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.maven.plugins:maven-jar-plugin:3.4.0: 538/1460 (36.85%)
- org.apache.maven.plugins:maven-jar-plugin:4.0.0-beta-1: 502/1205 (41.66%)

**Line:**
- org.apache.maven.plugins:maven-jar-plugin:3.4.0: 103/278 (37.05%)
- org.apache.maven.plugins:maven-jar-plugin:4.0.0-beta-1: 103/254 (40.55%)

**Method:**
- org.apache.maven.plugins:maven-jar-plugin:3.4.0: 14/47 (29.79%)
- org.apache.maven.plugins:maven-jar-plugin:4.0.0-beta-1: 14/44 (31.82%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.4.0/src/test/java/org_apache_maven_plugins/maven_jar_plugin/HelpMojoTest.java 2/tests/src/org.apache.maven.plugins/maven-jar-plugin/4.0.0-beta-1/src/test/java/org_apache_maven_plugins/maven_jar_plugin/HelpMojoTest.java
index 4252dfd3bf..fb831c8a6b 100644
--- 1/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.4.0/src/test/java/org_apache_maven_plugins/maven_jar_plugin/HelpMojoTest.java
+++ 2/tests/src/org.apache.maven.plugins/maven-jar-plugin/4.0.0-beta-1/src/test/java/org_apache_maven_plugins/maven_jar_plugin/HelpMojoTest.java
@@ -6,16 +6,147 @@
  */
 package org_apache_maven_plugins.maven_jar_plugin;
 
-import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.apache.maven.api.plugin.Log;
 import org.apache.maven.plugins.maven_jar_plugin.HelpMojo;
 import org.junit.jupiter.api.Test;
 
 public class HelpMojoTest {
     @Test
-    void executeLoadsPluginHelpResource() {
+    void executeLoadsPluginHelpResource() throws ReflectiveOperationException {
+        CapturingLog log = new CapturingLog();
+        HelpMojo mojo = configuredHelpMojo(log);
+
+        mojo.execute();
+
+        assertThat(log.infoMessages())
+                .singleElement()
+                .satisfies(message -> assertThat(message).contains("jar:jar"));
+    }
+
+    private static HelpMojo configuredHelpMojo(Log log) throws ReflectiveOperationException {
         HelpMojo mojo = new HelpMojo();
+        Field loggerField = HelpMojo.class.getDeclaredField("logger");
+        loggerField.setAccessible(true);
+        loggerField.set(mojo, log);
+        return mojo;
+    }
+
+    private static final class CapturingLog implements Log {
+        private final List<String> infoMessages = new ArrayList<>();
+
+        private List<String> infoMessages() {
+            return infoMessages;
+        }
+
+        @Override
+        public boolean isDebugEnabled() {
+            return false;
+        }
+
+        @Override
+        public void debug(CharSequence content) {
+        }
+
+        @Override
+        public void debug(CharSequence content, Throwable error) {
+        }
+
+        @Override
+        public void debug(Throwable error) {
+        }
+
+        @Override
+        public void debug(Supplier<String> content) {
+        }
+
+        @Override
+        public void debug(Supplier<String> content, Throwable error) {
+        }
+
+        @Override
+        public boolean isInfoEnabled() {
+            return true;
+        }
+
+        @Override
+        public void info(CharSequence content) {
+            infoMessages.add(content.toString());
+        }
+
+        @Override
+        public void info(CharSequence content, Throwable error) {
+            info(content);
+        }
+
+        @Override
+        public void info(Throwable error) {
+        }
+
+        @Override
+        public void info(Supplier<String> content) {
+            info(content.get());
+        }
+
+        @Override
+        public void info(Supplier<String> content, Throwable error) {
+            info(content);
+        }
+
+        @Override
+        public boolean isWarnEnabled() {
+            return false;
+        }
+
+        @Override
+        public void warn(CharSequence content) {
+        }
+
+        @Override
+        public void warn(CharSequence content, Throwable error) {
+        }
+
+        @Override
+        public void warn(Throwable error) {
+        }
+
+        @Override
+        public void warn(Supplier<String> content) {
+        }
+
+        @Override
+        public void warn(Supplier<String> content, Throwable error) {
+        }
+
+        @Override
+        public boolean isErrorEnabled() {
+            return false;
+        }
+
+        @Override
+        public void error(CharSequence content) {
+        }
+
+        @Override
+        public void error(CharSequence content, Throwable error) {
+        }
+
+        @Override
+        public void error(Throwable error) {
+        }
+
+        @Override
+        public void error(Supplier<String> content) {
+        }
 
-        assertThatCode(mojo::execute).doesNotThrowAnyException();
+        @Override
+        public void error(Supplier<String> content, Throwable error) {
+        }
     }
 }
diff --git 1/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.4.0/user-code-filter.json 2/tests/src/org.apache.maven.plugins/maven-jar-plugin/4.0.0-beta-1/user-code-filter.json
index 1755ef9170..1fdb6f6039 100644
--- 1/tests/src/org.apache.maven.plugins/maven-jar-plugin/3.4.0/user-code-filter.json
+++ 2/tests/src/org.apache.maven.plugins/maven-jar-plugin/4.0.0-beta-1/user-code-filter.json
@@ -4,7 +4,7 @@
       "excludeClasses" : "**"
     },
     {
-      "includeClasses" : "org.apache.maven.plugins.jar.**"
+      "includeClasses" : "org.apache.maven.plugins.maven_jar_plugin.**"
     },
     {
       "includeClasses" : "org.apache.maven.plugins.**"

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
