### PR TITLE
[GenAI] Add support for org.scodec:scodec-core_3:2.2.0 using gpt-5.5

### DIFF
--- a/metadata/org.scodec/scodec-core_3/2.2.0/reachability-metadata.json
+++ b/metadata/org.scodec/scodec-core_3/2.2.0/reachability-metadata.json
@@ -1,0 +1,37 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "scodec.Codec"
+      },
+      "type": "scodec.Codec$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "scodec.codecs.DiscriminatorCodec"
+      },
+      "type": "scodec.codecs.DiscriminatorCodec",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "scodec.codecs.ConditionalCodec"
+      },
+      "type": "scodec.codecs.ConditionalCodec",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.scodec/scodec-core_3/index.json
+++ b/metadata/org.scodec/scodec-core_3/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.2.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/scodec/scodec-core_3/$version$/scodec-core_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/scodec/scodec",
+    "test-code-url" : "https://github.com/scodec/scodec/tree/v$version$/unitTests",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/scodec/scodec-core_3/$version$/scodec-core_3-$version$-javadoc.jar",
+    "description" : "scodec-core is a Scala combinator library for encoding and decoding binary data using typed codecs. It provides a pure functional DSL for mapping protocol structures to Scala values with composable codecs, detailed errors, and support for derived case class codecs.",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "2.2.0"
+    ],
+    "allowed-packages" : [
+      "scodec"
+    ]
+  }
+]

--- a/stats/org.scodec/scodec-core_3/2.2.0/execution-metrics.json
+++ b/stats/org.scodec/scodec-core_3/2.2.0/execution-metrics.json
@@ -1,0 +1,82 @@
+{
+  "add_new_library_support:2026-06-10": {
+    "timestamp": "2026-06-10T15:57:44.472500Z",
+    "library": "org.scodec:scodec-core_3:2.2.0",
+    "starting_commit": "388ed2b39ca6596ee4d3bd3ce3b3a781593200a0",
+    "ending_commit": "d91fa9bc093423bea47a01f95634a244ca0b2140",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.2.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4419,
+          "missed": 12523,
+          "ratio": 0.260831,
+          "total": 16942
+        },
+        "line": {
+          "covered": 587,
+          "missed": 857,
+          "ratio": 0.40651,
+          "total": 1444
+        },
+        "method": {
+          "covered": 414,
+          "missed": 1411,
+          "ratio": 0.226849,
+          "total": 1825
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "degraded",
+      "action": "no_action",
+      "issue_number": 4943,
+      "issue_label": "library-new-request",
+      "library": "org.scodec:scodec-core_3:2.2.0",
+      "summary": "Library preparation preflight did not produce usable advisory setup.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#4943 Support for org.scodec:scodec-core_3:2.2.0; label=library-new-request; body_chars=0; body_error=CalledProcessError: Command '['gh', 'issue', 'view', '4943', '--repo', 'oracle/graalvm-reachability-metadata', '--json', 'body']' returned non-zero exit status 1."
+        },
+        {
+          "name": "existing_tests",
+          "summary": "0 existing test file path(s) included"
+        }
+      ],
+      "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
+      "model": "oca/gpt-5.5",
+      "prompt_path": "library-preflight-prompt.txt",
+      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.scodec:scodec-core_3:2.2.0/library-preparation-preflight/pi-generation-2026-06-10T15-19-33-036766Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 260049,
+      "cached_input_tokens_used": 2532352,
+      "output_tokens_used": 21767,
+      "iterations": 3,
+      "cost_usd": 1.9192,
+      "generated_loc": 193,
+      "tested_library_loc": 587,
+      "metadata_entries": 6,
+      "code_coverage_percent": 40.65
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.scodec/scodec-core_3/2.2.0/src/test/scala/org_scodec/scodec_core_3/Scodec_core_3Test.scala",
+      "metadata_file": "metadata/org.scodec/scodec-core_3/2.2.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.scodec/scodec-core_3/2.2.0/stats.json
+++ b/stats/org.scodec/scodec-core_3/2.2.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.2.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 4419,
+        "missed" : 12523,
+        "ratio" : 0.260831,
+        "total" : 16942
+      },
+      "line" : {
+        "covered" : 587,
+        "missed" : 857,
+        "ratio" : 0.40651,
+        "total" : 1444
+      },
+      "method" : {
+        "covered" : 414,
+        "missed" : 1411,
+        "ratio" : 0.226849,
+        "total" : 1825
+      }
+    }
+  } ]
+}

--- a/tests/src/org.scodec/scodec-core_3/2.2.0/.gitignore
+++ b/tests/src/org.scodec/scodec-core_3/2.2.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.scodec/scodec-core_3/2.2.0/build.gradle
+++ b/tests/src/org.scodec/scodec-core_3/2.2.0/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.scodec:scodec-core_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.scodec/scodec-core_3/2.2.0/gradle.properties
+++ b/tests/src/org.scodec/scodec-core_3/2.2.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.scodec:scodec-core_3:2.2.0
+library.version = 2.2.0
+metadata.dir = org.scodec/scodec-core_3/2.2.0/

--- a/tests/src/org.scodec/scodec-core_3/2.2.0/settings.gradle
+++ b/tests/src/org.scodec/scodec-core_3/2.2.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.scodec.scodec-core_3_tests'

--- a/tests/src/org.scodec/scodec-core_3/2.2.0/src/test/scala/org_scodec/scodec_core_3/Scodec_core_3Test.scala
+++ b/tests/src/org.scodec/scodec-core_3/2.2.0/src/test/scala/org_scodec/scodec_core_3/Scodec_core_3Test.scala
@@ -6,11 +6,181 @@
  */
 package org_scodec.scodec_core_3
 
+import java.util.UUID
+
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import org.junit.jupiter.api.Test
+import scodec.{Attempt, Codec, DecodeResult, Err, SizeBound}
+import scodec.bits.{BitVector, ByteVector}
+import scodec.codecs.*
 
 class Scodec_core_3Test {
+  private case class Frame(version: Int, messageType: Int, body: String)
+
+  private case class DerivedRecord(id: Int, enabled: Boolean, name: String) derives Codec
+
+  private sealed trait DerivedMessage derives Codec
+  private case class DerivedPing(id: Int) extends DerivedMessage
+  private case class DerivedData(name: String, payload: ByteVector) extends DerivedMessage
+
+  private sealed trait Command
+  private case object Start extends Command
+  private case class Write(payload: ByteVector) extends Command
+  private case class Numbered(value: Int) extends Command
+
+  private enum Priority {
+    case Low, Medium, High
+  }
+
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
+  def numericAndPrimitiveCodecsUseDocumentedBinaryLayouts(): Unit = {
+    assertRoundTrip(uint8, 255)
+    assertRoundTrip(int16, -1234)
+    assertRoundTrip(int32L, 0x12345678)
+    assertRoundTrip(uint32, 0xffffffffL)
+    assertRoundTrip(float, 12.5f)
+    assertRoundTrip(doubleL, -0.25d)
+    assertRoundTrip(bool, true)
+    assertRoundTrip(uuid, UUID.fromString("00112233-4455-6677-8899-aabbccddeeff"))
+
+    assertEquals("1234", uint16.encode(0x1234).require.toHex)
+    assertEquals("3412", uint16L.encode(0x1234).require.toHex)
+    assertEquals("fffffffe", int32.encode(-2).require.toHex)
+    assertEquals("78563412", int32L.encode(0x12345678).require.toHex)
+    val exampleUuid: UUID = UUID.fromString("00112233-4455-6677-8899-aabbccddeeff")
+    assertEquals("00112233445566778899aabbccddeeff", uuid.encode(exampleUuid).require.toHex)
+  }
+
+  @Test
+  def variableSizedCollectionsAndOptionalFieldsRoundTripWithRemainders(): Unit = {
+    val payload: ByteVector = ByteVector(0xde, 0xad, 0xbe, 0xef)
+    val payloadCodec: Codec[ByteVector] = variableSizeBytes(uint8, bytes)
+    val encodedPayload: BitVector = payloadCodec.encode(payload).require
+
+    assertEquals("04deadbeef", encodedPayload.toHex)
+
+    val decodedWithRemainder: DecodeResult[ByteVector] =
+      payloadCodec.decode(encodedPayload ++ ByteVector(0xff).bits).require
+    assertEquals(payload, decodedWithRemainder.value)
+    assertEquals("ff", decodedWithRemainder.remainder.toHex)
+
+    assertRoundTrip(listOfN(uint8, uint4), List(1, 2, 15))
+    assertRoundTrip(vectorOfN(uint8, int16), Vector(-3, 0, 4096))
+    assertRoundTrip(optional(bool, uint8), Some(42))
+    assertRoundTrip(optional(bool, uint8), None)
+    assertRoundTrip(conditional(included = true, ascii), Some("included"))
+    assertRoundTrip(conditional(included = false, ascii), None)
+  }
+
+  @Test
+  def tupleCompositionAndCaseClassIsomorphismsBuildStructuredCodecs(): Unit = {
+    val frameCodec: Codec[Frame] =
+      Codec.fromTuple((uint4, uint4, variableSizeBytes(uint8, utf8))).as[Frame]
+    val frame: Frame = Frame(version = 2, messageType = 12, body = "ok")
+    val encodedFrame: BitVector = frameCodec.encode(frame).require
+
+    assertEquals("2c026f6b", encodedFrame.toHex)
+    assertDecodedCompletely(frameCodec, encodedFrame, frame)
+
+    val consumedCodec: Codec[ByteVector] =
+      uint8.consume(length => bytes(length))(body => body.size.toInt)
+    val body: ByteVector = ByteVector(1, 2, 3, 4, 5)
+
+    assertEquals("050102030405", consumedCodec.encode(body).require.toHex)
+    assertRoundTrip(consumedCodec, body)
+  }
+
+  @Test
+  def derivedProductAndSumCodecsEncodeAllFields(): Unit = {
+    val product: DerivedRecord = DerivedRecord(7, enabled = true, "derived")
+    assertRoundTrip(Codec[DerivedRecord], product)
+
+    val ping: DerivedMessage = DerivedPing(99)
+    val data: DerivedMessage = DerivedData("blob", ByteVector(1, 3, 3, 7))
+
+    assertRoundTrip(Codec[DerivedMessage], ping)
+    assertRoundTrip(Codec[DerivedMessage], data)
+    assertEquals("0000000063", Codec[DerivedMessage].encode(ping).require.toHex)
+  }
+
+  @Test
+  def discriminatorAndMappedEnumCodecsSelectTheExpectedVariant(): Unit = {
+    val commandCodec: Codec[Command] = discriminated[Command]
+      .by(uint8)
+      .singleton(1, Start)
+      .typecase(2, variableSizeBytes(uint8, bytes).as[Write])
+      .typecase(3, int16.as[Numbered])
+
+    assertEquals("01", commandCodec.encode(Start).require.toHex)
+    assertEquals("0203010203", commandCodec.encode(Write(ByteVector(1, 2, 3))).require.toHex)
+    assertEquals("03fffb", commandCodec.encode(Numbered(-5)).require.toHex)
+    assertRoundTrip(commandCodec, Start)
+    assertRoundTrip(commandCodec, Write(ByteVector(9, 8, 7)))
+    assertRoundTrip(commandCodec, Numbered(1024))
+
+    val priorityCodec: Codec[Priority] = mappedEnum(
+      uint8,
+      Priority.Low -> 1,
+      Priority.Medium -> 2,
+      Priority.High -> 3
+    )
+
+    assertEquals("03", priorityCodec.encode(Priority.High).require.toHex)
+    assertDecodedCompletely(priorityCodec, BitVector.fromValidHex("02"), Priority.Medium)
+    assertTrue(priorityCodec.decode(BitVector.fromValidHex("ff")).isFailure)
+  }
+
+  @Test
+  def fixedSizeDelimitedAndCompressedCodecsRespectTheirBoundaries(): Unit = {
+    val strictBytes: Codec[ByteVector] = bytesStrict(3)
+    assertRoundTrip(strictBytes, ByteVector(0xaa, 0xbb, 0xcc))
+    assertTrue(strictBytes.encode(ByteVector(0xaa, 0xbb)).isFailure)
+
+    val paddedBytes: Codec[ByteVector] = bytes(4)
+    assertEquals("01020000", paddedBytes.encode(ByteVector(1, 2)).require.toHex)
+    assertDecodedCompletely(paddedBytes, BitVector.fromValidHex("01020000"), ByteVector(1, 2, 0, 0))
+
+    val delimitedText: Codec[String] =
+      variableSizeDelimited(constant(ByteVector(0)), utf8, multipleValueSize = 8)
+    assertEquals("68656c6c6f00", delimitedText.encode("hello").require.toHex)
+    assertRoundTrip(delimitedText, "hello")
+
+    val compressedText: Codec[String] = zlib(variableSizeBytes(uint8, utf8), chunkSize = 32)
+    assertRoundTrip(compressedText, "compressible text compressible text")
+  }
+
+  @Test
+  def attemptsErrorsAndSizeBoundsExposeFailureDetails(): Unit = {
+    val failedEncode: Attempt[BitVector] = uint8.withContext("header").encode(300)
+    assertTrue(failedEncode.isFailure)
+    val failureMessage: String = failedEncode.fold(_.messageWithContext, _ => "")
+    assertTrue(failureMessage.contains("header"))
+
+    val constantFailure: Attempt[DecodeResult[Unit]] =
+      constant(ByteVector(1, 2)).decode(ByteVector(1, 3).bits)
+    assertTrue(constantFailure.isFailure)
+    val recovered: Attempt[DecodeResult[Unit]] =
+      constantFailure.recover { case _: Err => DecodeResult((), BitVector.empty) }
+    assertEquals("recovered", recovered.map(_ => "recovered").require)
+
+    assertTrue(uint8.complete.decode(BitVector.fromValidHex("01ff")).isFailure)
+    assertEquals(42, Attempt.fromOption(Some(42), Err("missing")).require)
+    assertEquals("fallback", Attempt.fromOption[String](None, Err("missing")).getOrElse("fallback"))
+
+    val exactByte: SizeBound = SizeBound.exact(8)
+    val variableTail: SizeBound = SizeBound.atLeast(16)
+    assertEquals(Some(8L), uint8.sizeBound.exact)
+    assertEquals(SizeBound.atLeast(24), exactByte + variableTail)
+    assertFalse((exactByte | variableTail).exact.isDefined)
+  }
+
+  private def assertRoundTrip[A](codec: Codec[A], value: A): Unit = {
+    assertDecodedCompletely(codec, codec.encode(value).require, value)
+  }
+
+  private def assertDecodedCompletely[A](codec: Codec[A], bits: BitVector, expected: A): Unit = {
+    val decoded: DecodeResult[A] = codec.decode(bits).require
+    assertEquals(expected, decoded.value)
+    assertTrue(decoded.remainder.isEmpty, s"Unexpected remainder: ${decoded.remainder.toHex}")
   }
 }

--- a/tests/src/org.scodec/scodec-core_3/2.2.0/src/test/scala/org_scodec/scodec_core_3/Scodec_core_3Test.scala
+++ b/tests/src/org.scodec/scodec-core_3/2.2.0/src/test/scala/org_scodec/scodec_core_3/Scodec_core_3Test.scala
@@ -150,6 +150,30 @@ class Scodec_core_3Test {
   }
 
   @Test
+  def checksummedCodecsValidateFramedPayloadIntegrity(): Unit = {
+    val xorChecksum: BitVector => BitVector = bits => {
+      val checksumByte: Int = bits.toByteArray.foldLeft(0) { (checksum: Int, byte: Byte) =>
+        checksum ^ (byte & 0xff)
+      }
+      ByteVector(checksumByte).bits
+    }
+    val frameCodec: Codec[(BitVector, BitVector)] =
+      Codec.fromTuple((variableSizeBytes(uint8, bits), bits(8)))
+    val textCodec: Codec[String] = checksummed(utf8, xorChecksum, frameCodec)
+    val encodedText: BitVector = textCodec.encode("ok").require
+
+    assertEquals("026f6b04", encodedText.toHex)
+    assertDecodedCompletely(textCodec, encodedText, "ok")
+
+    val decodedWithRemainder: DecodeResult[String] =
+      textCodec.decode(encodedText ++ ByteVector(0xff).bits).require
+    assertEquals("ok", decodedWithRemainder.value)
+    assertEquals("ff", decodedWithRemainder.remainder.toHex)
+
+    assertTrue(textCodec.decode(BitVector.fromValidHex("026f6b05")).isFailure)
+  }
+
+  @Test
   def attemptsErrorsAndSizeBoundsExposeFailureDetails(): Unit = {
     val failedEncode: Attempt[BitVector] = uint8.withContext("header").encode(300)
     assertTrue(failedEncode.isFailure)

--- a/tests/src/org.scodec/scodec-core_3/2.2.0/src/test/scala/org_scodec/scodec_core_3/Scodec_core_3Test.scala
+++ b/tests/src/org.scodec/scodec-core_3/2.2.0/src/test/scala/org_scodec/scodec_core_3/Scodec_core_3Test.scala
@@ -150,6 +150,32 @@ class Scodec_core_3Test {
   }
 
   @Test
+  def lookaheadCodecsInspectInputWithoutConsumingIt(): Unit = {
+    val input: BitVector = BitVector.fromValidHex("2a03616263ff")
+
+    val peekedHeader: DecodeResult[Int] = peek(uint8).decode(input).require
+    assertEquals(42, peekedHeader.value)
+    assertEquals(input, peekedHeader.remainder)
+
+    val matchedMagic: DecodeResult[Boolean] =
+      lookahead(constant(ByteVector(0x2a))).decode(input).require
+    assertTrue(matchedMagic.value)
+    assertEquals(input, matchedMagic.remainder)
+
+    val missingMagic: DecodeResult[Boolean] =
+      lookahead(constant(ByteVector(0x7f))).decode(input).require
+    assertFalse(missingMagic.value)
+    assertEquals(input, missingMagic.remainder)
+
+    val framedPayloadCodec: Codec[BitVector] = peekVariableSizeBytes(uint8)
+    val framedBits: DecodeResult[BitVector] =
+      framedPayloadCodec.decode(BitVector.fromValidHex("03616263ff")).require
+    assertEquals("03616263", framedBits.value.toHex)
+    assertEquals("ff", framedBits.remainder.toHex)
+    assertEquals("03616263", framedPayloadCodec.encode(framedBits.value).require.toHex)
+  }
+
+  @Test
   def checksummedCodecsValidateFramedPayloadIntegrity(): Unit = {
     val xorChecksum: BitVector => BitVector = bits => {
       val checksumByte: Int = bits.toByteArray.foldLeft(0) { (checksum: Int, byte: Byte) =>

--- a/tests/src/org.scodec/scodec-core_3/2.2.0/src/test/scala/org_scodec/scodec_core_3/Scodec_core_3Test.scala
+++ b/tests/src/org.scodec/scodec-core_3/2.2.0/src/test/scala/org_scodec/scodec_core_3/Scodec_core_3Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_scodec.scodec_core_3
+
+import org.junit.jupiter.api.Test
+
+class Scodec_core_3Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/org.scodec/scodec-core_3/2.2.0/user-code-filter.json
+++ b/tests/src/org.scodec/scodec-core_3/2.2.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "scodec.**"
+    }
+  ]
+}

--- a/tests/src/org.scodec/scodec-core_3/2.2.0/user-code-filter.json
+++ b/tests/src/org.scodec/scodec-core_3/2.2.0/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "scodec.**"
+      "includeClasses" : "scodec.**"
+    },
+    {
+      "includeClasses" : "org_scodec.scodec_core_3.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #4943

This PR introduces tests and metadata for org.scodec:scodec-core_3:2.2.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 260049
- Cached input tokens: 2532352
- Output tokens: 21767
- Metadata entries: 6
- Iterations: 3
- Library coverage percentage: 40.65
- Generated lines of code: 193
- Tested library lines of code: 587

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `a26f50b698303902d869debc6f8859d85650610a`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 4419/16942 (26.08%)
- Line: 587/1444 (40.65%)
- Method: 414/1825 (22.68%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
