### PR TITLE
[GenAI] Add support for org.jetbrains.kotlinx:kotlinx-coroutines-swing:1.10.2 using gpt-5.5

### DIFF
--- a/metadata/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/reachability-metadata.json
+++ b/metadata/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/reachability-metadata.json
@@ -1,0 +1,1745 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "com.sun.swing.internal.plaf.basic.resources.basic"
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "com.sun.swing.internal.plaf.metal.resources.metal"
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "java.awt.AlphaComposite",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "extraAlpha"
+        },
+        {
+          "name": "rule"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "java.awt.Color",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "getRGB",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "java.awt.Component",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "appContext"
+        },
+        {
+          "name": "background"
+        },
+        {
+          "name": "foreground"
+        },
+        {
+          "name": "graphicsConfig"
+        },
+        {
+          "name": "height"
+        },
+        {
+          "name": "isPacked"
+        },
+        {
+          "name": "name"
+        },
+        {
+          "name": "peer"
+        },
+        {
+          "name": "width"
+        },
+        {
+          "name": "x"
+        },
+        {
+          "name": "y"
+        }
+      ],
+      "methods": [
+        {
+          "name": "getLocationOnScreen_NoTreeLock",
+          "parameterTypes": []
+        },
+        {
+          "name": "getParent_NoClientCode",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "java.awt.GraphicsEnvironment",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "isHeadless",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "java.awt.Rectangle",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "int",
+            "int",
+            "int",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "java.awt.event.KeyEvent",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "VK_RIGHT"
+        },
+        {
+          "name": "VK_SPACE"
+        },
+        {
+          "name": "isProxyActive"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "java.awt.geom.AffineTransform",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "m00"
+        },
+        {
+          "name": "m01"
+        },
+        {
+          "name": "m02"
+        },
+        {
+          "name": "m10"
+        },
+        {
+          "name": "m11"
+        },
+        {
+          "name": "m12"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "java.awt.geom.GeneralPath",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "int",
+            "byte[]",
+            "int",
+            "float[]",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "java.awt.geom.Path2D",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "numTypes"
+        },
+        {
+          "name": "pointTypes"
+        },
+        {
+          "name": "windingRule"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "java.awt.geom.Path2D$Float",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "floatCoords"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "java.awt.geom.Point2D$Float",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "x"
+        },
+        {
+          "name": "y"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "float",
+            "float"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "java.awt.geom.Rectangle2D$Float",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "height"
+        },
+        {
+          "name": "width"
+        },
+        {
+          "name": "x"
+        },
+        {
+          "name": "y"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "float",
+            "float",
+            "float",
+            "float"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "java.awt.image.ColorModel",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "colorSpace"
+        },
+        {
+          "name": "colorSpaceType"
+        },
+        {
+          "name": "isAlphaPremultiplied"
+        },
+        {
+          "name": "is_sRGB"
+        },
+        {
+          "name": "nBits"
+        },
+        {
+          "name": "numComponents"
+        },
+        {
+          "name": "supportsAlpha"
+        },
+        {
+          "name": "transparency"
+        }
+      ],
+      "methods": [
+        {
+          "name": "getRGBdefault",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "java.awt.image.ComponentSampleModel",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "bandOffsets"
+        },
+        {
+          "name": "bankIndices"
+        },
+        {
+          "name": "numBands"
+        },
+        {
+          "name": "numBanks"
+        },
+        {
+          "name": "pixelStride"
+        },
+        {
+          "name": "scanlineStride"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "java.awt.image.IndexColorModel",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "allgrayopaque"
+        },
+        {
+          "name": "map_size"
+        },
+        {
+          "name": "rgb"
+        },
+        {
+          "name": "transparent_index"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "java.awt.image.Raster",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "dataBuffer"
+        },
+        {
+          "name": "height"
+        },
+        {
+          "name": "minX"
+        },
+        {
+          "name": "minY"
+        },
+        {
+          "name": "numBands"
+        },
+        {
+          "name": "numDataElements"
+        },
+        {
+          "name": "parent"
+        },
+        {
+          "name": "sampleModel"
+        },
+        {
+          "name": "sampleModelTranslateX"
+        },
+        {
+          "name": "sampleModelTranslateY"
+        },
+        {
+          "name": "width"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "java.awt.image.SampleModel",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "dataType"
+        },
+        {
+          "name": "height"
+        },
+        {
+          "name": "numBands"
+        },
+        {
+          "name": "width"
+        }
+      ],
+      "methods": [
+        {
+          "name": "getDataElements",
+          "parameterTypes": [
+            "int",
+            "int",
+            "java.lang.Object",
+            "java.awt.image.DataBuffer"
+          ]
+        },
+        {
+          "name": "getPixels",
+          "parameterTypes": [
+            "int",
+            "int",
+            "int",
+            "int",
+            "int[]",
+            "java.awt.image.DataBuffer"
+          ]
+        },
+        {
+          "name": "getSample",
+          "parameterTypes": [
+            "int",
+            "int",
+            "int",
+            "java.awt.image.DataBuffer"
+          ]
+        },
+        {
+          "name": "setDataElements",
+          "parameterTypes": [
+            "int",
+            "int",
+            "java.lang.Object",
+            "java.awt.image.DataBuffer"
+          ]
+        },
+        {
+          "name": "setPixels",
+          "parameterTypes": [
+            "int",
+            "int",
+            "int",
+            "int",
+            "int[]",
+            "java.awt.image.DataBuffer"
+          ]
+        },
+        {
+          "name": "setSample",
+          "parameterTypes": [
+            "int",
+            "int",
+            "int",
+            "int",
+            "java.awt.image.DataBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "java.lang.System",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "load",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "javax.swing.plaf.basic.BasicListUI",
+      "methods": [
+        {
+          "name": "createUI",
+          "parameterTypes": [
+            "javax.swing.JComponent"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "javax.swing.plaf.basic.BasicMenuItemUI",
+      "methods": [
+        {
+          "name": "createUI",
+          "parameterTypes": [
+            "javax.swing.JComponent"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "javax.swing.plaf.basic.BasicPanelUI",
+      "methods": [
+        {
+          "name": "createUI",
+          "parameterTypes": [
+            "javax.swing.JComponent"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "javax.swing.plaf.basic.BasicPopupMenuUI",
+      "methods": [
+        {
+          "name": "createUI",
+          "parameterTypes": [
+            "javax.swing.JComponent"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "javax.swing.plaf.basic.BasicTableHeaderUI",
+      "methods": [
+        {
+          "name": "createUI",
+          "parameterTypes": [
+            "javax.swing.JComponent"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "javax.swing.plaf.basic.BasicTableUI",
+      "methods": [
+        {
+          "name": "createUI",
+          "parameterTypes": [
+            "javax.swing.JComponent"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "javax.swing.plaf.basic.BasicViewportUI",
+      "methods": [
+        {
+          "name": "createUI",
+          "parameterTypes": [
+            "javax.swing.JComponent"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "javax.swing.plaf.metal.MetalButtonUI",
+      "methods": [
+        {
+          "name": "createUI",
+          "parameterTypes": [
+            "javax.swing.JComponent"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "javax.swing.plaf.metal.MetalComboBoxUI",
+      "methods": [
+        {
+          "name": "createUI",
+          "parameterTypes": [
+            "javax.swing.JComponent"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "javax.swing.plaf.metal.MetalLabelUI",
+      "methods": [
+        {
+          "name": "createUI",
+          "parameterTypes": [
+            "javax.swing.JComponent"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "javax.swing.plaf.metal.MetalScrollBarUI",
+      "methods": [
+        {
+          "name": "createUI",
+          "parameterTypes": [
+            "javax.swing.JComponent"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "javax.swing.plaf.metal.MetalScrollPaneUI",
+      "methods": [
+        {
+          "name": "createUI",
+          "parameterTypes": [
+            "javax.swing.JComponent"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "javax.swing.plaf.metal.MetalTextFieldUI",
+      "methods": [
+        {
+          "name": "createUI",
+          "parameterTypes": [
+            "javax.swing.JComponent"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.awt.SunHints",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "INTVAL_STROKE_PURE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.awt.SunToolkit",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "awtLock",
+          "parameterTypes": []
+        },
+        {
+          "name": "awtLockNotify",
+          "parameterTypes": []
+        },
+        {
+          "name": "awtLockNotifyAll",
+          "parameterTypes": []
+        },
+        {
+          "name": "awtLockWait",
+          "parameterTypes": [
+            "long"
+          ]
+        },
+        {
+          "name": "awtUnlock",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.awt.X11.XErrorHandlerUtil",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "init",
+          "parameterTypes": [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.awt.X11.XToolkit",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "modLockIsShiftLock"
+        },
+        {
+          "name": "numLockMask"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.awt.image.ByteComponentRaster",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "bandOffset"
+        },
+        {
+          "name": "data"
+        },
+        {
+          "name": "dataOffsets"
+        },
+        {
+          "name": "pixelStride"
+        },
+        {
+          "name": "scanlineStride"
+        },
+        {
+          "name": "type"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.awt.image.GifImageDecoder",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "outCode"
+        },
+        {
+          "name": "prefix"
+        },
+        {
+          "name": "suffix"
+        }
+      ],
+      "methods": [
+        {
+          "name": "readBytes",
+          "parameterTypes": [
+            "byte[]",
+            "int",
+            "int"
+          ]
+        },
+        {
+          "name": "sendPixels",
+          "parameterTypes": [
+            "int",
+            "int",
+            "int",
+            "int",
+            "byte[]",
+            "java.awt.image.ColorModel"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.awt.image.ImageRepresentation",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "numSrcLUT"
+        },
+        {
+          "name": "srcLUTtransIndex"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.awt.resources.awt"
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.font.CharToGlyphMapper",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "charToGlyph",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.font.Font2D",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "canDisplay",
+          "parameterTypes": [
+            "char"
+          ]
+        },
+        {
+          "name": "charToGlyphRaw",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "charToVariationGlyphRaw",
+          "parameterTypes": [
+            "int",
+            "int"
+          ]
+        },
+        {
+          "name": "getMapper",
+          "parameterTypes": []
+        },
+        {
+          "name": "getTableBytes",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.font.FontStrike",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "getGlyphMetrics",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.font.FontUtilities",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "debugFonts",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.font.FreetypeFontScaler",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "invalidateScaler",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.font.GlyphList",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "gposx"
+        },
+        {
+          "name": "gposy"
+        },
+        {
+          "name": "images"
+        },
+        {
+          "name": "lcdRGBOrder"
+        },
+        {
+          "name": "lcdSubPixPos"
+        },
+        {
+          "name": "len"
+        },
+        {
+          "name": "positions"
+        },
+        {
+          "name": "usePositions"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.font.PhysicalStrike",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "pScalerContext"
+        }
+      ],
+      "methods": [
+        {
+          "name": "adjustPoint",
+          "parameterTypes": [
+            "java.awt.geom.Point2D$Float"
+          ]
+        },
+        {
+          "name": "getGlyphPoint",
+          "parameterTypes": [
+            "int",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.font.StrikeMetrics",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "float",
+            "float",
+            "float",
+            "float",
+            "float",
+            "float",
+            "float",
+            "float",
+            "float",
+            "float"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.font.TrueTypeFont",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "readBlock",
+          "parameterTypes": [
+            "java.nio.ByteBuffer",
+            "int",
+            "int"
+          ]
+        },
+        {
+          "name": "readBytes",
+          "parameterTypes": [
+            "int",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.font.Type1Font",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "readFile",
+          "parameterTypes": [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.Disposer",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "addRecord",
+          "parameterTypes": [
+            "java.lang.Object",
+            "long",
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.InvalidPipeException",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.NullSurfaceData",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.SunGraphics2D",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "clipRegion"
+        },
+        {
+          "name": "composite"
+        },
+        {
+          "name": "eargb"
+        },
+        {
+          "name": "lcdTextContrast"
+        },
+        {
+          "name": "pixel"
+        },
+        {
+          "name": "strokeHint"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.SurfaceData",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "pData"
+        },
+        {
+          "name": "valid"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.loops.Blit",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.loops.BlitBg",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.loops.CompositeType",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "AnyAlpha"
+        },
+        {
+          "name": "Src"
+        },
+        {
+          "name": "SrcNoEa"
+        },
+        {
+          "name": "SrcOver"
+        },
+        {
+          "name": "SrcOverNoEa"
+        },
+        {
+          "name": "Xor"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.loops.DrawGlyphList",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.loops.DrawGlyphListAA",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.loops.DrawGlyphListLCD",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.loops.DrawLine",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.loops.DrawParallelogram",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.loops.DrawPath",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.loops.DrawPolygons",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.loops.DrawRect",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.loops.FillParallelogram",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.loops.FillPath",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.loops.FillRect",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.loops.FillSpans",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.loops.GraphicsPrimitive",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "pNativePrim"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.loops.GraphicsPrimitiveMgr",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "register",
+          "parameterTypes": [
+            "sun.java2d.loops.GraphicsPrimitive[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.loops.GraphicsPrimitive[]"
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.loops.MaskBlit",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.loops.MaskFill",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.loops.ScaledBlit",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.loops.SurfaceType",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "Any3Byte"
+        },
+        {
+          "name": "Any4Byte"
+        },
+        {
+          "name": "AnyByte"
+        },
+        {
+          "name": "AnyColor"
+        },
+        {
+          "name": "AnyInt"
+        },
+        {
+          "name": "AnyShort"
+        },
+        {
+          "name": "ByteBinary1Bit"
+        },
+        {
+          "name": "ByteBinary2Bit"
+        },
+        {
+          "name": "ByteBinary4Bit"
+        },
+        {
+          "name": "ByteGray"
+        },
+        {
+          "name": "ByteIndexed"
+        },
+        {
+          "name": "ByteIndexedBm"
+        },
+        {
+          "name": "FourByteAbgr"
+        },
+        {
+          "name": "FourByteAbgrPre"
+        },
+        {
+          "name": "Index12Gray"
+        },
+        {
+          "name": "Index8Gray"
+        },
+        {
+          "name": "IntArgb"
+        },
+        {
+          "name": "IntArgbBm"
+        },
+        {
+          "name": "IntArgbPre"
+        },
+        {
+          "name": "IntBgr"
+        },
+        {
+          "name": "IntRgb"
+        },
+        {
+          "name": "IntRgbx"
+        },
+        {
+          "name": "OpaqueColor"
+        },
+        {
+          "name": "ThreeByteBgr"
+        },
+        {
+          "name": "Ushort4444Argb"
+        },
+        {
+          "name": "Ushort555Rgb"
+        },
+        {
+          "name": "Ushort555Rgbx"
+        },
+        {
+          "name": "Ushort565Rgb"
+        },
+        {
+          "name": "UshortGray"
+        },
+        {
+          "name": "UshortIndexed"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.loops.TransformHelper",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.loops.XORComposite",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "alphaMask"
+        },
+        {
+          "name": "xorColor"
+        },
+        {
+          "name": "xorPixel"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.marlin.DMarlinRenderingEngine",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.pipe.Region",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "bands"
+        },
+        {
+          "name": "endIndex"
+        },
+        {
+          "name": "hix"
+        },
+        {
+          "name": "hiy"
+        },
+        {
+          "name": "lox"
+        },
+        {
+          "name": "loy"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.pipe.RegionIterator",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "curIndex"
+        },
+        {
+          "name": "numXbands"
+        },
+        {
+          "name": "region"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "type": "sun.java2d.xr.XRSurfaceData",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "picture"
+        },
+        {
+          "name": "xid"
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "bundle": "com.sun.swing.internal.plaf.basic.resources.basic"
+    },
+    {
+      "bundle": "com.sun.swing.internal.plaf.metal.resources.metal"
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "module": "java.desktop",
+      "glob": "javax/swing/plaf/metal/icons/*.gif"
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "module": "java.desktop",
+      "glob": "javax/swing/plaf/metal/icons/ocean/*.gif"
+    },
+    {
+      "condition": {
+        "typeReached": "kotlinx.coroutines.swing.Swing"
+      },
+      "module": "java.desktop",
+      "glob": "javax/swing/plaf/metal/icons/ocean/*.png"
+    }
+  ]
+}

--- a/metadata/org.jetbrains.kotlinx/kotlinx-coroutines-swing/index.json
+++ b/metadata/org.jetbrains.kotlinx/kotlinx-coroutines-swing/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.10.2",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-swing/$version$/kotlinx-coroutines-swing-$version$-sources.jar",
+    "repository-url" : "https://github.com/Kotlin/kotlinx.coroutines",
+    "test-code-url" : "https://github.com/Kotlin/kotlinx.coroutines/tree/$version$/ui/kotlinx-coroutines-swing/test",
+    "documentation-url" : "https://github.com/Kotlin/kotlinx.coroutines/blob/$version$/ui/kotlinx-coroutines-swing/README.md",
+    "description" : "kotlinx-coroutines-swing adds Swing integration for Kotlin coroutines by providing Dispatchers.Swing and a Dispatchers.Main implementation for Swing UI applications. It lets coroutine code schedule work on the Swing event dispatch thread while using the standard coroutine dispatcher APIs.",
+    "language" : {
+      "name" : "kotlin",
+      "version" : "2.1"
+    },
+    "tested-versions" : [
+      "1.10.2"
+    ],
+    "allowed-packages" : [
+      "kotlinx.coroutines.swing"
+    ]
+  }
+]

--- a/stats/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/execution-metrics.json
+++ b/stats/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/execution-metrics.json
@@ -1,0 +1,82 @@
+{
+  "add_new_library_support:2026-06-10": {
+    "timestamp": "2026-06-10T14:55:47.995917Z",
+    "library": "org.jetbrains.kotlinx:kotlinx-coroutines-swing:1.10.2",
+    "starting_commit": "1196bfd211c1d8513b9ac364a9ccb3e577cb8000",
+    "ending_commit": "de0181d5c081ae1da30ad4eed9a1464f436fe93c",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.10.2",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 110,
+          "missed": 24,
+          "ratio": 0.820896,
+          "total": 134
+        },
+        "line": {
+          "covered": 27,
+          "missed": 5,
+          "ratio": 0.84375,
+          "total": 32
+        },
+        "method": {
+          "covered": 17,
+          "missed": 5,
+          "ratio": 0.772727,
+          "total": 22
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "degraded",
+      "action": "no_action",
+      "issue_number": 5272,
+      "issue_label": "library-new-request",
+      "library": "org.jetbrains.kotlinx:kotlinx-coroutines-swing:1.10.2",
+      "summary": "Library preparation preflight did not produce usable advisory setup.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#5272 Support for org.jetbrains.kotlinx:kotlinx-coroutines-swing:1.10.2; label=library-new-request; body_chars=304"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "0 existing test file path(s) included"
+        }
+      ],
+      "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
+      "model": "oca/gpt-5.5",
+      "prompt_path": "library-preflight-prompt.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.jetbrains.kotlinx:kotlinx-coroutines-swing:1.10.2/library-preparation-preflight/pi-generation-2026-06-10T14-20-51-173169Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 201507,
+      "cached_input_tokens_used": 1223680,
+      "output_tokens_used": 18624,
+      "iterations": 3,
+      "cost_usd": 1.1705,
+      "generated_loc": 233,
+      "tested_library_loc": 27,
+      "metadata_entries": 380,
+      "code_coverage_percent": 84.38
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/src/test/kotlin/org_jetbrains_kotlinx/kotlinx_coroutines_swing/Kotlinx_coroutines_swingTest.kt",
+      "metadata_file": "metadata/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/stats.json
+++ b/stats/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.10.2",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 110,
+        "missed" : 24,
+        "ratio" : 0.820896,
+        "total" : 134
+      },
+      "line" : {
+        "covered" : 27,
+        "missed" : 5,
+        "ratio" : 0.84375,
+        "total" : 32
+      },
+      "method" : {
+        "covered" : 17,
+        "missed" : 5,
+        "ratio" : 0.772727,
+        "total" : 22
+      }
+    }
+  } ]
+}

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/.gitignore
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-swing:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "21"
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/gradle.properties
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.jetbrains.kotlinx:kotlinx-coroutines-swing:1.10.2
+library.version = 1.10.2
+metadata.dir = org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/settings.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.jetbrains.kotlinx.kotlinx-coroutines-swing_tests'

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/src/test/kotlin/org_jetbrains_kotlinx/kotlinx_coroutines_swing/Kotlinx_coroutines_swingTest.kt
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/src/test/kotlin/org_jetbrains_kotlinx/kotlinx_coroutines_swing/Kotlinx_coroutines_swingTest.kt
@@ -15,10 +15,13 @@ import javax.swing.JLabel
 import javax.swing.SwingUtilities
 import kotlin.coroutines.resume
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
@@ -61,6 +64,27 @@ public class Kotlinx_coroutines_swingTest {
 
         assertThat(observations).containsExactly(true, true)
         assertThat(label.text).isEqualTo("finished")
+    }
+
+    @Test
+    public fun asyncCoroutinesOnSwingDispatcherReturnValuesFromEventDispatchThread(): Unit = runBlockingWithTimeout {
+        val label: JLabel = JLabel("unset")
+
+        val firstUpdate: Deferred<String> = async(Dispatchers.Swing) {
+            label.text = "first"
+            "first:${label.text}:${SwingUtilities.isEventDispatchThread()}"
+        }
+        val secondUpdate: Deferred<String> = async(Dispatchers.Swing) {
+            label.text = "${label.text}-second"
+            "second:${label.text}:${SwingUtilities.isEventDispatchThread()}"
+        }
+        val updates: List<String> = awaitAll(firstUpdate, secondUpdate)
+
+        assertThat(updates).containsExactly(
+            "first:first:true",
+            "second:first-second:true",
+        )
+        assertThat(label.text).isEqualTo("first-second")
     }
 
     @Test

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/src/test/kotlin/org_jetbrains_kotlinx/kotlinx_coroutines_swing/Kotlinx_coroutines_swingTest.kt
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/src/test/kotlin/org_jetbrains_kotlinx/kotlinx_coroutines_swing/Kotlinx_coroutines_swingTest.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.swing.Swing
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -101,6 +102,26 @@ public class Kotlinx_coroutines_swingTest {
 
         assertThat(initialThreadWasEdt).isFalse()
         assertThat(ranOnEventDispatchThread).isTrue()
+    }
+
+    @Test
+    public fun yieldingInSwingContextLetsQueuedEventDispatchThreadWorkRunFirst(): Unit = runBlockingWithTimeout {
+        val events: CopyOnWriteArrayList<String> = CopyOnWriteArrayList()
+
+        withContext(Dispatchers.Swing) {
+            events.add("before-yield:${SwingUtilities.isEventDispatchThread()}")
+            SwingUtilities.invokeLater {
+                events.add("queued-event:${SwingUtilities.isEventDispatchThread()}")
+            }
+            yield()
+            events.add("after-yield:${SwingUtilities.isEventDispatchThread()}")
+        }
+
+        assertThat(events).containsExactly(
+            "before-yield:true",
+            "queued-event:true",
+            "after-yield:true",
+        )
     }
 
     @Test

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/src/test/kotlin/org_jetbrains_kotlinx/kotlinx_coroutines_swing/Kotlinx_coroutines_swingTest.kt
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/src/test/kotlin/org_jetbrains_kotlinx/kotlinx_coroutines_swing/Kotlinx_coroutines_swingTest.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jetbrains_kotlinx.kotlinx_coroutines_swing
+
+import org.junit.jupiter.api.Test
+
+class Kotlinx_coroutines_swingTest {
+    @Test
+    fun test() {
+        println("This is just a placeholder, implement your test")
+    }
+}

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/src/test/kotlin/org_jetbrains_kotlinx/kotlinx_coroutines_swing/Kotlinx_coroutines_swingTest.kt
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/src/test/kotlin/org_jetbrains_kotlinx/kotlinx_coroutines_swing/Kotlinx_coroutines_swingTest.kt
@@ -6,11 +6,222 @@
  */
 package org_jetbrains_kotlinx.kotlinx_coroutines_swing
 
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.swing.JButton
+import javax.swing.JLabel
+import javax.swing.SwingUtilities
+import kotlin.coroutines.resume
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.swing.Swing
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-class Kotlinx_coroutines_swingTest {
+public class Kotlinx_coroutines_swingTest {
     @Test
-    fun test() {
-        println("This is just a placeholder, implement your test")
+    public fun mainDispatcherIsProvidedBySwingModule(): Unit = runBlockingWithTimeout {
+        assertThat(Dispatchers.Main).isSameAs(Dispatchers.Swing)
+        assertThat(Dispatchers.Main.immediate).isSameAs(Dispatchers.Swing.immediate)
+
+        val ranOnEventDispatchThread: Boolean = withContext(Dispatchers.Main) {
+            SwingUtilities.isEventDispatchThread()
+        }
+
+        assertThat(ranOnEventDispatchThread).isTrue()
     }
+
+    @Test
+    public fun swingDispatcherRunsCoroutinesOnEventDispatchThreadAndUpdatesComponents(): Unit = runBlockingWithTimeout {
+        val label: JLabel = JLabel("initial")
+        val observations: List<Boolean> = withContext(Dispatchers.Swing) {
+            val beforeDelayOnEdt: Boolean = SwingUtilities.isEventDispatchThread()
+            label.text = "started"
+
+            delay(10)
+
+            val afterDelayOnEdt: Boolean = SwingUtilities.isEventDispatchThread()
+            label.text = "finished"
+            listOf(beforeDelayOnEdt, afterDelayOnEdt)
+        }
+
+        assertThat(observations).containsExactly(true, true)
+        assertThat(label.text).isEqualTo("finished")
+    }
+
+    @Test
+    public fun immediateDispatcherRunsInlineWhenAlreadyOnEventDispatchThread(): Unit {
+        val events: CopyOnWriteArrayList<String> = CopyOnWriteArrayList()
+        val queuedCoroutineRan: CountDownLatch = CountDownLatch(1)
+        val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Swing)
+
+        try {
+            invokeOnEventDispatchThread {
+                events.add("entered")
+                scope.launch {
+                    events.add("queued")
+                    queuedCoroutineRan.countDown()
+                }
+
+                runBlocking {
+                    withContext(Dispatchers.Swing.immediate) {
+                        events.add("immediate")
+                    }
+                }
+                events.add("leaving")
+            }
+
+            assertThat(queuedCoroutineRan.await(5, TimeUnit.SECONDS)).isTrue()
+            assertThat(events).containsExactly("entered", "immediate", "leaving", "queued")
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    public fun immediateDispatcherDispatchesFromBackgroundThreadsToEventDispatchThread(): Unit = runBlockingWithTimeout {
+        val initialThreadWasEdt: Boolean = SwingUtilities.isEventDispatchThread()
+
+        val ranOnEventDispatchThread: Boolean = withContext(Dispatchers.Swing.immediate) {
+            SwingUtilities.isEventDispatchThread()
+        }
+
+        assertThat(initialThreadWasEdt).isFalse()
+        assertThat(ranOnEventDispatchThread).isTrue()
+    }
+
+    @Test
+    public fun timeoutInsideSwingContextCancelsSuspendedCoroutineOnEventDispatchThread(): Unit = runBlockingWithTimeout {
+        val finallyRanOnEventDispatchThread: AtomicBoolean = AtomicBoolean(false)
+
+        val failure: Throwable = assertFails {
+            withContext(Dispatchers.Swing) {
+                withTimeout(50) {
+                    try {
+                        suspendCancellableCoroutine<Unit> { }
+                    } finally {
+                        finallyRanOnEventDispatchThread.set(SwingUtilities.isEventDispatchThread())
+                    }
+                }
+            }
+        }
+
+        assertThat(failure).isInstanceOf(TimeoutCancellationException::class.java)
+        assertThat(finallyRanOnEventDispatchThread.get()).isTrue()
+    }
+
+    @Test
+    public fun cancellingDelayedSwingCoroutineRunsFinallyOnEventDispatchThread(): Unit = runBlockingWithTimeout {
+        val started: CountDownLatch = CountDownLatch(1)
+        val completedFinally: CountDownLatch = CountDownLatch(1)
+        val finallyRanOnEventDispatchThread: AtomicBoolean = AtomicBoolean(false)
+        val job: Job = launch(Dispatchers.Swing) {
+            try {
+                started.countDown()
+                delay(TimeUnit.MINUTES.toMillis(1))
+            } finally {
+                finallyRanOnEventDispatchThread.set(SwingUtilities.isEventDispatchThread())
+                completedFinally.countDown()
+            }
+        }
+
+        assertThat(started.await(5, TimeUnit.SECONDS)).isTrue()
+        job.cancelAndJoin()
+
+        assertThat(completedFinally.await(5, TimeUnit.SECONDS)).isTrue()
+        assertThat(finallyRanOnEventDispatchThread.get()).isTrue()
+    }
+
+    @Test
+    public fun swingEventHandlersCanLaunchCoroutinesThatResumeOnEventDispatchThread(): Unit {
+        val button: JButton = JButton("ready")
+        val completed: CountDownLatch = CountDownLatch(1)
+        val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Swing)
+        val resumedOnEventDispatchThread: AtomicBoolean = AtomicBoolean(false)
+
+        try {
+            button.addActionListener {
+                scope.launch {
+                    button.text = "running"
+                    delay(10)
+                    resumedOnEventDispatchThread.set(SwingUtilities.isEventDispatchThread())
+                    button.text = "done"
+                    completed.countDown()
+                }
+            }
+
+            invokeOnEventDispatchThread { button.doClick() }
+
+            assertThat(completed.await(5, TimeUnit.SECONDS)).isTrue()
+            assertThat(resumedOnEventDispatchThread.get()).isTrue()
+            assertThat(invokeOnEventDispatchThread { button.text }).isEqualTo("done")
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    public fun swingDispatcherCanAwaitCallbacksScheduledOnEventDispatchQueue(): Unit = runBlockingWithTimeout {
+        val message: String = withContext(Dispatchers.Swing) {
+            suspendCancellableCoroutine { continuation ->
+                SwingUtilities.invokeLater {
+                    continuation.resume("callback on EDT: ${SwingUtilities.isEventDispatchThread()}")
+                }
+            }
+        }
+
+        assertThat(message).isEqualTo("callback on EDT: true")
+    }
+
+    private fun <T> runBlockingWithTimeout(block: suspend CoroutineScope.() -> T): T = runBlocking {
+        withTimeout(5_000) {
+            block()
+        }
+    }
+
+    private suspend fun assertFails(block: suspend () -> Unit): Throwable {
+        try {
+            block()
+        } catch (throwable: Throwable) {
+            return throwable
+        }
+        throw AssertionError("Expected the suspending operation to fail")
+    }
+
+    private fun <T> invokeOnEventDispatchThread(action: () -> T): T {
+        if (SwingUtilities.isEventDispatchThread()) {
+            return action()
+        }
+
+        val result: EdtResult<T> = EdtResult()
+        SwingUtilities.invokeAndWait {
+            try {
+                result.value = action()
+            } catch (throwable: Throwable) {
+                result.failure = throwable
+            }
+        }
+        result.failure?.let { throw it }
+
+        @Suppress("UNCHECKED_CAST")
+        return result.value as T
+    }
+}
+
+private class EdtResult<T> {
+    var value: T? = null
+    var failure: Throwable? = null
 }

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/user-code-filter.json
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "kotlinx.coroutines.swing.**"
+      "includeClasses" : "kotlinx.coroutines.swing.**"
+    },
+    {
+      "includeClasses" : "org_jetbrains_kotlinx.kotlinx_coroutines_swing.**"
     }
   ]
 }

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/user-code-filter.json
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "kotlinx.coroutines.swing.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #5272

This PR introduces tests and metadata for org.jetbrains.kotlinx:kotlinx-coroutines-swing:1.10.2, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 201507
- Cached input tokens: 1223680
- Output tokens: 18624
- Metadata entries: 380
- Iterations: 3
- Library coverage percentage: 84.38
- Generated lines of code: 233
- Tested library lines of code: 27

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `2063f6673bd185df5f647d60d70521e02195870e`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 110/134 (82.09%)
- Line: 27/32 (84.38%)
- Method: 17/22 (77.27%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
