### PR TITLE
[Automation] Generated metadata for org.jboss:jandex:2.4.5.Final

### DIFF
--- a/metadata/org.jboss/jandex/2.4.5.Final/reachability-metadata.json
+++ b/metadata/org.jboss/jandex/2.4.5.Final/reachability-metadata.json
@@ -1,0 +1,38 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.jboss.jandex.StrongInternPool"
+      },
+      "type": "java.lang.String",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.jandex.StrongInternPool"
+      },
+      "type": "org.jboss.jandex.StrongInternPool",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.jandex.Utils"
+      },
+      "type": "org.jboss.jandex.AnnotationInstance[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.jandex.Utils"
+      },
+      "type": "org.jboss.jandex.ClassInfo[]"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.jboss.jandex.Indexer"
+      },
+      "glob": "org_jboss/jandex/IndexerTest$IndexedSample.class"
+    }
+  ]
+}

--- a/metadata/org.jboss/jandex/index.json
+++ b/metadata/org.jboss/jandex/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.4.5.Final",
+    "test-version" : "2.4.2.Final",
+    "tested-versions" : [
+      "2.4.5.Final"
+    ],
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/jboss/jandex/$version$/jandex-$version$-sources.jar",
+    "repository-url" : "https://github.com/smallrye/jandex",
+    "test-code-url" : "https://github.com/smallrye/jandex/tree/$version$/src/test/java",
+    "documentation-url" : "https://github.com/smallrye/jandex/blob/$version$/README.md",
+    "description" : "Jandex indexes Java class metadata and annotations into a compact structure for fast offline lookup. It also provides APIs and tools to query, persist, and reload that index without relying on runtime reflection.",
+    "allowed-packages" : [
+      "org.jboss.jandex"
+    ]
+  },
+  {
     "metadata-version" : "2.4.2.Final",
     "source-code-url" : "https://repo1.maven.org/maven2/org/jboss/jandex/$version$/jandex-$version$-sources.jar",
     "repository-url" : "https://github.com/smallrye/jandex",

--- a/stats/org.jboss/jandex/2.4.5.Final/execution-metrics.json
+++ b/stats/org.jboss/jandex/2.4.5.Final/execution-metrics.json
@@ -1,0 +1,137 @@
+{
+  "fix_ni_run:2026-06-10": {
+    "timestamp": "2026-06-10T02:23:20.215377Z",
+    "library": "org.jboss:jandex:2.4.5.Final",
+    "starting_commit": "cf46581ffcef7b574d89b113c913b906b202f63b",
+    "ending_commit": "5ada4d9473928567a3cdfad1db70e086cdc3cc26",
+    "previous_library": "org.jboss:jandex:2.4.2.Final",
+    "strategy_name": "library_update_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.4.5.Final",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 4,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4696,
+          "missed": 23324,
+          "ratio": 0.167595,
+          "total": 28020
+        },
+        "line": {
+          "covered": 836,
+          "missed": 4950,
+          "ratio": 0.144487,
+          "total": 5786
+        },
+        "method": {
+          "covered": 146,
+          "missed": 1059,
+          "ratio": 0.121162,
+          "total": 1205
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.4.2.Final",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 3,
+        "totalCalls": 3
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4650,
+          "missed": 22747,
+          "ratio": 0.169727,
+          "total": 27397
+        },
+        "line": {
+          "covered": 827,
+          "missed": 4863,
+          "ratio": 0.145343,
+          "total": 5690
+        },
+        "method": {
+          "covered": 147,
+          "missed": 1052,
+          "ratio": 0.122602,
+          "total": 1199
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "degraded",
+      "action": "no_action",
+      "issue_number": 2048,
+      "issue_label": "fails-native-image-run",
+      "library": "org.jboss:jandex:2.4.5.Final",
+      "summary": "Library preparation preflight did not produce usable advisory setup.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#2048 [Automation] native-image run fails for org.jboss:jandex:2.4.5.Final; label=fails-native-image-run; body_chars=8015"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "7 existing test file path(s) included"
+        }
+      ],
+      "current_library": "org.jboss:jandex:2.4.2.Final",
+      "new_version": "2.4.5.Final",
+      "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
+      "model": "oca/gpt-5.5",
+      "prompt_path": "library-preflight-prompt.txt",
+      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.jboss:jandex:2.4.5.Final/library-preparation-preflight/pi-generation-2026-06-10T02-00-23-386888Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 0,
+      "cached_input_tokens_used": 0,
+      "output_tokens_used": 0,
+      "iterations": 0,
+      "cost_usd": 0.0,
+      "tested_library_loc": 836,
+      "metadata_entries": 7,
+      "previous_library_metadata_entries": 3,
+      "code_coverage_percent": 14.45,
+      "previous_library_coverage_percent": 14.53
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.jboss/jandex/2.4.2.Final/src/test/java/org_jboss/jandex/IndexerTest.java",
+      "metadata_file": "metadata/org.jboss/jandex/2.4.5.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.jboss/jandex/2.4.5.Final/stats.json
+++ b/stats/org.jboss/jandex/2.4.5.Final/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "2.4.5.Final",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 3,
+          "totalCalls" : 3
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 4,
+      "totalCalls" : 4
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 4696,
+        "missed" : 23324,
+        "ratio" : 0.167595,
+        "total" : 28020
+      },
+      "line" : {
+        "covered" : 836,
+        "missed" : 4950,
+        "ratio" : 0.144487,
+        "total" : 5786
+      },
+      "method" : {
+        "covered" : 146,
+        "missed" : 1059,
+        "ratio" : 0.121162,
+        "total" : 1205
+      }
+    }
+  } ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: oracle/graalvm-reachability-metadata#2048

This PR provides new metadata needed for the org.jboss:jandex:2.4.5.Final, addressing Native Image run failures caused by changes in the updated library version.

Summary:
- Metadata entries (previous `org.jboss:jandex:2.4.2.Final`): 3
- Metadata entries (new `org.jboss:jandex:2.4.5.Final`): 7
- Library coverage (previous): 14.53%
- Library coverage (new): 14.45%
- Strategy: library_update_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 0
- Cached input tokens: 0
- Output tokens: 0
- Iterations: 0

### Forge

- Forge monitored branch: `forge-dedup-workflow-helpers`
- Forge branch: `forge-dedup-workflow-helpers`
- Forge commit hash: `0cf13c4fc7d01cdd528756e55342f4cc8e536254`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.jboss:jandex:2.4.2.Final: 3/3 covered calls (100.00%)
- org.jboss:jandex:2.4.5.Final: 4/4 covered calls (100.00%)

**Reflection:**
- org.jboss:jandex:2.4.2.Final: 2/2 covered calls (100.00%)
- org.jboss:jandex:2.4.5.Final: 3/3 covered calls (100.00%)

**Resources:**
- org.jboss:jandex:2.4.2.Final: 1/1 covered calls (100.00%)
- org.jboss:jandex:2.4.5.Final: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.jboss:jandex:2.4.2.Final: 4650/27397 (16.97%)
- org.jboss:jandex:2.4.5.Final: 4696/28020 (16.76%)

**Line:**
- org.jboss:jandex:2.4.2.Final: 827/5690 (14.53%)
- org.jboss:jandex:2.4.5.Final: 836/5786 (14.45%)

**Method:**
- org.jboss:jandex:2.4.2.Final: 147/1199 (12.26%)
- org.jboss:jandex:2.4.5.Final: 146/1205 (12.12%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
