### PR TITLE
[GenAI] Test fix for org.apache.maven.scm:maven-scm-provider-gitexe:2.1.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.maven.scm/maven-scm-provider-gitexe/2.1.0/reachability-metadata.json
+++ b/metadata/org.apache.maven.scm/maven-scm-provider-gitexe/2.1.0/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.maven.scm.provider.git.gitexe.command.GitCommandLineUtils"
+      },
+      "glob" : "org/slf4j/impl/StaticLoggerBinder.class"
+    }
+  ]
+}

--- a/metadata/org.apache.maven.scm/maven-scm-provider-gitexe/index.json
+++ b/metadata/org.apache.maven.scm/maven-scm-provider-gitexe/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.1.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm-provider-gitexe/$version$/maven-scm-provider-gitexe-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/maven-scm",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm/$version$/maven-scm-$version$-source-release.zip",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm-provider-gitexe/$version$/maven-scm-provider-gitexe-$version$-javadoc.jar",
+    "description" : "This artifact provides the Apache Maven SCM provider implementation that talks to Git through the installed Git command-line executable. It lets Maven SCM integrations perform Git operations such as checkout, update, tag, status, and changelog through the shared Maven SCM API.",
     "tested-versions" : [
       "2.1.0"
     ],

--- a/metadata/org.apache.maven.scm/maven-scm-provider-gitexe/index.json
+++ b/metadata/org.apache.maven.scm/maven-scm-provider-gitexe/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.1.0",
+    "tested-versions" : [
+      "2.1.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.maven.scm.provider.git.gitexe"
+    ]
+  },
+  {
     "metadata-version" : "2.0.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm-provider-gitexe/$version$/maven-scm-provider-gitexe-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/maven-scm",

--- a/stats/org.apache.maven.scm/maven-scm-provider-gitexe/2.1.0/execution-metrics.json
+++ b/stats/org.apache.maven.scm/maven-scm-provider-gitexe/2.1.0/execution-metrics.json
@@ -1,0 +1,123 @@
+{
+  "fix_javac_fail:2026-06-10": {
+    "timestamp": "2026-06-10T20:41:03.656708Z",
+    "library": "org.apache.maven.scm:maven-scm-provider-gitexe:2.1.0",
+    "starting_commit": "bb093d2f859ab145e0c1cbb464fe9bf49c9d7bcd",
+    "ending_commit": "712b101aaac78e4c54f724c8750891eee8d9be18",
+    "previous_library": "org.apache.maven.scm:maven-scm-provider-gitexe:2.0.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.1.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 835,
+          "missed": 4157,
+          "ratio": 0.167268,
+          "total": 4992
+        },
+        "line": {
+          "covered": 192,
+          "missed": 947,
+          "ratio": 0.168569,
+          "total": 1139
+        },
+        "method": {
+          "covered": 36,
+          "missed": 134,
+          "ratio": 0.211765,
+          "total": 170
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.0.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 806,
+          "missed": 4011,
+          "ratio": 0.167324,
+          "total": 4817
+        },
+        "line": {
+          "covered": 185,
+          "missed": 926,
+          "ratio": 0.166517,
+          "total": 1111
+        },
+        "method": {
+          "covered": 34,
+          "missed": 132,
+          "ratio": 0.204819,
+          "total": 166
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "no_action",
+      "issue_number": 8331,
+      "issue_label": "fails-javac-compile",
+      "library": "org.apache.maven.scm:maven-scm-provider-gitexe:2.1.0",
+      "summary": "No extra setup is required: the 2.1.0 artifact brings its Maven SCM, git-commons, Plexus, Commons, javax.inject, and SLF4J API dependencies transitively, and meaningful coverage can be reached with command-line construction and output-consumer parsing without external services.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [
+        "The library is the Maven SCM provider that shells out to the local `git` executable when command execution paths are tested. Ubuntu CI normally has `git`, but tests can avoid relying on it by covering command-line factories and consumers.",
+        "If generated tests choose to execute real commits or tags in a temporary repository, the test code may need to configure repo-local `user.name` and `user.email`; this is not required before meaningful coverage is reachable.",
+        "SLF4J may use its no-op backend because no binding is present, but this is not a setup blocker."
+      ],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#8331 [Automation] javac compile fails for org.apache.maven.scm:maven-scm-provider-gitexe:2.1.0; label=fails-javac-compile; body_chars=8015"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "8 existing test file path(s) included"
+        }
+      ],
+      "current_library": "org.apache.maven.scm:maven-scm-provider-gitexe:2.0.0",
+      "new_version": "2.1.0",
+      "model": "oca/gpt-5.5",
+      "input_tokens_used": 80332,
+      "output_tokens_used": 4580,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.apache.maven.scm:maven-scm-provider-gitexe:2.1.0/library-preparation-preflight/pi-generation-2026-06-10T20-26-35-941854Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 29297,
+      "cached_input_tokens_used": 283648,
+      "output_tokens_used": 4852,
+      "iterations": 1,
+      "cost_usd": 0.2874,
+      "tested_library_loc": 192,
+      "metadata_entries": 1,
+      "test_only_metadata_entries": 2,
+      "previous_library_metadata_entries": 1,
+      "previous_library_test_only_metadata_entries": 2,
+      "code_coverage_percent": 16.86,
+      "previous_library_coverage_percent": 16.65
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.1.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/Maven_scm_provider_gitexeTest.java",
+      "metadata_file": "metadata/org.apache.maven.scm/maven-scm-provider-gitexe/2.1.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.maven.scm/maven-scm-provider-gitexe/2.1.0/stats.json
+++ b/stats/org.apache.maven.scm/maven-scm-provider-gitexe/2.1.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.1.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 835,
+        "missed" : 4157,
+        "ratio" : 0.167268,
+        "total" : 4992
+      },
+      "line" : {
+        "covered" : 192,
+        "missed" : 947,
+        "ratio" : 0.168569,
+        "total" : 1139
+      },
+      "method" : {
+        "covered" : 36,
+        "missed" : 134,
+        "ratio" : 0.211765,
+        "total" : 170
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.1.0/.gitignore
+++ b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.1.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.1.0/build.gradle
+++ b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.1.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.maven.scm:maven-scm-provider-gitexe:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.1.0/gradle.properties
+++ b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.1.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.maven.scm:maven-scm-provider-gitexe:2.1.0
+library.version = 2.1.0
+metadata.dir = org.apache.maven.scm/maven-scm-provider-gitexe/2.1.0/

--- a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.1.0/settings.gradle
+++ b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.1.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.maven.scm.maven-scm-provider-gitexe_tests'

--- a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.1.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/GitExeCommandLineConstructionTest.java
+++ b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.1.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/GitExeCommandLineConstructionTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_scm.maven_scm_provider_gitexe;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.maven.scm.CommandParameter;
+import org.apache.maven.scm.CommandParameters;
+import org.apache.maven.scm.ScmBranch;
+import org.apache.maven.scm.ScmFileSet;
+import org.apache.maven.scm.ScmTag;
+import org.apache.maven.scm.provider.git.gitexe.command.checkin.GitCheckInCommand;
+import org.apache.maven.scm.provider.git.gitexe.command.checkout.GitCheckOutCommand;
+import org.apache.maven.scm.provider.git.gitexe.command.diff.GitDiffCommand;
+import org.apache.maven.scm.provider.git.gitexe.command.info.GitInfoCommand;
+import org.apache.maven.scm.provider.git.gitexe.command.remoteinfo.GitRemoteInfoCommand;
+import org.apache.maven.scm.provider.git.gitexe.command.remove.GitRemoveCommand;
+import org.apache.maven.scm.provider.git.gitexe.command.tag.GitTagCommand;
+import org.apache.maven.scm.provider.git.gitexe.command.update.GitUpdateCommand;
+import org.apache.maven.scm.provider.git.repository.GitScmProviderRepository;
+import org.codehaus.plexus.util.cli.Commandline;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GitExeCommandLineConstructionTest {
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void checkoutUpdateRemoteAndInfoFactoriesBuildExpectedGitArguments() throws Exception {
+        File workingDirectory = temporaryDirectory.toFile();
+        GitScmProviderRepository repository = new GitScmProviderRepository("https://example.invalid/team/project.git");
+        ScmBranch featureBranch = new ScmBranch("feature/native-tests");
+
+        Commandline checkoutCommandLine =
+                GitCheckOutCommand.createCommandLine(repository, workingDirectory, featureBranch);
+        assertGitExecutable(checkoutCommandLine);
+        assertThat(checkoutCommandLine.getWorkingDirectory()).isEqualTo(workingDirectory);
+        assertThat(checkoutCommandLine.getArguments()).containsExactly("checkout", "feature/native-tests");
+
+        Commandline updateCommandLine = GitUpdateCommand.createCommandLine(repository, workingDirectory, featureBranch);
+        assertGitExecutable(updateCommandLine);
+        assertThat(updateCommandLine.getWorkingDirectory()).isEqualTo(workingDirectory);
+        assertThat(updateCommandLine.getArguments())
+                .containsExactly("pull", "https://example.invalid/team/project.git", "feature/native-tests");
+
+        Commandline latestRevisionCommandLine =
+                GitUpdateCommand.createLatestRevisionCommandLine(repository, workingDirectory, featureBranch);
+        assertThat(latestRevisionCommandLine.getArguments())
+                .containsExactly("log", "-n1", "--date-order", "feature/native-tests");
+
+        Commandline remoteInfoCommandLine = new GitRemoteInfoCommand(Map.of()).createCommandLine(repository);
+        assertGitExecutable(remoteInfoCommandLine);
+        File temporaryRoot = new File(System.getProperty("java.io.tmpdir"));
+        assertThat(remoteInfoCommandLine.getWorkingDirectory()).isEqualTo(temporaryRoot);
+        assertThat(remoteInfoCommandLine.getArguments())
+                .containsExactly("ls-remote", "https://example.invalid/team/project.git");
+
+        CommandParameters infoParameters = new CommandParameters();
+        infoParameters.setInt(CommandParameter.SCM_SHORT_REVISION_LENGTH, 12);
+        Commandline infoCommandLine = GitInfoCommand.createCommandLine(
+                repository, new ScmFileSet(workingDirectory), infoParameters);
+        assertThat(infoCommandLine.getArguments())
+                .containsExactly("rev-parse", "--verify", "--short=12", "HEAD");
+    }
+
+    @Test
+    void diffTagCommitAndRemoveFactoriesBuildExpectedArguments() throws Exception {
+        File workingDirectory = temporaryDirectory.toFile();
+        Path trackedPath = temporaryDirectory.resolve("tracked.txt");
+        Path messagePath = temporaryDirectory.resolve("message.txt");
+        Path removableDirectory = temporaryDirectory.resolve("directory-to-remove");
+        Files.writeString(trackedPath, "content\n", StandardCharsets.UTF_8);
+        Files.writeString(messagePath, "message\n", StandardCharsets.UTF_8);
+        Files.createDirectories(removableDirectory);
+
+        GitScmProviderRepository repository = new GitScmProviderRepository("https://example.invalid/team/project.git");
+        ScmTag startTag = new ScmTag("v1.0.0");
+        ScmTag endTag = new ScmTag("v1.1.0");
+
+        Commandline cachedDiffCommandLine = GitDiffCommand.createCommandLine(workingDirectory, startTag, endTag, true);
+        assertGitExecutable(cachedDiffCommandLine);
+        assertThat(cachedDiffCommandLine.getArguments())
+                .containsExactly("diff", "--cached", "v1.0.0", "v1.1.0");
+
+        Commandline rawDiffCommandLine = GitDiffCommand.createDiffRawCommandLine(workingDirectory, "HEAD");
+        assertThat(rawDiffCommandLine.getArguments()).containsExactly("diff", "--raw", "HEAD");
+
+        Commandline tagCommandLine = GitTagCommand.createCommandLine(
+                repository, workingDirectory, "v1.1.0", messagePath.toFile(), false);
+        assertThat(tagCommandLine.getArguments())
+                .containsExactly("tag", "-F", messagePath.toAbsolutePath().toString(), "v1.1.0");
+
+        Commandline signedTagCommandLine = GitTagCommand.createCommandLine(
+                repository, workingDirectory, "v1.1.0", messagePath.toFile(), true);
+        assertThat(signedTagCommandLine.getArguments())
+                .containsExactly("tag", "-s", "-F", messagePath.toAbsolutePath().toString(), "v1.1.0");
+
+        Commandline tagPushCommandLine = GitTagCommand.createPushCommandLine(
+                repository, new ScmFileSet(workingDirectory, trackedPath.toFile()), "v1.1.0");
+        assertThat(tagPushCommandLine.getArguments())
+                .containsExactly("push", "https://example.invalid/team/project.git", "refs/tags/v1.1.0");
+
+        ScmFileSet trackedFileSet = new ScmFileSet(workingDirectory, trackedPath.toFile());
+        Commandline commitCommandLine =
+                GitCheckInCommand.createCommitCommandLine(repository, trackedFileSet, messagePath.toFile());
+        assertThat(commitCommandLine.getArguments())
+                .containsExactly("commit", "--verbose", "-F", messagePath.toAbsolutePath().toString());
+
+        Commandline removeCommandLine = GitRemoveCommand.createCommandLine(
+                workingDirectory, List.of(removableDirectory.toFile(), trackedPath.toFile()));
+        assertThat(removeCommandLine.getArguments()).contains("rm", "-r", "directory-to-remove", "tracked.txt");
+    }
+
+    private static void assertGitExecutable(Commandline commandLine) {
+        assertThat(commandLine.getExecutable()).isIn("git", "'git'");
+    }
+}

--- a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.1.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/GitExeCommandLineConstructionTest.java
+++ b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.1.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/GitExeCommandLineConstructionTest.java
@@ -16,8 +16,11 @@ import java.util.Map;
 import org.apache.maven.scm.CommandParameter;
 import org.apache.maven.scm.CommandParameters;
 import org.apache.maven.scm.ScmBranch;
+import org.apache.maven.scm.ScmException;
 import org.apache.maven.scm.ScmFileSet;
 import org.apache.maven.scm.ScmTag;
+import org.apache.maven.scm.command.info.InfoItem;
+import org.apache.maven.scm.provider.ScmProviderRepository;
 import org.apache.maven.scm.provider.git.gitexe.command.checkin.GitCheckInCommand;
 import org.apache.maven.scm.provider.git.gitexe.command.checkout.GitCheckOutCommand;
 import org.apache.maven.scm.provider.git.gitexe.command.diff.GitDiffCommand;
@@ -69,10 +72,12 @@ public class GitExeCommandLineConstructionTest {
 
         CommandParameters infoParameters = new CommandParameters();
         infoParameters.setInt(CommandParameter.SCM_SHORT_REVISION_LENGTH, 12);
-        Commandline infoCommandLine = GitInfoCommand.createCommandLine(
-                repository, new ScmFileSet(workingDirectory), infoParameters);
+        Commandline infoCommandLine = new CapturingGitInfoCommand()
+                .createInfoCommandLine(repository, new ScmFileSet(workingDirectory), infoParameters);
+        assertGitExecutable(infoCommandLine);
+        assertThat(infoCommandLine.getWorkingDirectory()).isEqualTo(workingDirectory);
         assertThat(infoCommandLine.getArguments())
-                .containsExactly("rev-parse", "--verify", "--short=12", "HEAD");
+                .containsExactly("log", "-1", "--no-merges", "--format=format:%H %aI %aE %aN");
     }
 
     @Test
@@ -125,5 +130,24 @@ public class GitExeCommandLineConstructionTest {
 
     private static void assertGitExecutable(Commandline commandLine) {
         assertThat(commandLine.getExecutable()).isIn("git", "'git'");
+    }
+
+    private static final class CapturingGitInfoCommand extends GitInfoCommand {
+        private Commandline commandLine;
+
+        Commandline createInfoCommandLine(
+                ScmProviderRepository repository,
+                ScmFileSet fileSet,
+                CommandParameters parameters) throws ScmException {
+            executeCommand(repository, fileSet, parameters);
+            return commandLine;
+        }
+
+        @Override
+        protected InfoItem executeInfoCommand(
+                Commandline cli, CommandParameters parameters, File scmFile) {
+            commandLine = cli;
+            return new InfoItem();
+        }
     }
 }

--- a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.1.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/Maven_scm_provider_gitexeTest.java
+++ b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.1.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/Maven_scm_provider_gitexeTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_scm.maven_scm_provider_gitexe;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.maven.scm.ScmFile;
+import org.apache.maven.scm.ScmFileStatus;
+import org.apache.maven.scm.command.remoteinfo.RemoteInfoScmResult;
+import org.apache.maven.scm.provider.git.gitexe.command.remoteinfo.GitRemoteInfoConsumer;
+import org.apache.maven.scm.provider.git.gitexe.command.status.GitStatusConsumer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+public class Maven_scm_provider_gitexeTest {
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void statusConsumerParsesPorcelainStatusOutputIntoScmFiles() throws Exception {
+        Path addedPath = temporaryDirectory.resolve("added.txt");
+        Path modifiedPath = temporaryDirectory.resolve("modified.txt");
+        Path renamedPath = temporaryDirectory.resolve("renamed.txt");
+        Path spacedPath = temporaryDirectory.resolve("space name.txt");
+        Files.writeString(addedPath, "added\n", StandardCharsets.UTF_8);
+        Files.writeString(modifiedPath, "modified\n", StandardCharsets.UTF_8);
+        Files.writeString(renamedPath, "renamed\n", StandardCharsets.UTF_8);
+        Files.writeString(spacedPath, "spaced\n", StandardCharsets.UTF_8);
+
+        GitStatusConsumer consumer = new GitStatusConsumer(temporaryDirectory.toFile());
+        consumer.consumeLine("A  added.txt");
+        consumer.consumeLine(" M modified.txt");
+        consumer.consumeLine(" D deleted.txt");
+        consumer.consumeLine("R  old-name.txt -> renamed.txt");
+        consumer.consumeLine(" M \"space name.txt\"");
+        consumer.consumeLine("?? ignored-by-maven-scm.txt");
+
+        assertThat(consumer.getChangedFiles())
+                .extracting(ScmFile::getPath, ScmFile::getStatus)
+                .containsExactly(
+                        tuple("added.txt", ScmFileStatus.ADDED),
+                        tuple("modified.txt", ScmFileStatus.MODIFIED),
+                        tuple("deleted.txt", ScmFileStatus.DELETED),
+                        tuple("old-name.txt", ScmFileStatus.RENAMED),
+                        tuple("renamed.txt", ScmFileStatus.RENAMED),
+                        tuple("space name.txt", ScmFileStatus.MODIFIED));
+    }
+
+    @Test
+    void remoteInfoConsumerParsesBranchesAndTagsFromLsRemoteOutput() {
+        GitRemoteInfoConsumer consumer = new GitRemoteInfoConsumer("git ls-remote origin");
+        consumer.consumeLine("1111111111111111111111111111111111111111\trefs/heads/main");
+        consumer.consumeLine("2222222222222222222222222222222222222222 refs/heads/feature/native-tests");
+        consumer.consumeLine("3333333333333333333333333333333333333333\trefs/tags/v1.0.0");
+        consumer.consumeLine("4444444444444444444444444444444444444444 refs/pull/7/head");
+
+        RemoteInfoScmResult result = consumer.getRemoteInfoScmResult();
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getCommandLine()).isEqualTo("git ls-remote origin");
+        assertThat(result.getBranches())
+                .containsEntry("main", "1111111111111111111111111111111111111111")
+                .containsEntry("feature/native-tests", "2222222222222222222222222222222222222222")
+                .hasSize(2);
+        assertThat(result.getTags())
+                .containsEntry("v1.0.0", "3333333333333333333333333333333333333333")
+                .hasSize(1);
+    }
+}

--- a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.1.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.1.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org_apache_maven_scm.maven_scm_provider_gitexe.GitExeCommandLineConstructionTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_apache_maven_scm.maven_scm_provider_gitexe.GitExeCommandLineConstructionTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.1.0/user-code-filter.json
+++ b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.1.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.maven.scm.provider.git.gitexe.**"
+    },
+    {
+      "includeClasses" : "org_apache_maven_scm.maven_scm_provider_gitexe.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #8331

This PR provides test fixes and new metadata for org.apache.maven.scm:maven-scm-provider-gitexe:2.1.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 29297
- Cached input tokens: 283648
- Output tokens: 4852
- Metadata entries: 1
- Test-only metadata entries: 2
- Iterations: 1
- Library coverage percentage: 16.86
- Previous library version metadata entries: 1
- Previous library version test-only metadata entries: 2
- Previous library version coverage percentage: 16.65

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `db73836318e00e8ed60aae718694ad1a1d036a08`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.maven.scm:maven-scm-provider-gitexe:2.0.0: 0/0 covered calls (100.00%)
- org.apache.maven.scm:maven-scm-provider-gitexe:2.1.0: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.maven.scm:maven-scm-provider-gitexe:2.0.0: 806/4817 (16.73%)
- org.apache.maven.scm:maven-scm-provider-gitexe:2.1.0: 835/4992 (16.73%)

**Line:**
- org.apache.maven.scm:maven-scm-provider-gitexe:2.0.0: 185/1111 (16.65%)
- org.apache.maven.scm:maven-scm-provider-gitexe:2.1.0: 192/1139 (16.86%)

**Method:**
- org.apache.maven.scm:maven-scm-provider-gitexe:2.0.0: 34/166 (20.48%)
- org.apache.maven.scm:maven-scm-provider-gitexe:2.1.0: 36/170 (21.18%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/GitExeCommandLineConstructionTest.java b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.1.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/GitExeCommandLineConstructionTest.java
index 23d0d036a2..d804d9ae02 100644
--- a/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/GitExeCommandLineConstructionTest.java
+++ b/tests/src/org.apache.maven.scm/maven-scm-provider-gitexe/2.1.0/src/test/java/org_apache_maven_scm/maven_scm_provider_gitexe/GitExeCommandLineConstructionTest.java
@@ -16,8 +16,11 @@ import java.util.Map;
 import org.apache.maven.scm.CommandParameter;
 import org.apache.maven.scm.CommandParameters;
 import org.apache.maven.scm.ScmBranch;
+import org.apache.maven.scm.ScmException;
 import org.apache.maven.scm.ScmFileSet;
 import org.apache.maven.scm.ScmTag;
+import org.apache.maven.scm.command.info.InfoItem;
+import org.apache.maven.scm.provider.ScmProviderRepository;
 import org.apache.maven.scm.provider.git.gitexe.command.checkin.GitCheckInCommand;
 import org.apache.maven.scm.provider.git.gitexe.command.checkout.GitCheckOutCommand;
 import org.apache.maven.scm.provider.git.gitexe.command.diff.GitDiffCommand;
@@ -69,10 +72,12 @@ public class GitExeCommandLineConstructionTest {
 
         CommandParameters infoParameters = new CommandParameters();
         infoParameters.setInt(CommandParameter.SCM_SHORT_REVISION_LENGTH, 12);
-        Commandline infoCommandLine = GitInfoCommand.createCommandLine(
-                repository, new ScmFileSet(workingDirectory), infoParameters);
+        Commandline infoCommandLine = new CapturingGitInfoCommand()
+                .createInfoCommandLine(repository, new ScmFileSet(workingDirectory), infoParameters);
+        assertGitExecutable(infoCommandLine);
+        assertThat(infoCommandLine.getWorkingDirectory()).isEqualTo(workingDirectory);
         assertThat(infoCommandLine.getArguments())
-                .containsExactly("rev-parse", "--verify", "--short=12", "HEAD");
+                .containsExactly("log", "-1", "--no-merges", "--format=format:%H %aI %aE %aN");
     }
 
     @Test
@@ -126,4 +131,23 @@ public class GitExeCommandLineConstructionTest {
     private static void assertGitExecutable(Commandline commandLine) {
         assertThat(commandLine.getExecutable()).isIn("git", "'git'");
     }
+
+    private static final class CapturingGitInfoCommand extends GitInfoCommand {
+        private Commandline commandLine;
+
+        Commandline createInfoCommandLine(
+                ScmProviderRepository repository,
+                ScmFileSet fileSet,
+                CommandParameters parameters) throws ScmException {
+            executeCommand(repository, fileSet, parameters);
+            return commandLine;
+        }
+
+        @Override
+        protected InfoItem executeInfoCommand(
+                Commandline cli, CommandParameters parameters, File scmFile) {
+            commandLine = cli;
+            return new InfoItem();
+        }
+    }
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
