### PR TITLE
[GenAI] Add support for org.apache.camel:camel-jackson:4.20.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.camel/camel-jackson/4.20.0/reachability-metadata.json
+++ b/metadata/org.apache.camel/camel-jackson/4.20.0/reachability-metadata.json
@@ -1,0 +1,94 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.camel.component.jackson.converter.JacksonTypeConverters"
+      },
+      "type" : "com.fasterxml.jackson.databind.ext.Java7SupportImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.camel.component.jackson.transform.JsonDataTypeTransformer"
+      },
+      "type" : "com.fasterxml.jackson.databind.node.ObjectNode"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.camel.component.jackson.converter.JacksonTypeConverters"
+      },
+      "type" : "java.io.Serializable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.camel.component.jackson.AbstractJacksonDataFormat"
+      },
+      "type" : "java.lang.Class",
+      "methods" : [
+        {
+          "name" : "isRecord",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.camel.component.jackson.converter.JacksonTypeConverters"
+      },
+      "type" : "java.lang.Class",
+      "methods" : [
+        {
+          "name" : "isRecord",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.camel.component.jackson.transform.JsonPojoDataTypeTransformer"
+      },
+      "type" : "java.lang.Class",
+      "methods" : [
+        {
+          "name" : "isRecord",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.camel.component.jackson.converter.JacksonTypeConverters"
+      },
+      "type" : "java.lang.Comparable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.camel.component.jackson.converter.JacksonTypeConverters"
+      },
+      "type" : "java.lang.Double"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.camel.component.jackson.converter.JacksonTypeConverters"
+      },
+      "type" : "java.lang.Number"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.camel.component.jackson.converter.JacksonTypeConverters"
+      },
+      "type" : "java.lang.constant.Constable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.camel.component.jackson.converter.JacksonTypeConverters"
+      },
+      "type" : "java.lang.constant.ConstantDesc"
+    }
+  ]
+}

--- a/metadata/org.apache.camel/camel-jackson/index.json
+++ b/metadata/org.apache.camel/camel-jackson/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.20.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/apache/camel/camel-jackson/$version$/camel-jackson-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/camel",
+    "test-code-url" : "https://github.com/apache/camel/tree/camel-$version$/components/camel-jackson/src/test",
+    "documentation-url" : "https://github.com/apache/camel/blob/camel-$version$/components/camel-jackson/src/main/docs/jackson-dataformat.adoc",
+    "description" : "Apache Camel Jackson provides the JSON Jackson data format for marshalling Java objects to JSON and unmarshalling JSON back to Java objects in Camel routes. It also integrates Jackson with Camel type conversion and JSON data transformers so routes can exchange JSON, JsonNode, and POJO values.",
+    "tested-versions" : [
+      "4.20.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.camel.component.jackson"
+    ]
+  }
+]

--- a/stats/org.apache.camel/camel-jackson/4.20.0/execution-metrics.json
+++ b/stats/org.apache.camel/camel-jackson/4.20.0/execution-metrics.json
@@ -1,0 +1,88 @@
+{
+  "add_new_library_support:2026-06-10": {
+    "timestamp": "2026-06-10T09:56:12.523492Z",
+    "library": "org.apache.camel:camel-jackson:4.20.0",
+    "starting_commit": "967692df683233c2db65cccfc1f0cb07727a47da",
+    "ending_commit": "c540eb269a04bb4a58e0e82287a43ee7bd8ff992",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.20.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1287,
+          "missed": 2195,
+          "ratio": 0.369615,
+          "total": 3482
+        },
+        "line": {
+          "covered": 324,
+          "missed": 555,
+          "ratio": 0.368601,
+          "total": 879
+        },
+        "method": {
+          "covered": 78,
+          "missed": 124,
+          "ratio": 0.386139,
+          "total": 202
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "no_action",
+      "issue_number": 4509,
+      "issue_label": "library-new-request",
+      "library": "org.apache.camel:camel-jackson:4.20.0",
+      "summary": "No extra dependency, Docker image, environment variable, or system property is required. The resolved artifact brings Camel core engine and Jackson databind transitively, and meaningful coverage is reachable by instantiating `JacksonDataFormat` with a `DefaultCamelContext` and exercising marshal/unmarshal directly.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [
+        "Route-style tests using endpoints such as `direct:` or `mock:` may require separate Camel endpoint/test artifacts, but those are not required to exercise `camel-jackson` itself.",
+        "If tests specifically target Camel's Jackson POJO type-converter path, they may need to set CamelContext global options such as `CamelJacksonEnableTypeConverter` and `CamelJacksonTypeConverterToPojo`, but this is optional coverage rather than required setup."
+      ],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#4509 Support for org.apache.camel:camel-jackson:4.20.0; label=library-new-request; body_chars=106"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "0 existing test file path(s) included"
+        }
+      ],
+      "model": "oca/gpt-5.5",
+      "input_tokens_used": 34470,
+      "output_tokens_used": 3916,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.apache.camel:camel-jackson:4.20.0/library-preparation-preflight/pi-generation-2026-06-10T09-22-39-029790Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 311680,
+      "cached_input_tokens_used": 2239488,
+      "output_tokens_used": 20285,
+      "iterations": 4,
+      "cost_usd": 1.7283,
+      "generated_loc": 208,
+      "tested_library_loc": 324,
+      "metadata_entries": 15,
+      "test_only_metadata_entries": 42,
+      "code_coverage_percent": 36.86
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.camel/camel-jackson/4.20.0/src/test/java/org_apache_camel/camel_jackson/Camel_jacksonTest.java",
+      "metadata_file": "metadata/org.apache.camel/camel-jackson/4.20.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.camel/camel-jackson/4.20.0/stats.json
+++ b/stats/org.apache.camel/camel-jackson/4.20.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.20.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1287,
+        "missed" : 2195,
+        "ratio" : 0.369615,
+        "total" : 3482
+      },
+      "line" : {
+        "covered" : 324,
+        "missed" : 555,
+        "ratio" : 0.368601,
+        "total" : 879
+      },
+      "method" : {
+        "covered" : 78,
+        "missed" : 124,
+        "ratio" : 0.386139,
+        "total" : 202
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.camel/camel-jackson/4.20.0/.gitignore
+++ b/tests/src/org.apache.camel/camel-jackson/4.20.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.camel/camel-jackson/4.20.0/build.gradle
+++ b/tests/src/org.apache.camel/camel-jackson/4.20.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.camel:camel-jackson:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.camel/camel-jackson/4.20.0/gradle.properties
+++ b/tests/src/org.apache.camel/camel-jackson/4.20.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.camel:camel-jackson:4.20.0
+library.version = 4.20.0
+metadata.dir = org.apache.camel/camel-jackson/4.20.0/

--- a/tests/src/org.apache.camel/camel-jackson/4.20.0/settings.gradle
+++ b/tests/src/org.apache.camel/camel-jackson/4.20.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.camel.camel-jackson_tests'

--- a/tests/src/org.apache.camel/camel-jackson/4.20.0/src/test/java/org_apache_camel/camel_jackson/Camel_jacksonTest.java
+++ b/tests/src/org.apache.camel/camel-jackson/4.20.0/src/test/java/org_apache_camel/camel_jackson/Camel_jacksonTest.java
@@ -22,8 +22,10 @@ import org.apache.camel.Exchange;
 import org.apache.camel.component.jackson.JacksonConstants;
 import org.apache.camel.component.jackson.JacksonDataFormat;
 import org.apache.camel.component.jackson.ListJacksonDataFormat;
+import org.apache.camel.component.jackson.SchemaHelper;
 import org.apache.camel.component.jackson.converter.JacksonTypeConverters;
 import org.apache.camel.component.jackson.transform.JsonDataTypeTransformer;
+import org.apache.camel.component.jackson.transform.JsonPojoDataTypeTransformer;
 import org.apache.camel.component.jackson.transform.JsonStructDataTypeTransformer;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.spi.DataType;
@@ -172,6 +174,27 @@ public class Camel_jacksonTest {
     }
 
     @Test
+    void transformsJsonPayloadsIntoPojoDataTypes() throws Exception {
+        try (DefaultCamelContext camelContext = new DefaultCamelContext()) {
+            Exchange exchange = new DefaultExchange(camelContext);
+            exchange.setProperty(SchemaHelper.CONTENT_CLASS, RouteEvent.class.getName());
+            exchange.getMessage().setBody(bytes("""
+                    {"route":"direct:orders","attempts":3,"enabled":true}
+                    """));
+            JsonPojoDataTypeTransformer transformer = new JsonPojoDataTypeTransformer();
+            transformer.setCamelContext(camelContext);
+
+            transformer.transform(exchange.getMessage(), DataType.ANY, DataType.ANY);
+
+            RouteEvent event = exchange.getMessage().getBody(RouteEvent.class);
+            assertThat(event.route).isEqualTo("direct:orders");
+            assertThat(event.attempts).isEqualTo(3);
+            assertThat(event.enabled).isTrue();
+            assertThat(exchange.getMessage().getHeader(Exchange.CONTENT_TYPE)).isEqualTo(MimeType.JAVA_OBJECT.type());
+        }
+    }
+
+    @Test
     void transformsJsonPayloadsBetweenTextAndStructuredDataTypes() throws Exception {
         try (DefaultCamelContext camelContext = new DefaultCamelContext()) {
             Exchange exchange = new DefaultExchange(camelContext);
@@ -195,6 +218,12 @@ public class Camel_jacksonTest {
                     .contains("\"steps\":[\"unmarshal\",\"process\"]");
             assertThat(exchange.getMessage().getHeader(Exchange.CONTENT_TYPE)).isEqualTo(MimeType.JSON.type());
         }
+    }
+
+    public static final class RouteEvent {
+        public String route;
+        public int attempts;
+        public boolean enabled;
     }
 
     private static <T extends JacksonDataFormat> T start(T dataFormat, DefaultCamelContext camelContext) {

--- a/tests/src/org.apache.camel/camel-jackson/4.20.0/src/test/java/org_apache_camel/camel_jackson/Camel_jacksonTest.java
+++ b/tests/src/org.apache.camel/camel-jackson/4.20.0/src/test/java/org_apache_camel/camel_jackson/Camel_jacksonTest.java
@@ -23,7 +23,11 @@ import org.apache.camel.component.jackson.JacksonConstants;
 import org.apache.camel.component.jackson.JacksonDataFormat;
 import org.apache.camel.component.jackson.ListJacksonDataFormat;
 import org.apache.camel.component.jackson.converter.JacksonTypeConverters;
+import org.apache.camel.component.jackson.transform.JsonDataTypeTransformer;
+import org.apache.camel.component.jackson.transform.JsonStructDataTypeTransformer;
 import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.spi.DataType;
+import org.apache.camel.spi.MimeType;
 import org.apache.camel.support.DefaultExchange;
 import org.junit.jupiter.api.Test;
 
@@ -164,6 +168,32 @@ public class Camel_jacksonTest {
             assertThat(json).contains("\"component\":\"jackson\"");
             assertThat(parsedFromString).containsEntry("component", "jackson").containsEntry("count", 4);
             assertThat(parsedFromStream).containsEntry("component", "jackson").containsEntry("count", 4);
+        }
+    }
+
+    @Test
+    void transformsJsonPayloadsBetweenTextAndStructuredDataTypes() throws Exception {
+        try (DefaultCamelContext camelContext = new DefaultCamelContext()) {
+            Exchange exchange = new DefaultExchange(camelContext);
+            exchange.getMessage().setBody(bytes("""
+                    {"route":"direct:start","steps":["unmarshal","process"]}
+                    """));
+
+            new JsonStructDataTypeTransformer().transform(exchange.getMessage(), DataType.ANY, DataType.ANY);
+
+            JsonNode structuredBody = exchange.getMessage().getBody(JsonNode.class);
+            assertThat(structuredBody.path("route").asText()).isEqualTo("direct:start");
+            assertThat(structuredBody.path("steps").size()).isEqualTo(2);
+            assertThat(exchange.getMessage().getHeader(Exchange.CONTENT_TYPE)).isEqualTo(MimeType.STRUCT.type());
+
+            new JsonDataTypeTransformer().transform(exchange.getMessage(), DataType.ANY, DataType.ANY);
+
+            byte[] jsonBody = exchange.getMessage().getBody(byte[].class);
+            String rendered = new String(jsonBody, StandardCharsets.UTF_8);
+            assertThat(rendered)
+                    .contains("\"route\":\"direct:start\"")
+                    .contains("\"steps\":[\"unmarshal\",\"process\"]");
+            assertThat(exchange.getMessage().getHeader(Exchange.CONTENT_TYPE)).isEqualTo(MimeType.JSON.type());
         }
     }
 

--- a/tests/src/org.apache.camel/camel-jackson/4.20.0/src/test/java/org_apache_camel/camel_jackson/Camel_jacksonTest.java
+++ b/tests/src/org.apache.camel/camel-jackson/4.20.0/src/test/java/org_apache_camel/camel_jackson/Camel_jacksonTest.java
@@ -6,11 +6,174 @@
  */
 package org_apache_camel.camel_jackson;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.Reader;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.camel.Exchange;
+import org.apache.camel.component.jackson.JacksonConstants;
+import org.apache.camel.component.jackson.JacksonDataFormat;
+import org.apache.camel.component.jackson.ListJacksonDataFormat;
+import org.apache.camel.component.jackson.converter.JacksonTypeConverters;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.DefaultExchange;
 import org.junit.jupiter.api.Test;
 
-class Camel_jacksonTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Camel_jacksonTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void marshalsMapToJsonAndSetsContentTypeHeader() throws Exception {
+        try (DefaultCamelContext camelContext = new DefaultCamelContext()) {
+            Exchange exchange = new DefaultExchange(camelContext);
+            JacksonDataFormat dataFormat = new JacksonDataFormat();
+            dataFormat.setPrettyPrint(true);
+            start(dataFormat, camelContext);
+
+            Map<String, Object> body = new LinkedHashMap<>();
+            body.put("name", "Camel");
+            body.put("active", true);
+            body.put("attempts", 3);
+
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            try {
+                dataFormat.marshal(exchange, body, output);
+            } finally {
+                dataFormat.stop();
+            }
+
+            String json = output.toString(StandardCharsets.UTF_8);
+            assertThat(json).contains(System.lineSeparator()).contains("\"name\" : \"Camel\"");
+            assertThat(exchange.getMessage().getHeader(Exchange.CONTENT_TYPE)).isEqualTo("application/json");
+        }
+    }
+
+    @Test
+    void unmarshalsObjectAndArrayPayloadsDirectlyThroughDataFormats() throws Exception {
+        try (DefaultCamelContext camelContext = new DefaultCamelContext()) {
+            Exchange exchange = new DefaultExchange(camelContext);
+            JacksonDataFormat mapFormat = new JacksonDataFormat();
+            mapFormat.useMap();
+            start(mapFormat, camelContext);
+            ListJacksonDataFormat listFormat = start(new ListJacksonDataFormat(LinkedHashMap.class), camelContext);
+
+            try {
+                Object object = mapFormat.unmarshal(exchange, new ByteArrayInputStream(bytes("""
+                        {"id":"route-1","retries":2,"enabled":true}
+                        """)));
+                Object list = listFormat.unmarshal(exchange, bytes("""
+                        [{"id":"route-1"},{"id":"route-2"}]
+                        """));
+
+                assertThat(object).isInstanceOf(LinkedHashMap.class);
+                assertThat((Map<String, Object>) object)
+                        .containsEntry("id", "route-1")
+                        .containsEntry("retries", 2)
+                        .containsEntry("enabled", true);
+                assertThat(list).isInstanceOf(List.class);
+                assertThat((List<Map<String, Object>>) list)
+                        .extracting(entry -> entry.get("id"))
+                        .containsExactly("route-1", "route-2");
+            } finally {
+                listFormat.stop();
+                mapFormat.stop();
+            }
+        }
+    }
+
+    @Test
+    void supportsHeaderSelectedUnmarshalTypeAndMultipleInputKinds() throws Exception {
+        try (DefaultCamelContext camelContext = new DefaultCamelContext()) {
+            Exchange exchange = new DefaultExchange(camelContext);
+            JacksonDataFormat dataFormat = start(new JacksonDataFormat(LinkedHashMap.class), camelContext);
+            dataFormat.setAllowUnmarshallType(true);
+            exchange.getIn().setHeader(JacksonConstants.UNMARSHAL_TYPE, TreeMap.class.getName());
+
+            try {
+                Object fromString = dataFormat.unmarshal(exchange, "{\"b\":2,\"a\":1}");
+                Object fromReader = dataFormat.unmarshal(exchange, new StringReader("{\"name\":\"reader\"}"));
+                JsonNode jsonNode = dataFormat.getObjectMapper().readTree("{\"name\":\"node\"}");
+                Object fromJsonNode = dataFormat.unmarshal(exchange, jsonNode);
+
+                assertThat(fromString).isInstanceOf(TreeMap.class);
+                assertThat(((Map<String, Object>) fromString).keySet()).containsExactly("a", "b");
+                assertThat(fromReader).isInstanceOf(TreeMap.class);
+                assertThat((Map<String, Object>) fromReader).containsEntry("name", "reader");
+                assertThat(fromJsonNode).isInstanceOf(TreeMap.class);
+                assertThat((Map<String, Object>) fromJsonNode).containsEntry("name", "node");
+            } finally {
+                dataFormat.stop();
+            }
+        }
+    }
+
+    @Test
+    void convertsBetweenJsonNodeAndCamelFriendlyTypes() throws Exception {
+        try (DefaultCamelContext camelContext = new DefaultCamelContext()) {
+            Exchange exchange = new DefaultExchange(camelContext);
+            JacksonTypeConverters converters = new JacksonTypeConverters();
+            Map<String, Object> source = new LinkedHashMap<>();
+            source.put("answer", 42);
+            source.put("flag", true);
+            source.put("ratio", 2.5D);
+
+            JsonNode node = converters.toJsonNode(source, exchange);
+            String rendered = converters.toString(node, exchange);
+            byte[] renderedBytes = converters.toByteArray(node, exchange);
+            InputStream renderedStream = converters.toInputStream(node, exchange);
+            Reader renderedReader = converters.toReader(node, exchange);
+            Map<String, Object> convertedMap = converters.toMap(node, exchange);
+
+            assertThat(node.path("answer").asInt()).isEqualTo(42);
+            assertThat(rendered).contains("\"answer\" : 42");
+            assertThat(converters.toJsonNode(renderedBytes, exchange).path("flag").asBoolean()).isTrue();
+            assertThat(converters.toJsonNode(renderedStream, exchange).path("ratio").asDouble()).isEqualTo(2.5D);
+            assertThat(converters.toJsonNode(renderedReader, exchange).path("answer").asInt()).isEqualTo(42);
+            assertThat(convertedMap).containsEntry("answer", 42).containsEntry("flag", true);
+            assertThat(converters.toInteger(node.path("answer"), exchange)).isEqualTo(42);
+            assertThat(converters.toBoolean(node.path("flag"), exchange)).isTrue();
+            assertThat(converters.toDouble(node.path("ratio"), exchange)).isEqualTo(2.5D);
+        }
+    }
+
+    @Test
+    void typeConverterHonorsGlobalOptionsForJsonRenderingAndParsing() throws Exception {
+        try (DefaultCamelContext camelContext = new DefaultCamelContext()) {
+            camelContext.getGlobalOptions().put(JacksonConstants.ENABLE_TYPE_CONVERTER, "true");
+            camelContext.getGlobalOptions().put(JacksonConstants.TYPE_CONVERTER_TO_POJO, "true");
+            Exchange exchange = new DefaultExchange(camelContext);
+            JacksonTypeConverters converters = new JacksonTypeConverters();
+            Map<String, Object> source = new LinkedHashMap<>();
+            source.put("component", "jackson");
+            source.put("count", 4);
+
+            String json = converters.convertTo(String.class, exchange, source, null);
+            byte[] jsonBytes = converters.convertTo(byte[].class, exchange, source, null);
+            Map<String, Object> parsedFromString = converters.convertTo(Map.class, exchange, json, null);
+            Map<String, Object> parsedFromStream = converters.convertTo(
+                    Map.class, exchange, new ByteArrayInputStream(jsonBytes), null);
+
+            assertThat(json).contains("\"component\":\"jackson\"");
+            assertThat(parsedFromString).containsEntry("component", "jackson").containsEntry("count", 4);
+            assertThat(parsedFromStream).containsEntry("component", "jackson").containsEntry("count", 4);
+        }
+    }
+
+    private static <T extends JacksonDataFormat> T start(T dataFormat, DefaultCamelContext camelContext) {
+        dataFormat.setCamelContext(camelContext);
+        dataFormat.start();
+        return dataFormat;
+    }
+
+    private static byte[] bytes(String content) {
+        return content.getBytes(StandardCharsets.UTF_8);
     }
 }

--- a/tests/src/org.apache.camel/camel-jackson/4.20.0/src/test/java/org_apache_camel/camel_jackson/Camel_jacksonTest.java
+++ b/tests/src/org.apache.camel/camel-jackson/4.20.0/src/test/java/org_apache_camel/camel_jackson/Camel_jacksonTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_camel.camel_jackson;
+
+import org.junit.jupiter.api.Test;
+
+class Camel_jacksonTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.apache.camel/camel-jackson/4.20.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.camel/camel-jackson/4.20.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,251 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "type" : "java.util.TreeMap"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "type" : "org.apache.camel.component.jackson.converter.JacksonTypeConvertersLoader",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "type" : "org.apache.camel.converter.CamelBaseBulkConverterLoader",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "type" : "org.apache.camel.converter.stream.CamelSupportBulkConverterLoader",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "type" : "org.apache.camel.impl.DefaultCamelContext"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.camel.component.jackson.transform.JsonPojoDataTypeTransformer"
+      },
+      "type" : "org_apache_camel.camel_jackson.Camel_jacksonTest$RouteEvent",
+      "fields" : [
+        {
+          "name" : "attempts"
+        },
+        {
+          "name" : "enabled"
+        },
+        {
+          "name" : "route"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "glob" : "META-INF/maven/org.apache.camel/camel-base-engine/pom.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "glob" : "META-INF/services/org.apache.camel.spi.ContextServicePlugin"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "glob" : "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "glob" : "META-INF/services/org/apache/camel/Injector"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "glob" : "META-INF/services/org/apache/camel/TypeConverterLoader"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "glob" : "META-INF/services/org/apache/camel/UberTypeConverterLoader"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "glob" : "META-INF/services/org/apache/camel/cli-connector-factory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "glob" : "META-INF/services/org/apache/camel/dev-console/default-registry"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "glob" : "META-INF/services/org/apache/camel/health-check/default-registry"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "glob" : "META-INF/services/org/apache/camel/lru-cache-factory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "glob" : "META-INF/services/org/apache/camel/management/ManagementStrategyFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "glob" : "META-INF/services/org/apache/camel/model-reifier-factory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "glob" : "META-INF/services/org/apache/camel/reactive-executor"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "glob" : "META-INF/services/org/apache/camel/startup-step-recorder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "glob" : "META-INF/services/org/apache/camel/thread-factory-listener"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "glob" : "META-INF/services/org/apache/camel/thread-pool-factory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "glob" : "org/apache/camel/util/META-INF/services/org/apache/camel/Injector"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "glob" : "org/apache/camel/util/META-INF/services/org/apache/camel/cli-connector-factory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "glob" : "org/apache/camel/util/META-INF/services/org/apache/camel/dev-console/default-registry"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "glob" : "org/apache/camel/util/META-INF/services/org/apache/camel/health-check/default-registry"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "glob" : "org/apache/camel/util/META-INF/services/org/apache/camel/management/ManagementStrategyFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "glob" : "org/apache/camel/util/META-INF/services/org/apache/camel/model-reifier-factory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "glob" : "org/apache/camel/util/META-INF/services/org/apache/camel/reactive-executor"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "glob" : "org/apache/camel/util/META-INF/services/org/apache/camel/startup-step-recorder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "glob" : "org/apache/camel/util/META-INF/services/org/apache/camel/thread-factory-listener"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "glob" : "org/apache/camel/util/META-INF/services/org/apache/camel/thread-pool-factory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_camel.camel_jackson.Camel_jacksonTest"
+      },
+      "glob" : "org/slf4j/impl/StaticLoggerBinder.class"
+    }
+  ]
+}

--- a/tests/src/org.apache.camel/camel-jackson/4.20.0/user-code-filter.json
+++ b/tests/src/org.apache.camel/camel-jackson/4.20.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.apache.camel.component.jackson.**"
+    }
+  ]
+}

--- a/tests/src/org.apache.camel/camel-jackson/4.20.0/user-code-filter.json
+++ b/tests/src/org.apache.camel/camel-jackson/4.20.0/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.apache.camel.component.jackson.**"
+      "includeClasses" : "org.apache.camel.component.jackson.**"
+    },
+    {
+      "includeClasses" : "org_apache_camel.camel_jackson.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #4509

This PR introduces tests and metadata for org.apache.camel:camel-jackson:4.20.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 311680
- Cached input tokens: 2239488
- Output tokens: 20285
- Metadata entries: 15
- Test-only metadata entries: 42
- Iterations: 4
- Library coverage percentage: 36.86
- Generated lines of code: 208
- Tested library lines of code: 324

### Forge

- Forge monitored branch: `forge-dedup-workflow-helpers`
- Forge branch: `forge-dedup-workflow-helpers`
- Forge commit hash: `d83da677856f74a5e0ef17f79b95368804f7562c`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1287/3482 (36.96%)
- Line: 324/879 (36.86%)
- Method: 78/202 (38.61%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
