### PR TITLE
[GenAI] Mark javax.jms:jms as not for Native Image

### DIFF
--- a/metadata/javax.jms/jms/index.json
+++ b/metadata/javax.jms/jms/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The Maven Central entry for javax.jms:jms:1.1 publishes only POM metadata and no JAR, so there are no JVM class files for Native Image to analyze.",
+    "replacement": "javax.jms:jms-api:1.1-rev-1"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #3040

This PR records `javax.jms:jms` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The Maven Central entry for javax.jms:jms:1.1 publishes only POM metadata and no JAR, so there are no JVM class files for Native Image to analyze.

Replacement guidance:
- javax.jms:jms-api:1.1-rev-1

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `ddaf5d14dea186418911de0e26f5f95a0b48b498`

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
