### PR TITLE
Allow TCK test runs to skip JaCoCo

### DIFF
--- a/docs/tck.md
+++ b/docs/tck.md
@@ -51,6 +51,10 @@ The core per-coordinate lifecycle, delegated to the per-coordinate build
 (§AR-build-infrastructure). The lanes run in order — compile, JVM tests, native
 build, native tests.
 
+The JVM and full test lanes accept `-PskipJacoco=true` to run without JaCoCo
+instrumentation when the caller needs only pass/fail execution and not coverage
+data.
+
 | Task | Lane |
 | --- | --- |
 | `compileTestJava` | Compile the coordinate's test sources. |

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
@@ -22,6 +22,8 @@ plugins {
     id 'jacoco'
 }
 
+def skipJacoco = providers.gradleProperty("skipJacoco").map { it.toBoolean() }.getOrElse(false)
+
 repositories {
     mavenLocal()
     mavenCentral()
@@ -478,6 +480,10 @@ tasks.register("mergeNativeTraceMetadata", Exec) { Exec task ->
 
 // Ensure detailed exception/stacktrace logging for all Test tasks, including nativeTest
 tasks.withType(Test).configureEach {
+    // §TCK-test-harness.3: downstream pass/fail gates can run without coverage instrumentation.
+    if (skipJacoco) {
+        jacoco.enabled = false
+    }
     systemProperty "junit.jupiter.execution.timeout.default", "${maxJUnitTestTimeoutSeconds} s"
     systemProperty "junit.jupiter.execution.timeout.mode", "enabled"
     systemProperty "junit.jupiter.execution.timeout.thread.mode.default", "separate_thread"

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/JavaTestInvocationTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/JavaTestInvocationTask.java
@@ -6,6 +6,7 @@
  */
 package org.graalvm.internal.tck.harness.tasks;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -16,10 +17,13 @@ public abstract class JavaTestInvocationTask extends AllCoordinatesExecTask {
 
     @Override
     public List<String> commandFor(String coordinates) {
-        return List.of(
+        List<String> command = new ArrayList<>(List.of(
                 tckExtension.getRepoRoot().get().getAsFile().toPath().resolve("gradlew").toString(),
                 "test"
-        );
+        ));
+        // §TCK-test-harness.3
+        appendProperty(command, "skipJacoco");
+        return command;
     }
 
     @Override

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/TestInvocationTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/TestInvocationTask.java
@@ -40,6 +40,8 @@ public abstract class TestInvocationTask extends AllCoordinatesExecTask {
             defaultArgs.add("-Porg.gradle.java.installations.paths=" + installPathsProperty.get());
         }
         appendProperty(defaultArgs, "metadataConfigDirs");
+        // §TCK-test-harness.3
+        appendProperty(defaultArgs, "skipJacoco");
         return defaultArgs;
     }
 


### PR DESCRIPTION
## Summary

- add `-PskipJacoco=true` support for TCK pass/fail test lanes
- disable the JaCoCo `Test` task extension when that property is set
- forward `skipJacoco` from the root TCK harness into child `javaTest` and `test`/`nativeTest` Gradle invocations

Fixes #8324

## Testing

- `git diff --check`
- `grund check`

Note: I also attempted `./gradlew --no-daemon help -PskipJacoco=true`, but the wrapper produced no progress after initial daemon startup output and was stopped.
