### PR TITLE
[GenAI] Test fix for org.apache.parquet:parquet-jackson:1.16.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.parquet/parquet-jackson/1.16.0/reachability-metadata.json
+++ b/metadata/org.apache.parquet/parquet-jackson/1.16.0/reachability-metadata.json
@@ -1,0 +1,505 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedConstructor"
+      },
+      "type" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedConstructor",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedConstructor"
+      },
+      "type" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedWithParams",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedConstructor"
+      },
+      "type" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedMember",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedConstructor"
+      },
+      "type" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedConstructor$Serialization",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedConstructor"
+      },
+      "type" : "java.lang.Class",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedConstructor"
+      },
+      "type" : "java.lang.Class[]",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedConstructor"
+      },
+      "type" : "java.lang.String",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedField"
+      },
+      "type" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedField",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedField"
+      },
+      "type" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedMember",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedField"
+      },
+      "type" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedField$Serialization",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedField"
+      },
+      "type" : "java.lang.Class",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedField"
+      },
+      "type" : "java.lang.String",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedMethod"
+      },
+      "type" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedMethod",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedMethod"
+      },
+      "type" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedWithParams",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedMethod"
+      },
+      "type" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedMember",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedMethod"
+      },
+      "type" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedMethod$Serialization",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedMethod"
+      },
+      "type" : "java.lang.Class",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedMethod"
+      },
+      "type" : "java.lang.Class[]",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedMethod"
+      },
+      "type" : "java.lang.String",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.ext.Java7Support"
+      },
+      "type" : "shaded.parquet.com.fasterxml.jackson.databind.ext.Java7SupportImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.ext.Java7Handlers"
+      },
+      "type" : "shaded.parquet.com.fasterxml.jackson.databind.ext.Java7HandlersImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.ext.OptionalHandlerFactory"
+      },
+      "type" : "shaded.parquet.com.fasterxml.jackson.databind.ext.DOMDeserializer$DocumentDeserializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.ext.OptionalHandlerFactory"
+      },
+      "type" : "shaded.parquet.com.fasterxml.jackson.databind.ext.DOMDeserializer$NodeDeserializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.ext.OptionalHandlerFactory"
+      },
+      "type" : "shaded.parquet.com.fasterxml.jackson.databind.ext.DOMSerializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.ext.DOMDeserializer"
+      },
+      "type" : "com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.ext.DOMSerializer"
+      },
+      "type" : "com.sun.org.apache.xerces.internal.dom.DOMImplementationSourceImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.ext.DOMSerializer"
+      },
+      "type" : "com.sun.org.apache.xerces.internal.dom.DOMXSImplementationSourceImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "com.sun.org.apache.xerces.internal.dom.ChildNode"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "com.sun.org.apache.xerces.internal.dom.DeferredAttrImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "com.sun.org.apache.xerces.internal.dom.DeferredAttrNSImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "com.sun.org.apache.xerces.internal.dom.DeferredCDATASectionImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "com.sun.org.apache.xerces.internal.dom.DeferredCommentImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "com.sun.org.apache.xerces.internal.dom.DeferredDOMImplementationImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "com.sun.org.apache.xerces.internal.dom.CoreDocumentImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "com.sun.org.apache.xerces.internal.dom.DeferredDocumentImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "com.sun.org.apache.xerces.internal.dom.DeferredDocumentTypeImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "com.sun.org.apache.xerces.internal.dom.DeferredElementDefinitionImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "com.sun.org.apache.xerces.internal.dom.DeferredElementImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "com.sun.org.apache.xerces.internal.dom.DeferredElementNSImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "com.sun.org.apache.xerces.internal.dom.DeferredEntityImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "com.sun.org.apache.xerces.internal.dom.DeferredEntityReferenceImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "com.sun.org.apache.xerces.internal.dom.DeferredNode"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "com.sun.org.apache.xerces.internal.dom.DeferredNotationImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "com.sun.org.apache.xerces.internal.dom.DeferredProcessingInstructionImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "com.sun.org.apache.xerces.internal.dom.DeferredTextImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "com.sun.org.apache.xerces.internal.dom.DocumentImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "com.sun.org.apache.xerces.internal.dom.ElementImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "com.sun.org.apache.xerces.internal.dom.NodeImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "com.sun.org.apache.xerces.internal.dom.ParentNode"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "java.io.Serializable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "java.lang.Cloneable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "org.w3c.dom.Document"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "org.w3c.dom.Node"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "org.w3c.dom.NodeList"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "org.w3c.dom.events.DocumentEvent"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "org.w3c.dom.events.EventTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "org.w3c.dom.ranges.DocumentRange"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "org.w3c.dom.traversal.DocumentTraversal"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "java.lang.Record"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.util.ClassUtil$EnumTypeLocator"
+      },
+      "type" : "java.util.EnumMap",
+      "fields" : [
+        {
+          "name" : "keyType"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.util.ClassUtil$EnumTypeLocator"
+      },
+      "type" : "java.util.EnumSet",
+      "fields" : [
+        {
+          "name" : "elementType"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.deser.std.DateDeserializers$CalendarDeserializer"
+      },
+      "type" : "java.util.GregorianCalendar",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.core.util.VersionUtil"
+      },
+      "type" : "shaded.parquet.com.fasterxml.jackson.core.json.PackageVersion",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.ext.DOMDeserializer"
+      },
+      "glob" : "META-INF/services/javax.xml.parsers.DocumentBuilderFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.ext.DOMSerializer"
+      },
+      "glob" : "META-INF/services/org.w3c.dom.DOMImplementationSourceList"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.ext.DOMSerializer"
+      },
+      "glob" : "META-INF/services/javax.xml.transform.TransformerFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.ext.DOMSerializer"
+      },
+      "module" : "java.xml",
+      "glob" : "com/sun/org/apache/xml/internal/serializer/Encodings.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "shaded.parquet.com.fasterxml.jackson.databind.ext.DOMSerializer"
+      },
+      "module" : "java.xml",
+      "glob" : "com/sun/org/apache/xml/internal/serializer/XMLEntities.properties"
+    }
+  ]
+}

--- a/metadata/org.apache.parquet/parquet-jackson/index.json
+++ b/metadata/org.apache.parquet/parquet-jackson/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.16.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/parquet/parquet-jackson/$version$/parquet-jackson-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/parquet-java",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/parquet/parquet-jackson/$version$/parquet-jackson-$version$-tests.jar",
+    "documentation-url" : "N/A",
+    "description" : "Apache Parquet Jackson is the Parquet Java module that packages shaded Jackson libraries for use by Apache Parquet. It relocates Jackson classes under shaded.parquet.com.fasterxml.jackson so Parquet components can perform JSON serialization and parsing while avoiding dependency conflicts with applications.",
     "tested-versions" : [
       "1.16.0"
     ],

--- a/metadata/org.apache.parquet/parquet-jackson/index.json
+++ b/metadata/org.apache.parquet/parquet-jackson/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.16.0",
+    "tested-versions" : [
+      "1.16.0"
+    ],
+    "allowed-packages" : [
+      "shaded.parquet.com.fasterxml.jackson"
+    ]
+  },
+  {
     "metadata-version" : "1.12.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/parquet/parquet-jackson/$version$/parquet-jackson-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/parquet-java",

--- a/stats/org.apache.parquet/parquet-jackson/1.16.0/execution-metrics.json
+++ b/stats/org.apache.parquet/parquet-jackson/1.16.0/execution-metrics.json
@@ -1,0 +1,143 @@
+{
+  "fix_java_run_fail:2026-06-09": {
+    "timestamp": "2026-06-09T15:32:40.235921Z",
+    "library": "org.apache.parquet:parquet-jackson:1.16.0",
+    "starting_commit": "f02a332a98f12f0e154f47be5ab4f36102bf6220",
+    "ending_commit": "9a7170755a68116aee9f80bf0e26e95b1999c535",
+    "previous_library": "org.apache.parquet:parquet-jackson:1.12.2",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.16.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 75,
+            "totalCalls": 75
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 76,
+        "totalCalls": 76
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 38806,
+          "missed": 218758,
+          "ratio": 0.150665,
+          "total": 257564
+        },
+        "line": {
+          "covered": 9316,
+          "missed": 47634,
+          "ratio": 0.163582,
+          "total": 56950
+        },
+        "method": {
+          "covered": 2100,
+          "missed": 9229,
+          "ratio": 0.185365,
+          "total": 11329
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.12.2",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 69,
+            "totalCalls": 69
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 70,
+        "totalCalls": 70
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 31919,
+          "missed": 170591,
+          "ratio": 0.157617,
+          "total": 202510
+        },
+        "line": {
+          "covered": 7718,
+          "missed": 39405,
+          "ratio": 0.163784,
+          "total": 47123
+        },
+        "method": {
+          "covered": 1745,
+          "missed": 7566,
+          "ratio": 0.187413,
+          "total": 9311
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "no_action",
+      "issue_number": 8256,
+      "issue_label": "fails-java-run",
+      "library": "org.apache.parquet:parquet-jackson:1.16.0",
+      "summary": "No extra setup is needed: parquet-jackson is a shaded Jackson-only artifact with no runtime Maven dependencies beyond the JDK, no Docker-backed service, and no required initialization before using the shaded Jackson APIs.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [
+        "The observed failure appears to be a test expectation/API behavior change in the shaded Jackson version used by parquet-jackson 1.16.0, not a missing dependency or environment setup issue."
+      ],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#8256 [Automation] java run fails for org.apache.parquet:parquet-jackson:1.16.0; label=fails-java-run; body_chars=8015"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "31 existing test file path(s) included"
+        }
+      ],
+      "current_library": "org.apache.parquet:parquet-jackson:1.12.2",
+      "new_version": "1.16.0",
+      "model": "oca/gpt-5.5",
+      "input_tokens_used": 47487,
+      "output_tokens_used": 1946,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.apache.parquet:parquet-jackson:1.16.0/library-preparation-preflight/pi-generation-2026-06-09T14-52-25-050839Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 381331,
+      "cached_input_tokens_used": 2746368,
+      "output_tokens_used": 25205,
+      "iterations": 8,
+      "cost_usd": 2.1294,
+      "tested_library_loc": 9316,
+      "metadata_entries": 101,
+      "test_only_metadata_entries": 9,
+      "previous_library_metadata_entries": 99,
+      "previous_library_test_only_metadata_entries": 9,
+      "code_coverage_percent": 16.36,
+      "previous_library_coverage_percent": 16.38
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/AnnotatedMethodCollectorTest.java",
+      "metadata_file": "metadata/org.apache.parquet/parquet-jackson/1.16.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.parquet/parquet-jackson/1.16.0/stats.json
+++ b/stats/org.apache.parquet/parquet-jackson/1.16.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "1.16.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 75,
+          "totalCalls" : 75
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 76,
+      "totalCalls" : 76
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 38806,
+        "missed" : 218758,
+        "ratio" : 0.150665,
+        "total" : 257564
+      },
+      "line" : {
+        "covered" : 9316,
+        "missed" : 47634,
+        "ratio" : 0.163582,
+        "total" : 56950
+      },
+      "method" : {
+        "covered" : 2100,
+        "missed" : 9229,
+        "ratio" : 0.185365,
+        "total" : 11329
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/.gitignore
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/build.gradle
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 
 tasks.withType(Test).configureEach {
     jvmArgs '--add-opens=java.base/java.util=ALL-UNNAMED'
+    systemProperty 'org.graalvm.nativeimage.imagecode', 'runtime'
 }
 
 graalvmNative {

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/build.gradle
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.parquet:parquet-jackson:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+tasks.withType(Test).configureEach {
+    jvmArgs '--add-opens=java.base/java.util=ALL-UNNAMED'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+    binaries {
+        all {
+            buildArgs.add('--add-opens=java.base/java.util=ALL-UNNAMED')
+        }
+    }
+}

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/gradle.properties
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.parquet:parquet-jackson:1.16.0
+library.version = 1.16.0
+metadata.dir = org.apache.parquet/parquet-jackson/1.16.0/

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/settings.gradle
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.parquet.parquet-jackson_tests'

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/AnnotatedConstructorTest.java
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/AnnotatedConstructorTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_parquet.parquet_jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.lang.reflect.Constructor;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedConstructor;
+import shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotationMap;
+
+public class AnnotatedConstructorTest {
+    @Test
+    void invokesConstructorsThroughCallHelpers() throws Exception {
+        final AnnotatedConstructor oneArgument = annotatedConstructor(String.class);
+        final AnnotatedConstructor twoArguments = annotatedConstructor(String.class, int.class);
+
+        final ConstructedWithOneArgument one =
+                (ConstructedWithOneArgument) oneArgument.call1("alpha");
+        final ConstructedWithTwoArguments two =
+                (ConstructedWithTwoArguments) twoArguments.call(new Object[] {"beta", 7});
+
+        assertThat(one.value()).isEqualTo("alpha");
+        assertThat(two.description()).isEqualTo("beta:7");
+    }
+
+    @Test
+    void restoresSerializedConstructor() throws Exception {
+        final AnnotatedConstructor original = annotatedConstructor(String.class, int.class);
+
+        final AnnotatedConstructor restored = roundTrip(original);
+        final ConstructedWithTwoArguments value =
+                (ConstructedWithTwoArguments) restored.call(new Object[] {"gamma", 11});
+
+        assertThat(restored.getDeclaringClass()).isEqualTo(ConstructedWithTwoArguments.class);
+        assertThat(restored.getParameterCount()).isEqualTo(2);
+        assertThat(value.description()).isEqualTo("gamma:11");
+    }
+
+    private static AnnotatedConstructor annotatedConstructor(Class<?>... parameterTypes)
+            throws NoSuchMethodException {
+        final Class<?> type = parameterTypes.length == 1
+                ? ConstructedWithOneArgument.class
+                : ConstructedWithTwoArguments.class;
+        final Constructor<?> constructor = type.getConstructor(parameterTypes);
+        final AnnotationMap[] parameterAnnotations = new AnnotationMap[parameterTypes.length];
+        return new AnnotatedConstructor(
+                null, constructor, new AnnotationMap(), parameterAnnotations);
+    }
+
+    private static AnnotatedConstructor roundTrip(AnnotatedConstructor constructor)
+            throws Exception {
+        final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+            output.writeObject(constructor);
+        }
+
+        final ByteArrayInputStream inputBytes = new ByteArrayInputStream(bytes.toByteArray());
+        try (ObjectInputStream input = new ObjectInputStream(inputBytes)) {
+            return (AnnotatedConstructor) input.readObject();
+        }
+    }
+
+    public static final class ConstructedWithOneArgument {
+        private final String value;
+
+        public ConstructedWithOneArgument(String value) {
+            this.value = value;
+        }
+
+        public String value() {
+            return value;
+        }
+    }
+
+    public static final class ConstructedWithTwoArguments {
+        private final String name;
+        private final int count;
+
+        public ConstructedWithTwoArguments(String name, int count) {
+            this.name = name;
+            this.count = count;
+        }
+
+        public String description() {
+            return name + ":" + count;
+        }
+    }
+}

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/AnnotatedCreatorCollectorTest.java
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/AnnotatedCreatorCollectorTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_parquet.parquet_jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.parquet.com.fasterxml.jackson.annotation.JsonCreator;
+import shaded.parquet.com.fasterxml.jackson.annotation.JsonProperty;
+import shaded.parquet.com.fasterxml.jackson.databind.ObjectMapper;
+
+public class AnnotatedCreatorCollectorTest {
+    @Test
+    void mixInAnnotationsSelectStaticFactoryCreator() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.addMixIn(FactoryCreatedBean.class, FactoryCreatedBeanMixin.class);
+
+        final FactoryCreatedBean value = mapper.readValue(
+                "{\"creator_name\":\"alpha\"}", FactoryCreatedBean.class);
+
+        assertThat(value.name()).isEqualTo("alpha");
+    }
+
+    private abstract static class FactoryCreatedBeanMixin {
+        @JsonCreator
+        public static FactoryCreatedBean fromJson(@JsonProperty("creator_name") String name) {
+            return null;
+        }
+    }
+
+    public static final class FactoryCreatedBean {
+        private final String name;
+
+        private FactoryCreatedBean(String name) {
+            this.name = name;
+        }
+
+        public static FactoryCreatedBean fromJson(String name) {
+            return new FactoryCreatedBean(name);
+        }
+
+        public String name() {
+            return name;
+        }
+    }
+}

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/AnnotatedFieldTest.java
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/AnnotatedFieldTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_parquet.parquet_jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.parquet.com.fasterxml.jackson.databind.BeanDescription;
+import shaded.parquet.com.fasterxml.jackson.databind.ObjectMapper;
+import shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedField;
+import shaded.parquet.com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
+
+public class AnnotatedFieldTest {
+    @Test
+    void annotatedFieldReadsAndWritesBeanFieldValues() {
+        final AnnotatedField field = annotatedField("value");
+        final FieldBackedBean bean = new FieldBackedBean("initial");
+
+        assertThat(field.getValue(bean)).isEqualTo("initial");
+
+        field.setValue(bean, "updated");
+
+        assertThat(bean.value).isEqualTo("updated");
+        assertThat(field.getValue(bean)).isEqualTo("updated");
+    }
+
+    @Test
+    void serializedAnnotatedFieldResolvesDeclaredBeanField() throws Exception {
+        final AnnotatedField field = annotatedField("value");
+
+        final AnnotatedField resolved = roundTrip(field);
+
+        assertThat(resolved.getName()).isEqualTo("value");
+        assertThat(resolved.getDeclaringClass()).isEqualTo(FieldBackedBean.class);
+        assertThat(resolved.getValue(new FieldBackedBean("restored"))).isEqualTo("restored");
+    }
+
+    private static AnnotatedField annotatedField(String name) {
+        final ObjectMapper mapper = new ObjectMapper();
+        final BeanDescription description = mapper.getSerializationConfig()
+                .introspect(mapper.constructType(FieldBackedBean.class));
+        final List<BeanPropertyDefinition> properties = description.findProperties();
+
+        return properties.stream()
+                .filter(property -> name.equals(property.getName()))
+                .map(BeanPropertyDefinition::getField)
+                .filter(field -> field != null)
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Missing annotated field: " + name));
+    }
+
+    private static AnnotatedField roundTrip(AnnotatedField field) throws Exception {
+        final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+            output.writeObject(field);
+        }
+
+        try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+            return (AnnotatedField) input.readObject();
+        }
+    }
+
+    public static final class FieldBackedBean {
+        public String value;
+
+        public FieldBackedBean(String value) {
+            this.value = value;
+        }
+    }
+}

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/AnnotatedMethodCollectorTest.java
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/AnnotatedMethodCollectorTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_parquet.parquet_jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.parquet.com.fasterxml.jackson.annotation.JsonIgnore;
+import shaded.parquet.com.fasterxml.jackson.annotation.JsonProperty;
+import shaded.parquet.com.fasterxml.jackson.databind.JsonNode;
+import shaded.parquet.com.fasterxml.jackson.databind.ObjectMapper;
+
+public class AnnotatedMethodCollectorTest {
+    @Test
+    void objectMapperUsesBeanAndObjectMethodMixIns() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.addMixIn(MethodBean.class, MethodBeanMixin.class);
+        mapper.addMixIn(Object.class, ObjectHashCodeMixin.class);
+
+        final MethodBean original = new MethodBean("alpha", "secret");
+
+        final JsonNode tree = mapper.readTree(mapper.writeValueAsString(original));
+
+        assertThat(tree.get("external_name").asText()).isEqualTo("alpha");
+        assertThat(tree.has("hidden")).isFalse();
+        assertThat(tree.get("object_hash").asInt()).isEqualTo(original.hashCode());
+
+        final MethodBean restored = mapper.readValue("{\"external_name\":\"beta\"}", MethodBean.class);
+
+        assertThat(restored.getName()).isEqualTo("beta");
+    }
+
+    private abstract static class MethodBeanMixin {
+        @JsonProperty("external_name")
+        abstract String getName();
+
+        @JsonProperty("external_name")
+        abstract void setName(String name);
+
+        @JsonIgnore
+        abstract String getHidden();
+    }
+
+    private abstract static class ObjectHashCodeMixin {
+        @JsonProperty("object_hash")
+        public abstract int hashCode();
+    }
+
+    public static final class MethodBean {
+        private String name;
+        private String hidden;
+
+        public MethodBean() {
+        }
+
+        MethodBean(String name, String hidden) {
+            this.name = name;
+            this.hidden = hidden;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getHidden() {
+            return hidden;
+        }
+
+        public void setHidden(String hidden) {
+            this.hidden = hidden;
+        }
+    }
+}

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/AnnotatedMethodTest.java
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/AnnotatedMethodTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_parquet.parquet_jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
+import shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotationMap;
+
+public class AnnotatedMethodTest {
+    @Test
+    void invokesStaticMethodsThroughCallHelpers() throws Exception {
+        final AnnotatedMethod noArgs = annotatedMethod("staticNoArgs");
+        final AnnotatedMethod oneArg = annotatedMethod("staticOneArg", String.class);
+        final AnnotatedMethod twoArgs =
+                annotatedMethod("staticTwoArgs", String.class, String.class);
+
+        assertThat(noArgs.call()).isEqualTo("static-value");
+        assertThat(oneArg.call1("alpha")).isEqualTo("one:alpha");
+        assertThat(twoArgs.call(new Object[] {"left", "right"})).isEqualTo("left:right");
+    }
+
+    @Test
+    void invokesInstanceMethodsThroughCallHelpersAndPropertyAccessors() throws Exception {
+        final Subject subject = new Subject("initial");
+        final AnnotatedMethod instanceNoArgs = annotatedMethod("instanceNoArgs");
+        final AnnotatedMethod join = annotatedMethod("join", String.class, String.class);
+        final AnnotatedMethod getValue = annotatedMethod("getValue");
+        final AnnotatedMethod setValue = annotatedMethod("setValue", String.class);
+
+        assertThat(instanceNoArgs.callOn(subject)).isEqualTo("instance:initial");
+        assertThat(join.callOnWith(subject, "left", "right")).isEqualTo("initial:left:right");
+
+        setValue.setValue(subject, "updated");
+
+        assertThat(getValue.getValue(subject)).isEqualTo("updated");
+    }
+
+    @Test
+    void restoresSerializedMethod() throws Exception {
+        final AnnotatedMethod original = annotatedMethod("staticNoArgs");
+
+        final AnnotatedMethod restored = roundTrip(original);
+
+        assertThat(restored.getName()).isEqualTo("staticNoArgs");
+        assertThat(restored.call()).isEqualTo("static-value");
+    }
+
+    private static AnnotatedMethod annotatedMethod(String name, Class<?>... parameterTypes)
+            throws NoSuchMethodException {
+        final Method method = Subject.class.getMethod(name, parameterTypes);
+        final AnnotationMap[] parameterAnnotations = new AnnotationMap[parameterTypes.length];
+        return new AnnotatedMethod(null, method, new AnnotationMap(), parameterAnnotations);
+    }
+
+    private static AnnotatedMethod roundTrip(AnnotatedMethod method) throws Exception {
+        final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+            output.writeObject(method);
+        }
+
+        final ByteArrayInputStream inputBytes = new ByteArrayInputStream(bytes.toByteArray());
+        try (ObjectInputStream input = new ObjectInputStream(inputBytes)) {
+            return (AnnotatedMethod) input.readObject();
+        }
+    }
+
+    public static final class Subject {
+        private String value;
+
+        public Subject(String value) {
+            this.value = value;
+        }
+
+        public static String staticNoArgs() {
+            return "static-value";
+        }
+
+        public static String staticOneArg(String value) {
+            return "one:" + value;
+        }
+
+        public static String staticTwoArgs(String left, String right) {
+            return left + ":" + right;
+        }
+
+        public String instanceNoArgs() {
+            return "instance:" + value;
+        }
+
+        public String join(String left, String right) {
+            return value + ":" + left + ":" + right;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+}

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/ArrayBuildersTest.java
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/ArrayBuildersTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_parquet.parquet_jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.parquet.com.fasterxml.jackson.databind.util.ArrayBuilders;
+
+public class ArrayBuildersTest {
+    @Test
+    void insertInListNoDupMovesExistingElementToHeadInNewArrayOfSameComponentType() {
+        final String first = "first";
+        final String duplicate = "duplicate";
+        final String last = "last";
+        final String[] values = new String[] {first, duplicate, last};
+
+        final String[] result = ArrayBuilders.insertInListNoDup(values, duplicate);
+
+        assertThat(result).isNotSameAs(values);
+        assertThat(result.getClass().getComponentType()).isEqualTo(String.class);
+        assertThat(result).containsExactly(duplicate, first, last);
+        assertThat(values).containsExactly(first, duplicate, last);
+    }
+
+    @Test
+    void insertInListNoDupPrependsMissingElementInNewArrayOfSameComponentType() {
+        final String[] values = new String[] {"first", "second"};
+
+        final String[] result = ArrayBuilders.insertInListNoDup(values, "new");
+
+        assertThat(result).isNotSameAs(values);
+        assertThat(result.getClass().getComponentType()).isEqualTo(String.class);
+        assertThat(result).containsExactly("new", "first", "second");
+        assertThat(values).containsExactly("first", "second");
+    }
+}

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/ArrayTypeTest.java
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/ArrayTypeTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_parquet.parquet_jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.parquet.com.fasterxml.jackson.databind.JavaType;
+import shaded.parquet.com.fasterxml.jackson.databind.type.ArrayType;
+import shaded.parquet.com.fasterxml.jackson.databind.type.TypeFactory;
+
+public class ArrayTypeTest {
+    @Test
+    void constructsArrayTypeAndReplacesContentType() {
+        final TypeFactory typeFactory = TypeFactory.defaultInstance();
+
+        final ArrayType stringArrayType = typeFactory.constructArrayType(String.class);
+
+        assertThat(stringArrayType.isArrayType()).isTrue();
+        assertThat(stringArrayType.getRawClass()).isEqualTo(String[].class);
+        assertThat(stringArrayType.getContentType().getRawClass()).isEqualTo(String.class);
+
+        final JavaType integerType = typeFactory.constructType(Integer.class);
+        final JavaType integerArrayType = stringArrayType.withContentType(integerType);
+
+        assertThat(integerArrayType).isInstanceOf(ArrayType.class);
+        assertThat(integerArrayType.getRawClass()).isEqualTo(Integer[].class);
+        assertThat(integerArrayType.getContentType()).isEqualTo(integerType);
+    }
+}

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/BasicBeanDescriptionTest.java
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/BasicBeanDescriptionTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_parquet.parquet_jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.parquet.com.fasterxml.jackson.databind.BeanDescription;
+import shaded.parquet.com.fasterxml.jackson.databind.ObjectMapper;
+
+public class BasicBeanDescriptionTest {
+    @Test
+    void instantiateBeanCreatesDefaultConstructibleBean() {
+        final ObjectMapper mapper = new ObjectMapper();
+        final BeanDescription description = mapper.getDeserializationConfig()
+                .introspect(mapper.constructType(DefaultConstructibleBean.class));
+
+        final Object bean = description.instantiateBean(true);
+
+        assertThat(bean).isInstanceOf(DefaultConstructibleBean.class);
+        assertThat(((DefaultConstructibleBean) bean).value).isEqualTo("created by constructor");
+    }
+
+    public static final class DefaultConstructibleBean {
+        private final String value;
+
+        public DefaultConstructibleBean() {
+            value = "created by constructor";
+        }
+    }
+}

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/BeanAsArrayBuilderDeserializerTest.java
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/BeanAsArrayBuilderDeserializerTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_parquet.parquet_jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.parquet.com.fasterxml.jackson.annotation.JsonFormat;
+import shaded.parquet.com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import shaded.parquet.com.fasterxml.jackson.databind.ObjectMapper;
+import shaded.parquet.com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import shaded.parquet.com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+public class BeanAsArrayBuilderDeserializerTest {
+    @Test
+    void deserializesArrayShapedValueThroughBuilderBuildMethod() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+
+        final ArrayBuiltBean bean = mapper.readValue(
+                """
+                [ "builder-array", 19 ]
+                """,
+                ArrayBuiltBean.class);
+
+        assertThat(bean.name()).isEqualTo("builder-array");
+        assertThat(bean.count()).isEqualTo(19);
+    }
+
+    @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+    @JsonPropertyOrder({ "name", "count" })
+    @JsonDeserialize(builder = ArrayBuiltBeanBuilder.class)
+    public static final class ArrayBuiltBean {
+        private final String name;
+        private final int count;
+
+        private ArrayBuiltBean(String name, int count) {
+            this.name = name;
+            this.count = count;
+        }
+
+        String name() {
+            return name;
+        }
+
+        int count() {
+            return count;
+        }
+    }
+
+    @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+    @JsonPropertyOrder({ "name", "count" })
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class ArrayBuiltBeanBuilder {
+        public String name;
+        public int count;
+
+        public ArrayBuiltBean build() {
+            return new ArrayBuiltBean(name, count);
+        }
+    }
+}

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/BeanDeserializerBaseTest.java
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/BeanDeserializerBaseTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_parquet.parquet_jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.parquet.com.fasterxml.jackson.databind.ObjectMapper;
+
+public class BeanDeserializerBaseTest {
+    @Test
+    void deserializesNonStaticInnerClassPropertyWithEnclosingBeanConstructor() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+
+        final EnclosingBean bean = mapper.readValue("""
+                {
+                  "inner" : {
+                    "value" : "created by enclosing bean"
+                  }
+                }
+                """, EnclosingBean.class);
+
+        assertThat(bean.inner).isNotNull();
+        assertThat(bean.inner.value).isEqualTo("created by enclosing bean");
+        assertThat(bean.inner.enclosing()).isSameAs(bean);
+    }
+
+    public static class EnclosingBean {
+        public InnerBean inner;
+
+        public class InnerBean {
+            public String value;
+
+            EnclosingBean enclosing() {
+                return EnclosingBean.this;
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/BeanPropertyWriterTest.java
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/BeanPropertyWriterTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_parquet.parquet_jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.parquet.com.fasterxml.jackson.annotation.JsonFilter;
+import shaded.parquet.com.fasterxml.jackson.annotation.JsonFormat;
+import shaded.parquet.com.fasterxml.jackson.core.JsonGenerator;
+import shaded.parquet.com.fasterxml.jackson.databind.ObjectMapper;
+import shaded.parquet.com.fasterxml.jackson.databind.SerializerProvider;
+import shaded.parquet.com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
+import shaded.parquet.com.fasterxml.jackson.databind.ser.PropertyWriter;
+import shaded.parquet.com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
+import shaded.parquet.com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+
+public class BeanPropertyWriterTest {
+    @Test
+    void serializesFieldAndGetterPropertiesAsObjectFields() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+        final CapturingFilter filter = new CapturingFilter();
+        final SimpleFilterProvider filters = new SimpleFilterProvider()
+                .addFilter("capture", filter);
+
+        final String json = mapper.writer(filters)
+                .writeValueAsString(new FilteredBean("field-value", "method-value"));
+
+        assertThat(json).contains("\"fieldValue\":\"field-value\"");
+        assertThat(json).contains("\"methodValue\":\"method-value\"");
+        assertThat(filter.values()).containsEntry("fieldValue", "field-value")
+                .containsEntry("methodValue", "method-value");
+    }
+
+    @Test
+    void serializesFieldAndGetterPropertiesAsArrayElements() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+
+        final String json = mapper.writeValueAsString(new ArrayBean("field-value", "method-value"));
+
+        assertThat(json).contains("\"field-value\"");
+        assertThat(json).contains("\"method-value\"");
+        assertThat(json).startsWith("[").endsWith("]");
+    }
+
+    private static final class CapturingFilter extends SimpleBeanPropertyFilter {
+        private final Map<String, Object> values = new LinkedHashMap<>();
+
+        @Override
+        public void serializeAsField(
+                Object pojo,
+                JsonGenerator generator,
+                SerializerProvider provider,
+                BeanPropertyWriter writer) throws Exception {
+            values.put(writer.getName(), writer.get(pojo));
+            writer.serializeAsField(pojo, generator, provider);
+        }
+
+        @Override
+        public void serializeAsField(
+                Object pojo,
+                JsonGenerator generator,
+                SerializerProvider provider,
+                PropertyWriter writer) throws Exception {
+            if (writer instanceof BeanPropertyWriter) {
+                values.put(writer.getName(), ((BeanPropertyWriter) writer).get(pojo));
+            }
+            writer.serializeAsField(pojo, generator, provider);
+        }
+
+        Map<String, Object> values() {
+            return values;
+        }
+    }
+
+    @JsonFilter("capture")
+    public static final class FilteredBean {
+        public final String fieldValue;
+        private final String methodValue;
+
+        public FilteredBean(String fieldValue, String methodValue) {
+            this.fieldValue = fieldValue;
+            this.methodValue = methodValue;
+        }
+
+        public String getMethodValue() {
+            return methodValue;
+        }
+    }
+
+    @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+    public static final class ArrayBean {
+        public final String fieldValue;
+        private final String methodValue;
+
+        public ArrayBean(String fieldValue, String methodValue) {
+            this.fieldValue = fieldValue;
+            this.methodValue = methodValue;
+        }
+
+        public String getMethodValue() {
+            return methodValue;
+        }
+    }
+}

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/ClassUtilInnerEnumTypeLocatorTest.java
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/ClassUtilInnerEnumTypeLocatorTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_parquet.parquet_jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.EnumMap;
+import java.util.EnumSet;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.parquet.com.fasterxml.jackson.databind.util.ClassUtil;
+
+public class ClassUtilInnerEnumTypeLocatorTest {
+    @Test
+    void locatesEnumTypeForEmptyEnumSet() {
+        final EnumSet<Color> colors = EnumSet.noneOf(Color.class);
+
+        final Class<? extends Enum<?>> enumType = ClassUtil.findEnumType(colors);
+
+        assertThat(enumType).isEqualTo(Color.class);
+    }
+
+    @Test
+    void locatesEnumTypeForEmptyEnumMap() {
+        final EnumMap<Color, String> colors = new EnumMap<Color, String>(Color.class);
+
+        final Class<? extends Enum<?>> enumType = ClassUtil.findEnumType(colors);
+
+        assertThat(enumType).isEqualTo(Color.class);
+    }
+
+    private enum Color {
+        RED,
+        BLUE
+    }
+}

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/ClassUtilTest.java
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/ClassUtilTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_parquet.parquet_jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.reflect.Method;
+import java.util.Base64;
+
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+
+import shaded.parquet.com.fasterxml.jackson.databind.util.ClassUtil;
+
+public class ClassUtilTest {
+    private static final String SUBJECT_CLASS_NAME =
+            "org_apache_parquet.parquet_jackson.ClassUtilTestSubject";
+    private static final String DEPENDENCY_CLASS_NAME =
+            "org_apache_parquet.parquet_jackson.ClassUtilTestDependency";
+    private static final String SUBJECT_CLASS_BYTES = """
+            yv66vgAAADQAEgoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+AQADKClW\
+            BwAIAQA6b3JnX2FwYWNoZV9wYXJxdWV0L3BhcnF1ZXRfamFja3Nvbi9DbGFzc1V0aWxUZXN0RGVw\
+            ZW5kZW5jeQoABwADBwALAQA3b3JnX2FwYWNoZV9wYXJxdWV0L3BhcnF1ZXRfamFja3Nvbi9DbGFz\
+            c1V0aWxUZXN0U3ViamVjdAEABENvZGUBAA9MaW5lTnVtYmVyVGFibGUBAApkZXBlbmRlbmN5\
+            AQA+KClMb3JnX2FwYWNoZV9wYXJxdWV0L3BhcnF1ZXRfamFja3Nvbi9DbGFzc1V0aWxUZXN0RGVw\
+            ZW5kZW5jeTsBAApTb3VyY2VGaWxlAQAZQ2xhc3NVdGlsVGVzdFN1YmplY3QuamF2YQAxAAoAAg\
+            AAAAAAAgABAAUABgABAAwAAAAdAAEAAQAAAAUqtwABsQAAAAEADQAAAAYAAQAAAAMAAQAOAA8A\
+            AQAMAAAAIAACAAEAAAAIuwAHWbcACbAAAAABAA0AAAAGAAEAAAAFAAEAEAAAAAIAEQ==\
+            """;
+
+    @Test
+    void createsInstancesAndFindsDefaultConstructor() {
+        final ClassUtilTestBean bean = ClassUtil.createInstance(ClassUtilTestBean.class, true);
+
+        assertThat(bean.value()).isEqualTo("created");
+        assertThat(ClassUtil.findConstructor(ClassUtilTestBean.class, true).getDeclaringClass())
+                .isEqualTo(ClassUtilTestBean.class);
+    }
+
+    @Test
+    void exposesDeclaredMembersAndConstructors() {
+        assertThat(ClassUtil.getDeclaredFields(ClassUtilTestBean.class))
+                .extracting(field -> field.getName())
+                .contains("value");
+        assertThat(ClassUtil.getDeclaredMethods(ClassUtilTestBean.class))
+                .extracting(Method::getName)
+                .contains("value");
+        assertThat(ClassUtil.getClassMethods(ClassUtilTestBean.class))
+                .extracting(Method::getName)
+                .contains("value");
+        assertThat(ClassUtil.getConstructors(ClassUtilTestBean.class))
+                .anySatisfy(ctor -> assertThat(ctor.getParamCount()).isZero());
+    }
+
+    @Test
+    void findsAnnotatedEnumValue() {
+        final Enum<?> enumValue = findFirstMarkerValue();
+
+        assertThat(enumValue).isEqualTo(ClassUtilTestAnnotatedEnum.SELECTED);
+    }
+
+    @Test
+    void reloadsClassMethodsWithThreadContextClassLoaderWhenInitialResolutionFails() throws Exception {
+        final ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(ClassUtilTest.class.getClassLoader());
+        try {
+            final Class<?> isolatedSubjectClass = new DependencyHidingClassLoader().loadClass(SUBJECT_CLASS_NAME);
+
+            assertThat(ClassUtil.getClassMethods(isolatedSubjectClass))
+                    .extracting(Method::getName)
+                    .contains("dependency");
+        } catch (Error error) {
+            if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                throw error;
+            }
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static Enum<?> findFirstMarkerValue() {
+        return ClassUtil.findFirstAnnotatedEnumValue(
+                (Class) ClassUtilTestAnnotatedEnum.class, ClassUtilTestMarker.class);
+    }
+
+    private static final class DependencyHidingClassLoader extends ClassLoader {
+        DependencyHidingClassLoader() {
+            super(null);
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (SUBJECT_CLASS_NAME.equals(name)) {
+                final Class<?> subjectClass = findClass(name);
+                if (resolve) {
+                    resolveClass(subjectClass);
+                }
+                return subjectClass;
+            }
+            if (DEPENDENCY_CLASS_NAME.equals(name)) {
+                throw new ClassNotFoundException(name);
+            }
+            return super.loadClass(name, resolve);
+        }
+
+        @Override
+        protected Class<?> findClass(String name) throws ClassNotFoundException {
+            if (!SUBJECT_CLASS_NAME.equals(name)) {
+                throw new ClassNotFoundException(name);
+            }
+            final byte[] bytes = Base64.getDecoder().decode(SUBJECT_CLASS_BYTES);
+            return defineClass(name, bytes, 0, bytes.length);
+        }
+    }
+}
+
+final class ClassUtilTestBean {
+    private final String value;
+
+    ClassUtilTestBean() {
+        this.value = "created";
+    }
+
+    String value() {
+        return value;
+    }
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface ClassUtilTestMarker {
+}
+
+enum ClassUtilTestAnnotatedEnum {
+    FIRST,
+
+    @ClassUtilTestMarker
+    SELECTED
+}
+
+final class ClassUtilTestDependency {
+}
+
+final class ClassUtilTestSubject {
+    ClassUtilTestDependency dependency() {
+        return new ClassUtilTestDependency();
+    }
+}

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/DateDeserializersInnerCalendarDeserializerTest.java
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/DateDeserializersInnerCalendarDeserializerTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_parquet.parquet_jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.GregorianCalendar;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.parquet.com.fasterxml.jackson.databind.ObjectMapper;
+
+public class DateDeserializersInnerCalendarDeserializerTest {
+    @Test
+    void deserializesGregorianCalendarUsingItsDefaultConstructor() throws Exception {
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final long timestampMillis = 1_700_000_000_000L;
+
+        final GregorianCalendar calendar = objectMapper.readValue(
+                Long.toString(timestampMillis), GregorianCalendar.class);
+
+        assertThat(calendar).isInstanceOf(GregorianCalendar.class);
+        assertThat(calendar.getTimeInMillis()).isEqualTo(timestampMillis);
+    }
+}

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/FieldPropertyTest.java
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/FieldPropertyTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_parquet.parquet_jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.parquet.com.fasterxml.jackson.annotation.JsonBackReference;
+import shaded.parquet.com.fasterxml.jackson.annotation.JsonCreator;
+import shaded.parquet.com.fasterxml.jackson.annotation.JsonManagedReference;
+import shaded.parquet.com.fasterxml.jackson.databind.ObjectMapper;
+import shaded.parquet.com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import shaded.parquet.com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+public class FieldPropertyTest {
+    @Test
+    void deserializesJsonObjectFieldsIntoBeanFields() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+
+        final FieldBean bean = mapper.readValue(
+                """
+                {
+                  "name": "alpha",
+                  "count": 7
+                }
+                """,
+                FieldBean.class);
+
+        assertThat(bean.name).isEqualTo("alpha");
+        assertThat(bean.count).isEqualTo(7);
+    }
+
+    @Test
+    void deserializesJsonObjectFieldsIntoBuilderFields() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+
+        final BuiltBean bean = mapper.readValue(
+                """
+                {
+                  "name": "builder-alpha",
+                  "count": 11
+                }
+                """,
+                BuiltBean.class);
+
+        assertThat(bean.name).isEqualTo("builder-alpha");
+        assertThat(bean.count).isEqualTo(11);
+    }
+
+    @Test
+    void linksManagedAndBackReferenceFields() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+
+        final Parent parent = mapper.readValue(
+                """
+                {
+                  "name": "parent",
+                  "child": {
+                    "name": "child"
+                  }
+                }
+                """,
+                Parent.class);
+
+        assertThat(parent.name).isEqualTo("parent");
+        assertThat(parent.child.name).isEqualTo("child");
+        assertThat(parent.child.parent).isSameAs(parent);
+    }
+
+    public static final class FieldBean {
+        public String name;
+        public int count;
+    }
+
+    @JsonDeserialize(builder = BuiltBeanBuilder.class)
+    public static final class BuiltBean {
+        public final String name;
+        public final int count;
+
+        private BuiltBean(String name, int count) {
+            this.name = name;
+            this.count = count;
+        }
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class BuiltBeanBuilder {
+        public String name;
+        public int count;
+
+        @JsonCreator
+        public BuiltBeanBuilder() {
+        }
+
+        public BuiltBean build() {
+            return new BuiltBean(name, count);
+        }
+    }
+
+    public static final class Parent {
+        public String name;
+
+        @JsonManagedReference
+        public Child child;
+    }
+
+    public static final class Child {
+        public String name;
+
+        @JsonBackReference
+        public Parent parent;
+    }
+}

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/JDK14UtilInnerRecordAccessorTest.java
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/JDK14UtilInnerRecordAccessorTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_parquet.parquet_jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.parquet.com.fasterxml.jackson.annotation.JsonProperty;
+import shaded.parquet.com.fasterxml.jackson.databind.ObjectMapper;
+
+public class JDK14UtilInnerRecordAccessorTest {
+    @Test
+    void serializesRecordComponentsByName() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+        final InventoryItem item = new InventoryItem("book", 3);
+
+        final String json = mapper.writeValueAsString(item);
+
+        assertThat(json).contains("\"label\":\"book\"");
+        assertThat(json).contains("\"quantity\":3");
+    }
+
+    @Test
+    void deserializesRecordUsingCanonicalConstructor() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+
+        final InventoryItem item = mapper.readValue("""
+                {
+                  "label": "pencil",
+                  "quantity": 12
+                }
+                """, InventoryItem.class);
+
+        assertThat(item).isEqualTo(new InventoryItem("pencil", 12));
+    }
+
+    public record InventoryItem(@JsonProperty("label") String name, int quantity) {
+    }
+}

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/JacksonAnnotationIntrospectorTest.java
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/JacksonAnnotationIntrospectorTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_parquet.parquet_jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.parquet.com.fasterxml.jackson.annotation.JsonAlias;
+import shaded.parquet.com.fasterxml.jackson.annotation.JsonProperty;
+import shaded.parquet.com.fasterxml.jackson.databind.ObjectMapper;
+import shaded.parquet.com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
+
+public class JacksonAnnotationIntrospectorTest {
+    @Test
+    void readsJsonPropertyAndAliasAnnotationsFromEnumConstants() {
+        final JacksonAnnotationIntrospector introspector = new JacksonAnnotationIntrospector();
+        final AnnotatedEnum[] enumValues = AnnotatedEnum.values();
+        final String[] names = {"ALPHA", "BETA"};
+        final String[][] aliases = new String[enumValues.length][];
+
+        assertThat(introspector.findEnumValue(AnnotatedEnum.ALPHA)).isEqualTo("alpha-json");
+        assertThat(introspector.findEnumValues(AnnotatedEnum.class, enumValues, names))
+                .containsExactly("alpha-json", "BETA");
+
+        introspector.findEnumAliases(AnnotatedEnum.class, enumValues, aliases);
+
+        assertThat(aliases[0]).containsExactly("alpha-alias", "first-alias");
+        assertThat(aliases[1]).isNull();
+    }
+
+    @Test
+    void objectMapperUsesAnnotatedEnumNamesAndAliases() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+
+        assertThat(mapper.writeValueAsString(AnnotatedEnum.ALPHA)).isEqualTo("\"alpha-json\"");
+        assertThat(mapper.readValue("\"alpha-json\"", AnnotatedEnum.class)).isEqualTo(AnnotatedEnum.ALPHA);
+        assertThat(mapper.readValue("\"alpha-alias\"", AnnotatedEnum.class)).isEqualTo(AnnotatedEnum.ALPHA);
+        assertThat(mapper.readValue("\"BETA\"", AnnotatedEnum.class)).isEqualTo(AnnotatedEnum.BETA);
+    }
+
+    public enum AnnotatedEnum {
+        @JsonProperty("alpha-json")
+        @JsonAlias({"alpha-alias", "first-alias"})
+        ALPHA,
+
+        BETA
+    }
+}

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/JacksonAnnotationIntrospectorTest.java
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/JacksonAnnotationIntrospectorTest.java
@@ -13,24 +13,29 @@ import org.junit.jupiter.api.Test;
 import shaded.parquet.com.fasterxml.jackson.annotation.JsonAlias;
 import shaded.parquet.com.fasterxml.jackson.annotation.JsonProperty;
 import shaded.parquet.com.fasterxml.jackson.databind.ObjectMapper;
+import shaded.parquet.com.fasterxml.jackson.databind.SerializationConfig;
+import shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedClass;
 import shaded.parquet.com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 
 public class JacksonAnnotationIntrospectorTest {
     @Test
     void readsJsonPropertyAndAliasAnnotationsFromEnumConstants() {
         final JacksonAnnotationIntrospector introspector = new JacksonAnnotationIntrospector();
+        final ObjectMapper mapper = new ObjectMapper();
+        final SerializationConfig config = mapper.getSerializationConfig();
+        final AnnotatedClass annotatedClass = config.introspectClassAnnotations(AnnotatedEnum.class)
+                .getClassInfo();
         final AnnotatedEnum[] enumValues = AnnotatedEnum.values();
         final String[] names = {"ALPHA", "BETA"};
         final String[][] aliases = new String[enumValues.length][];
 
-        assertThat(introspector.findEnumValue(AnnotatedEnum.ALPHA)).isEqualTo("alpha-json");
-        assertThat(introspector.findEnumValues(AnnotatedEnum.class, enumValues, names))
+        assertThat(introspector.findEnumValues(config, annotatedClass, enumValues, names))
                 .containsExactly("alpha-json", "BETA");
 
-        introspector.findEnumAliases(AnnotatedEnum.class, enumValues, aliases);
+        introspector.findEnumAliases(config, annotatedClass, enumValues, aliases);
 
         assertThat(aliases[0]).containsExactly("alpha-alias", "first-alias");
-        assertThat(aliases[1]).isNull();
+        assertThat(aliases[1]).isEmpty();
     }
 
     @Test

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/JacksonAnnotationIntrospectorTest.java
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/JacksonAnnotationIntrospectorTest.java
@@ -39,6 +39,22 @@ public class JacksonAnnotationIntrospectorTest {
     }
 
     @Test
+    void legacyEnumAnnotationLookupReadsDeclaredEnumFields() {
+        final JacksonAnnotationIntrospector introspector = new JacksonAnnotationIntrospector();
+        final AnnotatedEnum[] enumValues = AnnotatedEnum.values();
+        final String[] names = {"ALPHA", "BETA"};
+        final String[][] aliases = new String[enumValues.length][];
+
+        assertThat(introspector.findEnumValues(AnnotatedEnum.class, enumValues, names))
+                .containsExactly("alpha-json", "BETA");
+
+        introspector.findEnumAliases(AnnotatedEnum.class, enumValues, aliases);
+
+        assertThat(aliases[0]).containsExactly("alpha-alias", "first-alias");
+        assertThat(aliases[1]).isNull();
+    }
+
+    @Test
     void objectMapperUsesAnnotatedEnumNamesAndAliases() throws Exception {
         final ObjectMapper mapper = new ObjectMapper();
 

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/MethodPropertyTest.java
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/MethodPropertyTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_parquet.parquet_jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.parquet.com.fasterxml.jackson.annotation.JsonMerge;
+import shaded.parquet.com.fasterxml.jackson.databind.ObjectMapper;
+import shaded.parquet.com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import shaded.parquet.com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+public class MethodPropertyTest {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void deserializesJsonObjectFieldsUsingSetterMethods() throws Exception {
+        final MethodBackedBean bean = MAPPER.readValue(
+                """
+                {
+                  "name": "coffee"
+                }
+                """,
+                MethodBackedBean.class);
+
+        assertThat(bean.getName()).isEqualTo("coffee");
+    }
+
+    @Test
+    void deserializesJsonObjectFieldsUsingBuilderMethods() throws Exception {
+        final MethodBackedBuiltBean bean = MAPPER.readValue(
+                """
+                {
+                  "name": "espresso"
+                }
+                """,
+                MethodBackedBuiltBean.class);
+
+        assertThat(bean.getName()).isEqualTo("espresso");
+    }
+
+    @Test
+    void mergesJsonObjectFieldsUsingSetterMethods() throws Exception {
+        final MethodBackedMergeBean bean = MAPPER.readValue(
+                """
+                {
+                  "drink": {
+                    "name": "latte"
+                  }
+                }
+                """,
+                MethodBackedMergeBean.class);
+
+        assertThat(bean.getDrink().getName()).isEqualTo("latte");
+    }
+
+    @Test
+    void mergesJsonObjectFieldsUsingBuilderMethods() throws Exception {
+        final MethodBackedMergeBuiltBean bean = MAPPER.readValue(
+                """
+                {
+                  "drink": {
+                    "name": "mocha"
+                  }
+                }
+                """,
+                MethodBackedMergeBuiltBean.class);
+
+        assertThat(bean.getDrink().getName()).isEqualTo("mocha");
+    }
+
+    public static final class MethodBackedBean {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    @JsonDeserialize(builder = MethodBackedBuiltBeanBuilder.class)
+    public static final class MethodBackedBuiltBean {
+        private final String name;
+
+        private MethodBackedBuiltBean(MethodBackedBuiltBeanBuilder builder) {
+            this.name = builder.name;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class MethodBackedBuiltBeanBuilder {
+        private String name;
+
+        public MethodBackedBuiltBeanBuilder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public MethodBackedBuiltBean build() {
+            return new MethodBackedBuiltBean(this);
+        }
+    }
+
+    public static final class MethodBackedMergeBean {
+        private Drink drink;
+
+        public Drink getDrink() {
+            return drink;
+        }
+
+        @JsonMerge
+        public void setDrink(Drink drink) {
+            this.drink = drink;
+        }
+    }
+
+    @JsonDeserialize(builder = MethodBackedMergeBuiltBeanBuilder.class)
+    public static final class MethodBackedMergeBuiltBean {
+        private final Drink drink;
+
+        private MethodBackedMergeBuiltBean(MethodBackedMergeBuiltBeanBuilder builder) {
+            this.drink = builder.drink;
+        }
+
+        public Drink getDrink() {
+            return drink;
+        }
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class MethodBackedMergeBuiltBeanBuilder {
+        private Drink drink;
+
+        public Drink getDrink() {
+            return drink;
+        }
+
+        @JsonMerge
+        public MethodBackedMergeBuiltBeanBuilder drink(Drink drink) {
+            this.drink = drink;
+            return this;
+        }
+
+        public MethodBackedMergeBuiltBean build() {
+            return new MethodBackedMergeBuiltBean(this);
+        }
+    }
+
+    public static final class Drink {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/NativeImageUtilTest.java
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/NativeImageUtilTest.java
@@ -21,6 +21,13 @@ public class NativeImageUtilTest {
     void detectsClassesWithAvailableReflectionMembers() {
         assertThat(NativeImageUtil.isInNativeImageAndIsAtRuntime()).isTrue();
         assertThat(NativeImageUtil.needsReflectionConfiguration(ReflectionVisibleBean.class)).isFalse();
+        assertThat(NativeImageUtil.needsReflectionConfiguration(MethodOnlyBean.class)).isFalse();
+    }
+
+    public static class MethodOnlyBean {
+        public String value() {
+            return "value";
+        }
     }
 
     public static class ReflectionVisibleBean {

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/NativeImageUtilTest.java
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/NativeImageUtilTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_parquet.parquet_jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.parquet.com.fasterxml.jackson.databind.util.NativeImageUtil;
+
+public class NativeImageUtilTest {
+    static {
+        System.setProperty("org.graalvm.nativeimage.imagecode", "runtime");
+    }
+
+    @Test
+    void detectsClassesWithAvailableReflectionMembers() {
+        assertThat(NativeImageUtil.isInNativeImageAndIsAtRuntime()).isTrue();
+        assertThat(NativeImageUtil.needsReflectionConfiguration(ReflectionVisibleBean.class)).isFalse();
+    }
+
+    public static class ReflectionVisibleBean {
+        public String value;
+
+        public ReflectionVisibleBean() {
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+}

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/ObjectArrayDeserializerTest.java
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/ObjectArrayDeserializerTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_parquet.parquet_jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.parquet.com.fasterxml.jackson.databind.DeserializationFeature;
+import shaded.parquet.com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ObjectArrayDeserializerTest {
+    @Test
+    void unwrapsSingleObjectValueIntoTypedObjectArray() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper()
+                .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
+
+        final Document[] values = mapper.readValue("{\"name\":\"parquet\"}", Document[].class);
+
+        assertThat(values).extracting(Document::getName).containsExactly("parquet");
+    }
+
+    public static class Document {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(final String name) {
+            this.name = name;
+        }
+    }
+}

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/ObjectBufferTest.java
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/ObjectBufferTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_parquet.parquet_jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.parquet.com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ObjectBufferTest {
+    @Test
+    void deserializesJsonArrayIntoTypedObjectArray() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+        final String json = """
+                [
+                  {"name":"alpha"},
+                  {"name":"beta"}
+                ]
+                """;
+
+        final Record[] records = mapper.readValue(json, Record[].class);
+
+        assertThat(records).extracting(Record::getName).containsExactly("alpha", "beta");
+    }
+
+    public static class Record {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(final String name) {
+            this.name = name;
+        }
+    }
+}

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/OptionalHandlerFactoryTest.java
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/OptionalHandlerFactoryTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_parquet.parquet_jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+import shaded.parquet.com.fasterxml.jackson.databind.ObjectMapper;
+
+public class OptionalHandlerFactoryTest {
+    @Test
+    void mapsDomDocumentsThroughJacksonPublicApi() throws Exception {
+        final ObjectMapper objectMapper = new ObjectMapper();
+
+        final Document document = objectMapper.readValue(
+                "\"<message><text>hello parquet</text></message>\"", Document.class);
+        final String serializedDocument = objectMapper.writeValueAsString(document);
+
+        assertThat(document.getDocumentElement().getTagName()).isEqualTo("message");
+        assertThat(document.getDocumentElement().getTextContent()).isEqualTo("hello parquet");
+        assertThat(serializedDocument).contains("message", "hello parquet");
+    }
+}

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/SetterlessPropertyTest.java
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/SetterlessPropertyTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_parquet.parquet_jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.parquet.com.fasterxml.jackson.annotation.JsonAutoDetect;
+import shaded.parquet.com.fasterxml.jackson.annotation.PropertyAccessor;
+import shaded.parquet.com.fasterxml.jackson.databind.ObjectMapper;
+
+public class SetterlessPropertyTest {
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.NONE);
+
+    @Test
+    void deserializesIntoCollectionReturnedByGetterWithoutSetter() throws Exception {
+        final SetterlessCollectionBean bean = MAPPER.readValue(
+                """
+                {
+                  "ingredients" : [
+                    { "name" : "coffee" },
+                    { "name" : "milk" }
+                  ]
+                }
+                """,
+                SetterlessCollectionBean.class);
+
+        assertThat(bean.getIngredients()).extracting(Ingredient::getName).containsExactly("coffee", "milk");
+    }
+
+    public static final class SetterlessCollectionBean {
+        private final List<Ingredient> values = new ArrayList<>();
+
+        public List<Ingredient> getIngredients() {
+            return values;
+        }
+    }
+
+    public static final class Ingredient {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/StdKeyDeserializerInnerStringCtorKeyDeserializerTest.java
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/StdKeyDeserializerInnerStringCtorKeyDeserializerTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_parquet.parquet_jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.parquet.com.fasterxml.jackson.databind.ObjectMapper;
+
+public class StdKeyDeserializerInnerStringCtorKeyDeserializerTest {
+    @Test
+    void deserializesMapKeyUsingSingleStringConstructor() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+
+        final KeyedValues values = mapper.readValue("""
+                {
+                  "values" : {
+                    "alpha" : "first",
+                    "beta" : "second"
+                  }
+                }
+                """, KeyedValues.class);
+
+        assertThat(values.values)
+                .containsEntry(new ConstructedKey("alpha"), "first")
+                .containsEntry(new ConstructedKey("beta"), "second");
+    }
+
+    public static class KeyedValues {
+        public Map<ConstructedKey, String> values;
+    }
+
+    public static final class ConstructedKey {
+        private final String value;
+
+        public ConstructedKey(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (!(other instanceof ConstructedKey)) {
+                return false;
+            }
+            final ConstructedKey that = (ConstructedKey) other;
+            return value.equals(that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return value.hashCode();
+        }
+    }
+}

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/StdKeyDeserializerInnerStringFactoryKeyDeserializerTest.java
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/StdKeyDeserializerInnerStringFactoryKeyDeserializerTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_parquet.parquet_jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.parquet.com.fasterxml.jackson.databind.ObjectMapper;
+
+public class StdKeyDeserializerInnerStringFactoryKeyDeserializerTest {
+    @Test
+    void deserializesMapKeyUsingStaticStringFactoryMethod() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+
+        final KeyedValues values = mapper.readValue("""
+                {
+                  "values" : {
+                    "alpha" : "first",
+                    "beta" : "second"
+                  }
+                }
+                """, KeyedValues.class);
+
+        assertThat(values.values)
+                .containsEntry(StringFactoryKey.valueOf("alpha"), "first")
+                .containsEntry(StringFactoryKey.valueOf("beta"), "second");
+    }
+
+    public static class KeyedValues {
+        public Map<StringFactoryKey, String> values;
+    }
+
+    public static final class StringFactoryKey {
+        private final String value;
+
+        private StringFactoryKey(String value, boolean fromFactory) {
+            this.value = value;
+        }
+
+        public static StringFactoryKey valueOf(String value) {
+            return new StringFactoryKey(value, true);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (!(other instanceof StringFactoryKey)) {
+                return false;
+            }
+            final StringFactoryKey that = (StringFactoryKey) other;
+            return value.equals(that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return value.hashCode();
+        }
+    }
+}

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/TypeFactoryTest.java
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/TypeFactoryTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_parquet.parquet_jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.parquet.com.fasterxml.jackson.databind.type.TypeFactory;
+
+public class TypeFactoryTest {
+    private static final String TARGET_CLASS_NAME =
+            "org_apache_parquet.parquet_jackson.TypeFactoryTestTarget";
+
+    @Test
+    void findsClassByNameWithThreadContextClassLoader() throws Exception {
+        final TypeFactory typeFactory = TypeFactory.defaultInstance();
+
+        final Class<?> targetClass = typeFactory.findClass(TARGET_CLASS_NAME);
+
+        assertThat(targetClass).isEqualTo(TypeFactoryTestTarget.class);
+    }
+
+    @Test
+    void fallsBackToDefaultClassLookupWhenThreadContextClassLoaderCannotLoadClass() throws Exception {
+        final ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(new RejectingClassLoader());
+        try {
+            final TypeFactory typeFactory = TypeFactory.defaultInstance();
+
+            final Class<?> targetClass = typeFactory.findClass(TARGET_CLASS_NAME);
+
+            assertThat(targetClass).isEqualTo(TypeFactoryTestTarget.class);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    private static final class RejectingClassLoader extends ClassLoader {
+        RejectingClassLoader() {
+            super(null);
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            throw new ClassNotFoundException(name);
+        }
+    }
+}
+
+final class TypeFactoryTestTarget {
+}

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/TypeFactoryTest.java
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/TypeFactoryTest.java
@@ -8,6 +8,9 @@ package org_apache_parquet.parquet_jackson;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Type;
+
 import org.junit.jupiter.api.Test;
 
 import shaded.parquet.com.fasterxml.jackson.databind.type.TypeFactory;
@@ -37,6 +40,20 @@ public class TypeFactoryTest {
             assertThat(targetClass).isEqualTo(TypeFactoryTestTarget.class);
         } finally {
             Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    @Test
+    void resolvesRawClassForGenericArrayType() {
+        final Class<?> rawClass = TypeFactory.rawClass(new StringGenericArrayType());
+
+        assertThat(rawClass).isEqualTo(String[].class);
+    }
+
+    private static final class StringGenericArrayType implements GenericArrayType {
+        @Override
+        public Type getGenericComponentType() {
+            return String.class;
         }
     }
 

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/VersionUtilTest.java
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/VersionUtilTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_parquet.parquet_jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.parquet.com.fasterxml.jackson.core.Version;
+import shaded.parquet.com.fasterxml.jackson.core.json.JsonReadFeature;
+import shaded.parquet.com.fasterxml.jackson.core.util.VersionUtil;
+
+public class VersionUtilTest {
+    @Test
+    void versionForReadsJacksonPackageVersion() {
+        final Version version = VersionUtil.versionFor(JsonReadFeature.class);
+
+        assertThat(version).isNotNull();
+        assertThat(version.isUnknownVersion()).isFalse();
+        assertThat(version.getGroupId()).isEqualTo("shaded.parquet.com.fasterxml.jackson.core");
+        assertThat(version.getArtifactId()).isEqualTo("jackson-core");
+        assertThat(version.getMajorVersion()).isPositive();
+    }
+
+    @Test
+    void mavenVersionForReadsPomPropertiesFromClassLoaderResource() {
+        final ClassLoader classLoader = VersionUtilTest.class.getClassLoader();
+
+        final Version version = VersionUtil.mavenVersionFor(
+                classLoader, "org.apache.parquet.test", "versionutil-fixture");
+
+        assertThat(version).isNotNull();
+        assertThat(version.isUnknownVersion()).isFalse();
+        assertThat(version.toString()).isEqualTo("4.5.6-fixture");
+        assertThat(version.getGroupId()).isEqualTo("org.apache.parquet.test");
+        assertThat(version.getArtifactId()).isEqualTo("versionutil-fixture");
+    }
+}

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/resources/META-INF/maven/org/apache/parquet/test/versionutil-fixture/pom.properties
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/resources/META-INF/maven/org/apache/parquet/test/versionutil-fixture/pom.properties
@@ -1,0 +1,3 @@
+groupId=org.apache.parquet.test
+artifactId=versionutil-fixture
+version=4.5.6-fixture

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,40 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org_apache_parquet.parquet_jackson.ClassUtilTest"
+      },
+      "type" : "org_apache_parquet.parquet_jackson.ClassUtilTestBean",
+      "allDeclaredFields" : true,
+      "allDeclaredMethods" : true,
+      "allDeclaredConstructors" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_parquet.parquet_jackson.ClassUtilTest"
+      },
+      "type" : "org_apache_parquet.parquet_jackson.ClassUtilTestAnnotatedEnum",
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_parquet.parquet_jackson.ClassUtilTest"
+      },
+      "type" : "org_apache_parquet.parquet_jackson.ClassUtilTestMarker"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_parquet.parquet_jackson.TypeFactoryTest"
+      },
+      "type" : "org_apache_parquet.parquet_jackson.TypeFactoryTestTarget"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org_apache_parquet.parquet_jackson.VersionUtilTest"
+      },
+      "glob" : "META-INF/maven/org/apache/parquet/test/versionutil-fixture/pom.properties"
+    }
+  ]
+}

--- a/tests/src/org.apache.parquet/parquet-jackson/1.16.0/user-code-filter.json
+++ b/tests/src/org.apache.parquet/parquet-jackson/1.16.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "shaded.parquet.com.fasterxml.jackson.**"
+    },
+    {
+      "includeClasses" : "org_apache_parquet.parquet_jackson.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #8256

This PR provides test fixes and new metadata for org.apache.parquet:parquet-jackson:1.16.0, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 381331
- Cached input tokens: 2746368
- Output tokens: 25205
- Metadata entries: 101
- Test-only metadata entries: 9
- Iterations: 8
- Library coverage percentage: 16.36
- Previous library version metadata entries: 99
- Previous library version test-only metadata entries: 9
- Previous library version coverage percentage: 16.38

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `09b404829a904783cd4ac5414b071a132f73cdca`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.parquet:parquet-jackson:1.12.2: 70/70 covered calls (100.00%)
- org.apache.parquet:parquet-jackson:1.16.0: 76/76 covered calls (100.00%)

**Reflection:**
- org.apache.parquet:parquet-jackson:1.12.2: 69/69 covered calls (100.00%)
- org.apache.parquet:parquet-jackson:1.16.0: 75/75 covered calls (100.00%)

**Resources:**
- org.apache.parquet:parquet-jackson:1.12.2: 1/1 covered calls (100.00%)
- org.apache.parquet:parquet-jackson:1.16.0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.parquet:parquet-jackson:1.12.2: 31919/202510 (15.76%)
- org.apache.parquet:parquet-jackson:1.16.0: 38806/257564 (15.07%)

**Line:**
- org.apache.parquet:parquet-jackson:1.12.2: 7718/47123 (16.38%)
- org.apache.parquet:parquet-jackson:1.16.0: 9316/56950 (16.36%)

**Method:**
- org.apache.parquet:parquet-jackson:1.12.2: 1745/9311 (18.74%)
- org.apache.parquet:parquet-jackson:1.16.0: 2100/11329 (18.54%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.parquet/parquet-jackson/1.12.2/build.gradle 2/tests/src/org.apache.parquet/parquet-jackson/1.16.0/build.gradle
index ddd41b14a4..f25b2b9705 100644
--- 1/tests/src/org.apache.parquet/parquet-jackson/1.12.2/build.gradle
+++ 2/tests/src/org.apache.parquet/parquet-jackson/1.16.0/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 
 tasks.withType(Test).configureEach {
     jvmArgs '--add-opens=java.base/java.util=ALL-UNNAMED'
+    systemProperty 'org.graalvm.nativeimage.imagecode', 'runtime'
 }
 
 graalvmNative {
diff --git 1/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/AnnotatedCreatorCollectorTest.java 2/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/AnnotatedCreatorCollectorTest.java
new file mode 100644
index 0000000000..c4ace6d772
--- /dev/null
+++ 2/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/AnnotatedCreatorCollectorTest.java
@@ -0,0 +1,51 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_parquet.parquet_jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.parquet.com.fasterxml.jackson.annotation.JsonCreator;
+import shaded.parquet.com.fasterxml.jackson.annotation.JsonProperty;
+import shaded.parquet.com.fasterxml.jackson.databind.ObjectMapper;
+
+public class AnnotatedCreatorCollectorTest {
+    @Test
+    void mixInAnnotationsSelectStaticFactoryCreator() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.addMixIn(FactoryCreatedBean.class, FactoryCreatedBeanMixin.class);
+
+        final FactoryCreatedBean value = mapper.readValue(
+                "{\"creator_name\":\"alpha\"}", FactoryCreatedBean.class);
+
+        assertThat(value.name()).isEqualTo("alpha");
+    }
+
+    private abstract static class FactoryCreatedBeanMixin {
+        @JsonCreator
+        public static FactoryCreatedBean fromJson(@JsonProperty("creator_name") String name) {
+            return null;
+        }
+    }
+
+    public static final class FactoryCreatedBean {
+        private final String name;
+
+        private FactoryCreatedBean(String name) {
+            this.name = name;
+        }
+
+        public static FactoryCreatedBean fromJson(String name) {
+            return new FactoryCreatedBean(name);
+        }
+
+        public String name() {
+            return name;
+        }
+    }
+}
diff --git 1/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/JDK14UtilInnerRecordAccessorTest.java 2/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/JDK14UtilInnerRecordAccessorTest.java
new file mode 100644
index 0000000000..14296cc0b5
--- /dev/null
+++ 2/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/JDK14UtilInnerRecordAccessorTest.java
@@ -0,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_parquet.parquet_jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.parquet.com.fasterxml.jackson.annotation.JsonProperty;
+import shaded.parquet.com.fasterxml.jackson.databind.ObjectMapper;
+
+public class JDK14UtilInnerRecordAccessorTest {
+    @Test
+    void serializesRecordComponentsByName() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+        final InventoryItem item = new InventoryItem("book", 3);
+
+        final String json = mapper.writeValueAsString(item);
+
+        assertThat(json).contains("\"label\":\"book\"");
+        assertThat(json).contains("\"quantity\":3");
+    }
+
+    @Test
+    void deserializesRecordUsingCanonicalConstructor() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+
+        final InventoryItem item = mapper.readValue("""
+                {
+                  "label": "pencil",
+                  "quantity": 12
+                }
+                """, InventoryItem.class);
+
+        assertThat(item).isEqualTo(new InventoryItem("pencil", 12));
+    }
+
+    public record InventoryItem(@JsonProperty("label") String name, int quantity) {
+    }
+}
diff --git 1/tests/src/org.apache.parquet/parquet-jackson/1.12.2/src/test/java/org_apache_parquet/parquet_jackson/JacksonAnnotationIntrospectorTest.java 2/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/JacksonAnnotationIntrospectorTest.java
index ff7c527a01..c307d5a92a 100644
--- 1/tests/src/org.apache.parquet/parquet-jackson/1.12.2/src/test/java/org_apache_parquet/parquet_jackson/JacksonAnnotationIntrospectorTest.java
+++ 2/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/JacksonAnnotationIntrospectorTest.java
@@ -13,17 +13,38 @@ import org.junit.jupiter.api.Test;
 import shaded.parquet.com.fasterxml.jackson.annotation.JsonAlias;
 import shaded.parquet.com.fasterxml.jackson.annotation.JsonProperty;
 import shaded.parquet.com.fasterxml.jackson.databind.ObjectMapper;
+import shaded.parquet.com.fasterxml.jackson.databind.SerializationConfig;
+import shaded.parquet.com.fasterxml.jackson.databind.introspect.AnnotatedClass;
 import shaded.parquet.com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 
 public class JacksonAnnotationIntrospectorTest {
     @Test
     void readsJsonPropertyAndAliasAnnotationsFromEnumConstants() {
+        final JacksonAnnotationIntrospector introspector = new JacksonAnnotationIntrospector();
+        final ObjectMapper mapper = new ObjectMapper();
+        final SerializationConfig config = mapper.getSerializationConfig();
+        final AnnotatedClass annotatedClass = config.introspectClassAnnotations(AnnotatedEnum.class)
+                .getClassInfo();
+        final AnnotatedEnum[] enumValues = AnnotatedEnum.values();
+        final String[] names = {"ALPHA", "BETA"};
+        final String[][] aliases = new String[enumValues.length][];
+
+        assertThat(introspector.findEnumValues(config, annotatedClass, enumValues, names))
+                .containsExactly("alpha-json", "BETA");
+
+        introspector.findEnumAliases(config, annotatedClass, enumValues, aliases);
+
+        assertThat(aliases[0]).containsExactly("alpha-alias", "first-alias");
+        assertThat(aliases[1]).isEmpty();
+    }
+
+    @Test
+    void legacyEnumAnnotationLookupReadsDeclaredEnumFields() {
         final JacksonAnnotationIntrospector introspector = new JacksonAnnotationIntrospector();
         final AnnotatedEnum[] enumValues = AnnotatedEnum.values();
         final String[] names = {"ALPHA", "BETA"};
         final String[][] aliases = new String[enumValues.length][];
 
-        assertThat(introspector.findEnumValue(AnnotatedEnum.ALPHA)).isEqualTo("alpha-json");
         assertThat(introspector.findEnumValues(AnnotatedEnum.class, enumValues, names))
                 .containsExactly("alpha-json", "BETA");
 
diff --git 1/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/NativeImageUtilTest.java 2/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/NativeImageUtilTest.java
new file mode 100644
index 0000000000..3e451523fa
--- /dev/null
+++ 2/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/NativeImageUtilTest.java
@@ -0,0 +1,43 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_parquet.parquet_jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import shaded.parquet.com.fasterxml.jackson.databind.util.NativeImageUtil;
+
+public class NativeImageUtilTest {
+    static {
+        System.setProperty("org.graalvm.nativeimage.imagecode", "runtime");
+    }
+
+    @Test
+    void detectsClassesWithAvailableReflectionMembers() {
+        assertThat(NativeImageUtil.isInNativeImageAndIsAtRuntime()).isTrue();
+        assertThat(NativeImageUtil.needsReflectionConfiguration(ReflectionVisibleBean.class)).isFalse();
+        assertThat(NativeImageUtil.needsReflectionConfiguration(MethodOnlyBean.class)).isFalse();
+    }
+
+    public static class MethodOnlyBean {
+        public String value() {
+            return "value";
+        }
+    }
+
+    public static class ReflectionVisibleBean {
+        public String value;
+
+        public ReflectionVisibleBean() {
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+}
diff --git 1/tests/src/org.apache.parquet/parquet-jackson/1.12.2/src/test/java/org_apache_parquet/parquet_jackson/TypeFactoryTest.java 2/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/TypeFactoryTest.java
index 4687f4020c..a95d01193e 100644
--- 1/tests/src/org.apache.parquet/parquet-jackson/1.12.2/src/test/java/org_apache_parquet/parquet_jackson/TypeFactoryTest.java
+++ 2/tests/src/org.apache.parquet/parquet-jackson/1.16.0/src/test/java/org_apache_parquet/parquet_jackson/TypeFactoryTest.java
@@ -8,6 +8,9 @@ package org_apache_parquet.parquet_jackson;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Type;
+
 import org.junit.jupiter.api.Test;
 
 import shaded.parquet.com.fasterxml.jackson.databind.type.TypeFactory;
@@ -40,6 +43,20 @@ public class TypeFactoryTest {
         }
     }
 
+    @Test
+    void resolvesRawClassForGenericArrayType() {
+        final Class<?> rawClass = TypeFactory.rawClass(new StringGenericArrayType());
+
+        assertThat(rawClass).isEqualTo(String[].class);
+    }
+
+    private static final class StringGenericArrayType implements GenericArrayType {
+        @Override
+        public Type getGenericComponentType() {
+            return String.class;
+        }
+    }
+
     private static final class RejectingClassLoader extends ClassLoader {
         RejectingClassLoader() {
             super(null);

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
