### PR TITLE
[Automation] Generated metadata for org.jboss:jandex:3.0.7

### DIFF
--- a/metadata/org.jboss/jandex/3.0.7/reachability-metadata.json
+++ b/metadata/org.jboss/jandex/3.0.7/reachability-metadata.json
@@ -1,0 +1,44 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.jboss.jandex.StrongInternPool"
+      },
+      "type": "java.lang.String",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.jandex.StrongInternPool"
+      },
+      "type": "org.jboss.jandex.StrongInternPool",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.jandex.Utils"
+      },
+      "type": "org.jboss.jandex.AnnotationInstance[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.jandex.Utils"
+      },
+      "type": "org.jboss.jandex.ClassInfo[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.jandex.JandexReflection"
+      },
+      "type": "org_jboss.jandex.JandexReflectionTest$SampleType"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.jboss.jandex.Indexer"
+      },
+      "glob": "org_jboss/jandex/IndexerTest$IndexedSample.class"
+    }
+  ]
+}

--- a/metadata/org.jboss/jandex/3.0.7/reachability-metadata.json
+++ b/metadata/org.jboss/jandex/3.0.7/reachability-metadata.json
@@ -1,44 +1,38 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org.jboss.jandex.StrongInternPool"
+      "condition" : {
+        "typeReached" : "org.jboss.jandex.StrongInternPool"
       },
-      "type": "java.lang.String",
-      "serializable": true
+      "type" : "java.lang.String",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.jandex.StrongInternPool"
+      "condition" : {
+        "typeReached" : "org.jboss.jandex.StrongInternPool"
       },
-      "type": "org.jboss.jandex.StrongInternPool",
-      "serializable": true
+      "type" : "org.jboss.jandex.StrongInternPool",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.jandex.Utils"
+      "condition" : {
+        "typeReached" : "org.jboss.jandex.Utils"
       },
-      "type": "org.jboss.jandex.AnnotationInstance[]"
+      "type" : "org.jboss.jandex.AnnotationInstance[]"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.jandex.Utils"
+      "condition" : {
+        "typeReached" : "org.jboss.jandex.Utils"
       },
-      "type": "org.jboss.jandex.ClassInfo[]"
-    },
-    {
-      "condition": {
-        "typeReached": "org.jboss.jandex.JandexReflection"
-      },
-      "type": "org_jboss.jandex.JandexReflectionTest$SampleType"
+      "type" : "org.jboss.jandex.ClassInfo[]"
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "org.jboss.jandex.Indexer"
+      "condition" : {
+        "typeReached" : "org.jboss.jandex.Indexer"
       },
-      "glob": "org_jboss/jandex/IndexerTest$IndexedSample.class"
+      "glob" : "org_jboss/jandex/IndexerTest$IndexedSample.class"
     }
   ]
 }

--- a/metadata/org.jboss/jandex/index.json
+++ b/metadata/org.jboss/jandex/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.0.7",
+    "test-version" : "3.0.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/smallrye/jandex/$version$/jandex-$version$-sources.jar",
+    "repository-url" : "https://github.com/smallrye/jandex",
+    "test-code-url" : "https://github.com/smallrye/jandex/tree/$version$/core/src/test/java",
+    "documentation-url" : "https://github.com/smallrye/jandex/blob/$version$/doc/modules/ROOT/pages/index.adoc",
+    "description" : "Jandex is a Java class file indexer and offline reflection library that builds a compact index of class metadata, annotations, declarations, types, and inheritance information. It provides APIs and tools to query, persist, and reload that index for build-time or runtime frameworks without scanning bytecode repeatedly.",
+    "tested-versions" : [
+      "3.0.7"
+    ],
+    "allowed-packages" : [
+      "org.jboss.jandex"
+    ]
+  },
+  {
     "metadata-version" : "3.0.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/smallrye/jandex/$version$/jandex-$version$-sources.jar",
     "repository-url" : "https://github.com/smallrye/jandex",

--- a/stats/org.jboss/jandex/3.0.7/execution-metrics.json
+++ b/stats/org.jboss/jandex/3.0.7/execution-metrics.json
@@ -1,0 +1,139 @@
+{
+  "fix_ni_run:2026-06-10": {
+    "timestamp": "2026-06-10T21:15:04.607598Z",
+    "library": "org.jboss:jandex:3.0.7",
+    "starting_commit": "a77451bca3be6cdc1e812ca558df2937b83604b2",
+    "ending_commit": "5e32e56b3b166bd3aa76112ce9c1bc2f404b1ce6",
+    "previous_library": "org.jboss:jandex:3.0.0",
+    "strategy_name": "library_update_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.0.7",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 5,
+            "totalCalls": 5
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 6,
+        "totalCalls": 6
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5985,
+          "missed": 32164,
+          "ratio": 0.156885,
+          "total": 38149
+        },
+        "line": {
+          "covered": 1071,
+          "missed": 6663,
+          "ratio": 0.138479,
+          "total": 7734
+        },
+        "method": {
+          "covered": 218,
+          "missed": 1319,
+          "ratio": 0.141835,
+          "total": 1537
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.0.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 5,
+        "totalCalls": 5
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 6004,
+          "missed": 30499,
+          "ratio": 0.16448,
+          "total": 36503
+        },
+        "line": {
+          "covered": 1043,
+          "missed": 6341,
+          "ratio": 0.141251,
+          "total": 7384
+        },
+        "method": {
+          "covered": 212,
+          "missed": 1276,
+          "ratio": 0.142473,
+          "total": 1488
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "degraded",
+      "action": "no_action",
+      "issue_number": 8332,
+      "issue_label": "fails-native-image-run",
+      "library": "org.jboss:jandex:3.0.7",
+      "summary": "Library preparation preflight did not produce usable advisory setup.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#8332 [Automation] native-image run fails for org.jboss:jandex:3.0.7; label=fails-native-image-run; body_chars=8015"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "9 existing test file path(s) included"
+        }
+      ],
+      "current_library": "org.jboss:jandex:3.0.0",
+      "new_version": "3.0.7",
+      "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
+      "model": "oca/gpt-5.5",
+      "prompt_path": "library-preflight-prompt.txt",
+      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.jboss:jandex:3.0.7/library-preparation-preflight/pi-generation-2026-06-10T20-56-42-295620Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 0,
+      "cached_input_tokens_used": 0,
+      "output_tokens_used": 0,
+      "iterations": 0,
+      "cost_usd": 0.0,
+      "tested_library_loc": 1071,
+      "metadata_entries": 7,
+      "test_only_metadata_entries": 2,
+      "previous_library_metadata_entries": 6,
+      "previous_library_test_only_metadata_entries": 2,
+      "code_coverage_percent": 13.85,
+      "previous_library_coverage_percent": 14.13
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.jboss/jandex/3.0.0/src/test/java/org_jboss/jandex/IndexerTest.java",
+      "metadata_file": "metadata/org.jboss/jandex/3.0.7/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.jboss/jandex/3.0.7/stats.json
+++ b/stats/org.jboss/jandex/3.0.7/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "3.0.7",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 5,
+          "totalCalls" : 5
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 6,
+      "totalCalls" : 6
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 5985,
+        "missed" : 32164,
+        "ratio" : 0.156885,
+        "total" : 38149
+      },
+      "line" : {
+        "covered" : 1071,
+        "missed" : 6663,
+        "ratio" : 0.138479,
+        "total" : 7734
+      },
+      "method" : {
+        "covered" : 218,
+        "missed" : 1319,
+        "ratio" : 0.141835,
+        "total" : 1537
+      }
+    }
+  } ]
+}

--- a/tests/src/org.jboss/jandex/3.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.jboss/jandex/3.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -5,6 +5,12 @@
         "typeReached" : "org.jboss.jandex.JandexReflection"
       },
       "type" : "org_jboss.jandex.JandexReflectionTest$SampleType[][]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.jandex.JandexReflection"
+      },
+      "type" : "org_jboss.jandex.JandexReflectionTest$SampleType"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: oracle/graalvm-reachability-metadata#8332

This PR provides new metadata needed for the org.jboss:jandex:3.0.7, addressing Native Image run failures caused by changes in the updated library version.

Summary:
- Metadata entries (previous `org.jboss:jandex:3.0.0`): 6
- Test-only metadata entries (previous `org.jboss:jandex:3.0.0`): 2
- Metadata entries (new `org.jboss:jandex:3.0.7`): 7
- Test-only metadata entries (new `org.jboss:jandex:3.0.7`): 2
- Library coverage (previous): 14.13%
- Library coverage (new): 13.85%
- Strategy: library_update_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 0
- Cached input tokens: 0
- Output tokens: 0
- Iterations: 0

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `db73836318e00e8ed60aae718694ad1a1d036a08`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.jboss:jandex:3.0.0: 5/5 covered calls (100.00%)
- org.jboss:jandex:3.0.7: 6/6 covered calls (100.00%)

**Reflection:**
- org.jboss:jandex:3.0.0: 4/4 covered calls (100.00%)
- org.jboss:jandex:3.0.7: 5/5 covered calls (100.00%)

**Resources:**
- org.jboss:jandex:3.0.0: 1/1 covered calls (100.00%)
- org.jboss:jandex:3.0.7: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.jboss:jandex:3.0.0: 6004/36503 (16.45%)
- org.jboss:jandex:3.0.7: 5985/38149 (15.69%)

**Line:**
- org.jboss:jandex:3.0.0: 1043/7384 (14.13%)
- org.jboss:jandex:3.0.7: 1071/7734 (13.85%)

**Method:**
- org.jboss:jandex:3.0.0: 212/1488 (14.25%)
- org.jboss:jandex:3.0.7: 218/1537 (14.18%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
