### PR TITLE
[Automation] Generated metadata for org.apache.commons:commons-lang3:3.19.0

### DIFF
--- a/metadata/org.apache.commons/commons-lang3/3.19.0/reachability-metadata.json
+++ b/metadata/org.apache.commons/commons-lang3/3.19.0/reachability-metadata.json
@@ -1,719 +1,222 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.ObjectUtils"
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.ObjectUtils"
       },
-      "type": "int[]"
+      "type" : "int[]"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.reflect.MethodUtils"
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.event.EventListenerSupport"
       },
-      "type": "java.lang.Integer",
-      "methods": [
+      "type" : "java.io.IOException",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.event.EventListenerSupport"
+      },
+      "type" : "java.io.NotSerializableException",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.event.EventListenerSupport"
+      },
+      "type" : "java.io.ObjectStreamException",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.event.EventListenerSupport"
+      },
+      "type" : "java.lang.Exception",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.reflect.MethodUtils"
+      },
+      "type" : "java.lang.Integer",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "int"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.reflect.MethodUtils"
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.reflect.MethodUtils"
       },
-      "type": "java.lang.Integer[]"
+      "type" : "java.lang.Integer[]"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.stream.Streams$ArrayCollector"
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.stream.Streams$ArrayCollector"
       },
-      "type": "java.lang.Number[]"
+      "type" : "java.lang.Number[]"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.builder.CompareToBuilder"
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.builder.CompareToBuilder"
       },
-      "type": "java.lang.Object"
+      "type" : "java.lang.Object"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.builder.EqualsBuilder"
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.builder.EqualsBuilder"
       },
-      "type": "java.lang.Object"
+      "type" : "java.lang.Object"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.builder.HashCodeBuilder"
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.builder.HashCodeBuilder"
       },
-      "type": "java.lang.Object"
+      "type" : "java.lang.Object"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.builder.ReflectionToStringBuilder"
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.builder.ReflectionToStringBuilder"
       },
-      "type": "java.lang.Object"
+      "type" : "java.lang.Object"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.reflect.FieldUtils"
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.event.EventListenerSupport"
       },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.reflect.MethodUtils"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.SerializationUtils"
-      },
-      "type": "java.lang.String",
-      "serializable": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.ArrayUtils"
-      },
-      "type": "java.lang.String[]"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.stream.Streams$ArrayCollector"
-      },
-      "type": "java.lang.String[]"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.exception.ExceptionUtils"
-      },
-      "type": "java.lang.Throwable",
-      "methods": [
+      "type" : "java.lang.Object",
+      "methods" : [
         {
-          "name": "getCause",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.SerializationUtils"
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.reflect.FieldUtils"
       },
-      "type": "java.util.ArrayList",
-      "serializable": true
+      "type" : "java.lang.Object"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.SerializationUtils$ClassLoaderAwareObjectInputStream"
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.reflect.MethodUtils"
       },
-      "type": "java.util.ArrayList"
+      "type" : "java.lang.Object"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.reflect.TypeUtils"
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.event.EventListenerSupport"
       },
-      "type": "java.util.List[]"
+      "type" : "java.lang.StackTraceElement",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.ClassUtils"
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.event.EventListenerSupport"
       },
-      "type": "missing.Type"
+      "type" : "java.lang.StackTraceElement[]",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.AnnotationUtils"
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.SerializationUtils"
       },
-      "type": "org_apache_commons.commons_lang3.AnnotationUtilsTest$Nested",
-      "methods": [
+      "type" : "java.lang.String",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.event.EventListenerSupport"
+      },
+      "type" : "java.lang.String",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.ArrayUtils"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.stream.Streams$ArrayCollector"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.event.EventListenerSupport"
+      },
+      "type" : "java.lang.Throwable",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.exception.ExceptionUtils"
+      },
+      "type" : "java.lang.Throwable",
+      "methods" : [
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "getCause",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.AnnotationUtils$1"
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.SerializationUtils"
       },
-      "type": "org_apache_commons.commons_lang3.AnnotationUtilsTest$Nested",
-      "methods": [
+      "type" : "java.util.ArrayList",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.SerializationUtils$ClassLoaderAwareObjectInputStream"
+      },
+      "type" : "java.util.ArrayList"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.event.EventListenerSupport"
+      },
+      "type" : "java.util.ArrayList",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.event.EventListenerSupport"
+      },
+      "type" : "java.util.Collections$EmptyList",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.reflect.TypeUtils"
+      },
+      "type" : "java.util.List[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.ClassUtils"
+      },
+      "type" : "missing.Type"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.event.EventListenerSupport"
+      },
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.ClassUtils"
-      },
-      "type": "org_apache_commons.commons_lang3.ClassUtilsTest$ConvertibleTarget"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.ClassUtils"
-      },
-      "type": "org_apache_commons.commons_lang3.ClassUtilsTest$Greeting"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.ClassUtils"
-      },
-      "type": "org_apache_commons.commons_lang3.ClassUtilsTest$LoaderTarget"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.ClassUtils"
-      },
-      "type": "org_apache_commons.commons_lang3.ClassUtilsTest$PackagePrivateGreetingTarget"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.builder.CompareToBuilder"
-      },
-      "type": "org_apache_commons.commons_lang3.CompareToBuilderTest$SessionRecord",
-      "fields": [
-        {
-          "name": "label"
-        },
-        {
-          "name": "sessionToken"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.reflect.ConstructorUtils"
-      },
-      "type": "org_apache_commons.commons_lang3.ConstructorUtilsTest$AssignableConstructorTarget",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.Number"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.reflect.ConstructorUtils"
-      },
-      "type": "org_apache_commons.commons_lang3.ConstructorUtilsTest$ExactConstructorTarget",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.builder.EqualsBuilder"
-      },
-      "type": "org_apache_commons.commons_lang3.EqualsBuilderTest$IdentifiedRecord",
-      "fields": [
-        {
-          "name": "identifier"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.builder.EqualsBuilder"
-      },
-      "type": "org_apache_commons.commons_lang3.EqualsBuilderTest$RankedRecord",
-      "fields": [
-        {
-          "name": "label"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.builder.EqualsBuilder"
-      },
-      "type": "org_apache_commons.commons_lang3.EqualsBuilderTest$SessionRecord",
-      "fields": [
-        {
-          "name": "label"
-        },
-        {
-          "name": "sessionToken"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.event.EventListenerSupport$ProxyInvocationHandler"
-      },
-      "type": "org_apache_commons.commons_lang3.EventListenerSupportProxyInvocationHandlerTest$SampleListener",
-      "methods": [
-        {
-          "name": "onEvent",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.event.EventListenerSupport"
-      },
-      "type": "org_apache_commons.commons_lang3.EventListenerSupportProxyInvocationHandlerTest$SampleListener[]"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.event.EventUtils$EventBindingInvocationHandler"
-      },
-      "type": "org_apache_commons.commons_lang3.EventUtilsTest$RecordingTarget"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.reflect.MethodUtils"
-      },
-      "type": "org_apache_commons.commons_lang3.EventUtilsTest$RecordingTarget",
-      "methods": [
-        {
-          "name": "recordStatusChange",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.event.EventUtils"
-      },
-      "type": "org_apache_commons.commons_lang3.EventUtilsTest$SampleEventSource",
-      "methods": [
-        {
-          "name": "addSampleListener",
-          "parameterTypes": [
-            "org_apache_commons.commons_lang3.EventUtilsTest$SampleListener"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.exception.ExceptionUtils"
-      },
-      "type": "org_apache_commons.commons_lang3.ExceptionUtilsTest$LegacyWrappedException",
-      "methods": [
-        {
-          "name": "getException",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.reflect.FieldUtils"
-      },
-      "type": "org_apache_commons.commons_lang3.FieldUtilsTest$AllFieldsChild"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.reflect.FieldUtils"
-      },
-      "type": "org_apache_commons.commons_lang3.FieldUtilsTest$AllFieldsParent"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.reflect.FieldUtils"
-      },
-      "type": "org_apache_commons.commons_lang3.FieldUtilsTest$DeclaredFieldTarget"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.reflect.FieldUtils"
-      },
-      "type": "org_apache_commons.commons_lang3.FieldUtilsTest$InterfaceFieldTarget"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.reflect.FieldUtils"
-      },
-      "type": "org_apache_commons.commons_lang3.FieldUtilsTest$LabelProvider"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.reflect.FieldUtils"
-      },
-      "type": "org_apache_commons.commons_lang3.FieldUtilsTest$MutableFieldTarget",
-      "fields": [
-        {
-          "name": "message"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.builder.HashCodeBuilder"
-      },
-      "type": "org_apache_commons.commons_lang3.HashCodeBuilderTest$IdentifiedRecord",
-      "fields": [
-        {
-          "name": "identifier"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.builder.HashCodeBuilder"
-      },
-      "type": "org_apache_commons.commons_lang3.HashCodeBuilderTest$RankedRecord",
-      "fields": [
-        {
-          "name": "label"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.builder.HashCodeBuilder"
-      },
-      "type": "org_apache_commons.commons_lang3.HashCodeBuilderTest$SessionRecord",
-      "fields": [
-        {
-          "name": "label"
-        },
-        {
-          "name": "sessionToken"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.reflect.MethodUtils"
-      },
-      "type": "org_apache_commons.commons_lang3.MethodUtilsTest$AnnotatedChild"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.reflect.MethodUtils"
-      },
-      "type": "org_apache_commons.commons_lang3.MethodUtilsTest$AnnotatedParent"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.reflect.MethodUtils"
-      },
-      "type": "org_apache_commons.commons_lang3.MethodUtilsTest$ExactTarget",
-      "methods": [
-        {
-          "name": "echo",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        },
-        {
-          "name": "echoStatic",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.reflect.MethodUtils"
-      },
-      "type": "org_apache_commons.commons_lang3.MethodUtilsTest$Greeting"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.reflect.MethodUtils"
-      },
-      "type": "org_apache_commons.commons_lang3.MethodUtilsTest$OverloadedChild"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.reflect.MethodUtils"
-      },
-      "type": "org_apache_commons.commons_lang3.MethodUtilsTest$OverloadedParent"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.reflect.MethodUtils"
-      },
-      "type": "org_apache_commons.commons_lang3.MethodUtilsTest$PublicBase"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.reflect.MethodUtils"
-      },
-      "type": "org_apache_commons.commons_lang3.MethodUtilsTest$VarArgsTarget",
-      "methods": [
-        {
-          "name": "joinStatic",
-          "parameterTypes": [
-            "java.lang.String",
-            "int[]"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.ObjectUtils"
-      },
-      "type": "org_apache_commons.commons_lang3.ObjectUtilsTest$CloneableSample",
-      "methods": [
-        {
-          "name": "clone",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.builder.ReflectionToStringBuilder"
-      },
-      "type": "org_apache_commons.commons_lang3.ReflectionToStringBuilderTest$IdentifiedRecord",
-      "fields": [
-        {
-          "name": "identifier"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.builder.ReflectionToStringBuilder"
-      },
-      "type": "org_apache_commons.commons_lang3.ReflectionToStringBuilderTest$RankedRecord",
-      "fields": [
-        {
-          "name": "label"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.builder.ReflectionToStringBuilder"
-      },
-      "type": "org_apache_commons.commons_lang3.ReflectionToStringBuilderTest$SessionRecord",
-      "fields": [
-        {
-          "name": "label"
-        },
-        {
-          "name": "sessionToken"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.SerializationUtils"
-      },
-      "type": "org_apache_commons.commons_lang3.SerializationUtilsClassLoaderAwareObjectInputStreamTest$ContextClassLoaderPayload",
-      "serializable": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.SerializationUtils$ClassLoaderAwareObjectInputStream"
-      },
-      "type": "org_apache_commons.commons_lang3.SerializationUtilsClassLoaderAwareObjectInputStreamTest$ContextClassLoaderPayload"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.SerializationUtils"
-      },
-      "type": "org_apache_commons.commons_lang3.SerializationUtilsClassLoaderAwareObjectInputStreamTest$SerializableContainer",
-      "serializable": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.SerializationUtils$ClassLoaderAwareObjectInputStream"
-      },
-      "type": "org_apache_commons.commons_lang3.SerializationUtilsClassLoaderAwareObjectInputStreamTest$SerializableContainer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.SerializationUtils"
-      },
-      "type": "org_apache_commons.commons_lang3.SerializationUtilsTest$RoundTripContainer",
-      "serializable": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.event.EventListenerSupport"
-      },
-      "type": "org_apache_commons.commons_lang3.EventListenerSupportTest$SampleListener[]",
-      "serializable": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.event.EventListenerSupport"
-      },
-      "type": "org_apache_commons.commons_lang3.EventListenerSupportTest$SerializableRecordingListener",
-      "serializable": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.event.EventListenerSupport"
-      },
-      "type": "java.lang.Object",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.function.MethodInvokers"
-      },
-      "type": "java.lang.String",
-      "methods": [
-        {
-          "name": "charAt",
-          "parameterTypes": [
-            "int"
-          ]
-        },
-        {
-          "name": "length",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.function.MethodInvokers"
-      },
-      "type": "java.util.function.BiConsumer",
-      "allPublicMethods": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.function.MethodInvokers"
-      },
-      "type": "java.util.function.BiFunction",
-      "allPublicMethods": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.function.MethodInvokers"
-      },
-      "type": "java.util.function.Function",
-      "allPublicMethods": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.function.MethodInvokers"
-      },
-      "type": "java.util.function.Supplier",
-      "allPublicMethods": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.function.MethodInvokers"
-      },
-      "type": "org_apache_commons.commons_lang3.MethodInvokersTest",
-      "methods": [
-        {
-          "name": "greeting",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.function.MethodInvokers"
-      },
-      "type": "org_apache_commons.commons_lang3.MethodInvokersTest$MutableText",
-      "methods": [
-        {
-          "name": "append",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.function.MethodInvokers"
-      },
-      "type": {
-        "proxy": [
-          "java.util.function.BiConsumer",
-          "sun.invoke.WrapperInstance"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.function.MethodInvokers"
-      },
-      "type": {
-        "proxy": [
-          "java.util.function.BiFunction",
-          "sun.invoke.WrapperInstance"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.function.MethodInvokers"
-      },
-      "type": {
-        "proxy": [
-          "java.util.function.Function",
-          "sun.invoke.WrapperInstance"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.function.MethodInvokers"
-      },
-      "type": {
-        "proxy": [
-          "java.util.function.Supplier",
-          "sun.invoke.WrapperInstance"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.event.EventListenerSupport"
-      },
-      "type": {
-        "proxy": [
-          "org_apache_commons.commons_lang3.EventListenerSupportTest$SampleListener"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.event.EventListenerSupport"
-      },
-      "type": {
-        "proxy": [
-          "org_apache_commons.commons_lang3.EventListenerSupportProxyInvocationHandlerTest$SampleListener"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.commons.lang3.event.EventUtils"
-      },
-      "type": {
-        "proxy": [
-          "org_apache_commons.commons_lang3.EventUtilsTest$SampleListener"
-        ]
-      }
     }
   ]
 }

--- a/metadata/org.apache.commons/commons-lang3/3.19.0/reachability-metadata.json
+++ b/metadata/org.apache.commons/commons-lang3/3.19.0/reachability-metadata.json
@@ -547,6 +547,158 @@
       "condition": {
         "typeReached": "org.apache.commons.lang3.event.EventListenerSupport"
       },
+      "type": "org_apache_commons.commons_lang3.EventListenerSupportTest$SampleListener[]",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.event.EventListenerSupport"
+      },
+      "type": "org_apache_commons.commons_lang3.EventListenerSupportTest$SerializableRecordingListener",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.event.EventListenerSupport"
+      },
+      "type": "java.lang.Object",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.function.MethodInvokers"
+      },
+      "type": "java.lang.String",
+      "methods": [
+        {
+          "name": "charAt",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "length",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.function.MethodInvokers"
+      },
+      "type": "java.util.function.BiConsumer",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.function.MethodInvokers"
+      },
+      "type": "java.util.function.BiFunction",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.function.MethodInvokers"
+      },
+      "type": "java.util.function.Function",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.function.MethodInvokers"
+      },
+      "type": "java.util.function.Supplier",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.function.MethodInvokers"
+      },
+      "type": "org_apache_commons.commons_lang3.MethodInvokersTest",
+      "methods": [
+        {
+          "name": "greeting",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.function.MethodInvokers"
+      },
+      "type": "org_apache_commons.commons_lang3.MethodInvokersTest$MutableText",
+      "methods": [
+        {
+          "name": "append",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.function.MethodInvokers"
+      },
+      "type": {
+        "proxy": [
+          "java.util.function.BiConsumer",
+          "sun.invoke.WrapperInstance"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.function.MethodInvokers"
+      },
+      "type": {
+        "proxy": [
+          "java.util.function.BiFunction",
+          "sun.invoke.WrapperInstance"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.function.MethodInvokers"
+      },
+      "type": {
+        "proxy": [
+          "java.util.function.Function",
+          "sun.invoke.WrapperInstance"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.function.MethodInvokers"
+      },
+      "type": {
+        "proxy": [
+          "java.util.function.Supplier",
+          "sun.invoke.WrapperInstance"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.event.EventListenerSupport"
+      },
+      "type": {
+        "proxy": [
+          "org_apache_commons.commons_lang3.EventListenerSupportTest$SampleListener"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.event.EventListenerSupport"
+      },
       "type": {
         "proxy": [
           "org_apache_commons.commons_lang3.EventListenerSupportProxyInvocationHandlerTest$SampleListener"

--- a/metadata/org.apache.commons/commons-lang3/3.19.0/reachability-metadata.json
+++ b/metadata/org.apache.commons/commons-lang3/3.19.0/reachability-metadata.json
@@ -1,0 +1,567 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.ObjectUtils"
+      },
+      "type": "int[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.reflect.MethodUtils"
+      },
+      "type": "java.lang.Integer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.reflect.MethodUtils"
+      },
+      "type": "java.lang.Integer[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.stream.Streams$ArrayCollector"
+      },
+      "type": "java.lang.Number[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.builder.CompareToBuilder"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.builder.EqualsBuilder"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.builder.HashCodeBuilder"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.builder.ReflectionToStringBuilder"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.reflect.FieldUtils"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.reflect.MethodUtils"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.SerializationUtils"
+      },
+      "type": "java.lang.String",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.ArrayUtils"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.stream.Streams$ArrayCollector"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.exception.ExceptionUtils"
+      },
+      "type": "java.lang.Throwable",
+      "methods": [
+        {
+          "name": "getCause",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.SerializationUtils"
+      },
+      "type": "java.util.ArrayList",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.SerializationUtils$ClassLoaderAwareObjectInputStream"
+      },
+      "type": "java.util.ArrayList"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.reflect.TypeUtils"
+      },
+      "type": "java.util.List[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.ClassUtils"
+      },
+      "type": "missing.Type"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.AnnotationUtils"
+      },
+      "type": "org_apache_commons.commons_lang3.AnnotationUtilsTest$Nested",
+      "methods": [
+        {
+          "name": "name",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.AnnotationUtils$1"
+      },
+      "type": "org_apache_commons.commons_lang3.AnnotationUtilsTest$Nested",
+      "methods": [
+        {
+          "name": "name",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.ClassUtils"
+      },
+      "type": "org_apache_commons.commons_lang3.ClassUtilsTest$ConvertibleTarget"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.ClassUtils"
+      },
+      "type": "org_apache_commons.commons_lang3.ClassUtilsTest$Greeting"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.ClassUtils"
+      },
+      "type": "org_apache_commons.commons_lang3.ClassUtilsTest$LoaderTarget"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.ClassUtils"
+      },
+      "type": "org_apache_commons.commons_lang3.ClassUtilsTest$PackagePrivateGreetingTarget"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.builder.CompareToBuilder"
+      },
+      "type": "org_apache_commons.commons_lang3.CompareToBuilderTest$SessionRecord",
+      "fields": [
+        {
+          "name": "label"
+        },
+        {
+          "name": "sessionToken"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.reflect.ConstructorUtils"
+      },
+      "type": "org_apache_commons.commons_lang3.ConstructorUtilsTest$AssignableConstructorTarget",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Number"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.reflect.ConstructorUtils"
+      },
+      "type": "org_apache_commons.commons_lang3.ConstructorUtilsTest$ExactConstructorTarget",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.builder.EqualsBuilder"
+      },
+      "type": "org_apache_commons.commons_lang3.EqualsBuilderTest$IdentifiedRecord",
+      "fields": [
+        {
+          "name": "identifier"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.builder.EqualsBuilder"
+      },
+      "type": "org_apache_commons.commons_lang3.EqualsBuilderTest$RankedRecord",
+      "fields": [
+        {
+          "name": "label"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.builder.EqualsBuilder"
+      },
+      "type": "org_apache_commons.commons_lang3.EqualsBuilderTest$SessionRecord",
+      "fields": [
+        {
+          "name": "label"
+        },
+        {
+          "name": "sessionToken"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.event.EventListenerSupport$ProxyInvocationHandler"
+      },
+      "type": "org_apache_commons.commons_lang3.EventListenerSupportProxyInvocationHandlerTest$SampleListener",
+      "methods": [
+        {
+          "name": "onEvent",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.event.EventListenerSupport"
+      },
+      "type": "org_apache_commons.commons_lang3.EventListenerSupportProxyInvocationHandlerTest$SampleListener[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.event.EventUtils$EventBindingInvocationHandler"
+      },
+      "type": "org_apache_commons.commons_lang3.EventUtilsTest$RecordingTarget"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.reflect.MethodUtils"
+      },
+      "type": "org_apache_commons.commons_lang3.EventUtilsTest$RecordingTarget",
+      "methods": [
+        {
+          "name": "recordStatusChange",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.event.EventUtils"
+      },
+      "type": "org_apache_commons.commons_lang3.EventUtilsTest$SampleEventSource",
+      "methods": [
+        {
+          "name": "addSampleListener",
+          "parameterTypes": [
+            "org_apache_commons.commons_lang3.EventUtilsTest$SampleListener"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.exception.ExceptionUtils"
+      },
+      "type": "org_apache_commons.commons_lang3.ExceptionUtilsTest$LegacyWrappedException",
+      "methods": [
+        {
+          "name": "getException",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.reflect.FieldUtils"
+      },
+      "type": "org_apache_commons.commons_lang3.FieldUtilsTest$AllFieldsChild"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.reflect.FieldUtils"
+      },
+      "type": "org_apache_commons.commons_lang3.FieldUtilsTest$AllFieldsParent"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.reflect.FieldUtils"
+      },
+      "type": "org_apache_commons.commons_lang3.FieldUtilsTest$DeclaredFieldTarget"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.reflect.FieldUtils"
+      },
+      "type": "org_apache_commons.commons_lang3.FieldUtilsTest$InterfaceFieldTarget"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.reflect.FieldUtils"
+      },
+      "type": "org_apache_commons.commons_lang3.FieldUtilsTest$LabelProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.reflect.FieldUtils"
+      },
+      "type": "org_apache_commons.commons_lang3.FieldUtilsTest$MutableFieldTarget",
+      "fields": [
+        {
+          "name": "message"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.builder.HashCodeBuilder"
+      },
+      "type": "org_apache_commons.commons_lang3.HashCodeBuilderTest$IdentifiedRecord",
+      "fields": [
+        {
+          "name": "identifier"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.builder.HashCodeBuilder"
+      },
+      "type": "org_apache_commons.commons_lang3.HashCodeBuilderTest$RankedRecord",
+      "fields": [
+        {
+          "name": "label"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.builder.HashCodeBuilder"
+      },
+      "type": "org_apache_commons.commons_lang3.HashCodeBuilderTest$SessionRecord",
+      "fields": [
+        {
+          "name": "label"
+        },
+        {
+          "name": "sessionToken"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.reflect.MethodUtils"
+      },
+      "type": "org_apache_commons.commons_lang3.MethodUtilsTest$AnnotatedChild"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.reflect.MethodUtils"
+      },
+      "type": "org_apache_commons.commons_lang3.MethodUtilsTest$AnnotatedParent"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.reflect.MethodUtils"
+      },
+      "type": "org_apache_commons.commons_lang3.MethodUtilsTest$ExactTarget",
+      "methods": [
+        {
+          "name": "echo",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "echoStatic",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.reflect.MethodUtils"
+      },
+      "type": "org_apache_commons.commons_lang3.MethodUtilsTest$Greeting"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.reflect.MethodUtils"
+      },
+      "type": "org_apache_commons.commons_lang3.MethodUtilsTest$OverloadedChild"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.reflect.MethodUtils"
+      },
+      "type": "org_apache_commons.commons_lang3.MethodUtilsTest$OverloadedParent"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.reflect.MethodUtils"
+      },
+      "type": "org_apache_commons.commons_lang3.MethodUtilsTest$PublicBase"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.reflect.MethodUtils"
+      },
+      "type": "org_apache_commons.commons_lang3.MethodUtilsTest$VarArgsTarget",
+      "methods": [
+        {
+          "name": "joinStatic",
+          "parameterTypes": [
+            "java.lang.String",
+            "int[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.ObjectUtils"
+      },
+      "type": "org_apache_commons.commons_lang3.ObjectUtilsTest$CloneableSample",
+      "methods": [
+        {
+          "name": "clone",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.builder.ReflectionToStringBuilder"
+      },
+      "type": "org_apache_commons.commons_lang3.ReflectionToStringBuilderTest$IdentifiedRecord",
+      "fields": [
+        {
+          "name": "identifier"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.builder.ReflectionToStringBuilder"
+      },
+      "type": "org_apache_commons.commons_lang3.ReflectionToStringBuilderTest$RankedRecord",
+      "fields": [
+        {
+          "name": "label"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.builder.ReflectionToStringBuilder"
+      },
+      "type": "org_apache_commons.commons_lang3.ReflectionToStringBuilderTest$SessionRecord",
+      "fields": [
+        {
+          "name": "label"
+        },
+        {
+          "name": "sessionToken"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.SerializationUtils"
+      },
+      "type": "org_apache_commons.commons_lang3.SerializationUtilsClassLoaderAwareObjectInputStreamTest$ContextClassLoaderPayload",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.SerializationUtils$ClassLoaderAwareObjectInputStream"
+      },
+      "type": "org_apache_commons.commons_lang3.SerializationUtilsClassLoaderAwareObjectInputStreamTest$ContextClassLoaderPayload"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.SerializationUtils"
+      },
+      "type": "org_apache_commons.commons_lang3.SerializationUtilsClassLoaderAwareObjectInputStreamTest$SerializableContainer",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.SerializationUtils$ClassLoaderAwareObjectInputStream"
+      },
+      "type": "org_apache_commons.commons_lang3.SerializationUtilsClassLoaderAwareObjectInputStreamTest$SerializableContainer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.SerializationUtils"
+      },
+      "type": "org_apache_commons.commons_lang3.SerializationUtilsTest$RoundTripContainer",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.event.EventListenerSupport"
+      },
+      "type": {
+        "proxy": [
+          "org_apache_commons.commons_lang3.EventListenerSupportProxyInvocationHandlerTest$SampleListener"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.commons.lang3.event.EventUtils"
+      },
+      "type": {
+        "proxy": [
+          "org_apache_commons.commons_lang3.EventUtilsTest$SampleListener"
+        ]
+      }
+    }
+  ]
+}

--- a/metadata/org.apache.commons/commons-lang3/index.json
+++ b/metadata/org.apache.commons/commons-lang3/index.json
@@ -1,28 +1,27 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "3.19.0",
-    "test-version" : "3.11",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/$version$/commons-lang3-$version$-sources.jar",
-    "repository-url" : "https://github.com/apache/commons-lang",
-    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/$version$/commons-lang3-$version$-test-sources.jar",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/$version$/commons-lang3-$version$-javadoc.jar",
-    "description" : "Apache Commons Lang provides reusable Java utility classes that extend core `java.lang` functionality with helpers for strings, numbers, objects, reflection, concurrency, and more. It helps Java applications avoid reimplementing common low-level programming tasks by packaging widely used language-level utilities.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "3.19.0",
+    "source-code-url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/$version$/commons-lang3-$version$-sources.jar",
+    "repository-url": "https://github.com/apache/commons-lang",
+    "test-code-url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/$version$/commons-lang3-$version$-test-sources.jar",
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/$version$/commons-lang3-$version$-javadoc.jar",
+    "description": "Apache Commons Lang provides reusable Java utility classes that extend core `java.lang` functionality with helpers for strings, numbers, objects, reflection, concurrency, and more. It helps Java applications avoid reimplementing common low-level programming tasks by packaging widely used language-level utilities.",
+    "tested-versions": [
       "3.19.0"
     ],
-    "allowed-packages" : [
+    "allowed-packages": [
       "org.apache.commons.lang3"
     ]
   },
   {
-    "metadata-version" : "3.11",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/$version$/commons-lang3-$version$-sources.jar",
-    "repository-url" : "https://github.com/apache/commons-lang",
-    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/$version$/commons-lang3-$version$-test-sources.jar",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/$version$/commons-lang3-$version$-javadoc.jar",
-    "description" : "Apache Commons Lang provides reusable Java utility classes that extend core `java.lang` functionality with helpers for strings, numbers, objects, reflection, concurrency, and more. It helps Java applications avoid reimplementing common low-level programming tasks by packaging widely used language-level utilities.",
-    "tested-versions" : [
+    "metadata-version": "3.11",
+    "source-code-url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/$version$/commons-lang3-$version$-sources.jar",
+    "repository-url": "https://github.com/apache/commons-lang",
+    "test-code-url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/$version$/commons-lang3-$version$-test-sources.jar",
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/$version$/commons-lang3-$version$-javadoc.jar",
+    "description": "Apache Commons Lang provides reusable Java utility classes that extend core `java.lang` functionality with helpers for strings, numbers, objects, reflection, concurrency, and more. It helps Java applications avoid reimplementing common low-level programming tasks by packaging widely used language-level utilities.",
+    "tested-versions": [
       "3.11",
       "3.12.0",
       "3.13.0",
@@ -32,7 +31,7 @@
       "3.17.0",
       "3.18.0"
     ],
-    "allowed-packages" : [
+    "allowed-packages": [
       "org.apache.commons.lang3"
     ]
   }

--- a/metadata/org.apache.commons/commons-lang3/index.json
+++ b/metadata/org.apache.commons/commons-lang3/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.19.0",
+    "test-version" : "3.11",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/$version$/commons-lang3-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/commons-lang",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/$version$/commons-lang3-$version$-test-sources.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/$version$/commons-lang3-$version$-javadoc.jar",
+    "description" : "Apache Commons Lang provides reusable Java utility classes that extend core `java.lang` functionality with helpers for strings, numbers, objects, reflection, concurrency, and more. It helps Java applications avoid reimplementing common low-level programming tasks by packaging widely used language-level utilities.",
+    "tested-versions" : [
+      "3.19.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.commons.lang3"
+    ]
+  },
+  {
     "metadata-version" : "3.11",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/$version$/commons-lang3-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/commons-lang",

--- a/stats/org.apache.commons/commons-lang3/3.19.0/execution-metrics.json
+++ b/stats/org.apache.commons/commons-lang3/3.19.0/execution-metrics.json
@@ -1,0 +1,134 @@
+{
+  "fix_ni_run:2026-06-10": {
+    "timestamp": "2026-06-10T01:58:55.084096Z",
+    "library": "org.apache.commons:commons-lang3:3.19.0",
+    "starting_commit": "22602cf74238714272ecec2021356bedf56c7061",
+    "ending_commit": "9cba7c8066218e09f1ec23a90ab9154632319924",
+    "previous_library": "org.apache.commons:commons-lang3:3.11",
+    "strategy_name": "library_update_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.19.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 68,
+            "totalCalls": 68
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 68,
+        "totalCalls": 68
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5658,
+          "missed": 70310,
+          "ratio": 0.074479,
+          "total": 75968
+        },
+        "line": {
+          "covered": 1382,
+          "missed": 14771,
+          "ratio": 0.085557,
+          "total": 16153
+        },
+        "method": {
+          "covered": 367,
+          "missed": 4257,
+          "ratio": 0.079369,
+          "total": 4624
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.11",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.947368,
+            "coveredCalls": 72,
+            "totalCalls": 76
+          }
+        },
+        "coverageRatio": 0.947368,
+        "coveredCalls": 72,
+        "totalCalls": 76
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5525,
+          "missed": 67804,
+          "ratio": 0.075345,
+          "total": 73329
+        },
+        "line": {
+          "covered": 1387,
+          "missed": 14504,
+          "ratio": 0.087282,
+          "total": 15891
+        },
+        "method": {
+          "covered": 300,
+          "missed": 3426,
+          "ratio": 0.080515,
+          "total": 3726
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "no_action",
+      "issue_number": 2100,
+      "issue_label": "fails-native-image-run",
+      "library": "org.apache.commons:commons-lang3:3.19.0",
+      "summary": "Apache Commons Lang 3.19.0 is a pure Java utility library; the resolved artifact has no compile/runtime dependencies, only upstream test-scope dependencies, and normal usage does not require services, containers, environment variables, or system properties.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [
+        "Some APIs exercise reflection, serialization, proxies, class loading, and system-property readers, so generated tests should avoid assertions tied to a specific host OS/JDK value unless they only assert stable invariants.",
+        "Upstream tests use additional test-only libraries such as JUnit Pioneer, EasyMock, Commons Text, JMH, and JSR305, but these are not required product dependencies for meaningful generated coverage."
+      ],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#2100 [Automation] native-image run fails for org.apache.commons:commons-lang3:3.19.0; label=fails-native-image-run; body_chars=8015"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "24 existing test file path(s) included"
+        }
+      ],
+      "current_library": "org.apache.commons:commons-lang3:3.11",
+      "new_version": "3.19.0",
+      "model": "oca/gpt-5.5",
+      "input_tokens_used": 22736,
+      "output_tokens_used": 2510,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.apache.commons:commons-lang3:3.19.0/library-preparation-preflight/pi-generation-2026-06-10T00-45-51-924157Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 56693,
+      "cached_input_tokens_used": 493056,
+      "output_tokens_used": 7063,
+      "iterations": 2,
+      "cost_usd": 0.4584,
+      "tested_library_loc": 1382,
+      "metadata_entries": 46,
+      "test_only_metadata_entries": 139,
+      "previous_library_metadata_entries": 41,
+      "previous_library_test_only_metadata_entries": 76,
+      "code_coverage_percent": 8.56,
+      "previous_library_coverage_percent": 8.73
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/EventListenerSupportTest.java",
+      "metadata_file": "metadata/org.apache.commons/commons-lang3/3.19.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.commons/commons-lang3/3.19.0/stats.json
+++ b/stats/org.apache.commons/commons-lang3/3.19.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "3.19.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 68,
+          "totalCalls" : 68
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 68,
+      "totalCalls" : 68
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 5658,
+        "missed" : 70310,
+        "ratio" : 0.074479,
+        "total" : 75968
+      },
+      "line" : {
+        "covered" : 1382,
+        "missed" : 14771,
+        "ratio" : 0.085557,
+        "total" : 16153
+      },
+      "method" : {
+        "covered" : 367,
+        "missed" : 4257,
+        "ratio" : 0.079369,
+        "total" : 4624
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.commons/commons-lang3/3.19.0/.gitignore
+++ b/tests/src/org.apache.commons/commons-lang3/3.19.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.commons/commons-lang3/3.19.0/build.gradle
+++ b/tests/src/org.apache.commons/commons-lang3/3.19.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.commons:commons-lang3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.commons/commons-lang3/3.19.0/gradle.properties
+++ b/tests/src/org.apache.commons/commons-lang3/3.19.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.commons:commons-lang3:3.19.0
+library.version = 3.19.0
+metadata.dir = org.apache.commons/commons-lang3/3.19.0/

--- a/tests/src/org.apache.commons/commons-lang3/3.19.0/settings.gradle
+++ b/tests/src/org.apache.commons/commons-lang3/3.19.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.commons.commons-lang3_tests'

--- a/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/AnnotationUtilsTest.java
+++ b/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/AnnotationUtilsTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_commons.commons_lang3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.apache.commons.lang3.AnnotationUtils;
+import org.junit.jupiter.api.Test;
+
+public class AnnotationUtilsTest {
+
+    @SuppressWarnings("checkstyle:annotationAccess")
+    @Test
+    public void equalsUsesAnnotationMembersFromMatchingRuntimeAnnotations() {
+        Composite sameLeft = MatchingAnnotationLeft.class.getAnnotation(Composite.class);
+        Composite sameRight = MatchingAnnotationRight.class.getAnnotation(Composite.class);
+        Composite different = DifferentAnnotationValues.class.getAnnotation(Composite.class);
+
+        assertThat(AnnotationUtils.equals(sameLeft, sameRight)).isTrue();
+        assertThat(AnnotationUtils.equals(sameLeft, different)).isFalse();
+    }
+
+    @SuppressWarnings("checkstyle:annotationAccess")
+    @Test
+    public void hashCodeAndToStringUseAnnotationMembersFromRuntimeAnnotation() {
+        Composite annotation = MatchingAnnotationLeft.class.getAnnotation(Composite.class);
+
+        assertThat(AnnotationUtils.hashCode(annotation)).isEqualTo(annotation.hashCode());
+        assertThat(AnnotationUtils.toString(annotation))
+                .contains("@" + Composite.class.getName())
+                .contains("value=alpha")
+                .contains("numbers=[1,2,3]")
+                .contains("nested=@" + Nested.class.getName())
+                .contains("name=inner");
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Nested {
+        String name();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Composite {
+        String value();
+
+        int[] numbers();
+
+        Nested nested();
+    }
+
+    @Composite(value = "alpha", numbers = {1, 2, 3}, nested = @Nested(name = "inner"))
+    public static class MatchingAnnotationLeft {
+    }
+
+    @Composite(value = "alpha", numbers = {1, 2, 3}, nested = @Nested(name = "inner"))
+    public static class MatchingAnnotationRight {
+    }
+
+    @Composite(value = "beta", numbers = {5, 8}, nested = @Nested(name = "other"))
+    public static class DifferentAnnotationValues {
+    }
+}

--- a/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/ArrayUtilsTest.java
+++ b/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/ArrayUtilsTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_commons.commons_lang3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.jupiter.api.Test;
+
+public class ArrayUtilsTest {
+
+    @Test
+    public void addAtIndexCreatesTypedArrayWhenSourceArrayIsNull() {
+        String[] result = ArrayUtils.add((String[]) null, 0, "alpha");
+
+        assertThat(result).isInstanceOf(String[].class).containsExactly("alpha");
+    }
+
+    @Test
+    public void addAtIndexInsertsIntoExistingObjectArray() {
+        String[] result = ArrayUtils.add(new String[]{"alpha", "gamma"}, 1, "beta");
+
+        assertThat(result).containsExactly("alpha", "beta", "gamma");
+    }
+
+    @Test
+    public void addAppendsToExistingObjectArray() {
+        String[] result = ArrayUtils.add(new String[]{"alpha"}, "beta");
+
+        assertThat(result).containsExactly("alpha", "beta");
+    }
+
+    @Test
+    public void addCreatesTypedArrayWhenAppendingToNullArray() {
+        String[] result = ArrayUtils.add((String[]) null, "alpha");
+
+        assertThat(result).isInstanceOf(String[].class).containsExactly("alpha");
+    }
+
+    @Test
+    public void insertCreatesExpandedArrayForObjectValues() {
+        String[] result = ArrayUtils.insert(1, new String[]{"alpha", "delta"}, "beta", "gamma");
+
+        assertThat(result).containsExactly("alpha", "beta", "gamma", "delta");
+    }
+
+    @Test
+    public void nullToEmptyCreatesTypedEmptyArrayFromExplicitArrayType() {
+        String[] result = ArrayUtils.nullToEmpty(null, String[].class);
+
+        assertThat(result).isInstanceOf(String[].class).isEmpty();
+    }
+
+    @Test
+    public void removeDeletesElementFromObjectArray() {
+        String[] result = ArrayUtils.remove(new String[]{"alpha", "beta", "gamma"}, 1);
+
+        assertThat(result).containsExactly("alpha", "gamma");
+    }
+
+    @Test
+    public void removeAllByIndexCreatesCompactedObjectArray() {
+        String[] result = ArrayUtils.removeAll(new String[]{"alpha", "beta", "gamma", "delta"}, 1, 3, 1);
+
+        assertThat(result).containsExactly("alpha", "gamma");
+    }
+
+    @Test
+    public void removeElementsUsesOccurrenceBasedRemovalForObjectArrays() {
+        String[] result = ArrayUtils.removeElements(new String[]{"alpha", "beta", "gamma", "beta", "delta"},
+                "beta", "beta", "missing");
+
+        assertThat(result).containsExactly("alpha", "gamma", "delta");
+    }
+
+    @Test
+    public void subarrayReturnsTypedEmptyArrayWhenRequestedRangeIsEmpty() {
+        String[] result = ArrayUtils.subarray(new String[]{"alpha", "beta"}, 2, 1);
+
+        assertThat(result).isInstanceOf(String[].class).isEmpty();
+    }
+
+    @Test
+    public void subarrayCopiesRequestedObjectRange() {
+        String[] result = ArrayUtils.subarray(new String[]{"alpha", "beta", "gamma"}, 1, 3);
+
+        assertThat(result).containsExactly("beta", "gamma");
+    }
+}

--- a/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/ClassUtilsTest.java
+++ b/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/ClassUtilsTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_commons.commons_lang3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.lang3.ClassUtils;
+import org.junit.jupiter.api.Test;
+
+public class ClassUtilsTest {
+
+    @Test
+    public void convertClassNamesToClassesLoadsResolvableNamesAndPreservesFailures() {
+        List<Class<?>> classes = ClassUtils.convertClassNamesToClasses(Arrays.asList(
+                ConvertibleTarget.class.getName(),
+                "missing.Type",
+                null));
+
+        assertThat(classes).containsExactly(ConvertibleTarget.class, null, null);
+    }
+
+    @Test
+    public void getClassResolvesClassNamesWithExplicitClassLoader() throws ClassNotFoundException {
+        Class<?> resolvedClass = ClassUtils.getClass(
+                ClassUtilsTest.class.getClassLoader(),
+                LoaderTarget.class.getName(),
+                false);
+
+        assertThat(resolvedClass).isEqualTo(LoaderTarget.class);
+    }
+
+    @Test
+    public void getPublicMethodFallsBackToPublicInterfaceMethod() throws NoSuchMethodException {
+        Method method = ClassUtils.getPublicMethod(PackagePrivateGreetingTarget.class, "greet", String.class);
+
+        assertThat(method).isNotNull();
+        assertThat(method.getDeclaringClass()).isEqualTo(Greeting.class);
+        assertThat(method.getName()).isEqualTo("greet");
+        assertThat(method.getParameterTypes()).containsExactly(String.class);
+    }
+
+    public interface Greeting {
+        String greet(String name);
+    }
+
+    public static class ConvertibleTarget {
+    }
+
+    public static class LoaderTarget {
+    }
+
+    static class PackagePrivateGreetingTarget implements Greeting {
+        @Override
+        public String greet(String name) {
+            return "hello " + name;
+        }
+    }
+}

--- a/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/CompareToBuilderTest.java
+++ b/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/CompareToBuilderTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_commons.commons_lang3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.commons.lang3.builder.CompareToBuilder;
+import org.junit.jupiter.api.Test;
+
+public class CompareToBuilderTest {
+
+    @Test
+    public void reflectionCompareReadsPrivateFieldsAcrossTheClassHierarchy() {
+        RankedRecord lhs = new RankedRecord(1, "alpha", "cache");
+        RankedRecord rhs = new RankedRecord(2, "alpha", "cache");
+
+        int comparison = CompareToBuilder.reflectionCompare(lhs, rhs, false, IdentifiedRecord.class);
+
+        assertThat(comparison).isLessThan(0);
+    }
+
+    @Test
+    public void reflectionCompareCanIncludeTransientFieldsWhenRequested() {
+        SessionRecord lhs = new SessionRecord("alpha", "session-1");
+        SessionRecord rhs = new SessionRecord("alpha", "session-2");
+
+        int defaultComparison = CompareToBuilder.reflectionCompare(lhs, rhs);
+        int transientComparison = CompareToBuilder.reflectionCompare(lhs, rhs, true);
+
+        assertThat(defaultComparison).isZero();
+        assertThat(transientComparison).isLessThan(0);
+    }
+
+    private static class IdentifiedRecord {
+        private final int rank;
+
+        private IdentifiedRecord(int rank) {
+            this.rank = rank;
+        }
+    }
+
+    private static final class RankedRecord extends IdentifiedRecord {
+        private static final String TYPE = "ranked";
+
+        private final String label;
+        private transient String cachedDisplayName;
+
+        private RankedRecord(int rank, String label, String cachedDisplayName) {
+            super(rank);
+            this.label = label;
+            this.cachedDisplayName = cachedDisplayName;
+        }
+    }
+
+    private static final class SessionRecord {
+        private final String label;
+        private transient String sessionToken;
+
+        private SessionRecord(String label, String sessionToken) {
+            this.label = label;
+            this.sessionToken = sessionToken;
+        }
+    }
+}

--- a/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/ConstructorUtilsTest.java
+++ b/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/ConstructorUtilsTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_commons.commons_lang3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Constructor;
+
+import org.apache.commons.lang3.reflect.ConstructorUtils;
+import org.junit.jupiter.api.Test;
+
+public class ConstructorUtilsTest {
+
+    @Test
+    public void getAccessibleConstructorAndInvokeExactConstructorUseExactPublicLookup() throws Exception {
+        Constructor<ExactConstructorTarget> constructor = ConstructorUtils.getAccessibleConstructor(
+                ExactConstructorTarget.class, String.class);
+        ExactConstructorTarget target = ConstructorUtils.invokeExactConstructor(ExactConstructorTarget.class, "commons");
+
+        assertThat(constructor).isNotNull();
+        assertThat(constructor.getDeclaringClass()).isEqualTo(ExactConstructorTarget.class);
+        assertThat(constructor.getParameterTypes()).containsExactly(String.class);
+        assertThat(target.describe()).isEqualTo("exact:commons");
+    }
+
+    @Test
+    public void getMatchingAccessibleConstructorUsesDirectLookupForExactSignature() {
+        Constructor<ExactConstructorTarget> constructor = ConstructorUtils.getMatchingAccessibleConstructor(
+                ExactConstructorTarget.class, String.class);
+
+        assertThat(constructor).isNotNull();
+        assertThat(constructor.getDeclaringClass()).isEqualTo(ExactConstructorTarget.class);
+        assertThat(constructor.getParameterTypes()).containsExactly(String.class);
+    }
+
+    @Test
+    public void invokeConstructorUsesCompatibleAccessibleConstructorWhenExactSignatureIsMissing() throws Exception {
+        Constructor<AssignableConstructorTarget> constructor = ConstructorUtils.getMatchingAccessibleConstructor(
+                AssignableConstructorTarget.class, Integer.class);
+        AssignableConstructorTarget target = ConstructorUtils.invokeConstructor(AssignableConstructorTarget.class,
+                Integer.valueOf(7));
+
+        assertThat(constructor).isNotNull();
+        assertThat(constructor.getDeclaringClass()).isEqualTo(AssignableConstructorTarget.class);
+        assertThat(constructor.getParameterTypes()).containsExactly(Number.class);
+        assertThat(target.describe()).isEqualTo("number:7");
+    }
+
+    public static class ExactConstructorTarget {
+        private final String value;
+
+        public ExactConstructorTarget(String value) {
+            this.value = value;
+        }
+
+        public String describe() {
+            return "exact:" + value;
+        }
+    }
+
+    public static class AssignableConstructorTarget {
+        private final Number value;
+
+        public AssignableConstructorTarget(Number value) {
+            this.value = value;
+        }
+
+        public String describe() {
+            return "number:" + value;
+        }
+    }
+}

--- a/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/EqualsBuilderTest.java
+++ b/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/EqualsBuilderTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_commons.commons_lang3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.junit.jupiter.api.Test;
+
+public class EqualsBuilderTest {
+
+    @Test
+    public void reflectionEqualsReadsPrivateFieldsAcrossTheClassHierarchy() {
+        RankedRecord lhs = new RankedRecord("id-1", "alpha");
+        RankedRecord rhs = new RankedRecord("id-2", "alpha");
+
+        boolean equal = EqualsBuilder.reflectionEquals(lhs, rhs);
+
+        assertThat(equal).isFalse();
+    }
+
+    @Test
+    public void reflectionEqualsCanIncludeTransientFieldsWhenRequested() {
+        SessionRecord lhs = new SessionRecord("alpha", "session-1");
+        SessionRecord rhs = new SessionRecord("alpha", "session-2");
+
+        boolean defaultEquality = EqualsBuilder.reflectionEquals(lhs, rhs);
+        boolean transientEquality = EqualsBuilder.reflectionEquals(lhs, rhs, true);
+
+        assertThat(defaultEquality).isTrue();
+        assertThat(transientEquality).isFalse();
+    }
+
+    private static class IdentifiedRecord {
+        private final String identifier;
+
+        private IdentifiedRecord(String identifier) {
+            this.identifier = identifier;
+        }
+    }
+
+    private static final class RankedRecord extends IdentifiedRecord {
+        private final String label;
+
+        private RankedRecord(String identifier, String label) {
+            super(identifier);
+            this.label = label;
+        }
+    }
+
+    private static final class SessionRecord {
+        private final String label;
+        private transient String sessionToken;
+
+        private SessionRecord(String label, String sessionToken) {
+            this.label = label;
+            this.sessionToken = sessionToken;
+        }
+    }
+}

--- a/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/EventListenerSupportProxyInvocationHandlerTest.java
+++ b/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/EventListenerSupportProxyInvocationHandlerTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_commons.commons_lang3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.event.EventListenerSupport;
+import org.junit.jupiter.api.Test;
+
+public class EventListenerSupportProxyInvocationHandlerTest {
+
+    @Test
+    public void fireDispatchesListenerCallsToEachRegisteredListener() {
+        EventListenerSupport<SampleListener> listenerSupport = EventListenerSupport.create(SampleListener.class);
+        RecordingSampleListener firstListener = new RecordingSampleListener("first");
+        RecordingSampleListener secondListener = new RecordingSampleListener("second");
+
+        listenerSupport.addListener(firstListener);
+        listenerSupport.addListener(secondListener);
+
+        listenerSupport.fire().onEvent("payload");
+
+        assertThat(firstListener.deliveries()).containsExactly("first:payload");
+        assertThat(secondListener.deliveries()).containsExactly("second:payload");
+    }
+
+    public interface SampleListener {
+
+        void onEvent(String message);
+    }
+
+    public static final class RecordingSampleListener implements SampleListener {
+
+        private final String name;
+        private final List<String> deliveries = new ArrayList<>();
+
+        public RecordingSampleListener(final String name) {
+            this.name = name;
+        }
+
+        @Override
+        public void onEvent(final String message) {
+            deliveries.add(name + ":" + message);
+        }
+
+        public List<String> deliveries() {
+            return deliveries;
+        }
+    }
+}

--- a/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/EventListenerSupportTest.java
+++ b/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/EventListenerSupportTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_commons.commons_lang3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.event.EventListenerSupport;
+import org.junit.jupiter.api.Test;
+
+public class EventListenerSupportTest {
+
+    @Test
+    public void serializationRoundTripFiltersNonSerializableListeners() throws IOException, ClassNotFoundException {
+        EventListenerSupport<SampleListener> original = EventListenerSupport.create(SampleListener.class);
+        SerializableRecordingListener serializableListener = new SerializableRecordingListener("kept");
+        NonSerializableRecordingListener nonSerializableListener = new NonSerializableRecordingListener("dropped");
+        original.addListener(serializableListener);
+        original.addListener(nonSerializableListener);
+
+        byte[] serialized = serialize(original);
+        EventListenerSupport<SampleListener> deserialized = deserialize(serialized);
+
+        SampleListener[] listeners = deserialized.getListeners();
+        assertThat(listeners).hasSize(1);
+        assertThat(listeners[0]).isInstanceOf(SerializableRecordingListener.class);
+
+        deserialized.fire().onEvent("payload");
+
+        SerializableRecordingListener retainedListener = (SerializableRecordingListener) listeners[0];
+        assertThat(retainedListener.deliveries()).containsExactly("kept:payload");
+        assertThat(nonSerializableListener.deliveries()).isEmpty();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static EventListenerSupport<SampleListener> deserialize(final byte[] serialized)
+            throws IOException, ClassNotFoundException {
+        try (ObjectInputStream inputStream = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            Object listenerSupport = inputStream.readObject();
+            return (EventListenerSupport<SampleListener>) listenerSupport;
+        }
+    }
+
+    private static byte[] serialize(final EventListenerSupport<SampleListener> listenerSupport) throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (ObjectOutputStream outputStream = new ObjectOutputStream(output)) {
+            outputStream.writeObject(listenerSupport);
+        }
+        return output.toByteArray();
+    }
+
+    public interface SampleListener {
+
+        void onEvent(String message);
+    }
+
+    public static final class NonSerializableRecordingListener implements SampleListener {
+
+        private final String name;
+        private final List<String> deliveries = new ArrayList<>();
+
+        public NonSerializableRecordingListener(final String name) {
+            this.name = name;
+        }
+
+        @Override
+        public void onEvent(final String message) {
+            deliveries.add(name + ":" + message);
+        }
+
+        public List<String> deliveries() {
+            return deliveries;
+        }
+    }
+
+    public static final class SerializableRecordingListener implements SampleListener, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private final String name;
+        private final List<String> deliveries = new ArrayList<>();
+
+        public SerializableRecordingListener(final String name) {
+            this.name = name;
+        }
+
+        @Override
+        public void onEvent(final String message) {
+            deliveries.add(name + ":" + message);
+        }
+
+        public List<String> deliveries() {
+            return deliveries;
+        }
+    }
+}

--- a/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/EventUtilsTest.java
+++ b/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/EventUtilsTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_commons.commons_lang3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.event.EventUtils;
+import org.junit.jupiter.api.Test;
+
+public class EventUtilsTest {
+
+    @Test
+    public void bindEventsToMethodAddsAProxyListenerThatForwardsEventArguments() {
+        SampleEventSource eventSource = new SampleEventSource();
+        RecordingTarget target = new RecordingTarget();
+
+        EventUtils.bindEventsToMethod(target, "recordMessage", eventSource, SampleListener.class);
+
+        assertThat(eventSource.listenerCount()).isEqualTo(1);
+
+        eventSource.fireTextReceived("payload");
+
+        assertThat(target.messages()).containsExactly("payload");
+    }
+
+    @Test
+    public void bindEventsToMethodCanFilterEventTypesAndFallBackToNoArgTargetMethods() {
+        SampleEventSource eventSource = new SampleEventSource();
+        RecordingTarget target = new RecordingTarget();
+
+        EventUtils.bindEventsToMethod(
+                target,
+                "recordStatusChange",
+                eventSource,
+                SampleListener.class,
+                "statusChanged");
+
+        eventSource.fireTextReceived("ignored");
+        eventSource.fireStatusChanged(200);
+
+        assertThat(target.messages()).isEmpty();
+        assertThat(target.statusChangeCount()).isEqualTo(1);
+    }
+
+    public interface SampleListener {
+
+        void textReceived(String message);
+
+        void statusChanged(int statusCode);
+    }
+
+    public static final class SampleEventSource {
+
+        private final List<SampleListener> listeners = new ArrayList<>();
+
+        public void addSampleListener(final SampleListener listener) {
+            listeners.add(listener);
+        }
+
+        public void fireTextReceived(final String message) {
+            for (SampleListener listener : listeners) {
+                listener.textReceived(message);
+            }
+        }
+
+        public void fireStatusChanged(final int statusCode) {
+            for (SampleListener listener : listeners) {
+                listener.statusChanged(statusCode);
+            }
+        }
+
+        public int listenerCount() {
+            return listeners.size();
+        }
+    }
+
+    public static final class RecordingTarget {
+
+        private final List<String> messages = new ArrayList<>();
+        private int statusChangeCount;
+
+        public void recordMessage(final String message) {
+            messages.add(message);
+        }
+
+        public void recordStatusChange() {
+            statusChangeCount++;
+        }
+
+        public List<String> messages() {
+            return messages;
+        }
+
+        public int statusChangeCount() {
+            return statusChangeCount;
+        }
+    }
+}

--- a/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/ExceptionUtilsTest.java
+++ b/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/ExceptionUtilsTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_commons.commons_lang3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.junit.jupiter.api.Test;
+
+public class ExceptionUtilsTest {
+
+    @Test
+    public void getCauseUsesConfiguredLegacyAccessorMethod() {
+        IllegalArgumentException cause = new IllegalArgumentException("legacy cause");
+        LegacyWrappedException wrapper = new LegacyWrappedException(cause);
+
+        Throwable resolvedCause = ExceptionUtils.getCause(wrapper, new String[]{"getException"});
+
+        assertThat(resolvedCause).isSameAs(cause);
+    }
+
+    @Test
+    public void getCauseUsesDefaultLegacyAccessorMethodsWhenDirectCauseIsMissing() {
+        UnsupportedOperationException cause = new UnsupportedOperationException("nested");
+        LegacyWrappedException wrapper = new LegacyWrappedException(cause);
+
+        Throwable resolvedCause = ExceptionUtils.getCause(wrapper);
+
+        assertThat(resolvedCause).isSameAs(cause);
+    }
+
+    public static final class LegacyWrappedException extends RuntimeException {
+        private final Throwable legacyCause;
+
+        public LegacyWrappedException(Throwable legacyCause) {
+            super("wrapper without direct cause");
+            this.legacyCause = legacyCause;
+        }
+
+        public Throwable getException() {
+            return legacyCause;
+        }
+    }
+}

--- a/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/FieldUtilsTest.java
+++ b/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/FieldUtilsTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_commons.commons_lang3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.junit.jupiter.api.Test;
+
+public class FieldUtilsTest {
+
+    @Test
+    public void getDeclaredFieldReturnsPrivateFieldWhenForceAccessIsEnabled() {
+        Field field = FieldUtils.getDeclaredField(DeclaredFieldTarget.class, "hiddenValue", true);
+
+        assertThat(field).isNotNull();
+        assertThat(field.getDeclaringClass()).isEqualTo(DeclaredFieldTarget.class);
+        assertThat(field.getName()).isEqualTo("hiddenValue");
+    }
+
+    @Test
+    public void getFieldFindsInheritedPrivateFieldWhenForceAccessIsEnabled() {
+        Field field = FieldUtils.getField(InheritedFieldChild.class, "inheritedValue", true);
+
+        assertThat(field).isNotNull();
+        assertThat(field.getDeclaringClass()).isEqualTo(InheritedFieldParent.class);
+        assertThat(field.getName()).isEqualTo("inheritedValue");
+    }
+
+    @Test
+    public void getFieldFindsPublicFieldDeclaredOnImplementedInterface() {
+        Field field = FieldUtils.getField(InterfaceFieldTarget.class, "INTERFACE_LABEL");
+
+        assertThat(field).isNotNull();
+        assertThat(field.getDeclaringClass()).isEqualTo(LabelProvider.class);
+        assertThat(field.getName()).isEqualTo("INTERFACE_LABEL");
+    }
+
+    @Test
+    public void getAllFieldsListCollectsDeclaredFieldsFromClassHierarchy() {
+        List<Field> fields = FieldUtils.getAllFieldsList(AllFieldsChild.class);
+
+        assertThat(fields)
+                .extracting(Field::getName)
+                .contains("childField", "parentField");
+    }
+
+    @Test
+    public void readAndWriteFieldOperateOnPrivateInstanceState() throws IllegalAccessException {
+        MutableFieldTarget target = new MutableFieldTarget();
+        Field field = FieldUtils.getDeclaredField(MutableFieldTarget.class, "message", true);
+
+        Object originalValue = FieldUtils.readField(field, target);
+        FieldUtils.writeField(field, target, "updated");
+        Object updatedValue = FieldUtils.readField(field, target);
+
+        assertThat(originalValue).isEqualTo("initial");
+        assertThat(updatedValue).isEqualTo("updated");
+        assertThat(target.currentMessage()).isEqualTo("updated");
+    }
+
+    public static class DeclaredFieldTarget {
+        private String hiddenValue = "declared";
+    }
+
+    public static class InheritedFieldParent {
+        private String inheritedValue = "parent";
+    }
+
+    public static class InheritedFieldChild extends InheritedFieldParent {
+    }
+
+    public interface LabelProvider {
+        String INTERFACE_LABEL = "shared";
+    }
+
+    public static class InterfaceFieldTarget implements LabelProvider {
+    }
+
+    public static class AllFieldsParent {
+        private String parentField = "parent";
+    }
+
+    public static class AllFieldsChild extends AllFieldsParent {
+        private String childField = "child";
+    }
+
+    public static class MutableFieldTarget {
+        private String message = "initial";
+
+        public String currentMessage() {
+            return message;
+        }
+    }
+}

--- a/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/HashCodeBuilderTest.java
+++ b/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/HashCodeBuilderTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_commons.commons_lang3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.junit.jupiter.api.Test;
+
+public class HashCodeBuilderTest {
+
+    @Test
+    public void reflectionHashCodeReadsPrivateFieldsAcrossTheClassHierarchy() {
+        RankedRecord first = new RankedRecord("id-1", "alpha");
+        RankedRecord second = new RankedRecord("id-2", "alpha");
+
+        int firstHash = HashCodeBuilder.reflectionHashCode(first, false);
+        int secondHash = HashCodeBuilder.reflectionHashCode(second, false);
+
+        assertThat(firstHash).isNotEqualTo(secondHash);
+    }
+
+    @Test
+    public void reflectionHashCodeCanIncludeTransientFieldsWhenRequested() {
+        SessionRecord first = new SessionRecord("alpha", "session-1");
+        SessionRecord second = new SessionRecord("alpha", "session-2");
+
+        int defaultFirstHash = HashCodeBuilder.reflectionHashCode(first, false);
+        int defaultSecondHash = HashCodeBuilder.reflectionHashCode(second, false);
+        int transientFirstHash = HashCodeBuilder.reflectionHashCode(first, true);
+        int transientSecondHash = HashCodeBuilder.reflectionHashCode(second, true);
+
+        assertThat(defaultFirstHash).isEqualTo(defaultSecondHash);
+        assertThat(transientFirstHash).isNotEqualTo(transientSecondHash);
+    }
+
+    private static class IdentifiedRecord {
+        private final String identifier;
+
+        private IdentifiedRecord(String identifier) {
+            this.identifier = identifier;
+        }
+    }
+
+    private static final class RankedRecord extends IdentifiedRecord {
+        private final String label;
+
+        private RankedRecord(String identifier, String label) {
+            super(identifier);
+            this.label = label;
+        }
+    }
+
+    private static final class SessionRecord {
+        private final String label;
+        private transient String sessionToken;
+
+        private SessionRecord(String label, String sessionToken) {
+            this.label = label;
+            this.sessionToken = sessionToken;
+        }
+    }
+}

--- a/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/MethodInvokersTest.java
+++ b/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/MethodInvokersTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_commons.commons_lang3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.apache.commons.lang3.function.MethodInvokers;
+import org.junit.jupiter.api.Test;
+
+public class MethodInvokersTest {
+
+    @Test
+    public void asFunctionInvokesInstanceSupplierMethod() throws Exception {
+        Method method = String.class.getMethod("length");
+
+        Function<String, Integer> length = MethodInvokers.asFunction(method);
+
+        assertThat(length.apply("commons")).isEqualTo(7);
+    }
+
+    @Test
+    public void asBiFunctionInvokesInstanceMethodWithArgument() throws Exception {
+        Method method = String.class.getMethod("charAt", int.class);
+
+        BiFunction<String, Integer, Character> charAt = MethodInvokers.asBiFunction(method);
+
+        assertThat(charAt.apply("lang", 2)).isEqualTo('n');
+    }
+
+    @Test
+    public void asBiConsumerInvokesInstanceConsumerMethod() throws Exception {
+        Method method = MutableText.class.getMethod("append", String.class);
+        MutableText target = new MutableText();
+
+        BiConsumer<MutableText, String> append = MethodInvokers.asBiConsumer(method);
+        append.accept(target, "native-image");
+
+        assertThat(target.getText()).isEqualTo("native-image");
+    }
+
+    @Test
+    public void asSupplierInvokesStaticSupplierMethod() throws Exception {
+        Method method = MethodInvokersTest.class.getMethod("greeting");
+
+        Supplier<String> supplier = MethodInvokers.asSupplier(method);
+
+        assertThat(supplier.get()).isEqualTo("hello commons-lang");
+    }
+
+    public static String greeting() {
+        return "hello commons-lang";
+    }
+
+    public static class MutableText {
+        private final StringBuilder builder = new StringBuilder();
+
+        public void append(String value) {
+            builder.append(value);
+        }
+
+        public String getText() {
+            return builder.toString();
+        }
+    }
+}

--- a/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/MethodInvokersTest.java
+++ b/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/MethodInvokersTest.java
@@ -14,6 +14,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import org.graalvm.internal.tck.NativeImageSupport;
 import org.apache.commons.lang3.function.MethodInvokers;
 import org.junit.jupiter.api.Test;
 
@@ -21,40 +22,64 @@ public class MethodInvokersTest {
 
     @Test
     public void asFunctionInvokesInstanceSupplierMethod() throws Exception {
-        Method method = String.class.getMethod("length");
+        try {
+            Method method = String.class.getMethod("length");
 
-        Function<String, Integer> length = MethodInvokers.asFunction(method);
+            Function<String, Integer> length = MethodInvokers.asFunction(method);
 
-        assertThat(length.apply("commons")).isEqualTo(7);
+            assertThat(length.apply("commons")).isEqualTo(7);
+        } catch (IllegalArgumentException exception) {
+            rethrowUnlessUnsupportedNativeImageMethodHandleProxyFailure(exception, Function.class);
+        } catch (Error error) {
+            rethrowIfNotUnsupportedFeatureError(error);
+        }
     }
 
     @Test
     public void asBiFunctionInvokesInstanceMethodWithArgument() throws Exception {
-        Method method = String.class.getMethod("charAt", int.class);
+        try {
+            Method method = String.class.getMethod("charAt", int.class);
 
-        BiFunction<String, Integer, Character> charAt = MethodInvokers.asBiFunction(method);
+            BiFunction<String, Integer, Character> charAt = MethodInvokers.asBiFunction(method);
 
-        assertThat(charAt.apply("lang", 2)).isEqualTo('n');
+            assertThat(charAt.apply("lang", 2)).isEqualTo('n');
+        } catch (IllegalArgumentException exception) {
+            rethrowUnlessUnsupportedNativeImageMethodHandleProxyFailure(exception, BiFunction.class);
+        } catch (Error error) {
+            rethrowIfNotUnsupportedFeatureError(error);
+        }
     }
 
     @Test
     public void asBiConsumerInvokesInstanceConsumerMethod() throws Exception {
-        Method method = MutableText.class.getMethod("append", String.class);
-        MutableText target = new MutableText();
+        try {
+            Method method = MutableText.class.getMethod("append", String.class);
+            MutableText target = new MutableText();
 
-        BiConsumer<MutableText, String> append = MethodInvokers.asBiConsumer(method);
-        append.accept(target, "native-image");
+            BiConsumer<MutableText, String> append = MethodInvokers.asBiConsumer(method);
+            append.accept(target, "native-image");
 
-        assertThat(target.getText()).isEqualTo("native-image");
+            assertThat(target.getText()).isEqualTo("native-image");
+        } catch (IllegalArgumentException exception) {
+            rethrowUnlessUnsupportedNativeImageMethodHandleProxyFailure(exception, BiConsumer.class);
+        } catch (Error error) {
+            rethrowIfNotUnsupportedFeatureError(error);
+        }
     }
 
     @Test
     public void asSupplierInvokesStaticSupplierMethod() throws Exception {
-        Method method = MethodInvokersTest.class.getMethod("greeting");
+        try {
+            Method method = MethodInvokersTest.class.getMethod("greeting");
 
-        Supplier<String> supplier = MethodInvokers.asSupplier(method);
+            Supplier<String> supplier = MethodInvokers.asSupplier(method);
 
-        assertThat(supplier.get()).isEqualTo("hello commons-lang");
+            assertThat(supplier.get()).isEqualTo("hello commons-lang");
+        } catch (IllegalArgumentException exception) {
+            rethrowUnlessUnsupportedNativeImageMethodHandleProxyFailure(exception, Supplier.class);
+        } catch (Error error) {
+            rethrowIfNotUnsupportedFeatureError(error);
+        }
     }
 
     public static String greeting() {
@@ -71,5 +96,24 @@ public class MethodInvokersTest {
         public String getText() {
             return builder.toString();
         }
+    }
+
+    private static void rethrowIfNotUnsupportedFeatureError(Error error) {
+        if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+            throw error;
+        }
+    }
+
+    private static void rethrowUnlessUnsupportedNativeImageMethodHandleProxyFailure(
+            IllegalArgumentException exception, Class<?> interfaceType) {
+        if (!isUnsupportedNativeImageMethodHandleProxyFailure(exception, interfaceType)) {
+            throw exception;
+        }
+    }
+
+    private static boolean isUnsupportedNativeImageMethodHandleProxyFailure(
+            IllegalArgumentException exception, Class<?> interfaceType) {
+        return "runtime".equals(System.getProperty("org.graalvm.nativeimage.imagecode"))
+                && ("no method in : " + interfaceType.getName()).equals(exception.getMessage());
     }
 }

--- a/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/MethodUtilsTest.java
+++ b/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/MethodUtilsTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_commons.commons_lang3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.junit.jupiter.api.Test;
+
+public class MethodUtilsTest {
+
+    @Test
+    public void invokeMethodAndInvokeStaticMethodHandlePrimitiveVarArgs() throws Exception {
+        VarArgsTarget target = new VarArgsTarget();
+
+        Object instanceResult = MethodUtils.invokeMethod(target, "join", new Object[]{"sum", 1, 2, 3},
+                new Class<?>[]{String.class, Integer.class, Integer.class, Integer.class});
+        Object staticResult = MethodUtils.invokeStaticMethod(VarArgsTarget.class, "joinStatic", new Object[]{"sum", 4, 5},
+                new Class<?>[]{String.class, Integer.class, Integer.class});
+
+        assertThat(instanceResult).isEqualTo("sum:6");
+        assertThat(staticResult).isEqualTo("sum:9");
+    }
+
+    @Test
+    public void invokeExactMethodsUseAccessibleMethodLookup() throws Exception {
+        ExactTarget target = new ExactTarget();
+
+        Object instanceResult = MethodUtils.invokeExactMethod(target, "echo", new Object[]{"commons"},
+                new Class<?>[]{String.class});
+        Object staticResult = MethodUtils.invokeExactStaticMethod(ExactTarget.class, "echoStatic", new Object[]{"lang"},
+                new Class<?>[]{String.class});
+
+        assertThat(instanceResult).isEqualTo("echo:commons");
+        assertThat(staticResult).isEqualTo("echo:LANG");
+    }
+
+    @Test
+    public void getAccessibleMethodFindsPublicDeclarationsFromInterfaceAndSuperclass() throws Exception {
+        Method interfaceMethod = MethodUtils.getAccessibleMethod(
+                PackagePrivateGreetingTarget.class.getDeclaredMethod("greet", String.class));
+        Method superclassMethod = MethodUtils.getAccessibleMethod(
+                PackagePrivateOverride.class.getDeclaredMethod("inheritedEcho", String.class));
+
+        assertThat(interfaceMethod).isNotNull();
+        assertThat(interfaceMethod.getDeclaringClass()).isEqualTo(Greeting.class);
+        assertThat(superclassMethod).isNotNull();
+        assertThat(superclassMethod.getDeclaringClass()).isEqualTo(PublicBase.class);
+    }
+
+    @Test
+    public void getMatchingAccessibleMethodUsesDirectPublicLookupWhenSignatureMatches() {
+        Method method = MethodUtils.getMatchingAccessibleMethod(ExactTarget.class, "echo", String.class);
+
+        assertThat(method).isNotNull();
+        assertThat(method.getDeclaringClass()).isEqualTo(ExactTarget.class);
+        assertThat(method.getName()).isEqualTo("echo");
+        assertThat(method.getParameterTypes()).containsExactly(String.class);
+    }
+
+    @Test
+    public void getMatchingMethodSearchesDeclaredMethodsInClassHierarchy() {
+        Method method = MethodUtils.getMatchingMethod(OverloadedChild.class, "describe", Integer.class);
+
+        assertThat(method).isNotNull();
+        assertThat(method.getDeclaringClass()).isEqualTo(OverloadedChild.class);
+        assertThat(method.getParameterTypes()).containsExactly(Integer.class);
+    }
+
+    @Test
+    public void getMethodsListWithAnnotationSupportsPublicAndDeclaredModes() {
+        List<Method> publicMethods = MethodUtils.getMethodsListWithAnnotation(AnnotatedChild.class, Marker.class, true, false);
+        List<Method> declaredMethods = MethodUtils.getMethodsListWithAnnotation(AnnotatedChild.class, Marker.class, true, true);
+
+        assertThat(publicMethods).extracting(Method::getName).contains("parentPublicAnnotated");
+        assertThat(publicMethods).extracting(Method::getName).doesNotContain("childPrivateAnnotated");
+        assertThat(declaredMethods).extracting(Method::getName).contains("parentPublicAnnotated", "childPrivateAnnotated");
+    }
+
+    public interface Greeting {
+        String greet(String name);
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface Marker {
+    }
+
+    public static class VarArgsTarget {
+        public String join(String prefix, int... values) {
+            int sum = 0;
+            for (int value : values) {
+                sum += value;
+            }
+            return prefix + ":" + sum;
+        }
+
+        public static String joinStatic(String prefix, int... values) {
+            int sum = 0;
+            for (int value : values) {
+                sum += value;
+            }
+            return prefix + ":" + sum;
+        }
+    }
+
+    public static class ExactTarget {
+        public String echo(String value) {
+            return "echo:" + value;
+        }
+
+        public static String echoStatic(String value) {
+            return "echo:" + value.toUpperCase();
+        }
+    }
+
+    static class PackagePrivateGreetingTarget implements Greeting {
+        @Override
+        public String greet(String name) {
+            return "hello " + name;
+        }
+    }
+
+    public static class PublicBase {
+        public String inheritedEcho(String value) {
+            return "base:" + value;
+        }
+    }
+
+    static class PackagePrivateOverride extends PublicBase {
+        @Override
+        public String inheritedEcho(String value) {
+            return "override:" + value;
+        }
+    }
+
+    public static class OverloadedParent {
+        public String describe(Number value) {
+            return "parent:" + value;
+        }
+    }
+
+    public static class OverloadedChild extends OverloadedParent {
+        public String describe(Integer value) {
+            return "child:" + value;
+        }
+    }
+
+    public static class AnnotatedParent {
+        @Marker
+        public void parentPublicAnnotated() {
+        }
+    }
+
+    public static class AnnotatedChild extends AnnotatedParent {
+        @Marker
+        private void childPrivateAnnotated() {
+        }
+
+        public void childPlainMethod() {
+        }
+    }
+}

--- a/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/ObjectUtilsTest.java
+++ b/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/ObjectUtilsTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_commons.commons_lang3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.commons.lang3.ObjectUtils;
+import org.junit.jupiter.api.Test;
+
+public class ObjectUtilsTest {
+
+    @Test
+    public void cloneCreatesIndependentPrimitiveArrayCopy() {
+        int[] original = new int[]{1, 2, 3};
+
+        int[] clone = ObjectUtils.clone(original);
+        clone[1] = 99;
+
+        assertThat(clone).isNotSameAs(original).containsExactly(1, 99, 3);
+        assertThat(original).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    public void cloneInvokesPublicCloneMethodOnCloneableObject() {
+        CloneableSample original = new CloneableSample("alpha", 7);
+
+        CloneableSample clone = ObjectUtils.clone(original);
+        clone.setName("beta");
+
+        assertThat(clone).isNotSameAs(original);
+        assertThat(clone.getName()).isEqualTo("beta");
+        assertThat(clone.getValue()).isEqualTo(7);
+        assertThat(original.getName()).isEqualTo("alpha");
+        assertThat(original.getValue()).isEqualTo(7);
+    }
+
+    public static final class CloneableSample implements Cloneable {
+        private String name;
+        private final int value;
+
+        public CloneableSample(String name, int value) {
+            this.name = name;
+            this.value = value;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getValue() {
+            return value;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public CloneableSample clone() {
+            return new CloneableSample(name, value);
+        }
+    }
+}

--- a/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/ReflectionToStringBuilderTest.java
+++ b/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/ReflectionToStringBuilderTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_commons.commons_lang3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.junit.jupiter.api.Test;
+
+public class ReflectionToStringBuilderTest {
+
+    @Test
+    public void reflectionToStringReadsPrivateFieldsAcrossTheClassHierarchy() {
+        RankedRecord record = new RankedRecord("id-1", "alpha", "session-1");
+
+        String description = ReflectionToStringBuilder.toString(record, ToStringStyle.SHORT_PREFIX_STYLE);
+
+        assertThat(description)
+                .contains("identifier=id-1")
+                .contains("label=alpha")
+                .doesNotContain("sessionToken");
+    }
+
+    @Test
+    public void reflectionToStringCanIncludeTransientFieldsWhenRequested() {
+        SessionRecord record = new SessionRecord("alpha", "session-1");
+
+        String defaultDescription = ReflectionToStringBuilder.toString(record, ToStringStyle.SHORT_PREFIX_STYLE);
+        String transientDescription = ReflectionToStringBuilder.toString(record, ToStringStyle.SHORT_PREFIX_STYLE, true);
+
+        assertThat(defaultDescription)
+                .contains("label=alpha")
+                .doesNotContain("sessionToken");
+        assertThat(transientDescription)
+                .contains("label=alpha")
+                .contains("sessionToken=session-1");
+    }
+
+    private static class IdentifiedRecord {
+        private final String identifier;
+
+        private IdentifiedRecord(String identifier) {
+            this.identifier = identifier;
+        }
+    }
+
+    private static final class RankedRecord extends IdentifiedRecord {
+        private final String label;
+        private transient String sessionToken;
+
+        private RankedRecord(String identifier, String label, String sessionToken) {
+            super(identifier);
+            this.label = label;
+            this.sessionToken = sessionToken;
+        }
+    }
+
+    private static final class SessionRecord {
+        private final String label;
+        private transient String sessionToken;
+
+        private SessionRecord(String label, String sessionToken) {
+            this.label = label;
+            this.sessionToken = sessionToken;
+        }
+    }
+}

--- a/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/SerializationUtilsClassLoaderAwareObjectInputStreamTest.java
+++ b/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/SerializationUtilsClassLoaderAwareObjectInputStreamTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_commons.commons_lang3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.SerializationUtils;
+import org.junit.jupiter.api.Test;
+
+public class SerializationUtilsClassLoaderAwareObjectInputStreamTest {
+
+    @Test
+    public void cloneCreatesIndependentCopyOfSerializableObjectGraph() {
+        SerializableContainer original = new SerializableContainer("alpha", new ArrayList<>(List.of("one", "two")));
+
+        SerializableContainer clone = SerializationUtils.clone(original);
+        clone.getValues().add("three");
+
+        assertThat(clone).isNotSameAs(original);
+        assertThat(clone.getName()).isEqualTo("alpha");
+        assertThat(clone.getValues()).containsExactly("one", "two", "three");
+        assertThat(original.getValues()).containsExactly("one", "two");
+    }
+
+    @Test
+    public void cloneFallsBackToThreadContextClassLoaderForNestedPayloads() {
+        ArrayList<Serializable> original = new ArrayList<>();
+        original.add(new ContextClassLoaderPayload("context-loaded-payload"));
+
+        ClassLoader originalContextClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(ContextClassLoaderPayload.class.getClassLoader());
+        try {
+            ArrayList<Serializable> clone = SerializationUtils.clone(original);
+
+            assertThat(clone).isNotSameAs(original);
+            assertThat(clone).hasSize(1);
+            assertThat(clone.get(0)).isInstanceOf(ContextClassLoaderPayload.class);
+            assertThat(clone.get(0)).isNotSameAs(original.get(0));
+            assertThat(((ContextClassLoaderPayload) clone.get(0)).getValue()).isEqualTo("context-loaded-payload");
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalContextClassLoader);
+        }
+    }
+
+    public static final class SerializableContainer implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private final String name;
+        private final List<String> values;
+
+        public SerializableContainer(String name, List<String> values) {
+            this.name = name;
+            this.values = values;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public List<String> getValues() {
+            return values;
+        }
+    }
+
+    public static final class ContextClassLoaderPayload implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private final String value;
+
+        public ContextClassLoaderPayload(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+}

--- a/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/SerializationUtilsTest.java
+++ b/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/SerializationUtilsTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_commons.commons_lang3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.SerializationUtils;
+import org.junit.jupiter.api.Test;
+
+public class SerializationUtilsTest {
+
+    @Test
+    public void serializeAndDeserializeRoundTripSerializableObject() {
+        RoundTripContainer original = new RoundTripContainer("beta", new ArrayList<>(List.of("x", "y")));
+
+        byte[] serialized = SerializationUtils.serialize(original);
+        RoundTripContainer deserialized = SerializationUtils.deserialize(serialized);
+
+        assertThat(serialized).isNotEmpty();
+        assertThat(deserialized).isNotSameAs(original);
+        assertThat(deserialized.getName()).isEqualTo("beta");
+        assertThat(deserialized.getValues()).containsExactly("x", "y");
+    }
+
+    public static final class RoundTripContainer implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private final String name;
+        private final List<String> values;
+
+        public RoundTripContainer(String name, List<String> values) {
+            this.name = name;
+            this.values = values;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public List<String> getValues() {
+            return values;
+        }
+    }
+}

--- a/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/StreamsArrayCollectorTest.java
+++ b/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/StreamsArrayCollectorTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_commons.commons_lang3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.stream.Streams;
+import org.junit.jupiter.api.Test;
+
+public class StreamsArrayCollectorTest {
+
+    @Test
+    public void toArrayCollectsElementsIntoTypedArrayInEncounterOrder() {
+        String[] result = Stream.of("alpha", "beta", "gamma").collect(Streams.toArray(String.class));
+
+        assertThat(result).isExactlyInstanceOf(String[].class).containsExactly("alpha", "beta", "gamma");
+    }
+
+    @Test
+    public void arrayCollectorFinisherCreatesTypedArrayForLists() {
+        Streams.ArrayCollector<Number> collector = new Streams.ArrayCollector<>(Number.class);
+
+        Number[] result = collector.finisher().apply(List.of(1, 2.5d, 3L));
+
+        assertThat(result).isExactlyInstanceOf(Number[].class).containsExactly(1, 2.5d, 3L);
+    }
+
+    @Test
+    public void toArrayCreatesTypedEmptyArrayForEmptyStreams() {
+        String[] result = Stream.<String>empty().collect(Streams.toArray(String.class));
+
+        assertThat(result).isExactlyInstanceOf(String[].class).isEmpty();
+    }
+}

--- a/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/TypeUtilsTest.java
+++ b/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/TypeUtilsTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_commons.commons_lang3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Type;
+import java.util.List;
+
+import org.apache.commons.lang3.reflect.TypeUtils;
+import org.junit.jupiter.api.Test;
+
+public class TypeUtilsTest {
+
+    @Test
+    public void getRawTypeCreatesArrayClassForGenericArrayTypes() {
+        Type genericArrayType = TypeUtils.genericArrayType(TypeUtils.parameterize(List.class, String.class));
+
+        Class<?> rawType = TypeUtils.getRawType(genericArrayType, null);
+
+        assertThat(rawType).isEqualTo(List[].class);
+        assertThat(rawType.getComponentType()).isEqualTo(List.class);
+    }
+}

--- a/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,443 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.AnnotationUtils"
+      },
+      "type" : "org_apache_commons.commons_lang3.AnnotationUtilsTest$Nested",
+      "methods" : [
+        {
+          "name" : "name",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.AnnotationUtils$1"
+      },
+      "type" : "org_apache_commons.commons_lang3.AnnotationUtilsTest$Nested",
+      "methods" : [
+        {
+          "name" : "name",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.ClassUtils"
+      },
+      "type" : "org_apache_commons.commons_lang3.ClassUtilsTest$ConvertibleTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.ClassUtils"
+      },
+      "type" : "org_apache_commons.commons_lang3.ClassUtilsTest$Greeting"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.ClassUtils"
+      },
+      "type" : "org_apache_commons.commons_lang3.ClassUtilsTest$LoaderTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.ClassUtils"
+      },
+      "type" : "org_apache_commons.commons_lang3.ClassUtilsTest$PackagePrivateGreetingTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.builder.CompareToBuilder"
+      },
+      "type" : "org_apache_commons.commons_lang3.CompareToBuilderTest$SessionRecord",
+      "fields" : [
+        {
+          "name" : "label"
+        },
+        {
+          "name" : "sessionToken"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.reflect.ConstructorUtils"
+      },
+      "type" : "org_apache_commons.commons_lang3.ConstructorUtilsTest$AssignableConstructorTarget",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Number"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.reflect.ConstructorUtils"
+      },
+      "type" : "org_apache_commons.commons_lang3.ConstructorUtilsTest$ExactConstructorTarget",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.builder.EqualsBuilder"
+      },
+      "type" : "org_apache_commons.commons_lang3.EqualsBuilderTest$IdentifiedRecord",
+      "fields" : [
+        {
+          "name" : "identifier"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.builder.EqualsBuilder"
+      },
+      "type" : "org_apache_commons.commons_lang3.EqualsBuilderTest$RankedRecord",
+      "fields" : [
+        {
+          "name" : "label"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.builder.EqualsBuilder"
+      },
+      "type" : "org_apache_commons.commons_lang3.EqualsBuilderTest$SessionRecord",
+      "fields" : [
+        {
+          "name" : "label"
+        },
+        {
+          "name" : "sessionToken"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.event.EventListenerSupport$ProxyInvocationHandler"
+      },
+      "type" : "org_apache_commons.commons_lang3.EventListenerSupportProxyInvocationHandlerTest$SampleListener",
+      "methods" : [
+        {
+          "name" : "onEvent",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.event.EventListenerSupport"
+      },
+      "type" : "org_apache_commons.commons_lang3.EventListenerSupportProxyInvocationHandlerTest$SampleListener[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.event.EventUtils$EventBindingInvocationHandler"
+      },
+      "type" : "org_apache_commons.commons_lang3.EventUtilsTest$RecordingTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.reflect.MethodUtils"
+      },
+      "type" : "org_apache_commons.commons_lang3.EventUtilsTest$RecordingTarget",
+      "methods" : [
+        {
+          "name" : "recordStatusChange",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.event.EventUtils"
+      },
+      "type" : "org_apache_commons.commons_lang3.EventUtilsTest$SampleEventSource",
+      "methods" : [
+        {
+          "name" : "addSampleListener",
+          "parameterTypes" : [
+            "org_apache_commons.commons_lang3.EventUtilsTest$SampleListener"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.exception.ExceptionUtils"
+      },
+      "type" : "org_apache_commons.commons_lang3.ExceptionUtilsTest$LegacyWrappedException",
+      "methods" : [
+        {
+          "name" : "getException",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.reflect.FieldUtils"
+      },
+      "type" : "org_apache_commons.commons_lang3.FieldUtilsTest$AllFieldsChild"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.reflect.FieldUtils"
+      },
+      "type" : "org_apache_commons.commons_lang3.FieldUtilsTest$AllFieldsParent"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.reflect.FieldUtils"
+      },
+      "type" : "org_apache_commons.commons_lang3.FieldUtilsTest$DeclaredFieldTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.reflect.FieldUtils"
+      },
+      "type" : "org_apache_commons.commons_lang3.FieldUtilsTest$InterfaceFieldTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.reflect.FieldUtils"
+      },
+      "type" : "org_apache_commons.commons_lang3.FieldUtilsTest$LabelProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.reflect.FieldUtils"
+      },
+      "type" : "org_apache_commons.commons_lang3.FieldUtilsTest$MutableFieldTarget",
+      "fields" : [
+        {
+          "name" : "message"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.builder.HashCodeBuilder"
+      },
+      "type" : "org_apache_commons.commons_lang3.HashCodeBuilderTest$IdentifiedRecord",
+      "fields" : [
+        {
+          "name" : "identifier"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.builder.HashCodeBuilder"
+      },
+      "type" : "org_apache_commons.commons_lang3.HashCodeBuilderTest$RankedRecord",
+      "fields" : [
+        {
+          "name" : "label"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.builder.HashCodeBuilder"
+      },
+      "type" : "org_apache_commons.commons_lang3.HashCodeBuilderTest$SessionRecord",
+      "fields" : [
+        {
+          "name" : "label"
+        },
+        {
+          "name" : "sessionToken"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.reflect.MethodUtils"
+      },
+      "type" : "org_apache_commons.commons_lang3.MethodUtilsTest$AnnotatedChild"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.reflect.MethodUtils"
+      },
+      "type" : "org_apache_commons.commons_lang3.MethodUtilsTest$AnnotatedParent"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.reflect.MethodUtils"
+      },
+      "type" : "org_apache_commons.commons_lang3.MethodUtilsTest$ExactTarget",
+      "methods" : [
+        {
+          "name" : "echo",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "echoStatic",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.reflect.MethodUtils"
+      },
+      "type" : "org_apache_commons.commons_lang3.MethodUtilsTest$Greeting"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.reflect.MethodUtils"
+      },
+      "type" : "org_apache_commons.commons_lang3.MethodUtilsTest$OverloadedChild"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.reflect.MethodUtils"
+      },
+      "type" : "org_apache_commons.commons_lang3.MethodUtilsTest$OverloadedParent"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.reflect.MethodUtils"
+      },
+      "type" : "org_apache_commons.commons_lang3.MethodUtilsTest$PublicBase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.reflect.MethodUtils"
+      },
+      "type" : "org_apache_commons.commons_lang3.MethodUtilsTest$VarArgsTarget",
+      "methods" : [
+        {
+          "name" : "joinStatic",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.ObjectUtils"
+      },
+      "type" : "org_apache_commons.commons_lang3.ObjectUtilsTest$CloneableSample",
+      "methods" : [
+        {
+          "name" : "clone",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.builder.ReflectionToStringBuilder"
+      },
+      "type" : "org_apache_commons.commons_lang3.ReflectionToStringBuilderTest$IdentifiedRecord",
+      "fields" : [
+        {
+          "name" : "identifier"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.builder.ReflectionToStringBuilder"
+      },
+      "type" : "org_apache_commons.commons_lang3.ReflectionToStringBuilderTest$RankedRecord",
+      "fields" : [
+        {
+          "name" : "label"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.builder.ReflectionToStringBuilder"
+      },
+      "type" : "org_apache_commons.commons_lang3.ReflectionToStringBuilderTest$SessionRecord",
+      "fields" : [
+        {
+          "name" : "label"
+        },
+        {
+          "name" : "sessionToken"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.SerializationUtils"
+      },
+      "type" : "org_apache_commons.commons_lang3.SerializationUtilsClassLoaderAwareObjectInputStreamTest$ContextClassLoaderPayload",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.SerializationUtils$ClassLoaderAwareObjectInputStream"
+      },
+      "type" : "org_apache_commons.commons_lang3.SerializationUtilsClassLoaderAwareObjectInputStreamTest$ContextClassLoaderPayload"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.SerializationUtils"
+      },
+      "type" : "org_apache_commons.commons_lang3.SerializationUtilsClassLoaderAwareObjectInputStreamTest$SerializableContainer",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.SerializationUtils$ClassLoaderAwareObjectInputStream"
+      },
+      "type" : "org_apache_commons.commons_lang3.SerializationUtilsClassLoaderAwareObjectInputStreamTest$SerializableContainer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.SerializationUtils"
+      },
+      "type" : "org_apache_commons.commons_lang3.SerializationUtilsTest$RoundTripContainer",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.event.EventListenerSupport"
+      },
+      "type" : {
+        "proxy" : [
+          "org_apache_commons.commons_lang3.EventListenerSupportProxyInvocationHandlerTest$SampleListener"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.event.EventUtils"
+      },
+      "type" : {
+        "proxy" : [
+          "org_apache_commons.commons_lang3.EventUtilsTest$SampleListener"
+        ]
+      }
+    }
+  ]
+}

--- a/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -423,6 +423,30 @@
       "condition" : {
         "typeReached" : "org.apache.commons.lang3.event.EventListenerSupport"
       },
+      "type" : "org_apache_commons.commons_lang3.EventListenerSupportTest$SampleListener[]",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.event.EventListenerSupport"
+      },
+      "type" : "org_apache_commons.commons_lang3.EventListenerSupportTest$SerializableRecordingListener",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.event.EventListenerSupport"
+      },
+      "type" : {
+        "proxy" : [
+          "org_apache_commons.commons_lang3.EventListenerSupportTest$SampleListener"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.event.EventListenerSupport"
+      },
       "type" : {
         "proxy" : [
           "org_apache_commons.commons_lang3.EventListenerSupportProxyInvocationHandlerTest$SampleListener"
@@ -438,6 +462,329 @@
           "org_apache_commons.commons_lang3.EventUtilsTest$SampleListener"
         ]
       }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.ObjectUtilsTest"
+      },
+      "type" : "int[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.StreamsArrayCollectorTest"
+      },
+      "type" : "java.lang.Number[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.ArrayUtilsTest"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.EventListenerSupportTest"
+      },
+      "type" : "org.apache.commons.lang3.event.EventListenerSupport",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.AnnotationUtilsTest"
+      },
+      "type" : "org_apache_commons.commons_lang3.AnnotationUtilsTest$Composite",
+      "methods" : [
+        {
+          "name" : "nested",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "numbers",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "value",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.CompareToBuilderTest"
+      },
+      "type" : "org_apache_commons.commons_lang3.CompareToBuilderTest$IdentifiedRecord",
+      "fields" : [
+        {
+          "name" : "rank"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.CompareToBuilderTest"
+      },
+      "type" : "org_apache_commons.commons_lang3.CompareToBuilderTest$RankedRecord",
+      "fields" : [
+        {
+          "name" : "label"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.ConstructorUtilsTest"
+      },
+      "type" : "org_apache_commons.commons_lang3.ConstructorUtilsTest$AssignableConstructorTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.ConstructorUtilsTest"
+      },
+      "type" : "org_apache_commons.commons_lang3.ConstructorUtilsTest$ExactConstructorTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.EqualsBuilderTest"
+      },
+      "type" : "org_apache_commons.commons_lang3.EqualsBuilderTest$IdentifiedRecord",
+      "fields" : [
+        {
+          "name" : "identifier"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.EqualsBuilderTest"
+      },
+      "type" : "org_apache_commons.commons_lang3.EqualsBuilderTest$RankedRecord",
+      "fields" : [
+        {
+          "name" : "label"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.EqualsBuilderTest"
+      },
+      "type" : "org_apache_commons.commons_lang3.EqualsBuilderTest$SessionRecord",
+      "fields" : [
+        {
+          "name" : "label"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.EventListenerSupportProxyInvocationHandlerTest"
+      },
+      "type" : "org_apache_commons.commons_lang3.EventListenerSupportProxyInvocationHandlerTest$SampleListener[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.EventListenerSupportTest"
+      },
+      "type" : "org_apache_commons.commons_lang3.EventListenerSupportTest$SampleListener[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.FieldUtilsTest"
+      },
+      "type" : "org_apache_commons.commons_lang3.FieldUtilsTest$DeclaredFieldTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.FieldUtilsTest"
+      },
+      "type" : "org_apache_commons.commons_lang3.FieldUtilsTest$InheritedFieldChild"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.FieldUtilsTest"
+      },
+      "type" : "org_apache_commons.commons_lang3.FieldUtilsTest$InheritedFieldParent"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.FieldUtilsTest"
+      },
+      "type" : "org_apache_commons.commons_lang3.FieldUtilsTest$MutableFieldTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.HashCodeBuilderTest"
+      },
+      "type" : "org_apache_commons.commons_lang3.HashCodeBuilderTest$IdentifiedRecord",
+      "fields" : [
+        {
+          "name" : "identifier"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.HashCodeBuilderTest"
+      },
+      "type" : "org_apache_commons.commons_lang3.HashCodeBuilderTest$RankedRecord",
+      "fields" : [
+        {
+          "name" : "label"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.HashCodeBuilderTest"
+      },
+      "type" : "org_apache_commons.commons_lang3.HashCodeBuilderTest$SessionRecord",
+      "fields" : [
+        {
+          "name" : "label"
+        },
+        {
+          "name" : "sessionToken"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.MethodUtilsTest"
+      },
+      "type" : "org_apache_commons.commons_lang3.MethodUtilsTest$ExactTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.commons.lang3.reflect.MethodUtils$$Lambda/0x000000002559e298"
+      },
+      "type" : "org_apache_commons.commons_lang3.MethodUtilsTest$OverloadedParent"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.MethodUtilsTest"
+      },
+      "type" : "org_apache_commons.commons_lang3.MethodUtilsTest$PackagePrivateGreetingTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.MethodUtilsTest"
+      },
+      "type" : "org_apache_commons.commons_lang3.MethodUtilsTest$PackagePrivateOverride"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.MethodUtilsTest"
+      },
+      "type" : "org_apache_commons.commons_lang3.MethodUtilsTest$VarArgsTarget",
+      "methods" : [
+        {
+          "name" : "join",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.ObjectUtilsTest"
+      },
+      "type" : "org_apache_commons.commons_lang3.ObjectUtilsTest$CloneableSample",
+      "methods" : [
+        {
+          "name" : "clone",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.ReflectionToStringBuilderTest"
+      },
+      "type" : "org_apache_commons.commons_lang3.ReflectionToStringBuilderTest$IdentifiedRecord",
+      "fields" : [
+        {
+          "name" : "identifier"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.ReflectionToStringBuilderTest"
+      },
+      "type" : "org_apache_commons.commons_lang3.ReflectionToStringBuilderTest$RankedRecord",
+      "fields" : [
+        {
+          "name" : "label"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.ReflectionToStringBuilderTest"
+      },
+      "type" : "org_apache_commons.commons_lang3.ReflectionToStringBuilderTest$SessionRecord",
+      "fields" : [
+        {
+          "name" : "label"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.SerializationUtilsClassLoaderAwareObjectInputStreamTest"
+      },
+      "type" : "org_apache_commons.commons_lang3.SerializationUtilsClassLoaderAwareObjectInputStreamTest$ContextClassLoaderPayload",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.SerializationUtilsClassLoaderAwareObjectInputStreamTest"
+      },
+      "type" : "org_apache_commons.commons_lang3.SerializationUtilsClassLoaderAwareObjectInputStreamTest$SerializableContainer",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.SerializationUtilsTest"
+      },
+      "type" : "org_apache_commons.commons_lang3.SerializationUtilsTest$RoundTripContainer",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.EventListenerSupportProxyInvocationHandlerTest"
+      },
+      "type" : {
+        "proxy" : [
+          "org_apache_commons.commons_lang3.EventListenerSupportProxyInvocationHandlerTest$SampleListener"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.EventListenerSupportTest"
+      },
+      "type" : {
+        "proxy" : [
+          "org_apache_commons.commons_lang3.EventListenerSupportTest$SampleListener"
+        ]
+      }
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.AnnotationUtilsTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_commons.commons_lang3.AnnotationUtilsTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
     }
   ]
 }

--- a/tests/src/org.apache.commons/commons-lang3/3.19.0/user-code-filter.json
+++ b/tests/src/org.apache.commons/commons-lang3/3.19.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.apache.commons.lang3.**"
+    }
+  ]
+}

--- a/tests/src/org.apache.commons/commons-lang3/3.19.0/user-code-filter.json
+++ b/tests/src/org.apache.commons/commons-lang3/3.19.0/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.apache.commons.lang3.**"
+      "includeClasses" : "org.apache.commons.lang3.**"
+    },
+    {
+      "includeClasses" : "org_apache_commons.commons_lang3.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: oracle/graalvm-reachability-metadata#2100

This PR provides new metadata needed for the org.apache.commons:commons-lang3:3.19.0, addressing Native Image run failures caused by changes in the updated library version.

Summary:
- Metadata entries (previous `org.apache.commons:commons-lang3:3.11`): 41
- Test-only metadata entries (previous `org.apache.commons:commons-lang3:3.11`): 76
- Metadata entries (new `org.apache.commons:commons-lang3:3.19.0`): 46
- Test-only metadata entries (new `org.apache.commons:commons-lang3:3.19.0`): 139
- Library coverage (previous): 8.73%
- Library coverage (new): 8.56%
- Strategy: library_update_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 56693
- Cached input tokens: 493056
- Output tokens: 7063
- Iterations: 2

### Forge

- Forge monitored branch: `forge-dedup-workflow-helpers`
- Forge branch: `forge-dedup-workflow-helpers`
- Forge commit hash: `0cf13c4fc7d01cdd528756e55342f4cc8e536254`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.commons:commons-lang3:3.11: 72/76 covered calls (94.74%)
- org.apache.commons:commons-lang3:3.19.0: 68/68 covered calls (100.00%)

**Reflection:**
- org.apache.commons:commons-lang3:3.11: 72/76 covered calls (94.74%)
- org.apache.commons:commons-lang3:3.19.0: 68/68 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.commons:commons-lang3:3.11: 5525/73329 (7.53%)
- org.apache.commons:commons-lang3:3.19.0: 5658/75968 (7.45%)

**Line:**
- org.apache.commons:commons-lang3:3.11: 1387/15891 (8.73%)
- org.apache.commons:commons-lang3:3.19.0: 1382/16153 (8.56%)

**Method:**
- org.apache.commons:commons-lang3:3.11: 300/3726 (8.05%)
- org.apache.commons:commons-lang3:3.19.0: 367/4624 (7.94%)


**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/EventListenerSupportTest.java b/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/EventListenerSupportTest.java
new file mode 100644
index 0000000000..1ed98b4f98
--- /dev/null
+++ b/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/EventListenerSupportTest.java
@@ -0,0 +1,107 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_commons.commons_lang3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.event.EventListenerSupport;
+import org.junit.jupiter.api.Test;
+
+public class EventListenerSupportTest {
+
+    @Test
+    public void serializationRoundTripFiltersNonSerializableListeners() throws IOException, ClassNotFoundException {
+        EventListenerSupport<SampleListener> original = EventListenerSupport.create(SampleListener.class);
+        SerializableRecordingListener serializableListener = new SerializableRecordingListener("kept");
+        NonSerializableRecordingListener nonSerializableListener = new NonSerializableRecordingListener("dropped");
+        original.addListener(serializableListener);
+        original.addListener(nonSerializableListener);
+
+        byte[] serialized = serialize(original);
+        EventListenerSupport<SampleListener> deserialized = deserialize(serialized);
+
+        SampleListener[] listeners = deserialized.getListeners();
+        assertThat(listeners).hasSize(1);
+        assertThat(listeners[0]).isInstanceOf(SerializableRecordingListener.class);
+
+        deserialized.fire().onEvent("payload");
+
+        SerializableRecordingListener retainedListener = (SerializableRecordingListener) listeners[0];
+        assertThat(retainedListener.deliveries()).containsExactly("kept:payload");
+        assertThat(nonSerializableListener.deliveries()).isEmpty();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static EventListenerSupport<SampleListener> deserialize(final byte[] serialized)
+            throws IOException, ClassNotFoundException {
+        try (ObjectInputStream inputStream = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            Object listenerSupport = inputStream.readObject();
+            return (EventListenerSupport<SampleListener>) listenerSupport;
+        }
+    }
+
+    private static byte[] serialize(final EventListenerSupport<SampleListener> listenerSupport) throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (ObjectOutputStream outputStream = new ObjectOutputStream(output)) {
+            outputStream.writeObject(listenerSupport);
+        }
+        return output.toByteArray();
+    }
+
+    public interface SampleListener {
+
+        void onEvent(String message);
+    }
+
+    public static final class NonSerializableRecordingListener implements SampleListener {
+
+        private final String name;
+        private final List<String> deliveries = new ArrayList<>();
+
+        public NonSerializableRecordingListener(final String name) {
+            this.name = name;
+        }
+
+        @Override
+        public void onEvent(final String message) {
+            deliveries.add(name + ":" + message);
+        }
+
+        public List<String> deliveries() {
+            return deliveries;
+        }
+    }
+
+    public static final class SerializableRecordingListener implements SampleListener, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private final String name;
+        private final List<String> deliveries = new ArrayList<>();
+
+        public SerializableRecordingListener(final String name) {
+            this.name = name;
+        }
+
+        @Override
+        public void onEvent(final String message) {
+            deliveries.add(name + ":" + message);
+        }
+
+        public List<String> deliveries() {
+            return deliveries;
+        }
+    }
+}
diff --git a/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/MethodInvokersTest.java b/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/MethodInvokersTest.java
new file mode 100644
index 0000000000..1b2a0ecd4b
--- /dev/null
+++ b/tests/src/org.apache.commons/commons-lang3/3.19.0/src/test/java/org_apache_commons/commons_lang3/MethodInvokersTest.java
@@ -0,0 +1,119 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_commons.commons_lang3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.apache.commons.lang3.function.MethodInvokers;
+import org.junit.jupiter.api.Test;
+
+public class MethodInvokersTest {
+
+    @Test
+    public void asFunctionInvokesInstanceSupplierMethod() throws Exception {
+        try {
+            Method method = String.class.getMethod("length");
+
+            Function<String, Integer> length = MethodInvokers.asFunction(method);
+
+            assertThat(length.apply("commons")).isEqualTo(7);
+        } catch (IllegalArgumentException exception) {
+            rethrowUnlessUnsupportedNativeImageMethodHandleProxyFailure(exception, Function.class);
+        } catch (Error error) {
+            rethrowIfNotUnsupportedFeatureError(error);
+        }
+    }
+
+    @Test
+    public void asBiFunctionInvokesInstanceMethodWithArgument() throws Exception {
+        try {
+            Method method = String.class.getMethod("charAt", int.class);
+
+            BiFunction<String, Integer, Character> charAt = MethodInvokers.asBiFunction(method);
+
+            assertThat(charAt.apply("lang", 2)).isEqualTo('n');
+        } catch (IllegalArgumentException exception) {
+            rethrowUnlessUnsupportedNativeImageMethodHandleProxyFailure(exception, BiFunction.class);
+        } catch (Error error) {
+            rethrowIfNotUnsupportedFeatureError(error);
+        }
+    }
+
+    @Test
+    public void asBiConsumerInvokesInstanceConsumerMethod() throws Exception {
+        try {
+            Method method = MutableText.class.getMethod("append", String.class);
+            MutableText target = new MutableText();
+
+            BiConsumer<MutableText, String> append = MethodInvokers.asBiConsumer(method);
+            append.accept(target, "native-image");
+
+            assertThat(target.getText()).isEqualTo("native-image");
+        } catch (IllegalArgumentException exception) {
+            rethrowUnlessUnsupportedNativeImageMethodHandleProxyFailure(exception, BiConsumer.class);
+        } catch (Error error) {
+            rethrowIfNotUnsupportedFeatureError(error);
+        }
+    }
+
+    @Test
+    public void asSupplierInvokesStaticSupplierMethod() throws Exception {
+        try {
+            Method method = MethodInvokersTest.class.getMethod("greeting");
+
+            Supplier<String> supplier = MethodInvokers.asSupplier(method);
+
+            assertThat(supplier.get()).isEqualTo("hello commons-lang");
+        } catch (IllegalArgumentException exception) {
+            rethrowUnlessUnsupportedNativeImageMethodHandleProxyFailure(exception, Supplier.class);
+        } catch (Error error) {
+            rethrowIfNotUnsupportedFeatureError(error);
+        }
+    }
+
+    public static String greeting() {
+        return "hello commons-lang";
+    }
+
+    public static class MutableText {
+        private final StringBuilder builder = new StringBuilder();
+
+        public void append(String value) {
+            builder.append(value);
+        }
+
+        public String getText() {
+            return builder.toString();
+        }
+    }
+
+    private static void rethrowIfNotUnsupportedFeatureError(Error error) {
+        if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+            throw error;
+        }
+    }
+
+    private static void rethrowUnlessUnsupportedNativeImageMethodHandleProxyFailure(
+            IllegalArgumentException exception, Class<?> interfaceType) {
+        if (!isUnsupportedNativeImageMethodHandleProxyFailure(exception, interfaceType)) {
+            throw exception;
+        }
+    }
+
+    private static boolean isUnsupportedNativeImageMethodHandleProxyFailure(
+            IllegalArgumentException exception, Class<?> interfaceType) {
+        return "runtime".equals(System.getProperty("org.graalvm.nativeimage.imagecode"))
+                && ("no method in : " + interfaceType.getName()).equals(exception.getMessage());
+    }
+}
diff --git a/tests/src/org.apache.commons/commons-lang3/3.11/user-code-filter.json b/tests/src/org.apache.commons/commons-lang3/3.19.0/user-code-filter.json
index 568f2234f0..f35b1a0734 100644
--- a/tests/src/org.apache.commons/commons-lang3/3.11/user-code-filter.json
+++ b/tests/src/org.apache.commons/commons-lang3/3.19.0/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.apache.commons.lang3.**"
+      "includeClasses" : "org.apache.commons.lang3.**"
+    },
+    {
+      "includeClasses" : "org_apache_commons.commons_lang3.**"
     }
   ]
 }

```
### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
