### PR TITLE
[GenAI] Test fix for org.jboss:jandex:3.0.0 using gpt-5.5

### DIFF
--- a/metadata/org.jboss/jandex/3.0.0/reachability-metadata.json
+++ b/metadata/org.jboss/jandex/3.0.0/reachability-metadata.json
@@ -1,0 +1,38 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.jboss.jandex.Indexer"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.jandex.JandexReflection"
+      },
+      "type": "org_jboss.jandex.JandexReflectionTest$SampleType[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.jandex.StrongInternPool"
+      },
+      "type": "java.lang.String",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.jandex.StrongInternPool"
+      },
+      "type": "org.jboss.jandex.StrongInternPool",
+      "serializable": true
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.jboss.jandex.Indexer"
+      },
+      "glob": "org_jboss/jandex/IndexerTest$IndexedSample.class"
+    }
+  ]
+}

--- a/metadata/org.jboss/jandex/3.0.0/reachability-metadata.json
+++ b/metadata/org.jboss/jandex/3.0.0/reachability-metadata.json
@@ -1,38 +1,32 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org.jboss.jandex.Indexer"
+      "condition" : {
+        "typeReached" : "org.jboss.jandex.Indexer"
       },
-      "type": "java.lang.StackTraceElement[]"
+      "type" : "java.lang.StackTraceElement[]"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.jandex.JandexReflection"
+      "condition" : {
+        "typeReached" : "org.jboss.jandex.StrongInternPool"
       },
-      "type": "org_jboss.jandex.JandexReflectionTest$SampleType[][]"
+      "type" : "java.lang.String",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.jandex.StrongInternPool"
+      "condition" : {
+        "typeReached" : "org.jboss.jandex.StrongInternPool"
       },
-      "type": "java.lang.String",
-      "serializable": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.jboss.jandex.StrongInternPool"
-      },
-      "type": "org.jboss.jandex.StrongInternPool",
-      "serializable": true
+      "type" : "org.jboss.jandex.StrongInternPool",
+      "serializable" : true
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "org.jboss.jandex.Indexer"
+      "condition" : {
+        "typeReached" : "org.jboss.jandex.Indexer"
       },
-      "glob": "org_jboss/jandex/IndexerTest$IndexedSample.class"
+      "glob" : "org_jboss/jandex/IndexerTest$IndexedSample.class"
     }
   ]
 }

--- a/metadata/org.jboss/jandex/index.json
+++ b/metadata/org.jboss/jandex/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "3.0.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/smallrye/jandex/$version$/jandex-$version$-sources.jar",
+    "repository-url" : "https://github.com/smallrye/jandex",
+    "test-code-url" : "https://github.com/smallrye/jandex/tree/$version$/core/src/test/java",
+    "documentation-url" : "https://github.com/smallrye/jandex/blob/$version$/doc/modules/ROOT/pages/index.adoc",
+    "description" : "Jandex is a Java class file indexer and offline reflection library that builds a compact index of class metadata, annotations, declarations, types, and inheritance information. It provides APIs and tools to query, persist, and reload that index for build-time or runtime frameworks without scanning bytecode repeatedly.",
     "tested-versions" : [
       "3.0.0"
     ],

--- a/metadata/org.jboss/jandex/index.json
+++ b/metadata/org.jboss/jandex/index.json
@@ -1,16 +1,25 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.0.0",
+    "tested-versions" : [
+      "3.0.0"
+    ],
+    "allowed-packages" : [
+      "org.jboss.jandex"
+    ]
+  },
+  {
     "metadata-version" : "2.4.5.Final",
     "test-version" : "2.4.2.Final",
-    "tested-versions" : [
-      "2.4.5.Final"
-    ],
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/jboss/jandex/$version$/jandex-$version$-sources.jar",
     "repository-url" : "https://github.com/smallrye/jandex",
     "test-code-url" : "https://github.com/smallrye/jandex/tree/$version$/src/test/java",
     "documentation-url" : "https://github.com/smallrye/jandex/blob/$version$/README.md",
     "description" : "Jandex indexes Java class metadata and annotations into a compact structure for fast offline lookup. It also provides APIs and tools to query, persist, and reload that index without relying on runtime reflection.",
+    "tested-versions" : [
+      "2.4.5.Final"
+    ],
     "allowed-packages" : [
       "org.jboss.jandex"
     ]

--- a/stats/org.jboss/jandex/3.0.0/execution-metrics.json
+++ b/stats/org.jboss/jandex/3.0.0/execution-metrics.json
@@ -1,0 +1,144 @@
+{
+  "fix_javac_fail:2026-06-10": {
+    "timestamp": "2026-06-10T09:41:17.532929Z",
+    "library": "org.jboss:jandex:3.0.0",
+    "starting_commit": "f5e33d58a26fa8f20533c56a6b321cd07495d1f5",
+    "ending_commit": "a8b3b586f911884c049cb2b16db22196d7842cf3",
+    "previous_library": "org.jboss:jandex:2.4.2.Final",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.0.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 5,
+        "totalCalls": 5
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 6004,
+          "missed": 30499,
+          "ratio": 0.16448,
+          "total": 36503
+        },
+        "line": {
+          "covered": 1043,
+          "missed": 6341,
+          "ratio": 0.141251,
+          "total": 7384
+        },
+        "method": {
+          "covered": 212,
+          "missed": 1276,
+          "ratio": 0.142473,
+          "total": 1488
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.4.2.Final",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 3,
+        "totalCalls": 3
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4650,
+          "missed": 22747,
+          "ratio": 0.169727,
+          "total": 27397
+        },
+        "line": {
+          "covered": 827,
+          "missed": 4863,
+          "ratio": 0.145343,
+          "total": 5690
+        },
+        "method": {
+          "covered": 147,
+          "missed": 1052,
+          "ratio": 0.122602,
+          "total": 1199
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "no_action",
+      "issue_number": 8308,
+      "issue_label": "fails-javac-compile",
+      "library": "org.jboss:jandex:3.0.0",
+      "summary": "No extra setup is needed: Jandex 3.0.0 is a self-contained class-indexing/offline-reflection library, resolves via Maven relocation from org.jboss:jandex to io.smallrye:jandex, and meaningful coverage can use in-memory/sample class indexing, querying, and index read/write without services, Docker, system properties, or extra dependencies.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [
+        "org.jboss:jandex:3.0.0 is a relocation POM to io.smallrye:jandex:3.0.0 while the Java package remains org.jboss.jandex.",
+        "The failing existing test is due to an API compatibility issue around Indexer#indexClass usage, not missing setup.",
+        "The artifact has an optional/provided Ant integration; only tests that directly exercise JandexAntTask would need an Ant dependency, but that is not required for meaningful core coverage."
+      ],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#8308 [Automation] javac compile fails for org.jboss:jandex:3.0.0; label=fails-javac-compile; body_chars=8015"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "7 existing test file path(s) included"
+        }
+      ],
+      "current_library": "org.jboss:jandex:2.4.2.Final",
+      "new_version": "3.0.0",
+      "model": "oca/gpt-5.5",
+      "input_tokens_used": 44992,
+      "output_tokens_used": 3239,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.jboss:jandex:3.0.0/library-preparation-preflight/pi-generation-2026-06-10T09-20-39-976129Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 102324,
+      "cached_input_tokens_used": 484352,
+      "output_tokens_used": 4844,
+      "iterations": 2,
+      "cost_usd": 0.3875,
+      "tested_library_loc": 1043,
+      "metadata_entries": 6,
+      "test_only_metadata_entries": 1,
+      "previous_library_metadata_entries": 3,
+      "code_coverage_percent": 14.13,
+      "previous_library_coverage_percent": 14.53
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.jboss/jandex/3.0.0/src/test/java/org_jboss/jandex/JandexReflectionTest.java",
+      "metadata_file": "metadata/org.jboss/jandex/3.0.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.jboss/jandex/3.0.0/stats.json
+++ b/stats/org.jboss/jandex/3.0.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "3.0.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 4,
+          "totalCalls" : 4
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 5,
+      "totalCalls" : 5
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 6004,
+        "missed" : 30499,
+        "ratio" : 0.16448,
+        "total" : 36503
+      },
+      "line" : {
+        "covered" : 1043,
+        "missed" : 6341,
+        "ratio" : 0.141251,
+        "total" : 7384
+      },
+      "method" : {
+        "covered" : 212,
+        "missed" : 1276,
+        "ratio" : 0.142473,
+        "total" : 1488
+      }
+    }
+  } ]
+}

--- a/tests/src/org.jboss/jandex/3.0.0/.gitignore
+++ b/tests/src/org.jboss/jandex/3.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.jboss/jandex/3.0.0/build.gradle
+++ b/tests/src/org.jboss/jandex/3.0.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.jboss:jandex:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.jboss/jandex/3.0.0/gradle.properties
+++ b/tests/src/org.jboss/jandex/3.0.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.jboss:jandex:3.0.0
+library.version = 3.0.0
+metadata.dir = org.jboss/jandex/3.0.0/

--- a/tests/src/org.jboss/jandex/3.0.0/settings.gradle
+++ b/tests/src/org.jboss/jandex/3.0.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.jboss.jandex_tests'

--- a/tests/src/org.jboss/jandex/3.0.0/src/test/java/org_jboss/jandex/IndexerTest.java
+++ b/tests/src/org.jboss/jandex/3.0.0/src/test/java/org_jboss/jandex/IndexerTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss.jandex;
+
+import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.Indexer;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class IndexerTest {
+    @Test
+    void indexesLoadedClassFromItsClassResource() throws IOException {
+        Indexer indexer = new Indexer();
+
+        ClassInfo classInfo = indexer.indexClass(IndexedSample.class);
+        Index index = indexer.complete();
+
+        assertThat(classInfo.name().toString()).isEqualTo(IndexedSample.class.getName());
+        assertThat(classInfo.classAnnotation(DotName.createSimple(SampleAnnotation.class.getName()))).isNotNull();
+        assertThat(classInfo.firstMethod("value")).isNotNull();
+        assertThat(index.getClassByName(DotName.createSimple(IndexedSample.class.getName()))).isNotNull();
+    }
+
+    @SampleAnnotation("sample")
+    static class IndexedSample {
+        String value() {
+            return "value";
+        }
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    @interface SampleAnnotation {
+        String value();
+    }
+}

--- a/tests/src/org.jboss/jandex/3.0.0/src/test/java/org_jboss/jandex/IndexerTest.java
+++ b/tests/src/org.jboss/jandex/3.0.0/src/test/java/org_jboss/jandex/IndexerTest.java
@@ -25,13 +25,15 @@ public class IndexerTest {
     void indexesLoadedClassFromItsClassResource() throws IOException {
         Indexer indexer = new Indexer();
 
-        ClassInfo classInfo = indexer.indexClass(IndexedSample.class);
+        indexer.indexClass(IndexedSample.class);
         Index index = indexer.complete();
+        ClassInfo classInfo = index.getClassByName(IndexedSample.class);
 
+        assertThat(classInfo).isNotNull();
         assertThat(classInfo.name().toString()).isEqualTo(IndexedSample.class.getName());
-        assertThat(classInfo.classAnnotation(DotName.createSimple(SampleAnnotation.class.getName()))).isNotNull();
+        assertThat(classInfo.declaredAnnotation(DotName.createSimple(SampleAnnotation.class.getName()))).isNotNull();
         assertThat(classInfo.firstMethod("value")).isNotNull();
-        assertThat(index.getClassByName(DotName.createSimple(IndexedSample.class.getName()))).isNotNull();
+        assertThat(index.getClassByName(IndexedSample.class)).isSameAs(classInfo);
     }
 
     @SampleAnnotation("sample")

--- a/tests/src/org.jboss/jandex/3.0.0/src/test/java/org_jboss/jandex/JandexReflectionTest.java
+++ b/tests/src/org.jboss/jandex/3.0.0/src/test/java/org_jboss/jandex/JandexReflectionTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss.jandex;
+
+import org.jboss.jandex.ArrayType;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.JandexReflection;
+import org.jboss.jandex.Type;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JandexReflectionTest {
+    @Test
+    void loadsRawArrayClassFromJandexClassType() {
+        Type componentType = Type.create(DotName.createSimple(SampleType.class.getName()), Type.Kind.CLASS);
+        ArrayType arrayType = ArrayType.create(componentType, 2);
+
+        Class<?> loadedType = JandexReflection.loadRawType(arrayType);
+
+        assertThat(loadedType).isEqualTo(SampleType[][].class);
+    }
+
+    static final class SampleType {
+    }
+}

--- a/tests/src/org.jboss/jandex/3.0.0/src/test/java/org_jboss/jandex/StrongInternPoolTest.java
+++ b/tests/src/org.jboss/jandex/3.0.0/src/test/java/org_jboss/jandex/StrongInternPoolTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss.jandex;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StrongInternPoolTest {
+    @Test
+    void serializesAndDeserializesInternedEntries() throws Exception {
+        Object pool = newPool();
+
+        String alpha = new String("alpha");
+        String beta = new String("beta");
+
+        assertThat(intern(pool, alpha)).isSameAs(alpha);
+        assertThat(intern(pool, new String("alpha"))).isSameAs(alpha);
+        assertThat(intern(pool, beta)).isSameAs(beta);
+        assertThat(intern(pool, null)).isNull();
+        assertThat(size(pool)).isEqualTo(3);
+
+        Object restoredPool = deserialize(serialize(pool));
+
+        assertThat(size(restoredPool)).isEqualTo(3);
+        assertThat(contains(restoredPool, "alpha")).isTrue();
+        assertThat(contains(restoredPool, "beta")).isTrue();
+        assertThat(contains(restoredPool, null)).isTrue();
+
+        String duplicateAlpha = new String("alpha");
+        Object restoredAlpha = intern(restoredPool, duplicateAlpha);
+        assertThat(restoredAlpha).isEqualTo("alpha");
+        assertThat(restoredAlpha).isNotSameAs(duplicateAlpha);
+        assertThat(size(restoredPool)).isEqualTo(3);
+    }
+
+    private static Object newPool() throws Exception {
+        Constructor<?> constructor = strongInternPoolClass().getDeclaredConstructor();
+        constructor.setAccessible(true);
+        return constructor.newInstance();
+    }
+
+    private static Object intern(Object pool, Object entry) throws Exception {
+        Method method = strongInternPoolClass().getDeclaredMethod("intern", Object.class);
+        method.setAccessible(true);
+        return method.invoke(pool, entry);
+    }
+
+    private static int size(Object pool) throws Exception {
+        Method method = strongInternPoolClass().getDeclaredMethod("size");
+        method.setAccessible(true);
+        return (Integer) method.invoke(pool);
+    }
+
+    private static boolean contains(Object pool, Object entry) throws Exception {
+        Method method = strongInternPoolClass().getDeclaredMethod("contains", Object.class);
+        method.setAccessible(true);
+        return (Boolean) method.invoke(pool, entry);
+    }
+
+    private static byte[] serialize(Object pool) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+            output.writeObject(pool);
+        }
+        return bytes.toByteArray();
+    }
+
+    private static Object deserialize(byte[] bytes) throws Exception {
+        try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+            return input.readObject();
+        }
+    }
+
+    private static Class<?> strongInternPoolClass() throws ClassNotFoundException {
+        return Class.forName("org.jboss.jandex.StrongInternPool");
+    }
+}

--- a/tests/src/org.jboss/jandex/3.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.jboss/jandex/3.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.jandex.JandexReflection"
+      },
+      "type" : "org_jboss.jandex.JandexReflectionTest$SampleType[][]"
+    }
+  ]
+}

--- a/tests/src/org.jboss/jandex/3.0.0/user-code-filter.json
+++ b/tests/src/org.jboss/jandex/3.0.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.jboss.jandex.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #8308

This PR provides test fixes and new metadata for org.jboss:jandex:3.0.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 102324
- Cached input tokens: 484352
- Output tokens: 4844
- Metadata entries: 6
- Test-only metadata entries: 1
- Iterations: 2
- Library coverage percentage: 14.13
- Previous library version metadata entries: 3
- Previous library version coverage percentage: 14.53

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `558b05d94798fc345679f30dfb888df4506a507e`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.jboss:jandex:2.4.2.Final: 3/3 covered calls (100.00%)
- org.jboss:jandex:3.0.0: 5/5 covered calls (100.00%)

**Reflection:**
- org.jboss:jandex:2.4.2.Final: 2/2 covered calls (100.00%)
- org.jboss:jandex:3.0.0: 4/4 covered calls (100.00%)

**Resources:**
- org.jboss:jandex:2.4.2.Final: 1/1 covered calls (100.00%)
- org.jboss:jandex:3.0.0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.jboss:jandex:2.4.2.Final: 4650/27397 (16.97%)
- org.jboss:jandex:3.0.0: 6004/36503 (16.45%)

**Line:**
- org.jboss:jandex:2.4.2.Final: 827/5690 (14.53%)
- org.jboss:jandex:3.0.0: 1043/7384 (14.13%)

**Method:**
- org.jboss:jandex:2.4.2.Final: 147/1199 (12.26%)
- org.jboss:jandex:3.0.0: 212/1488 (14.25%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.jboss/jandex/2.4.2.Final/src/test/java/org_jboss/jandex/IndexerTest.java 2/tests/src/org.jboss/jandex/3.0.0/src/test/java/org_jboss/jandex/IndexerTest.java
index d971461f21..d1075eb485 100644
--- 1/tests/src/org.jboss/jandex/2.4.2.Final/src/test/java/org_jboss/jandex/IndexerTest.java
+++ 2/tests/src/org.jboss/jandex/3.0.0/src/test/java/org_jboss/jandex/IndexerTest.java
@@ -25,13 +25,15 @@ public class IndexerTest {
     void indexesLoadedClassFromItsClassResource() throws IOException {
         Indexer indexer = new Indexer();
 
-        ClassInfo classInfo = indexer.indexClass(IndexedSample.class);
+        indexer.indexClass(IndexedSample.class);
         Index index = indexer.complete();
+        ClassInfo classInfo = index.getClassByName(IndexedSample.class);
 
+        assertThat(classInfo).isNotNull();
         assertThat(classInfo.name().toString()).isEqualTo(IndexedSample.class.getName());
-        assertThat(classInfo.classAnnotation(DotName.createSimple(SampleAnnotation.class.getName()))).isNotNull();
+        assertThat(classInfo.declaredAnnotation(DotName.createSimple(SampleAnnotation.class.getName()))).isNotNull();
         assertThat(classInfo.firstMethod("value")).isNotNull();
-        assertThat(index.getClassByName(DotName.createSimple(IndexedSample.class.getName()))).isNotNull();
+        assertThat(index.getClassByName(IndexedSample.class)).isSameAs(classInfo);
     }
 
     @SampleAnnotation("sample")
diff --git 1/tests/src/org.jboss/jandex/3.0.0/src/test/java/org_jboss/jandex/JandexReflectionTest.java 2/tests/src/org.jboss/jandex/3.0.0/src/test/java/org_jboss/jandex/JandexReflectionTest.java
new file mode 100644
index 0000000000..4781ed8c87
--- /dev/null
+++ 2/tests/src/org.jboss/jandex/3.0.0/src/test/java/org_jboss/jandex/JandexReflectionTest.java
@@ -0,0 +1,30 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss.jandex;
+
+import org.jboss.jandex.ArrayType;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.JandexReflection;
+import org.jboss.jandex.Type;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JandexReflectionTest {
+    @Test
+    void loadsRawArrayClassFromJandexClassType() {
+        Type componentType = Type.create(DotName.createSimple(SampleType.class.getName()), Type.Kind.CLASS);
+        ArrayType arrayType = ArrayType.create(componentType, 2);
+
+        Class<?> loadedType = JandexReflection.loadRawType(arrayType);
+
+        assertThat(loadedType).isEqualTo(SampleType[][].class);
+    }
+
+    static final class SampleType {
+    }
+}

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
