### PR TITLE
[GenAI] Test fix for org.apache.maven.scm:maven-scm-provider-gitexe:2.0.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/reachability-metadata.json
+++ b/metadata/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.maven.scm.provider.git.gitexe.command.GitCommandLineUtils"
+      },
+      "glob" : "org/slf4j/impl/StaticLoggerBinder.class"
+    }
+  ]
+}

--- a/metadata/org.apache.maven.scm/maven-scm-provider-gitexe/index.json
+++ b/metadata/org.apache.maven.scm/maven-scm-provider-gitexe/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.0.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm-provider-gitexe/$version$/maven-scm-provider-gitexe-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/maven-scm",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm/$version$/maven-scm-$version$-source-release.zip",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm-provider-gitexe/$version$/maven-scm-provider-gitexe-$version$-javadoc.jar",
+    "description" : "This artifact provides the Apache Maven SCM provider implementation that talks to Git through the installed Git command-line executable. It lets Maven SCM integrations perform Git operations such as checkout, update, tag, status, and changelog through the shared Maven SCM API.",
     "tested-versions" : [
       "2.0.0"
     ],

--- a/metadata/org.apache.maven.scm/maven-scm-provider-gitexe/index.json
+++ b/metadata/org.apache.maven.scm/maven-scm-provider-gitexe/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.0.0",
+    "tested-versions" : [
+      "2.0.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.maven.scm.provider.git.gitexe"
+    ]
+  },
+  {
     "metadata-version" : "1.11.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm-provider-gitexe/$version$/maven-scm-provider-gitexe-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/maven-scm",

--- a/stats/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/execution-metrics.json
+++ b/stats/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/execution-metrics.json
@@ -1,0 +1,123 @@
+{
+  "fix_javac_fail:2026-06-10": {
+    "timestamp": "2026-06-10T14:37:15.390986Z",
+    "library": "org.apache.maven.scm:maven-scm-provider-gitexe:2.0.0",
+    "starting_commit": "793c2321b7cfc81cd214f5d87260858c967be835",
+    "ending_commit": "dbc1f2d3bf3b7e7f2f0e9053d91eb8b7ce5dc89f",
+    "previous_library": "org.apache.maven.scm:maven-scm-provider-gitexe:1.11.1",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.0.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 806,
+          "missed": 4011,
+          "ratio": 0.167324,
+          "total": 4817
+        },
+        "line": {
+          "covered": 185,
+          "missed": 926,
+          "ratio": 0.166517,
+          "total": 1111
+        },
+        "method": {
+          "covered": 34,
+          "missed": 132,
+          "ratio": 0.204819,
+          "total": 166
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.11.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 750,
+          "missed": 3822,
+          "ratio": 0.164042,
+          "total": 4572
+        },
+        "line": {
+          "covered": 167,
+          "missed": 838,
+          "ratio": 0.166169,
+          "total": 1005
+        },
+        "method": {
+          "covered": 29,
+          "missed": 125,
+          "ratio": 0.188312,
+          "total": 154
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "no_action",
+      "issue_number": 8307,
+      "issue_label": "fails-javac-compile",
+      "library": "org.apache.maven.scm:maven-scm-provider-gitexe:2.0.0",
+      "summary": "No extra Maven dependency, Docker image, environment variable, or system property is required. The 2.0.0 artifact already resolves its needed runtime dependencies; the failure is from 1.x test code using APIs removed or changed in Maven SCM 2.0.0, not from missing setup.",
+      "deterministic_setup": [],
+      "agent_guidance": "For 2.0.0 tests, avoid org.apache.maven.scm.log.DefaultLog because the legacy Maven SCM logging API was removed in favor of SLF4J-backed consumers. Use the 2.0.0 constructors, such as GitStatusConsumer(File), GitRemoteInfoConsumer(String), and an instance of GitRemoteInfoCommand with an environment map before calling createCommandLine. Meaningful coverage can be built with command-line construction and consumer parsing without adding dependencies or external services.",
+      "risks": [
+        "Tests that execute real provider commands may invoke the local git executable; prefer temporary local repositories and avoid network remotes. Ubuntu runners normally include git, but command-construction and parser tests avoid this dependency.",
+        "Adding an old maven-scm-api dependency to restore DefaultLog would mask the actual 2.0.0 API change and risks classpath conflicts.",
+        "SLF4J may run with a no-op binding if no logging backend is present; this is not a setup blocker for tests."
+      ],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#8307 [Automation] javac compile fails for org.apache.maven.scm:maven-scm-provider-gitexe:2.0.0; label=fails-javac-compile; body_chars=8015"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "8 existing test file path(s) included"
+        }
+      ],
+      "current_library": "org.apache.maven.scm:maven-scm-provider-gitexe:1.11.1",
+      "new_version": "2.0.0",
+      "model": "oca/gpt-5.5",
+      "input_tokens_used": 46329,
+      "output_tokens_used": 3694,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.apache.maven.scm:maven-scm-provider-gitexe:2.0.0/library-preparation-preflight/pi-generation-2026-06-10T14-24-51-835874Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 26714,
+      "cached_input_tokens_used": 140800,
+      "output_tokens_used": 1517,
+      "iterations": 1,
+      "cost_usd": 0.1159,
+      "tested_library_loc": 185,
+      "metadata_entries": 1,
+      "test_only_metadata_entries": 2,
+      "previous_library_metadata_entries": 0,
+      "previous_library_test_only_metadata_entries": 2,
+      "code_coverage_percent": 16.65,
+      "previous_library_coverage_percent": 16.62
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/Maven_scm_provider_gitexeTest.java",
+      "metadata_file": "metadata/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/stats.json
+++ b/stats/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.0.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 806,
+        "missed" : 4011,
+        "ratio" : 0.167324,
+        "total" : 4817
+      },
+      "line" : {
+        "covered" : 185,
+        "missed" : 926,
+        "ratio" : 0.166517,
+        "total" : 1111
+      },
+      "method" : {
+        "covered" : 34,
+        "missed" : 132,
+        "ratio" : 0.204819,
+        "total" : 166
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/.gitignore
+++ b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/build.gradle
+++ b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.maven.scm:maven-scm-provider-gitexe:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/gradle.properties
+++ b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.maven.scm:maven-scm-provider-gitexe:2.0.0
+library.version = 2.0.0
+metadata.dir = org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/

--- a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/settings.gradle
+++ b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.maven.scm.maven-scm-provider-gitexe_tests'

--- a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/GitExeCommandLineConstructionTest.java
+++ b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/GitExeCommandLineConstructionTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_scm.maven_scm_provider_gitexe;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.maven.scm.CommandParameter;
+import org.apache.maven.scm.CommandParameters;
+import org.apache.maven.scm.ScmBranch;
+import org.apache.maven.scm.ScmFileSet;
+import org.apache.maven.scm.ScmTag;
+import org.apache.maven.scm.provider.git.gitexe.command.checkin.GitCheckInCommand;
+import org.apache.maven.scm.provider.git.gitexe.command.checkout.GitCheckOutCommand;
+import org.apache.maven.scm.provider.git.gitexe.command.diff.GitDiffCommand;
+import org.apache.maven.scm.provider.git.gitexe.command.info.GitInfoCommand;
+import org.apache.maven.scm.provider.git.gitexe.command.remoteinfo.GitRemoteInfoCommand;
+import org.apache.maven.scm.provider.git.gitexe.command.remove.GitRemoveCommand;
+import org.apache.maven.scm.provider.git.gitexe.command.tag.GitTagCommand;
+import org.apache.maven.scm.provider.git.gitexe.command.update.GitUpdateCommand;
+import org.apache.maven.scm.provider.git.repository.GitScmProviderRepository;
+import org.codehaus.plexus.util.cli.Commandline;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GitExeCommandLineConstructionTest {
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void checkoutUpdateRemoteAndInfoFactoriesBuildExpectedGitArguments() throws Exception {
+        File workingDirectory = temporaryDirectory.toFile();
+        GitScmProviderRepository repository = new GitScmProviderRepository("https://example.invalid/team/project.git");
+        ScmBranch featureBranch = new ScmBranch("feature/native-tests");
+
+        Commandline checkoutCommandLine =
+                GitCheckOutCommand.createCommandLine(repository, workingDirectory, featureBranch);
+        assertGitExecutable(checkoutCommandLine);
+        assertThat(checkoutCommandLine.getWorkingDirectory()).isEqualTo(workingDirectory);
+        assertThat(checkoutCommandLine.getArguments()).containsExactly("checkout", "feature/native-tests");
+
+        Commandline updateCommandLine = GitUpdateCommand.createCommandLine(repository, workingDirectory, featureBranch);
+        assertGitExecutable(updateCommandLine);
+        assertThat(updateCommandLine.getWorkingDirectory()).isEqualTo(workingDirectory);
+        assertThat(updateCommandLine.getArguments())
+                .containsExactly("pull", "https://example.invalid/team/project.git", "feature/native-tests");
+
+        Commandline latestRevisionCommandLine =
+                GitUpdateCommand.createLatestRevisionCommandLine(repository, workingDirectory, featureBranch);
+        assertThat(latestRevisionCommandLine.getArguments())
+                .containsExactly("log", "-n1", "--date-order", "feature/native-tests");
+
+        Commandline remoteInfoCommandLine = GitRemoteInfoCommand.createCommandLine(repository);
+        assertGitExecutable(remoteInfoCommandLine);
+        File temporaryRoot = new File(System.getProperty("java.io.tmpdir"));
+        assertThat(remoteInfoCommandLine.getWorkingDirectory()).isEqualTo(temporaryRoot);
+        assertThat(remoteInfoCommandLine.getArguments())
+                .containsExactly("ls-remote", "https://example.invalid/team/project.git");
+
+        CommandParameters infoParameters = new CommandParameters();
+        infoParameters.setInt(CommandParameter.SCM_SHORT_REVISION_LENGTH, 12);
+        Commandline infoCommandLine = GitInfoCommand.createCommandLine(
+                repository, new ScmFileSet(workingDirectory), infoParameters);
+        assertThat(infoCommandLine.getArguments())
+                .containsExactly("rev-parse", "--verify", "--short=12", "HEAD");
+    }
+
+    @Test
+    void diffTagCommitAndRemoveFactoriesBuildExpectedArguments() throws Exception {
+        File workingDirectory = temporaryDirectory.toFile();
+        Path trackedPath = temporaryDirectory.resolve("tracked.txt");
+        Path messagePath = temporaryDirectory.resolve("message.txt");
+        Path removableDirectory = temporaryDirectory.resolve("directory-to-remove");
+        Files.writeString(trackedPath, "content\n", StandardCharsets.UTF_8);
+        Files.writeString(messagePath, "message\n", StandardCharsets.UTF_8);
+        Files.createDirectories(removableDirectory);
+
+        GitScmProviderRepository repository = new GitScmProviderRepository("https://example.invalid/team/project.git");
+        ScmTag startTag = new ScmTag("v1.0.0");
+        ScmTag endTag = new ScmTag("v1.1.0");
+
+        Commandline cachedDiffCommandLine = GitDiffCommand.createCommandLine(workingDirectory, startTag, endTag, true);
+        assertGitExecutable(cachedDiffCommandLine);
+        assertThat(cachedDiffCommandLine.getArguments())
+                .containsExactly("diff", "--cached", "v1.0.0", "v1.1.0");
+
+        Commandline rawDiffCommandLine = GitDiffCommand.createDiffRawCommandLine(workingDirectory, "HEAD");
+        assertThat(rawDiffCommandLine.getArguments()).containsExactly("diff", "--raw", "HEAD");
+
+        Commandline tagCommandLine = GitTagCommand.createCommandLine(
+                repository, workingDirectory, "v1.1.0", messagePath.toFile(), false);
+        assertThat(tagCommandLine.getArguments())
+                .containsExactly("tag", "-F", messagePath.toAbsolutePath().toString(), "v1.1.0");
+
+        Commandline signedTagCommandLine = GitTagCommand.createCommandLine(
+                repository, workingDirectory, "v1.1.0", messagePath.toFile(), true);
+        assertThat(signedTagCommandLine.getArguments())
+                .containsExactly("tag", "-s", "-F", messagePath.toAbsolutePath().toString(), "v1.1.0");
+
+        Commandline tagPushCommandLine = GitTagCommand.createPushCommandLine(
+                repository, new ScmFileSet(workingDirectory, trackedPath.toFile()), "v1.1.0");
+        assertThat(tagPushCommandLine.getArguments())
+                .containsExactly("push", "https://example.invalid/team/project.git", "refs/tags/v1.1.0");
+
+        ScmFileSet trackedFileSet = new ScmFileSet(workingDirectory, trackedPath.toFile());
+        Commandline commitCommandLine =
+                GitCheckInCommand.createCommitCommandLine(repository, trackedFileSet, messagePath.toFile());
+        assertThat(commitCommandLine.getArguments())
+                .containsExactly("commit", "--verbose", "-F", messagePath.toAbsolutePath().toString());
+
+        Commandline removeCommandLine = GitRemoveCommand.createCommandLine(
+                workingDirectory, List.of(removableDirectory.toFile(), trackedPath.toFile()));
+        assertThat(removeCommandLine.getArguments()).contains("rm", "-r", "directory-to-remove", "tracked.txt");
+    }
+
+    private static void assertGitExecutable(Commandline commandLine) {
+        assertThat(commandLine.getExecutable()).isIn("git", "'git'");
+    }
+}

--- a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/GitExeCommandLineConstructionTest.java
+++ b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/GitExeCommandLineConstructionTest.java
@@ -11,6 +11,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.maven.scm.CommandParameter;
 import org.apache.maven.scm.CommandParameters;
@@ -59,7 +60,7 @@ public class GitExeCommandLineConstructionTest {
         assertThat(latestRevisionCommandLine.getArguments())
                 .containsExactly("log", "-n1", "--date-order", "feature/native-tests");
 
-        Commandline remoteInfoCommandLine = GitRemoteInfoCommand.createCommandLine(repository);
+        Commandline remoteInfoCommandLine = new GitRemoteInfoCommand(Map.of()).createCommandLine(repository);
         assertGitExecutable(remoteInfoCommandLine);
         File temporaryRoot = new File(System.getProperty("java.io.tmpdir"));
         assertThat(remoteInfoCommandLine.getWorkingDirectory()).isEqualTo(temporaryRoot);

--- a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/Maven_scm_provider_gitexeTest.java
+++ b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/Maven_scm_provider_gitexeTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_scm.maven_scm_provider_gitexe;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.maven.scm.ScmFile;
+import org.apache.maven.scm.ScmFileStatus;
+import org.apache.maven.scm.command.remoteinfo.RemoteInfoScmResult;
+import org.apache.maven.scm.log.DefaultLog;
+import org.apache.maven.scm.provider.git.gitexe.command.remoteinfo.GitRemoteInfoConsumer;
+import org.apache.maven.scm.provider.git.gitexe.command.status.GitStatusConsumer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+public class Maven_scm_provider_gitexeTest {
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void statusConsumerParsesPorcelainStatusOutputIntoScmFiles() throws Exception {
+        Path addedPath = temporaryDirectory.resolve("added.txt");
+        Path modifiedPath = temporaryDirectory.resolve("modified.txt");
+        Path renamedPath = temporaryDirectory.resolve("renamed.txt");
+        Path spacedPath = temporaryDirectory.resolve("space name.txt");
+        Files.writeString(addedPath, "added\n", StandardCharsets.UTF_8);
+        Files.writeString(modifiedPath, "modified\n", StandardCharsets.UTF_8);
+        Files.writeString(renamedPath, "renamed\n", StandardCharsets.UTF_8);
+        Files.writeString(spacedPath, "spaced\n", StandardCharsets.UTF_8);
+
+        GitStatusConsumer consumer = new GitStatusConsumer(new DefaultLog(), temporaryDirectory.toFile());
+        consumer.consumeLine("A  added.txt");
+        consumer.consumeLine(" M modified.txt");
+        consumer.consumeLine(" D deleted.txt");
+        consumer.consumeLine("R  old-name.txt -> renamed.txt");
+        consumer.consumeLine(" M \"space name.txt\"");
+        consumer.consumeLine("?? ignored-by-maven-scm.txt");
+
+        assertThat(consumer.getChangedFiles())
+                .extracting(ScmFile::getPath, ScmFile::getStatus)
+                .containsExactly(
+                        tuple("added.txt", ScmFileStatus.ADDED),
+                        tuple("modified.txt", ScmFileStatus.MODIFIED),
+                        tuple("deleted.txt", ScmFileStatus.DELETED),
+                        tuple("old-name.txt", ScmFileStatus.RENAMED),
+                        tuple("renamed.txt", ScmFileStatus.RENAMED),
+                        tuple("space name.txt", ScmFileStatus.MODIFIED));
+    }
+
+    @Test
+    void remoteInfoConsumerParsesBranchesAndTagsFromLsRemoteOutput() {
+        GitRemoteInfoConsumer consumer = new GitRemoteInfoConsumer(new DefaultLog(), "git ls-remote origin");
+        consumer.consumeLine("1111111111111111111111111111111111111111\trefs/heads/main");
+        consumer.consumeLine("2222222222222222222222222222222222222222 refs/heads/feature/native-tests");
+        consumer.consumeLine("3333333333333333333333333333333333333333\trefs/tags/v1.0.0");
+        consumer.consumeLine("4444444444444444444444444444444444444444 refs/pull/7/head");
+
+        RemoteInfoScmResult result = consumer.getRemoteInfoScmResult();
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getCommandLine()).isEqualTo("git ls-remote origin");
+        assertThat(result.getBranches())
+                .containsEntry("main", "1111111111111111111111111111111111111111")
+                .containsEntry("feature/native-tests", "2222222222222222222222222222222222222222")
+                .hasSize(2);
+        assertThat(result.getTags())
+                .containsEntry("v1.0.0", "3333333333333333333333333333333333333333")
+                .hasSize(1);
+    }
+}

--- a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/Maven_scm_provider_gitexeTest.java
+++ b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/Maven_scm_provider_gitexeTest.java
@@ -13,7 +13,6 @@ import java.nio.file.Path;
 import org.apache.maven.scm.ScmFile;
 import org.apache.maven.scm.ScmFileStatus;
 import org.apache.maven.scm.command.remoteinfo.RemoteInfoScmResult;
-import org.apache.maven.scm.log.DefaultLog;
 import org.apache.maven.scm.provider.git.gitexe.command.remoteinfo.GitRemoteInfoConsumer;
 import org.apache.maven.scm.provider.git.gitexe.command.status.GitStatusConsumer;
 import org.junit.jupiter.api.Test;
@@ -37,7 +36,7 @@ public class Maven_scm_provider_gitexeTest {
         Files.writeString(renamedPath, "renamed\n", StandardCharsets.UTF_8);
         Files.writeString(spacedPath, "spaced\n", StandardCharsets.UTF_8);
 
-        GitStatusConsumer consumer = new GitStatusConsumer(new DefaultLog(), temporaryDirectory.toFile());
+        GitStatusConsumer consumer = new GitStatusConsumer(temporaryDirectory.toFile());
         consumer.consumeLine("A  added.txt");
         consumer.consumeLine(" M modified.txt");
         consumer.consumeLine(" D deleted.txt");
@@ -58,7 +57,7 @@ public class Maven_scm_provider_gitexeTest {
 
     @Test
     void remoteInfoConsumerParsesBranchesAndTagsFromLsRemoteOutput() {
-        GitRemoteInfoConsumer consumer = new GitRemoteInfoConsumer(new DefaultLog(), "git ls-remote origin");
+        GitRemoteInfoConsumer consumer = new GitRemoteInfoConsumer("git ls-remote origin");
         consumer.consumeLine("1111111111111111111111111111111111111111\trefs/heads/main");
         consumer.consumeLine("2222222222222222222222222222222222222222 refs/heads/feature/native-tests");
         consumer.consumeLine("3333333333333333333333333333333333333333\trefs/tags/v1.0.0");

--- a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org_apache_maven_scm.maven_scm_provider_gitexe.GitExeCommandLineConstructionTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_maven_scm.maven_scm_provider_gitexe.GitExeCommandLineConstructionTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/user-code-filter.json
+++ b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.maven.scm.provider.git.gitexe.**"
+    },
+    {
+      "includeClasses" : "org_apache_maven_scm.maven_scm_provider_gitexe.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #8307

This PR provides test fixes and new metadata for org.apache.maven.scm:maven-scm-provider-gitexe:2.0.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 26714
- Cached input tokens: 140800
- Output tokens: 1517
- Metadata entries: 1
- Test-only metadata entries: 2
- Iterations: 1
- Library coverage percentage: 16.65
- Previous library version metadata entries: 0
- Previous library version test-only metadata entries: 2
- Previous library version coverage percentage: 16.62

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `90f07ca4185f5cf4214f8c3a290871559f63524f`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.maven.scm:maven-scm-provider-gitexe:1.11.1: 0/0 covered calls (100.00%)
- org.apache.maven.scm:maven-scm-provider-gitexe:2.0.0: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.maven.scm:maven-scm-provider-gitexe:1.11.1: 750/4572 (16.40%)
- org.apache.maven.scm:maven-scm-provider-gitexe:2.0.0: 806/4817 (16.73%)

**Line:**
- org.apache.maven.scm:maven-scm-provider-gitexe:1.11.1: 167/1005 (16.62%)
- org.apache.maven.scm:maven-scm-provider-gitexe:2.0.0: 185/1111 (16.65%)

**Method:**
- org.apache.maven.scm:maven-scm-provider-gitexe:1.11.1: 29/154 (18.83%)
- org.apache.maven.scm:maven-scm-provider-gitexe:2.0.0: 34/166 (20.48%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/1.11.1/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/GitExeCommandLineConstructionTest.java b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/GitExeCommandLineConstructionTest.java
index 4fef424cf5..23d0d036a2 100644
--- a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/1.11.1/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/GitExeCommandLineConstructionTest.java
+++ b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/GitExeCommandLineConstructionTest.java
@@ -11,6 +11,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.maven.scm.CommandParameter;
 import org.apache.maven.scm.CommandParameters;
@@ -59,7 +60,7 @@ public class GitExeCommandLineConstructionTest {
         assertThat(latestRevisionCommandLine.getArguments())
                 .containsExactly("log", "-n1", "--date-order", "feature/native-tests");
 
-        Commandline remoteInfoCommandLine = GitRemoteInfoCommand.createCommandLine(repository);
+        Commandline remoteInfoCommandLine = new GitRemoteInfoCommand(Map.of()).createCommandLine(repository);
         assertGitExecutable(remoteInfoCommandLine);
         File temporaryRoot = new File(System.getProperty("java.io.tmpdir"));
         assertThat(remoteInfoCommandLine.getWorkingDirectory()).isEqualTo(temporaryRoot);
diff --git a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/1.11.1/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/Maven_scm_provider_gitexeTest.java b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/Maven_scm_provider_gitexeTest.java
index ef2bf5939b..75b860bded 100644
--- a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/1.11.1/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/Maven_scm_provider_gitexeTest.java
+++ b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/Maven_scm_provider_gitexeTest.java
@@ -13,7 +13,6 @@ import java.nio.file.Path;
 import org.apache.maven.scm.ScmFile;
 import org.apache.maven.scm.ScmFileStatus;
 import org.apache.maven.scm.command.remoteinfo.RemoteInfoScmResult;
-import org.apache.maven.scm.log.DefaultLog;
 import org.apache.maven.scm.provider.git.gitexe.command.remoteinfo.GitRemoteInfoConsumer;
 import org.apache.maven.scm.provider.git.gitexe.command.status.GitStatusConsumer;
 import org.junit.jupiter.api.Test;
@@ -37,7 +36,7 @@ public class Maven_scm_provider_gitexeTest {
         Files.writeString(renamedPath, "renamed\n", StandardCharsets.UTF_8);
         Files.writeString(spacedPath, "spaced\n", StandardCharsets.UTF_8);
 
-        GitStatusConsumer consumer = new GitStatusConsumer(new DefaultLog(), temporaryDirectory.toFile());
+        GitStatusConsumer consumer = new GitStatusConsumer(temporaryDirectory.toFile());
         consumer.consumeLine("A  added.txt");
         consumer.consumeLine(" M modified.txt");
         consumer.consumeLine(" D deleted.txt");
@@ -58,7 +57,7 @@ public class Maven_scm_provider_gitexeTest {
 
     @Test
     void remoteInfoConsumerParsesBranchesAndTagsFromLsRemoteOutput() {
-        GitRemoteInfoConsumer consumer = new GitRemoteInfoConsumer(new DefaultLog(), "git ls-remote origin");
+        GitRemoteInfoConsumer consumer = new GitRemoteInfoConsumer("git ls-remote origin");
         consumer.consumeLine("1111111111111111111111111111111111111111\trefs/heads/main");
         consumer.consumeLine("2222222222222222222222222222222222222222 refs/heads/feature/native-tests");
         consumer.consumeLine("3333333333333333333333333333333333333333\trefs/tags/v1.0.0");

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
