### PR TITLE
[GenAI] Test fix for io.smallrye.common:smallrye-common-resource:2.19.0 using gpt-5.5

### DIFF
--- a/metadata/io.smallrye.common/smallrye-common-resource/2.19.0/reachability-metadata.json
+++ b/metadata/io.smallrye.common/smallrye-common-resource/2.19.0/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.smallrye.common.resource.URLResource"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "io.smallrye.common.resource.URLResource"
+      },
+      "type": "sun.util.resources.cldr.CalendarData"
+    }
+  ]
+}

--- a/metadata/io.smallrye.common/smallrye-common-resource/index.json
+++ b/metadata/io.smallrye.common/smallrye-common-resource/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.19.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/smallrye/common/smallrye-common-resource/$version$/smallrye-common-resource-$version$-sources.jar",
+    "repository-url" : "https://github.com/smallrye/smallrye-common",
+    "test-code-url" : "https://github.com/smallrye/smallrye-common/tree/$version$/resource/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/smallrye/common/smallrye-common-resource/$version$/smallrye-common-resource-$version$-javadoc.jar",
+    "description" : "SmallRye Common Resource provides abstractions for locating and loading resources for class loading and related purposes. It includes loaders and resource representations for paths, URLs, JAR files, and in-memory resources.",
     "tested-versions" : [
       "2.19.0"
     ],

--- a/metadata/io.smallrye.common/smallrye-common-resource/index.json
+++ b/metadata/io.smallrye.common/smallrye-common-resource/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.19.0",
+    "tested-versions" : [
+      "2.19.0"
+    ],
+    "allowed-packages" : [
+      "io.smallrye.common.resource"
+    ]
+  },
+  {
     "metadata-version" : "2.14.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/smallrye/common/smallrye-common-resource/$version$/smallrye-common-resource-$version$-sources.jar",
     "repository-url" : "https://github.com/smallrye/smallrye-common/",

--- a/stats/io.smallrye.common/smallrye-common-resource/2.19.0/execution-metrics.json
+++ b/stats/io.smallrye.common/smallrye-common-resource/2.19.0/execution-metrics.json
@@ -1,0 +1,115 @@
+{
+  "fix_java_run_fail:2026-06-09": {
+    "timestamp": "2026-06-09T21:22:21.699454Z",
+    "library": "io.smallrye.common:smallrye-common-resource:2.19.0",
+    "starting_commit": "06752bb66740243a7f5755bcb5ba050fa04d75e8",
+    "ending_commit": "1bfb086558ad57f33fd22fa9489a178f40fe705a",
+    "previous_library": "io.smallrye.common:smallrye-common-resource:2.14.0",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.19.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1515,
+          "missed": 912,
+          "ratio": 0.624227,
+          "total": 2427
+        },
+        "line": {
+          "covered": 372,
+          "missed": 228,
+          "ratio": 0.62,
+          "total": 600
+        },
+        "method": {
+          "covered": 112,
+          "missed": 42,
+          "ratio": 0.727273,
+          "total": 154
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.14.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1271,
+          "missed": 615,
+          "ratio": 0.673913,
+          "total": 1886
+        },
+        "line": {
+          "covered": 334,
+          "missed": 175,
+          "ratio": 0.656189,
+          "total": 509
+        },
+        "method": {
+          "covered": 98,
+          "missed": 16,
+          "ratio": 0.859649,
+          "total": 114
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "degraded",
+      "action": "no_action",
+      "issue_number": 8272,
+      "issue_label": "fails-java-run",
+      "library": "io.smallrye.common:smallrye-common-resource:2.19.0",
+      "summary": "Library preparation preflight did not produce usable advisory setup.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#8272 [Automation] java run fails for io.smallrye.common:smallrye-common-resource:2.19.0; label=fails-java-run; body_chars=8015"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "6 existing test file path(s) included"
+        }
+      ],
+      "current_library": "io.smallrye.common:smallrye-common-resource:2.14.0",
+      "new_version": "2.19.0",
+      "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
+      "model": "oca/gpt-5.5",
+      "prompt_path": "library-preflight-prompt.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/io.smallrye.common:smallrye-common-resource:2.19.0/library-preparation-preflight/pi-generation-2026-06-09T21-13-43-463603Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 33158,
+      "cached_input_tokens_used": 305664,
+      "output_tokens_used": 3001,
+      "iterations": 1,
+      "cost_usd": 0.2428,
+      "tested_library_loc": 372,
+      "metadata_entries": 2,
+      "previous_library_metadata_entries": 2,
+      "code_coverage_percent": 62.0,
+      "previous_library_coverage_percent": 65.62
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.smallrye.common/smallrye-common-resource/2.19.0/src/test/java/io_smallrye_common/smallrye_common_resource/Smallrye_common_resourceTest.java",
+      "metadata_file": "metadata/io.smallrye.common/smallrye-common-resource/2.19.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.smallrye.common/smallrye-common-resource/2.19.0/stats.json
+++ b/stats/io.smallrye.common/smallrye-common-resource/2.19.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.19.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1515,
+        "missed" : 912,
+        "ratio" : 0.624227,
+        "total" : 2427
+      },
+      "line" : {
+        "covered" : 372,
+        "missed" : 228,
+        "ratio" : 0.62,
+        "total" : 600
+      },
+      "method" : {
+        "covered" : 112,
+        "missed" : 42,
+        "ratio" : 0.727273,
+        "total" : 154
+      }
+    }
+  } ]
+}

--- a/tests/src/io.smallrye.common/smallrye-common-resource/2.19.0/.gitignore
+++ b/tests/src/io.smallrye.common/smallrye-common-resource/2.19.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.smallrye.common/smallrye-common-resource/2.19.0/build.gradle
+++ b/tests/src/io.smallrye.common/smallrye-common-resource/2.19.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.smallrye.common:smallrye-common-resource:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.smallrye.common/smallrye-common-resource/2.19.0/gradle.properties
+++ b/tests/src/io.smallrye.common/smallrye-common-resource/2.19.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.smallrye.common:smallrye-common-resource:2.19.0
+library.version = 2.19.0
+metadata.dir = io.smallrye.common/smallrye-common-resource/2.19.0/

--- a/tests/src/io.smallrye.common/smallrye-common-resource/2.19.0/settings.gradle
+++ b/tests/src/io.smallrye.common/smallrye-common-resource/2.19.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.smallrye.common.smallrye-common-resource_tests'

--- a/tests/src/io.smallrye.common/smallrye-common-resource/2.19.0/src/test/java/io_smallrye_common/smallrye_common_resource/Smallrye_common_resourceTest.java
+++ b/tests/src/io.smallrye.common/smallrye-common-resource/2.19.0/src/test/java/io_smallrye_common/smallrye_common_resource/Smallrye_common_resourceTest.java
@@ -1,0 +1,337 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_smallrye_common.smallrye_common_resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+
+import io.smallrye.common.resource.JarFileResourceLoader;
+import io.smallrye.common.resource.MemoryInputStream;
+import io.smallrye.common.resource.MemoryResource;
+import io.smallrye.common.resource.PathResource;
+import io.smallrye.common.resource.PathResourceLoader;
+import io.smallrye.common.resource.Resource;
+import io.smallrye.common.resource.ResourceLoader;
+import io.smallrye.common.resource.ResourceURLConnection;
+import io.smallrye.common.resource.ResourceUtils;
+import io.smallrye.common.resource.URLResource;
+import io.smallrye.common.resource.URLResourceLoader;
+import org.junit.jupiter.api.Test;
+
+public class Smallrye_common_resourceTest {
+    @Test
+    void canonicalizesRelativePathsWithoutEscapingAboveTheResourceRoot() {
+        assertThat(ResourceUtils.canonicalizeRelativePath("")).isEmpty();
+        assertThat(ResourceUtils.canonicalizeRelativePath("/")).isEmpty();
+        assertThat(ResourceUtils.canonicalizeRelativePath("./assets//images/./logo.png"))
+                .isEqualTo("assets/images/logo.png");
+        assertThat(ResourceUtils.canonicalizeRelativePath("assets/config/../data/./sample.txt"))
+                .isEqualTo("assets/data/sample.txt");
+        assertThat(ResourceUtils.canonicalizeRelativePath("../../outside.txt")).isEqualTo("outside.txt");
+    }
+
+    @Test
+    void memoryResourceProvidesRepeatableStreamsBuffersCopiesAndUrls() throws IOException {
+        byte[] content = bytes("smallrye resource\nline two");
+        MemoryResource resource = new MemoryResource("folder/./sample.txt", content);
+
+        assertThat(resource.pathName()).isEqualTo("folder/sample.txt");
+        assertThat(resource.size()).isEqualTo(content.length);
+        assertThat(resource.modifiedTime()).isNotNull();
+        assertThat(resource.codeSigners()).isEmpty();
+        assertThat(resource.isDirectory()).isFalse();
+        assertThat(resource.asString(StandardCharsets.UTF_8)).isEqualTo("smallrye resource\nline two");
+        assertThat(readRemaining(resource.asBuffer())).isEqualTo(content);
+        assertThat(resource.asBuffer().isReadOnly()).isTrue();
+
+        try (MemoryInputStream stream = resource.openStream()) {
+            assertThat(stream.markSupported()).isTrue();
+            assertThat(stream.available()).isEqualTo(content.length);
+            assertThat(stream.read()).isEqualTo('s');
+            stream.mark(100);
+            assertThat(stream.skip(8)).isEqualTo(8);
+            stream.reset();
+            assertThat(stream.readAllBytes()).isEqualTo(bytes("mallrye resource\nline two"));
+        }
+        assertThatThrownBy(() -> {
+            try (MemoryInputStream stream = resource.openStream()) {
+                stream.close();
+                stream.read();
+            }
+        }).isInstanceOf(IOException.class).hasMessage("Stream closed");
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        assertThat(resource.copyTo(outputStream)).isEqualTo(content.length);
+        assertThat(outputStream.toByteArray()).isEqualTo(content);
+
+        ByteArrayOutputStream channelOutput = new ByteArrayOutputStream();
+        assertThat(resource.copyTo(Channels.newChannel(channelOutput))).isEqualTo(content.length);
+        assertThat(channelOutput.toByteArray()).isEqualTo(content);
+
+        Path copiedFile = Files.createTempFile("smallrye-resource-memory", ".txt");
+        try {
+            assertThat(resource.copyTo(copiedFile)).isEqualTo(content.length);
+            assertThat(Files.readAllBytes(copiedFile)).isEqualTo(content);
+        } finally {
+            Files.deleteIfExists(copiedFile);
+        }
+
+        URL url = resource.url();
+        assertThat(url).isSameAs(resource.url());
+        assertThat(url.getProtocol()).isEqualTo("memory");
+        URLConnection connection = url.openConnection();
+        assertThat(connection).isInstanceOf(ResourceURLConnection.class);
+        ResourceURLConnection resourceConnection = (ResourceURLConnection) connection;
+        assertThat(resourceConnection.resource()).isSameAs(resource);
+        assertThat(resourceConnection.getContentLengthLong()).isEqualTo(content.length);
+        assertThat(resourceConnection.getContentType()).isEqualTo("application/octet-stream");
+        assertThat(resourceConnection.getLastModified()).isEqualTo(resource.modifiedTime().toEpochMilli());
+        assertThat((byte[]) resourceConnection.getContent()).isEqualTo(content);
+        assertThat(readRemaining((ByteBuffer) resourceConnection.getContent(ByteBuffer.class))).isEqualTo(content);
+        assertThat(resourceConnection.getContent(Resource.class)).isSameAs(resource);
+        try (InputStream stream = resourceConnection.getInputStream()) {
+            assertThat(stream.readAllBytes()).isEqualTo(content);
+        }
+    }
+
+    @Test
+    void pathResourceLoaderFindsFilesDirectoriesChildrenAndManifest() throws IOException {
+        Path root = Files.createTempDirectory("smallrye-resource-path");
+        Path nested = Files.createDirectories(root.resolve("nested"));
+        Path leaf = nested.resolve("leaf.txt");
+        Files.writeString(leaf, "leaf content", StandardCharsets.UTF_8);
+        Files.createDirectories(root.resolve("META-INF"));
+        Files.writeString(root.resolve("META-INF/MANIFEST.MF"),
+                "Manifest-Version: 1.0\r\nCreated-By: SmallRye resource test\r\n\r\n",
+                StandardCharsets.UTF_8);
+
+        PathResourceLoader loader = new PathResourceLoader(root);
+
+        assertThat(loader.baseUrl().getProtocol()).isEqualTo("file");
+        assertThat(loader.findResource("missing.txt")).isNull();
+        assertThat(loader.manifest().getMainAttributes().getValue("Created-By"))
+                .isEqualTo("SmallRye resource test");
+
+        Resource fileResource = loader.findResource("nested/./leaf.txt");
+        assertThat(fileResource).isInstanceOf(PathResource.class);
+        assertThat(fileResource.pathName()).isEqualTo("nested/leaf.txt");
+        assertThat(fileResource.isDirectory()).isFalse();
+        assertThat(fileResource.size()).isEqualTo(bytes("leaf content").length);
+        assertThat(fileResource.asString(StandardCharsets.UTF_8)).isEqualTo("leaf content");
+        assertThat(fileResource.modifiedTime()).isNotNull();
+        assertThat(Files.isSameFile(((PathResource) fileResource).path(), leaf)).isTrue();
+        try (InputStream stream = fileResource.url().openStream()) {
+            assertThat(stream.readAllBytes()).isEqualTo(bytes("leaf content"));
+        }
+
+        Resource directory = loader.findResource("nested");
+        assertThat(directory).isNotNull();
+        assertThat(directory.isDirectory()).isTrue();
+        assertThat(resourcePathNames(directory.openDirectoryStream())).containsExactly("nested/leaf.txt");
+
+        Resource childResource = loader.getChildLoader("nested").findResource("leaf.txt");
+        assertThat(childResource).isNotNull();
+        assertThat(childResource.asString(StandardCharsets.UTF_8)).isEqualTo("leaf content");
+    }
+
+    @Test
+    void jarResourceLoaderReadsManifestFilesDirectoriesAndChildResources() throws IOException {
+        Path jarPath = Files.createTempFile("smallrye-resource", ".jar");
+        createSampleJar(jarPath);
+
+        try (JarFileResourceLoader loader = new JarFileResourceLoader(jarPath)) {
+            assertThat(loader.baseUrl().getProtocol()).isEqualTo("file");
+            assertThat(loader.manifest().getMainAttributes().getValue("Implementation-Title"))
+                    .isEqualTo("smallrye-resource-test");
+            assertThat(loader.findResource("absent.txt")).isNull();
+
+            Resource file = loader.findResource("assets/./data.txt");
+            assertThat(file.pathName()).isEqualTo("assets/data.txt");
+            assertThat(file.isDirectory()).isFalse();
+            assertThat(file.size()).isEqualTo(bytes("jar data").length);
+            assertThat(file.asString(StandardCharsets.UTF_8)).isEqualTo("jar data");
+            assertThat(file.codeSigners()).isEmpty();
+            assertThat(file.url().getProtocol()).isEqualTo("jar");
+            assertThat(((ResourceURLConnection) file.url().openConnection()).resource()).isSameAs(file);
+
+            Resource directory = loader.findResource("assets");
+            assertThat(directory).isNotNull();
+            assertThat(directory.isDirectory()).isTrue();
+            assertThat(resourcePathNames(directory.openDirectoryStream()))
+                    .containsExactly("assets/data.txt", "assets/nested");
+
+            Resource child = loader.getChildLoader("assets").findResource("nested/item.txt");
+            assertThat(child).isNotNull();
+            assertThat(child.asString(StandardCharsets.UTF_8)).isEqualTo("nested item");
+        }
+    }
+
+    @Test
+    void jarResourceLoaderCanReadAnArchiveSuppliedAsAResource() throws IOException {
+        Path jarPath = Files.createTempFile("smallrye-resource-memory-archive", ".jar");
+        createSampleJar(jarPath);
+        MemoryResource archiveResource = new MemoryResource("archives/sample.jar", Files.readAllBytes(jarPath));
+
+        try (JarFileResourceLoader loader = new JarFileResourceLoader(archiveResource)) {
+            Resource file = loader.findResource("assets/data.txt");
+
+            assertThat(file).isNotNull();
+            assertThat(loader.baseUrl()).isSameAs(archiveResource.url());
+            assertThat(file.asString(StandardCharsets.UTF_8)).isEqualTo("jar data");
+            assertThat(loader.manifest().getMainAttributes().getValue("Implementation-Title"))
+                    .isEqualTo("smallrye-resource-test");
+        }
+    }
+
+    @Test
+    void jarResourceLoaderResolvesRuntimeVersionedEntriesFromMultiReleaseArchives() throws IOException {
+        Path jarPath = Files.createTempFile("smallrye-resource-multi-release", ".jar");
+        createMultiReleaseJar(jarPath);
+
+        try (JarFileResourceLoader loader = new JarFileResourceLoader(jarPath)) {
+            Resource resource = loader.findResource("versioned/data.txt");
+
+            assertThat(resource).isNotNull();
+            assertThat(resource.pathName()).isEqualTo("versioned/data.txt");
+            assertThat(resource.asString(StandardCharsets.UTF_8)).isEqualTo("runtime-specific data");
+        }
+    }
+
+    @Test
+    void urlResourceLoaderWrapsFileUrlResources() throws IOException {
+        Path root = Files.createTempDirectory("smallrye-resource-url");
+        Path nested = Files.createDirectories(root.resolve("nested"));
+        Files.writeString(nested.resolve("from-url.txt"), "url content", StandardCharsets.UTF_8);
+
+        URLResourceLoader loader = new URLResourceLoader(root.toUri().toURL());
+        Resource resource = loader.findResource("nested/./from-url.txt");
+
+        assertThat(loader.baseUrl()).isEqualTo(root.toUri().toURL());
+        assertThat(resource).isInstanceOf(URLResource.class);
+        assertThat(resource.pathName()).isEqualTo("nested/from-url.txt");
+        assertThat(resource.url().getProtocol()).isEqualTo("file");
+        assertThat(resource.size()).isEqualTo(bytes("url content").length);
+        assertThat(resource.modifiedTime()).isNotNull();
+        assertThat(resource.asString(StandardCharsets.UTF_8)).isEqualTo("url content");
+    }
+
+    @Test
+    void resourceReadStreamTransformsContentClosesStreamAndUnwrapsIoFailures() throws IOException {
+        MemoryResource resource = new MemoryResource("stream/data.txt", bytes("stream content"));
+        MemoryInputStream[] openedStreams = new MemoryInputStream[1];
+
+        String value = resource.readStream(inputStream -> {
+            openedStreams[0] = (MemoryInputStream) inputStream;
+            try {
+                return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8).toUpperCase(Locale.ROOT);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        });
+
+        assertThat(value).isEqualTo("STREAM CONTENT");
+        assertThatThrownBy(() -> openedStreams[0].read()).isInstanceOf(IOException.class)
+                .hasMessage("Stream closed");
+        assertThatThrownBy(() -> resource.readStream(inputStream -> {
+            throw new UncheckedIOException(new IOException("reader failed"));
+        })).isInstanceOf(IOException.class).hasMessage("reader failed");
+    }
+
+    @Test
+    void emptyResourceLoaderAndDefaultMethodsAreSafeNoops() throws IOException {
+        ResourceLoader emptyLoader = ResourceLoader.EMPTY;
+
+        assertThat(emptyLoader.findResource("anything.txt")).isNull();
+        assertThat(emptyLoader.getChildLoader("")).isSameAs(emptyLoader);
+        assertThat(emptyLoader.getChildLoader("child").findResource("anything.txt")).isNull();
+        assertThat(emptyLoader.manifest()).isNull();
+        assertThatThrownBy(emptyLoader::baseUrl).isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Base URL is not supported by this resource loader");
+        assertThatCode(emptyLoader::release).doesNotThrowAnyException();
+        assertThatCode(emptyLoader::close).doesNotThrowAnyException();
+    }
+
+    private static byte[] bytes(String value) {
+        return value.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static byte[] readRemaining(ByteBuffer buffer) {
+        byte[] content = new byte[buffer.remaining()];
+        buffer.get(content);
+        return content;
+    }
+
+    private static List<String> resourcePathNames(DirectoryStream<Resource> directoryStream) throws IOException {
+        try (DirectoryStream<Resource> stream = directoryStream) {
+            List<String> names = new ArrayList<>();
+            for (Resource resource : stream) {
+                names.add(resource.pathName());
+            }
+            return names;
+        }
+    }
+
+    private static void createSampleJar(Path jarPath) throws IOException {
+        Manifest manifest = new Manifest();
+        Attributes attributes = manifest.getMainAttributes();
+        attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        attributes.putValue("Implementation-Title", "smallrye-resource-test");
+
+        try (JarOutputStream outputStream = new JarOutputStream(Files.newOutputStream(jarPath), manifest)) {
+            putDirectory(outputStream, "assets/");
+            putEntry(outputStream, "assets/data.txt", "jar data");
+            putDirectory(outputStream, "assets/nested/");
+            putEntry(outputStream, "assets/nested/item.txt", "nested item");
+        }
+    }
+
+    private static void createMultiReleaseJar(Path jarPath) throws IOException {
+        Manifest manifest = new Manifest();
+        Attributes attributes = manifest.getMainAttributes();
+        attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        attributes.putValue("Multi-Release", "true");
+
+        try (JarOutputStream outputStream = new JarOutputStream(Files.newOutputStream(jarPath), manifest)) {
+            putEntry(outputStream, "versioned/data.txt", "base data");
+            putEntry(outputStream, "META-INF/versions/9/versioned/data.txt", "runtime-specific data");
+        }
+    }
+
+    private static void putDirectory(JarOutputStream outputStream, String name) throws IOException {
+        JarEntry entry = new JarEntry(name);
+        outputStream.putNextEntry(entry);
+        outputStream.closeEntry();
+    }
+
+    private static void putEntry(JarOutputStream outputStream, String name, String content) throws IOException {
+        JarEntry entry = new JarEntry(name);
+        outputStream.putNextEntry(entry);
+        outputStream.write(bytes(content));
+        outputStream.closeEntry();
+    }
+}

--- a/tests/src/io.smallrye.common/smallrye-common-resource/2.19.0/src/test/java/io_smallrye_common/smallrye_common_resource/Smallrye_common_resourceTest.java
+++ b/tests/src/io.smallrye.common/smallrye-common-resource/2.19.0/src/test/java/io_smallrye_common/smallrye_common_resource/Smallrye_common_resourceTest.java
@@ -209,16 +209,22 @@ public class Smallrye_common_resourceTest {
     }
 
     @Test
-    void jarResourceLoaderResolvesRuntimeVersionedEntriesFromMultiReleaseArchives() throws IOException {
+    void jarResourceLoaderReadsBaseAndExplicitVersionedEntriesFromMultiReleaseArchives() throws IOException {
         Path jarPath = Files.createTempFile("smallrye-resource-multi-release", ".jar");
         createMultiReleaseJar(jarPath);
 
         try (JarFileResourceLoader loader = new JarFileResourceLoader(jarPath)) {
-            Resource resource = loader.findResource("versioned/data.txt");
+            assertThat(loader.manifest().getMainAttributes().getValue("Multi-Release")).isEqualTo("true");
 
-            assertThat(resource).isNotNull();
-            assertThat(resource.pathName()).isEqualTo("versioned/data.txt");
-            assertThat(resource.asString(StandardCharsets.UTF_8)).isEqualTo("runtime-specific data");
+            Resource baseResource = loader.findResource("versioned/data.txt");
+            assertThat(baseResource).isNotNull();
+            assertThat(baseResource.pathName()).isEqualTo("versioned/data.txt");
+            assertThat(baseResource.asString(StandardCharsets.UTF_8)).isEqualTo("base data");
+
+            Resource versionedResource = loader.findResource("META-INF/versions/9/versioned/data.txt");
+            assertThat(versionedResource).isNotNull();
+            assertThat(versionedResource.pathName()).isEqualTo("META-INF/versions/9/versioned/data.txt");
+            assertThat(versionedResource.asString(StandardCharsets.UTF_8)).isEqualTo("runtime-specific data");
         }
     }
 

--- a/tests/src/io.smallrye.common/smallrye-common-resource/2.19.0/user-code-filter.json
+++ b/tests/src/io.smallrye.common/smallrye-common-resource/2.19.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "io.smallrye.common.resource.**"
+    }
+  ]
+}

--- a/tests/src/io.smallrye.common/smallrye-common-resource/2.19.0/user-code-filter.json
+++ b/tests/src/io.smallrye.common/smallrye-common-resource/2.19.0/user-code-filter.json
@@ -5,6 +5,9 @@
     },
     {
       "includeClasses" : "io.smallrye.common.resource.**"
+    },
+    {
+      "includeClasses" : "io_smallrye_common.smallrye_common_resource.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #8272

This PR provides test fixes and new metadata for io.smallrye.common:smallrye-common-resource:2.19.0, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 33158
- Cached input tokens: 305664
- Output tokens: 3001
- Metadata entries: 2
- Iterations: 1
- Library coverage percentage: 62.0
- Previous library version metadata entries: 2
- Previous library version coverage percentage: 65.62

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `0a83934bae88e1bcbbe256143056d13e01842075`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.smallrye.common:smallrye-common-resource:2.14.0: 0/0 covered calls (100.00%)
- io.smallrye.common:smallrye-common-resource:2.19.0: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.smallrye.common:smallrye-common-resource:2.14.0: 1271/1886 (67.39%)
- io.smallrye.common:smallrye-common-resource:2.19.0: 1515/2427 (62.42%)

**Line:**
- io.smallrye.common:smallrye-common-resource:2.14.0: 334/509 (65.62%)
- io.smallrye.common:smallrye-common-resource:2.19.0: 372/600 (62.00%)

**Method:**
- io.smallrye.common:smallrye-common-resource:2.14.0: 98/114 (85.96%)
- io.smallrye.common:smallrye-common-resource:2.19.0: 112/154 (72.73%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/io.smallrye.common/smallrye-common-resource/2.14.0/src/test/java/io_smallrye_common/smallrye_common_resource/Smallrye_common_resourceTest.java 2/tests/src/io.smallrye.common/smallrye-common-resource/2.19.0/src/test/java/io_smallrye_common/smallrye_common_resource/Smallrye_common_resourceTest.java
index 15f90e72e7..a5ed674e34 100644
--- 1/tests/src/io.smallrye.common/smallrye-common-resource/2.14.0/src/test/java/io_smallrye_common/smallrye_common_resource/Smallrye_common_resourceTest.java
+++ 2/tests/src/io.smallrye.common/smallrye-common-resource/2.19.0/src/test/java/io_smallrye_common/smallrye_common_resource/Smallrye_common_resourceTest.java
@@ -209,16 +209,22 @@ public class Smallrye_common_resourceTest {
     }
 
     @Test
-    void jarResourceLoaderResolvesRuntimeVersionedEntriesFromMultiReleaseArchives() throws IOException {
+    void jarResourceLoaderReadsBaseAndExplicitVersionedEntriesFromMultiReleaseArchives() throws IOException {
         Path jarPath = Files.createTempFile("smallrye-resource-multi-release", ".jar");
         createMultiReleaseJar(jarPath);
 
         try (JarFileResourceLoader loader = new JarFileResourceLoader(jarPath)) {
-            Resource resource = loader.findResource("versioned/data.txt");
+            assertThat(loader.manifest().getMainAttributes().getValue("Multi-Release")).isEqualTo("true");
 
-            assertThat(resource).isNotNull();
-            assertThat(resource.pathName()).isEqualTo("versioned/data.txt");
-            assertThat(resource.asString(StandardCharsets.UTF_8)).isEqualTo("runtime-specific data");
+            Resource baseResource = loader.findResource("versioned/data.txt");
+            assertThat(baseResource).isNotNull();
+            assertThat(baseResource.pathName()).isEqualTo("versioned/data.txt");
+            assertThat(baseResource.asString(StandardCharsets.UTF_8)).isEqualTo("base data");
+
+            Resource versionedResource = loader.findResource("META-INF/versions/9/versioned/data.txt");
+            assertThat(versionedResource).isNotNull();
+            assertThat(versionedResource.pathName()).isEqualTo("META-INF/versions/9/versioned/data.txt");
+            assertThat(versionedResource.asString(StandardCharsets.UTF_8)).isEqualTo("runtime-specific data");
         }
     }
 
diff --git 1/tests/src/io.smallrye.common/smallrye-common-resource/2.14.0/user-code-filter.json 2/tests/src/io.smallrye.common/smallrye-common-resource/2.19.0/user-code-filter.json
index 7620c46b93..0279d6b9ae 100644
--- 1/tests/src/io.smallrye.common/smallrye-common-resource/2.14.0/user-code-filter.json
+++ 2/tests/src/io.smallrye.common/smallrye-common-resource/2.19.0/user-code-filter.json
@@ -5,6 +5,9 @@
     },
     {
       "includeClasses" : "io.smallrye.common.resource.**"
+    },
+    {
+      "includeClasses" : "io_smallrye_common.smallrye_common_resource.**"
     }
   ]
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
