### PR TITLE
[Automation] Generated metadata for io.quarkus:quarkus-junit-common:3.37.0.CR1

### DIFF
--- a/metadata/io.quarkus/quarkus-junit-common/3.37.0.CR1/reachability-metadata.json
+++ b/metadata/io.quarkus/quarkus-junit-common/3.37.0.CR1/reachability-metadata.json
@@ -1,0 +1,66 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.quarkus.test.junit.common.ClearCache"
+      },
+      "type": "ch.qos.logback.classic.Logger"
+    },
+    {
+      "condition": {
+        "typeReached": "io.quarkus.test.junit.common.ClearCache"
+      },
+      "type": "com.sun.naming.internal.ResourceManager"
+    },
+    {
+      "condition": {
+        "typeReached": "io_quarkus.quarkus_junit_common.ClearCacheTest"
+      },
+      "type": "io_quarkus.quarkus_junit_common.ClearCacheTest$Markers",
+      "methods": [
+        {
+          "name": "value",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.quarkus.test.junit.common.ClearCache"
+      },
+      "type": "org.apache.log4j.LogManager"
+    },
+    {
+      "condition": {
+        "typeReached": "io.quarkus.test.junit.common.ClearCache"
+      },
+      "type": "org.apache.logging.log4j.Logger"
+    },
+    {
+      "condition": {
+        "typeReached": "io.quarkus.test.junit.common.ClearCache"
+      },
+      "type": "org.jboss.logmanager.LogManager"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io_quarkus.quarkus_junit_common.ClearCacheTest"
+      },
+      "glob": "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition": {
+        "typeReached": "io_quarkus.quarkus_junit_common.ClearCacheTest"
+      },
+      "glob": "META-INF/services/org.assertj.core.presentation.Representation"
+    },
+    {
+      "condition": {
+        "typeReached": "io.quarkus.test.junit.common.ClearCache"
+      },
+      "glob": "META-INF/services/org.jboss.logging.LoggerProvider"
+    }
+  ]
+}

--- a/metadata/io.quarkus/quarkus-junit-common/3.37.0.CR1/reachability-metadata.json
+++ b/metadata/io.quarkus/quarkus-junit-common/3.37.0.CR1/reachability-metadata.json
@@ -1,66 +1,51 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "io.quarkus.test.junit.common.ClearCache"
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.KotlinReflectionUtils"
       },
-      "type": "ch.qos.logback.classic.Logger"
+      "type" : "kotlin.Metadata"
     },
     {
-      "condition": {
-        "typeReached": "io.quarkus.test.junit.common.ClearCache"
+      "condition" : {
+        "typeReached" : "io.quarkus.test.junit.common.ClearCache"
       },
-      "type": "com.sun.naming.internal.ResourceManager"
-    },
-    {
-      "condition": {
-        "typeReached": "io_quarkus.quarkus_junit_common.ClearCacheTest"
-      },
-      "type": "io_quarkus.quarkus_junit_common.ClearCacheTest$Markers",
-      "methods": [
+      "type" : "org.junit.platform.commons.util.AnnotationUtils",
+      "fields" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "repeatableAnnotationContainerCache"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "io.quarkus.test.junit.common.ClearCache"
+      "condition" : {
+        "typeReached" : "io.quarkus.test.junit.common.ClearCache"
       },
-      "type": "org.apache.log4j.LogManager"
-    },
-    {
-      "condition": {
-        "typeReached": "io.quarkus.test.junit.common.ClearCache"
-      },
-      "type": "org.apache.logging.log4j.Logger"
-    },
-    {
-      "condition": {
-        "typeReached": "io.quarkus.test.junit.common.ClearCache"
-      },
-      "type": "org.jboss.logmanager.LogManager"
+      "type" : "com.sun.naming.internal.ResourceManager",
+      "fields" : [
+        {
+          "name" : "propertiesCache"
+        }
+      ]
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "io_quarkus.quarkus_junit_common.ClearCacheTest"
-      },
-      "glob": "META-INF/services/org.assertj.core.configuration.Configuration"
+      "glob" : "META-INF/services/org.junit.platform.commons.support.scanning.ClasspathScanner"
     },
     {
-      "condition": {
-        "typeReached": "io_quarkus.quarkus_junit_common.ClearCacheTest"
+      "condition" : {
+        "typeReached" : "io.quarkus.test.junit.common.ClearCache"
       },
-      "glob": "META-INF/services/org.assertj.core.presentation.Representation"
-    },
+      "glob" : "META-INF/services/org.jboss.logging.LoggerProvider"
+    }
+  ],
+  "serialization" : [
     {
-      "condition": {
-        "typeReached": "io.quarkus.test.junit.common.ClearCache"
+      "condition" : {
+        "typeReached" : "org.junit.platform.engine.UniqueId"
       },
-      "glob": "META-INF/services/org.jboss.logging.LoggerProvider"
+      "type" : "org.junit.platform.engine.UniqueId$SerializedForm"
     }
   ]
 }

--- a/metadata/io.quarkus/quarkus-junit-common/index.json
+++ b/metadata/io.quarkus/quarkus-junit-common/index.json
@@ -13,7 +13,8 @@
     ],
     "allowed-packages" : [
       "io.quarkus.test.junit.common",
-      "org.junit.platform.commons.util"
+      "org.junit.platform.commons.util",
+      "org.junit.platform.engine"
     ]
   },
   {

--- a/metadata/io.quarkus/quarkus-junit-common/index.json
+++ b/metadata/io.quarkus/quarkus-junit-common/index.json
@@ -1,6 +1,22 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.37.0.CR1",
+    "test-version" : "3.33.1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-junit-common/$version$/quarkus-junit-common-$version$-sources.jar",
+    "repository-url" : "https://github.com/quarkusio/quarkus",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-junit-common/$version$/quarkus-junit-common-$version$-javadoc.jar",
+    "description" : "Quarkus JUnit Common provides shared testing support classes used by Quarkus JUnit test framework modules. It contains common JUnit integration utilities and execution conditions that are reused by the internal and public Quarkus JUnit artifacts.",
+    "tested-versions" : [
+      "3.37.0.CR1"
+    ],
+    "allowed-packages" : [
+      "io.quarkus.test.junit.common",
+      "org.junit.platform.commons.util"
+    ]
+  },
+  {
     "metadata-version" : "3.33.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-junit-common/$version$/quarkus-junit-common-$version$-sources.jar",
     "repository-url" : "https://github.com/quarkusio/quarkus",

--- a/stats/io.quarkus/quarkus-junit-common/3.37.0.CR1/execution-metrics.json
+++ b/stats/io.quarkus/quarkus-junit-common/3.37.0.CR1/execution-metrics.json
@@ -1,0 +1,127 @@
+{
+  "fix_ni_run:2026-06-10": {
+    "timestamp": "2026-06-10T23:29:11.810818Z",
+    "library": "io.quarkus:quarkus-junit-common:3.37.0.CR1",
+    "starting_commit": "b1d3ecc76b4e34a557e7b81d977303aa2f5b2e95",
+    "ending_commit": "98b5b84c9802664c023ee12faed49ba5fa51752a",
+    "previous_library": "io.quarkus:quarkus-junit-common:3.33.1",
+    "strategy_name": "library_update_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.37.0.CR1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 2,
+        "totalCalls": 2
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 43,
+          "missed": 111,
+          "ratio": 0.279221,
+          "total": 154
+        },
+        "line": {
+          "covered": 20,
+          "missed": 34,
+          "ratio": 0.37037,
+          "total": 54
+        },
+        "method": {
+          "covered": 6,
+          "missed": 7,
+          "ratio": 0.461538,
+          "total": 13
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.33.1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 2,
+        "totalCalls": 2
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 43,
+          "missed": 87,
+          "ratio": 0.330769,
+          "total": 130
+        },
+        "line": {
+          "covered": 20,
+          "missed": 26,
+          "ratio": 0.434783,
+          "total": 46
+        },
+        "method": {
+          "covered": 6,
+          "missed": 5,
+          "ratio": 0.545455,
+          "total": 11
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "degraded",
+      "action": "no_action",
+      "issue_number": 8330,
+      "issue_label": "fails-native-image-run",
+      "library": "io.quarkus:quarkus-junit-common:3.37.0.CR1",
+      "summary": "Library preparation preflight did not produce usable advisory setup.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#8330 [Automation] native-image run fails for io.quarkus:quarkus-junit-common:3.37.0.CR1; label=fails-native-image-run; body_chars=8015"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "6 existing test file path(s) included"
+        }
+      ],
+      "current_library": "io.quarkus:quarkus-junit-common:3.33.1",
+      "new_version": "3.37.0.CR1",
+      "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
+      "model": "oca/gpt-5.5",
+      "prompt_path": "library-preflight-prompt.txt",
+      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/io.quarkus:quarkus-junit-common:3.37.0.CR1/library-preparation-preflight/pi-generation-2026-06-10T23-12-11-723088Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 0,
+      "cached_input_tokens_used": 0,
+      "output_tokens_used": 0,
+      "iterations": 0,
+      "cost_usd": 0.0,
+      "tested_library_loc": 20,
+      "metadata_entries": 7,
+      "previous_library_metadata_entries": 7,
+      "code_coverage_percent": 37.04,
+      "previous_library_coverage_percent": 43.48
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.quarkus/quarkus-junit-common/3.33.1/src/test/java/io_quarkus/quarkus_junit_common/ClearCacheTest.java",
+      "metadata_file": "metadata/io.quarkus/quarkus-junit-common/3.37.0.CR1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.quarkus/quarkus-junit-common/3.37.0.CR1/stats.json
+++ b/stats/io.quarkus/quarkus-junit-common/3.37.0.CR1/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "3.37.0.CR1",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 2,
+      "totalCalls" : 2
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 43,
+        "missed" : 111,
+        "ratio" : 0.279221,
+        "total" : 154
+      },
+      "line" : {
+        "covered" : 20,
+        "missed" : 34,
+        "ratio" : 0.37037,
+        "total" : 54
+      },
+      "method" : {
+        "covered" : 6,
+        "missed" : 7,
+        "ratio" : 0.461538,
+        "total" : 13
+      }
+    }
+  } ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: oracle/graalvm-reachability-metadata#8330

This PR provides new metadata needed for the io.quarkus:quarkus-junit-common:3.37.0.CR1, addressing Native Image run failures caused by changes in the updated library version.

Summary:
- Metadata entries (previous `io.quarkus:quarkus-junit-common:3.33.1`): 7
- Metadata entries (new `io.quarkus:quarkus-junit-common:3.37.0.CR1`): 7
- Library coverage (previous): 43.48%
- Library coverage (new): 37.04%
- Strategy: library_update_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 0
- Cached input tokens: 0
- Output tokens: 0
- Iterations: 0

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `a931cff1d81644140d4db152fc6ab134dbc4aa8b`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.quarkus:quarkus-junit-common:3.33.1: 2/2 covered calls (100.00%)
- io.quarkus:quarkus-junit-common:3.37.0.CR1: 2/2 covered calls (100.00%)

**Reflection:**
- io.quarkus:quarkus-junit-common:3.33.1: 2/2 covered calls (100.00%)
- io.quarkus:quarkus-junit-common:3.37.0.CR1: 2/2 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.quarkus:quarkus-junit-common:3.33.1: 43/130 (33.08%)
- io.quarkus:quarkus-junit-common:3.37.0.CR1: 43/154 (27.92%)

**Line:**
- io.quarkus:quarkus-junit-common:3.33.1: 20/46 (43.48%)
- io.quarkus:quarkus-junit-common:3.37.0.CR1: 20/54 (37.04%)

**Method:**
- io.quarkus:quarkus-junit-common:3.33.1: 6/11 (54.55%)
- io.quarkus:quarkus-junit-common:3.37.0.CR1: 6/13 (46.15%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
