### PR TITLE
[GenAI] Add support for org.apache.camel:camel-core-engine:4.19.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.camel/camel-core-engine/4.19.0/reachability-metadata.json
+++ b/metadata/org.apache.camel/camel-core-engine/4.19.0/reachability-metadata.json
@@ -1,0 +1,96 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.camel.impl.engine.SimpleCamelContext"
+      },
+      "type" : "org.apache.camel.processor.DefaultProcessorFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.camel.impl.engine.SimpleCamelContext"
+      },
+      "type" : "org.apache.camel.processor.DefaultInternalProcessorFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.camel.impl.engine.SimpleCamelContext"
+      },
+      "type" : "org.apache.camel.processor.DefaultAnnotationBasedProcessorFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.camel.impl.engine.SimpleCamelContext"
+      },
+      "type" : "org.apache.camel.processor.DefaultDeferServiceFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.camel.impl.engine.DefaultLanguageResolver"
+      },
+      "type" : "org.apache.camel.language.constant.ConstantLanguage",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.camel.impl.engine.SimpleCamelContext"
+      },
+      "glob" : "META-INF/services/org/apache/camel/processor-factory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.camel.impl.engine.SimpleCamelContext"
+      },
+      "glob" : "META-INF/services/org/apache/camel/internal-processor-factory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.camel.impl.engine.SimpleCamelContext"
+      },
+      "glob" : "META-INF/services/org/apache/camel/annotation-processor-factory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.camel.impl.engine.SimpleCamelContext"
+      },
+      "glob" : "META-INF/services/org/apache/camel/defer-service-factory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.camel.impl.engine.DefaultLanguageResolver"
+      },
+      "glob" : "META-INF/services/org/apache/camel/language/constant"
+    }
+  ]
+}

--- a/metadata/org.apache.camel/camel-core-engine/index.json
+++ b/metadata/org.apache.camel/camel-core-engine/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.19.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/camel/camel-core-engine/$version$/camel-core-engine-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/camel",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/camel/camel/$version$/camel-$version$-source-release.zip",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/camel/camel-core-engine/$version$/camel-core-engine-$version$-javadoc.jar",
+    "description" : "Apache Camel Core Engine provides the runtime engine for Camel routes without bundling core components. It brings together the core context implementation and generated configurators that wire Camel APIs, model reification, support utilities, management hooks, and the base engine into an embeddable integration runtime.",
+    "tested-versions" : [
+      "4.19.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.camel.impl"
+    ]
+  }
+]

--- a/stats/org.apache.camel/camel-core-engine/4.19.0/execution-metrics.json
+++ b/stats/org.apache.camel/camel-core-engine/4.19.0/execution-metrics.json
@@ -1,0 +1,82 @@
+{
+  "add_new_library_support:2026-06-10": {
+    "timestamp": "2026-06-10T05:26:47.059485Z",
+    "library": "org.apache.camel:camel-core-engine:4.19.0",
+    "starting_commit": "45fef43e2146410119554da1646878a0be61adea",
+    "ending_commit": "802096c8e073c7c2bbc45d3016ef943bcd3c0691",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.19.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1149,
+          "missed": 6295,
+          "ratio": 0.154352,
+          "total": 7444
+        },
+        "line": {
+          "covered": 301,
+          "missed": 1326,
+          "ratio": 0.185003,
+          "total": 1627
+        },
+        "method": {
+          "covered": 59,
+          "missed": 186,
+          "ratio": 0.240816,
+          "total": 245
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "degraded",
+      "action": "no_action",
+      "issue_number": 4508,
+      "issue_label": "library-new-request",
+      "library": "org.apache.camel:camel-core-engine:4.19.0",
+      "summary": "Library preparation preflight did not produce usable advisory setup.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#4508 Support for org.apache.camel:camel-core-engine:4.19.0; label=library-new-request; body_chars=110"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "0 existing test file path(s) included"
+        }
+      ],
+      "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
+      "model": "oca/gpt-5.5",
+      "prompt_path": "library-preflight-prompt.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/org.apache.camel:camel-core-engine:4.19.0/library-preparation-preflight/pi-generation-2026-06-10T05-02-28-983598Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 177564,
+      "cached_input_tokens_used": 1185280,
+      "output_tokens_used": 14194,
+      "iterations": 6,
+      "cost_usd": 1.0184,
+      "generated_loc": 211,
+      "tested_library_loc": 301,
+      "metadata_entries": 15,
+      "code_coverage_percent": 18.5
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.camel/camel-core-engine/4.19.0/src/test/java/org_apache_camel/camel_core_engine/Camel_core_engineTest.java",
+      "metadata_file": "metadata/org.apache.camel/camel-core-engine/4.19.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.camel/camel-core-engine/4.19.0/stats.json
+++ b/stats/org.apache.camel/camel-core-engine/4.19.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.19.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1149,
+        "missed" : 6295,
+        "ratio" : 0.154352,
+        "total" : 7444
+      },
+      "line" : {
+        "covered" : 301,
+        "missed" : 1326,
+        "ratio" : 0.185003,
+        "total" : 1627
+      },
+      "method" : {
+        "covered" : 59,
+        "missed" : 186,
+        "ratio" : 0.240816,
+        "total" : 245
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.camel/camel-core-engine/4.19.0/.gitignore
+++ b/tests/src/org.apache.camel/camel-core-engine/4.19.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.camel/camel-core-engine/4.19.0/build.gradle
+++ b/tests/src/org.apache.camel/camel-core-engine/4.19.0/build.gradle
@@ -12,6 +12,8 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.apache.camel:camel-core-engine:$libraryVersion"
+    testImplementation "org.apache.camel:camel-core-languages:$libraryVersion"
+    testImplementation "org.apache.camel:camel-direct:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.apache.camel/camel-core-engine/4.19.0/build.gradle
+++ b/tests/src/org.apache.camel/camel-core-engine/4.19.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.camel:camel-core-engine:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.camel/camel-core-engine/4.19.0/gradle.properties
+++ b/tests/src/org.apache.camel/camel-core-engine/4.19.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.camel:camel-core-engine:4.19.0
+library.version = 4.19.0
+metadata.dir = org.apache.camel/camel-core-engine/4.19.0/

--- a/tests/src/org.apache.camel/camel-core-engine/4.19.0/settings.gradle
+++ b/tests/src/org.apache.camel/camel-core-engine/4.19.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.camel.camel-core-engine_tests'

--- a/tests/src/org.apache.camel/camel-core-engine/4.19.0/src/test/java/org_apache_camel/camel_core_engine/Camel_core_engineTest.java
+++ b/tests/src/org.apache.camel/camel-core-engine/4.19.0/src/test/java/org_apache_camel/camel_core_engine/Camel_core_engineTest.java
@@ -156,6 +156,57 @@ public class Camel_core_engineTest {
     }
 
     @Test
+    void routesMessagesWithContentBasedRouterChoice() throws Exception {
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            context.addComponent("direct", new DirectComponent());
+            context.addRoutes(new RouteBuilder() {
+                @Override
+                public void configure() {
+                    from("direct:classify")
+                            .routeId("content-based-route")
+                            .choice()
+                            .when(exchange -> "gold".equals(
+                                    exchange.getMessage().getHeader("customerTier", String.class)))
+                                .setHeader("routeBranch").constant("priority")
+                                .setBody(exchange -> "priority:"
+                                        + exchange.getMessage().getBody(String.class))
+                            .when(exchange -> exchange.getMessage().getBody(String.class).contains("audit"))
+                                .setHeader("routeBranch").constant("audit")
+                                .setBody(exchange -> "audit:"
+                                        + exchange.getMessage().getBody(String.class))
+                            .otherwise()
+                                .setHeader("routeBranch").constant("standard")
+                                .setBody(exchange -> "standard:"
+                                        + exchange.getMessage().getBody(String.class))
+                            .end();
+                }
+            });
+            context.start();
+
+            try (ProducerTemplate template = context.createProducerTemplate()) {
+                Exchange priority = template.request("direct:classify", exchange -> {
+                    exchange.getMessage().setHeader("customerTier", "gold");
+                    exchange.getMessage().setBody("invoice");
+                });
+                Exchange audit = template.request("direct:classify", exchange ->
+                        exchange.getMessage().setBody("audit-log"));
+                Exchange standard = template.request("direct:classify", exchange ->
+                        exchange.getMessage().setBody("status"));
+
+                assertThat(priority.getException()).isNull();
+                assertThat(priority.getMessage().getBody(String.class)).isEqualTo("priority:invoice");
+                assertThat(priority.getMessage().getHeader("routeBranch", String.class)).isEqualTo("priority");
+                assertThat(audit.getException()).isNull();
+                assertThat(audit.getMessage().getBody(String.class)).isEqualTo("audit:audit-log");
+                assertThat(audit.getMessage().getHeader("routeBranch", String.class)).isEqualTo("audit");
+                assertThat(standard.getException()).isNull();
+                assertThat(standard.getMessage().getBody(String.class)).isEqualTo("standard:status");
+                assertThat(standard.getMessage().getHeader("routeBranch", String.class)).isEqualTo("standard");
+            }
+        }
+    }
+
+    @Test
     void removesRoutesAndComponentsFromRunningContext() throws Exception {
         try (DefaultCamelContext context = new DefaultCamelContext()) {
             DirectComponent directComponent = new DirectComponent();

--- a/tests/src/org.apache.camel/camel-core-engine/4.19.0/src/test/java/org_apache_camel/camel_core_engine/Camel_core_engineTest.java
+++ b/tests/src/org.apache.camel/camel-core-engine/4.19.0/src/test/java/org_apache_camel/camel_core_engine/Camel_core_engineTest.java
@@ -6,11 +6,135 @@
  */
 package org_apache_camel.camel_core_engine;
 
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.direct.DirectComponent;
+import org.apache.camel.impl.DefaultCamelContext;
 import org.junit.jupiter.api.Test;
 
-class Camel_core_engineTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Camel_core_engineTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void routesMessagesThroughStartedCamelContext() throws Exception {
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            context.addComponent("direct", new DirectComponent());
+            context.addRoutes(new RouteBuilder() {
+                @Override
+                public void configure() {
+                    from("direct:uppercase")
+                            .routeId("uppercase-route")
+                            .group("core-engine")
+                            .process(exchange -> {
+                                String body = exchange.getMessage().getBody(String.class);
+                                exchange.getMessage().setHeader("originalLength", body.length());
+                                exchange.getMessage().setBody(body.toUpperCase(Locale.ROOT));
+                            });
+                }
+            });
+
+            context.start();
+
+            assertThat(context.getRoutesSize()).isEqualTo(1);
+            assertThat(context.getRouteIds()).containsExactly("uppercase-route");
+            assertThat(context.getRoutesByGroup("core-engine")).hasSize(1);
+
+            try (ProducerTemplate template = context.createProducerTemplate()) {
+                Exchange result = template.request("direct:uppercase", exchange -> {
+                    exchange.getMessage().setBody("camel");
+                    exchange.getMessage().setHeader("requestId", "request-1");
+                });
+
+                assertThat(result.getException()).isNull();
+                assertThat(result.getMessage().getBody(String.class)).isEqualTo("CAMEL");
+                assertThat(result.getMessage().getHeader("originalLength", Integer.class)).isEqualTo(5);
+                assertThat(result.getMessage().getHeader("requestId", String.class)).isEqualTo("request-1");
+            }
+        }
+    }
+
+    @Test
+    void materializesRouteTemplateAndProcessesExchange() throws Exception {
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            context.addComponent("direct", new DirectComponent());
+            context.addRoutes(new RouteBuilder() {
+                @Override
+                public void configure() {
+                    routeTemplate("appendTemplate")
+                            .templateParameter("entrypoint")
+                            .from("direct:{{entrypoint}}")
+                            .process(exchange -> {
+                                String body = exchange.getMessage().getBody(String.class);
+                                String suffix = exchange.getMessage().getHeader("suffix", String.class);
+                                exchange.getMessage().setBody(body + suffix);
+                            });
+                }
+            });
+
+            String routeId = context.addRouteFromTemplate(
+                    "templated-append-route", "appendTemplate", Map.of("entrypoint", "append"));
+            context.start();
+
+            assertThat(routeId).isEqualTo("templated-append-route");
+            assertThat(context.getRouteTemplateDefinition("appendTemplate")).isNotNull();
+            assertThat(context.getRouteDefinition("templated-append-route")).isNotNull();
+
+            try (ProducerTemplate template = context.createProducerTemplate()) {
+                String response = template.requestBodyAndHeader(
+                        "direct:append", "core", "suffix", "-engine", String.class);
+
+                assertThat(response).isEqualTo("core-engine");
+            }
+        }
+    }
+
+    @Test
+    void resolvesPropertiesVariablesAndCoreTypeConverters() throws Exception {
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            Properties properties = new Properties();
+            properties.setProperty("message.prefix", "Apache Camel");
+            context.getPropertiesComponent().setInitialProperties(properties);
+            context.setVariable("message.suffix", "core engine");
+            context.start();
+
+            assertThat(context.resolvePropertyPlaceholders("{{message.prefix}}"))
+                    .isEqualTo("Apache Camel");
+            assertThat(context.getVariable("message.suffix", String.class)).isEqualTo("core engine");
+            assertThat(context.getTypeConverter().mandatoryConvertTo(Integer.class, "4190"))
+                    .isEqualTo(4190);
+        }
+    }
+
+    @Test
+    void removesRoutesAndComponentsFromRunningContext() throws Exception {
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            DirectComponent directComponent = new DirectComponent();
+            context.addComponent("direct", directComponent);
+            context.addRoutes(new RouteBuilder() {
+                @Override
+                public void configure() {
+                    from("direct:removable")
+                            .routeId("removable-route")
+                            .setBody(exchange -> "handled:" + exchange.getMessage().getBody(String.class));
+                }
+            });
+            context.start();
+
+            try (ProducerTemplate template = context.createProducerTemplate()) {
+                assertThat(template.requestBody("direct:removable", "before", String.class))
+                        .isEqualTo("handled:before");
+            }
+
+            context.getRouteController().stopRoute("removable-route");
+            assertThat(context.removeRoute("removable-route")).isTrue();
+            assertThat(context.getRoute("removable-route")).isNull();
+            assertThat(context.removeComponent("direct")).isSameAs(directComponent);
+            assertThat(context.hasComponent("direct")).isNull();
+        }
     }
 }

--- a/tests/src/org.apache.camel/camel-core-engine/4.19.0/src/test/java/org_apache_camel/camel_core_engine/Camel_core_engineTest.java
+++ b/tests/src/org.apache.camel/camel-core-engine/4.19.0/src/test/java/org_apache_camel/camel_core_engine/Camel_core_engineTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_camel.camel_core_engine;
+
+import org.junit.jupiter.api.Test;
+
+class Camel_core_engineTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.apache.camel/camel-core-engine/4.19.0/src/test/java/org_apache_camel/camel_core_engine/Camel_core_engineTest.java
+++ b/tests/src/org.apache.camel/camel-core-engine/4.19.0/src/test/java/org_apache_camel/camel_core_engine/Camel_core_engineTest.java
@@ -111,6 +111,51 @@ public class Camel_core_engineTest {
     }
 
     @Test
+    void handlesRouteExceptionsWithOnExceptionClause() throws Exception {
+        try (DefaultCamelContext context = new DefaultCamelContext()) {
+            context.addComponent("direct", new DirectComponent());
+            context.addRoutes(new RouteBuilder() {
+                @Override
+                public void configure() {
+                    onException(IllegalArgumentException.class)
+                            .handled(true)
+                            .process(exchange -> {
+                                Throwable caught = exchange.getProperty(Exchange.EXCEPTION_CAUGHT, Throwable.class);
+                                exchange.getMessage().setHeader(
+                                        "handledExceptionType", caught.getClass().getSimpleName());
+                            })
+                            .setBody().constant("recovered");
+
+                    from("direct:validate")
+                            .routeId("exception-handler-route")
+                            .process(exchange -> {
+                                String body = exchange.getMessage().getBody(String.class);
+                                if (body.isBlank()) {
+                                    throw new IllegalArgumentException("body must not be blank");
+                                }
+                                exchange.getMessage().setBody("accepted:" + body);
+                            });
+                }
+            });
+            context.start();
+
+            try (ProducerTemplate template = context.createProducerTemplate()) {
+                Exchange accepted = template.request("direct:validate", exchange ->
+                        exchange.getMessage().setBody("camel"));
+                Exchange recovered = template.request("direct:validate", exchange ->
+                        exchange.getMessage().setBody(" "));
+
+                assertThat(accepted.getException()).isNull();
+                assertThat(accepted.getMessage().getBody(String.class)).isEqualTo("accepted:camel");
+                assertThat(recovered.getException()).isNull();
+                assertThat(recovered.getMessage().getBody(String.class)).isEqualTo("recovered");
+                assertThat(recovered.getMessage().getHeader("handledExceptionType", String.class))
+                        .isEqualTo(IllegalArgumentException.class.getSimpleName());
+            }
+        }
+    }
+
+    @Test
     void removesRoutesAndComponentsFromRunningContext() throws Exception {
         try (DefaultCamelContext context = new DefaultCamelContext()) {
             DirectComponent directComponent = new DirectComponent();

--- a/tests/src/org.apache.camel/camel-core-engine/4.19.0/user-code-filter.json
+++ b/tests/src/org.apache.camel/camel-core-engine/4.19.0/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.apache.camel.impl.**"
+      "includeClasses" : "org.apache.camel.impl.**"
+    },
+    {
+      "includeClasses" : "org_apache_camel.camel_core_engine.**"
     }
   ]
 }

--- a/tests/src/org.apache.camel/camel-core-engine/4.19.0/user-code-filter.json
+++ b/tests/src/org.apache.camel/camel-core-engine/4.19.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.apache.camel.impl.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #4508

This PR introduces tests and metadata for org.apache.camel:camel-core-engine:4.19.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 177564
- Cached input tokens: 1185280
- Output tokens: 14194
- Metadata entries: 15
- Iterations: 6
- Library coverage percentage: 18.5
- Generated lines of code: 211
- Tested library lines of code: 301

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `e7aefb9265d06fd5e70906b66ae96af12921f4bc`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1149/7444 (15.44%)
- Line: 301/1627 (18.50%)
- Method: 59/245 (24.08%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
