### PR TITLE
[GenAI] Test fix for com.fasterxml.jackson.module:jackson-module-scala_3:2.15.0 using gpt-5.5

### DIFF
--- a/metadata/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/reachability-metadata.json
+++ b/metadata/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/reachability-metadata.json
@@ -1,0 +1,591 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.deser.EnumerationDeserializer"
+      },
+      "type" : "com.fasterxml.jackson.core.sym.CharsToNameCanonicalizer$Bucket[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.JacksonModule"
+      },
+      "type" : "com.fasterxml.jackson.databind.deser.Deserializers[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.deser.EnumerationDeserializerModule"
+      },
+      "type" : "com.fasterxml.jackson.databind.deser.Deserializers[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.deser.SeqDeserializerModule"
+      },
+      "type" : "com.fasterxml.jackson.databind.deser.Deserializers[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.deser.SortedMapDeserializerModule"
+      },
+      "type" : "com.fasterxml.jackson.databind.deser.Deserializers[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.deser.SortedSetDeserializerModule"
+      },
+      "type" : "com.fasterxml.jackson.databind.deser.Deserializers[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.deser.SymbolDeserializerModule"
+      },
+      "type" : "com.fasterxml.jackson.databind.deser.Deserializers[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.deser.UnsortedMapDeserializerModule"
+      },
+      "type" : "com.fasterxml.jackson.databind.deser.Deserializers[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.deser.UnsortedSetDeserializerModule"
+      },
+      "type" : "com.fasterxml.jackson.databind.deser.Deserializers[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.deser.UntypedObjectDeserializerModule"
+      },
+      "type" : "com.fasterxml.jackson.databind.deser.Deserializers[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.deser.EnumerationDeserializerModule"
+      },
+      "type" : "com.fasterxml.jackson.databind.deser.KeyDeserializers[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.ScalaAnnotationIntrospectorModule"
+      },
+      "type" : "com.fasterxml.jackson.databind.deser.ValueInstantiators[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.ScalaAnnotationIntrospectorModule"
+      },
+      "type" : "com.fasterxml.jackson.databind.ext.Java7HandlersImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.JacksonModule"
+      },
+      "type" : "com.fasterxml.jackson.databind.ser.Serializers[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.ser.EitherSerializerModule"
+      },
+      "type" : "com.fasterxml.jackson.databind.ser.Serializers[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.ser.OptionSerializerModule"
+      },
+      "type" : "com.fasterxml.jackson.databind.ser.Serializers[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.ser.SymbolSerializerModule"
+      },
+      "type" : "com.fasterxml.jackson.databind.ser.Serializers[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.ser.TupleSerializerModule"
+      },
+      "type" : "com.fasterxml.jackson.databind.ser.Serializers[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$"
+      },
+      "type" : "com.fasterxml.jackson.module.scala.introspect.PropertyDescriptor[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$"
+      },
+      "type" : "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$"
+      },
+      "type" : "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$"
+      },
+      "type" : "java.lang.reflect.Field[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$"
+      },
+      "type" : "java.lang.reflect.Method[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.ser.EnumerationSerializer"
+      },
+      "type" : "scala.Enumeration$Value",
+      "fields" : [
+        {
+          "name" : "$outer"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.ScalaAnnotationIntrospectorModule"
+      },
+      "type" : "scala.Product",
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.ScalaAnnotationIntrospectorModule"
+      },
+      "type" : "scala.Equals",
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$"
+      },
+      "type" : "scala.Tuple2[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$"
+      },
+      "type" : "scala.Tuple2",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Object",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.deser.TupleDeserializer"
+      },
+      "type" : "scala.Tuple3",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Object",
+            "java.lang.Object",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$"
+      },
+      "type" : "scala.Tuple3[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.deser.UnsortedMapDeserializerModule$$anon$1"
+      },
+      "type" : "scala.collection.concurrent.INodeBase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.JacksonModule"
+      },
+      "type" : "com.fasterxml.jackson.module.scala.JacksonModule$"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.JacksonModule"
+      },
+      "type" : "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.JacksonModule"
+      },
+      "type" : "com.fasterxml.jackson.module.scala.JacksonModule$",
+      "fields" : [
+        {
+          "name" : "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.DefaultScalaModule$"
+      },
+      "type" : "com.fasterxml.jackson.module.scala.DefaultScalaModule$",
+      "fields" : [
+        {
+          "name" : "MODULE$"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.JacksonModule$"
+      },
+      "type" : "com.fasterxml.jackson.module.scala.JacksonModule$",
+      "fields" : [
+        {
+          "name" : "MODULE$"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.JavaTypeable$"
+      },
+      "type" : "com.fasterxml.jackson.module.scala.JavaTypeable$"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.JavaTypeable$"
+      },
+      "type" : "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.JacksonModule"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.DefaultScalaModule$"
+      },
+      "type" : "com.fasterxml.jackson.module.scala.DefaultScalaModule$",
+      "fields" : [
+        {
+          "name" : "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.JavaParameterIntrospector$"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.JavaParameterIntrospector$"
+      },
+      "type" : "java.lang.reflect.Method[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.JavaParameterIntrospector$"
+      },
+      "type" : "scala.Tuple4[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.JavaParameterIntrospector$"
+      },
+      "type" : "scala.Tuple4",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Object",
+            "java.lang.Object",
+            "java.lang.Object",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.deser.JavaEnumDeserializerResolver"
+      },
+      "type" : "com.fasterxml.jackson.module.scala.introspect.EnumValueIntrospector$"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.ScalaAnnotationIntrospectorModule"
+      },
+      "type" : "scala.collection.Map",
+      "methods" : [
+        {
+          "name" : "apply",
+          "parameterTypes" : [
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.deser.EnumerationDeserializer"
+      },
+      "type" : "scala.collection.Map",
+      "methods" : [
+        {
+          "name" : "apply",
+          "parameterTypes" : [
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$"
+      },
+      "type" : "scala.Tuple4[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$"
+      },
+      "type" : "scala.Tuple4",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Object",
+            "java.lang.Object",
+            "java.lang.Object",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.ser.EnumerationSerializer"
+      },
+      "type" : "scala.runtime.EnumerationValues"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.ser.EnumerationSerializer"
+      },
+      "type" : "scala.runtime.EnumerationValues$"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.ser.EnumerationSerializer"
+      },
+      "type" : "scala.runtime.EnumValue"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.ser.EnumerationSerializer"
+      },
+      "type" : "scala.runtime.EnumValue$"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.deser.ScalaObjectDeserializerModule$"
+      },
+      "type" : "com.fasterxml.jackson.module.scala.deser.ScalaObjectDeserializerModule$",
+      "fields" : [
+        {
+          "name" : "MODULE$"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.deser.UntypedObjectDeserializerResolver$"
+      },
+      "type" : "com.fasterxml.jackson.module.scala.deser.UntypedObjectDeserializerResolver$"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.deser.GenericFactoryDeserializerResolver"
+      },
+      "type" : "int[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.deser.GenericMapFactoryDeserializerResolver"
+      },
+      "type" : "int[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.deser.GenericFactoryDeserializerResolver"
+      },
+      "type" : "int[][]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.deser.GenericMapFactoryDeserializerResolver"
+      },
+      "type" : "int[][]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.deser.GenericFactoryDeserializerResolver"
+      },
+      "type" : "scala.Tuple2[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.deser.GenericMapFactoryDeserializerResolver"
+      },
+      "type" : "scala.Tuple2[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.deser.UntypedObjectDeserializerResolver$"
+      },
+      "type" : "com.fasterxml.jackson.module.scala.deser.UntypedObjectDeserializerResolver$",
+      "fields" : [
+        {
+          "name" : "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.util.ClassW$$anon$1"
+      },
+      "type" : "java.util.ArrayList",
+      "allPublicFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.util.ClassW$$anon$1"
+      },
+      "type" : "java.util.LinkedHashMap",
+      "allPublicFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.util.ClassW$$anon$1"
+      },
+      "type" : "com.fasterxml.jackson.module.scala.util.ClassW$$anon$1",
+      "fields" : [
+        {
+          "name" : "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.util.OptionW$$anon$1"
+      },
+      "type" : "com.fasterxml.jackson.module.scala.util.OptionW$$anon$1",
+      "fields" : [
+        {
+          "name" : "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.util.StringW$$anon$1"
+      },
+      "type" : "com.fasterxml.jackson.module.scala.util.StringW$$anon$1",
+      "fields" : [
+        {
+          "name" : "0bitmap$1"
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.JacksonModule$"
+      },
+      "glob" : "com/fasterxml/jackson/module/scala/build.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.util.ClassW$$anon$1"
+      },
+      "glob" : "java/util/ArrayList.tasty"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.util.ClassW$$anon$1"
+      },
+      "glob" : "java/util/LinkedHashMap.tasty"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$"
+      },
+      "glob" : "com_fasterxml_jackson_module/jackson_module_scala_3/BeanIntrospectorDefaultedValue.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$"
+      },
+      "glob" : "com_fasterxml_jackson_module/jackson_module_scala_3/BeanIntrospectorDefaultedValue.tasty"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$"
+      },
+      "glob" : "com_fasterxml_jackson_module/jackson_module_scala_3/BeanIntrospectorDefaultedValue$.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$"
+      },
+      "glob" : "com_fasterxml_jackson_module/jackson_module_scala_3/BeanIntrospectorAccessorBean.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$"
+      },
+      "glob" : "com_fasterxml_jackson_module/jackson_module_scala_3/BeanIntrospectorAccessorBean.tasty"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.ScalaAnnotationIntrospectorModule"
+      },
+      "glob" : "com_fasterxml_jackson_module/jackson_module_scala_3/EnumResolverEnvelope.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.ScalaAnnotationIntrospectorModule"
+      },
+      "glob" : "com_fasterxml_jackson_module/jackson_module_scala_3/EnumResolverEnvelope.tasty"
+    }
+  ]
+}

--- a/metadata/com.fasterxml.jackson.module/jackson-module-scala_3/index.json
+++ b/metadata/com.fasterxml.jackson.module/jackson-module-scala_3/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.15.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/module/jackson-module-scala_3/$version$/jackson-module-scala_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/FasterXML/jackson-module-scala",
+    "test-code-url" : "https://github.com/FasterXML/jackson-module-scala/tree/v$version$/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/module/jackson-module-scala_3/$version$/jackson-module-scala_3-$version$-javadoc.jar",
+    "description" : "Jackson Module Scala adds Jackson databind support for Scala-specific types and language constructs. It provides serializers and deserializers for case classes, collections, maps, tuples, options, enumerations, and related Scala values so Scala applications can use Jackson object mapping.",
     "language" : {
       "name" : "scala",
       "version" : "3"

--- a/metadata/com.fasterxml.jackson.module/jackson-module-scala_3/index.json
+++ b/metadata/com.fasterxml.jackson.module/jackson-module-scala_3/index.json
@@ -1,6 +1,19 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.15.0",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "2.15.0"
+    ],
+    "allowed-packages" : [
+      "com.fasterxml.jackson.module.scala"
+    ]
+  },
+  {
     "metadata-version" : "2.13.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/module/jackson-module-scala_3/$version$/jackson-module-scala_3-$version$-sources.jar",
     "repository-url" : "https://github.com/FasterXML/jackson-module-scala",

--- a/stats/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/execution-metrics.json
+++ b/stats/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/execution-metrics.json
@@ -1,0 +1,139 @@
+{
+  "fix_java_run_fail:2026-06-09": {
+    "timestamp": "2026-06-09T22:05:32.255090Z",
+    "library": "com.fasterxml.jackson.module:jackson-module-scala_3:2.15.0",
+    "starting_commit": "71b31936cb14b214e785044d27ecf7a0e45999c8",
+    "ending_commit": "f9ce5af71e1d970b5f62dc12755f887a2bf57877",
+    "previous_library": "com.fasterxml.jackson.module:jackson-module-scala_3:2.13.2",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.15.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 25,
+            "totalCalls": 25
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 27,
+        "totalCalls": 27
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5239,
+          "missed": 13248,
+          "ratio": 0.283388,
+          "total": 18487
+        },
+        "line": {
+          "covered": 635,
+          "missed": 1021,
+          "ratio": 0.383454,
+          "total": 1656
+        },
+        "method": {
+          "covered": 358,
+          "missed": 1510,
+          "ratio": 0.191649,
+          "total": 1868
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.13.2",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 25,
+            "totalCalls": 25
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 27,
+        "totalCalls": 27
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5005,
+          "missed": 11823,
+          "ratio": 0.297421,
+          "total": 16828
+        },
+        "line": {
+          "covered": 592,
+          "missed": 759,
+          "ratio": 0.438194,
+          "total": 1351
+        },
+        "method": {
+          "covered": 336,
+          "missed": 1295,
+          "ratio": 0.206009,
+          "total": 1631
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "degraded",
+      "action": "no_action",
+      "issue_number": 8271,
+      "issue_label": "fails-java-run",
+      "library": "com.fasterxml.jackson.module:jackson-module-scala_3:2.15.0",
+      "summary": "Library preparation preflight did not produce usable advisory setup.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#8271 [Automation] java run fails for com.fasterxml.jackson.module:jackson-module-scala_3:2.15.0; label=fails-java-run; body_chars=8015"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "12 existing test file path(s) included"
+        }
+      ],
+      "current_library": "com.fasterxml.jackson.module:jackson-module-scala_3:2.13.2",
+      "new_version": "2.15.0",
+      "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
+      "model": "oca/gpt-5.5",
+      "prompt_path": "library-preflight-prompt.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/com.fasterxml.jackson.module:jackson-module-scala_3:2.15.0/library-preparation-preflight/pi-generation-2026-06-09T21-53-35-488337Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 21796,
+      "cached_input_tokens_used": 121856,
+      "output_tokens_used": 954,
+      "iterations": 1,
+      "cost_usd": 0.0895,
+      "tested_library_loc": 635,
+      "metadata_entries": 99,
+      "test_only_metadata_entries": 21,
+      "previous_library_metadata_entries": 75,
+      "previous_library_test_only_metadata_entries": 21,
+      "code_coverage_percent": 38.35,
+      "previous_library_coverage_percent": 43.82
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/src/test/scala/com_fasterxml_jackson_module/jackson_module_scala_3/EnumerationSerializerTest.scala",
+      "metadata_file": "metadata/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/stats.json
+++ b/stats/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "2.15.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 25,
+          "totalCalls" : 25
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 27,
+      "totalCalls" : 27
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 5239,
+        "missed" : 13248,
+        "ratio" : 0.283388,
+        "total" : 18487
+      },
+      "line" : {
+        "covered" : 635,
+        "missed" : 1021,
+        "ratio" : 0.383454,
+        "total" : 1656
+      },
+      "method" : {
+        "covered" : 358,
+        "missed" : 1510,
+        "ratio" : 0.191649,
+        "total" : 1868
+      }
+    }
+  } ]
+}

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/.gitignore
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/build.gradle
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.fasterxml.jackson.module:jackson-module-scala_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/gradle.properties
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.fasterxml.jackson.module:jackson-module-scala_3:2.15.0
+library.version = 2.15.0
+metadata.dir = com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/settings.gradle
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.fasterxml.jackson.module.jackson-module-scala_3_tests'

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,84 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$"
+      },
+      "type" : "com_fasterxml_jackson_module.jackson_module_scala_3.BeanIntrospectorDefaultedValue",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$"
+      },
+      "type" : "com_fasterxml_jackson_module.jackson_module_scala_3.BeanIntrospectorDefaultedValue$",
+      "fields" : [
+        {
+          "name" : "MODULE$"
+        }
+      ],
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$"
+      },
+      "type" : "com_fasterxml_jackson_module.jackson_module_scala_3.BeanIntrospectorAccessorBean",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$"
+      },
+      "type" : "com_fasterxml_jackson_module.jackson_module_scala_3.BeanIntrospectorAccessorBean$"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.ScalaAnnotationIntrospectorModule"
+      },
+      "type" : "com_fasterxml_jackson_module.jackson_module_scala_3.EnumResolverEnvelope",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "methods" : [
+        {
+          "name" : "state_$eq",
+          "parameterTypes" : [
+            "scala.Enumeration$Value"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.scala.introspect.BeanIntrospector$"
+      },
+      "type" : "com_fasterxml_jackson_module.jackson_module_scala_3.EnumResolverEnvelope$"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_module.jackson_module_scala_3.EnumerationDeserializerFixture$"
+      },
+      "type" : "com_fasterxml_jackson_module.jackson_module_scala_3.EnumerationDeserializerFixture$",
+      "fields" : [
+        {
+          "name" : "MODULE$"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_module.jackson_module_scala_3.EnumerationSerializerFixture$"
+      },
+      "type" : "com_fasterxml_jackson_module.jackson_module_scala_3.EnumerationSerializerFixture$",
+      "fields" : [
+        {
+          "name" : "MODULE$"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/src/test/scala/com_fasterxml_jackson_module/jackson_module_scala_3/BeanIntrospectorTest.scala
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/src/test/scala/com_fasterxml_jackson_module/jackson_module_scala_3/BeanIntrospectorTest.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_module.jackson_module_scala_3
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.fasterxml.jackson.module.scala.introspect.BeanDescriptor
+import com.fasterxml.jackson.module.scala.introspect.BeanIntrospector
+import com.fasterxml.jackson.module.scala.introspect.PropertyDescriptor
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class BeanIntrospectorTest {
+  private val mapper: ObjectMapper = new ObjectMapper().registerModule(DefaultScalaModule)
+
+  @Test
+  def appliesScalaConstructorDefaultsDuringDeserialization(): Unit = {
+    val value: BeanIntrospectorDefaultedValue =
+      mapper.readValue("""{"name":"sample"}""", classOf[BeanIntrospectorDefaultedValue])
+
+    assertThat(value).isEqualTo(BeanIntrospectorDefaultedValue("sample", 7))
+  }
+
+  @Test
+  def exposesConstructorDefaultMetadataForCaseClassParameters(): Unit = {
+    val descriptor: BeanDescriptor = BeanIntrospector(classOf[BeanIntrospectorDefaultedValue])
+    val countProperty: Option[PropertyDescriptor] = descriptor.properties.find(_.name == "count")
+
+    assertThat(countProperty.isDefined).isTrue()
+    assertThat(countProperty.get.param.isDefined).isTrue()
+
+    val defaultSupplier: Option[() => AnyRef] = countProperty.get.param.flatMap(_.defaultValue)
+    assertThat(defaultSupplier.isDefined).isTrue()
+    assertThat(defaultSupplier.get.apply()).isEqualTo(7)
+  }
+
+  @Test
+  def discoversScalaGetterSetterAndLazyValProperties(): Unit = {
+    val descriptor: BeanDescriptor = BeanIntrospector(classOf[BeanIntrospectorAccessorBean])
+    val propertyNames: Set[String] = descriptor.properties.map(_.name).toSet
+
+    assertThat(propertyNames.contains("nickname")).isTrue()
+    assertThat(propertyNames.contains("computedNickname")).isTrue()
+  }
+
+  @Test
+  def bindsScalaSetterDiscoveredByTheRegisteredModule(): Unit = {
+    val bean: BeanIntrospectorAccessorBean =
+      mapper.readValue("""{"nickname":"Ada"}""", classOf[BeanIntrospectorAccessorBean])
+
+    assertThat(bean.nickname).isEqualTo("Ada")
+    assertThat(mapper.writeValueAsString(bean)).contains("\"nickname\":\"Ada\"")
+  }
+}
+
+final case class BeanIntrospectorDefaultedValue(name: String, count: Int = 7)
+
+class BeanIntrospectorAccessorBean() {
+  private var storedNickname: String = "initial"
+
+  lazy val computedNickname: String = s"$storedNickname-computed"
+
+  def nickname: String = storedNickname
+
+  def nickname_=(value: String): Unit = {
+    storedNickname = value
+  }
+}

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/src/test/scala/com_fasterxml_jackson_module/jackson_module_scala_3/EnumResolverTest.scala
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/src/test/scala/com_fasterxml_jackson_module/jackson_module_scala_3/EnumResolverTest.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_module.jackson_module_scala_3
+
+import com.fasterxml.jackson.core.`type`.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.fasterxml.jackson.module.scala.JsonScalaEnumeration
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+import scala.annotation.meta.field
+
+class EnumResolverTest {
+  private val mapper: ObjectMapper = new ObjectMapper().registerModule(DefaultScalaModule)
+
+  @Test
+  def deserializesAnnotatedEnumerationValueFromString(): Unit = {
+    val value: EnumResolverEnvelope =
+      mapper.readValue("""{"state":"Published"}""", classOf[EnumResolverEnvelope])
+
+    assertThat(value.state).isEqualTo(EnumResolverFixture.Published)
+  }
+}
+
+object EnumResolverFixture extends Enumeration {
+  val Draft: Value = Value("Draft")
+  val Published: Value = Value("Published")
+}
+
+class EnumResolverFixtureType extends TypeReference[EnumResolverFixture.type]
+
+class EnumResolverEnvelope {
+  @(JsonScalaEnumeration @field)(classOf[EnumResolverFixtureType])
+  var state: EnumResolverFixture.Value = EnumResolverFixture.Draft
+}

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/src/test/scala/com_fasterxml_jackson_module/jackson_module_scala_3/EnumerationDeserializerTest.scala
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/src/test/scala/com_fasterxml_jackson_module/jackson_module_scala_3/EnumerationDeserializerTest.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_module.jackson_module_scala_3
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class EnumerationDeserializerTest {
+  private val mapper: ObjectMapper = new ObjectMapper().registerModule(DefaultScalaModule)
+
+  @Test
+  def deserializesLegacyScalaEnumerationObjectShape(): Unit = {
+    val enumClassName: String = EnumerationDeserializerFixture.getClass.getName.stripSuffix("$")
+    val json: String = s"""{"enumClass":"$enumClassName","value":"Medium"}"""
+
+    val value: scala.Enumeration#Value = mapper.readValue(json, classOf[scala.Enumeration#Value])
+
+    assertThat(value).isEqualTo(EnumerationDeserializerFixture.Medium)
+  }
+}
+
+object EnumerationDeserializerFixture extends Enumeration {
+  val Low: Value = Value("Low")
+  val Medium: Value = Value("Medium")
+  val High: Value = Value("High")
+}

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/src/test/scala/com_fasterxml_jackson_module/jackson_module_scala_3/EnumerationSerializerTest.scala
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/src/test/scala/com_fasterxml_jackson_module/jackson_module_scala_3/EnumerationSerializerTest.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_module.jackson_module_scala_3
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class EnumerationSerializerTest {
+  private val mapper: ObjectMapper = new ObjectMapper().registerModule(DefaultScalaModule)
+
+  @Test
+  def serializesLegacyScalaEnumerationObjectShape(): Unit = {
+    val json: String = mapper.writeValueAsString(EnumerationSerializerFixture.Running)
+    val tree: JsonNode = mapper.readTree(json)
+
+    val expectedEnumClass: String = EnumerationSerializerFixture.getClass.getName.stripSuffix("$")
+
+    assertThat(tree.get("enumClass").asText()).isEqualTo(expectedEnumClass)
+    assertThat(tree.get("value").asText()).isEqualTo("Running")
+  }
+}
+
+object EnumerationSerializerFixture extends Enumeration {
+  val Waiting: Value = Value("Waiting")
+  val Running: Value = Value("Running")
+  val Finished: Value = Value("Finished")
+}

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/src/test/scala/com_fasterxml_jackson_module/jackson_module_scala_3/ScalaObjectDeserializerTest.scala
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/src/test/scala/com_fasterxml_jackson_module/jackson_module_scala_3/ScalaObjectDeserializerTest.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_module.jackson_module_scala_3
+
+import com.fasterxml.jackson.databind.Module
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.deser.ScalaObjectDeserializerModule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ScalaObjectDeserializerTest {
+  private val mapper: ObjectMapper = new ObjectMapper().registerModule(ScalaObjectDeserializerModule)
+
+  @Test
+  def deserializesScalaObjectAsItsSingletonInstance(): Unit = {
+    val value: Module = mapper.readValue("{}", ScalaObjectDeserializerModule.getClass)
+
+    assertThat(value).isSameAs(ScalaObjectDeserializerModule)
+    assertThat(value.getModuleName).isEqualTo("JacksonModule")
+  }
+}

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/src/test/scala/com_fasterxml_jackson_module/jackson_module_scala_3/ScalaObjectDeserializerTest.scala
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/src/test/scala/com_fasterxml_jackson_module/jackson_module_scala_3/ScalaObjectDeserializerTest.scala
@@ -20,6 +20,6 @@ class ScalaObjectDeserializerTest {
     val value: Module = mapper.readValue("{}", ScalaObjectDeserializerModule.getClass)
 
     assertThat(value).isSameAs(ScalaObjectDeserializerModule)
-    assertThat(value.getModuleName).isEqualTo("JacksonModule")
+    assertThat(value.getModuleName).isEqualTo("ScalaObjectDeserializerModule")
   }
 }

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/src/test/scala/com_fasterxml_jackson_module/jackson_module_scala_3/TupleDeserializerTest.scala
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/src/test/scala/com_fasterxml_jackson_module/jackson_module_scala_3/TupleDeserializerTest.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_module.jackson_module_scala_3
+
+import com.fasterxml.jackson.core.`type`.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class TupleDeserializerTest {
+  private val mapper: ObjectMapper = new ObjectMapper().registerModule(DefaultScalaModule)
+
+  @Test
+  def deserializesParameterizedScalaTupleFromArray(): Unit = {
+    val value: (String, Int) =
+      mapper.readValue("""["Ada", 7]""", new TypeReference[(String, Int)] {})
+
+    assertThat(value).isEqualTo(("Ada", 7))
+  }
+}

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/user-code-filter.json
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.fasterxml.jackson.module.scala.**"
+    },
+    {
+      "includeClasses" : "com_fasterxml_jackson_module.jackson_module_scala_3.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #8271

This PR provides test fixes and new metadata for com.fasterxml.jackson.module:jackson-module-scala_3:2.15.0, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 21796
- Cached input tokens: 121856
- Output tokens: 954
- Metadata entries: 99
- Test-only metadata entries: 21
- Iterations: 1
- Library coverage percentage: 38.35
- Previous library version metadata entries: 75
- Previous library version test-only metadata entries: 21
- Previous library version coverage percentage: 43.82

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `cd8c173737df2ff5320d094ed4c8ce44614c13f7`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.fasterxml.jackson.module:jackson-module-scala_3:2.13.2: 27/27 covered calls (100.00%)
- com.fasterxml.jackson.module:jackson-module-scala_3:2.15.0: 27/27 covered calls (100.00%)

**Reflection:**
- com.fasterxml.jackson.module:jackson-module-scala_3:2.13.2: 25/25 covered calls (100.00%)
- com.fasterxml.jackson.module:jackson-module-scala_3:2.15.0: 25/25 covered calls (100.00%)

**Resources:**
- com.fasterxml.jackson.module:jackson-module-scala_3:2.13.2: 2/2 covered calls (100.00%)
- com.fasterxml.jackson.module:jackson-module-scala_3:2.15.0: 2/2 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.fasterxml.jackson.module:jackson-module-scala_3:2.13.2: 5005/16828 (29.74%)
- com.fasterxml.jackson.module:jackson-module-scala_3:2.15.0: 5239/18487 (28.34%)

**Line:**
- com.fasterxml.jackson.module:jackson-module-scala_3:2.13.2: 592/1351 (43.82%)
- com.fasterxml.jackson.module:jackson-module-scala_3:2.15.0: 635/1656 (38.35%)

**Method:**
- com.fasterxml.jackson.module:jackson-module-scala_3:2.13.2: 336/1631 (20.60%)
- com.fasterxml.jackson.module:jackson-module-scala_3:2.15.0: 358/1868 (19.16%)

**Comparison between existing test version and AI-Generated update**

```diff

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
