### PR TITLE
[GenAI] Add support for com.squareup.moshi:moshi:1.15.2 using gpt-5.5

### DIFF
--- a/metadata/com.squareup.moshi/moshi/1.15.2/reachability-metadata.json
+++ b/metadata/com.squareup.moshi/moshi/1.15.2/reachability-metadata.json
@@ -1,0 +1,416 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.AdapterMethodsFactory"
+      },
+      "type": "com.squareup.moshi.JsonAdapter"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.ClassFactory"
+      },
+      "type": "com.squareup.moshi.JsonEncodingException"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.AdapterMethodsFactory"
+      },
+      "type": "com.squareup.moshi.JsonReader"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.AdapterMethodsFactory"
+      },
+      "type": "com.squareup.moshi.JsonWriter"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.internal.Util"
+      },
+      "type": "com_squareup_moshi.moshi.ConcreteMoshiCaseJsonAdapter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.squareup.moshi.Moshi"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.internal.Util"
+      },
+      "type": "com_squareup_moshi.moshi.ConcreteNoArgCaseJsonAdapter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.internal.Util"
+      },
+      "type": "com_squareup_moshi.moshi.DefaultsConstructorCase"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.internal.Util"
+      },
+      "type": "com_squareup_moshi.moshi.GenericMoshiCaseJsonAdapter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.squareup.moshi.Moshi",
+            "java.lang.reflect.Type[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.internal.Util"
+      },
+      "type": "com_squareup_moshi.moshi.GenericTypeArrayOnlyCaseJsonAdapter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.reflect.Type[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.Types"
+      },
+      "type": "com_squareup_moshi.moshi.QualifiedFieldHolder"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.RecordJsonAdapter"
+      },
+      "type": "com_squareup_moshi.moshi.RecordPayload",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String",
+            "int",
+            "boolean"
+          ]
+        },
+        {
+          "name": "count",
+          "parameterTypes": []
+        },
+        {
+          "name": "enabled",
+          "parameterTypes": []
+        },
+        {
+          "name": "name",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.RecordJsonAdapter$1"
+      },
+      "type": "com_squareup_moshi.moshi.RecordPayload"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.AdapterMethodsFactory"
+      },
+      "type": "com_squareup_moshi.moshi.StreamingDistance"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.AdapterMethodsFactory"
+      },
+      "type": "com_squareup_moshi.moshi.StreamingDistanceAdapter"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.AdapterMethodsFactory$AdapterMethod"
+      },
+      "type": "com_squareup_moshi.moshi.StreamingDistanceAdapter",
+      "methods": [
+        {
+          "name": "fromJson",
+          "parameterTypes": [
+            "com.squareup.moshi.JsonReader",
+            "com.squareup.moshi.JsonAdapter"
+          ]
+        },
+        {
+          "name": "toJson",
+          "parameterTypes": [
+            "com.squareup.moshi.JsonWriter",
+            "com_squareup_moshi.moshi.StreamingDistance",
+            "com.squareup.moshi.JsonAdapter"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.RecordJsonAdapter"
+      },
+      "type": "java.lang.Class[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.RecordJsonAdapter$1"
+      },
+      "type": "java.lang.Class[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.AdapterMethodsFactory"
+      },
+      "type": "java.lang.Integer"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.JsonReader$Options"
+      },
+      "type": "java.lang.Integer[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.AdapterMethodsFactory"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.AdapterMethodsFactory$AdapterMethod"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.ClassJsonAdapter$1"
+      },
+      "type": "java.lang.Throwable"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.AdapterMethodsFactory"
+      },
+      "type": "java.lang.annotation.Annotation[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.AdapterMethodsFactory$AdapterMethod"
+      },
+      "type": "java.lang.annotation.Annotation[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.internal.Util"
+      },
+      "type": "java.lang.annotation.Annotation[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.AdapterMethodsFactory"
+      },
+      "type": "java.lang.annotation.Annotation[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.AdapterMethodsFactory$AdapterMethod"
+      },
+      "type": "java.lang.annotation.Annotation[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.internal.Util"
+      },
+      "type": "java.lang.annotation.ElementType[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.RecordJsonAdapter"
+      },
+      "type": "java.lang.invoke.BoundMethodHandle$Species_LI"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.RecordJsonAdapter"
+      },
+      "type": "java.lang.invoke.Invokers"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.RecordJsonAdapter"
+      },
+      "type": "java.lang.invoke.LambdaForm$Name[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.RecordJsonAdapter"
+      },
+      "type": "java.lang.invoke.MethodHandleImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.internal.Util"
+      },
+      "type": "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.ClassJsonAdapter$1"
+      },
+      "type": "java.lang.reflect.Field[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.AdapterMethodsFactory"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.JsonReader$Options"
+      },
+      "type": "okio.ByteString[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.RecordJsonAdapter"
+      },
+      "type": "sun.invoke.util.ValueConversions"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.AdapterMethodsFactory"
+      },
+      "type": {
+        "proxy": [
+          "com.squareup.moshi.FromJson"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.internal.Util"
+      },
+      "type": {
+        "proxy": [
+          "com.squareup.moshi.JsonClass"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.Types"
+      },
+      "type": {
+        "proxy": [
+          "com.squareup.moshi.JsonQualifier"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.AdapterMethodsFactory"
+      },
+      "type": {
+        "proxy": [
+          "com.squareup.moshi.ToJson"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.Types"
+      },
+      "type": {
+        "proxy": [
+          "com_squareup_moshi.moshi.UppercaseQualifier"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.AdapterMethodsFactory"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.Types"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.internal.Util"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.internal.Util"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Target"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.Types"
+      },
+      "type": {
+        "proxy": [
+          "kotlin.Metadata"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.internal.Util"
+      },
+      "type": {
+        "proxy": [
+          "kotlin.Metadata"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.Types"
+      },
+      "type": {
+        "proxy": [
+          "kotlin.annotation.Retention"
+        ]
+      }
+    }
+  ]
+}

--- a/metadata/com.squareup.moshi/moshi/1.15.2/reachability-metadata.json
+++ b/metadata/com.squareup.moshi/moshi/1.15.2/reachability-metadata.json
@@ -1,570 +1,386 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "com.squareup.moshi.AdapterMethodsFactory"
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.AdapterMethodsFactory"
       },
-      "type": "com.squareup.moshi.JsonAdapter"
+      "type" : "com.squareup.moshi.JsonAdapter"
     },
     {
-      "condition": {
-        "typeReached": "com.squareup.moshi.ClassFactory"
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.ClassFactory"
       },
-      "type": "com.squareup.moshi.JsonDataException"
+      "type" : "com.squareup.moshi.JsonDataException"
     },
     {
-      "condition": {
-        "typeReached": "com.squareup.moshi.ClassFactory$1"
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.ClassFactory$1"
       },
-      "type": "com.squareup.moshi.JsonDataException",
-      "methods": [
+      "type" : "com.squareup.moshi.JsonDataException",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.squareup.moshi.ClassFactory"
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.ClassFactory"
       },
-      "type": "com.squareup.moshi.JsonEncodingException"
+      "type" : "com.squareup.moshi.JsonEncodingException"
     },
     {
-      "condition": {
-        "typeReached": "com.squareup.moshi.ClassFactory$2"
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.ClassFactory$2"
       },
-      "type": "com.squareup.moshi.JsonEncodingException",
-      "unsafeAllocated": true
+      "type" : "com.squareup.moshi.JsonEncodingException",
+      "unsafeAllocated" : true
     },
     {
-      "condition": {
-        "typeReached": "com.squareup.moshi.AdapterMethodsFactory"
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.AdapterMethodsFactory"
       },
-      "type": "com.squareup.moshi.JsonReader"
+      "type" : "com.squareup.moshi.JsonReader"
     },
     {
-      "condition": {
-        "typeReached": "com.squareup.moshi.AdapterMethodsFactory"
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.AdapterMethodsFactory"
       },
-      "type": "com.squareup.moshi.JsonWriter"
+      "type" : "com.squareup.moshi.JsonWriter"
     },
     {
-      "condition": {
-        "typeReached": "com.squareup.moshi.StandardJsonAdapters$EnumJsonAdapter"
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.RecordJsonAdapter"
       },
-      "type": "com_squareup_moshi.moshi.CompassDirection"
+      "type" : "java.lang.Class[]"
     },
     {
-      "condition": {
-        "typeReached": "com.squareup.moshi.internal.Util"
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.RecordJsonAdapter$1"
       },
-      "type": "com_squareup_moshi.moshi.ConcreteMoshiCaseJsonAdapter",
-      "methods": [
+      "type" : "java.lang.Class[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.AdapterMethodsFactory"
+      },
+      "type" : "java.lang.Integer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.JsonReader$Options"
+      },
+      "type" : "java.lang.Integer[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.AdapterMethodsFactory"
+      },
+      "type" : "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.AdapterMethodsFactory$AdapterMethod"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.ClassJsonAdapter$1"
+      },
+      "type" : "java.lang.Throwable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.AdapterMethodsFactory"
+      },
+      "type" : "java.lang.annotation.Annotation[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.AdapterMethodsFactory$AdapterMethod"
+      },
+      "type" : "java.lang.annotation.Annotation[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.internal.Util"
+      },
+      "type" : "java.lang.annotation.Annotation[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.AdapterMethodsFactory"
+      },
+      "type" : "java.lang.annotation.Annotation[][]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.AdapterMethodsFactory$AdapterMethod"
+      },
+      "type" : "java.lang.annotation.Annotation[][]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.internal.Util"
+      },
+      "type" : "java.lang.annotation.ElementType[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.RecordJsonAdapter"
+      },
+      "type" : "java.lang.invoke.BoundMethodHandle$Species_LI"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.RecordJsonAdapter"
+      },
+      "type" : "java.lang.invoke.Invokers"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.RecordJsonAdapter"
+      },
+      "type" : "java.lang.invoke.LambdaForm$Name[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.RecordJsonAdapter"
+      },
+      "type" : "java.lang.invoke.MethodHandleImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.internal.Util"
+      },
+      "type" : "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.ClassJsonAdapter$1"
+      },
+      "type" : "java.lang.reflect.Field[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.AdapterMethodsFactory"
+      },
+      "type" : "java.lang.reflect.Method[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.JsonReader$Options"
+      },
+      "type" : "okio.ByteString[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.ClassFactory"
+      },
+      "type" : "org.assertj.core.data.Index"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.ClassFactory$2"
+      },
+      "type" : "org.assertj.core.data.Index",
+      "unsafeAllocated" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.ClassJsonAdapter$FieldBinding"
+      },
+      "type" : "org.assertj.core.data.Index",
+      "fields" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
-            "com.squareup.moshi.Moshi"
-          ]
+          "name" : "value"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.squareup.moshi.internal.Util"
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.RecordJsonAdapter"
       },
-      "type": "com_squareup_moshi.moshi.ConcreteNoArgCaseJsonAdapter",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
+      "type" : "sun.invoke.util.ValueConversions"
     },
     {
-      "condition": {
-        "typeReached": "com.squareup.moshi.internal.Util"
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.AdapterMethodsFactory"
       },
-      "type": "com_squareup_moshi.moshi.DefaultsConstructorCase"
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.internal.Util"
-      },
-      "type": "com_squareup_moshi.moshi.GenericMoshiCaseJsonAdapter",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "com.squareup.moshi.Moshi",
-            "java.lang.reflect.Type[]"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.internal.Util"
-      },
-      "type": "com_squareup_moshi.moshi.GenericTypeArrayOnlyCaseJsonAdapter",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.reflect.Type[]"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.Types"
-      },
-      "type": "com_squareup_moshi.moshi.QualifiedFieldHolder"
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.RecordJsonAdapter"
-      },
-      "type": "com_squareup_moshi.moshi.RecordPayload",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.String",
-            "int",
-            "boolean"
-          ]
-        },
-        {
-          "name": "count",
-          "parameterTypes": []
-        },
-        {
-          "name": "enabled",
-          "parameterTypes": []
-        },
-        {
-          "name": "name",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.RecordJsonAdapter$1"
-      },
-      "type": "com_squareup_moshi.moshi.RecordPayload"
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.Moshi"
-      },
-      "type": "com_squareup_moshi.moshi.ReversedQualifier"
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.Types"
-      },
-      "type": "com_squareup_moshi.moshi.RuntimeQualifier"
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.AdapterMethodsFactory"
-      },
-      "type": "com_squareup_moshi.moshi.StreamingDistance"
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.AdapterMethodsFactory"
-      },
-      "type": "com_squareup_moshi.moshi.StreamingDistanceAdapter"
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.AdapterMethodsFactory$AdapterMethod"
-      },
-      "type": "com_squareup_moshi.moshi.StreamingDistanceAdapter",
-      "methods": [
-        {
-          "name": "fromJson",
-          "parameterTypes": [
-            "com.squareup.moshi.JsonReader",
-            "com.squareup.moshi.JsonAdapter"
-          ]
-        },
-        {
-          "name": "toJson",
-          "parameterTypes": [
-            "com.squareup.moshi.JsonWriter",
-            "com_squareup_moshi.moshi.StreamingDistance",
-            "com.squareup.moshi.JsonAdapter"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.RecordJsonAdapter"
-      },
-      "type": "java.lang.Class[]"
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.RecordJsonAdapter$1"
-      },
-      "type": "java.lang.Class[]"
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.AdapterMethodsFactory"
-      },
-      "type": "java.lang.Integer"
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.JsonReader$Options"
-      },
-      "type": "java.lang.Integer[]"
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.AdapterMethodsFactory"
-      },
-      "type": "java.lang.StackTraceElement[]"
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.AdapterMethodsFactory$AdapterMethod"
-      },
-      "type": "java.lang.String[]"
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.ClassJsonAdapter$1"
-      },
-      "type": "java.lang.Throwable"
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.AdapterMethodsFactory"
-      },
-      "type": "java.lang.annotation.Annotation[]"
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.AdapterMethodsFactory$AdapterMethod"
-      },
-      "type": "java.lang.annotation.Annotation[]"
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.internal.Util"
-      },
-      "type": "java.lang.annotation.Annotation[]"
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.AdapterMethodsFactory"
-      },
-      "type": "java.lang.annotation.Annotation[][]"
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.AdapterMethodsFactory$AdapterMethod"
-      },
-      "type": "java.lang.annotation.Annotation[][]"
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.internal.Util"
-      },
-      "type": "java.lang.annotation.ElementType[]"
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.RecordJsonAdapter"
-      },
-      "type": "java.lang.invoke.BoundMethodHandle$Species_LI"
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.RecordJsonAdapter"
-      },
-      "type": "java.lang.invoke.Invokers"
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.RecordJsonAdapter"
-      },
-      "type": "java.lang.invoke.LambdaForm$Name[]"
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.RecordJsonAdapter"
-      },
-      "type": "java.lang.invoke.MethodHandleImpl"
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.internal.Util"
-      },
-      "type": "java.lang.reflect.Constructor[]"
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.ClassJsonAdapter$1"
-      },
-      "type": "java.lang.reflect.Field[]"
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.AdapterMethodsFactory"
-      },
-      "type": "java.lang.reflect.Method[]"
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.JsonReader$Options"
-      },
-      "type": "okio.ByteString[]"
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.ClassFactory"
-      },
-      "type": "org.assertj.core.data.Index"
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.ClassFactory$2"
-      },
-      "type": "org.assertj.core.data.Index",
-      "unsafeAllocated": true
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.ClassJsonAdapter$FieldBinding"
-      },
-      "type": "org.assertj.core.data.Index",
-      "fields": [
-        {
-          "name": "value"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.RecordJsonAdapter"
-      },
-      "type": "sun.invoke.util.ValueConversions"
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.AdapterMethodsFactory"
-      },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "com.squareup.moshi.FromJson"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.squareup.moshi.internal.Util"
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.internal.Util"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "com.squareup.moshi.Json"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.squareup.moshi.internal.Util"
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.internal.Util"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "com.squareup.moshi.JsonClass"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.squareup.moshi.Moshi"
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.Moshi"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "com.squareup.moshi.JsonQualifier"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.squareup.moshi.Types"
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.Types"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "com.squareup.moshi.JsonQualifier"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.squareup.moshi.AdapterMethodsFactory"
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.AdapterMethodsFactory"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "com.squareup.moshi.ToJson"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.squareup.moshi.Types"
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.AdapterMethodsFactory"
       },
-      "type": {
-        "proxy": [
-          "com_squareup_moshi.moshi.ReversedQualifier"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.Types"
-      },
-      "type": {
-        "proxy": [
-          "com_squareup_moshi.moshi.RuntimeQualifier"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.Types"
-      },
-      "type": {
-        "proxy": [
-          "com_squareup_moshi.moshi.UppercaseQualifier"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "com.squareup.moshi.AdapterMethodsFactory"
-      },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Retention"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.squareup.moshi.ClassFactory$2"
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.ClassFactory$2"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Retention"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.squareup.moshi.Moshi"
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.Moshi"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Retention"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.squareup.moshi.Types"
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.Types"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Retention"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.squareup.moshi.internal.Util"
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.internal.Util"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Retention"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.squareup.moshi.internal.Util"
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.internal.Util"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Target"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.squareup.moshi.ClassFactory$2"
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.ClassFactory$2"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "jdk.internal.vm.annotation.ForceInline"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.squareup.moshi.Moshi"
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.Moshi"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "kotlin.Metadata"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.squareup.moshi.Types"
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.Types"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "kotlin.Metadata"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.squareup.moshi.internal.Util"
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.internal.Util"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "kotlin.Metadata"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.squareup.moshi.Moshi"
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.Moshi"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "kotlin.annotation.Retention"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.squareup.moshi.Types"
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.Types"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "kotlin.annotation.Retention"
         ]
       }

--- a/metadata/com.squareup.moshi/moshi/1.15.2/reachability-metadata.json
+++ b/metadata/com.squareup.moshi/moshi/1.15.2/reachability-metadata.json
@@ -164,6 +164,12 @@
     },
     {
       "condition": {
+        "typeReached": "com.squareup.moshi.Types"
+      },
+      "type": "com_squareup_moshi.moshi.RuntimeQualifier"
+    },
+    {
+      "condition": {
         "typeReached": "com.squareup.moshi.AdapterMethodsFactory"
       },
       "type": "com_squareup_moshi.moshi.StreamingDistance"
@@ -420,6 +426,16 @@
       "type": {
         "proxy": [
           "com_squareup_moshi.moshi.ReversedQualifier"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.Types"
+      },
+      "type": {
+        "proxy": [
+          "com_squareup_moshi.moshi.RuntimeQualifier"
         ]
       }
     },

--- a/metadata/com.squareup.moshi/moshi/1.15.2/reachability-metadata.json
+++ b/metadata/com.squareup.moshi/moshi/1.15.2/reachability-metadata.json
@@ -10,7 +10,32 @@
       "condition": {
         "typeReached": "com.squareup.moshi.ClassFactory"
       },
+      "type": "com.squareup.moshi.JsonDataException"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.ClassFactory$1"
+      },
+      "type": "com.squareup.moshi.JsonDataException",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.ClassFactory"
+      },
       "type": "com.squareup.moshi.JsonEncodingException"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.ClassFactory$2"
+      },
+      "type": "com.squareup.moshi.JsonEncodingException",
+      "unsafeAllocated": true
     },
     {
       "condition": {
@@ -23,6 +48,12 @@
         "typeReached": "com.squareup.moshi.AdapterMethodsFactory"
       },
       "type": "com.squareup.moshi.JsonWriter"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.StandardJsonAdapters$EnumJsonAdapter"
+      },
+      "type": "com_squareup_moshi.moshi.CompassDirection"
     },
     {
       "condition": {
@@ -124,6 +155,12 @@
         "typeReached": "com.squareup.moshi.RecordJsonAdapter$1"
       },
       "type": "com_squareup_moshi.moshi.RecordPayload"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.Moshi"
+      },
+      "type": "com_squareup_moshi.moshi.ReversedQualifier"
     },
     {
       "condition": {
@@ -288,6 +325,30 @@
     },
     {
       "condition": {
+        "typeReached": "com.squareup.moshi.ClassFactory"
+      },
+      "type": "org.assertj.core.data.Index"
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.ClassFactory$2"
+      },
+      "type": "org.assertj.core.data.Index",
+      "unsafeAllocated": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.ClassJsonAdapter$FieldBinding"
+      },
+      "type": "org.assertj.core.data.Index",
+      "fields": [
+        {
+          "name": "value"
+        }
+      ]
+    },
+    {
+      "condition": {
         "typeReached": "com.squareup.moshi.RecordJsonAdapter"
       },
       "type": "sun.invoke.util.ValueConversions"
@@ -308,7 +369,27 @@
       },
       "type": {
         "proxy": [
+          "com.squareup.moshi.Json"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.internal.Util"
+      },
+      "type": {
+        "proxy": [
           "com.squareup.moshi.JsonClass"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.Moshi"
+      },
+      "type": {
+        "proxy": [
+          "com.squareup.moshi.JsonQualifier"
         ]
       }
     },
@@ -338,6 +419,16 @@
       },
       "type": {
         "proxy": [
+          "com_squareup_moshi.moshi.ReversedQualifier"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.Types"
+      },
+      "type": {
+        "proxy": [
           "com_squareup_moshi.moshi.UppercaseQualifier"
         ]
       }
@@ -345,6 +436,26 @@
     {
       "condition": {
         "typeReached": "com.squareup.moshi.AdapterMethodsFactory"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.ClassFactory$2"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.Moshi"
       },
       "type": {
         "proxy": [
@@ -384,6 +495,26 @@
     },
     {
       "condition": {
+        "typeReached": "com.squareup.moshi.ClassFactory$2"
+      },
+      "type": {
+        "proxy": [
+          "jdk.internal.vm.annotation.ForceInline"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.Moshi"
+      },
+      "type": {
+        "proxy": [
+          "kotlin.Metadata"
+        ]
+      }
+    },
+    {
+      "condition": {
         "typeReached": "com.squareup.moshi.Types"
       },
       "type": {
@@ -399,6 +530,16 @@
       "type": {
         "proxy": [
           "kotlin.Metadata"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.squareup.moshi.Moshi"
+      },
+      "type": {
+        "proxy": [
+          "kotlin.annotation.Retention"
         ]
       }
     },

--- a/metadata/com.squareup.moshi/moshi/index.json
+++ b/metadata/com.squareup.moshi/moshi/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.15.2",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/squareup/moshi/moshi/$version$/moshi-$version$-sources.jar",
+    "repository-url" : "https://github.com/square/moshi",
+    "test-code-url" : "https://github.com/square/moshi/tree/$version$/moshi/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/squareup/moshi/moshi/$version$/moshi-$version$-javadoc.jar",
+    "description" : "Moshi is a JSON library for Android, Java, and Kotlin that converts Java and Kotlin objects to and from JSON. The moshi artifact provides the core streaming reader/writer, adapter APIs, built-in type adapters, and reflection-based binding for Java model classes.",
+    "language" : {
+      "name" : "kotlin",
+      "version" : "1.8"
+    },
+    "tested-versions" : [
+      "1.15.2"
+    ],
+    "allowed-packages" : [
+      "com.squareup.moshi"
+    ]
+  }
+]

--- a/stats/com.squareup.moshi/moshi/1.15.2/execution-metrics.json
+++ b/stats/com.squareup.moshi/moshi/1.15.2/execution-metrics.json
@@ -1,0 +1,89 @@
+{
+  "add_new_library_support:2026-06-10": {
+    "timestamp": "2026-06-10T01:24:22.291484Z",
+    "library": "com.squareup.moshi:moshi:1.15.2",
+    "starting_commit": "b3b53d6b7c1b448bb073bb01283333edfcb6fb72",
+    "ending_commit": "abcd29b9390db08f84e515c7795646b0feccebfd",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.15.2",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.933333,
+            "coveredCalls": 28,
+            "totalCalls": 30
+          }
+        },
+        "coverageRatio": 0.933333,
+        "coveredCalls": 28,
+        "totalCalls": 30
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4411,
+          "missed": 11353,
+          "ratio": 0.279815,
+          "total": 15764
+        },
+        "line": {
+          "covered": 1036,
+          "missed": 2266,
+          "ratio": 0.313749,
+          "total": 3302
+        },
+        "method": {
+          "covered": 198,
+          "missed": 337,
+          "ratio": 0.370093,
+          "total": 535
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "degraded",
+      "action": "no_action",
+      "issue_number": 4490,
+      "issue_label": "library-new-request",
+      "library": "com.squareup.moshi:moshi:1.15.2",
+      "summary": "Library preparation preflight did not produce usable advisory setup.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#4490 Support for com.squareup.moshi:moshi:1.15.2; label=library-new-request; body_chars=100"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "0 existing test file path(s) included"
+        }
+      ],
+      "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
+      "model": "oca/gpt-5.5",
+      "prompt_path": "library-preflight-prompt.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/com.squareup.moshi:moshi:1.15.2/library-preparation-preflight/pi-generation-2026-06-10T00-04-26-093483Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 748401,
+      "cached_input_tokens_used": 4275200,
+      "output_tokens_used": 62501,
+      "iterations": 18,
+      "cost_usd": 4.0126,
+      "generated_loc": 568,
+      "tested_library_loc": 1036,
+      "metadata_entries": 54,
+      "test_only_metadata_entries": 27,
+      "code_coverage_percent": 31.37
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.squareup.moshi/moshi/1.15.2/src/test/kotlin/com_squareup_moshi/moshi/ClassJsonAdapterInnerFieldBindingTest.kt",
+      "metadata_file": "metadata/com.squareup.moshi/moshi/1.15.2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.squareup.moshi/moshi/1.15.2/stats.json
+++ b/stats/com.squareup.moshi/moshi/1.15.2/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "1.15.2",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.933333,
+          "coveredCalls" : 28,
+          "totalCalls" : 30
+        }
+      },
+      "coverageRatio" : 0.933333,
+      "coveredCalls" : 28,
+      "totalCalls" : 30
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 4411,
+        "missed" : 11353,
+        "ratio" : 0.279815,
+        "total" : 15764
+      },
+      "line" : {
+        "covered" : 1036,
+        "missed" : 2266,
+        "ratio" : 0.313749,
+        "total" : 3302
+      },
+      "method" : {
+        "covered" : 198,
+        "missed" : 337,
+        "ratio" : 0.370093,
+        "total" : 535
+      }
+    }
+  } ]
+}

--- a/tests/src/com.squareup.moshi/moshi/1.15.2/.gitignore
+++ b/tests/src/com.squareup.moshi/moshi/1.15.2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.squareup.moshi/moshi/1.15.2/build.gradle
+++ b/tests/src/com.squareup.moshi/moshi/1.15.2/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.squareup.moshi:moshi:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "21"
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.squareup.moshi/moshi/1.15.2/gradle.properties
+++ b/tests/src/com.squareup.moshi/moshi/1.15.2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.squareup.moshi:moshi:1.15.2
+library.version = 1.15.2
+metadata.dir = com.squareup.moshi/moshi/1.15.2/

--- a/tests/src/com.squareup.moshi/moshi/1.15.2/settings.gradle
+++ b/tests/src/com.squareup.moshi/moshi/1.15.2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.squareup.moshi.moshi_tests'

--- a/tests/src/com.squareup.moshi/moshi/1.15.2/src/test/kotlin/com_squareup_moshi/moshi/AdapterMethodsFactoryInnerAdapterMethodTest.kt
+++ b/tests/src/com.squareup.moshi/moshi/1.15.2/src/test/kotlin/com_squareup_moshi/moshi/AdapterMethodsFactoryInnerAdapterMethodTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_squareup_moshi.moshi
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.ToJson
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+public class AdapterMethodsFactoryInnerAdapterMethodTest {
+    private val moshi: Moshi = Moshi.Builder()
+        .add(StreamingDistanceAdapter())
+        .build()
+
+    @Test
+    public fun invokesToJsonAdapterMethodWithWriterValueAndDelegateAdapter(): Unit {
+        val adapter: JsonAdapter<StreamingDistance> = moshi.adapter(StreamingDistance::class.java)
+
+        val json: String = adapter.toJson(StreamingDistance(42))
+
+        assertThat(json).isEqualTo("""{"meters":42}""")
+    }
+
+    @Test
+    public fun invokesFromJsonAdapterMethodWithReaderAndDelegateAdapter(): Unit {
+        val adapter: JsonAdapter<StreamingDistance> = moshi.adapter(StreamingDistance::class.java)
+
+        val decoded: StreamingDistance? = adapter.fromJson("""{"meters":7,"unit":"m"}""")
+
+        assertThat(decoded).isEqualTo(StreamingDistance(7))
+    }
+}
+
+public data class StreamingDistance(public val meters: Int)
+
+public class StreamingDistanceAdapter {
+    @ToJson
+    public fun toJson(
+        writer: JsonWriter,
+        value: StreamingDistance,
+        intAdapter: JsonAdapter<Int>,
+    ): Unit {
+        writer.beginObject()
+        writer.name("meters")
+        intAdapter.toJson(writer, value.meters)
+        writer.endObject()
+    }
+
+    @FromJson
+    public fun fromJson(
+        reader: JsonReader,
+        intAdapter: JsonAdapter<Int>,
+    ): StreamingDistance {
+        reader.beginObject()
+        var meters: Int = 0
+        while (reader.hasNext()) {
+            when (reader.nextName()) {
+                "meters" -> meters = intAdapter.fromJson(reader) ?: 0
+                else -> reader.skipValue()
+            }
+        }
+        reader.endObject()
+        return StreamingDistance(meters)
+    }
+}

--- a/tests/src/com.squareup.moshi/moshi/1.15.2/src/test/kotlin/com_squareup_moshi/moshi/ArrayJsonAdapterTest.kt
+++ b/tests/src/com.squareup.moshi/moshi/1.15.2/src/test/kotlin/com_squareup_moshi/moshi/ArrayJsonAdapterTest.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_squareup_moshi.moshi
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+public class ArrayJsonAdapterTest {
+    @Test
+    public fun decodesObjectArrayFromJsonArray(): Unit {
+        val moshi: Moshi = Moshi.Builder().build()
+        val adapter: JsonAdapter<Array<String>> = moshi.adapter(Array<String>::class.java)
+
+        val decoded: Array<String>? = adapter.fromJson("[\"red\",\"green\",\"blue\"]")
+
+        assertThat(decoded).containsExactly("red", "green", "blue")
+    }
+}

--- a/tests/src/com.squareup.moshi/moshi/1.15.2/src/test/kotlin/com_squareup_moshi/moshi/ClassFactoryAnonymous3Test.kt
+++ b/tests/src/com.squareup.moshi/moshi/1.15.2/src/test/kotlin/com_squareup_moshi/moshi/ClassFactoryAnonymous3Test.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_squareup_moshi.moshi
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonEncodingException
+import com.squareup.moshi.Moshi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+public class ClassFactoryAnonymous3Test {
+    private val moshi: Moshi = Moshi.Builder().build()
+
+    @Test
+    public fun deserializesJavaTypeWithoutNoArgConstructor(): Unit {
+        val adapter: JsonAdapter<JsonEncodingException> = moshi.adapter(JsonEncodingException::class.java)
+
+        val value: JsonEncodingException? = adapter.fromJson("{}")
+
+        assertThat(value).isInstanceOf(JsonEncodingException::class.java)
+        assertThat(value?.message).isNull()
+    }
+}

--- a/tests/src/com.squareup.moshi/moshi/1.15.2/src/test/kotlin/com_squareup_moshi/moshi/ClassFactoryTest.kt
+++ b/tests/src/com.squareup.moshi/moshi/1.15.2/src/test/kotlin/com_squareup_moshi/moshi/ClassFactoryTest.kt
@@ -7,6 +7,7 @@
 package com_squareup_moshi.moshi
 
 import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.JsonEncodingException
 import com.squareup.moshi.Moshi
 import org.assertj.core.api.Assertions.assertThat
@@ -14,6 +15,17 @@ import org.junit.jupiter.api.Test
 
 public class ClassFactoryTest {
     private val moshi: Moshi = Moshi.Builder().build()
+
+    @Test
+    public fun createsAdapterForConcreteJavaTypeWithNoArgConstructor(): Unit {
+        val adapter: JsonAdapter<JsonDataException> = moshi.adapter(JsonDataException::class.java)
+
+        val json: String = adapter.toJson(JsonDataException())
+        val value: JsonDataException? = adapter.fromJson("{}")
+
+        assertThat(json).isEqualTo("{}")
+        assertThat(value).isNotNull()
+    }
 
     @Test
     public fun createsAdapterForConcreteJavaTypeWithoutNoArgConstructor(): Unit {

--- a/tests/src/com.squareup.moshi/moshi/1.15.2/src/test/kotlin/com_squareup_moshi/moshi/ClassFactoryTest.kt
+++ b/tests/src/com.squareup.moshi/moshi/1.15.2/src/test/kotlin/com_squareup_moshi/moshi/ClassFactoryTest.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_squareup_moshi.moshi
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonEncodingException
+import com.squareup.moshi.Moshi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+public class ClassFactoryTest {
+    private val moshi: Moshi = Moshi.Builder().build()
+
+    @Test
+    public fun createsAdapterForConcreteJavaTypeWithoutNoArgConstructor(): Unit {
+        val adapter: JsonAdapter<JsonEncodingException> = moshi.adapter(JsonEncodingException::class.java)
+
+        val json: String = adapter.toJson(JsonEncodingException("bad encoding"))
+
+        assertThat(json).isEqualTo("{}")
+    }
+}

--- a/tests/src/com.squareup.moshi/moshi/1.15.2/src/test/kotlin/com_squareup_moshi/moshi/ClassJsonAdapterInnerFieldBindingTest.kt
+++ b/tests/src/com.squareup.moshi/moshi/1.15.2/src/test/kotlin/com_squareup_moshi/moshi/ClassJsonAdapterInnerFieldBindingTest.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_squareup_moshi.moshi
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Index
+import org.junit.jupiter.api.Test
+
+public class ClassJsonAdapterInnerFieldBindingTest {
+    private val moshi: Moshi = Moshi.Builder().build()
+
+    @Test
+    public fun readsAndWritesJavaObjectFieldsWithReflectiveClassAdapter(): Unit {
+        val adapter: JsonAdapter<Index> = moshi.adapter(Index::class.java)
+
+        val json: String = adapter.toJson(Index.atIndex(3))
+        val decoded: Index? = adapter.fromJson("""{"value":5}""")
+
+        assertThat(json).isEqualTo("""{"value":3}""")
+        assertThat(decoded).isEqualTo(Index.atIndex(5))
+    }
+}

--- a/tests/src/com.squareup.moshi/moshi/1.15.2/src/test/kotlin/com_squareup_moshi/moshi/MoshiTest.kt
+++ b/tests/src/com.squareup.moshi/moshi/1.15.2/src/test/kotlin/com_squareup_moshi/moshi/MoshiTest.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_squareup_moshi.moshi
+
+import org.junit.jupiter.api.Test
+
+class MoshiTest {
+    @Test
+    fun test() {
+        println("This is just a placeholder, implement your test")
+    }
+}

--- a/tests/src/com.squareup.moshi/moshi/1.15.2/src/test/kotlin/com_squareup_moshi/moshi/MoshiTest.kt
+++ b/tests/src/com.squareup.moshi/moshi/1.15.2/src/test/kotlin/com_squareup_moshi/moshi/MoshiTest.kt
@@ -6,11 +6,52 @@
  */
 package com_squareup_moshi.moshi
 
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonQualifier
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.Moshi
+import java.lang.reflect.Type
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-class MoshiTest {
+public class MoshiTest {
     @Test
-    fun test() {
-        println("This is just a placeholder, implement your test")
+    public fun usesQualifierSpecificAdapterRegisteredByType(): Unit {
+        val moshi: Moshi = Moshi.Builder()
+            .add(
+                String::class.java as Type,
+                ReversedQualifier::class.java,
+                ReversingStringJsonAdapter,
+            )
+            .build()
+
+        val qualifiedAdapter: JsonAdapter<String> = moshi.adapter(
+            String::class.java,
+            ReversedQualifier::class.java,
+        )
+        val unqualifiedAdapter: JsonAdapter<String> = moshi.adapter(String::class.java)
+
+        assertThat(qualifiedAdapter.fromJson("\"ihsom\"")).isEqualTo("moshi")
+        assertThat(qualifiedAdapter.toJson("moshi")).isEqualTo("\"ihsom\"")
+        assertThat(unqualifiedAdapter.fromJson("\"plain\"")).isEqualTo("plain")
+    }
+}
+
+@JsonQualifier
+@Retention(AnnotationRetention.RUNTIME)
+public annotation class ReversedQualifier
+
+public object ReversingStringJsonAdapter : JsonAdapter<String>() {
+    override fun fromJson(reader: JsonReader): String? {
+        return reader.nextString().reversed()
+    }
+
+    override fun toJson(writer: JsonWriter, value: String?): Unit {
+        if (value == null) {
+            writer.nullValue()
+        } else {
+            writer.value(value.reversed())
+        }
     }
 }

--- a/tests/src/com.squareup.moshi/moshi/1.15.2/src/test/kotlin/com_squareup_moshi/moshi/RecordJsonAdapterAnonymous1Test.kt
+++ b/tests/src/com.squareup.moshi/moshi/1.15.2/src/test/kotlin/com_squareup_moshi/moshi/RecordJsonAdapterAnonymous1Test.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_squareup_moshi.moshi
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+public class RecordJsonAdapterAnonymous1Test {
+    private val moshi: Moshi = Moshi.Builder().build()
+
+    @Test
+    public fun createsAdapterForJvmRecordAndRoundTripsJson(): Unit {
+        val adapter: JsonAdapter<RecordPayload> = moshi.adapter(RecordPayload::class.java)
+
+        val encoded: String = adapter.toJson(RecordPayload("moshi", 3, true))
+        val decoded: RecordPayload? = adapter.fromJson(
+            """{"name":"moshi","count":3,"enabled":true,"unknown":"ignored"}""",
+        )
+
+        assertThat(encoded).isEqualTo("""{"name":"moshi","count":3,"enabled":true}""")
+        assertThat(decoded).isEqualTo(RecordPayload("moshi", 3, true))
+    }
+}
+
+@JvmRecord
+public data class RecordPayload(
+    public val name: String,
+    public val count: Int,
+    public val enabled: Boolean,
+)

--- a/tests/src/com.squareup.moshi/moshi/1.15.2/src/test/kotlin/com_squareup_moshi/moshi/StandardJsonAdaptersInnerEnumJsonAdapterTest.kt
+++ b/tests/src/com.squareup.moshi/moshi/1.15.2/src/test/kotlin/com_squareup_moshi/moshi/StandardJsonAdaptersInnerEnumJsonAdapterTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_squareup_moshi.moshi
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+public class StandardJsonAdaptersInnerEnumJsonAdapterTest {
+    @Test
+    public fun readsAndWritesEnumConstantsUsingJsonNames(): Unit {
+        val adapter: JsonAdapter<CompassDirection> = Moshi.Builder()
+            .build()
+            .adapter(CompassDirection::class.java)
+
+        assertThat(adapter.fromJson("\"n\"")).isEqualTo(CompassDirection.NORTH)
+        assertThat(adapter.fromJson("\"south\"")).isEqualTo(CompassDirection.SOUTH)
+        assertThat(adapter.toJson(CompassDirection.NORTH)).isEqualTo("\"n\"")
+        assertThat(adapter.toJson(CompassDirection.EAST)).isEqualTo("\"EAST\"")
+    }
+}
+
+public enum class CompassDirection {
+    @Json(name = "n")
+    NORTH,
+
+    @Json(name = "south")
+    SOUTH,
+
+    EAST,
+}

--- a/tests/src/com.squareup.moshi/moshi/1.15.2/src/test/kotlin/com_squareup_moshi/moshi/TypesAnonymous1Test.kt
+++ b/tests/src/com.squareup.moshi/moshi/1.15.2/src/test/kotlin/com_squareup_moshi/moshi/TypesAnonymous1Test.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_squareup_moshi.moshi
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonQualifier
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.Moshi
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+import java.lang.reflect.Type
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+public class TypesAnonymous1Test {
+    @Test
+    public fun delegatesUnhandledObjectMethodsFromRuntimeQualifierProxy(): Unit {
+        RuntimeQualifierFactory.capturedAnnotation = null
+        val moshi: Moshi = Moshi.Builder()
+            .add(RuntimeQualifierFactory())
+            .build()
+
+        val adapter: JsonAdapter<String> = moshi.adapter(
+            String::class.java,
+            RuntimeQualifier::class.java,
+        )
+        assertThat(adapter).isNotNull()
+        val annotation: Annotation = requireNotNull(RuntimeQualifierFactory.capturedAnnotation)
+        val handler: java.lang.reflect.InvocationHandler = Proxy.getInvocationHandler(annotation)
+        val getClassMethod: Method = Any::class.java.getMethod("getClass")
+
+        val result: Any? = handler.invoke(annotation, getClassMethod, emptyArray<Any?>())
+
+        assertThat(result).isEqualTo(annotation.javaClass)
+    }
+}
+
+@JsonQualifier
+@Retention(AnnotationRetention.RUNTIME)
+public annotation class RuntimeQualifier
+
+public class RuntimeQualifierFactory : JsonAdapter.Factory {
+    public companion object {
+        public var capturedAnnotation: Annotation? = null
+    }
+
+    override fun create(
+        type: Type,
+        annotations: Set<Annotation>,
+        moshi: Moshi,
+    ): JsonAdapter<*>? {
+        if (type != String::class.java || annotations.size != 1) {
+            return null
+        }
+        capturedAnnotation = annotations.single()
+        return RuntimeQualifierStringAdapter
+    }
+}
+
+public object RuntimeQualifierStringAdapter : JsonAdapter<String>() {
+    override fun fromJson(reader: JsonReader): String? {
+        return reader.nextString()
+    }
+
+    override fun toJson(writer: JsonWriter, value: String?): Unit {
+        writer.value(value)
+    }
+}

--- a/tests/src/com.squareup.moshi/moshi/1.15.2/src/test/kotlin/com_squareup_moshi/moshi/TypesTest.kt
+++ b/tests/src/com.squareup.moshi/moshi/1.15.2/src/test/kotlin/com_squareup_moshi/moshi/TypesTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_squareup_moshi.moshi
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonQualifier
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import java.lang.reflect.Type
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+public class TypesTest {
+    @Test
+    public fun returnsRawTypeForGenericArrayTypes(): Unit {
+        val arrayType: Type = Types.arrayOf(String::class.java)
+
+        val rawType: Class<*> = Types.getRawType(arrayType)
+
+        assertThat(rawType.isArray).isTrue()
+        assertThat(rawType.componentType).isEqualTo(String::class.java)
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    public fun readsJsonQualifierAnnotationsFromFields(): Unit {
+        val annotations: Set<Annotation> = Types.getFieldJsonQualifierAnnotations(
+            QualifiedFieldHolder::class.java,
+            "name",
+        )
+
+        assertThat(annotations).hasSize(1)
+        assertThat(annotations.single().annotationClass.java)
+            .isEqualTo(UppercaseQualifier::class.java)
+    }
+
+    @Test
+    public fun createsRuntimeJsonQualifierImplementationForAdapterLookup(): Unit {
+        val moshi: Moshi = Moshi.Builder()
+            .add(UppercaseStringAdapterFactory())
+            .build()
+
+        val adapter: JsonAdapter<String> = moshi.adapter(
+            String::class.java,
+            UppercaseQualifier::class.java,
+        )
+
+        assertThat(adapter.fromJson("\"moshi\"")).isEqualTo("MOSHI")
+        assertThat(adapter.toJson("moshi")).isEqualTo("\"MOSHI\"")
+    }
+}
+
+public class QualifiedFieldHolder {
+    @field:UppercaseQualifier
+    public val name: String = "moshi"
+}
+
+@JsonQualifier
+@Retention(AnnotationRetention.RUNTIME)
+public annotation class UppercaseQualifier
+
+public class UppercaseStringAdapterFactory : JsonAdapter.Factory {
+    override fun create(
+        type: Type,
+        annotations: Set<Annotation>,
+        moshi: Moshi,
+    ): JsonAdapter<*>? {
+        if (type != String::class.java) {
+            return null
+        }
+        val remainingAnnotations: Set<Annotation> = Types.nextAnnotations(
+            annotations,
+            UppercaseQualifier::class.java,
+        ) ?: return null
+        if (remainingAnnotations.isNotEmpty()) {
+            return null
+        }
+        return UppercaseStringAdapter
+    }
+}
+
+public object UppercaseStringAdapter : JsonAdapter<String>() {
+    override fun fromJson(reader: JsonReader): String? {
+        return reader.nextString().uppercase()
+    }
+
+    override fun toJson(writer: JsonWriter, value: String?): Unit {
+        if (value == null) {
+            writer.nullValue()
+        } else {
+            writer.value(value.uppercase())
+        }
+    }
+}

--- a/tests/src/com.squareup.moshi/moshi/1.15.2/src/test/kotlin/com_squareup_moshi/moshi/UtilTest.kt
+++ b/tests/src/com.squareup.moshi/moshi/1.15.2/src/test/kotlin/com_squareup_moshi/moshi/UtilTest.kt
@@ -1,0 +1,182 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_squareup_moshi.moshi
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import com.squareup.moshi.internal.Util
+import java.lang.reflect.Constructor
+import java.lang.reflect.Type
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+public class UtilTest {
+    private val moshi: Moshi = Moshi.Builder().build()
+
+    @Test
+    public fun usesGeneratedAdapterConstructorWithMoshiAndTypeArrayForParameterizedTypes() {
+        val type: Type = Types.newParameterizedType(
+            GenericMoshiCase::class.java,
+            String::class.java,
+        )
+        val adapter: JsonAdapter<GenericMoshiCase<String>> = moshi.adapter(type)
+
+        val json: String = adapter.toJson(GenericMoshiCase("alpha"))
+
+        assertThat(json).isEqualTo("""{"value":"alpha","adapter":"moshiTypeArray"}""")
+    }
+
+    @Test
+    public fun usesGeneratedAdapterConstructorWithTypeArrayForParameterizedTypes() {
+        val type: Type = Types.newParameterizedType(
+            GenericTypeArrayOnlyCase::class.java,
+            String::class.java,
+        )
+        val adapter: JsonAdapter<GenericTypeArrayOnlyCase<String>> = moshi.adapter(type)
+
+        val json: String = adapter.toJson(GenericTypeArrayOnlyCase("bravo"))
+
+        assertThat(json).isEqualTo("""{"adapter":"typeArray","type":"java.lang.String"}""")
+    }
+
+    @Test
+    public fun usesGeneratedAdapterConstructorWithMoshiForConcreteTypes() {
+        val adapter: JsonAdapter<ConcreteMoshiCase> = moshi.adapter(ConcreteMoshiCase::class.java)
+
+        val json: String = adapter.toJson(ConcreteMoshiCase("charlie"))
+
+        assertThat(json).isEqualTo("""{"name":"charlie","adapter":"moshi"}""")
+    }
+
+    @Test
+    public fun usesGeneratedAdapterNoArgConstructorForConcreteTypes() {
+        val adapter: JsonAdapter<ConcreteNoArgCase> = moshi.adapter(ConcreteNoArgCase::class.java)
+
+        val json: String = adapter.toJson(ConcreteNoArgCase("delta"))
+
+        assertThat(json).isEqualTo("""{"name":"delta","adapter":"noArg"}""")
+    }
+
+    @Test
+    public fun looksUpKotlinDefaultsConstructor() {
+        val constructor: Constructor<DefaultsConstructorCase> =
+            Util.lookupDefaultsConstructor(DefaultsConstructorCase::class.java)
+
+        assertThat(constructor).isNotNull()
+    }
+}
+
+@JsonClass(generateAdapter = true)
+public data class GenericMoshiCase<T>(val value: T)
+
+public class GenericMoshiCaseJsonAdapter<T>(
+    moshi: Moshi,
+    private val typeArguments: Array<Type>,
+) : JsonAdapter<GenericMoshiCase<T>>() {
+    private val valueAdapter: JsonAdapter<T> = moshi.adapter(typeArguments[0])
+
+    override fun fromJson(reader: JsonReader): GenericMoshiCase<T>? {
+        reader.beginObject()
+        var result: T? = null
+        while (reader.hasNext()) {
+            when (reader.nextName()) {
+                "value" -> result = valueAdapter.fromJson(reader)
+                else -> reader.skipValue()
+            }
+        }
+        reader.endObject()
+        @Suppress("UNCHECKED_CAST")
+        return GenericMoshiCase(result as T)
+    }
+
+    override fun toJson(writer: JsonWriter, value: GenericMoshiCase<T>?) {
+        writer.beginObject()
+        writer.name("value")
+        valueAdapter.toJson(writer, value!!.value)
+        writer.name("adapter").value("moshiTypeArray")
+        writer.endObject()
+    }
+}
+
+@JsonClass(generateAdapter = true)
+public data class GenericTypeArrayOnlyCase<T>(val value: T)
+
+public class GenericTypeArrayOnlyCaseJsonAdapter<T>(
+    private val typeArguments: Array<Type>,
+) : JsonAdapter<GenericTypeArrayOnlyCase<T>>() {
+    override fun fromJson(reader: JsonReader): GenericTypeArrayOnlyCase<T>? {
+        throw UnsupportedOperationException("fromJson is not used by this test adapter")
+    }
+
+    override fun toJson(writer: JsonWriter, value: GenericTypeArrayOnlyCase<T>?) {
+        writer.beginObject()
+        writer.name("adapter").value("typeArray")
+        writer.name("type").value(typeArguments[0].typeName)
+        writer.endObject()
+    }
+}
+
+@JsonClass(generateAdapter = true)
+public data class ConcreteMoshiCase(val name: String)
+
+public class ConcreteMoshiCaseJsonAdapter(
+    moshi: Moshi,
+) : JsonAdapter<ConcreteMoshiCase>() {
+    private val stringAdapter: JsonAdapter<String> = moshi.adapter(String::class.java)
+
+    override fun fromJson(reader: JsonReader): ConcreteMoshiCase? {
+        reader.beginObject()
+        var name: String = ""
+        while (reader.hasNext()) {
+            when (reader.nextName()) {
+                "name" -> name = stringAdapter.fromJson(reader).orEmpty()
+                else -> reader.skipValue()
+            }
+        }
+        reader.endObject()
+        return ConcreteMoshiCase(name)
+    }
+
+    override fun toJson(writer: JsonWriter, value: ConcreteMoshiCase?) {
+        writer.beginObject()
+        writer.name("name")
+        stringAdapter.toJson(writer, value!!.name)
+        writer.name("adapter").value("moshi")
+        writer.endObject()
+    }
+}
+
+@JsonClass(generateAdapter = true)
+public data class ConcreteNoArgCase(val name: String)
+
+public class ConcreteNoArgCaseJsonAdapter : JsonAdapter<ConcreteNoArgCase>() {
+    override fun fromJson(reader: JsonReader): ConcreteNoArgCase? {
+        reader.beginObject()
+        var name: String = ""
+        while (reader.hasNext()) {
+            when (reader.nextName()) {
+                "name" -> name = reader.nextString()
+                else -> reader.skipValue()
+            }
+        }
+        reader.endObject()
+        return ConcreteNoArgCase(name)
+    }
+
+    override fun toJson(writer: JsonWriter, value: ConcreteNoArgCase?) {
+        writer.beginObject()
+        writer.name("name").value(value!!.name)
+        writer.name("adapter").value("noArg")
+        writer.endObject()
+    }
+}
+
+public data class DefaultsConstructorCase(val name: String = "echo")

--- a/tests/src/com.squareup.moshi/moshi/1.15.2/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.squareup.moshi/moshi/1.15.2/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,188 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.StandardJsonAdapters$EnumJsonAdapter"
+      },
+      "type" : "com_squareup_moshi.moshi.CompassDirection"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.internal.Util"
+      },
+      "type" : "com_squareup_moshi.moshi.ConcreteMoshiCaseJsonAdapter",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "com.squareup.moshi.Moshi"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.internal.Util"
+      },
+      "type" : "com_squareup_moshi.moshi.ConcreteNoArgCaseJsonAdapter",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.internal.Util"
+      },
+      "type" : "com_squareup_moshi.moshi.DefaultsConstructorCase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.internal.Util"
+      },
+      "type" : "com_squareup_moshi.moshi.GenericMoshiCaseJsonAdapter",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "com.squareup.moshi.Moshi",
+            "java.lang.reflect.Type[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.internal.Util"
+      },
+      "type" : "com_squareup_moshi.moshi.GenericTypeArrayOnlyCaseJsonAdapter",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.reflect.Type[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.Types"
+      },
+      "type" : "com_squareup_moshi.moshi.QualifiedFieldHolder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.RecordJsonAdapter"
+      },
+      "type" : "com_squareup_moshi.moshi.RecordPayload",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int",
+            "boolean"
+          ]
+        },
+        {
+          "name" : "count",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "enabled",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "name",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.RecordJsonAdapter$1"
+      },
+      "type" : "com_squareup_moshi.moshi.RecordPayload"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.Moshi"
+      },
+      "type" : "com_squareup_moshi.moshi.ReversedQualifier"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.Types"
+      },
+      "type" : "com_squareup_moshi.moshi.RuntimeQualifier"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.AdapterMethodsFactory"
+      },
+      "type" : "com_squareup_moshi.moshi.StreamingDistance"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.AdapterMethodsFactory"
+      },
+      "type" : "com_squareup_moshi.moshi.StreamingDistanceAdapter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.AdapterMethodsFactory$AdapterMethod"
+      },
+      "type" : "com_squareup_moshi.moshi.StreamingDistanceAdapter",
+      "methods" : [
+        {
+          "name" : "fromJson",
+          "parameterTypes" : [
+            "com.squareup.moshi.JsonReader",
+            "com.squareup.moshi.JsonAdapter"
+          ]
+        },
+        {
+          "name" : "toJson",
+          "parameterTypes" : [
+            "com.squareup.moshi.JsonWriter",
+            "com_squareup_moshi.moshi.StreamingDistance",
+            "com.squareup.moshi.JsonAdapter"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.Types"
+      },
+      "type" : {
+        "proxy" : [
+          "com_squareup_moshi.moshi.ReversedQualifier"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.Types"
+      },
+      "type" : {
+        "proxy" : [
+          "com_squareup_moshi.moshi.RuntimeQualifier"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.Types"
+      },
+      "type" : {
+        "proxy" : [
+          "com_squareup_moshi.moshi.UppercaseQualifier"
+        ]
+      }
+    }
+  ]
+}

--- a/tests/src/com.squareup.moshi/moshi/1.15.2/user-code-filter.json
+++ b/tests/src/com.squareup.moshi/moshi/1.15.2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.squareup.moshi.**"
+    }
+  ]
+}

--- a/tests/src/com.squareup.moshi/moshi/1.15.2/user-code-filter.json
+++ b/tests/src/com.squareup.moshi/moshi/1.15.2/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.squareup.moshi.**"
+      "includeClasses" : "com.squareup.moshi.**"
+    },
+    {
+      "includeClasses" : "com_squareup_moshi.moshi.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #4490

This PR introduces tests and metadata for com.squareup.moshi:moshi:1.15.2, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 748401
- Cached input tokens: 4275200
- Output tokens: 62501
- Metadata entries: 54
- Test-only metadata entries: 27
- Iterations: 18
- Library coverage percentage: 31.37
- Generated lines of code: 568
- Tested library lines of code: 1036

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `7fac61c14310905081b8c25059089791849f4dda`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 28/30 covered calls (93.33%)
- Reflection: 28/30 covered calls (93.33%)

Library coverage:
- Instruction: 4411/15764 (27.98%)
- Line: 1036/3302 (31.37%)
- Method: 198/535 (37.01%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
