### PR TITLE
[GenAI] Test fix for org.apache.maven.scm:maven-scm-provider-gitexe:1.10.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/reachability-metadata.json
+++ b/metadata/org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/reachability-metadata.json
@@ -1,16 +1,1 @@
-{
-  "resources": [
-    {
-      "condition": {
-        "typeReached": "org_apache_maven_scm.maven_scm_provider_gitexe.GitExeCommandLineConstructionTest"
-      },
-      "glob": "META-INF/services/org.assertj.core.configuration.Configuration"
-    },
-    {
-      "condition": {
-        "typeReached": "org_apache_maven_scm.maven_scm_provider_gitexe.GitExeCommandLineConstructionTest"
-      },
-      "glob": "META-INF/services/org.assertj.core.presentation.Representation"
-    }
-  ]
-}
+{ }

--- a/metadata/org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/reachability-metadata.json
+++ b/metadata/org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org_apache_maven_scm.maven_scm_provider_gitexe.GitExeCommandLineConstructionTest"
+      },
+      "glob": "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition": {
+        "typeReached": "org_apache_maven_scm.maven_scm_provider_gitexe.GitExeCommandLineConstructionTest"
+      },
+      "glob": "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/metadata/org.apache.maven.scm/maven-scm-provider-gitexe/index.json
+++ b/metadata/org.apache.maven.scm/maven-scm-provider-gitexe/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.10.0",
+    "tested-versions" : [
+      "1.10.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.maven.scm.provider.git.gitexe"
+    ]
+  },
+  {
     "metadata-version" : "1.9.5",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm-provider-gitexe/$version$/maven-scm-provider-gitexe-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/maven-scm",

--- a/metadata/org.apache.maven.scm/maven-scm-provider-gitexe/index.json
+++ b/metadata/org.apache.maven.scm/maven-scm-provider-gitexe/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.10.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm-provider-gitexe/$version$/maven-scm-provider-gitexe-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/maven-scm",
+    "test-code-url" : "https://github.com/apache/maven-scm/tree/maven-scm-$version$/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test",
+    "documentation-url" : "https://maven.apache.org/scm-archives/scm-$version$/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/",
+    "description" : "This artifact provides the Apache Maven SCM provider implementation that talks to Git through the installed Git command-line executable. It lets Maven SCM integrations perform Git operations such as checkout, update, tag, status, and changelog through the shared Maven SCM API.",
     "tested-versions" : [
       "1.10.0"
     ],

--- a/stats/org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/execution-metrics.json
+++ b/stats/org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/execution-metrics.json
@@ -1,0 +1,121 @@
+{
+  "fix_java_run_fail:2026-06-09": {
+    "timestamp": "2026-06-09T17:06:12.906798Z",
+    "library": "org.apache.maven.scm:maven-scm-provider-gitexe:1.10.0",
+    "starting_commit": "16a7d71a3e35730a39f57ffb56d5ef0ff6dee9bf",
+    "ending_commit": "811c0dea739f2429656166b346ee4375a17384ba",
+    "previous_library": "org.apache.maven.scm:maven-scm-provider-gitexe:1.9.5",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.10.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 740,
+          "missed": 3745,
+          "ratio": 0.164994,
+          "total": 4485
+        },
+        "line": {
+          "covered": 164,
+          "missed": 823,
+          "ratio": 0.16616,
+          "total": 987
+        },
+        "method": {
+          "covered": 29,
+          "missed": 122,
+          "ratio": 0.192053,
+          "total": 151
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.9.5",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 750,
+          "missed": 3710,
+          "ratio": 0.168161,
+          "total": 4460
+        },
+        "line": {
+          "covered": 166,
+          "missed": 812,
+          "ratio": 0.169734,
+          "total": 978
+        },
+        "method": {
+          "covered": 29,
+          "missed": 117,
+          "ratio": 0.19863,
+          "total": 146
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "no_action",
+      "issue_number": 8228,
+      "issue_label": "fails-java-run",
+      "library": "org.apache.maven.scm:maven-scm-provider-gitexe:1.10.0",
+      "summary": "No extra Maven dependency, Docker service, or deterministic setup is needed. The artifact resolves with its required Maven SCM, Plexus, commons-io, and commons-lang dependencies, and the provider is a Git CLI wrapper rather than a server-backed client.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [
+        "Tests that execute real provider commands may need to initialize a temporary local Git repository and configure Git user identity, but this is ordinary test logic rather than deterministic repository setup.",
+        "The reported failure appears related to brittle assertions around Plexus Commandline executable quoting in 1.10.0, not missing external setup."
+      ],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#8228 [Automation] java run fails for org.apache.maven.scm:maven-scm-provider-gitexe:1.10.0; label=fails-java-run; body_chars=8015"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "7 existing test file path(s) included"
+        }
+      ],
+      "current_library": "org.apache.maven.scm:maven-scm-provider-gitexe:1.9.5",
+      "new_version": "1.10.0",
+      "model": "oca/gpt-5.5",
+      "input_tokens_used": 25961,
+      "output_tokens_used": 2911,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.apache.maven.scm:maven-scm-provider-gitexe:1.10.0/library-preparation-preflight/pi-generation-2026-06-09T16-50-34-071918Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 57270,
+      "cached_input_tokens_used": 346112,
+      "output_tokens_used": 2893,
+      "iterations": 2,
+      "cost_usd": 0.2599,
+      "tested_library_loc": 164,
+      "metadata_entries": 0,
+      "test_only_metadata_entries": 2,
+      "previous_library_metadata_entries": 0,
+      "code_coverage_percent": 16.62,
+      "previous_library_coverage_percent": 16.97
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/Maven_scm_provider_gitexeTest.java",
+      "metadata_file": "metadata/org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/stats.json
+++ b/stats/org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.10.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 740,
+        "missed" : 3745,
+        "ratio" : 0.164994,
+        "total" : 4485
+      },
+      "line" : {
+        "covered" : 164,
+        "missed" : 823,
+        "ratio" : 0.16616,
+        "total" : 987
+      },
+      "method" : {
+        "covered" : 29,
+        "missed" : 122,
+        "ratio" : 0.192053,
+        "total" : 151
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/.gitignore
+++ b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/build.gradle
+++ b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.maven.scm:maven-scm-provider-gitexe:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/gradle.properties
+++ b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.maven.scm:maven-scm-provider-gitexe:1.10.0
+library.version = 1.10.0
+metadata.dir = org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/

--- a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/settings.gradle
+++ b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.maven.scm.maven-scm-provider-gitexe_tests'

--- a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/GitExeCommandLineConstructionTest.java
+++ b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/GitExeCommandLineConstructionTest.java
@@ -44,12 +44,12 @@ public class GitExeCommandLineConstructionTest {
 
         Commandline checkoutCommandLine =
                 GitCheckOutCommand.createCommandLine(repository, workingDirectory, featureBranch);
-        assertThat(checkoutCommandLine.getExecutable()).isEqualTo("git");
+        assertGitExecutable(checkoutCommandLine);
         assertThat(checkoutCommandLine.getWorkingDirectory()).isEqualTo(workingDirectory);
         assertThat(checkoutCommandLine.getArguments()).containsExactly("checkout", "feature/native-tests");
 
         Commandline updateCommandLine = GitUpdateCommand.createCommandLine(repository, workingDirectory, featureBranch);
-        assertThat(updateCommandLine.getExecutable()).isEqualTo("git");
+        assertGitExecutable(updateCommandLine);
         assertThat(updateCommandLine.getWorkingDirectory()).isEqualTo(workingDirectory);
         assertThat(updateCommandLine.getArguments())
                 .containsExactly("pull", "https://example.invalid/team/project.git", "feature/native-tests");
@@ -60,7 +60,7 @@ public class GitExeCommandLineConstructionTest {
                 .containsExactly("log", "-n1", "--date-order", "feature/native-tests");
 
         Commandline remoteInfoCommandLine = GitRemoteInfoCommand.createCommandLine(repository);
-        assertThat(remoteInfoCommandLine.getExecutable()).isEqualTo("git");
+        assertGitExecutable(remoteInfoCommandLine);
         File temporaryRoot = new File(System.getProperty("java.io.tmpdir"));
         assertThat(remoteInfoCommandLine.getWorkingDirectory()).isEqualTo(temporaryRoot);
         assertThat(remoteInfoCommandLine.getArguments())
@@ -75,7 +75,7 @@ public class GitExeCommandLineConstructionTest {
     }
 
     @Test
-    void diffTagCommitAndRemoveFactoriesIncludeTargetFilesAndMessageFiles() throws Exception {
+    void diffTagCommitAndRemoveFactoriesBuildExpectedArguments() throws Exception {
         File workingDirectory = temporaryDirectory.toFile();
         Path trackedPath = temporaryDirectory.resolve("tracked.txt");
         Path messagePath = temporaryDirectory.resolve("message.txt");
@@ -89,7 +89,7 @@ public class GitExeCommandLineConstructionTest {
         ScmTag endTag = new ScmTag("v1.1.0");
 
         Commandline cachedDiffCommandLine = GitDiffCommand.createCommandLine(workingDirectory, startTag, endTag, true);
-        assertThat(cachedDiffCommandLine.getExecutable()).isEqualTo("git");
+        assertGitExecutable(cachedDiffCommandLine);
         assertThat(cachedDiffCommandLine.getArguments())
                 .containsExactly("diff", "--cached", "v1.0.0", "v1.1.0");
 
@@ -110,10 +110,14 @@ public class GitExeCommandLineConstructionTest {
         Commandline commitCommandLine =
                 GitCheckInCommand.createCommitCommandLine(repository, trackedFileSet, messagePath.toFile());
         assertThat(commitCommandLine.getArguments())
-                .contains("commit", "--verbose", "-F", messagePath.toAbsolutePath().toString(), "tracked.txt");
+                .containsExactly("commit", "--verbose", "-F", messagePath.toAbsolutePath().toString());
 
         Commandline removeCommandLine = GitRemoveCommand.createCommandLine(
                 workingDirectory, List.of(removableDirectory.toFile(), trackedPath.toFile()));
         assertThat(removeCommandLine.getArguments()).contains("rm", "-r", "directory-to-remove", "tracked.txt");
+    }
+
+    private static void assertGitExecutable(Commandline commandLine) {
+        assertThat(commandLine.getExecutable()).isIn("git", "'git'");
     }
 }

--- a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/GitExeCommandLineConstructionTest.java
+++ b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/GitExeCommandLineConstructionTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_scm.maven_scm_provider_gitexe;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.maven.scm.CommandParameter;
+import org.apache.maven.scm.CommandParameters;
+import org.apache.maven.scm.ScmBranch;
+import org.apache.maven.scm.ScmFileSet;
+import org.apache.maven.scm.ScmTag;
+import org.apache.maven.scm.provider.git.gitexe.command.checkin.GitCheckInCommand;
+import org.apache.maven.scm.provider.git.gitexe.command.checkout.GitCheckOutCommand;
+import org.apache.maven.scm.provider.git.gitexe.command.diff.GitDiffCommand;
+import org.apache.maven.scm.provider.git.gitexe.command.info.GitInfoCommand;
+import org.apache.maven.scm.provider.git.gitexe.command.remoteinfo.GitRemoteInfoCommand;
+import org.apache.maven.scm.provider.git.gitexe.command.remove.GitRemoveCommand;
+import org.apache.maven.scm.provider.git.gitexe.command.tag.GitTagCommand;
+import org.apache.maven.scm.provider.git.gitexe.command.update.GitUpdateCommand;
+import org.apache.maven.scm.provider.git.repository.GitScmProviderRepository;
+import org.codehaus.plexus.util.cli.Commandline;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GitExeCommandLineConstructionTest {
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void checkoutUpdateRemoteAndInfoFactoriesBuildExpectedGitArguments() throws Exception {
+        File workingDirectory = temporaryDirectory.toFile();
+        GitScmProviderRepository repository = new GitScmProviderRepository("https://example.invalid/team/project.git");
+        ScmBranch featureBranch = new ScmBranch("feature/native-tests");
+
+        Commandline checkoutCommandLine =
+                GitCheckOutCommand.createCommandLine(repository, workingDirectory, featureBranch);
+        assertThat(checkoutCommandLine.getExecutable()).isEqualTo("git");
+        assertThat(checkoutCommandLine.getWorkingDirectory()).isEqualTo(workingDirectory);
+        assertThat(checkoutCommandLine.getArguments()).containsExactly("checkout", "feature/native-tests");
+
+        Commandline updateCommandLine = GitUpdateCommand.createCommandLine(repository, workingDirectory, featureBranch);
+        assertThat(updateCommandLine.getExecutable()).isEqualTo("git");
+        assertThat(updateCommandLine.getWorkingDirectory()).isEqualTo(workingDirectory);
+        assertThat(updateCommandLine.getArguments())
+                .containsExactly("pull", "https://example.invalid/team/project.git", "feature/native-tests");
+
+        Commandline latestRevisionCommandLine =
+                GitUpdateCommand.createLatestRevisionCommandLine(repository, workingDirectory, featureBranch);
+        assertThat(latestRevisionCommandLine.getArguments())
+                .containsExactly("log", "-n1", "--date-order", "feature/native-tests");
+
+        Commandline remoteInfoCommandLine = GitRemoteInfoCommand.createCommandLine(repository);
+        assertThat(remoteInfoCommandLine.getExecutable()).isEqualTo("git");
+        File temporaryRoot = new File(System.getProperty("java.io.tmpdir"));
+        assertThat(remoteInfoCommandLine.getWorkingDirectory()).isEqualTo(temporaryRoot);
+        assertThat(remoteInfoCommandLine.getArguments())
+                .containsExactly("ls-remote", "https://example.invalid/team/project.git");
+
+        CommandParameters infoParameters = new CommandParameters();
+        infoParameters.setInt(CommandParameter.SCM_SHORT_REVISION_LENGTH, 12);
+        Commandline infoCommandLine = GitInfoCommand.createCommandLine(
+                repository, new ScmFileSet(workingDirectory), infoParameters);
+        assertThat(infoCommandLine.getArguments())
+                .containsExactly("rev-parse", "--verify", "--short=12", "HEAD");
+    }
+
+    @Test
+    void diffTagCommitAndRemoveFactoriesIncludeTargetFilesAndMessageFiles() throws Exception {
+        File workingDirectory = temporaryDirectory.toFile();
+        Path trackedPath = temporaryDirectory.resolve("tracked.txt");
+        Path messagePath = temporaryDirectory.resolve("message.txt");
+        Path removableDirectory = temporaryDirectory.resolve("directory-to-remove");
+        Files.writeString(trackedPath, "content\n", StandardCharsets.UTF_8);
+        Files.writeString(messagePath, "message\n", StandardCharsets.UTF_8);
+        Files.createDirectories(removableDirectory);
+
+        GitScmProviderRepository repository = new GitScmProviderRepository("https://example.invalid/team/project.git");
+        ScmTag startTag = new ScmTag("v1.0.0");
+        ScmTag endTag = new ScmTag("v1.1.0");
+
+        Commandline cachedDiffCommandLine = GitDiffCommand.createCommandLine(workingDirectory, startTag, endTag, true);
+        assertThat(cachedDiffCommandLine.getExecutable()).isEqualTo("git");
+        assertThat(cachedDiffCommandLine.getArguments())
+                .containsExactly("diff", "--cached", "v1.0.0", "v1.1.0");
+
+        Commandline rawDiffCommandLine = GitDiffCommand.createDiffRawCommandLine(workingDirectory, "HEAD");
+        assertThat(rawDiffCommandLine.getArguments()).containsExactly("diff", "--raw", "HEAD");
+
+        Commandline tagCommandLine = GitTagCommand.createCommandLine(
+                repository, workingDirectory, "v1.1.0", messagePath.toFile());
+        assertThat(tagCommandLine.getArguments())
+                .containsExactly("tag", "-F", messagePath.toAbsolutePath().toString(), "v1.1.0");
+
+        Commandline tagPushCommandLine = GitTagCommand.createPushCommandLine(
+                repository, new ScmFileSet(workingDirectory, trackedPath.toFile()), "v1.1.0");
+        assertThat(tagPushCommandLine.getArguments())
+                .containsExactly("push", "https://example.invalid/team/project.git", "refs/tags/v1.1.0");
+
+        ScmFileSet trackedFileSet = new ScmFileSet(workingDirectory, trackedPath.toFile());
+        Commandline commitCommandLine =
+                GitCheckInCommand.createCommitCommandLine(repository, trackedFileSet, messagePath.toFile());
+        assertThat(commitCommandLine.getArguments())
+                .contains("commit", "--verbose", "-F", messagePath.toAbsolutePath().toString(), "tracked.txt");
+
+        Commandline removeCommandLine = GitRemoveCommand.createCommandLine(
+                workingDirectory, List.of(removableDirectory.toFile(), trackedPath.toFile()));
+        assertThat(removeCommandLine.getArguments()).contains("rm", "-r", "directory-to-remove", "tracked.txt");
+    }
+}

--- a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/Maven_scm_provider_gitexeTest.java
+++ b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/Maven_scm_provider_gitexeTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_scm.maven_scm_provider_gitexe;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.maven.scm.ScmFile;
+import org.apache.maven.scm.ScmFileStatus;
+import org.apache.maven.scm.command.remoteinfo.RemoteInfoScmResult;
+import org.apache.maven.scm.log.DefaultLog;
+import org.apache.maven.scm.provider.git.gitexe.command.remoteinfo.GitRemoteInfoConsumer;
+import org.apache.maven.scm.provider.git.gitexe.command.status.GitStatusConsumer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+public class Maven_scm_provider_gitexeTest {
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void statusConsumerParsesPorcelainStatusOutputIntoScmFiles() throws Exception {
+        Path addedPath = temporaryDirectory.resolve("added.txt");
+        Path modifiedPath = temporaryDirectory.resolve("modified.txt");
+        Path renamedPath = temporaryDirectory.resolve("renamed.txt");
+        Path spacedPath = temporaryDirectory.resolve("space name.txt");
+        Files.writeString(addedPath, "added\n", StandardCharsets.UTF_8);
+        Files.writeString(modifiedPath, "modified\n", StandardCharsets.UTF_8);
+        Files.writeString(renamedPath, "renamed\n", StandardCharsets.UTF_8);
+        Files.writeString(spacedPath, "spaced\n", StandardCharsets.UTF_8);
+
+        GitStatusConsumer consumer = new GitStatusConsumer(new DefaultLog(), temporaryDirectory.toFile());
+        consumer.consumeLine("A  added.txt");
+        consumer.consumeLine(" M modified.txt");
+        consumer.consumeLine(" D deleted.txt");
+        consumer.consumeLine("R  old-name.txt -> renamed.txt");
+        consumer.consumeLine(" M \"space name.txt\"");
+        consumer.consumeLine("?? ignored-by-maven-scm.txt");
+
+        assertThat(consumer.getChangedFiles())
+                .extracting(ScmFile::getPath, ScmFile::getStatus)
+                .containsExactly(
+                        tuple("added.txt", ScmFileStatus.ADDED),
+                        tuple("modified.txt", ScmFileStatus.MODIFIED),
+                        tuple("deleted.txt", ScmFileStatus.DELETED),
+                        tuple("old-name.txt", ScmFileStatus.RENAMED),
+                        tuple("renamed.txt", ScmFileStatus.RENAMED),
+                        tuple("space name.txt", ScmFileStatus.MODIFIED));
+    }
+
+    @Test
+    void remoteInfoConsumerParsesBranchesAndTagsFromLsRemoteOutput() {
+        GitRemoteInfoConsumer consumer = new GitRemoteInfoConsumer(new DefaultLog(), "git ls-remote origin");
+        consumer.consumeLine("1111111111111111111111111111111111111111\trefs/heads/main");
+        consumer.consumeLine("2222222222222222222222222222222222222222 refs/heads/feature/native-tests");
+        consumer.consumeLine("3333333333333333333333333333333333333333\trefs/tags/v1.0.0");
+        consumer.consumeLine("4444444444444444444444444444444444444444 refs/pull/7/head");
+
+        RemoteInfoScmResult result = consumer.getRemoteInfoScmResult();
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getCommandLine()).isEqualTo("git ls-remote origin");
+        assertThat(result.getBranches())
+                .containsEntry("main", "1111111111111111111111111111111111111111")
+                .containsEntry("feature/native-tests", "2222222222222222222222222222222222222222")
+                .hasSize(2);
+        assertThat(result.getTags())
+                .containsEntry("v1.0.0", "3333333333333333333333333333333333333333")
+                .hasSize(1);
+    }
+}

--- a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org_apache_maven_scm.maven_scm_provider_gitexe.GitExeCommandLineConstructionTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_maven_scm.maven_scm_provider_gitexe.GitExeCommandLineConstructionTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/user-code-filter.json
+++ b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.maven.scm.provider.git.gitexe.**"
+    },
+    {
+      "includeClasses" : "org_apache_maven_scm.maven_scm_provider_gitexe.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #8228

This PR provides test fixes and new metadata for org.apache.maven.scm:maven-scm-provider-gitexe:1.10.0, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 57270
- Cached input tokens: 346112
- Output tokens: 2893
- Metadata entries: 0
- Test-only metadata entries: 2
- Iterations: 2
- Library coverage percentage: 16.62
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 16.97

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `476852ae462dd99f24a770e13647a9e2a1a1d936`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.maven.scm:maven-scm-provider-gitexe:1.9.5: 0/0 covered calls (100.00%)
- org.apache.maven.scm:maven-scm-provider-gitexe:1.10.0: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.maven.scm:maven-scm-provider-gitexe:1.9.5: 750/4460 (16.82%)
- org.apache.maven.scm:maven-scm-provider-gitexe:1.10.0: 740/4485 (16.50%)

**Line:**
- org.apache.maven.scm:maven-scm-provider-gitexe:1.9.5: 166/978 (16.97%)
- org.apache.maven.scm:maven-scm-provider-gitexe:1.10.0: 164/987 (16.62%)

**Method:**
- org.apache.maven.scm:maven-scm-provider-gitexe:1.9.5: 29/146 (19.86%)
- org.apache.maven.scm:maven-scm-provider-gitexe:1.10.0: 29/151 (19.21%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/1.9.5/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/GitExeCommandLineConstructionTest.java b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/GitExeCommandLineConstructionTest.java
index 85f024af81..490e3cd2f7 100644
--- a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/1.9.5/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/GitExeCommandLineConstructionTest.java
+++ b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/GitExeCommandLineConstructionTest.java
@@ -44,12 +44,12 @@ public class GitExeCommandLineConstructionTest {
 
         Commandline checkoutCommandLine =
                 GitCheckOutCommand.createCommandLine(repository, workingDirectory, featureBranch);
-        assertThat(checkoutCommandLine.getExecutable()).isEqualTo("git");
+        assertGitExecutable(checkoutCommandLine);
         assertThat(checkoutCommandLine.getWorkingDirectory()).isEqualTo(workingDirectory);
         assertThat(checkoutCommandLine.getArguments()).containsExactly("checkout", "feature/native-tests");
 
         Commandline updateCommandLine = GitUpdateCommand.createCommandLine(repository, workingDirectory, featureBranch);
-        assertThat(updateCommandLine.getExecutable()).isEqualTo("git");
+        assertGitExecutable(updateCommandLine);
         assertThat(updateCommandLine.getWorkingDirectory()).isEqualTo(workingDirectory);
         assertThat(updateCommandLine.getArguments())
                 .containsExactly("pull", "https://example.invalid/team/project.git", "feature/native-tests");
@@ -60,7 +60,7 @@ public class GitExeCommandLineConstructionTest {
                 .containsExactly("log", "-n1", "--date-order", "feature/native-tests");
 
         Commandline remoteInfoCommandLine = GitRemoteInfoCommand.createCommandLine(repository);
-        assertThat(remoteInfoCommandLine.getExecutable()).isEqualTo("git");
+        assertGitExecutable(remoteInfoCommandLine);
         File temporaryRoot = new File(System.getProperty("java.io.tmpdir"));
         assertThat(remoteInfoCommandLine.getWorkingDirectory()).isEqualTo(temporaryRoot);
         assertThat(remoteInfoCommandLine.getArguments())
@@ -75,7 +75,7 @@ public class GitExeCommandLineConstructionTest {
     }
 
     @Test
-    void diffTagCommitAndRemoveFactoriesIncludeTargetFilesAndMessageFiles() throws Exception {
+    void diffTagCommitAndRemoveFactoriesBuildExpectedArguments() throws Exception {
         File workingDirectory = temporaryDirectory.toFile();
         Path trackedPath = temporaryDirectory.resolve("tracked.txt");
         Path messagePath = temporaryDirectory.resolve("message.txt");
@@ -89,7 +89,7 @@ public class GitExeCommandLineConstructionTest {
         ScmTag endTag = new ScmTag("v1.1.0");
 
         Commandline cachedDiffCommandLine = GitDiffCommand.createCommandLine(workingDirectory, startTag, endTag, true);
-        assertThat(cachedDiffCommandLine.getExecutable()).isEqualTo("git");
+        assertGitExecutable(cachedDiffCommandLine);
         assertThat(cachedDiffCommandLine.getArguments())
                 .containsExactly("diff", "--cached", "v1.0.0", "v1.1.0");
 
@@ -110,10 +110,14 @@ public class GitExeCommandLineConstructionTest {
         Commandline commitCommandLine =
                 GitCheckInCommand.createCommitCommandLine(repository, trackedFileSet, messagePath.toFile());
         assertThat(commitCommandLine.getArguments())
-                .contains("commit", "--verbose", "-F", messagePath.toAbsolutePath().toString(), "tracked.txt");
+                .containsExactly("commit", "--verbose", "-F", messagePath.toAbsolutePath().toString());
 
         Commandline removeCommandLine = GitRemoveCommand.createCommandLine(
                 workingDirectory, List.of(removableDirectory.toFile(), trackedPath.toFile()));
         assertThat(removeCommandLine.getArguments()).contains("rm", "-r", "directory-to-remove", "tracked.txt");
     }
+
+    private static void assertGitExecutable(Commandline commandLine) {
+        assertThat(commandLine.getExecutable()).isIn("git", "'git'");
+    }
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
