### PR TITLE
[Automation] Generated metadata for org.glassfish.hk2:hk2-api:2.5.0

### DIFF
--- a/stats/org.glassfish.hk2/hk2-api/2.5.0/execution-metrics.json
+++ b/stats/org.glassfish.hk2/hk2-api/2.5.0/execution-metrics.json
@@ -107,5 +107,142 @@
       "test_file": "tests/src/org.glassfish.hk2/hk2-api/2.5.0/src/test/java/org_glassfish_hk2/hk2_api/ClasspathDescriptorFileFinderTest.java",
       "metadata_file": "metadata/org.glassfish.hk2/hk2-api/2.5.0/reachability-metadata.json"
     }
+  },
+  "fix_ni_run:2026-06-10": {
+    "timestamp": "2026-06-10T13:27:55.355894Z",
+    "library": "org.glassfish.hk2:hk2-api:2.5.0",
+    "starting_commit": "7c5439061827af319af070b1037f21e2bdb5cb4f",
+    "ending_commit": "7c5439061827af319af070b1037f21e2bdb5cb4f",
+    "previous_library": "org.glassfish.hk2:hk2-api:2.6.0",
+    "strategy_name": "library_update_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.5.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 6,
+            "totalCalls": 6
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 7,
+        "totalCalls": 7
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1309,
+          "missed": 9828,
+          "ratio": 0.117536,
+          "total": 11137
+        },
+        "line": {
+          "covered": 356,
+          "missed": 2154,
+          "ratio": 0.141833,
+          "total": 2510
+        },
+        "method": {
+          "covered": 85,
+          "missed": 499,
+          "ratio": 0.145548,
+          "total": 584
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.6.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 6,
+            "totalCalls": 6
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 7,
+        "totalCalls": 7
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1309,
+          "missed": 9834,
+          "ratio": 0.117473,
+          "total": 11143
+        },
+        "line": {
+          "covered": 356,
+          "missed": 2157,
+          "ratio": 0.141663,
+          "total": 2513
+        },
+        "method": {
+          "covered": 85,
+          "missed": 501,
+          "ratio": 0.145051,
+          "total": 586
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "degraded",
+      "action": "no_action",
+      "issue_number": 7353,
+      "issue_label": "fails-native-image-run",
+      "library": "org.glassfish.hk2:hk2-api:2.5.0",
+      "summary": "Library preparation preflight did not produce usable advisory setup.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#7353 [Automation] native-image run fails for org.glassfish.hk2:hk2-api:2.5.0; label=fails-native-image-run; body_chars=8015"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "26 existing test file path(s) included"
+        }
+      ],
+      "current_library": "org.glassfish.hk2:hk2-api:2.6.0",
+      "new_version": "2.5.0",
+      "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
+      "model": "oca/gpt-5.5",
+      "prompt_path": "library-preflight-prompt.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.glassfish.hk2:hk2-api:2.5.0/library-preparation-preflight/pi-generation-2026-06-10T13-14-02-140703Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 0,
+      "cached_input_tokens_used": 0,
+      "output_tokens_used": 0,
+      "iterations": 0,
+      "cost_usd": 0.0,
+      "tested_library_loc": 356,
+      "metadata_entries": 18,
+      "test_only_metadata_entries": 1,
+      "previous_library_metadata_entries": 18,
+      "previous_library_test_only_metadata_entries": 1,
+      "code_coverage_percent": 14.18,
+      "previous_library_coverage_percent": 14.17
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.glassfish.hk2/hk2-api/2.5.0/src/test/java/org_glassfish_hk2/hk2_api/ClasspathDescriptorFileFinderTest.java",
+      "metadata_file": "metadata/org.glassfish.hk2/hk2-api/2.5.0/reachability-metadata.json"
+    }
   }
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: oracle/graalvm-reachability-metadata#7353

This PR provides new metadata needed for the org.glassfish.hk2:hk2-api:2.5.0, addressing Native Image run failures caused by changes in the updated library version.

Summary:
- Metadata entries (previous `org.glassfish.hk2:hk2-api:2.6.0`): 18
- Test-only metadata entries (previous `org.glassfish.hk2:hk2-api:2.6.0`): 1
- Metadata entries (new `org.glassfish.hk2:hk2-api:2.5.0`): 18
- Test-only metadata entries (new `org.glassfish.hk2:hk2-api:2.5.0`): 1
- Library coverage (previous): 14.17%
- Library coverage (new): 14.18%
- Strategy: library_update_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 0
- Cached input tokens: 0
- Output tokens: 0
- Iterations: 0

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `b63c5eb96a4505ca6edd38bb246c3083a16234e6`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.glassfish.hk2:hk2-api:2.6.0: 7/7 covered calls (100.00%)
- org.glassfish.hk2:hk2-api:2.5.0: 7/7 covered calls (100.00%)

**Reflection:**
- org.glassfish.hk2:hk2-api:2.6.0: 6/6 covered calls (100.00%)
- org.glassfish.hk2:hk2-api:2.5.0: 6/6 covered calls (100.00%)

**Resources:**
- org.glassfish.hk2:hk2-api:2.6.0: 1/1 covered calls (100.00%)
- org.glassfish.hk2:hk2-api:2.5.0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.glassfish.hk2:hk2-api:2.6.0: 1309/11143 (11.75%)
- org.glassfish.hk2:hk2-api:2.5.0: 1309/11137 (11.75%)

**Line:**
- org.glassfish.hk2:hk2-api:2.6.0: 356/2513 (14.17%)
- org.glassfish.hk2:hk2-api:2.5.0: 356/2510 (14.18%)

**Method:**
- org.glassfish.hk2:hk2-api:2.6.0: 85/586 (14.51%)
- org.glassfish.hk2:hk2-api:2.5.0: 85/584 (14.55%)


**Comparison between existing test version and AI-Generated update**

```diff

```
### Local CI Verification

- Status: `success`
- Commands run: 0
- Fixup attempts: 0
