### PR TITLE
[GenAI] Test fix for net.sf.saxon:Saxon-HE:10.0 using gpt-5.5

### DIFF
--- a/metadata/net.sf.saxon/Saxon-HE/10.0/reachability-metadata.json
+++ b/metadata/net.sf.saxon/Saxon-HE/10.0/reachability-metadata.json
@@ -1,0 +1,247 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "net.sf.saxon.java.JavaPlatform"
+      },
+      "type" : "com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : "com.ctc.wstx.compat.Jdk14Impl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "net.sf.saxon.pull.StaxBridge"
+      },
+      "type" : "com.ctc.wstx.ent.ExtEntity",
+      "methods" : [
+        {
+          "name" : "getSystemId",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getPublicId",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getBaseURI",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "net.sf.saxon.pull.StaxBridge"
+      },
+      "type" : "com.ctc.wstx.ent.EntityDecl",
+      "methods" : [
+        {
+          "name" : "getName",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getSystemId",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getPublicId",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getBaseURI",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "net.sf.saxon.pull.StaxBridge"
+      },
+      "type" : "com.ctc.wstx.ent.UnparsedExtEntity",
+      "methods" : [
+        {
+          "name" : "getName",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getSystemId",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getPublicId",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getBaseURI",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "net.sf.saxon.expr.PJConverter$ToArray"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "net.sf.saxon.expr.PJConverter$ToCollection"
+      },
+      "type" : "java.util.LinkedList",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "net.sf.saxon.Configuration"
+      },
+      "type" : "net.sf.saxon.Configuration",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "net.sf.saxon.functions.registry.BuiltInFunctionSet"
+      },
+      "type" : "net.sf.saxon.functions.StringLength_1",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "net.sf.saxon.Configuration"
+      },
+      "type" : "net.sf.saxon.functions.String_1",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "net.sf.saxon.Configuration"
+      },
+      "type" : "net.sf.saxon.functions.Tokenize_1",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "net.sf.saxon.lib.StandardErrorListener"
+      },
+      "type" : "net.sf.saxon.lib.StandardErrorListener",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "net.sf.saxon.trans.DynamicLoader"
+      },
+      "type" : "net.sf.saxon.lib.StandardLogger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "net.sf.saxon.expr.PJConverter"
+      },
+      "type" : "net.sf.saxon.s9api.XdmAtomicValue"
+    },
+    {
+      "condition" : {
+        "typeReached" : "net.sf.saxon.expr.PJConverter$1"
+      },
+      "type" : "net.sf.saxon.s9api.XdmAtomicValue",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "net.sf.saxon.Configuration"
+      },
+      "type" : "org.w3c.dom.Document"
+    },
+    {
+      "condition" : {
+        "typeReached" : "net.sf.saxon.style.StyleNodeFactory"
+      },
+      "type" : "net.sf.saxon.style.AbsentExtensionElement",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "net.sf.saxon.pull.StaxBridge"
+      },
+      "glob" : "META-INF/services/java.net.spi.URLStreamHandlerProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "net.sf.saxon.java.JavaPlatform"
+      },
+      "glob" : "META-INF/services/javax.xml.parsers.SAXParserFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "net.sf.saxon.Configuration"
+      },
+      "glob" : "net/sf/saxon/data/profile.xsl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "net.sf.saxon.trans.DynamicLoader"
+      },
+      "glob" : "net/sf/saxon/data/profile.xsl"
+    }
+  ]
+}

--- a/metadata/net.sf.saxon/Saxon-HE/index.json
+++ b/metadata/net.sf.saxon/Saxon-HE/index.json
@@ -5,6 +5,11 @@
     "tested-versions" : [
       "10.0"
     ],
+    "source-code-url" : "https://repo1.maven.org/maven2/net/sf/saxon/Saxon-HE/$version$/Saxon-HE-$version$-sources.jar",
+    "repository-url" : "https://github.com/Saxonica/Saxon-HE",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://repo1.maven.org/maven2/net/sf/saxon/Saxon-HE/$version$/Saxon-HE-$version$-javadoc.jar",
+    "description" : "Saxon-HE is the open-source Java edition of Saxon, an XSLT, XQuery, and XPath processor. It provides APIs and command-line tools for transforming, querying, and processing XML documents using W3C standards.",
     "allowed-packages" : [
       "net.sf.saxon"
     ]

--- a/metadata/net.sf.saxon/Saxon-HE/index.json
+++ b/metadata/net.sf.saxon/Saxon-HE/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "10.0",
+    "tested-versions" : [
+      "10.0"
+    ],
+    "allowed-packages" : [
+      "net.sf.saxon"
+    ]
+  },
+  {
     "metadata-version" : "9.9.1-6",
     "source-code-url" : "https://repo1.maven.org/maven2/net/sf/saxon/Saxon-HE/$version$/Saxon-HE-$version$-sources.jar",
     "repository-url" : "https://github.com/Saxonica/Saxon-Archive",

--- a/stats/net.sf.saxon/Saxon-HE/10.0/execution-metrics.json
+++ b/stats/net.sf.saxon/Saxon-HE/10.0/execution-metrics.json
@@ -1,0 +1,145 @@
+{
+  "fix_javac_fail:2026-06-10": {
+    "timestamp": "2026-06-10T17:03:54.852961Z",
+    "library": "net.sf.saxon:Saxon-HE:10.0",
+    "starting_commit": "2e0e006203994caa98c2b22e24686aa9b498c078",
+    "ending_commit": "7efa78128cef06c1cbe801007b0ef08abf9f8ba6",
+    "previous_library": "net.sf.saxon:Saxon-HE:9.9.1-6",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "10.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 27,
+            "totalCalls": 27
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 8,
+            "totalCalls": 8
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 35,
+        "totalCalls": 35
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 45736,
+          "missed": 426383,
+          "ratio": 0.096874,
+          "total": 472119
+        },
+        "line": {
+          "covered": 10711,
+          "missed": 95959,
+          "ratio": 0.100412,
+          "total": 106670
+        },
+        "method": {
+          "covered": 2046,
+          "missed": 17011,
+          "ratio": 0.107362,
+          "total": 19057
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "9.9.1-6",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.692308,
+            "coveredCalls": 18,
+            "totalCalls": 26
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 8,
+            "totalCalls": 8
+          }
+        },
+        "coverageRatio": 0.764706,
+        "coveredCalls": 26,
+        "totalCalls": 34
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 45673,
+          "missed": 412663,
+          "ratio": 0.09965,
+          "total": 458336
+        },
+        "line": {
+          "covered": 10767,
+          "missed": 93209,
+          "ratio": 0.103553,
+          "total": 103976
+        },
+        "method": {
+          "covered": 2066,
+          "missed": 16418,
+          "ratio": 0.111772,
+          "total": 18484
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "no_action",
+      "issue_number": 8305,
+      "issue_label": "fails-javac-compile",
+      "library": "net.sf.saxon:Saxon-HE:10.0",
+      "summary": "Saxon-HE 10.0 is usable with the resolved artifact and its normal transitive dependency; meaningful in-memory XSLT/XPath/XML coverage is reachable without Docker, external services, or additional Maven dependencies. The reported failure is caused by Saxon 10 API changes in existing tests, not missing setup.",
+      "deterministic_setup": [],
+      "agent_guidance": "No new environment variables or system properties are required. Generated or repaired tests should prefer in-memory Saxon HE usage through s9api/JAXP APIs. For the current javac issue, adapt tests to Saxon 10 API changes such as `PullProvider.Event.START_DOCUMENT` / `START_ELEMENT` and non-generic `GroundedValue`.",
+      "risks": [
+        "Saxon documents optional integrations for third-party object models and libraries such as JDOM, JDOM2, XOM, DOM4J, Axiom, ICU, and XML resolver support; only add those if a test intentionally exercises that optional integration.",
+        "Existing tests include Woodstox for a StAX-specific scenario, but Woodstox is not required for baseline meaningful Saxon-HE coverage.",
+        "Avoid PE/EE-only Saxon features when targeting Saxon-HE."
+      ],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#8305 [Automation] javac compile fails for net.sf.saxon:Saxon-HE:10.0; label=fails-javac-compile; body_chars=8015"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "16 existing test file path(s) included"
+        }
+      ],
+      "current_library": "net.sf.saxon:Saxon-HE:9.9.1-6",
+      "new_version": "10.0",
+      "model": "oca/gpt-5.5",
+      "input_tokens_used": 35190,
+      "output_tokens_used": 4374,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/net.sf.saxon:Saxon-HE:10.0/library-preparation-preflight/pi-generation-2026-06-10T16-15-05-725631Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 246588,
+      "cached_input_tokens_used": 1550336,
+      "output_tokens_used": 20413,
+      "iterations": 6,
+      "cost_usd": 1.3876,
+      "tested_library_loc": 10711,
+      "metadata_entries": 43,
+      "test_only_metadata_entries": 21,
+      "previous_library_metadata_entries": 248,
+      "previous_library_test_only_metadata_entries": 21,
+      "code_coverage_percent": 10.04,
+      "previous_library_coverage_percent": 10.36
+    },
+    "artifacts": {
+      "test_file": "tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/StyleNodeFactoryTest.java",
+      "metadata_file": "metadata/net.sf.saxon/Saxon-HE/10.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/net.sf.saxon/Saxon-HE/10.0/stats.json
+++ b/stats/net.sf.saxon/Saxon-HE/10.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "10.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 27,
+          "totalCalls" : 27
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 8,
+          "totalCalls" : 8
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 35,
+      "totalCalls" : 35
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 45736,
+        "missed" : 426383,
+        "ratio" : 0.096874,
+        "total" : 472119
+      },
+      "line" : {
+        "covered" : 10711,
+        "missed" : 95959,
+        "ratio" : 0.100412,
+        "total" : 106670
+      },
+      "method" : {
+        "covered" : 2046,
+        "missed" : 17011,
+        "ratio" : 0.107362,
+        "total" : 19057
+      }
+    }
+  } ]
+}

--- a/tests/src/net.sf.saxon/Saxon-HE/10.0/.gitignore
+++ b/tests/src/net.sf.saxon/Saxon-HE/10.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/net.sf.saxon/Saxon-HE/10.0/build.gradle
+++ b/tests/src/net.sf.saxon/Saxon-HE/10.0/build.gradle
@@ -1,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "net.sf.saxon:Saxon-HE:$libraryVersion"
+    testImplementation 'com.fasterxml.woodstox:woodstox-core:6.5.1'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+tasks.withType(Test).configureEach {
+    jvmArgs += [
+        "--add-opens=java.xml/com.sun.org.apache.xerces.internal.jaxp=ALL-UNNAMED"
+    ]
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+    binaries {
+        all {
+            buildArgs.add('--add-opens=java.xml/com.sun.org.apache.xerces.internal.jaxp=ALL-UNNAMED')
+        }
+    }
+}

--- a/tests/src/net.sf.saxon/Saxon-HE/10.0/build.gradle
+++ b/tests/src/net.sf.saxon/Saxon-HE/10.0/build.gradle
@@ -10,9 +10,24 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 
+repositories {
+    exclusiveContent {
+        forRepository {
+            mavenCentral {
+                metadataSources {
+                    artifact()
+                }
+            }
+        }
+        filter {
+            includeGroup 'org.codehaus.woodstox'
+        }
+    }
+}
+
 dependencies {
     testImplementation "net.sf.saxon:Saxon-HE:$libraryVersion"
-    testImplementation 'com.fasterxml.woodstox:woodstox-core:6.5.1'
+    testImplementation 'org.codehaus.woodstox:wstx-asl:3.0.0@jar'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/net.sf.saxon/Saxon-HE/10.0/gradle.properties
+++ b/tests/src/net.sf.saxon/Saxon-HE/10.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = net.sf.saxon:Saxon-HE:10.0
+library.version = 10.0
+metadata.dir = net.sf.saxon/Saxon-HE/10.0/

--- a/tests/src/net.sf.saxon/Saxon-HE/10.0/settings.gradle
+++ b/tests/src/net.sf.saxon/Saxon-HE/10.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'net.sf.saxon.Saxon-HE_tests'

--- a/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/BuiltInFunctionSetTest.java
+++ b/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/BuiltInFunctionSetTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_sf_saxon.Saxon_HE;
+
+import net.sf.saxon.s9api.Processor;
+import net.sf.saxon.s9api.SaxonApiException;
+import net.sf.saxon.s9api.XdmAtomicValue;
+import net.sf.saxon.s9api.XdmItem;
+import net.sf.saxon.s9api.XPathCompiler;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BuiltInFunctionSetTest {
+    @Test
+    void evaluatesXPathExpressionUsingBuiltInFunction() throws SaxonApiException {
+        Processor processor = new Processor(false);
+        XPathCompiler compiler = processor.newXPathCompiler();
+
+        XdmItem result = compiler.evaluateSingle("string-length('Saxon')", null);
+
+        assertThat(result).isInstanceOf(XdmAtomicValue.class);
+        XdmAtomicValue atomicValue = (XdmAtomicValue) result;
+        assertThat(atomicValue.getLongValue()).isEqualTo(5L);
+    }
+}

--- a/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/ConfigurationTest.java
+++ b/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/ConfigurationTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_sf_saxon.Saxon_HE;
+
+import net.sf.saxon.Configuration;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.transform.stream.StreamSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConfigurationTest {
+    private static final String CONFIGURATION_CLASS_NAME = "net.sf.saxon.Configuration";
+    private static final String DATA_RESOURCE = "profile.xsl";
+    private static final String FULL_DATA_RESOURCE = "net/sf/saxon/data/" + DATA_RESOURCE;
+
+    @Test
+    void createsDefaultConfiguration() {
+        Configuration configuration = Configuration.newConfiguration();
+
+        assertThat(configuration).isInstanceOf(Configuration.class);
+    }
+
+    @Test
+    void instantiatesConfigurationWithProvidedClassLoader() throws Exception {
+        Configuration configuration = Configuration.instantiateConfiguration(
+                CONFIGURATION_CLASS_NAME,
+                Configuration.class.getClassLoader());
+
+        assertThat(configuration).isInstanceOf(Configuration.class);
+    }
+
+    @Test
+    void instantiatesConfigurationUsingClassForNameFallbackWhenProvidedClassLoaderCannotLoadClass()
+            throws Exception {
+        ClassLoader rejectingClassLoader = new RejectingClassLoader();
+
+        Configuration configuration = Configuration.instantiateConfiguration(
+                CONFIGURATION_CLASS_NAME,
+                rejectingClassLoader);
+
+        assertThat(configuration).isInstanceOf(Configuration.class);
+    }
+
+    @Test
+    void instantiatesConfigurationUsingClassForNameWhenContextClassLoaderIsUnavailable() throws Exception {
+        Thread currentThread = Thread.currentThread();
+        ClassLoader originalContextClassLoader = currentThread.getContextClassLoader();
+        currentThread.setContextClassLoader(null);
+        try {
+            Configuration configuration = Configuration.instantiateConfiguration(CONFIGURATION_CLASS_NAME, null);
+
+            assertThat(configuration).isInstanceOf(Configuration.class);
+        } finally {
+            currentThread.setContextClassLoader(originalContextClassLoader);
+        }
+    }
+
+    @Test
+    void locatesPackagedDataResource() throws IOException {
+        List<String> messages = new ArrayList<>();
+        List<ClassLoader> loaders = new ArrayList<>();
+
+        try (InputStream resource = Configuration.locateResource(DATA_RESOURCE, messages, loaders)) {
+            assertThat(resource).isNotNull();
+            assertThat(resource.read()).isNotEqualTo(-1);
+        }
+        assertThat(loaders).isNotEmpty();
+    }
+
+    @Test
+    void reportsMissingPackagedDataResource() throws IOException {
+        List<String> messages = new ArrayList<>();
+        List<ClassLoader> loaders = new ArrayList<>();
+
+        try (InputStream resource = Configuration.locateResource(
+                "missing-saxon-test-resource.xml", messages, loaders)) {
+            assertThat(resource).isNull();
+        }
+        assertThat(messages).isNotEmpty();
+        assertThat(loaders).isNotEmpty();
+    }
+
+    @Test
+    void locatesResourceSourceWithSystemId() throws IOException {
+        List<String> messages = new ArrayList<>();
+        List<ClassLoader> loaders = new ArrayList<>();
+
+        StreamSource source = Configuration.locateResourceSource(FULL_DATA_RESOURCE, messages, loaders);
+
+        assertThat(source.getSystemId()).contains(FULL_DATA_RESOURCE);
+        try (InputStream resource = source.getInputStream()) {
+            assertThat(resource).isNotNull();
+            assertThat(resource.read()).isNotEqualTo(-1);
+        }
+        assertThat(loaders).isNotEmpty();
+    }
+
+    @Test
+    void locatesResourceSourceFromFallbackClassLoaderWhenContextStreamCannotBeOpened() throws IOException {
+        ClassLoader saxonClassLoader = Configuration.class.getClassLoader();
+        URL resourceUrl = saxonClassLoader.getResource(FULL_DATA_RESOURCE);
+        assertThat(resourceUrl).isNotNull();
+        Thread currentThread = Thread.currentThread();
+        ClassLoader originalContextClassLoader = currentThread.getContextClassLoader();
+        currentThread.setContextClassLoader(new UrlOnlyResourceClassLoader(FULL_DATA_RESOURCE, resourceUrl));
+        try {
+            List<String> messages = new ArrayList<>();
+            List<ClassLoader> loaders = new ArrayList<>();
+
+            StreamSource source = Configuration.locateResourceSource(FULL_DATA_RESOURCE, messages, loaders);
+
+            assertThat(source.getSystemId()).isEqualTo(resourceUrl.toString());
+            try (InputStream resource = source.getInputStream()) {
+                assertThat(resource).isNotNull();
+                assertThat(resource.read()).isNotEqualTo(-1);
+            }
+            assertThat(messages).isNotEmpty();
+            assertThat(loaders).isNotEmpty();
+        } finally {
+            currentThread.setContextClassLoader(originalContextClassLoader);
+        }
+    }
+
+    private static final class RejectingClassLoader extends ClassLoader {
+        private RejectingClassLoader() {
+            super(Configuration.class.getClassLoader());
+        }
+
+        @Override
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            throw new ClassNotFoundException(name);
+        }
+    }
+
+    private static final class UrlOnlyResourceClassLoader extends ClassLoader {
+        private final String resourceName;
+        private final URL resourceUrl;
+
+        private UrlOnlyResourceClassLoader(String resourceName, URL resourceUrl) {
+            super(Configuration.class.getClassLoader());
+            this.resourceName = resourceName;
+            this.resourceUrl = resourceUrl;
+        }
+
+        @Override
+        public URL getResource(String name) {
+            if (resourceName.equals(name)) {
+                return resourceUrl;
+            }
+            return super.getResource(name);
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            if (resourceName.equals(name)) {
+                return null;
+            }
+            return super.getResourceAsStream(name);
+        }
+    }
+}

--- a/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/DynamicLoaderTest.java
+++ b/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/DynamicLoaderTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_sf_saxon.Saxon_HE;
+
+import net.sf.saxon.lib.StandardLogger;
+import net.sf.saxon.trans.DynamicLoader;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DynamicLoaderTest {
+    private static final String STANDARD_LOGGER_CLASS_NAME = "net.sf.saxon.lib.StandardLogger";
+    private static final String SAXON_DATA_RESOURCE = "net/sf/saxon/data/profile.xsl";
+
+    @Test
+    void loadsSaxonClassUsingClassForNameFallbackWhenProvidedClassLoaderRejectsIt() throws Exception {
+        DynamicLoader loader = new DynamicLoader();
+
+        Class<?> loadedClass = loader.getClass(
+                STANDARD_LOGGER_CLASS_NAME,
+                null,
+                new RejectingClassLoader());
+
+        assertThat(loadedClass).isEqualTo(StandardLogger.class);
+    }
+
+    @Test
+    void instantiatesSaxonClassWithoutTracing() throws Exception {
+        DynamicLoader loader = new DynamicLoader();
+
+        Object instance = loader.getInstance(STANDARD_LOGGER_CLASS_NAME, StandardLogger.class.getClassLoader());
+
+        assertThat(instance).isInstanceOf(StandardLogger.class);
+    }
+
+    @Test
+    void instantiatesSaxonClassWithTracing() throws Exception {
+        ByteArrayOutputStream log = new ByteArrayOutputStream();
+        StandardLogger traceLogger = new StandardLogger(new PrintStream(log, true, StandardCharsets.UTF_8));
+        DynamicLoader loader = new DynamicLoader();
+
+        Object instance = loader.getInstance(
+                STANDARD_LOGGER_CLASS_NAME,
+                traceLogger,
+                StandardLogger.class.getClassLoader());
+
+        assertThat(instance).isInstanceOf(StandardLogger.class);
+        assertThat(log.toString(StandardCharsets.UTF_8)).contains("Loading " + STANDARD_LOGGER_CLASS_NAME);
+    }
+
+    @Test
+    void opensSaxonResourceThroughConfiguredClassLoader() throws Exception {
+        DynamicLoader loader = new DynamicLoader();
+        loader.setClassLoader(StandardLogger.class.getClassLoader());
+
+        try (InputStream resource = loader.getResourceAsStream(SAXON_DATA_RESOURCE)) {
+            assertThat(resource).isNotNull();
+            assertThat(resource.read()).isNotEqualTo(-1);
+        }
+    }
+
+    private static final class RejectingClassLoader extends ClassLoader {
+        private RejectingClassLoader() {
+            super(StandardLogger.class.getClassLoader());
+        }
+
+        @Override
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            throw new ClassNotFoundException(name);
+        }
+    }
+}

--- a/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/JavaPlatformTest.java
+++ b/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/JavaPlatformTest.java
@@ -15,15 +15,35 @@ import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.DefaultHandler;
 
 import java.io.StringReader;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class JavaPlatformTest {
+    private static final String TRY_JDK9_FIELD = "tryJdk9";
+
     @Test
     void loadsParserForXmlFragmentsThatUsesSuppliedEntityResolver() throws Exception {
         XMLReader reader = new JavaPlatform().loadParserForXmlFragments();
+
+        assertThat(parseWithExternalEntity(reader)).containsExactly("root", "child");
+    }
+
+    @Test
+    void loadsParserForXmlFragmentsWhenJdk9DefaultParserLookupIsUnavailable() throws Exception {
+        boolean originalTryJdk9 = setTryJdk9(false);
+        try {
+            XMLReader reader = new JavaPlatform().loadParserForXmlFragments();
+
+            assertThat(parseWithExternalEntity(reader)).containsExactly("root", "child");
+        } finally {
+            setTryJdk9(originalTryJdk9);
+        }
+    }
+
+    private static List<String> parseWithExternalEntity(XMLReader reader) throws Exception {
         List<String> elementNames = new ArrayList<>();
         reader.setContentHandler(new DefaultHandler() {
             @Override
@@ -42,7 +62,14 @@ public class JavaPlatformTest {
                 <!DOCTYPE root [<!ENTITY fragment SYSTEM "urn:saxon-test-fragment">]>
                 <root>&fragment;</root>
                 """)));
+        return elementNames;
+    }
 
-        assertThat(elementNames).containsExactly("root", "child");
+    private static boolean setTryJdk9(boolean value) throws Exception {
+        Field tryJdk9 = JavaPlatform.class.getDeclaredField(TRY_JDK9_FIELD);
+        tryJdk9.setAccessible(true);
+        boolean previous = tryJdk9.getBoolean(null);
+        tryJdk9.setBoolean(null, value);
+        return previous;
     }
 }

--- a/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/JavaPlatformTest.java
+++ b/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/JavaPlatformTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_sf_saxon.Saxon_HE;
+
+import net.sf.saxon.java.JavaPlatform;
+
+import org.junit.jupiter.api.Test;
+import org.xml.sax.Attributes;
+import org.xml.sax.InputSource;
+import org.xml.sax.XMLReader;
+import org.xml.sax.helpers.DefaultHandler;
+
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JavaPlatformTest {
+    @Test
+    void loadsParserForXmlFragmentsThatUsesSuppliedEntityResolver() throws Exception {
+        XMLReader reader = new JavaPlatform().loadParserForXmlFragments();
+        List<String> elementNames = new ArrayList<>();
+        reader.setContentHandler(new DefaultHandler() {
+            @Override
+            public void startElement(String uri, String localName, String qName, Attributes attributes) {
+                elementNames.add(qName);
+            }
+        });
+        reader.setEntityResolver((publicId, systemId) -> {
+            if ("urn:saxon-test-fragment".equals(systemId)) {
+                return new InputSource(new StringReader("<child>fragment</child>"));
+            }
+            return null;
+        });
+
+        reader.parse(new InputSource(new StringReader("""
+                <!DOCTYPE root [<!ENTITY fragment SYSTEM "urn:saxon-test-fragment">]>
+                <root>&fragment;</root>
+                """)));
+
+        assertThat(elementNames).containsExactly("root", "child");
+    }
+}

--- a/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/PJConverterAnonymous1Test.java
+++ b/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/PJConverterAnonymous1Test.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_sf_saxon.Saxon_HE;
+
+import net.sf.saxon.Configuration;
+import net.sf.saxon.expr.PJConverter;
+import net.sf.saxon.expr.StaticProperty;
+import net.sf.saxon.s9api.XdmAtomicValue;
+import net.sf.saxon.type.BuiltInAtomicType;
+import net.sf.saxon.value.UntypedAtomicValue;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PJConverterAnonymous1Test {
+    @Test
+    void convertsUntypedAtomicValueToTargetWithStringConstructor() throws Exception {
+        Configuration configuration = Configuration.newConfiguration();
+        PJConverter converter = PJConverter.allocate(
+                configuration,
+                BuiltInAtomicType.UNTYPED_ATOMIC,
+                StaticProperty.ALLOWS_ONE,
+                XdmAtomicValue.class);
+
+        Object converted = converter.convert(
+                new UntypedAtomicValue("created reflectively"),
+                XdmAtomicValue.class,
+                null);
+
+        assertThat(converted).isInstanceOf(XdmAtomicValue.class);
+        assertThat(((XdmAtomicValue) converted).getStringValue()).isEqualTo("created reflectively");
+    }
+}

--- a/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/PJConverterInnerToArrayTest.java
+++ b/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/PJConverterInnerToArrayTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_sf_saxon.Saxon_HE;
+
+import net.sf.saxon.Configuration;
+import net.sf.saxon.expr.PJConverter;
+import net.sf.saxon.expr.StaticProperty;
+import net.sf.saxon.om.GroundedValue;
+import net.sf.saxon.s9api.XdmAtomicValue;
+import net.sf.saxon.s9api.XdmItem;
+import net.sf.saxon.s9api.XdmValue;
+import net.sf.saxon.type.BuiltInAtomicType;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PJConverterInnerToArrayTest {
+    @Test
+    void convertsXdmStringSequenceToJavaArray() throws Exception {
+        Configuration configuration = Configuration.newConfiguration();
+        PJConverter converter = PJConverter.allocate(
+                configuration,
+                BuiltInAtomicType.STRING,
+                StaticProperty.ALLOWS_ZERO_OR_MORE,
+                String[].class);
+        XdmValue source = new XdmValue(Arrays.<XdmItem>asList(
+                new XdmAtomicValue("alpha"),
+                new XdmAtomicValue("beta")));
+        GroundedValue<?> underlyingValue = source.getUnderlyingValue();
+
+        Object converted = converter.convert(underlyingValue, String[].class, null);
+
+        assertThat(converted).isInstanceOf(String[].class);
+        assertThat((String[]) converted).containsExactly("alpha", "beta");
+    }
+}

--- a/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/PJConverterInnerToArrayTest.java
+++ b/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/PJConverterInnerToArrayTest.java
@@ -33,7 +33,7 @@ public class PJConverterInnerToArrayTest {
         XdmValue source = new XdmValue(Arrays.<XdmItem>asList(
                 new XdmAtomicValue("alpha"),
                 new XdmAtomicValue("beta")));
-        GroundedValue<?> underlyingValue = source.getUnderlyingValue();
+        GroundedValue underlyingValue = source.getUnderlyingValue();
 
         Object converted = converter.convert(underlyingValue, String[].class, null);
 

--- a/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/PJConverterInnerToCollectionTest.java
+++ b/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/PJConverterInnerToCollectionTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_sf_saxon.Saxon_HE;
+
+import net.sf.saxon.Configuration;
+import net.sf.saxon.expr.PJConverter;
+import net.sf.saxon.expr.StaticProperty;
+import net.sf.saxon.om.GroundedValue;
+import net.sf.saxon.s9api.XdmAtomicValue;
+import net.sf.saxon.s9api.XdmItem;
+import net.sf.saxon.s9api.XdmValue;
+import net.sf.saxon.type.BuiltInAtomicType;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PJConverterInnerToCollectionTest {
+    @Test
+    void convertsXdmStringSequenceToRequestedCollectionType() throws Exception {
+        Configuration configuration = Configuration.newConfiguration();
+        PJConverter converter = PJConverter.allocate(
+                configuration,
+                BuiltInAtomicType.STRING,
+                StaticProperty.ALLOWS_ZERO_OR_MORE,
+                LinkedList.class);
+        XdmValue source = new XdmValue(Arrays.<XdmItem>asList(
+                new XdmAtomicValue("alpha"),
+                new XdmAtomicValue("beta")));
+        GroundedValue<?> underlyingValue = source.getUnderlyingValue();
+
+        Object converted = converter.convert(
+                underlyingValue,
+                LinkedList.class,
+                configuration.getConversionContext());
+
+        assertThat(converted).isInstanceOf(LinkedList.class);
+        LinkedList<?> convertedList = (LinkedList<?>) converted;
+        assertThat(convertedList).hasSize(2);
+        assertThat(convertedList.get(0)).isEqualTo("alpha");
+        assertThat(convertedList.get(1)).isEqualTo("beta");
+    }
+}

--- a/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/PJConverterInnerToCollectionTest.java
+++ b/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/PJConverterInnerToCollectionTest.java
@@ -34,7 +34,7 @@ public class PJConverterInnerToCollectionTest {
         XdmValue source = new XdmValue(Arrays.<XdmItem>asList(
                 new XdmAtomicValue("alpha"),
                 new XdmAtomicValue("beta")));
-        GroundedValue<?> underlyingValue = source.getUnderlyingValue();
+        GroundedValue underlyingValue = source.getUnderlyingValue();
 
         Object converted = converter.convert(
                 underlyingValue,

--- a/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/StandardErrorListenerTest.java
+++ b/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/StandardErrorListenerTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_sf_saxon.Saxon_HE;
+
+import net.sf.saxon.lib.StandardErrorListener;
+import net.sf.saxon.lib.StandardLogger;
+import net.sf.saxon.s9api.HostLanguage;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StandardErrorListenerTest {
+    @Test
+    void makeAnotherCreatesCleanListenerWithCurrentLogger() {
+        StandardLogger logger = new StandardLogger();
+        StandardErrorListener listener = new StandardErrorListener();
+        listener.setLogger(logger);
+        listener.setMaximumNumberOfWarnings(1);
+        listener.setStackTraceDetail(0);
+        listener.setMaxOrdinaryCharacter(127);
+
+        StandardErrorListener copy = listener.makeAnother(HostLanguage.XSLT);
+
+        assertThat(copy).isNotSameAs(listener);
+        assertThat(copy).isInstanceOf(StandardErrorListener.class);
+        assertThat(copy.getLogger()).isSameAs(logger);
+        assertThat(copy.getMaximumNumberOfWarnings()).isEqualTo(25);
+        assertThat(copy.getStackTraceDetail()).isEqualTo(2);
+    }
+}

--- a/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/StaxBridgeTest.java
+++ b/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/StaxBridgeTest.java
@@ -8,6 +8,7 @@ package net_sf_saxon.Saxon_HE;
 
 import com.ctc.wstx.stax.WstxInputFactory;
 
+import net.sf.saxon.Configuration;
 import net.sf.saxon.pull.PullProvider;
 import net.sf.saxon.pull.StaxBridge;
 import net.sf.saxon.pull.UnparsedEntity;
@@ -25,7 +26,7 @@ public class StaxBridgeTest {
     private static final String DOCUMENT_SYSTEM_ID = "https://example.test/documents/source.xml";
 
     @Test
-    void reportsUnparsedEntitiesFromWoodstoxExtensionDeclarations() throws Exception {
+    void reportsUnparsedEntitiesFromLegacyWoodstoxExtensionDeclarations() throws Exception {
         String xml = """
                 <!DOCTYPE root [
                     <!NOTATION png SYSTEM "image/png">
@@ -37,9 +38,10 @@ public class StaxBridgeTest {
         XMLStreamReader reader = inputFactory.createXMLStreamReader(DOCUMENT_SYSTEM_ID, new StringReader(xml));
         StaxBridge bridge = new StaxBridge();
         bridge.setXMLStreamReader(reader);
+        bridge.setPipelineConfiguration(Configuration.newConfiguration().makePipelineConfiguration());
         try {
-            assertThat(bridge.next()).isEqualTo(PullProvider.START_DOCUMENT);
-            assertThat(bridge.next()).isEqualTo(PullProvider.START_ELEMENT);
+            assertThat(bridge.next()).isEqualTo(PullProvider.Event.START_DOCUMENT);
+            assertThat(bridge.next()).isEqualTo(PullProvider.Event.START_ELEMENT);
 
             List<UnparsedEntity> entities = bridge.getUnparsedEntities();
 

--- a/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/StaxBridgeTest.java
+++ b/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/StaxBridgeTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_sf_saxon.Saxon_HE;
+
+import com.ctc.wstx.stax.WstxInputFactory;
+
+import net.sf.saxon.pull.PullProvider;
+import net.sf.saxon.pull.StaxBridge;
+import net.sf.saxon.pull.UnparsedEntity;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.StringReader;
+import java.util.List;
+
+import javax.xml.stream.XMLStreamReader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StaxBridgeTest {
+    private static final String DOCUMENT_SYSTEM_ID = "https://example.test/documents/source.xml";
+
+    @Test
+    void reportsUnparsedEntitiesFromWoodstoxExtensionDeclarations() throws Exception {
+        String xml = """
+                <!DOCTYPE root [
+                    <!NOTATION png SYSTEM "image/png">
+                    <!ENTITY logo PUBLIC "-//Example//Logo//EN" "images/logo.png" NDATA png>
+                ]>
+                <root/>
+                """;
+        WstxInputFactory inputFactory = new WstxInputFactory();
+        XMLStreamReader reader = inputFactory.createXMLStreamReader(DOCUMENT_SYSTEM_ID, new StringReader(xml));
+        StaxBridge bridge = new StaxBridge();
+        bridge.setXMLStreamReader(reader);
+        try {
+            assertThat(bridge.next()).isEqualTo(PullProvider.START_DOCUMENT);
+            assertThat(bridge.next()).isEqualTo(PullProvider.START_ELEMENT);
+
+            List<UnparsedEntity> entities = bridge.getUnparsedEntities();
+
+            assertThat(entities).hasSize(1);
+            UnparsedEntity entity = entities.get(0);
+            assertThat(entity.getName()).isEqualTo("logo");
+            assertThat(entity.getPublicId()).isEqualTo("-//Example//Logo//EN");
+            assertThat(entity.getSystemId()).endsWith("images/logo.png");
+            assertThat(entity.getBaseURI()).isNotBlank();
+        } finally {
+            bridge.close();
+        }
+    }
+}

--- a/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/StyleNodeFactoryTest.java
+++ b/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/StyleNodeFactoryTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_sf_saxon.Saxon_HE;
+
+import net.sf.saxon.TransformerFactoryImpl;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+
+import javax.xml.transform.Templates;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StyleNodeFactoryTest {
+    @Test
+    void usesFallbackForUnknownExtensionInstruction() throws Exception {
+        String stylesheet = """
+                <xsl:stylesheet version="3.0"
+                    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                    xmlns:ext="http://example.com/saxon-test-extension"
+                    extension-element-prefixes="ext">
+                    <xsl:output method="xml" omit-xml-declaration="yes"/>
+                    <xsl:template match="/">
+                        <result>
+                            <ext:instruction>
+                                <xsl:fallback>
+                                    <fallback>used</fallback>
+                                </xsl:fallback>
+                            </ext:instruction>
+                        </result>
+                    </xsl:template>
+                </xsl:stylesheet>
+                """;
+        TransformerFactoryImpl factory = new TransformerFactoryImpl();
+        Templates templates = factory.newTemplates(new StreamSource(new StringReader(stylesheet)));
+        Transformer transformer = templates.newTransformer();
+        StringWriter output = new StringWriter();
+
+        transformer.transform(
+                new StreamSource(new StringReader("<input/>")),
+                new StreamResult(output));
+
+        assertThat(output).hasToString("<result><fallback>used</fallback></result>");
+    }
+}

--- a/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/resources/META-INF/native-image/net.sf.saxon/Saxon-HE_tests/native-image.properties
+++ b/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/resources/META-INF/native-image/net.sf.saxon/Saxon-HE_tests/native-image.properties
@@ -1,0 +1,1 @@
+Args = --enable-url-protocols=https

--- a/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,132 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "net_sf_saxon.Saxon_HE.ConfigurationTest$RejectingClassLoader"
+      },
+      "type" : "net.sf.saxon.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "net_sf_saxon.Saxon_HE.DynamicLoaderTest"
+      },
+      "type" : "net.sf.saxon.lib.StandardLogger"
+    },
+    {
+      "condition" : {
+        "typeReached" : "net_sf_saxon.Saxon_HE.DynamicLoaderTest$RejectingClassLoader"
+      },
+      "type" : "net.sf.saxon.lib.StandardLogger"
+    },
+    {
+      "condition" : {
+        "typeReached" : "net_sf_saxon.Saxon_HE.BuiltInFunctionSetTest"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "net_sf_saxon.Saxon_HE.ConfigurationTest"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "net_sf_saxon.Saxon_HE.PJConverterAnonymous1Test"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "net_sf_saxon.Saxon_HE.StaxBridgeTest"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "net_sf_saxon.Saxon_HE.StyleNodeFactoryTest"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "net_sf_saxon.Saxon_HE.ConfigurationTest"
+      },
+      "type" : "sun.security.provider.X509Factory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "net_sf_saxon.Saxon_HE.ConfigurationTest"
+      },
+      "type" : "sun.security.rsa.RSASignature$SHA256withRSA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "net_sf_saxon.Saxon_HE.BuiltInFunctionSetTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "net_sf_saxon.Saxon_HE.BuiltInFunctionSetTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "net_sf_saxon.Saxon_HE.ConfigurationTest"
+      },
+      "glob" : "net/sf/saxon/data/missing-saxon-test-resource.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "net_sf_saxon.Saxon_HE.ConfigurationTest"
+      },
+      "glob" : "net/sf/saxon/data/profile.xsl"
+    }
+  ]
+}

--- a/tests/src/net.sf.saxon/Saxon-HE/10.0/user-code-filter.json
+++ b/tests/src/net.sf.saxon/Saxon-HE/10.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "net.sf.saxon.**"
+    },
+    {
+      "includeClasses" : "net_sf_saxon.Saxon_HE.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #8305

This PR provides test fixes and new metadata for net.sf.saxon:Saxon-HE:10.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 246588
- Cached input tokens: 1550336
- Output tokens: 20413
- Metadata entries: 43
- Test-only metadata entries: 21
- Iterations: 6
- Library coverage percentage: 10.04
- Previous library version metadata entries: 248
- Previous library version test-only metadata entries: 21
- Previous library version coverage percentage: 10.36

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `ae86b4ba7e59ca160a4df6d376ca1a2f93086ee5`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- net.sf.saxon:Saxon-HE:9.9.1-6: 26/34 covered calls (76.47%)
- net.sf.saxon:Saxon-HE:10.0: 35/35 covered calls (100.00%)

**Reflection:**
- net.sf.saxon:Saxon-HE:9.9.1-6: 18/26 covered calls (69.23%)
- net.sf.saxon:Saxon-HE:10.0: 27/27 covered calls (100.00%)

**Resources:**
- net.sf.saxon:Saxon-HE:9.9.1-6: 8/8 covered calls (100.00%)
- net.sf.saxon:Saxon-HE:10.0: 8/8 covered calls (100.00%)

#### Library coverage

**Instruction:**
- net.sf.saxon:Saxon-HE:9.9.1-6: 45673/458336 (9.96%)
- net.sf.saxon:Saxon-HE:10.0: 45736/472119 (9.69%)

**Line:**
- net.sf.saxon:Saxon-HE:9.9.1-6: 10767/103976 (10.36%)
- net.sf.saxon:Saxon-HE:10.0: 10711/106670 (10.04%)

**Method:**
- net.sf.saxon:Saxon-HE:9.9.1-6: 2066/18484 (11.18%)
- net.sf.saxon:Saxon-HE:10.0: 2046/19057 (10.74%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/net.sf.saxon/Saxon-HE/9.9.1-6/build.gradle 2/tests/src/net.sf.saxon/Saxon-HE/10.0/build.gradle
index d74ee46e4a..42b2cb0be7 100644
--- 1/tests/src/net.sf.saxon/Saxon-HE/9.9.1-6/build.gradle
+++ 2/tests/src/net.sf.saxon/Saxon-HE/10.0/build.gradle
@@ -10,9 +10,24 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 
+repositories {
+    exclusiveContent {
+        forRepository {
+            mavenCentral {
+                metadataSources {
+                    artifact()
+                }
+            }
+        }
+        filter {
+            includeGroup 'org.codehaus.woodstox'
+        }
+    }
+}
+
 dependencies {
     testImplementation "net.sf.saxon:Saxon-HE:$libraryVersion"
-    testImplementation 'com.fasterxml.woodstox:woodstox-core:6.5.1'
+    testImplementation 'org.codehaus.woodstox:wstx-asl:3.0.0@jar'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
diff --git 1/tests/src/net.sf.saxon/Saxon-HE/9.9.1-6/src/test/java/net_sf_saxon/Saxon_HE/JavaPlatformTest.java 2/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/JavaPlatformTest.java
index 8bbbb1408b..1d0572e078 100644
--- 1/tests/src/net.sf.saxon/Saxon-HE/9.9.1-6/src/test/java/net_sf_saxon/Saxon_HE/JavaPlatformTest.java
+++ 2/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/JavaPlatformTest.java
@@ -15,15 +15,35 @@ import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.DefaultHandler;
 
 import java.io.StringReader;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class JavaPlatformTest {
+    private static final String TRY_JDK9_FIELD = "tryJdk9";
+
     @Test
     void loadsParserForXmlFragmentsThatUsesSuppliedEntityResolver() throws Exception {
         XMLReader reader = new JavaPlatform().loadParserForXmlFragments();
+
+        assertThat(parseWithExternalEntity(reader)).containsExactly("root", "child");
+    }
+
+    @Test
+    void loadsParserForXmlFragmentsWhenJdk9DefaultParserLookupIsUnavailable() throws Exception {
+        boolean originalTryJdk9 = setTryJdk9(false);
+        try {
+            XMLReader reader = new JavaPlatform().loadParserForXmlFragments();
+
+            assertThat(parseWithExternalEntity(reader)).containsExactly("root", "child");
+        } finally {
+            setTryJdk9(originalTryJdk9);
+        }
+    }
+
+    private static List<String> parseWithExternalEntity(XMLReader reader) throws Exception {
         List<String> elementNames = new ArrayList<>();
         reader.setContentHandler(new DefaultHandler() {
             @Override
@@ -42,7 +62,14 @@ public class JavaPlatformTest {
                 <!DOCTYPE root [<!ENTITY fragment SYSTEM "urn:saxon-test-fragment">]>
                 <root>&fragment;</root>
                 """)));
+        return elementNames;
+    }
 
-        assertThat(elementNames).containsExactly("root", "child");
+    private static boolean setTryJdk9(boolean value) throws Exception {
+        Field tryJdk9 = JavaPlatform.class.getDeclaredField(TRY_JDK9_FIELD);
+        tryJdk9.setAccessible(true);
+        boolean previous = tryJdk9.getBoolean(null);
+        tryJdk9.setBoolean(null, value);
+        return previous;
     }
 }
diff --git 1/tests/src/net.sf.saxon/Saxon-HE/9.9.1-6/src/test/java/net_sf_saxon/Saxon_HE/PJConverterInnerToArrayTest.java 2/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/PJConverterInnerToArrayTest.java
index 5b186ad482..0a05cd47be 100644
--- 1/tests/src/net.sf.saxon/Saxon-HE/9.9.1-6/src/test/java/net_sf_saxon/Saxon_HE/PJConverterInnerToArrayTest.java
+++ 2/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/PJConverterInnerToArrayTest.java
@@ -33,7 +33,7 @@ public class PJConverterInnerToArrayTest {
         XdmValue source = new XdmValue(Arrays.<XdmItem>asList(
                 new XdmAtomicValue("alpha"),
                 new XdmAtomicValue("beta")));
-        GroundedValue<?> underlyingValue = source.getUnderlyingValue();
+        GroundedValue underlyingValue = source.getUnderlyingValue();
 
         Object converted = converter.convert(underlyingValue, String[].class, null);
 
diff --git 1/tests/src/net.sf.saxon/Saxon-HE/9.9.1-6/src/test/java/net_sf_saxon/Saxon_HE/PJConverterInnerToCollectionTest.java 2/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/PJConverterInnerToCollectionTest.java
index e69090f08c..04f0d11981 100644
--- 1/tests/src/net.sf.saxon/Saxon-HE/9.9.1-6/src/test/java/net_sf_saxon/Saxon_HE/PJConverterInnerToCollectionTest.java
+++ 2/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/PJConverterInnerToCollectionTest.java
@@ -34,7 +34,7 @@ public class PJConverterInnerToCollectionTest {
         XdmValue source = new XdmValue(Arrays.<XdmItem>asList(
                 new XdmAtomicValue("alpha"),
                 new XdmAtomicValue("beta")));
-        GroundedValue<?> underlyingValue = source.getUnderlyingValue();
+        GroundedValue underlyingValue = source.getUnderlyingValue();
 
         Object converted = converter.convert(
                 underlyingValue,
diff --git 1/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/StandardErrorListenerTest.java 2/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/StandardErrorListenerTest.java
new file mode 100644
index 0000000000..16487ea52e
--- /dev/null
+++ 2/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/StandardErrorListenerTest.java
@@ -0,0 +1,35 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_sf_saxon.Saxon_HE;
+
+import net.sf.saxon.lib.StandardErrorListener;
+import net.sf.saxon.lib.StandardLogger;
+import net.sf.saxon.s9api.HostLanguage;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StandardErrorListenerTest {
+    @Test
+    void makeAnotherCreatesCleanListenerWithCurrentLogger() {
+        StandardLogger logger = new StandardLogger();
+        StandardErrorListener listener = new StandardErrorListener();
+        listener.setLogger(logger);
+        listener.setMaximumNumberOfWarnings(1);
+        listener.setStackTraceDetail(0);
+        listener.setMaxOrdinaryCharacter(127);
+
+        StandardErrorListener copy = listener.makeAnother(HostLanguage.XSLT);
+
+        assertThat(copy).isNotSameAs(listener);
+        assertThat(copy).isInstanceOf(StandardErrorListener.class);
+        assertThat(copy.getLogger()).isSameAs(logger);
+        assertThat(copy.getMaximumNumberOfWarnings()).isEqualTo(25);
+        assertThat(copy.getStackTraceDetail()).isEqualTo(2);
+    }
+}
diff --git 1/tests/src/net.sf.saxon/Saxon-HE/9.9.1-6/src/test/java/net_sf_saxon/Saxon_HE/StaxBridgeTest.java 2/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/StaxBridgeTest.java
index 876ba36a5d..d9c9475a0a 100644
--- 1/tests/src/net.sf.saxon/Saxon-HE/9.9.1-6/src/test/java/net_sf_saxon/Saxon_HE/StaxBridgeTest.java
+++ 2/tests/src/net.sf.saxon/Saxon-HE/10.0/src/test/java/net_sf_saxon/Saxon_HE/StaxBridgeTest.java
@@ -8,6 +8,7 @@ package net_sf_saxon.Saxon_HE;
 
 import com.ctc.wstx.stax.WstxInputFactory;
 
+import net.sf.saxon.Configuration;
 import net.sf.saxon.pull.PullProvider;
 import net.sf.saxon.pull.StaxBridge;
 import net.sf.saxon.pull.UnparsedEntity;
@@ -25,7 +26,7 @@ public class StaxBridgeTest {
     private static final String DOCUMENT_SYSTEM_ID = "https://example.test/documents/source.xml";
 
     @Test
-    void reportsUnparsedEntitiesFromWoodstoxExtensionDeclarations() throws Exception {
+    void reportsUnparsedEntitiesFromLegacyWoodstoxExtensionDeclarations() throws Exception {
         String xml = """
                 <!DOCTYPE root [
                     <!NOTATION png SYSTEM "image/png">
@@ -37,9 +38,10 @@ public class StaxBridgeTest {
         XMLStreamReader reader = inputFactory.createXMLStreamReader(DOCUMENT_SYSTEM_ID, new StringReader(xml));
         StaxBridge bridge = new StaxBridge();
         bridge.setXMLStreamReader(reader);
+        bridge.setPipelineConfiguration(Configuration.newConfiguration().makePipelineConfiguration());
         try {
-            assertThat(bridge.next()).isEqualTo(PullProvider.START_DOCUMENT);
-            assertThat(bridge.next()).isEqualTo(PullProvider.START_ELEMENT);
+            assertThat(bridge.next()).isEqualTo(PullProvider.Event.START_DOCUMENT);
+            assertThat(bridge.next()).isEqualTo(PullProvider.Event.START_ELEMENT);
 
             List<UnparsedEntity> entities = bridge.getUnparsedEntities();
 

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
