### PR TITLE
[Automation] Generated metadata for org.apache.lucene:lucene-core:5.3.0

### DIFF
--- a/stats/org.apache.lucene/lucene-core/5.3.0/execution-metrics.json
+++ b/stats/org.apache.lucene/lucene-core/5.3.0/execution-metrics.json
@@ -107,5 +107,142 @@
       "test_file": "tests/src/org.apache.lucene/lucene-core/5.3.0/src/test/java/org_apache_lucene/lucene_core/CommandLineUtilTest.java",
       "metadata_file": "metadata/org.apache.lucene/lucene-core/5.3.0/reachability-metadata.json"
     }
+  },
+  "fix_ni_run:2026-06-10": {
+    "timestamp": "2026-06-10T13:19:01.818281Z",
+    "library": "org.apache.lucene:lucene-core:5.3.0",
+    "starting_commit": "0bf6426ddf42cd032a50b9ff8a38df7e31afca2c",
+    "ending_commit": "77ba2d73f9dbed0f9d1dfc981a1e6ea6baa337ae",
+    "previous_library": "org.apache.lucene:lucene-core:5.5.0",
+    "strategy_name": "library_update_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "5.3.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 29,
+            "totalCalls": 29
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 32,
+        "totalCalls": 32
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4033,
+          "missed": 267479,
+          "ratio": 0.014854,
+          "total": 271512
+        },
+        "line": {
+          "covered": 658,
+          "missed": 48752,
+          "ratio": 0.013317,
+          "total": 49410
+        },
+        "method": {
+          "covered": 163,
+          "missed": 8835,
+          "ratio": 0.018115,
+          "total": 8998
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "5.5.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 29,
+            "totalCalls": 29
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 31,
+        "totalCalls": 31
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4097,
+          "missed": 269593,
+          "ratio": 0.014969,
+          "total": 273690
+        },
+        "line": {
+          "covered": 670,
+          "missed": 49099,
+          "ratio": 0.013462,
+          "total": 49769
+        },
+        "method": {
+          "covered": 166,
+          "missed": 8913,
+          "ratio": 0.018284,
+          "total": 9079
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "degraded",
+      "action": "no_action",
+      "issue_number": 7345,
+      "issue_label": "fails-native-image-run",
+      "library": "org.apache.lucene:lucene-core:5.3.0",
+      "summary": "Library preparation preflight did not produce usable advisory setup.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#7345 [Automation] native-image run fails for org.apache.lucene:lucene-core:5.3.0; label=fails-native-image-run; body_chars=8015"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "34 existing test file path(s) included"
+        }
+      ],
+      "current_library": "org.apache.lucene:lucene-core:5.5.0",
+      "new_version": "5.3.0",
+      "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
+      "model": "oca/gpt-5.5",
+      "prompt_path": "library-preflight-prompt.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.apache.lucene:lucene-core:5.3.0/library-preparation-preflight/pi-generation-2026-06-10T13-08-19-807105Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 0,
+      "cached_input_tokens_used": 0,
+      "output_tokens_used": 0,
+      "iterations": 0,
+      "cost_usd": 0.0,
+      "tested_library_loc": 658,
+      "metadata_entries": 60,
+      "test_only_metadata_entries": 11,
+      "previous_library_metadata_entries": 60,
+      "previous_library_test_only_metadata_entries": 11,
+      "code_coverage_percent": 1.33,
+      "previous_library_coverage_percent": 1.35
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.lucene/lucene-core/5.3.0/src/test/java/org_apache_lucene/lucene_core/CommandLineUtilTest.java",
+      "metadata_file": "metadata/org.apache.lucene/lucene-core/5.3.0/reachability-metadata.json"
+    }
   }
 }

--- a/stats/org.apache.lucene/lucene-core/5.3.0/stats.json
+++ b/stats/org.apache.lucene/lucene-core/5.3.0/stats.json
@@ -20,21 +20,21 @@
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 4056,
-        "missed" : 267456,
-        "ratio" : 0.014939,
+        "covered" : 4033,
+        "missed" : 267479,
+        "ratio" : 0.014854,
         "total" : 271512
       },
       "line" : {
-        "covered" : 664,
-        "missed" : 48746,
-        "ratio" : 0.013439,
+        "covered" : 658,
+        "missed" : 48752,
+        "ratio" : 0.013317,
         "total" : 49410
       },
       "method" : {
-        "covered" : 164,
-        "missed" : 8834,
-        "ratio" : 0.018226,
+        "covered" : 163,
+        "missed" : 8835,
+        "ratio" : 0.018115,
         "total" : 8998
       }
     }


### PR DESCRIPTION
## What does this PR do?

Fixes: oracle/graalvm-reachability-metadata#7345

This PR provides new metadata needed for the org.apache.lucene:lucene-core:5.3.0, addressing Native Image run failures caused by changes in the updated library version.

Summary:
- Metadata entries (previous `org.apache.lucene:lucene-core:5.5.0`): 60
- Test-only metadata entries (previous `org.apache.lucene:lucene-core:5.5.0`): 11
- Metadata entries (new `org.apache.lucene:lucene-core:5.3.0`): 60
- Test-only metadata entries (new `org.apache.lucene:lucene-core:5.3.0`): 11
- Library coverage (previous): 1.35%
- Library coverage (new): 1.33%
- Strategy: library_update_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 0
- Cached input tokens: 0
- Output tokens: 0
- Iterations: 0

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `b63c5eb96a4505ca6edd38bb246c3083a16234e6`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.lucene:lucene-core:5.5.0: 31/31 covered calls (100.00%)
- org.apache.lucene:lucene-core:5.3.0: 32/32 covered calls (100.00%)

**Reflection:**
- org.apache.lucene:lucene-core:5.5.0: 29/29 covered calls (100.00%)
- org.apache.lucene:lucene-core:5.3.0: 29/29 covered calls (100.00%)

**Resources:**
- org.apache.lucene:lucene-core:5.5.0: 2/2 covered calls (100.00%)
- org.apache.lucene:lucene-core:5.3.0: 3/3 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.lucene:lucene-core:5.5.0: 4097/273690 (1.50%)
- org.apache.lucene:lucene-core:5.3.0: 4033/271512 (1.49%)

**Line:**
- org.apache.lucene:lucene-core:5.5.0: 670/49769 (1.35%)
- org.apache.lucene:lucene-core:5.3.0: 658/49410 (1.33%)

**Method:**
- org.apache.lucene:lucene-core:5.5.0: 166/9079 (1.83%)
- org.apache.lucene:lucene-core:5.3.0: 163/8998 (1.81%)


**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.lucene/lucene-core/5.5.0/src/test/java/org_apache_lucene/lucene_core/SPIClassIteratorTest.java 2/tests/src/org.apache.lucene/lucene-core/5.3.0/src/test/java/org_apache_lucene/lucene_core/SPIClassIteratorTest.java
index c5985fdb44..b2cb35cb26 100644
--- 1/tests/src/org.apache.lucene/lucene-core/5.5.0/src/test/java/org_apache_lucene/lucene_core/SPIClassIteratorTest.java
+++ 2/tests/src/org.apache.lucene/lucene-core/5.3.0/src/test/java/org_apache_lucene/lucene_core/SPIClassIteratorTest.java
@@ -30,10 +30,9 @@ public class SPIClassIteratorTest {
 
     @Test
     void findsServiceDefinitionWithSystemClassLoaderResources() {
-        ClassLoader classLoader = ClassLoader.getSystemClassLoader();
         SPIClassIterator<SPIClassIteratorSystemService> iterator = SPIClassIterator.get(
                 SPIClassIteratorSystemService.class,
-                classLoader);
+                null);
 
         assertThat(iterator.hasNext()).isTrue();
         assertThat(iterator.next()).isEqualTo(SPIClassIteratorSystemServiceImplementation.class);

```
### Local CI Verification

- Status: `success`
- Commands run: 0
- Fixup attempts: 0
