### PR TITLE
Keep Forge preflight artifacts out of PR worktrees

### DIFF
--- a/forge/docs/orchestration-scripts.md
+++ b/forge/docs/orchestration-scripts.md
@@ -101,6 +101,11 @@ evidence, selected deterministic setup, advisory guidance, and the result of
 applying each deterministic action. A preflight decision must not allow tests to
 rely on untracked downloads, undeclared optional dependencies, or Docker images
 that CI would reject (§FS-local-ci-equivalent-verification).
+The dispatcher stores preflight handoff and prompt/response evidence in an
+ignored per-run `local_repositories/preflight_info/` directory, not in the
+isolated reachability worktree; the workflow receives only the explicit handoff
+path, and durable evidence is the normalized record embedded in run metrics
+(§FS-forge-run-metrics).
 
 If the preflight decision cannot run or returns invalid, unavailable, or unsafe
 output, orchestration must degrade to a recorded no-action advisory result. It

--- a/forge/docs/orchestration-scripts.md
+++ b/forge/docs/orchestration-scripts.md
@@ -81,14 +81,14 @@ workflow driver routes each kind to a different consumer:
   the sole authority for rejecting work CI would not accept.
 
 - **Advisory guidance** is the residual reasoning the agent must apply inside the
-  generated test code (for example, exercise a driver against a stood-up
-  service, or set a system property before a factory lookup). Only this guidance
-  is passed to the workflow as prompt context, and it is evidence, not trusted
-  instructions. Deterministic setup the driver already applied is omitted from
-  the prompt so an iterating workflow does not re-attempt a completed edit; any
-  deterministic item the driver could not apply yet (for example, a `dependency`
-  edit for a new library whose scaffold does not exist until generation) falls
-  back into the advisory guidance so the agent still performs it.
+  generated test code or repo-local test configuration, especially environment
+  variables, system properties, or test initialization. The workflow prompt
+  receives the decision summary, the deterministic setup Forge already applied
+  or found present, and this advisory guidance as evidence, not trusted
+  instructions. Any deterministic item the driver could not apply yet (for
+  example, a `dependency` edit for a new library whose scaffold does not exist
+  until generation) falls back into the advisory guidance so the agent still
+  performs it.
 
 This split is what keeps deterministic, idempotent edits out of the iteration
 loop and confines the prompt to reasoning. The driver — not orchestration and

--- a/forge/fixture_github_issues/library-new-request-dynamic-access.yaml
+++ b/forge/fixture_github_issues/library-new-request-dynamic-access.yaml
@@ -35,13 +35,3 @@ comments:
       dynamic-access path. Keep generated tests if no dynamic-access call sites
       are found so the fixture still verifies routing, metrics, and publication
       handoff.
-library_preparation_preflight_response:
-  action: advisory_preparation
-  summary: "Fixture advisory setup for Google HTTP Client exercises preflight context handoff."
-  agent_guidance: >-
-    Cover HTTP transport-independent data model parsing and serialization paths.
-    Avoid live network calls; use in-memory requests, a mock transport, or
-    byte-array content, and prefer deterministic Google HTTP Client helpers that
-    run without external services.
-  risks:
-    - "Network-dependent tests would not satisfy local CI-equivalent verification."

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -222,6 +222,7 @@ LABEL_NOT_FOR_NATIVE_IMAGE = "not-for-native-image"
 FIXTURE_AUTHENTICATED_USER = "fixture-runner"
 
 SCRATCH_WORKTREE_DIRNAME = "forge_worktrees"
+PREFLIGHT_INFO_DIRNAME = "preflight_info"
 SCRATCH_REVIEW_WORKTREE_DIRNAME = "forge_review_worktrees"
 SCRATCH_FINAL_INDEX_VALIDATION_WORKTREE_DIRNAME = "forge_final_index_validation_worktrees"
 SCRATCH_METRICS_DIRNAME = "forge_run_metrics"
@@ -308,6 +309,7 @@ class ClaimedIssue:
     new_version: str | None = None
     large_library_resume_artifact: str | None = None
     large_library_part: int | None = None
+    preflight_info_path: str | None = None
 
 
 @dataclass(frozen=True)
@@ -4572,6 +4574,19 @@ def build_issue_run_id(issue_number: int) -> str:
     return f"{issue_number}-{uuid.uuid4().hex[:8]}"
 
 
+def create_preflight_info_dir(worktree_path: str) -> str:
+    """Create the ignored per-run directory for preflight handoff and evidence."""
+    run_id = os.path.basename(os.path.abspath(worktree_path))
+    preflight_info_path = os.path.join(
+        get_repo_root(),
+        "local_repositories",
+        PREFLIGHT_INFO_DIRNAME,
+        run_id,
+    )
+    os.makedirs(preflight_info_path, exist_ok=True)
+    return preflight_info_path
+
+
 def build_review_run_id(pr_number: int) -> str:
     """Create a unique ID for an isolated pull-request review run."""
     return f"pr-{pr_number}-{uuid.uuid4().hex[:8]}"
@@ -4719,6 +4734,8 @@ def cleanup_issue_workspace(claimed_issue: ClaimedIssue, canonical_metrics_repo_
         canonical_metrics_repo_path,
         claimed_issue.issue["number"],
     )
+    if claimed_issue.preflight_info_path:
+        shutil.rmtree(claimed_issue.preflight_info_path, ignore_errors=True)
     if claimed_issue.worktree_path in preservation_failed_worktree_paths:
         print(
             (
@@ -4961,6 +4978,7 @@ def claim_issue_for_processing(
             canonical_metrics_repo_path,
             issue["number"],
         )
+        preflight_info_path = create_preflight_info_dir(worktree_path)
         if large_library_resume_artifact:
             large_library_state = LargeLibraryProgressState.load(large_library_resume_artifact)
             large_library_state.save(large_library_state.default_path(scratch_metrics_repo_path))
@@ -4989,6 +5007,7 @@ def claim_issue_for_processing(
         new_version=new_version,
         large_library_resume_artifact=large_library_resume_artifact,
         large_library_part=large_library_part,
+        preflight_info_path=preflight_info_path,
     )
 
 
@@ -5017,11 +5036,13 @@ def build_fixture_claimed_issue(
             canonical_metrics_repo_path,
             issue_number,
         )
+        preflight_info_path = create_preflight_info_dir(worktree_path)
         log_stage(
             "fixture-worktree",
             (
                 f"Created isolated fixture worktree for issue #{issue_number}: "
-                f"worktree={worktree_path}, metrics={scratch_metrics_repo_path}"
+                f"worktree={worktree_path}, metrics={scratch_metrics_repo_path}, "
+                f"preflight={preflight_info_path}"
             ),
         )
     except BaseException as exc:
@@ -5072,6 +5093,7 @@ def build_fixture_claimed_issue(
         issue_coordinates=issue_coordinates,
         current_coordinates=current_coordinates,
         new_version=new_version,
+        preflight_info_path=preflight_info_path,
     )
 
 
@@ -5515,14 +5537,26 @@ def preserve_fixture_preflight_evidence(claimed_issue: ClaimedIssue) -> None:
     )
     os.makedirs(evidence_dir, exist_ok=True)
     evidence_files = [
-        (PENDING_METRICS_FILENAME, "pending-metrics.json"),
-        (LIBRARY_PREPARATION_PREFLIGHT_FILENAME, LIBRARY_PREPARATION_PREFLIGHT_FILENAME),
-        ("library-preflight-prompt.txt", "library-preflight-prompt.txt"),
-        ("library-preflight-response.txt", "library-preflight-response.txt"),
+        (claimed_issue.scratch_metrics_repo_path, PENDING_METRICS_FILENAME, "pending-metrics.json"),
+        (
+            claimed_issue.preflight_info_path or claimed_issue.scratch_metrics_repo_path,
+            LIBRARY_PREPARATION_PREFLIGHT_FILENAME,
+            LIBRARY_PREPARATION_PREFLIGHT_FILENAME,
+        ),
+        (
+            claimed_issue.preflight_info_path or claimed_issue.scratch_metrics_repo_path,
+            "library-preflight-prompt.txt",
+            "library-preflight-prompt.txt",
+        ),
+        (
+            claimed_issue.preflight_info_path or claimed_issue.scratch_metrics_repo_path,
+            "library-preflight-response.txt",
+            "library-preflight-response.txt",
+        ),
     ]
     copied_files: list[str] = []
-    for source_name, target_name in evidence_files:
-        source_path = os.path.join(claimed_issue.scratch_metrics_repo_path, source_name)
+    for source_root, source_name, target_name in evidence_files:
+        source_path = os.path.join(source_root, source_name)
         if not os.path.isfile(source_path):
             continue
         target_path = os.path.join(evidence_dir, target_name)

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -4097,11 +4097,6 @@ def run_library_preparation_preflight(
         strategy_name: str | None,
 ) -> str:
     """Run and persist the library-specific preparation preflight before workflow dispatch."""
-    fixture_response = False
-    if is_fixture_testing_enabled():
-        fixture_response = require_fixture_github_state().get_issue_library_preparation_preflight_response(
-            int(claimed_issue.issue["number"])
-        )
     return run_preflight_decision(
         claimed_issue=claimed_issue,
         strategy_name=strategy_name,
@@ -4109,7 +4104,6 @@ def run_library_preparation_preflight(
         init_agent=init_workflow_agent,
         default_strategy_name=DEFAULT_WORK_QUEUE_STRATEGY_NAME,
         default_model_name=DEFAULT_MODEL_NAME,
-        fixture_response=fixture_response,
     )
 
 
@@ -6508,8 +6502,8 @@ def process_fixture_issues_for_label(
 ) -> int:
     """Run the local fixture issues for one label, sequentially, one `run.log` each.
 
-    Fixture selection is local to the loaded YAML and has no live claim, preflight,
-    or work-queue concurrency to model, so a queue/label run is simply each matching
+    Fixture selection is local to the loaded YAML and has no live claim or
+    work-queue concurrency to model, so a queue/label run is simply each matching
     issue processed in turn under its own issue-scoped tee (§E2E-forge-workflow-testing.2).
     """
     if not environment_already_validated:

--- a/forge/utility_scripts/fixture_github.py
+++ b/forge/utility_scripts/fixture_github.py
@@ -84,7 +84,6 @@ class FixtureIssue:
     comments: list[FixtureComment]
     fixture_path: str
     url: str
-    library_preparation_preflight_response: Any | None = None
 
     def issue_view_payload(self, include_body: bool = False, include_state: bool = True) -> JsonObject:
         payload: JsonObject = {
@@ -127,8 +126,6 @@ class FixtureIssue:
             "comments": [comment.to_json() for comment in self.comments],
             "fixture_path": self.fixture_path,
         }
-        if self.library_preparation_preflight_response is not None:
-            payload["library_preparation_preflight_response"] = self.library_preparation_preflight_response
         return payload
 
 
@@ -172,9 +169,6 @@ class FixtureGitHubState:
 
     def get_issue_fixture_path(self, issue_number: int) -> str:
         return self._issue(issue_number).fixture_path
-
-    def get_issue_library_preparation_preflight_response(self, issue_number: int) -> Any | None:
-        return self._issue(issue_number).library_preparation_preflight_response
 
     def get_issue_project_number(self, issue_number: int) -> int:
         return self._issue(issue_number).project_number
@@ -621,15 +615,6 @@ def normalize_fixture_issue(raw_issue: JsonObject, fixture_path: str) -> Fixture
     blockers = _normalize_blockers(issue, context)
     comments = _normalize_comments(_optional_list(issue, "comments", context, default=[]), context)
     url = _optional_str(issue, "url", context, default=f"fixture://fixture_github_issues/{number}")
-    library_preparation_preflight_response = issue.get("library_preparation_preflight_response")
-    if library_preparation_preflight_response is not None and not isinstance(
-            library_preparation_preflight_response,
-            (dict, str),
-    ):
-        raise FixtureValidationError(
-            f"{context}: `library_preparation_preflight_response` must be an object or string"
-        )
-
     return FixtureIssue(
         number=number,
         title=title,
@@ -644,7 +629,6 @@ def normalize_fixture_issue(raw_issue: JsonObject, fixture_path: str) -> Fixture
         comments=comments,
         fixture_path=os.path.abspath(fixture_path),
         url=url,
-        library_preparation_preflight_response=library_preparation_preflight_response,
     )
 
 

--- a/forge/utility_scripts/library_preparation_preflight.py
+++ b/forge/utility_scripts/library_preparation_preflight.py
@@ -425,6 +425,11 @@ def _preflight_run_mode(fixture_response: Any | None) -> str:
     return "fixture (configured response)"
 
 
+def _preflight_artifact_root(claimed_issue: Any) -> str:
+    """Return the directory used for dispatcher preflight handoff and evidence."""
+    return getattr(claimed_issue, "preflight_info_path", None) or claimed_issue.scratch_metrics_repo_path
+
+
 def _write_and_log_preflight(claimed_issue: Any, record: dict[str, Any]) -> str:
     """Persist the record and log a one-line outcome, covering every decision path."""
     detail = f"status={record.get('status')} action={record.get('action')}"
@@ -438,7 +443,7 @@ def _write_and_log_preflight(claimed_issue: Any, record: dict[str, Any]) -> str:
         "library-preflight",
         f"Preflight decision for issue #{record.get('issue_number')}: {detail}",
     )
-    return write_library_preparation_preflight(claimed_issue.scratch_metrics_repo_path, record)
+    return write_library_preparation_preflight(_preflight_artifact_root(claimed_issue), record)
 
 
 def run_library_preparation_preflight(
@@ -469,8 +474,9 @@ def run_library_preparation_preflight(
         ),
     )
     prompt = _library_preflight_prompt(input_bundle)
+    preflight_artifact_root = _preflight_artifact_root(claimed_issue)
     prompt_path = _write_text_artifact(
-        claimed_issue.scratch_metrics_repo_path,
+        preflight_artifact_root,
         "library-preflight-prompt.txt",
         prompt,
     )
@@ -492,7 +498,7 @@ def run_library_preparation_preflight(
         try:
             response_text = _fixture_response_text(fixture_response)
             raw_response_path = _write_text_artifact(
-                claimed_issue.scratch_metrics_repo_path,
+                preflight_artifact_root,
                 "library-preflight-response.txt",
                 response_text,
             )
@@ -543,13 +549,13 @@ def run_library_preparation_preflight(
         )
         response_text = agent.send_prompt(prompt)
         raw_response_path = _write_text_artifact(
-            claimed_issue.scratch_metrics_repo_path,
+            preflight_artifact_root,
             "library-preflight-response.txt",
             response_text,
         )
         session_log_path = _relative_or_absolute_path(
             getattr(agent, "_session_log_path", None),
-            claimed_issue.scratch_metrics_repo_path,
+            preflight_artifact_root,
         )
         response_payload = _extract_preflight_json_response(response_text)
         record = _completed_library_preflight_record(
@@ -566,7 +572,7 @@ def run_library_preparation_preflight(
         if session_log_path is None and agent is not None:
             session_log_path = _relative_or_absolute_path(
                 getattr(agent, "_session_log_path", None),
-                claimed_issue.scratch_metrics_repo_path,
+                preflight_artifact_root,
             )
         record = _degraded_library_preflight_record(
             claimed_issue,

--- a/forge/utility_scripts/library_preparation_preflight.py
+++ b/forge/utility_scripts/library_preparation_preflight.py
@@ -353,31 +353,30 @@ def _completed_library_preflight_record(
 def _library_preflight_prompt(input_bundle: dict[str, Any]) -> str:
     """Build the LLM prompt instructing the agent to research preparation needs."""
     return (
-        "You are preparing a Forge workflow for a library issue. Decide whether this "
-        "library needs additional setup beyond the normal generated test scaffold, "
-        "such as optional Maven dependencies, a Docker-backed service and its allowed "
-        "image, or library initialization the test must perform before meaningful "
-        "coverage is reachable.\n\n"
+        "You are preparing a Forge workflow for a library issue. Decide whether the "
+        "library needs setup beyond the normal generated test scaffold before "
+        "meaningful coverage is reachable.\n\n"
         "Research the library yourself to make this decision. Investigate the resolved "
         "artifact and its dependencies, how the library is normally used, and its "
         "documentation. The JSON context below is only a starting point, not the limit "
         "of what you may consider. Do not modify the repository or apply any setup "
-        "yourself — return only the decision. The driver applies deterministic setup, "
-        "and local Gradle and Native Image verification remain authoritative.\n\n"
-        "Split any needed setup into two kinds. `deterministic_setup` is a typed list of "
-        "one-time, idempotent edits the driver applies for you; supported kinds:\n"
+        "yourself — return only the decision. Local Gradle and Native Image verification "
+        "remain authoritative.\n\n"
+        "The setup can be one of three things: an extra Maven dependency, a Docker "
+        "image the tests need, or an environment/system property the generated tests "
+        "must set. Represent dependencies and Docker images as `deterministic_setup` "
+        "entries the driver can apply before generation:\n"
         '  - {"kind": "dependency", "coordinate": "group:artifact:version", '
         '"scope": "testImplementation", "reason": "..."}\n'
         '  - {"kind": "docker_image", "image": "name:tag", "slug": "short-slug", "reason": "..."}\n'
-        "`agent_guidance` is concise reasoning the workflow agent must apply inside the generated "
-        "test code (for example, exercise a driver against a stood-up service, or set a system "
-        "property before a factory lookup). Do not restate deterministic edits as guidance.\n\n"
+        "Put environment variables, system properties, and other test-code setup in "
+        "`agent_guidance`. Do not restate deterministic entries as guidance.\n\n"
         "Return a single JSON object with this shape:\n"
         "{\n"
         '  "action": "no_action" | "advisory_preparation",\n'
         '  "summary": "short reason",\n'
-        '  "deterministic_setup": [ ... typed entries as above, if any ... ],\n'
-        '  "agent_guidance": "concise guidance for the workflow agent, if any",\n'
+        '  "deterministic_setup": [ ... dependency or docker_image entries, if any ... ],\n'
+        '  "agent_guidance": "environment/system property/test setup guidance, if any",\n'
         '  "risks": ["risk notes, if any"]\n'
         "}\n\n"
         "Choose no_action unless your research finds concrete evidence that extra setup is needed.\n\n"
@@ -755,6 +754,24 @@ def _describe_setup_entry(entry: dict[str, str]) -> str:
     return str(entry)
 
 
+def _applied_setup_descriptions(preflight: dict[str, Any]) -> list[str]:
+    """Describe deterministic setup already applied or already present."""
+    setup_by_key: dict[tuple[Any, Any], dict[str, str]] = {}
+    for entry in preflight.get("deterministic_setup") or []:
+        if isinstance(entry, dict):
+            setup_by_key[(entry.get("kind"), entry.get("coordinate") or entry.get("slug"))] = entry
+
+    descriptions: list[str] = []
+    for item in preflight.get("applied_setup") or []:
+        if not isinstance(item, dict) or item.get("result") not in {"applied", "already_present"}:
+            continue
+        key = (item.get("kind"), item.get("coordinate") or item.get("slug"))
+        entry = setup_by_key.get(key, item)
+        state = "already present" if item.get("result") == "already_present" else "applied"
+        descriptions.append(f"{_describe_setup_entry(entry)} ({state})")
+    return descriptions
+
+
 def _pending_setup_descriptions(preflight: dict[str, Any]) -> list[str]:
     """Describe deterministic entries the driver did not apply, for agent fallback."""
     results: dict[tuple[Any, Any], Any] = {}
@@ -773,12 +790,7 @@ def _pending_setup_descriptions(preflight: dict[str, Any]) -> list[str]:
 
 
 def format_library_preparation_preflight_context(preflight: dict[str, Any] | None) -> str:
-    """Render the advisory portion of a preflight record for workflow prompt context.
-
-    Deterministic setup the driver already applied is intentionally omitted so an
-    iterating workflow does not re-attempt a completed edit; only advisory guidance
-    and unapplied-setup fallback reach the prompt (§ORCH-forge-orchestration-spec.1.1).
-    """
+    """Render preflight summary, applied setup, and guidance for workflow prompts."""
     if not isinstance(preflight, dict):
         return NO_LIBRARY_PREPARATION_PREFLIGHT_CONTEXT
 
@@ -793,12 +805,15 @@ def format_library_preparation_preflight_context(preflight: dict[str, Any] | Non
         return NO_LIBRARY_PREPARATION_PREFLIGHT_CONTEXT
 
     guidance = str(preflight.get("agent_guidance") or "").strip()
+    applied_setup = _format_bullets(_applied_setup_descriptions(preflight))
     pending_setup = _format_bullets(_pending_setup_descriptions(preflight))
     risks = _format_bullets(preflight.get("risks") or [])
 
-    sections = ["Library preparation preflight produced advisory guidance."]
+    sections = ["Library preparation preflight produced setup context."]
     if summary:
         sections.extend(["", f"Summary: {summary}"])
+    if applied_setup:
+        sections.extend(["", "Already applied by Forge:", applied_setup])
     if guidance:
         sections.extend(["", "Agent guidance:", guidance])
     if pending_setup:

--- a/forge/utility_scripts/library_preparation_preflight.py
+++ b/forge/utility_scripts/library_preparation_preflight.py
@@ -408,22 +408,6 @@ def _write_text_artifact(root: str, file_name: str, content: str) -> str:
     return os.path.relpath(path, root)
 
 
-def _fixture_response_text(fixture_response: Any) -> str:
-    """Serialize a configured fixture response like an agent response body."""
-    if isinstance(fixture_response, str):
-        return fixture_response
-    return json.dumps(fixture_response, indent=2, ensure_ascii=False)
-
-
-def _preflight_run_mode(fixture_response: Any | None) -> str:
-    """Describe how the preflight decision is being produced, for logging."""
-    if fixture_response is False:
-        return "live"
-    if fixture_response is None:
-        return "fixture (no response configured)"
-    return "fixture (configured response)"
-
-
 def _preflight_artifact_root(claimed_issue: Any) -> str:
     """Return the directory used for dispatcher preflight handoff and evidence."""
     return getattr(claimed_issue, "preflight_info_path", None) or claimed_issue.scratch_metrics_repo_path
@@ -452,7 +436,6 @@ def run_library_preparation_preflight(
         init_agent: Callable[..., Any],
         default_strategy_name: str,
         default_model_name: str = DEFAULT_LIBRARY_PREFLIGHT_MODEL_NAME,
-        fixture_response: Any | None = None,
 ) -> str:
     """Run and persist the library-specific preparation preflight before workflow dispatch."""
     selected_strategy_name = (
@@ -468,7 +451,7 @@ def run_library_preparation_preflight(
         "library-preflight",
         (
             f"Running preflight for issue #{claimed_issue.issue['number']} "
-            f"({_preflight_run_mode(fixture_response)}) "
+            "(live) "
             f"library={input_bundle.get('library')} strategy={selected_strategy_name}"
         ),
     )
@@ -482,46 +465,6 @@ def run_library_preparation_preflight(
     raw_response_path: str | None = None
     session_log_path: str | None = None
     model_name = default_model_name
-
-    if fixture_response is None:
-        record = _degraded_library_preflight_record(
-            claimed_issue,
-            input_bundle,
-            "fixture-testing mode did not configure a library preparation preflight response",
-            model_name="fixture-no-response",
-            prompt_path=prompt_path,
-        )
-        return _write_and_log_preflight(claimed_issue, record)
-
-    if fixture_response is not False:
-        try:
-            response_text = _fixture_response_text(fixture_response)
-            raw_response_path = _write_text_artifact(
-                preflight_artifact_root,
-                "library-preflight-response.txt",
-                response_text,
-            )
-            response_payload = _extract_preflight_json_response(response_text)
-            record = _completed_library_preflight_record(
-                claimed_issue,
-                input_bundle,
-                response_payload,
-                "fixture-configured-response",
-                None,
-                prompt_path,
-                raw_response_path,
-                None,
-            )
-        except Exception as exc:
-            record = _degraded_library_preflight_record(
-                claimed_issue,
-                input_bundle,
-                f"{type(exc).__name__}: {exc}",
-                model_name="fixture-configured-response",
-                prompt_path=prompt_path,
-                raw_response_path=raw_response_path,
-            )
-        return _write_and_log_preflight(claimed_issue, record)
 
     strategy = load_strategy_by_name(selected_strategy_name)
     if strategy is None:


### PR DESCRIPTION
Stacked on #8270. This PR fixes issues found while exercising the native-image-run/preflight flow.

## Bugs fixed
- Preflight handoff and evidence files were written into the isolated issue worktree under `forge/`.
- The native-image-run checkpoint path can run broad staging, so those files could be committed into generated PRs even though they are process artifacts.
- Fixture evidence copying assumed preflight artifacts lived beside pending metrics, which tied diagnostic files to the in-repo metrics scratch root.

## Process refinements
- Store preflight JSON/prompt/response under ignored `forge/local_repositories/preflight_info/<run-id>/` instead of the PR worktree.
- Keep `.pending_metrics.json` and normal metrics behavior unchanged under the workflow metrics root.
- Pass the workflow agent a concise setup context that includes the summary, setup already applied by Forge, remaining setup guidance, and risks.
- Simplify the preflight prompt around the actual setup cases: extra dependency, Docker image, or environment/system property guidance.
