### PR TITLE
Route native-image-run fix driver through shared finalization + dynamic-access exploration

### DIFF
--- a/forge/ai_workflows/drivers/fix_ni_run.py
+++ b/forge/ai_workflows/drivers/fix_ni_run.py
@@ -265,8 +265,14 @@ def build_strategy_and_agent(
         artifact: str,
         version: str,
         library_preparation_preflight_context,
+        explore: bool,
 ):
-    """Construct the dynamic-access strategy object and its agent for the new coordinate."""
+    """Construct the dynamic-access strategy object and its agent for the new coordinate.
+
+    Source contexts are downloaded only when exploring: the skip-exploration path
+    finalizes the seed through `_finalize_successful_iteration`, which sends no
+    agent prompts and needs neither downloaded sources nor a live agent session.
+    """
     strategy = require_strategy_by_name(strategy_name)
     workflow_name = strategy.get("workflow")
     if not workflow_name:
@@ -281,14 +287,23 @@ def build_strategy_and_agent(
     build_gradle_file = os.path.join(tests_dir, "build.gradle")
     test_source_layout = resolve_test_source_layout(reachability_metadata_path, library, tests_dir)
 
-    forge_repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-    source_context_types = normalize_source_context_types(strategy.get("parameters", {}).get("source-context-types"))
-    prepared_source_context = prepare_source_contexts(
-        repo_root=forge_repo_root,
-        reachability_repo_path=reachability_metadata_path,
-        coordinate=library,
-        source_context_types=source_context_types,
-    )
+    source_context_overview = ""
+    source_context_available = False
+    source_context_files: list[str] = []
+    if explore:
+        forge_repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        source_context_types = normalize_source_context_types(
+            strategy.get("parameters", {}).get("source-context-types"),
+        )
+        prepared_source_context = prepare_source_contexts(
+            repo_root=forge_repo_root,
+            reachability_repo_path=reachability_metadata_path,
+            coordinate=library,
+            source_context_types=source_context_types,
+        )
+        source_context_overview = prepared_source_context.to_prompt_overview()
+        source_context_available = prepared_source_context.is_available
+        source_context_files = list(prepared_source_context.read_only_files)
 
     strategy_class = WorkflowStrategy.get_class(workflow_name)
     strategy_obj = strategy_class(
@@ -297,9 +312,9 @@ def build_strategy_and_agent(
         library=library,
         test_version=test_version,
         build_gradle_file=build_gradle_file,
-        source_context_overview=prepared_source_context.to_prompt_overview(),
-        source_context_available=prepared_source_context.is_available,
-        source_context_files=prepared_source_context.read_only_files,
+        source_context_overview=source_context_overview,
+        source_context_available=source_context_available,
+        source_context_files=source_context_files,
         test_language=test_source_layout.language,
         test_language_display_name=test_source_layout.display_language,
         test_source_dir_name=test_source_layout.source_dir_name,
@@ -314,7 +329,7 @@ def build_strategy_and_agent(
     agent = agent_class(
         model_name=model_name,
         editable_files=editable_files,
-        read_only_files=list(prepared_source_context.read_only_files),
+        read_only_files=source_context_files,
         working_dir=reachability_metadata_path,
         provider=strategy.get("provider"),
         library=library,
@@ -443,6 +458,7 @@ def main(argv=None) -> int:
         artifact=artifact,
         version=new_version,
         library_preparation_preflight_context=library_preparation_preflight_context,
+        explore=explore,
     )
 
     iterations = 0

--- a/forge/ai_workflows/drivers/fix_ni_run.py
+++ b/forge/ai_workflows/drivers/fix_ni_run.py
@@ -165,11 +165,12 @@ def create_or_switch_branch(reachability_metadata_path: str, branch: str) -> Non
 
 
 def commit_checkpoint(reachability_metadata_path: str, library: str) -> str:
-    """Commit the pre-generation state as a checkpoint and return its commit hash.
+    """Commit the seeded state as a checkpoint and return its commit hash.
 
-    The checkpoint captures any preflight setup so finalization and metrics can
-    treat seed and exploration output as the generated work
-    (§WF-forge-workflow-drivers).
+    The checkpoint captures the valid seed after artifact URL population and
+    before any exploratory test-suite split. If best-effort exploration resets to
+    this checkpoint, finalization can still publish the seeded fix
+    (§WF-native-image-run-fix-workflow.3).
     """
     subprocess.run(["git", "add", "-A"], cwd=reachability_metadata_path, check=False)
     subprocess.run(
@@ -399,7 +400,6 @@ def main(argv=None) -> int:
     )
     print(f"[pipeline] Creating branch: {branch}")
     create_or_switch_branch(reachability_metadata_path, branch)
-    checkpoint = commit_checkpoint(reachability_metadata_path, library)
 
     print(f"[pipeline] Running fixTestNativeImageRun for: {current_coordinates} -> {new_version}")
     result = run_fix_test_native_image_run(
@@ -444,6 +444,9 @@ def main(argv=None) -> int:
             print("[pipeline] Gradle test failed after Codex metadata fix. Skipping PR creation.", file=sys.stderr)
             return result.returncode
 
+    populate_artifact_urls(reachability_metadata_path, library)
+    checkpoint = commit_checkpoint(reachability_metadata_path, library)
+
     # Coverage gate: explore only when the new version has uncovered calls.
     explore = should_explore_new_version(reachability_metadata_path, group, artifact, new_version)
     if explore:
@@ -469,8 +472,18 @@ def main(argv=None) -> int:
         # Best-effort: a partial or failed explore must not abort. The seed is
         # already valid and the finalization gate decides PR eligibility.
         log_stage("explore", f"Dynamic-access exploration completed with status: {explore_status}")
+        if explore_status != RUN_STATUS_SUCCESS:
+            strategy_obj, _seed_agent, model_name, tests_root = build_strategy_and_agent(
+                strategy_name=args.strategy_name,
+                reachability_metadata_path=reachability_metadata_path,
+                library=library,
+                group=group,
+                artifact=artifact,
+                version=new_version,
+                library_preparation_preflight_context=library_preparation_preflight_context,
+                explore=False,
+            )
 
-    populate_artifact_urls(reachability_metadata_path, library)
     finalize_status, _ = strategy_obj._finalize_successful_iteration(base_commit=checkpoint)
     succeeded = finalize_status in {RUN_STATUS_SUCCESS, SUCCESS_WITH_INTERVENTION_STATUS}
 

--- a/forge/ai_workflows/drivers/fix_ni_run.py
+++ b/forge/ai_workflows/drivers/fix_ni_run.py
@@ -11,15 +11,40 @@ import sys
 if __package__ in (None, ""):
     sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
+import ai_workflows.agents  # noqa: F401 - triggers agent registration
+import ai_workflows.core  # noqa: F401 - triggers strategy registration
+from ai_workflows.agents import Agent
 from ai_workflows.core.fix_metadata_codex import run_codex_metadata_fix
+from ai_workflows.core.workflow_strategy import (
+    RUN_STATUS_SUCCESS,
+    SUCCESS_WITH_INTERVENTION_STATUS,
+    WorkflowStrategy,
+)
+from ai_workflows.drivers.improve_library_coverage import prepare_library_update_target
 from git_scripts.common_git import build_ai_branch_name, delete_remote_branch_if_exists
+from utility_scripts import metrics_writer
+from utility_scripts.dynamic_access_report import load_dynamic_access_coverage_report
 from utility_scripts.gradle_environment import gradle_command_environment
-from utility_scripts.library_finalization import run_library_finalization
 from utility_scripts.library_preparation_preflight import (
     prepare_library_preparation_preflight,
 )
+from utility_scripts.metadata_index import resolve_metadata_version, resolve_test_version
+from utility_scripts.metrics_writer import create_failure_run_metrics_output
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo, resolve_repo_roots
-from utility_scripts.source_context import populate_artifact_urls
+from utility_scripts.schema_validator import validate_run_metrics
+from utility_scripts.source_context import (
+    normalize_source_context_types,
+    populate_artifact_urls,
+    prepare_source_contexts,
+    resolve_test_source_layout,
+)
+from utility_scripts.stage_logger import log_stage
+from utility_scripts.strategy_loader import require_strategy_by_name
+from utility_scripts.workflow_setup import resolve_graalvm_java_home, validate_repo_paths
+
+DEFAULT_MODEL_NAME = "oca/gpt-5.5"
+DEFAULT_STRATEGY_NAME = "library_update_pi_gpt-5.5"
+METRICS_TASK_TYPE = "fix_ni_run"
 
 
 def build_parser():
@@ -57,10 +82,42 @@ def build_parser():
         help="Path where dispatcher-created workflow context artifacts are written.",
     )
     parser.add_argument(
+        "--strategy-name",
+        dest="strategy_name",
+        default=DEFAULT_STRATEGY_NAME,
+        metavar="NAME",
+        help=(
+            "Dynamic-access strategy used for the conditional exploration phase "
+            f"(default: {DEFAULT_STRATEGY_NAME})"
+        ),
+    )
+    parser.add_argument(
         "--library-preparation-preflight-path",
         help="Path to the dispatcher-created library preparation preflight JSON record.",
     )
     return parser
+
+
+def list_all_files(directory_path: str) -> list[str]:
+    """Recursively list all file paths in the given directory."""
+    files: list[str] = []
+    if not directory_path or not os.path.isdir(directory_path):
+        return files
+    for root_dir, _, file_names in os.walk(directory_path):
+        for file_name in file_names:
+            files.append(os.path.join(root_dir, file_name))
+    return files
+
+
+def resolve_repo_paths(explicit_repo_path, explicit_metrics_repo_path):
+    """Resolve repository paths for code and metrics outputs."""
+    resolved_reachability_repo, resolved_metrics_repo = resolve_repo_roots(
+        explicit_repo_path,
+        explicit_metrics_repo_path,
+    )
+    resolved_metrics_dir = os.path.join(resolved_metrics_repo, "script_run_metrics")
+    os.makedirs(resolved_metrics_dir, exist_ok=True)
+    return resolved_reachability_repo, resolved_metrics_dir, resolved_metrics_repo
 
 
 def run_fix_test_native_image_run(
@@ -107,15 +164,196 @@ def create_or_switch_branch(reachability_metadata_path: str, branch: str) -> Non
     )
 
 
+def commit_checkpoint(reachability_metadata_path: str, library: str) -> str:
+    """Commit the pre-generation state as a checkpoint and return its commit hash.
+
+    The checkpoint captures any preflight setup so finalization and metrics can
+    treat seed and exploration output as the generated work
+    (§WF-forge-workflow-drivers).
+    """
+    subprocess.run(["git", "add", "-A"], cwd=reachability_metadata_path, check=False)
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", f"Checkpoint for native-image-run fix of {library}"],
+        cwd=reachability_metadata_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return subprocess.check_output(
+        ["git", "rev-parse", "HEAD"],
+        cwd=reachability_metadata_path,
+        text=True,
+    ).strip()
+
+
+def run_dynamic_access_coverage_report(
+        reachability_metadata_path: str,
+        library: str,
+) -> subprocess.CompletedProcess[str]:
+    """Generate the dynamic-access coverage report for the new coordinate."""
+    require_complete_reachability_repo(reachability_metadata_path)
+    return subprocess.run(
+        [
+            "./gradlew", "generateDynamicAccessCoverageReport",
+            f"-Pcoordinates={library}",
+        ],
+        cwd=reachability_metadata_path,
+        env=gradle_command_environment(reachability_metadata_path),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+
+
+def should_explore_new_version(reachability_metadata_path: str, group: str, artifact: str, version: str) -> bool:
+    """Return True when the new version has uncovered dynamic-access call sites.
+
+    Exploration is conditional: an empty or fully-covered dynamic-access report
+    skips the version-specific suite preparation and exploration entirely, and
+    the workflow finalizes the metadata-first seed directly
+    (§WF-native-image-run-fix-workflow.3).
+    """
+    library = f"{group}:{artifact}:{version}"
+    result = run_dynamic_access_coverage_report(reachability_metadata_path, library)
+    if result.returncode != 0:
+        log_stage("coverage-gate", f"Dynamic-access report unavailable for {library}; skipping exploration")
+        print(result.stdout)
+        return False
+
+    test_version = resolve_test_version(reachability_metadata_path, group, artifact, version)
+    report_path = os.path.join(
+        reachability_metadata_path,
+        "tests", "src", group, artifact, test_version,
+        "build", "reports", "dynamic-access", "dynamic-access-coverage.json",
+    )
+    try:
+        report = load_dynamic_access_coverage_report(report_path)
+    except FileNotFoundError:
+        log_stage("coverage-gate", f"Dynamic-access report file missing for {library}; skipping exploration")
+        return False
+
+    uncovered_calls = max(report.total_calls - report.covered_calls, 0)
+    if not report.has_dynamic_access or report.total_calls == 0 or uncovered_calls == 0:
+        log_stage(
+            "coverage-gate",
+            "No uncovered dynamic-access calls for {library} "
+            "(hasDynamicAccess={has}, {covered}/{total} covered); skipping exploration".format(
+                library=library,
+                has=str(report.has_dynamic_access).lower(),
+                covered=report.covered_calls,
+                total=report.total_calls,
+            ),
+        )
+        return False
+
+    log_stage(
+        "coverage-gate",
+        "{uncovered} uncovered dynamic-access call(s) for {library}; preparing exploration".format(
+            uncovered=uncovered_calls,
+            library=library,
+        ),
+    )
+    return True
+
+
+def build_strategy_and_agent(
+        strategy_name: str,
+        reachability_metadata_path: str,
+        library: str,
+        group: str,
+        artifact: str,
+        version: str,
+        library_preparation_preflight_context,
+):
+    """Construct the dynamic-access strategy object and its agent for the new coordinate."""
+    strategy = require_strategy_by_name(strategy_name)
+    workflow_name = strategy.get("workflow")
+    if not workflow_name:
+        raise ValueError("Strategy is missing required field: workflow")
+    strategy_agent = strategy.get("agent")
+    if not strategy_agent:
+        raise ValueError("Strategy is missing required field: agent")
+
+    test_version = resolve_test_version(reachability_metadata_path, group, artifact, version)
+    metadata_version = resolve_metadata_version(reachability_metadata_path, group, artifact, version)
+    tests_dir = os.path.join(reachability_metadata_path, "tests", "src", group, artifact, test_version)
+    build_gradle_file = os.path.join(tests_dir, "build.gradle")
+    test_source_layout = resolve_test_source_layout(reachability_metadata_path, library, tests_dir)
+
+    forge_repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    source_context_types = normalize_source_context_types(strategy.get("parameters", {}).get("source-context-types"))
+    prepared_source_context = prepare_source_contexts(
+        repo_root=forge_repo_root,
+        reachability_repo_path=reachability_metadata_path,
+        coordinate=library,
+        source_context_types=source_context_types,
+    )
+
+    strategy_class = WorkflowStrategy.get_class(workflow_name)
+    strategy_obj = strategy_class(
+        strategy_obj=strategy,
+        reachability_repo_path=reachability_metadata_path,
+        library=library,
+        test_version=test_version,
+        build_gradle_file=build_gradle_file,
+        source_context_overview=prepared_source_context.to_prompt_overview(),
+        source_context_available=prepared_source_context.is_available,
+        source_context_files=prepared_source_context.read_only_files,
+        test_language=test_source_layout.language,
+        test_language_display_name=test_source_layout.display_language,
+        test_source_dir_name=test_source_layout.source_dir_name,
+        metadata_version=metadata_version,
+        library_preparation_preflight_context=library_preparation_preflight_context,
+    )
+
+    model_name = strategy.get("model") or DEFAULT_MODEL_NAME
+    editable_files = list_all_files(test_source_layout.source_root)
+    editable_files.append(build_gradle_file)
+    agent_class = Agent.get_class(strategy_agent)
+    agent = agent_class(
+        model_name=model_name,
+        editable_files=editable_files,
+        read_only_files=list(prepared_source_context.read_only_files),
+        working_dir=reachability_metadata_path,
+        provider=strategy.get("provider"),
+        library=library,
+        task_type="fix-native-image-run",
+        verbose=False,
+        mcps=strategy.get("mcps", []),
+        persistent_instructions=strategy_obj.persistent_instructions,
+    )
+    return strategy_obj, agent, model_name, test_source_layout.source_root
+
+
+def write_metrics(run_metrics: dict, metrics_repo_dir: str, metrics_repo_root: str | None) -> None:
+    """Append run metrics to execution-metrics.json (or local fallback) and write pending metrics."""
+    in_repo_root = metrics_writer.in_metadata_repo_metrics_root(metrics_repo_root)
+    if in_repo_root:
+        metrics_json = metrics_writer.execution_metrics_path(in_repo_root, run_metrics)
+        written = metrics_writer.append_execution_metrics(in_repo_root, run_metrics, METRICS_TASK_TYPE)
+        if written != metrics_json:
+            raise ValueError(f"ERROR: Resolved metrics path {metrics_json} does not match written path {written}")
+    else:
+        metrics_json = os.path.join(metrics_repo_dir, f"{METRICS_TASK_TYPE}.json")
+        metrics_writer.append_run_metrics(run_metrics, metrics_json)
+    if metrics_repo_root:
+        metrics_writer.write_pending_metrics(metrics_repo_root, run_metrics)
+    validate_run_metrics(metrics_json)
+
+
 def main(argv=None) -> int:
     """Run the Native Image fix driver.
 
     The single-run driver (§WF-forge-workflow-drivers) for
-    §WF-native-image-run-fix-workflow.
+    §WF-native-image-run-fix-workflow. `fixTestNativeImageRun` produces the seed;
+    dynamic-access exploration runs only when the new version has uncovered
+    calls; the shared `_finalize_successful_iteration` path (three native-test
+    lanes + dual-coordinate finalization) always gates PR eligibility.
     """
     args = build_parser().parse_args(sys.argv[1:] if argv is None else argv)
 
-    reachability_metadata_path, _ = resolve_repo_roots(
+    reachability_metadata_path, metrics_repo_dir, metrics_repo_root = resolve_repo_paths(
         args.reachability_metadata_path,
         args.metrics_repo_path,
     )
@@ -134,13 +372,19 @@ def main(argv=None) -> int:
         print("[pipeline] Library preparation preflight:")
         print(library_preparation_preflight_context)
 
-    group, artifact, _ = current_coordinates.split(":")
+    resolve_graalvm_java_home()
+    validate_repo_paths(reachability_metadata_path, metrics_repo_dir)
+    os.chdir(reachability_metadata_path)
+
+    group, artifact, old_version = current_coordinates.split(":")
+    library = f"{group}:{artifact}:{new_version}"
     branch = build_ai_branch_name(
         f"fix-native-image-run-{group}-{artifact}-{new_version}",
         cwd=reachability_metadata_path,
     )
     print(f"[pipeline] Creating branch: {branch}")
     create_or_switch_branch(reachability_metadata_path, branch)
+    checkpoint = commit_checkpoint(reachability_metadata_path, library)
 
     print(f"[pipeline] Running fixTestNativeImageRun for: {current_coordinates} -> {new_version}")
     result = run_fix_test_native_image_run(
@@ -150,7 +394,6 @@ def main(argv=None) -> int:
     )
 
     if result.returncode != 0:
-        library = f"{group}:{artifact}:{new_version}"
         generated_metadata_file = os.path.join(
             reachability_metadata_path,
             "metadata",
@@ -186,18 +429,78 @@ def main(argv=None) -> int:
             print("[pipeline] Gradle test failed after Codex metadata fix. Skipping PR creation.", file=sys.stderr)
             return result.returncode
 
-    library = f"{group}:{artifact}:{new_version}"
-    populate_artifact_urls(reachability_metadata_path, library)
+    # Coverage gate: explore only when the new version has uncovered calls.
+    explore = should_explore_new_version(reachability_metadata_path, group, artifact, new_version)
+    if explore:
+        print(f"[pipeline] Preparing version-specific test-suite for {library}")
+        prepare_library_update_target(reachability_metadata_path, group, artifact, new_version)
 
-    if not run_library_finalization(
-        repo_path=reachability_metadata_path,
+    strategy_obj, agent, model_name, tests_root = build_strategy_and_agent(
+        strategy_name=args.strategy_name,
+        reachability_metadata_path=reachability_metadata_path,
         library=library,
         group=group,
         artifact=artifact,
-        library_version=new_version,
-    ):
-        return 1
+        version=new_version,
+        library_preparation_preflight_context=library_preparation_preflight_context,
+    )
 
+    iterations = 0
+    if explore:
+        print(f"[pipeline] Running dynamic-access exploration for {library}")
+        run_result = strategy_obj.run(agent=agent, checkpoint_commit_hash=checkpoint)
+        explore_status, iterations = run_result[0], run_result[1]
+        # Best-effort: a partial or failed explore must not abort. The seed is
+        # already valid and the finalization gate decides PR eligibility.
+        log_stage("explore", f"Dynamic-access exploration completed with status: {explore_status}")
+
+    populate_artifact_urls(reachability_metadata_path, library)
+    finalize_status, _ = strategy_obj._finalize_successful_iteration(base_commit=checkpoint)
+    succeeded = finalize_status in {RUN_STATUS_SUCCESS, SUCCESS_WITH_INTERVENTION_STATUS}
+
+    if succeeded:
+        if finalize_status == SUCCESS_WITH_INTERVENTION_STATUS:
+            print("[pipeline] Finalization produced PR-eligible post-generation intervention output.")
+        ending_commit = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+        run_metrics = metrics_writer.create_java_run_fix_run_metrics_output_json(
+            repo_path=reachability_metadata_path,
+            package=group,
+            artifact=artifact,
+            previous_library_version=old_version,
+            new_library_version=new_version,
+            agent=agent,
+            model_name=model_name,
+            global_iterations=iterations,
+            tests_root=tests_root,
+            strategy_name=args.strategy_name,
+            status=finalize_status,
+            starting_commit=checkpoint,
+            ending_commit=ending_commit,
+            post_generation_intervention=strategy_obj.post_generation_intervention,
+            library_preparation_preflight=library_preparation_preflight,
+        )
+    else:
+        # Keep the generated working-tree state as the debugging surface for the
+        # next maintainer or Forge run (§WF-native-image-run-fix-workflow.5).
+        print("[pipeline] Finalization failed. Skipping PR creation.", file=sys.stderr)
+        ending_commit = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+        run_metrics = create_failure_run_metrics_output(
+            package=group,
+            artifact=artifact,
+            library_version=new_version,
+            agent=agent,
+            model_name=model_name,
+            global_iterations=iterations,
+            strategy_name=args.strategy_name,
+            starting_commit=checkpoint,
+            ending_commit=ending_commit,
+            library_preparation_preflight=library_preparation_preflight,
+        )
+
+    write_metrics(run_metrics, metrics_repo_dir, metrics_repo_root)
+
+    if not succeeded:
+        return 1
     print(f"[pipeline] Workflow succeeded for {current_coordinates}")
     return 0
 

--- a/forge/docs/workflows/native-image-run-fix.md
+++ b/forge/docs/workflows/native-image-run-fix.md
@@ -45,7 +45,7 @@ At a glance:
 ```mermaid
 flowchart TD
     Claim[forge_metadata.py claims<br/>fails-native-image-run issue] --> Entry[fix_ni_run.py]
-    Entry --> Branch[Create branch + checkpoint commit]
+    Entry --> Branch[Create/reset fix-native-image-run branch]
     Branch --> GradleFix[gradlew fixTestNativeImageRun]
     GradleFix --> FixOK{task passed?}
     FixOK -- no --> Metadata{metadata file generated?}
@@ -56,23 +56,26 @@ flowchart TD
     CodexOK -- yes --> Test[gradlew test -Pcoordinates=new version]
     Test --> TestOK{test passed?}
     TestOK -- no --> Fail
-    TestOK -- yes --> Report
-    FixOK -- yes --> Report[generateDynamicAccessCoverageReport<br/>for new coordinate]
+    TestOK -- yes --> Populate[populateArtifactURLs]
+    FixOK -- yes --> Populate
+    Populate --> Checkpoint[Commit seed checkpoint]
+    Checkpoint --> Report[generateDynamicAccessCoverageReport<br/>for new coordinate]
     Report --> Uncovered{uncovered<br/>dynamic-access calls?}
     Uncovered -- yes --> Prep[Prepare version-specific test-suite<br/>split shared index entry]
-    Prep --> Explore[dynamic-access explore phase<br/>merge discovered metadata]
-    Explore --> Finalize
-    Uncovered -- no --> Finalize[_finalize_successful_iteration:<br/>3 native-test lanes + dual-coordinate finalization]
-    Finalize --> FinalOK{finalization passed?}
+    Prep --> Explore{explore?}
+    Uncovered -- no --> Explore
+    Explore -- yes --> DynamicAccess[dynamic-access explore phase<br/>merge discovered metadata]
+    DynamicAccess --> Finalize
+    Explore -- no --> Finalize
+    Finalize[_finalize_successful_iteration:<br/>3 native-test lanes + dual-coordinate finalization] --> FinalOK{finalization passed?}
     FinalOK -- yes --> Metrics[Write run metrics + return success]
     FinalOK -- no --> Fail
 ```
 
 Required behavior:
 
-1. Create a workflow branch named from the group, artifact, and target version,
-   then commit an empty checkpoint as the pre-generation base so finalization and
-   metrics have a clean reference.
+1. Create or reset a workflow branch named from the group, artifact, and target
+   version before changing generated artifacts.
 2. Run `./gradlew fixTestNativeImageRun
    -PtestLibraryCoordinates=<old-coordinate> -PnewLibraryVersion=<new-version>`
    in the complete reachability repo worktree to produce the **seed**.
@@ -85,24 +88,28 @@ Required behavior:
    failed Gradle run (§FS-durable-generation-logs), then rerun
    `./gradlew test -Pcoordinates=<group>:<artifact>:<newVersion>`. If it still
    fails, fail the workflow instead of publishing a partial repair.
-5. **Coverage gate.** Generate the dynamic-access coverage report for the new
+5. Populate artifact URLs for the new coordinate before any source-context
+   preparation, then commit the seed checkpoint. This runs even when exploration
+   will be skipped, because the seeded PR still needs source, test,
+   documentation, and repository URL fields.
+6. **Coverage gate.** Generate the dynamic-access coverage report for the new
    coordinate (`generateDynamicAccessCoverageReport`). Exploration runs only when
    the report has dynamic access with uncovered call sites; an empty or
    fully-covered report skips exploration (and its suite preparation) entirely
    and proceeds straight to finalization, preserving the metadata-first behavior.
-6. **Conditional exploration.** When uncovered calls exist, prepare a
+7. **Conditional exploration.** When uncovered calls exist, prepare a
    version-specific test-suite the same way the explore-then-finalize drivers do
    — the seed leaves the new version sharing the old version's test directory, so
    the shared index entry is split into a version-specific entry that creates
    `tests/src/<group>/<artifact>/<newVersion>/` while preserving the seed
-   metadata (§WF-improve-library-coverage). Then run the dynamic-access explore
-   phase (§WF-dynamic-access-iterative-strategy) against the new version,
-   *merging* any newly discovered metadata into the existing
+   metadata and populated URL fields (§WF-improve-library-coverage). Then run the
+   dynamic-access explore phase (§WF-dynamic-access-iterative-strategy) against
+   the new version, *merging* any newly discovered metadata into the existing
    `metadata/<group>/<artifact>/<newVersion>/reachability-metadata.json`.
    Exploration is best-effort: a partial or failed explore does not abort the
-   workflow, because the seed is already valid and finalization is the gate.
-7. **Mandatory finalization.** Populate artifact URLs for the new coordinate and
-   run the shared `_finalize_successful_iteration` path
+   workflow, because a reset returns to the valid seed checkpoint and
+   finalization is the gate.
+8. **Mandatory finalization.** Run the shared `_finalize_successful_iteration` path
    (§WF-dynamic-access-iterative-strategy): `generateMetadata
    --agentAllowedPackages=fromJar` (the merge step that preserves seed/agent
    metadata), the three native-test lanes (current-defaults latest GraalVM,
@@ -110,7 +117,7 @@ Required behavior:
    §FS-local-ci-equivalent-verification.1) for both the requested and resolved
    metadata coordinates, then `run_library_finalization` per coordinate. Its
    status decides PR eligibility (§GIT-forge-publication).
-8. Write run metrics (previous-vs-new shape) to
+9. Write run metrics (previous-vs-new shape) to
    `stats/<group>/<artifact>/<metadataVersion>/execution-metrics.json` and the
    pending-metrics sidecar consumed by the PR step.
 

--- a/forge/docs/workflows/native-image-run-fix.md
+++ b/forge/docs/workflows/native-image-run-fix.md
@@ -33,15 +33,21 @@ worktree has been prepared by the workflow driver
 
 ## 3. Workflow
 
+`fixTestNativeImageRun` is a **seed generator, not a success gate**. A
+`fixes-native-image-run-fail` fix is PR-eligible only after it passes the same
+shared finalization path — including the three native-test lanes — as every
+other Forge driver (§WF-dynamic-access-iterative-strategy,
+§FS-local-ci-equivalent-verification.1). Finalization always runs; dynamic-access
+exploration runs only when the new version has uncovered call sites.
+
 At a glance:
 
 ```mermaid
 flowchart TD
     Claim[forge_metadata.py claims<br/>fails-native-image-run issue] --> Entry[fix_ni_run.py]
-    Entry --> Branch[Create/reset fix-native-image-run branch]
+    Entry --> Branch[Create branch + checkpoint commit]
     Branch --> GradleFix[gradlew fixTestNativeImageRun]
     GradleFix --> FixOK{task passed?}
-    FixOK -- yes --> Finalize[populateArtifactURLs<br/>run_library_finalization]
     FixOK -- no --> Metadata{metadata file generated?}
     Metadata -- no --> Fail[Return failure]
     Metadata -- yes --> Codex[run_codex_metadata_fix]
@@ -50,49 +56,84 @@ flowchart TD
     CodexOK -- yes --> Test[gradlew test -Pcoordinates=new version]
     Test --> TestOK{test passed?}
     TestOK -- no --> Fail
-    TestOK -- yes --> Finalize
+    TestOK -- yes --> Report
+    FixOK -- yes --> Report[generateDynamicAccessCoverageReport<br/>for new coordinate]
+    Report --> Uncovered{uncovered<br/>dynamic-access calls?}
+    Uncovered -- yes --> Prep[Prepare version-specific test-suite<br/>split shared index entry]
+    Prep --> Explore[dynamic-access explore phase<br/>merge discovered metadata]
+    Explore --> Finalize
+    Uncovered -- no --> Finalize[_finalize_successful_iteration:<br/>3 native-test lanes + dual-coordinate finalization]
     Finalize --> FinalOK{finalization passed?}
-    FinalOK -- yes --> Success[Return success]
+    FinalOK -- yes --> Metrics[Write run metrics + return success]
     FinalOK -- no --> Fail
 ```
 
 Required behavior:
 
-1. Create or reset a workflow branch named from the group, artifact, and target
-   version before changing generated artifacts.
+1. Create a workflow branch named from the group, artifact, and target version,
+   then commit an empty checkpoint as the pre-generation base so finalization and
+   metrics have a clean reference.
 2. Run `./gradlew fixTestNativeImageRun
    -PtestLibraryCoordinates=<old-coordinate> -PnewLibraryVersion=<new-version>`
-   in the complete reachability repo worktree.
+   in the complete reachability repo worktree to produce the **seed**.
 3. If the Gradle task fails before producing
    `metadata/<group>/<artifact>/<newVersion>/reachability-metadata.json`, fail
    the workflow. There is no reliable generated metadata base for Codex to
    repair.
 4. If metadata was generated but the Gradle task failed, invoke Codex metadata
    repair against the new coordinate using the same GraalVM environment as the
-   failed Gradle run (§FS-durable-generation-logs).
-5. After Codex repair succeeds, rerun
+   failed Gradle run (§FS-durable-generation-logs), then rerun
    `./gradlew test -Pcoordinates=<group>:<artifact>:<newVersion>`. If it still
-   fails, fail the workflow instead of publishing a partial repair
-   (§FS-local-ci-equivalent-verification).
-6. Populate artifact URLs for the new coordinate and run the standard library
-   finalization checks before returning success (§GIT-forge-publication).
+   fails, fail the workflow instead of publishing a partial repair.
+5. **Coverage gate.** Generate the dynamic-access coverage report for the new
+   coordinate (`generateDynamicAccessCoverageReport`). Exploration runs only when
+   the report has dynamic access with uncovered call sites; an empty or
+   fully-covered report skips exploration (and its suite preparation) entirely
+   and proceeds straight to finalization, preserving the metadata-first behavior.
+6. **Conditional exploration.** When uncovered calls exist, prepare a
+   version-specific test-suite the same way the explore-then-finalize drivers do
+   — the seed leaves the new version sharing the old version's test directory, so
+   the shared index entry is split into a version-specific entry that creates
+   `tests/src/<group>/<artifact>/<newVersion>/` while preserving the seed
+   metadata (§WF-improve-library-coverage). Then run the dynamic-access explore
+   phase (§WF-dynamic-access-iterative-strategy) against the new version,
+   *merging* any newly discovered metadata into the existing
+   `metadata/<group>/<artifact>/<newVersion>/reachability-metadata.json`.
+   Exploration is best-effort: a partial or failed explore does not abort the
+   workflow, because the seed is already valid and finalization is the gate.
+7. **Mandatory finalization.** Populate artifact URLs for the new coordinate and
+   run the shared `_finalize_successful_iteration` path
+   (§WF-dynamic-access-iterative-strategy): `generateMetadata
+   --agentAllowedPackages=fromJar` (the merge step that preserves seed/agent
+   metadata), the three native-test lanes (current-defaults latest GraalVM,
+   `future-defaults-all`, current-defaults on the GraalVM 25 toolchain —
+   §FS-local-ci-equivalent-verification.1) for both the requested and resolved
+   metadata coordinates, then `run_library_finalization` per coordinate. Its
+   status decides PR eligibility (§GIT-forge-publication).
+8. Write run metrics (previous-vs-new shape) to
+   `stats/<group>/<artifact>/<metadataVersion>/execution-metrics.json` and the
+   pending-metrics sidecar consumed by the PR step.
 
 ## 4. Outputs
 
 Successful runs produce:
 
-- Updated metadata under `metadata/<group>/<artifact>/<newVersion>/`.
-- Updated test/index/stats artifacts produced by the Gradle fix task and final
-  library finalization.
+- Updated metadata under `metadata/<group>/<artifact>/<newVersion>/`, merged from
+  the seed plus any dynamic-access discoveries.
+- When exploration ran, a version-specific test project under
+  `tests/src/<group>/<artifact>/<newVersion>/`; otherwise the metadata-first
+  layout sharing the old version's test directory.
+- Updated index/stats artifacts and dual-coordinate finalization output.
 - Durable logs for the Gradle fix task, Codex metadata fix when used, Gradle
-  retest, and finalization (§FS-durable-generation-logs).
-- A PR-eligible result for publication with the
-  `fixes-native-image-run-fail` label (§GIT-issue-linking).
-
-The workflow currently does not write the same metrics shape as the agent-based
-Java fail-fix and dynamic-access workflows. When metrics are added, they must
-follow the durable logging and local verification contracts before publication
-(§FS-local-ci-equivalent-verification).
+  retest, the explore phase, the three native-test lanes, and finalization
+  (§FS-durable-generation-logs).
+- Run metrics written to
+  `stats/<group>/<artifact>/<metadataVersion>/execution-metrics.json` following
+  the durable logging and local verification contracts
+  (§FS-local-ci-equivalent-verification).
+- A PR-eligible result for publication with the `fixes-native-image-run-fail`
+  label (§GIT-issue-linking), whose body includes the run metrics and an
+  old-vs-new test diff.
 
 ## 5. Failure Rules
 
@@ -101,8 +142,14 @@ The workflow fails when:
 - `fixTestNativeImageRun` fails before producing the new version metadata file.
 - Codex metadata repair exits non-zero or times out.
 - The post-Codex `./gradlew test -Pcoordinates=<new-coordinate>` fails.
-- Artifact URL population or library finalization fails.
-- Required logs for the generation or repair path are not preserved.
+- The shared finalization path fails: any of the three native-test lanes, the
+  dual-coordinate `run_library_finalization`, or artifact URL population
+  (§FS-local-ci-equivalent-verification.1).
+- Required logs for the generation, repair, or finalization path are not
+  preserved.
+
+A best-effort exploration that does not fully cover every uncovered call is **not**
+a failure; only the mandatory finalization gate determines PR eligibility.
 
 Failures must not open a PR or mark the issue done. The saved logs and generated
 working tree state are the debugging surface for the next maintainer or Forge

--- a/forge/git_scripts/make_pr_ni_run_fix.py
+++ b/forge/git_scripts/make_pr_ni_run_fix.py
@@ -4,6 +4,7 @@
 # work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 import argparse
+import json
 import os
 import subprocess
 import sys
@@ -17,15 +18,20 @@ from git_scripts.common_git import (
     find_issue_for_coordinates as find_issue_common,
     format_stats_diff,
     format_forge_revision_section,
+    get_model_display_name,
+    get_agent_name,
     build_ai_branch_name,
     delete_remote_branch_if_exists,
     get_configured_reviewers,
     run_git_transport,
 )
+from git_scripts.make_pr_javac_fix import generate_diff_text
+from utility_scripts.metadata_index import resolve_test_version
 from utility_scripts.metrics_writer import (
     count_metadata_entries,
     count_test_only_metadata_entries,
     collect_version_coverage_metrics,
+    read_pending_metrics,
 )
 from utility_scripts.library_stats import stats_artifact_dir
 from utility_scripts.local_ci_verification import (
@@ -140,6 +146,7 @@ def create_pull_request(
         repo_path: str,
         local_ci_verification: LocalCIVerificationResult | None = None,
         issue_number: int | None = None,
+        metrics_repo_path: str | None = None,
 ):
     """Create a GitHub pull request for the current branch."""
     origin_owner = get_origin_owner(cwd=repo_path)
@@ -158,6 +165,7 @@ def create_pull_request(
         repo_path=repo_path,
         local_ci_verification=local_ci_verification,
         issue_number=issue_number,
+        metrics_repo_path=metrics_repo_path,
     )
     cmd = [
         "gh", "pr", "create",
@@ -175,6 +183,52 @@ def create_pull_request(
     gh(*cmd[1:])
 
 
+def build_forge_metrics_summary_section(metrics_repo_path: str | None) -> str:
+    """Format the strategy/agent/token summary from pending run metrics, when available."""
+    if not metrics_repo_path:
+        return ""
+    try:
+        metrics_entry = read_pending_metrics(metrics_repo_path)
+    except (json.JSONDecodeError, TypeError, FileNotFoundError, OSError):
+        return ""
+    if not isinstance(metrics_entry, dict):
+        return ""
+    metrics = metrics_entry.get("metrics", {})
+    if not isinstance(metrics, dict):
+        metrics = {}
+    strategy_name = metrics_entry.get("strategy_name", "")
+    if not strategy_name and not metrics:
+        return ""
+    return (
+        "\n\n"
+        f"- Strategy: {strategy_name}\n"
+        f"- Agent: {get_agent_name(strategy_name)}\n"
+        f"- Model: {get_model_display_name(strategy_name)}\n"
+        f"- Input tokens: {int(metrics.get('input_tokens_used', 0) or 0)}\n"
+        f"- Cached input tokens: {int(metrics.get('cached_input_tokens_used', 0) or 0)}\n"
+        f"- Output tokens: {int(metrics.get('output_tokens_used', 0) or 0)}\n"
+        f"- Iterations: {int(metrics.get('iterations', 0) or 0)}"
+    )
+
+
+def build_test_comparison_section(group: str, artifact: str, old_version: str, new_version: str, repo_path: str) -> str:
+    """Format an old-vs-new test diff when exploration produced a version-specific suite.
+
+    The metadata-first seed keeps tests shared under the old version (no new-version
+    test dir), so the diff section is emitted only when exploration split a
+    version-specific suite (§WF-native-image-run-fix-workflow.3).
+    """
+    new_test_dir = os.path.join(repo_path, "tests", "src", group, artifact, new_version)
+    if not os.path.isdir(new_test_dir):
+        return ""
+    return (
+        "\n\n**Comparison between existing test version and AI-Generated update**\n\n"
+        "```diff\n"
+        f"{generate_diff_text(group, artifact, old_version, new_version, repo_path)}\n"
+        "```"
+    )
+
+
 def build_pull_request_preview(
         old_coordinates: str,
         new_coordinates: str,
@@ -183,6 +237,7 @@ def build_pull_request_preview(
         repo_path: str,
         local_ci_verification: LocalCIVerificationResult | None = None,
         issue_number: int | None = None,
+        metrics_repo_path: str | None = None,
 ) -> tuple[str, str, bool, bool]:
     """Build the PR title/body without creating a GitHub pull request."""
     issue_no = issue_number if issue_number is not None else find_issue_common(new_coordinates, REPO)
@@ -218,8 +273,10 @@ def build_pull_request_preview(
         f"This PR provides new metadata needed for the {new_coordinates}, "
         f"addressing Native Image run failures caused by changes in the updated library version."
         f"{metrics_section}"
+        f"{build_forge_metrics_summary_section(metrics_repo_path)}"
         f"\n\n{format_forge_revision_section()}"
         f"{format_stats_diff(repo_path, old_coordinates, new_coordinates)}"
+        f"{build_test_comparison_section(group, artifact, old_version, new_version, repo_path)}"
     )
     if severe_metadata_drop:
         body += format_severe_metadata_drop_pr_section(
@@ -315,10 +372,14 @@ def push_current_branch_to_origin(
         cwd=repo_path,
         check=True,
     )
+    # Exploration splits the seed's shared entry into a version-specific one, so
+    # the resolved test version is the new version; otherwise tests stay shared
+    # under the old version (metadata-first seed).
+    resolved_test_version = resolve_test_version(repo_path, group, artifact, new_version)
     stage_and_commit(
         group=group,
         artifact=artifact,
-        test_version=old_version,
+        test_version=resolved_test_version,
         metadata_version=new_version,
         coordinates=new_coordinates,
         repo_path=repo_path,
@@ -360,6 +421,7 @@ def main(argv=None):
         repo_path=repo_path,
         local_ci_verification=local_ci_verification,
         issue_number=issue_number,
+        metrics_repo_path=metrics_repo_path,
     )
 
 

--- a/forge/git_scripts/make_pr_ni_run_fix.py
+++ b/forge/git_scripts/make_pr_ni_run_fix.py
@@ -200,7 +200,7 @@ def build_forge_metrics_summary_section(metrics_repo_path: str | None) -> str:
     if not strategy_name and not metrics:
         return ""
     return (
-        "\n\n"
+        "\n"
         f"- Strategy: {strategy_name}\n"
         f"- Agent: {get_agent_name(strategy_name)}\n"
         f"- Model: {get_model_display_name(strategy_name)}\n"
@@ -259,7 +259,7 @@ def build_pull_request_preview(
     if new_test_entries > 0:
         new_test_entries_line = f"- Test-only metadata entries (new `{new_coordinates}`): {new_test_entries}\n"
     metrics_section = (
-        f"\n\n"
+        f"\n\nSummary:\n"
         f"- Metadata entries (previous `{old_coordinates}`): {previous_entries}\n"
         f"{previous_test_entries_line}"
         f"- Metadata entries (new `{new_coordinates}`): {new_entries}\n"
@@ -269,6 +269,7 @@ def build_pull_request_preview(
     )
     title = f"[Automation] Generated metadata for {new_coordinates}"
     body = (
+        f"## What does this PR do?\n\n"
         f"Fixes: {REPO}#{issue_no}\n\n"
         f"This PR provides new metadata needed for the {new_coordinates}, "
         f"addressing Native Image run failures caused by changes in the updated library version."


### PR DESCRIPTION
## What does this PR do?

Fixes: oracle/graalvm-reachability-metadata#8192

Routes the `fixes-native-image-run-fail` driver (`fix_ni_run.py`) through the
same shared finalization path as every other Forge driver, and adds
dynamic-access exploration on the new version.

### Problem

The native-image run-fix driver finalized through a weaker, divergent path than
every other driver:

- It called the low-level `run_library_finalization` directly instead of the
  shared `WorkflowStrategy._finalize_successful_iteration`. That bypassed the
  three native-test lanes (current-defaults latest GraalVM, `future-defaults-all`,
  current-defaults on the GraalVM 25 toolchain) and the dual-coordinate
  finalization — so a PR could be opened while still red on native runtime lanes.
- `fixTestNativeImageRun` only carried existing metadata forward; it never
  explored call sites that appear only in the *new* version.

### Change

- `fixTestNativeImageRun` is now a **seed generator, not a success gate**. A fix
  is PR-eligible only after passing the shared `_finalize_successful_iteration`
  path (all three native-test lanes + dual-coordinate finalization), which
  **always** runs.
- **Conditional dynamic-access exploration:** after the seed, the new
  coordinate's dynamic-access coverage report is generated. Exploration runs
  only when the report has uncovered call sites — an empty / fully-covered
  report skips suite preparation and exploration entirely and proceeds straight
  to finalization, preserving the metadata-first behavior. When exploring, a
  version-specific test suite is prepared the same way the explore-then-finalize
  drivers do (splitting the shared index entry), and discovered metadata is
  *merged* into the new version. Exploration is best-effort; the seed is already
  valid and finalization is the gate.
- **Metrics + PR diff:** run metrics are written to
  `stats/<group>/<artifact>/<metadataVersion>/execution-metrics.json` and the
  pending-metrics sidecar; the generated PR body now includes the run metrics
  summary and an old-vs-new test diff, matching the java-fix PRs.
- Spec updated first: `forge/docs/workflows/native-image-run-fix.md`
  (§WF-native-image-run-fix-workflow) §3 Workflow / §4 Outputs / §5 Failure
  Rules describe the seed → conditional explore → mandatory finalization flow.
