### PR TITLE
[Automation] Generated metadata for org.jboss.resteasy:resteasy-client:6.2.16.Final

### DIFF
--- a/metadata/org.jboss.resteasy/resteasy-client/6.2.16.Final/reachability-metadata.json
+++ b/metadata/org.jboss.resteasy/resteasy-client/6.2.16.Final/reachability-metadata.json
@@ -1,0 +1,1385 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages"
+      },
+      "type": "ch.qos.logback.classic.Logger"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "com.sun.crypto.provider.AESCipher$General",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "com.sun.crypto.provider.ARCFOURCipher",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Poly1305",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "com.sun.crypto.provider.DESCipher",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "com.sun.crypto.provider.DESedeCipher",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "com.sun.crypto.provider.GaloisCounterMode$AESGCM",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.concurrent.ContextualExecutors"
+      },
+      "type": "com.sun.jndi.url.java.javaURLContextFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.ContextParameterInjector$1"
+      },
+      "type": "jakarta.servlet.http.HttpServletResponse"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      },
+      "type": "java.lang.Class"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "java.lang.String"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "java.security.AlgorithmParametersSpi"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "java.security.KeyStoreSpi"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "org.apache.commons.logging.LogFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "org.apache.commons.logging.impl.Jdk14Logger",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "org.apache.commons.logging.impl.Log4JLogger"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "org.apache.commons.logging.impl.LogFactoryImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "org.apache.commons.logging.impl.WeakHashtable",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages"
+      },
+      "type": "org.apache.log4j.LogManager"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages"
+      },
+      "type": "org.apache.logging.log4j.Logger"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LoggingSupport"
+      },
+      "type": "org.jboss.logging.Logger",
+      "methods": [
+        {
+          "name": "getMessageLogger",
+          "parameterTypes": [
+            "java.lang.invoke.MethodHandles$Lookup",
+            "java.lang.Class",
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LoggingSupport"
+      },
+      "type": "org.jboss.logging.Messages",
+      "methods": [
+        {
+          "name": "getBundle",
+          "parameterTypes": [
+            "java.lang.invoke.MethodHandles$Lookup",
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages"
+      },
+      "type": "org.jboss.logmanager.LogManager"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.i18n.LogMessages"
+      },
+      "type": "org.jboss.resteasy.client.jaxrs.i18n.LogMessages_$logger",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.jboss.logging.Logger"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.i18n.LogMessages"
+      },
+      "type": "org.jboss.resteasy.client.jaxrs.i18n.LogMessages_$logger_en"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.i18n.LogMessages"
+      },
+      "type": "org.jboss.resteasy.client.jaxrs.i18n.LogMessages_$logger_en_US"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      },
+      "type": "org.jboss.resteasy.client.jaxrs.internal.CompletionStageRxInvokerProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.ProxyBuilder"
+      },
+      "type": "org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class",
+            "jakarta.ws.rs.client.WebTarget"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.ContextParameterInjector$1"
+      },
+      "type": "org.jboss.resteasy.core.ContextServletOutputStream"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.ClientInvocation"
+      },
+      "type": "org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.CommonProviders"
+      },
+      "type": "org.jboss.resteasy.plugins.interceptors.CacheControlFeature",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      },
+      "type": "org.jboss.resteasy.plugins.interceptors.CacheControlFeature"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.CommonProviders"
+      },
+      "type": "org.jboss.resteasy.plugins.interceptors.ClientContentEncodingAnnotationFeature",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      },
+      "type": "org.jboss.resteasy.plugins.interceptors.ClientContentEncodingAnnotationFeature"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      },
+      "type": "org.jboss.resteasy.plugins.interceptors.MessageSanitizerContainerResponseFilter"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      },
+      "type": "org.jboss.resteasy.plugins.interceptors.ServerContentEncodingAnnotationFeature"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.AbstractEntityProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.CommonProviders"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.AsyncStreamingOutputProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.AsyncStreamingOutputProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.AsyncStreamingOutputProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.AsyncStreamingOutputProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.ByteArrayProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.ByteArrayProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.ByteArrayProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.CompletionStageProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.DataSourceProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.DataSourceProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.DataSourceProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.CommonProviders"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.DefaultBooleanWriter"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.DefaultBooleanWriter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.DefaultBooleanWriter"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.DefaultBooleanWriter"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.CommonProviders"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.DefaultNumberWriter"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.DefaultNumberWriter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.DefaultNumberWriter"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.DefaultNumberWriter"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.DefaultTextPlain",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.DefaultTextPlain"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.DefaultTextPlain"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.DocumentProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.jboss.resteasy.spi.ResteasyConfiguration"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.DocumentProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.DocumentProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.FileProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.FileProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.FileProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.CommonProviders"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.FileRangeWriter"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.FileRangeWriter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.FileRangeWriter"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.FileRangeWriter"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.FormUrlEncodedProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.FormUrlEncodedProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.FormUrlEncodedProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.IIOImageProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.IIOImageProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.IIOImageProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.InputStreamProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.InputStreamProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.InputStreamProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.JaxrsFormProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.JaxrsFormProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.JaxrsFormProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.MultiValuedParamConverterProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.MultiValuedParamConverterProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.ReactiveStreamProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.ReaderProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.ReaderProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.ReaderProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.SourceProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.SourceProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.SourceProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.CommonProviders"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.StreamingOutputProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.StreamingOutputProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.StreamingOutputProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.StreamingOutputProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.StringTextStar",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.StringTextStar"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.StringTextStar"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.PropertyInjectorImpl"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.sse.SseEventProvider",
+      "fields": [
+        {
+          "name": "providers"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.sse.SseEventProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.sse.SseEventProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.sse.SseEventProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.sse.SseEventSinkInterceptor"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages"
+      },
+      "type": "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages_$logger",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.jboss.logging.Logger"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages"
+      },
+      "type": "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages_$logger_en"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages"
+      },
+      "type": "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages_$logger_en_US"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LoggingSupport"
+      },
+      "type": "org.jboss.resteasy.resteasy_jaxrs.i18n.Messages_$bundle",
+      "fields": [
+        {
+          "name": "INSTANCE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LoggingSupport"
+      },
+      "type": "org.jboss.resteasy.resteasy_jaxrs.i18n.Messages_$bundle_en"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LoggingSupport"
+      },
+      "type": "org.jboss.resteasy.resteasy_jaxrs.i18n.Messages_$bundle_en_US"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.tracing.RESTEasyTracingLogger$TRACING"
+      },
+      "type": "org.jboss.resteasy.tracing.api.RESTEasyTracing"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl"
+      },
+      "type": "org_jboss_resteasy.resteasy_client.ClientProxyTest$DefaultMethodClient"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl"
+      },
+      "type": "org_jboss_resteasy.resteasy_client.FormProcessorTest$FormClient"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.processors.FormProcessor"
+      },
+      "type": "org_jboss_resteasy.resteasy_client.FormProcessorTest$FormRequest",
+      "fields": [
+        {
+          "name": "fieldValue"
+        }
+      ],
+      "methods": [
+        {
+          "name": "getGetterValue",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl$DelegateClassLoader"
+      },
+      "type": "org_jboss_resteasy.resteasy_client.ProxyBuilderImplDelegateClassLoaderTest$TestResourceApi"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl"
+      },
+      "type": "org_jboss_resteasy.resteasy_client.ResponseObjectClient"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.extractors.ResponseObjectProxy"
+      },
+      "type": "org_jboss_resteasy.resteasy_client.RichResponse"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "sun.security.pkcs12.PKCS12KeyStore",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "sun.security.pkcs12.PKCS12KeyStore$DualFormatPKCS12",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "sun.security.provider.SHA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.util.MethodHashing"
+      },
+      "type": "sun.security.provider.SHA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "sun.security.provider.X509Factory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "sun.security.rsa.RSAKeyFactory$Legacy",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "sun.security.ssl.KeyManagerFactoryImpl$SunX509",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "sun.security.ssl.SSLContextImpl$DefaultSSLContext",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "sun.security.ssl.TrustManagerFactoryImpl$PKIXFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "sun.security.x509.AuthorityInfoAccessExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "sun.security.x509.AuthorityKeyIdentifierExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "sun.security.x509.BasicConstraintsExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "sun.security.x509.CRLDistributionPointsExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "sun.security.x509.CertificatePoliciesExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "sun.security.x509.ExtendedKeyUsageExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "sun.security.x509.KeyUsageExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "sun.security.x509.NetscapeCertTypeExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "sun.security.x509.PrivateKeyUsageExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "sun.security.x509.SubjectKeyIdentifierExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.PropertyInjectorImpl"
+      },
+      "type": {
+        "proxy": [
+          "jakarta.ws.rs.ext.Providers"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.ConstructorInjectorImpl"
+      },
+      "type": {
+        "proxy": [
+          "org.jboss.resteasy.spi.ResteasyConfiguration"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl"
+      },
+      "type": {
+        "proxy": [
+          "org_jboss_resteasy.resteasy_client.ClientProxyTest$DefaultMethodClient",
+          "org.jboss.resteasy.client.jaxrs.internal.proxy.ResteasyClientProxy"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl"
+      },
+      "type": {
+        "proxy": [
+          "org_jboss_resteasy.resteasy_client.FormProcessorTest$FormClient",
+          "org.jboss.resteasy.client.jaxrs.internal.proxy.ResteasyClientProxy"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl"
+      },
+      "type": {
+        "proxy": [
+          "org_jboss_resteasy.resteasy_client.ResponseObjectClient",
+          "org.jboss.resteasy.client.jaxrs.internal.proxy.ResteasyClientProxy"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.extractors.ResponseObjectProxy"
+      },
+      "type": {
+        "proxy": [
+          "org_jboss_resteasy.resteasy_client.RichResponse"
+        ]
+      }
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      },
+      "glob": "META-INF/services/jakarta.ws.rs.ext.Providers"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.ClientInvocation"
+      },
+      "glob": "META-INF/services/jakarta.ws.rs.ext.RuntimeDelegate"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "glob": "META-INF/services/java.net.spi.URLStreamHandlerProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.ContextParameterInjector$1"
+      },
+      "glob": "META-INF/services/java.util.spi.ResourceBundleControlProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "glob": "META-INF/services/org.apache.commons.logging.LogFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages"
+      },
+      "glob": "META-INF/services/org.jboss.logging.LoggerProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.PriorityServiceLoader"
+      },
+      "glob": "META-INF/services/org.jboss.resteasy.client.jaxrs.engine.ClientHttpEngineFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl"
+      },
+      "glob": "META-INF/services/org.jboss.resteasy.client.jaxrs.spi.ClientConfigProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.PriorityServiceLoader"
+      },
+      "glob": "META-INF/services/org.jboss.resteasy.client.jaxrs.spi.ClientConfigProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.config.SingletonConfigurationFactory$Holder"
+      },
+      "glob": "META-INF/services/org.jboss.resteasy.spi.config.ConfigurationFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "glob": "commons-logging.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.ContextParameterInjector$1"
+      },
+      "glob": "jakarta/servlet/LocalStrings.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.ContextParameterInjector$1"
+      },
+      "glob": "jakarta/servlet/LocalStrings_en.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.ContextParameterInjector$1"
+      },
+      "glob": "jakarta/servlet/LocalStrings_en_US.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.concurrent.ContextualExecutors"
+      },
+      "glob": "jndi.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "glob": "mozilla/public-suffix-list.txt"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "glob": "org/apache/http/client/version.properties"
+    },
+    {
+      "bundle": "jakarta.servlet.LocalStrings"
+    }
+  ]
+}

--- a/metadata/org.jboss.resteasy/resteasy-client/6.2.16.Final/reachability-metadata.json
+++ b/metadata/org.jboss.resteasy/resteasy-client/6.2.16.Final/reachability-metadata.json
@@ -2,6 +2,12 @@
   "reflection": [
     {
       "condition": {
+        "typeReached": "org.jboss.resteasy.spi.config.DefaultConfiguration$Resolver"
+      },
+      "type": "byte[][]"
+    },
+    {
+      "condition": {
         "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages"
       },
       "type": "ch.qos.logback.classic.Logger"
@@ -86,9 +92,93 @@
     },
     {
       "condition": {
+        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      },
+      "type": "jakarta.activation.DataSource"
+    },
+    {
+      "condition": {
         "typeReached": "org.jboss.resteasy.core.ContextParameterInjector$1"
       },
       "type": "jakarta.servlet.http.HttpServletResponse"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      },
+      "type": "jakarta.ws.rs.client.CompletionStageRxInvoker"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      },
+      "type": "jakarta.ws.rs.client.RxInvoker"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      },
+      "type": "jakarta.ws.rs.client.RxInvokerProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      },
+      "type": "jakarta.ws.rs.core.Form"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      },
+      "type": "jakarta.ws.rs.core.MultivaluedMap"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      },
+      "type": "jakarta.ws.rs.core.StreamingOutput"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      },
+      "type": "jakarta.ws.rs.ext.MessageBodyReader"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      },
+      "type": "jakarta.ws.rs.ext.MessageBodyWriter"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      },
+      "type": "jakarta.ws.rs.sse.OutboundSseEvent"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      },
+      "type": "java.io.File"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      },
+      "type": "java.io.InputStream"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      },
+      "type": "java.io.Reader"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      },
+      "type": "java.lang.Boolean"
     },
     {
       "condition": {
@@ -98,9 +188,45 @@
     },
     {
       "condition": {
+        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      },
+      "type": "java.lang.Number"
+    },
+    {
+      "condition": {
         "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
       "type": "java.lang.String"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LoggingSupport"
+      },
+      "type": "java.lang.invoke.Invokers"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.ClientProxy"
+      },
+      "type": "java.lang.invoke.LambdaForm$Name[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LoggingSupport"
+      },
+      "type": "java.lang.invoke.LambdaForm$Name[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LoggingSupport"
+      },
+      "type": "java.lang.invoke.MethodHandleImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "java.lang.invoke.VarHandleReferences$FieldStaticReadWrite"
     },
     {
       "condition": {
@@ -113,6 +239,30 @@
         "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
       "type": "java.security.KeyStoreSpi"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      },
+      "type": "java.util.concurrent.CompletionStage"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      },
+      "type": "javax.imageio.IIOImage"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      },
+      "type": "javax.net.ssl.SSLContext"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      },
+      "type": "javax.xml.transform.Source"
     },
     {
       "condition": {
@@ -229,6 +379,12 @@
     },
     {
       "condition": {
+        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LoggingSupport"
+      },
+      "type": "org.jboss.resteasy.client.jaxrs.i18n.LogMessages_$logger"
+    },
+    {
+      "condition": {
         "typeReached": "org.jboss.resteasy.client.jaxrs.i18n.LogMessages"
       },
       "type": "org.jboss.resteasy.client.jaxrs.i18n.LogMessages_$logger_en"
@@ -265,6 +421,12 @@
         "typeReached": "org.jboss.resteasy.core.ContextParameterInjector$1"
       },
       "type": "org.jboss.resteasy.core.ContextServletOutputStream"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      },
+      "type": "org.jboss.resteasy.core.messagebody.AsyncBufferedMessageBodyWriter"
     },
     {
       "condition": {
@@ -546,6 +708,12 @@
     },
     {
       "condition": {
+        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.FileRange"
+    },
+    {
+      "condition": {
         "typeReached": "org.jboss.resteasy.core.providerfactory.CommonProviders"
       },
       "type": "org.jboss.resteasy.plugins.providers.FileRangeWriter"
@@ -798,6 +966,12 @@
     },
     {
       "condition": {
+        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      },
+      "type": "org.jboss.resteasy.plugins.providers.sse.SseEventInputImpl"
+    },
+    {
+      "condition": {
         "typeReached": "org.jboss.resteasy.core.PropertyInjectorImpl"
       },
       "type": "org.jboss.resteasy.plugins.providers.sse.SseEventProvider",
@@ -853,6 +1027,12 @@
     },
     {
       "condition": {
+        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LoggingSupport"
+      },
+      "type": "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages_$logger"
+    },
+    {
+      "condition": {
         "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages"
       },
       "type": "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages_$logger_en"
@@ -888,9 +1068,27 @@
     },
     {
       "condition": {
+        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      },
+      "type": "org.jboss.resteasy.spi.AsyncMessageBodyWriter"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      },
+      "type": "org.jboss.resteasy.spi.AsyncStreamingOutput"
+    },
+    {
+      "condition": {
         "typeReached": "org.jboss.resteasy.tracing.RESTEasyTracingLogger$TRACING"
       },
       "type": "org.jboss.resteasy.tracing.api.RESTEasyTracing"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      },
+      "type": "org.w3c.dom.Document"
     },
     {
       "condition": {
@@ -1213,6 +1411,186 @@
     },
     {
       "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.ClientHelper"
+      },
+      "type": {
+        "proxy": [
+          "jakarta.annotation.Priority"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.processors.ProcessorFactory"
+      },
+      "type": {
+        "proxy": [
+          "jakarta.ws.rs.BeanParam"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.plugins.interceptors.ClientContentEncodingAnnotationFeature"
+      },
+      "type": {
+        "proxy": [
+          "jakarta.ws.rs.BeanParam"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.ClientHelper"
+      },
+      "type": {
+        "proxy": [
+          "jakarta.ws.rs.ConstrainedTo"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.ClientHelper"
+      },
+      "type": {
+        "proxy": [
+          "jakarta.ws.rs.Consumes"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.processors.FormProcessor"
+      },
+      "type": {
+        "proxy": [
+          "jakarta.ws.rs.FormParam"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.util.IsHttpMethod"
+      },
+      "type": {
+        "proxy": [
+          "jakarta.ws.rs.GET"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.extractors.ResponseObjectEntityExtractorFactory"
+      },
+      "type": {
+        "proxy": [
+          "jakarta.ws.rs.HeaderParam"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.util.IsHttpMethod"
+      },
+      "type": {
+        "proxy": [
+          "jakarta.ws.rs.HttpMethod"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.util.IsHttpMethod"
+      },
+      "type": {
+        "proxy": [
+          "jakarta.ws.rs.POST"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl"
+      },
+      "type": {
+        "proxy": [
+          "jakarta.ws.rs.Path"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.util.IsHttpMethod"
+      },
+      "type": {
+        "proxy": [
+          "jakarta.ws.rs.Path"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.ClientHelper"
+      },
+      "type": {
+        "proxy": [
+          "jakarta.ws.rs.Produces"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.ConstructorInjectorImpl"
+      },
+      "type": {
+        "proxy": [
+          "jakarta.ws.rs.core.Context"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.PropertyInjectorImpl"
+      },
+      "type": {
+        "proxy": [
+          "jakarta.ws.rs.core.Context"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.spi.util.PickConstructor"
+      },
+      "type": {
+        "proxy": [
+          "jakarta.ws.rs.core.Context"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.ClientHelper"
+      },
+      "type": {
+        "proxy": [
+          "jakarta.ws.rs.ext.Provider"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.ContextParameterInjector"
+      },
+      "type": {
+        "proxy": [
+          "jakarta.ws.rs.ext.Providers"
+        ]
+      }
+    },
+    {
+      "condition": {
         "typeReached": "org.jboss.resteasy.core.PropertyInjectorImpl"
       },
       "type": {
@@ -1223,7 +1601,167 @@
     },
     {
       "condition": {
+        "typeReached": "org.jboss.resteasy.plugins.interceptors.ClientContentEncodingAnnotationFeature"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Documented"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.util.IsHttpMethod"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Documented"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.ClientHelper"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Inherited"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.extractors.DefaultEntityExtractorFactory"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.extractors.ResponseObjectEntityExtractorFactory"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.processors.FormProcessor"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.PropertyInjectorImpl"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.providerfactory.ClientHelper"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.plugins.interceptors.ClientContentEncodingAnnotationFeature"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.util.IsHttpMethod"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.plugins.interceptors.ClientContentEncodingAnnotationFeature"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Target"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.util.IsHttpMethod"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Target"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.extractors.DefaultEntityExtractorFactory"
+      },
+      "type": {
+        "proxy": [
+          "org.jboss.resteasy.annotations.ResponseObject"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.extractors.ResponseObjectEntityExtractorFactory"
+      },
+      "type": {
+        "proxy": [
+          "org.jboss.resteasy.annotations.Status"
+        ]
+      }
+    },
+    {
+      "condition": {
         "typeReached": "org.jboss.resteasy.core.ConstructorInjectorImpl"
+      },
+      "type": {
+        "proxy": [
+          "org.jboss.resteasy.spi.ResteasyConfiguration"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.resteasy.core.ContextParameterInjector"
       },
       "type": {
         "proxy": [

--- a/metadata/org.jboss.resteasy/resteasy-client/6.2.16.Final/reachability-metadata.json
+++ b/metadata/org.jboss.resteasy/resteasy-client/6.2.16.Final/reachability-metadata.json
@@ -1,340 +1,340 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.config.DefaultConfiguration$Resolver"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.config.DefaultConfiguration$Resolver"
       },
-      "type": "byte[][]"
+      "type" : "byte[][]"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages"
       },
-      "type": "ch.qos.logback.classic.Logger"
+      "type" : "ch.qos.logback.classic.Logger"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "com.sun.crypto.provider.AESCipher$General",
-      "methods": [
+      "type" : "com.sun.crypto.provider.AESCipher$General",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "com.sun.crypto.provider.ARCFOURCipher",
-      "methods": [
+      "type" : "com.sun.crypto.provider.ARCFOURCipher",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Poly1305",
-      "methods": [
+      "type" : "com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Poly1305",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "com.sun.crypto.provider.DESCipher",
-      "methods": [
+      "type" : "com.sun.crypto.provider.DESCipher",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "com.sun.crypto.provider.DESedeCipher",
-      "methods": [
+      "type" : "com.sun.crypto.provider.DESedeCipher",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "com.sun.crypto.provider.GaloisCounterMode$AESGCM",
-      "methods": [
+      "type" : "com.sun.crypto.provider.GaloisCounterMode$AESGCM",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.concurrent.ContextualExecutors"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.concurrent.ContextualExecutors"
       },
-      "type": "com.sun.jndi.url.java.javaURLContextFactory"
+      "type" : "com.sun.jndi.url.java.javaURLContextFactory"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.util.Types"
       },
-      "type": "jakarta.activation.DataSource"
+      "type" : "jakarta.activation.DataSource"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.ContextParameterInjector$1"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.ContextParameterInjector$1"
       },
-      "type": "jakarta.servlet.http.HttpServletResponse"
+      "type" : "jakarta.servlet.http.HttpServletResponse"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.util.Types"
       },
-      "type": "jakarta.ws.rs.client.CompletionStageRxInvoker"
+      "type" : "jakarta.ws.rs.client.CompletionStageRxInvoker"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.util.Types"
       },
-      "type": "jakarta.ws.rs.client.RxInvoker"
+      "type" : "jakarta.ws.rs.client.RxInvoker"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.util.Types"
       },
-      "type": "jakarta.ws.rs.client.RxInvokerProvider"
+      "type" : "jakarta.ws.rs.client.RxInvokerProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.util.Types"
       },
-      "type": "jakarta.ws.rs.core.Form"
+      "type" : "jakarta.ws.rs.core.Form"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.util.Types"
       },
-      "type": "jakarta.ws.rs.core.MultivaluedMap"
+      "type" : "jakarta.ws.rs.core.MultivaluedMap"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.util.Types"
       },
-      "type": "jakarta.ws.rs.core.StreamingOutput"
+      "type" : "jakarta.ws.rs.core.StreamingOutput"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.util.Types"
       },
-      "type": "jakarta.ws.rs.ext.MessageBodyReader"
+      "type" : "jakarta.ws.rs.ext.MessageBodyReader"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.util.Types"
       },
-      "type": "jakarta.ws.rs.ext.MessageBodyWriter"
+      "type" : "jakarta.ws.rs.ext.MessageBodyWriter"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.util.Types"
       },
-      "type": "jakarta.ws.rs.sse.OutboundSseEvent"
+      "type" : "jakarta.ws.rs.sse.OutboundSseEvent"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.util.Types"
       },
-      "type": "java.io.File"
+      "type" : "java.io.File"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.util.Types"
       },
-      "type": "java.io.InputStream"
+      "type" : "java.io.InputStream"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.util.Types"
       },
-      "type": "java.io.Reader"
+      "type" : "java.io.Reader"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.util.Types"
       },
-      "type": "java.lang.Boolean"
+      "type" : "java.lang.Boolean"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.Utils"
       },
-      "type": "java.lang.Class"
+      "type" : "java.lang.Class"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.util.Types"
       },
-      "type": "java.lang.Number"
+      "type" : "java.lang.Number"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "java.lang.String"
+      "type" : "java.lang.String"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LoggingSupport"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.resteasy_jaxrs.i18n.LoggingSupport"
       },
-      "type": "java.lang.invoke.Invokers"
+      "type" : "java.lang.invoke.Invokers"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.ClientProxy"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.internal.proxy.ClientProxy"
       },
-      "type": "java.lang.invoke.LambdaForm$Name[]"
+      "type" : "java.lang.invoke.LambdaForm$Name[]"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LoggingSupport"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.resteasy_jaxrs.i18n.LoggingSupport"
       },
-      "type": "java.lang.invoke.LambdaForm$Name[]"
+      "type" : "java.lang.invoke.LambdaForm$Name[]"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LoggingSupport"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.resteasy_jaxrs.i18n.LoggingSupport"
       },
-      "type": "java.lang.invoke.MethodHandleImpl"
+      "type" : "java.lang.invoke.MethodHandleImpl"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "java.lang.invoke.VarHandleReferences$FieldStaticReadWrite"
+      "type" : "java.lang.invoke.VarHandleReferences$FieldStaticReadWrite"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "java.security.AlgorithmParametersSpi"
+      "type" : "java.security.AlgorithmParametersSpi"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "java.security.KeyStoreSpi"
+      "type" : "java.security.KeyStoreSpi"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.util.Types"
       },
-      "type": "java.util.concurrent.CompletionStage"
+      "type" : "java.util.concurrent.CompletionStage"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.util.Types"
       },
-      "type": "javax.imageio.IIOImage"
+      "type" : "javax.imageio.IIOImage"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "javax.net.ssl.SSLContext"
+      "type" : "javax.net.ssl.SSLContext"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.util.Types"
       },
-      "type": "javax.xml.transform.Source"
+      "type" : "javax.xml.transform.Source"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "org.apache.commons.logging.LogFactory"
+      "type" : "org.apache.commons.logging.LogFactory"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "org.apache.commons.logging.impl.Jdk14Logger",
-      "methods": [
+      "type" : "org.apache.commons.logging.impl.Jdk14Logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.String"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "org.apache.commons.logging.impl.Log4JLogger"
+      "type" : "org.apache.commons.logging.impl.Log4JLogger"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "org.apache.commons.logging.impl.LogFactoryImpl",
-      "methods": [
+      "type" : "org.apache.commons.logging.impl.LogFactoryImpl",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "org.apache.commons.logging.impl.WeakHashtable",
-      "methods": [
+      "type" : "org.apache.commons.logging.impl.WeakHashtable",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages"
       },
-      "type": "org.apache.log4j.LogManager"
+      "type" : "org.apache.log4j.LogManager"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages"
       },
-      "type": "org.apache.logging.log4j.Logger"
+      "type" : "org.apache.logging.log4j.Logger"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LoggingSupport"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.resteasy_jaxrs.i18n.LoggingSupport"
       },
-      "type": "org.jboss.logging.Logger",
-      "methods": [
+      "type" : "org.jboss.logging.Logger",
+      "methods" : [
         {
-          "name": "getMessageLogger",
-          "parameterTypes": [
+          "name" : "getMessageLogger",
+          "parameterTypes" : [
             "java.lang.invoke.MethodHandles$Lookup",
             "java.lang.Class",
             "java.lang.String"
@@ -343,14 +343,14 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LoggingSupport"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.resteasy_jaxrs.i18n.LoggingSupport"
       },
-      "type": "org.jboss.logging.Messages",
-      "methods": [
+      "type" : "org.jboss.logging.Messages",
+      "methods" : [
         {
-          "name": "getBundle",
-          "parameterTypes": [
+          "name" : "getBundle",
+          "parameterTypes" : [
             "java.lang.invoke.MethodHandles$Lookup",
             "java.lang.Class"
           ]
@@ -358,58 +358,58 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages"
       },
-      "type": "org.jboss.logmanager.LogManager"
+      "type" : "org.jboss.logmanager.LogManager"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.i18n.LogMessages"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.i18n.LogMessages"
       },
-      "type": "org.jboss.resteasy.client.jaxrs.i18n.LogMessages_$logger",
-      "methods": [
+      "type" : "org.jboss.resteasy.client.jaxrs.i18n.LogMessages_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LoggingSupport"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.resteasy_jaxrs.i18n.LoggingSupport"
       },
-      "type": "org.jboss.resteasy.client.jaxrs.i18n.LogMessages_$logger"
+      "type" : "org.jboss.resteasy.client.jaxrs.i18n.LogMessages_$logger"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.i18n.LogMessages"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.i18n.LogMessages"
       },
-      "type": "org.jboss.resteasy.client.jaxrs.i18n.LogMessages_$logger_en"
+      "type" : "org.jboss.resteasy.client.jaxrs.i18n.LogMessages_$logger_en"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.i18n.LogMessages"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.i18n.LogMessages"
       },
-      "type": "org.jboss.resteasy.client.jaxrs.i18n.LogMessages_$logger_en_US"
+      "type" : "org.jboss.resteasy.client.jaxrs.i18n.LogMessages_$logger_en_US"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
       },
-      "type": "org.jboss.resteasy.client.jaxrs.internal.CompletionStageRxInvokerProvider"
+      "type" : "org.jboss.resteasy.client.jaxrs.internal.CompletionStageRxInvokerProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.ProxyBuilder"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.ProxyBuilder"
       },
-      "type": "org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl",
-      "methods": [
+      "type" : "org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.Class",
             "jakarta.ws.rs.client.WebTarget"
           ]
@@ -417,857 +417,810 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.ContextParameterInjector$1"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.ContextParameterInjector$1"
       },
-      "type": "org.jboss.resteasy.core.ContextServletOutputStream"
+      "type" : "org.jboss.resteasy.core.ContextServletOutputStream"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.util.Types"
       },
-      "type": "org.jboss.resteasy.core.messagebody.AsyncBufferedMessageBodyWriter"
+      "type" : "org.jboss.resteasy.core.messagebody.AsyncBufferedMessageBodyWriter"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.ClientInvocation"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.internal.ClientInvocation"
       },
-      "type": "org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl"
+      "type" : "org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.CommonProviders"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.CommonProviders"
       },
-      "type": "org.jboss.resteasy.plugins.interceptors.CacheControlFeature",
-      "methods": [
+      "type" : "org.jboss.resteasy.plugins.interceptors.CacheControlFeature",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
       },
-      "type": "org.jboss.resteasy.plugins.interceptors.CacheControlFeature"
+      "type" : "org.jboss.resteasy.plugins.interceptors.CacheControlFeature"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.CommonProviders"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.CommonProviders"
       },
-      "type": "org.jboss.resteasy.plugins.interceptors.ClientContentEncodingAnnotationFeature",
-      "methods": [
+      "type" : "org.jboss.resteasy.plugins.interceptors.ClientContentEncodingAnnotationFeature",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
       },
-      "type": "org.jboss.resteasy.plugins.interceptors.ClientContentEncodingAnnotationFeature"
+      "type" : "org.jboss.resteasy.plugins.interceptors.ClientContentEncodingAnnotationFeature"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
       },
-      "type": "org.jboss.resteasy.plugins.interceptors.MessageSanitizerContainerResponseFilter"
+      "type" : "org.jboss.resteasy.plugins.interceptors.MessageSanitizerContainerResponseFilter"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
       },
-      "type": "org.jboss.resteasy.plugins.interceptors.ServerContentEncodingAnnotationFeature"
+      "type" : "org.jboss.resteasy.plugins.interceptors.ServerContentEncodingAnnotationFeature"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.Utils"
       },
-      "type": "org.jboss.resteasy.plugins.providers.AbstractEntityProvider"
+      "type" : "org.jboss.resteasy.plugins.providers.AbstractEntityProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.CommonProviders"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.CommonProviders"
       },
-      "type": "org.jboss.resteasy.plugins.providers.AsyncStreamingOutputProvider"
+      "type" : "org.jboss.resteasy.plugins.providers.AsyncStreamingOutputProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.Utils"
       },
-      "type": "org.jboss.resteasy.plugins.providers.AsyncStreamingOutputProvider",
-      "methods": [
+      "type" : "org.jboss.resteasy.plugins.providers.AsyncStreamingOutputProvider",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
       },
-      "type": "org.jboss.resteasy.plugins.providers.AsyncStreamingOutputProvider"
+      "type" : "org.jboss.resteasy.plugins.providers.AsyncStreamingOutputProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.InjectorFactory"
       },
-      "type": "org.jboss.resteasy.plugins.providers.AsyncStreamingOutputProvider"
+      "type" : "org.jboss.resteasy.plugins.providers.AsyncStreamingOutputProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.Utils"
       },
-      "type": "org.jboss.resteasy.plugins.providers.ByteArrayProvider",
-      "methods": [
+      "type" : "org.jboss.resteasy.plugins.providers.ByteArrayProvider",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
       },
-      "type": "org.jboss.resteasy.plugins.providers.ByteArrayProvider"
+      "type" : "org.jboss.resteasy.plugins.providers.ByteArrayProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.InjectorFactory"
       },
-      "type": "org.jboss.resteasy.plugins.providers.ByteArrayProvider"
+      "type" : "org.jboss.resteasy.plugins.providers.ByteArrayProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
       },
-      "type": "org.jboss.resteasy.plugins.providers.CompletionStageProvider"
+      "type" : "org.jboss.resteasy.plugins.providers.CompletionStageProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.Utils"
       },
-      "type": "org.jboss.resteasy.plugins.providers.DataSourceProvider",
-      "methods": [
+      "type" : "org.jboss.resteasy.plugins.providers.DataSourceProvider",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
       },
-      "type": "org.jboss.resteasy.plugins.providers.DataSourceProvider"
+      "type" : "org.jboss.resteasy.plugins.providers.DataSourceProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.InjectorFactory"
       },
-      "type": "org.jboss.resteasy.plugins.providers.DataSourceProvider"
+      "type" : "org.jboss.resteasy.plugins.providers.DataSourceProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.CommonProviders"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.CommonProviders"
       },
-      "type": "org.jboss.resteasy.plugins.providers.DefaultBooleanWriter"
+      "type" : "org.jboss.resteasy.plugins.providers.DefaultBooleanWriter"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.Utils"
       },
-      "type": "org.jboss.resteasy.plugins.providers.DefaultBooleanWriter",
-      "methods": [
+      "type" : "org.jboss.resteasy.plugins.providers.DefaultBooleanWriter",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
       },
-      "type": "org.jboss.resteasy.plugins.providers.DefaultBooleanWriter"
+      "type" : "org.jboss.resteasy.plugins.providers.DefaultBooleanWriter"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.InjectorFactory"
       },
-      "type": "org.jboss.resteasy.plugins.providers.DefaultBooleanWriter"
+      "type" : "org.jboss.resteasy.plugins.providers.DefaultBooleanWriter"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.CommonProviders"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.CommonProviders"
       },
-      "type": "org.jboss.resteasy.plugins.providers.DefaultNumberWriter"
+      "type" : "org.jboss.resteasy.plugins.providers.DefaultNumberWriter"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.Utils"
       },
-      "type": "org.jboss.resteasy.plugins.providers.DefaultNumberWriter",
-      "methods": [
+      "type" : "org.jboss.resteasy.plugins.providers.DefaultNumberWriter",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
       },
-      "type": "org.jboss.resteasy.plugins.providers.DefaultNumberWriter"
+      "type" : "org.jboss.resteasy.plugins.providers.DefaultNumberWriter"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.InjectorFactory"
       },
-      "type": "org.jboss.resteasy.plugins.providers.DefaultNumberWriter"
+      "type" : "org.jboss.resteasy.plugins.providers.DefaultNumberWriter"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.Utils"
       },
-      "type": "org.jboss.resteasy.plugins.providers.DefaultTextPlain",
-      "methods": [
+      "type" : "org.jboss.resteasy.plugins.providers.DefaultTextPlain",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
       },
-      "type": "org.jboss.resteasy.plugins.providers.DefaultTextPlain"
+      "type" : "org.jboss.resteasy.plugins.providers.DefaultTextPlain"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.InjectorFactory"
       },
-      "type": "org.jboss.resteasy.plugins.providers.DefaultTextPlain"
+      "type" : "org.jboss.resteasy.plugins.providers.DefaultTextPlain"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.Utils"
       },
-      "type": "org.jboss.resteasy.plugins.providers.DocumentProvider",
-      "methods": [
+      "type" : "org.jboss.resteasy.plugins.providers.DocumentProvider",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.resteasy.spi.ResteasyConfiguration"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
       },
-      "type": "org.jboss.resteasy.plugins.providers.DocumentProvider"
+      "type" : "org.jboss.resteasy.plugins.providers.DocumentProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.InjectorFactory"
       },
-      "type": "org.jboss.resteasy.plugins.providers.DocumentProvider"
+      "type" : "org.jboss.resteasy.plugins.providers.DocumentProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.Utils"
       },
-      "type": "org.jboss.resteasy.plugins.providers.FileProvider",
-      "methods": [
+      "type" : "org.jboss.resteasy.plugins.providers.FileProvider",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
       },
-      "type": "org.jboss.resteasy.plugins.providers.FileProvider"
+      "type" : "org.jboss.resteasy.plugins.providers.FileProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.InjectorFactory"
       },
-      "type": "org.jboss.resteasy.plugins.providers.FileProvider"
+      "type" : "org.jboss.resteasy.plugins.providers.FileProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.util.Types"
       },
-      "type": "org.jboss.resteasy.plugins.providers.FileRange"
+      "type" : "org.jboss.resteasy.plugins.providers.FileRange"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.CommonProviders"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.CommonProviders"
       },
-      "type": "org.jboss.resteasy.plugins.providers.FileRangeWriter"
+      "type" : "org.jboss.resteasy.plugins.providers.FileRangeWriter"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.Utils"
       },
-      "type": "org.jboss.resteasy.plugins.providers.FileRangeWriter",
-      "methods": [
+      "type" : "org.jboss.resteasy.plugins.providers.FileRangeWriter",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
       },
-      "type": "org.jboss.resteasy.plugins.providers.FileRangeWriter"
+      "type" : "org.jboss.resteasy.plugins.providers.FileRangeWriter"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.InjectorFactory"
       },
-      "type": "org.jboss.resteasy.plugins.providers.FileRangeWriter"
+      "type" : "org.jboss.resteasy.plugins.providers.FileRangeWriter"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.Utils"
       },
-      "type": "org.jboss.resteasy.plugins.providers.FormUrlEncodedProvider",
-      "methods": [
+      "type" : "org.jboss.resteasy.plugins.providers.FormUrlEncodedProvider",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
       },
-      "type": "org.jboss.resteasy.plugins.providers.FormUrlEncodedProvider"
+      "type" : "org.jboss.resteasy.plugins.providers.FormUrlEncodedProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.InjectorFactory"
       },
-      "type": "org.jboss.resteasy.plugins.providers.FormUrlEncodedProvider"
+      "type" : "org.jboss.resteasy.plugins.providers.FormUrlEncodedProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.Utils"
       },
-      "type": "org.jboss.resteasy.plugins.providers.IIOImageProvider",
-      "methods": [
+      "type" : "org.jboss.resteasy.plugins.providers.IIOImageProvider",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
       },
-      "type": "org.jboss.resteasy.plugins.providers.IIOImageProvider"
+      "type" : "org.jboss.resteasy.plugins.providers.IIOImageProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.InjectorFactory"
       },
-      "type": "org.jboss.resteasy.plugins.providers.IIOImageProvider"
+      "type" : "org.jboss.resteasy.plugins.providers.IIOImageProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.Utils"
       },
-      "type": "org.jboss.resteasy.plugins.providers.InputStreamProvider",
-      "methods": [
+      "type" : "org.jboss.resteasy.plugins.providers.InputStreamProvider",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
       },
-      "type": "org.jboss.resteasy.plugins.providers.InputStreamProvider"
+      "type" : "org.jboss.resteasy.plugins.providers.InputStreamProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.InjectorFactory"
       },
-      "type": "org.jboss.resteasy.plugins.providers.InputStreamProvider"
+      "type" : "org.jboss.resteasy.plugins.providers.InputStreamProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.Utils"
       },
-      "type": "org.jboss.resteasy.plugins.providers.JaxrsFormProvider",
-      "methods": [
+      "type" : "org.jboss.resteasy.plugins.providers.JaxrsFormProvider",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
       },
-      "type": "org.jboss.resteasy.plugins.providers.JaxrsFormProvider"
+      "type" : "org.jboss.resteasy.plugins.providers.JaxrsFormProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.InjectorFactory"
       },
-      "type": "org.jboss.resteasy.plugins.providers.JaxrsFormProvider"
+      "type" : "org.jboss.resteasy.plugins.providers.JaxrsFormProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl"
       },
-      "type": "org.jboss.resteasy.plugins.providers.MultiValuedParamConverterProvider",
-      "methods": [
+      "type" : "org.jboss.resteasy.plugins.providers.MultiValuedParamConverterProvider",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
       },
-      "type": "org.jboss.resteasy.plugins.providers.MultiValuedParamConverterProvider"
+      "type" : "org.jboss.resteasy.plugins.providers.MultiValuedParamConverterProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
       },
-      "type": "org.jboss.resteasy.plugins.providers.ReactiveStreamProvider"
+      "type" : "org.jboss.resteasy.plugins.providers.ReactiveStreamProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.Utils"
       },
-      "type": "org.jboss.resteasy.plugins.providers.ReaderProvider",
-      "methods": [
+      "type" : "org.jboss.resteasy.plugins.providers.ReaderProvider",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
       },
-      "type": "org.jboss.resteasy.plugins.providers.ReaderProvider"
+      "type" : "org.jboss.resteasy.plugins.providers.ReaderProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.InjectorFactory"
       },
-      "type": "org.jboss.resteasy.plugins.providers.ReaderProvider"
+      "type" : "org.jboss.resteasy.plugins.providers.ReaderProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.Utils"
       },
-      "type": "org.jboss.resteasy.plugins.providers.SourceProvider",
-      "methods": [
+      "type" : "org.jboss.resteasy.plugins.providers.SourceProvider",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
       },
-      "type": "org.jboss.resteasy.plugins.providers.SourceProvider"
+      "type" : "org.jboss.resteasy.plugins.providers.SourceProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.InjectorFactory"
       },
-      "type": "org.jboss.resteasy.plugins.providers.SourceProvider"
+      "type" : "org.jboss.resteasy.plugins.providers.SourceProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.CommonProviders"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.CommonProviders"
       },
-      "type": "org.jboss.resteasy.plugins.providers.StreamingOutputProvider"
+      "type" : "org.jboss.resteasy.plugins.providers.StreamingOutputProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.Utils"
       },
-      "type": "org.jboss.resteasy.plugins.providers.StreamingOutputProvider",
-      "methods": [
+      "type" : "org.jboss.resteasy.plugins.providers.StreamingOutputProvider",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
       },
-      "type": "org.jboss.resteasy.plugins.providers.StreamingOutputProvider"
+      "type" : "org.jboss.resteasy.plugins.providers.StreamingOutputProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.InjectorFactory"
       },
-      "type": "org.jboss.resteasy.plugins.providers.StreamingOutputProvider"
+      "type" : "org.jboss.resteasy.plugins.providers.StreamingOutputProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.Utils"
       },
-      "type": "org.jboss.resteasy.plugins.providers.StringTextStar",
-      "methods": [
+      "type" : "org.jboss.resteasy.plugins.providers.StringTextStar",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
       },
-      "type": "org.jboss.resteasy.plugins.providers.StringTextStar"
+      "type" : "org.jboss.resteasy.plugins.providers.StringTextStar"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.InjectorFactory"
       },
-      "type": "org.jboss.resteasy.plugins.providers.StringTextStar"
+      "type" : "org.jboss.resteasy.plugins.providers.StringTextStar"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.util.Types"
       },
-      "type": "org.jboss.resteasy.plugins.providers.sse.SseEventInputImpl"
+      "type" : "org.jboss.resteasy.plugins.providers.sse.SseEventInputImpl"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.PropertyInjectorImpl"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.PropertyInjectorImpl"
       },
-      "type": "org.jboss.resteasy.plugins.providers.sse.SseEventProvider",
-      "fields": [
+      "type" : "org.jboss.resteasy.plugins.providers.sse.SseEventProvider",
+      "fields" : [
         {
-          "name": "providers"
+          "name" : "providers"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.Utils"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.Utils"
       },
-      "type": "org.jboss.resteasy.plugins.providers.sse.SseEventProvider",
-      "methods": [
+      "type" : "org.jboss.resteasy.plugins.providers.sse.SseEventProvider",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
       },
-      "type": "org.jboss.resteasy.plugins.providers.sse.SseEventProvider"
+      "type" : "org.jboss.resteasy.plugins.providers.sse.SseEventProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.InjectorFactory"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.InjectorFactory"
       },
-      "type": "org.jboss.resteasy.plugins.providers.sse.SseEventProvider"
+      "type" : "org.jboss.resteasy.plugins.providers.sse.SseEventProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
       },
-      "type": "org.jboss.resteasy.plugins.providers.sse.SseEventSinkInterceptor"
+      "type" : "org.jboss.resteasy.plugins.providers.sse.SseEventSinkInterceptor"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages"
       },
-      "type": "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages_$logger",
-      "methods": [
+      "type" : "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LoggingSupport"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.resteasy_jaxrs.i18n.LoggingSupport"
       },
-      "type": "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages_$logger"
+      "type" : "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages_$logger"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages"
       },
-      "type": "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages_$logger_en"
+      "type" : "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages_$logger_en"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages"
       },
-      "type": "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages_$logger_en_US"
+      "type" : "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages_$logger_en_US"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LoggingSupport"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.resteasy_jaxrs.i18n.LoggingSupport"
       },
-      "type": "org.jboss.resteasy.resteasy_jaxrs.i18n.Messages_$bundle",
-      "fields": [
+      "type" : "org.jboss.resteasy.resteasy_jaxrs.i18n.Messages_$bundle",
+      "fields" : [
         {
-          "name": "INSTANCE"
+          "name" : "INSTANCE"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LoggingSupport"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.resteasy_jaxrs.i18n.LoggingSupport"
       },
-      "type": "org.jboss.resteasy.resteasy_jaxrs.i18n.Messages_$bundle_en"
+      "type" : "org.jboss.resteasy.resteasy_jaxrs.i18n.Messages_$bundle_en"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LoggingSupport"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.resteasy_jaxrs.i18n.LoggingSupport"
       },
-      "type": "org.jboss.resteasy.resteasy_jaxrs.i18n.Messages_$bundle_en_US"
+      "type" : "org.jboss.resteasy.resteasy_jaxrs.i18n.Messages_$bundle_en_US"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.util.Types"
       },
-      "type": "org.jboss.resteasy.spi.AsyncMessageBodyWriter"
+      "type" : "org.jboss.resteasy.spi.AsyncMessageBodyWriter"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.util.Types"
       },
-      "type": "org.jboss.resteasy.spi.AsyncStreamingOutput"
+      "type" : "org.jboss.resteasy.spi.AsyncStreamingOutput"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.tracing.RESTEasyTracingLogger$TRACING"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.tracing.RESTEasyTracingLogger$TRACING"
       },
-      "type": "org.jboss.resteasy.tracing.api.RESTEasyTracing"
+      "type" : "org.jboss.resteasy.tracing.api.RESTEasyTracing"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.util.Types"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.util.Types"
       },
-      "type": "org.w3c.dom.Document"
+      "type" : "org.w3c.dom.Document"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "org_jboss_resteasy.resteasy_client.ClientProxyTest$DefaultMethodClient"
-    },
-    {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl"
-      },
-      "type": "org_jboss_resteasy.resteasy_client.FormProcessorTest$FormClient"
-    },
-    {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.processors.FormProcessor"
-      },
-      "type": "org_jboss_resteasy.resteasy_client.FormProcessorTest$FormRequest",
-      "fields": [
+      "type" : "sun.security.pkcs12.PKCS12KeyStore",
+      "methods" : [
         {
-          "name": "fieldValue"
-        }
-      ],
-      "methods": [
-        {
-          "name": "getGetterValue",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl$DelegateClassLoader"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "org_jboss_resteasy.resteasy_client.ProxyBuilderImplDelegateClassLoaderTest$TestResourceApi"
-    },
-    {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl"
-      },
-      "type": "org_jboss_resteasy.resteasy_client.ResponseObjectClient"
-    },
-    {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.extractors.ResponseObjectProxy"
-      },
-      "type": "org_jboss_resteasy.resteasy_client.RichResponse"
-    },
-    {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
-      },
-      "type": "sun.security.pkcs12.PKCS12KeyStore",
-      "methods": [
+      "type" : "sun.security.pkcs12.PKCS12KeyStore$DualFormatPKCS12",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "sun.security.pkcs12.PKCS12KeyStore$DualFormatPKCS12",
-      "methods": [
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
-      },
-      "type": "sun.security.provider.NativePRNG",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.security.SecureRandomParameters"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "sun.security.provider.SHA",
-      "methods": [
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.util.MethodHashing"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.util.MethodHashing"
       },
-      "type": "sun.security.provider.SHA",
-      "methods": [
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "sun.security.provider.X509Factory",
-      "methods": [
+      "type" : "sun.security.provider.X509Factory",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "sun.security.rsa.RSAKeyFactory$Legacy",
-      "methods": [
+      "type" : "sun.security.rsa.RSAKeyFactory$Legacy",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "sun.security.ssl.KeyManagerFactoryImpl$SunX509",
-      "methods": [
+      "type" : "sun.security.ssl.KeyManagerFactoryImpl$SunX509",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "sun.security.ssl.SSLContextImpl$DefaultSSLContext",
-      "methods": [
+      "type" : "sun.security.ssl.SSLContextImpl$DefaultSSLContext",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "sun.security.ssl.TrustManagerFactoryImpl$PKIXFactory",
-      "methods": [
+      "type" : "sun.security.ssl.TrustManagerFactoryImpl$PKIXFactory",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "sun.security.x509.AuthorityInfoAccessExtension",
-      "methods": [
+      "type" : "sun.security.x509.AuthorityInfoAccessExtension",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.Boolean",
             "java.lang.Object"
           ]
@@ -1275,14 +1228,14 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "sun.security.x509.AuthorityKeyIdentifierExtension",
-      "methods": [
+      "type" : "sun.security.x509.AuthorityKeyIdentifierExtension",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.Boolean",
             "java.lang.Object"
           ]
@@ -1290,14 +1243,14 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "sun.security.x509.BasicConstraintsExtension",
-      "methods": [
+      "type" : "sun.security.x509.BasicConstraintsExtension",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.Boolean",
             "java.lang.Object"
           ]
@@ -1305,14 +1258,14 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "sun.security.x509.CRLDistributionPointsExtension",
-      "methods": [
+      "type" : "sun.security.x509.CRLDistributionPointsExtension",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.Boolean",
             "java.lang.Object"
           ]
@@ -1320,14 +1273,14 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "sun.security.x509.CertificatePoliciesExtension",
-      "methods": [
+      "type" : "sun.security.x509.CertificatePoliciesExtension",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.Boolean",
             "java.lang.Object"
           ]
@@ -1335,14 +1288,14 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "sun.security.x509.ExtendedKeyUsageExtension",
-      "methods": [
+      "type" : "sun.security.x509.ExtendedKeyUsageExtension",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.Boolean",
             "java.lang.Object"
           ]
@@ -1350,14 +1303,14 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "sun.security.x509.KeyUsageExtension",
-      "methods": [
+      "type" : "sun.security.x509.KeyUsageExtension",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.Boolean",
             "java.lang.Object"
           ]
@@ -1365,14 +1318,14 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "sun.security.x509.NetscapeCertTypeExtension",
-      "methods": [
+      "type" : "sun.security.x509.NetscapeCertTypeExtension",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.Boolean",
             "java.lang.Object"
           ]
@@ -1380,14 +1333,14 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "sun.security.x509.PrivateKeyUsageExtension",
-      "methods": [
+      "type" : "sun.security.x509.PrivateKeyUsageExtension",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.Boolean",
             "java.lang.Object"
           ]
@@ -1395,14 +1348,14 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "type": "sun.security.x509.SubjectKeyIdentifierExtension",
-      "methods": [
+      "type" : "sun.security.x509.SubjectKeyIdentifierExtension",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.Boolean",
             "java.lang.Object"
           ]
@@ -1410,514 +1363,471 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.ClientHelper"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.ClientHelper"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "jakarta.annotation.Priority"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.processors.ProcessorFactory"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.internal.proxy.processors.ProcessorFactory"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "jakarta.ws.rs.BeanParam"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.plugins.interceptors.ClientContentEncodingAnnotationFeature"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.interceptors.ClientContentEncodingAnnotationFeature"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "jakarta.ws.rs.BeanParam"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.ClientHelper"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.ClientHelper"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "jakarta.ws.rs.ConstrainedTo"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.ClientHelper"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.ClientHelper"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "jakarta.ws.rs.Consumes"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.processors.FormProcessor"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.internal.proxy.processors.FormProcessor"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "jakarta.ws.rs.FormParam"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.util.IsHttpMethod"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.util.IsHttpMethod"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "jakarta.ws.rs.GET"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.extractors.ResponseObjectEntityExtractorFactory"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.internal.proxy.extractors.ResponseObjectEntityExtractorFactory"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "jakarta.ws.rs.HeaderParam"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.util.IsHttpMethod"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.util.IsHttpMethod"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "jakarta.ws.rs.HttpMethod"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.util.IsHttpMethod"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.util.IsHttpMethod"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "jakarta.ws.rs.POST"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "jakarta.ws.rs.Path"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.util.IsHttpMethod"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.util.IsHttpMethod"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "jakarta.ws.rs.Path"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.ClientHelper"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.ClientHelper"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "jakarta.ws.rs.Produces"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.ConstructorInjectorImpl"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.ConstructorInjectorImpl"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "jakarta.ws.rs.core.Context"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.PropertyInjectorImpl"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.PropertyInjectorImpl"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "jakarta.ws.rs.core.Context"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.util.PickConstructor"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.util.PickConstructor"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "jakarta.ws.rs.core.Context"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.ClientHelper"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.ClientHelper"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "jakarta.ws.rs.ext.Provider"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.ContextParameterInjector"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.ContextParameterInjector"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "jakarta.ws.rs.ext.Providers"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.PropertyInjectorImpl"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.PropertyInjectorImpl"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "jakarta.ws.rs.ext.Providers"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.plugins.interceptors.ClientContentEncodingAnnotationFeature"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.interceptors.ClientContentEncodingAnnotationFeature"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Documented"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.util.IsHttpMethod"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.util.IsHttpMethod"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Documented"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.ClientHelper"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.ClientHelper"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Inherited"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Retention"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.extractors.DefaultEntityExtractorFactory"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.internal.proxy.extractors.DefaultEntityExtractorFactory"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Retention"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.extractors.ResponseObjectEntityExtractorFactory"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.internal.proxy.extractors.ResponseObjectEntityExtractorFactory"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Retention"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.processors.FormProcessor"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.internal.proxy.processors.FormProcessor"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Retention"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.PropertyInjectorImpl"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.PropertyInjectorImpl"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Retention"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.providerfactory.ClientHelper"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.providerfactory.ClientHelper"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Retention"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.plugins.interceptors.ClientContentEncodingAnnotationFeature"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.interceptors.ClientContentEncodingAnnotationFeature"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Retention"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.util.IsHttpMethod"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.util.IsHttpMethod"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Retention"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.plugins.interceptors.ClientContentEncodingAnnotationFeature"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.interceptors.ClientContentEncodingAnnotationFeature"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Target"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.util.IsHttpMethod"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.util.IsHttpMethod"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Target"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.extractors.DefaultEntityExtractorFactory"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.internal.proxy.extractors.DefaultEntityExtractorFactory"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "org.jboss.resteasy.annotations.ResponseObject"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.extractors.ResponseObjectEntityExtractorFactory"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.internal.proxy.extractors.ResponseObjectEntityExtractorFactory"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "org.jboss.resteasy.annotations.Status"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.ConstructorInjectorImpl"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.ConstructorInjectorImpl"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "org.jboss.resteasy.spi.ResteasyConfiguration"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.ContextParameterInjector"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.ContextParameterInjector"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "org.jboss.resteasy.spi.ResteasyConfiguration"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl"
-      },
-      "type": {
-        "proxy": [
-          "org_jboss_resteasy.resteasy_client.ClientProxyTest$DefaultMethodClient",
-          "org.jboss.resteasy.client.jaxrs.internal.proxy.ResteasyClientProxy"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl"
-      },
-      "type": {
-        "proxy": [
-          "org_jboss_resteasy.resteasy_client.FormProcessorTest$FormClient",
-          "org.jboss.resteasy.client.jaxrs.internal.proxy.ResteasyClientProxy"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl"
-      },
-      "type": {
-        "proxy": [
-          "org_jboss_resteasy.resteasy_client.ResponseObjectClient",
-          "org.jboss.resteasy.client.jaxrs.internal.proxy.ResteasyClientProxy"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.proxy.extractors.ResponseObjectProxy"
-      },
-      "type": {
-        "proxy": [
-          "org_jboss_resteasy.resteasy_client.RichResponse"
         ]
       }
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.RegisterBuiltin"
       },
-      "glob": "META-INF/services/jakarta.ws.rs.ext.Providers"
+      "glob" : "META-INF/services/jakarta.ws.rs.ext.Providers"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.ClientInvocation"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.internal.ClientInvocation"
       },
-      "glob": "META-INF/services/jakarta.ws.rs.ext.RuntimeDelegate"
+      "glob" : "META-INF/services/jakarta.ws.rs.ext.RuntimeDelegate"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "glob": "META-INF/services/java.net.spi.URLStreamHandlerProvider"
+      "glob" : "META-INF/services/java.net.spi.URLStreamHandlerProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.ContextParameterInjector$1"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.ContextParameterInjector$1"
       },
-      "glob": "META-INF/services/java.util.spi.ResourceBundleControlProvider"
+      "glob" : "META-INF/services/java.util.spi.ResourceBundleControlProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "glob": "META-INF/services/org.apache.commons.logging.LogFactory"
+      "glob" : "META-INF/services/org.apache.commons.logging.LogFactory"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages"
       },
-      "glob": "META-INF/services/org.jboss.logging.LoggerProvider"
+      "glob" : "META-INF/services/org.jboss.logging.LoggerProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.PriorityServiceLoader"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.PriorityServiceLoader"
       },
-      "glob": "META-INF/services/org.jboss.resteasy.client.jaxrs.engine.ClientHttpEngineFactory"
+      "glob" : "META-INF/services/org.jboss.resteasy.client.jaxrs.engine.ClientHttpEngineFactory"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl"
       },
-      "glob": "META-INF/services/org.jboss.resteasy.client.jaxrs.spi.ClientConfigProvider"
+      "glob" : "META-INF/services/org.jboss.resteasy.client.jaxrs.spi.ClientConfigProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.PriorityServiceLoader"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.PriorityServiceLoader"
       },
-      "glob": "META-INF/services/org.jboss.resteasy.client.jaxrs.spi.ClientConfigProvider"
+      "glob" : "META-INF/services/org.jboss.resteasy.client.jaxrs.spi.ClientConfigProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.spi.config.SingletonConfigurationFactory$Holder"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.spi.config.SingletonConfigurationFactory$Holder"
       },
-      "glob": "META-INF/services/org.jboss.resteasy.spi.config.ConfigurationFactory"
+      "glob" : "META-INF/services/org.jboss.resteasy.spi.config.ConfigurationFactory"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "glob": "commons-logging.properties"
+      "glob" : "commons-logging.properties"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.ContextParameterInjector$1"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.ContextParameterInjector$1"
       },
-      "glob": "jakarta/servlet/LocalStrings.properties"
+      "glob" : "jakarta/servlet/LocalStrings.properties"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.ContextParameterInjector$1"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.ContextParameterInjector$1"
       },
-      "glob": "jakarta/servlet/LocalStrings_en.properties"
+      "glob" : "jakarta/servlet/LocalStrings_en.properties"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.core.ContextParameterInjector$1"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.core.ContextParameterInjector$1"
       },
-      "glob": "jakarta/servlet/LocalStrings_en_US.properties"
+      "glob" : "jakarta/servlet/LocalStrings_en_US.properties"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.concurrent.ContextualExecutors"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.concurrent.ContextualExecutors"
       },
-      "glob": "jndi.properties"
+      "glob" : "jndi.properties"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "glob": "mozilla/public-suffix-list.txt"
+      "glob" : "mozilla/public-suffix-list.txt"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43"
       },
-      "glob": "org/apache/http/client/version.properties"
+      "glob" : "org/apache/http/client/version.properties"
     },
     {
-      "bundle": "jakarta.servlet.LocalStrings"
+      "bundle" : "jakarta.servlet.LocalStrings"
     }
   ]
 }

--- a/metadata/org.jboss.resteasy/resteasy-client/index.json
+++ b/metadata/org.jboss.resteasy/resteasy-client/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "6.2.16.Final",
+    "test-version" : "6.2.12.Final",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/jboss/resteasy/resteasy-client/$version$/resteasy-client-$version$-sources.jar",
+    "repository-url" : "https://github.com/resteasy/resteasy",
+    "test-code-url" : "https://github.com/resteasy/resteasy/tree/v$version$/resteasy-client/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/jboss/resteasy/resteasy-client/$version$/resteasy-client-$version$-javadoc.jar",
+    "description" : "RESTEasy Client provides the Jakarta REST client implementation for RESTEasy, including request building, providers, interceptors, and HTTP engine integrations. It lets applications invoke RESTful services through Jakarta REST APIs while using RESTEasy-specific configuration and runtime behavior.",
+    "tested-versions" : [
+      "6.2.16.Final"
+    ],
+    "allowed-packages" : [
+      "org.jboss.resteasy"
+    ]
+  },
+  {
     "metadata-version" : "6.2.12.Final",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/jboss/resteasy/resteasy-client/$version$/resteasy-client-$version$-sources.jar",
     "repository-url" : "https://github.com/resteasy/resteasy",

--- a/metadata/org.jboss.resteasy/resteasy-client/index.json
+++ b/metadata/org.jboss.resteasy/resteasy-client/index.json
@@ -1,32 +1,31 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "6.2.16.Final",
-    "test-version" : "6.2.12.Final",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/org/jboss/resteasy/resteasy-client/$version$/resteasy-client-$version$-sources.jar",
-    "repository-url" : "https://github.com/resteasy/resteasy",
-    "test-code-url" : "https://github.com/resteasy/resteasy/tree/v$version$/resteasy-client/src/test",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/org/jboss/resteasy/resteasy-client/$version$/resteasy-client-$version$-javadoc.jar",
-    "description" : "RESTEasy Client provides the Jakarta REST client implementation for RESTEasy, including request building, providers, interceptors, and HTTP engine integrations. It lets applications invoke RESTful services through Jakarta REST APIs while using RESTEasy-specific configuration and runtime behavior.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "6.2.16.Final",
+    "source-code-url": "https://repo.maven.apache.org/maven2/org/jboss/resteasy/resteasy-client/$version$/resteasy-client-$version$-sources.jar",
+    "repository-url": "https://github.com/resteasy/resteasy",
+    "test-code-url": "https://github.com/resteasy/resteasy/tree/v$version$/resteasy-client/src/test",
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/jboss/resteasy/resteasy-client/$version$/resteasy-client-$version$-javadoc.jar",
+    "description": "RESTEasy Client provides the Jakarta REST client implementation for RESTEasy, including request building, providers, interceptors, and HTTP engine integrations. It lets applications invoke RESTful services through Jakarta REST APIs while using RESTEasy-specific configuration and runtime behavior.",
+    "tested-versions": [
       "6.2.16.Final"
     ],
-    "allowed-packages" : [
+    "allowed-packages": [
       "org.jboss.resteasy"
     ]
   },
   {
-    "metadata-version" : "6.2.12.Final",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/org/jboss/resteasy/resteasy-client/$version$/resteasy-client-$version$-sources.jar",
-    "repository-url" : "https://github.com/resteasy/resteasy",
-    "test-code-url" : "https://github.com/resteasy/resteasy/tree/v$version$/resteasy-client/src/test",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/org/jboss/resteasy/resteasy-client/$version$/resteasy-client-$version$-javadoc.jar",
-    "tested-versions" : [
+    "metadata-version": "6.2.12.Final",
+    "source-code-url": "https://repo.maven.apache.org/maven2/org/jboss/resteasy/resteasy-client/$version$/resteasy-client-$version$-sources.jar",
+    "repository-url": "https://github.com/resteasy/resteasy",
+    "test-code-url": "https://github.com/resteasy/resteasy/tree/v$version$/resteasy-client/src/test",
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/jboss/resteasy/resteasy-client/$version$/resteasy-client-$version$-javadoc.jar",
+    "tested-versions": [
       "6.2.12.Final",
       "6.2.14.Final",
       "6.2.15.Final"
     ],
-    "allowed-packages" : [
+    "allowed-packages": [
       "org.jboss.resteasy"
     ]
   }

--- a/stats/org.jboss.resteasy/resteasy-client/6.2.16.Final/execution-metrics.json
+++ b/stats/org.jboss.resteasy/resteasy-client/6.2.16.Final/execution-metrics.json
@@ -1,0 +1,139 @@
+{
+  "fix_ni_run:2026-06-10": {
+    "timestamp": "2026-06-10T03:00:00.127350Z",
+    "library": "org.jboss.resteasy:resteasy-client:6.2.16.Final",
+    "starting_commit": "aedf84e79ba417d4c25cd23aff2c7a5c6e0f9c65",
+    "ending_commit": "468a9e4c5fc4b8ae0dae39b98737347ce4200716",
+    "previous_library": "org.jboss.resteasy:resteasy-client:6.2.12.Final",
+    "strategy_name": "library_update_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "6.2.16.Final",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 13,
+            "totalCalls": 13
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 6,
+            "totalCalls": 6
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 19,
+        "totalCalls": 19
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3235,
+          "missed": 12700,
+          "ratio": 0.203012,
+          "total": 15935
+        },
+        "line": {
+          "covered": 782,
+          "missed": 3107,
+          "ratio": 0.20108,
+          "total": 3889
+        },
+        "method": {
+          "covered": 198,
+          "missed": 876,
+          "ratio": 0.184358,
+          "total": 1074
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "6.2.12.Final",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.923077,
+            "coveredCalls": 12,
+            "totalCalls": 13
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 6,
+            "totalCalls": 6
+          }
+        },
+        "coverageRatio": 0.947368,
+        "coveredCalls": 18,
+        "totalCalls": 19
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3050,
+          "missed": 12821,
+          "ratio": 0.192174,
+          "total": 15871
+        },
+        "line": {
+          "covered": 744,
+          "missed": 3122,
+          "ratio": 0.192447,
+          "total": 3866
+        },
+        "method": {
+          "covered": 185,
+          "missed": 883,
+          "ratio": 0.173221,
+          "total": 1068
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "degraded",
+      "action": "no_action",
+      "issue_number": 2003,
+      "issue_label": "fails-native-image-run",
+      "library": "org.jboss.resteasy:resteasy-client:6.2.16.Final",
+      "summary": "Library preparation preflight did not produce usable advisory setup.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#2003 [Automation] native-image run fails for org.jboss.resteasy:resteasy-client:6.2.16.Final; label=fails-native-image-run; body_chars=8015"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "10 existing test file path(s) included"
+        }
+      ],
+      "current_library": "org.jboss.resteasy:resteasy-client:6.2.12.Final",
+      "new_version": "6.2.16.Final",
+      "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
+      "model": "oca/gpt-5.5",
+      "prompt_path": "library-preflight-prompt.txt",
+      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.jboss.resteasy:resteasy-client:6.2.16.Final/library-preparation-preflight/pi-generation-2026-06-10T02-25-42-411766Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 121692,
+      "cached_input_tokens_used": 864256,
+      "output_tokens_used": 11189,
+      "iterations": 3,
+      "cost_usd": 0.7678,
+      "tested_library_loc": 782,
+      "metadata_entries": 273,
+      "test_only_metadata_entries": 12,
+      "previous_library_metadata_entries": 188,
+      "previous_library_test_only_metadata_entries": 12,
+      "code_coverage_percent": 20.11,
+      "previous_library_coverage_percent": 19.24
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.jboss.resteasy/resteasy-client/6.2.16.Final/src/test/java/org_jboss_resteasy/resteasy_client/ClientProxyTest.java",
+      "metadata_file": "metadata/org.jboss.resteasy/resteasy-client/6.2.16.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.jboss.resteasy/resteasy-client/6.2.16.Final/stats.json
+++ b/stats/org.jboss.resteasy/resteasy-client/6.2.16.Final/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "6.2.16.Final",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 13,
+          "totalCalls" : 13
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 6,
+          "totalCalls" : 6
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 19,
+      "totalCalls" : 19
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3235,
+        "missed" : 12700,
+        "ratio" : 0.203012,
+        "total" : 15935
+      },
+      "line" : {
+        "covered" : 782,
+        "missed" : 3107,
+        "ratio" : 0.20108,
+        "total" : 3889
+      },
+      "method" : {
+        "covered" : 198,
+        "missed" : 876,
+        "ratio" : 0.184358,
+        "total" : 1074
+      }
+    }
+  } ]
+}

--- a/tests/src/org.jboss.resteasy/resteasy-client/6.2.16.Final/.gitignore
+++ b/tests/src/org.jboss.resteasy/resteasy-client/6.2.16.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.jboss.resteasy/resteasy-client/6.2.16.Final/build.gradle
+++ b/tests/src/org.jboss.resteasy/resteasy-client/6.2.16.Final/build.gradle
@@ -1,0 +1,48 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.jboss.resteasy:resteasy-client:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.release = 21
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}
+
+tasks.named("test") {
+    File java21Executable = [
+            System.getenv("JAVA21_HOME"),
+            "/usr/lib/jvm/java-21-openjdk-amd64"
+    ].findResult { String javaHome ->
+        if (javaHome == null) {
+            return null
+        }
+        File candidate = file("${javaHome}/bin/java")
+        candidate.isFile() ? candidate : null
+    }
+    if (java21Executable != null && (JavaVersion.current().majorVersion as int) >= 24) {
+        executable = java21Executable.absolutePath
+    }
+    jvmArgs += ["-Djava.security.manager=allow"]
+}

--- a/tests/src/org.jboss.resteasy/resteasy-client/6.2.16.Final/gradle.properties
+++ b/tests/src/org.jboss.resteasy/resteasy-client/6.2.16.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.jboss.resteasy:resteasy-client:6.2.16.Final
+library.version = 6.2.16.Final
+metadata.dir = org.jboss.resteasy/resteasy-client/6.2.16.Final/

--- a/tests/src/org.jboss.resteasy/resteasy-client/6.2.16.Final/settings.gradle
+++ b/tests/src/org.jboss.resteasy/resteasy-client/6.2.16.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.jboss.resteasy.resteasy-client_tests'

--- a/tests/src/org.jboss.resteasy/resteasy-client/6.2.16.Final/src/test/java/org_jboss_resteasy/resteasy_client/ClientProxyTest.java
+++ b/tests/src/org.jboss.resteasy/resteasy-client/6.2.16.Final/src/test/java/org_jboss_resteasy/resteasy_client/ClientProxyTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_resteasy.resteasy_client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.security.Permission;
+
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
+import org.junit.jupiter.api.Test;
+
+public class ClientProxyTest {
+
+    @Test
+    void defaultMethodInvocationUsesSpecialLookupWithoutSecurityManager() {
+        try (ResteasyClient client = new ResteasyClientBuilderImpl().build()) {
+            final DefaultMethodClient proxy = client.target("http://localhost:8080").proxy(DefaultMethodClient.class);
+
+            assertThat(proxy.greet("Resteasy")).isEqualTo("Hello Resteasy");
+        }
+    }
+
+    @Test
+    @SuppressWarnings("removal")
+    void defaultMethodInvocationUsesPrivilegedSpecialLookupWhenSecurityManagerCanBeInstalled() {
+        final SecurityManager previousSecurityManager = System.getSecurityManager();
+        boolean installedSecurityManager = false;
+        try {
+            try {
+                System.setSecurityManager(new PermissiveSecurityManager());
+                installedSecurityManager = true;
+            } catch (final UnsupportedOperationException unsupportedOperationException) {
+                assertThat(Runtime.version().feature())
+                        .as(unsupportedOperationException.getMessage())
+                        .isGreaterThanOrEqualTo(24);
+            }
+
+            try (ResteasyClient client = new ResteasyClientBuilderImpl().build()) {
+                final DefaultMethodClient proxy = client.target("http://localhost:8080").proxy(DefaultMethodClient.class);
+
+                assertThat(proxy.greet("Resteasy")).isEqualTo("Hello Resteasy");
+            }
+        } finally {
+            if (installedSecurityManager) {
+                System.setSecurityManager(previousSecurityManager);
+            }
+        }
+    }
+
+    private interface DefaultMethodClient {
+
+        default String greet(final String name) {
+            return "Hello " + name;
+        }
+    }
+
+    @SuppressWarnings("removal")
+    private static final class PermissiveSecurityManager extends SecurityManager {
+
+        @Override
+        public void checkPermission(final Permission permission) {
+        }
+    }
+}

--- a/tests/src/org.jboss.resteasy/resteasy-client/6.2.16.Final/src/test/java/org_jboss_resteasy/resteasy_client/FormProcessorTest.java
+++ b/tests/src/org.jboss.resteasy/resteasy-client/6.2.16.Final/src/test/java/org_jboss_resteasy/resteasy_client/FormProcessorTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_resteasy.resteasy_client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+
+import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.Response;
+
+import org.jboss.resteasy.client.jaxrs.ClientHttpEngine;
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.client.jaxrs.internal.AbortedResponse;
+import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
+import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
+import org.junit.jupiter.api.Test;
+
+class FormProcessorTest {
+
+    @Test
+    void beanParamUsesAnnotatedFieldsAndGettersToPopulateFormEntity() {
+        RecordingClientHttpEngine engine = new RecordingClientHttpEngine();
+        ResteasyClient client = new ResteasyClientBuilderImpl()
+                .httpEngine(engine)
+                .build();
+
+        try {
+            FormClient proxy = client.target("http://localhost:8080").proxy(FormClient.class);
+
+            try (Response response = proxy.submit(new FormRequest("field-data", "getter-data"))) {
+                assertThat(response.getStatus()).isEqualTo(204);
+            }
+            assertThat(engine.capturedInvocation).isNotNull();
+            assertThat(engine.capturedInvocation.getEntity()).isInstanceOf(Form.class);
+
+            Form form = (Form) engine.capturedInvocation.getEntity();
+            assertThat(form.asMap()).containsEntry("fieldValue", List.of("field-data"));
+            assertThat(form.asMap()).containsEntry("getterValue", List.of("getter-data"));
+        } finally {
+            client.close();
+        }
+    }
+
+    @Path("/forms")
+    private interface FormClient {
+
+        @POST
+        Response submit(@BeanParam FormRequest request);
+    }
+
+    private static final class FormRequest {
+        @FormParam("fieldValue")
+        private final String fieldValue;
+
+        private final String getterValue;
+
+        private FormRequest(final String fieldValue, final String getterValue) {
+            this.fieldValue = fieldValue;
+            this.getterValue = getterValue;
+        }
+
+        @FormParam("getterValue")
+        private String getGetterValue() {
+            return getterValue;
+        }
+    }
+
+    private static final class RecordingClientHttpEngine implements ClientHttpEngine {
+        private ClientInvocation capturedInvocation;
+
+        @Override
+        public SSLContext getSslContext() {
+            return null;
+        }
+
+        @Override
+        public HostnameVerifier getHostnameVerifier() {
+            return null;
+        }
+
+        @Override
+        public Response invoke(final Invocation invocation) {
+            capturedInvocation = (ClientInvocation) invocation;
+            return new AbortedResponse(capturedInvocation.getClientConfiguration(), Response.noContent().build());
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/tests/src/org.jboss.resteasy/resteasy-client/6.2.16.Final/src/test/java/org_jboss_resteasy/resteasy_client/ProxyBuilderImplDelegateClassLoaderTest.java
+++ b/tests/src/org.jboss.resteasy/resteasy-client/6.2.16.Final/src/test/java/org_jboss_resteasy/resteasy_client/ProxyBuilderImplDelegateClassLoaderTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_resteasy.resteasy_client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ProxyBuilderImplDelegateClassLoaderTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void loadClassUsesParentWhenParentCanResolveIt() throws ClassNotFoundException {
+        ClassLoader delegate = new EmptyClassLoader();
+        ClassLoader parent = TestResourceApi.class.getClassLoader();
+        ProxyBuilderImpl<TestResourceApi>.DelegateClassLoader loader = newDelegateClassLoader(delegate, parent);
+
+        Class<?> resolvedClass = loader.loadClass(TestResourceApi.class.getName());
+
+        assertThat(resolvedClass).isSameAs(TestResourceApi.class);
+    }
+
+    @Test
+    void loadClassFallsBackToDelegateWhenParentCannotResolveIt() throws ClassNotFoundException {
+        ClassLoader delegate = TestResourceApi.class.getClassLoader();
+        ClassLoader parent = new EmptyClassLoader();
+        ProxyBuilderImpl<TestResourceApi>.DelegateClassLoader loader = newDelegateClassLoader(delegate, parent);
+
+        Class<?> resolvedClass = loader.loadClass(TestResourceApi.class.getName());
+
+        assertThat(resolvedClass).isSameAs(TestResourceApi.class);
+    }
+
+    @Test
+    void getResourceUsesParentFirstAndThenDelegate() throws IOException {
+        URL parentUrl = createResourceUrl("parent-resource.txt", "parent");
+        URL delegateUrl = createResourceUrl("delegate-resource.txt", "delegate");
+        ClassLoader parent = new ResourceClassLoader(
+                Map.of("parent-resource", parentUrl),
+                Map.of(),
+                Map.of());
+        ClassLoader delegate = new ResourceClassLoader(
+                Map.of("delegate-resource", delegateUrl),
+                Map.of(),
+                Map.of());
+        ProxyBuilderImpl<TestResourceApi>.DelegateClassLoader loader = newDelegateClassLoader(delegate, parent);
+
+        URL resourceFromParent = loader.getResource("parent-resource");
+        URL resourceFromDelegate = loader.getResource("delegate-resource");
+
+        assertThat(resourceFromParent).isEqualTo(parentUrl);
+        assertThat(resourceFromDelegate).isEqualTo(delegateUrl);
+    }
+
+    @Test
+    void getResourcesCombinesParentAndDelegateResources() throws IOException {
+        URL parentUrl = createResourceUrl("parent-enumeration.txt", "parent");
+        URL delegateUrl = createResourceUrl("delegate-enumeration.txt", "delegate");
+        ClassLoader parent = new ResourceClassLoader(
+                Map.of(),
+                Map.of(),
+                Map.of("shared-resource", List.of(parentUrl)));
+        ClassLoader delegate = new ResourceClassLoader(
+                Map.of(),
+                Map.of(),
+                Map.of("shared-resource", List.of(delegateUrl)));
+        ProxyBuilderImpl<TestResourceApi>.DelegateClassLoader loader = newDelegateClassLoader(delegate, parent);
+
+        List<URL> resources = Collections.list(loader.getResources("shared-resource"));
+
+        assertThat(resources).containsExactly(parentUrl, delegateUrl);
+    }
+
+    @Test
+    void getResourceAsStreamUsesParentFirstAndThenDelegate() throws IOException {
+        ClassLoader parent = new ResourceClassLoader(
+                Map.of(),
+                Map.of("parent-stream", "parent stream".getBytes(StandardCharsets.UTF_8)),
+                Map.of());
+        ClassLoader delegate = new ResourceClassLoader(
+                Map.of(),
+                Map.of("delegate-stream", "delegate stream".getBytes(StandardCharsets.UTF_8)),
+                Map.of());
+        ProxyBuilderImpl<TestResourceApi>.DelegateClassLoader loader = newDelegateClassLoader(delegate, parent);
+
+        try (InputStream parentStream = loader.getResourceAsStream("parent-stream");
+                InputStream delegateStream = loader.getResourceAsStream("delegate-stream")) {
+            assertThat(readText(parentStream)).isEqualTo("parent stream");
+            assertThat(readText(delegateStream)).isEqualTo("delegate stream");
+        }
+    }
+
+    private ProxyBuilderImpl<TestResourceApi>.DelegateClassLoader newDelegateClassLoader(
+            final ClassLoader delegate,
+            final ClassLoader parent) {
+        ProxyBuilderImpl<TestResourceApi> proxyBuilder = new ProxyBuilderImpl<>(TestResourceApi.class, null);
+        return proxyBuilder.new DelegateClassLoader(delegate, parent);
+    }
+
+    private URL createResourceUrl(final String fileName, final String content) throws IOException {
+        Path resourceFile = tempDir.resolve(fileName);
+        Files.writeString(resourceFile, content, StandardCharsets.UTF_8);
+        return resourceFile.toUri().toURL();
+    }
+
+    private String readText(final InputStream inputStream) throws IOException {
+        assertThat(inputStream).isNotNull();
+        return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+    }
+
+    private interface TestResourceApi {
+    }
+
+    private static final class EmptyClassLoader extends ClassLoader {
+        private EmptyClassLoader() {
+            super(null);
+        }
+    }
+
+    private static final class ResourceClassLoader extends ClassLoader {
+        private final Map<String, URL> resourcesByName;
+        private final Map<String, byte[]> streamsByName;
+        private final Map<String, List<URL>> resourceCollectionsByName;
+
+        private ResourceClassLoader(
+                final Map<String, URL> resourcesByName,
+                final Map<String, byte[]> streamsByName,
+                final Map<String, List<URL>> resourceCollectionsByName) {
+            super(null);
+            this.resourcesByName = resourcesByName;
+            this.streamsByName = streamsByName;
+            this.resourceCollectionsByName = resourceCollectionsByName;
+        }
+
+        @Override
+        public URL getResource(final String name) {
+            return resourcesByName.get(name);
+        }
+
+        @Override
+        public Enumeration<URL> getResources(final String name) {
+            List<URL> resources = resourceCollectionsByName.getOrDefault(name, List.of());
+            return Collections.enumeration(resources);
+        }
+
+        @Override
+        public InputStream getResourceAsStream(final String name) {
+            byte[] bytes = streamsByName.get(name);
+            return (bytes == null) ? null : new ByteArrayInputStream(bytes);
+        }
+    }
+}

--- a/tests/src/org.jboss.resteasy/resteasy-client/6.2.16.Final/src/test/java/org_jboss_resteasy/resteasy_client/ResponseObjectProxyTest.java
+++ b/tests/src/org.jboss.resteasy/resteasy-client/6.2.16.Final/src/test/java/org_jboss_resteasy/resteasy_client/ResponseObjectProxyTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_resteasy.resteasy_client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.core.Response;
+
+import org.jboss.resteasy.annotations.ResponseObject;
+import org.jboss.resteasy.annotations.Status;
+import org.jboss.resteasy.client.jaxrs.ClientHttpEngine;
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.client.jaxrs.internal.AbortedResponse;
+import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
+import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
+import org.junit.jupiter.api.Test;
+
+class ResponseObjectProxyTest {
+
+    @Test
+    void responseObjectReturnTypeBuildsMethodHandlersAndCreatesProxyInstance() {
+        final RecordingClientHttpEngine engine = new RecordingClientHttpEngine();
+
+        try (ResteasyClient client = new ResteasyClientBuilderImpl()
+                .httpEngine(engine)
+                .build()) {
+            final ResponseObjectClient proxy = client.target("http://localhost:8080").proxy(ResponseObjectClient.class);
+
+            final RichResponse richResponse = proxy.fetch();
+
+            try (Response rawResponse = richResponse.rawResponse()) {
+                assertThat(richResponse.status()).isEqualTo(201);
+                assertThat(richResponse.requestId()).isEqualTo("request-123");
+                assertThat(rawResponse.getStatus()).isEqualTo(201);
+            }
+        }
+
+        assertThat(engine.capturedInvocation).isNotNull();
+    }
+}
+
+@Path("/responses")
+interface ResponseObjectClient {
+
+    @GET
+    @Path("/current")
+    RichResponse fetch();
+}
+
+@ResponseObject
+interface RichResponse {
+
+    @Status
+    int status();
+
+    @HeaderParam("X-Request-Id")
+    String requestId();
+
+    Response rawResponse();
+}
+
+final class RecordingClientHttpEngine implements ClientHttpEngine {
+    ClientInvocation capturedInvocation;
+
+    @Override
+    public SSLContext getSslContext() {
+        return null;
+    }
+
+    @Override
+    public HostnameVerifier getHostnameVerifier() {
+        return null;
+    }
+
+    @Override
+    public Response invoke(final Invocation invocation) {
+        capturedInvocation = (ClientInvocation) invocation;
+        return new AbortedResponse(
+                capturedInvocation.getClientConfiguration(),
+                Response.status(201)
+                        .header("X-Request-Id", "request-123")
+                        .build());
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/tests/src/org.jboss.resteasy/resteasy-client/6.2.16.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.jboss.resteasy/resteasy-client/6.2.16.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,94 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl"
+      },
+      "type" : "org_jboss_resteasy.resteasy_client.ClientProxyTest$DefaultMethodClient"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl"
+      },
+      "type" : "org_jboss_resteasy.resteasy_client.FormProcessorTest$FormClient"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.internal.proxy.processors.FormProcessor"
+      },
+      "type" : "org_jboss_resteasy.resteasy_client.FormProcessorTest$FormRequest",
+      "fields" : [
+        {
+          "name" : "fieldValue"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "getGetterValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl$DelegateClassLoader"
+      },
+      "type" : "org_jboss_resteasy.resteasy_client.ProxyBuilderImplDelegateClassLoaderTest$TestResourceApi"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl"
+      },
+      "type" : "org_jboss_resteasy.resteasy_client.ResponseObjectClient"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.internal.proxy.extractors.ResponseObjectProxy"
+      },
+      "type" : "org_jboss_resteasy.resteasy_client.RichResponse"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.internal.proxy.extractors.ResponseObjectProxy"
+      },
+      "type" : {
+        "proxy" : [
+          "org_jboss_resteasy.resteasy_client.RichResponse"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl"
+      },
+      "type" : {
+        "proxy" : [
+          "org_jboss_resteasy.resteasy_client.ClientProxyTest$DefaultMethodClient",
+          "org.jboss.resteasy.client.jaxrs.internal.proxy.ResteasyClientProxy"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl"
+      },
+      "type" : {
+        "proxy" : [
+          "org_jboss_resteasy.resteasy_client.FormProcessorTest$FormClient",
+          "org.jboss.resteasy.client.jaxrs.internal.proxy.ResteasyClientProxy"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl"
+      },
+      "type" : {
+        "proxy" : [
+          "org_jboss_resteasy.resteasy_client.ResponseObjectClient",
+          "org.jboss.resteasy.client.jaxrs.internal.proxy.ResteasyClientProxy"
+        ]
+      }
+    }
+  ]
+}

--- a/tests/src/org.jboss.resteasy/resteasy-client/6.2.16.Final/user-code-filter.json
+++ b/tests/src/org.jboss.resteasy/resteasy-client/6.2.16.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.jboss.resteasy.**"
+    }
+  ]
+}

--- a/tests/src/org.jboss.resteasy/resteasy-client/6.2.16.Final/user-code-filter.json
+++ b/tests/src/org.jboss.resteasy/resteasy-client/6.2.16.Final/user-code-filter.json
@@ -5,6 +5,18 @@
     },
     {
       "includeClasses" : "org.jboss.resteasy.**"
+    },
+    {
+      "includeClasses" : "org.jboss.resteasy.client.jaxrs.**"
+    },
+    {
+      "includeClasses" : "org.jboss.resteasy.plugins.providers.sse.client.**"
+    },
+    {
+      "includeClasses" : "org.jboss.resteasy.test.**"
+    },
+    {
+      "includeClasses" : "org_jboss_resteasy.resteasy_client.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: oracle/graalvm-reachability-metadata#2003

This PR provides new metadata needed for the org.jboss.resteasy:resteasy-client:6.2.16.Final, addressing Native Image run failures caused by changes in the updated library version.

Summary:
- Metadata entries (previous `org.jboss.resteasy:resteasy-client:6.2.12.Final`): 188
- Test-only metadata entries (previous `org.jboss.resteasy:resteasy-client:6.2.12.Final`): 12
- Metadata entries (new `org.jboss.resteasy:resteasy-client:6.2.16.Final`): 273
- Test-only metadata entries (new `org.jboss.resteasy:resteasy-client:6.2.16.Final`): 12
- Library coverage (previous): 19.24%
- Library coverage (new): 20.11%
- Strategy: library_update_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 121692
- Cached input tokens: 864256
- Output tokens: 11189
- Iterations: 3

### Forge

- Forge monitored branch: `forge-dedup-workflow-helpers`
- Forge branch: `forge-dedup-workflow-helpers`
- Forge commit hash: `0cf13c4fc7d01cdd528756e55342f4cc8e536254`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.jboss.resteasy:resteasy-client:6.2.12.Final: 18/19 covered calls (94.74%)
- org.jboss.resteasy:resteasy-client:6.2.16.Final: 19/19 covered calls (100.00%)

**Reflection:**
- org.jboss.resteasy:resteasy-client:6.2.12.Final: 12/13 covered calls (92.31%)
- org.jboss.resteasy:resteasy-client:6.2.16.Final: 13/13 covered calls (100.00%)

**Resources:**
- org.jboss.resteasy:resteasy-client:6.2.12.Final: 6/6 covered calls (100.00%)
- org.jboss.resteasy:resteasy-client:6.2.16.Final: 6/6 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.jboss.resteasy:resteasy-client:6.2.12.Final: 3050/15871 (19.22%)
- org.jboss.resteasy:resteasy-client:6.2.16.Final: 3235/15935 (20.30%)

**Line:**
- org.jboss.resteasy:resteasy-client:6.2.12.Final: 744/3866 (19.24%)
- org.jboss.resteasy:resteasy-client:6.2.16.Final: 782/3889 (20.11%)

**Method:**
- org.jboss.resteasy:resteasy-client:6.2.12.Final: 185/1068 (17.32%)
- org.jboss.resteasy:resteasy-client:6.2.16.Final: 198/1074 (18.44%)


**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/org.jboss.resteasy/resteasy-client/6.2.12.Final/build.gradle b/tests/src/org.jboss.resteasy/resteasy-client/6.2.16.Final/build.gradle
index 8a2ff7516f..c7ccbabe79 100644
--- a/tests/src/org.jboss.resteasy/resteasy-client/6.2.12.Final/build.gradle
+++ b/tests/src/org.jboss.resteasy/resteasy-client/6.2.16.Final/build.gradle
@@ -15,6 +15,10 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
+tasks.withType(JavaCompile).configureEach {
+    options.release = 21
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"
@@ -27,7 +31,18 @@ graalvmNative {
 }
 
 tasks.named("test") {
-    if ((JavaVersion.current().majorVersion as int) < 24) {
-        jvmArgs += ["-Djava.security.manager=allow"]
+    File java21Executable = [
+            System.getenv("JAVA21_HOME"),
+            "/usr/lib/jvm/java-21-openjdk-amd64"
+    ].findResult { String javaHome ->
+        if (javaHome == null) {
+            return null
+        }
+        File candidate = file("${javaHome}/bin/java")
+        candidate.isFile() ? candidate : null
+    }
+    if (java21Executable != null && (JavaVersion.current().majorVersion as int) >= 24) {
+        executable = java21Executable.absolutePath
     }
+    jvmArgs += ["-Djava.security.manager=allow"]
 }
diff --git a/tests/src/org.jboss.resteasy/resteasy-client/6.2.12.Final/src/test/java/org_jboss_resteasy/resteasy_client/ClientProxyTest.java b/tests/src/org.jboss.resteasy/resteasy-client/6.2.16.Final/src/test/java/org_jboss_resteasy/resteasy_client/ClientProxyTest.java
index 0c729ab6e5..d997a34404 100644
--- a/tests/src/org.jboss.resteasy/resteasy-client/6.2.12.Final/src/test/java/org_jboss_resteasy/resteasy_client/ClientProxyTest.java
+++ b/tests/src/org.jboss.resteasy/resteasy-client/6.2.16.Final/src/test/java/org_jboss_resteasy/resteasy_client/ClientProxyTest.java
@@ -7,8 +7,6 @@
 package org_jboss_resteasy.resteasy_client;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.security.Permission;
 
@@ -16,7 +14,7 @@ import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
 import org.junit.jupiter.api.Test;
 
-class ClientProxyTest {
+public class ClientProxyTest {
 
     @Test
     void defaultMethodInvocationUsesSpecialLookupWithoutSecurityManager() {
@@ -29,22 +27,28 @@ class ClientProxyTest {
 
     @Test
     @SuppressWarnings("removal")
-    void defaultMethodInvocationUsesPrivilegedSpecialLookupWithSecurityManager() {
-        // ClientProxy only reaches the privileged default-method path when a SecurityManager is installed.
-        // That runtime mode is unavailable on JDK 24+ and in Substrate VM.
-        assumeTrue(Runtime.version().feature() < 24, "Security Manager is not supported on this JDK");
-        assumeFalse(System.getProperty("java.vm.name", "").contains("Substrate VM"),
-                "Security Manager is not supported in native image tests");
-
+    void defaultMethodInvocationUsesPrivilegedSpecialLookupWhenSecurityManagerCanBeInstalled() {
         final SecurityManager previousSecurityManager = System.getSecurityManager();
-        System.setSecurityManager(new PermissiveSecurityManager());
+        boolean installedSecurityManager = false;
+        try {
+            try {
+                System.setSecurityManager(new PermissiveSecurityManager());
+                installedSecurityManager = true;
+            } catch (final UnsupportedOperationException unsupportedOperationException) {
+                assertThat(Runtime.version().feature())
+                        .as(unsupportedOperationException.getMessage())
+                        .isGreaterThanOrEqualTo(24);
+            }
 
-        try (ResteasyClient client = new ResteasyClientBuilderImpl().build()) {
-            final DefaultMethodClient proxy = client.target("http://localhost:8080").proxy(DefaultMethodClient.class);
+            try (ResteasyClient client = new ResteasyClientBuilderImpl().build()) {
+                final DefaultMethodClient proxy = client.target("http://localhost:8080").proxy(DefaultMethodClient.class);
 
-            assertThat(proxy.greet("Resteasy")).isEqualTo("Hello Resteasy");
+                assertThat(proxy.greet("Resteasy")).isEqualTo("Hello Resteasy");
+            }
         } finally {
-            System.setSecurityManager(previousSecurityManager);
+            if (installedSecurityManager) {
+                System.setSecurityManager(previousSecurityManager);
+            }
         }
     }
 
diff --git a/tests/src/org.jboss.resteasy/resteasy-client/6.2.12.Final/user-code-filter.json b/tests/src/org.jboss.resteasy/resteasy-client/6.2.16.Final/user-code-filter.json
index 52265c9e31..3d0522a91c 100644
--- a/tests/src/org.jboss.resteasy/resteasy-client/6.2.12.Final/user-code-filter.json
+++ b/tests/src/org.jboss.resteasy/resteasy-client/6.2.16.Final/user-code-filter.json
@@ -5,6 +5,18 @@
     },
     {
       "includeClasses" : "org.jboss.resteasy.**"
+    },
+    {
+      "includeClasses" : "org.jboss.resteasy.client.jaxrs.**"
+    },
+    {
+      "includeClasses" : "org.jboss.resteasy.plugins.providers.sse.client.**"
+    },
+    {
+      "includeClasses" : "org.jboss.resteasy.test.**"
+    },
+    {
+      "includeClasses" : "org_jboss_resteasy.resteasy_client.**"
     }
   ]
 }

```
### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
