### PR TITLE
[Automation] Generated metadata for io.vertx:vertx-web-client:5.0.1

### DIFF
--- a/metadata/io.vertx/vertx-web-client/5.0.1/reachability-metadata.json
+++ b/metadata/io.vertx/vertx-web-client/5.0.1/reachability-metadata.json
@@ -1,428 +1,72 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      "condition" : {
+        "typeReached" : "io.vertx.ext.web.client.impl.HttpRequestImpl"
       },
-      "type": "io.netty.bootstrap.ServerBootstrap$1"
+      "type" : "io.netty.buffer.AbstractReferenceCountedByteBuf"
     },
     {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      "condition" : {
+        "typeReached" : "io.vertx.ext.web.client.impl.HttpContext"
       },
-      "type": "io.netty.buffer.AbstractByteBufAllocator"
+      "type" : "io.netty.util.AbstractReferenceCounted"
     },
     {
-      "condition": {
-        "typeReached": "io.vertx.ext.web.client.impl.HttpRequestImpl"
+      "condition" : {
+        "typeReached" : "io.vertx.ext.web.client.impl.HttpContext"
       },
-      "type": "io.netty.buffer.AbstractReferenceCountedByteBuf"
+      "type" : "io.netty.util.Recycler$DefaultHandle"
     },
     {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      "condition" : {
+        "typeReached" : "io.vertx.ext.web.client.impl.HttpContext"
       },
-      "type": "io.netty.buffer.AdaptivePoolingAllocator$Chunk"
+      "type" : "io.netty.util.ReferenceCountUtil"
     },
     {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      "condition" : {
+        "typeReached" : "io.vertx.ext.web.client.impl.HttpRequestImpl"
       },
-      "type": "io.netty.buffer.AdaptivePoolingAllocator$Magazine"
+      "type" : "io.netty.util.internal.shaded.org.jctools.queues.atomic.BaseMpscLinkedAtomicArrayQueueColdProducerFields"
     },
     {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      "condition" : {
+        "typeReached" : "io.vertx.ext.web.client.impl.HttpRequestImpl"
       },
-      "type": "io.netty.channel.AbstractChannelHandlerContext"
+      "type" : "io.netty.util.internal.shaded.org.jctools.queues.atomic.BaseMpscLinkedAtomicArrayQueueConsumerFields"
     },
     {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      "condition" : {
+        "typeReached" : "io.vertx.ext.web.client.impl.HttpRequestImpl"
       },
-      "type": "io.netty.channel.ChannelOutboundBuffer"
+      "type" : "io.netty.util.internal.shaded.org.jctools.queues.atomic.BaseMpscLinkedAtomicArrayQueueProducerFields"
     },
     {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      "condition" : {
+        "typeReached" : "io.vertx.ext.web.client.impl.HttpRequestImpl"
       },
-      "type": "io.netty.channel.DefaultChannelConfig"
-    },
-    {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
-      },
-      "type": "io.netty.channel.DefaultChannelPipeline"
-    },
-    {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
-      },
-      "type": "io.netty.channel.DefaultChannelPipeline$HeadContext"
-    },
-    {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
-      },
-      "type": "io.netty.channel.DefaultChannelPipeline$TailContext"
-    },
-    {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
-      },
-      "type": "io.netty.resolver.dns.Cache$Entries"
-    },
-    {
-      "condition": {
-        "typeReached": "io.vertx.ext.web.client.impl.HttpContext"
-      },
-      "type": "io.netty.util.AbstractReferenceCounted"
-    },
-    {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
-      },
-      "type": "io.netty.util.DefaultAttributeMap"
-    },
-    {
-      "condition": {
-        "typeReached": "io.vertx.ext.web.client.impl.HttpContext"
-      },
-      "type": "io.netty.util.Recycler$DefaultHandle"
-    },
-    {
-      "condition": {
-        "typeReached": "io.vertx.ext.web.client.impl.HttpContext"
-      },
-      "type": "io.netty.util.ReferenceCountUtil"
-    },
-    {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
-      },
-      "type": "io.netty.util.concurrent.DefaultPromise"
-    },
-    {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
-      },
-      "type": "io.netty.util.concurrent.SingleThreadEventExecutor"
-    },
-    {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
-      },
-      "type": "io.netty.util.internal.CleanerJava24$CleanableDirectBufferImpl",
-      "methods": [
+      "type" : "java.lang.Thread",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.AutoCloseable",
-            "java.nio.ByteBuffer"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "io.vertx.ext.web.client.impl.HttpRequestImpl"
-      },
-      "type": "io.netty.util.internal.shaded.org.jctools.queues.atomic.BaseMpscLinkedAtomicArrayQueueColdProducerFields"
-    },
-    {
-      "condition": {
-        "typeReached": "io.vertx.ext.web.client.impl.HttpRequestImpl"
-      },
-      "type": "io.netty.util.internal.shaded.org.jctools.queues.atomic.BaseMpscLinkedAtomicArrayQueueConsumerFields"
-    },
-    {
-      "condition": {
-        "typeReached": "io.vertx.ext.web.client.impl.HttpRequestImpl"
-      },
-      "type": "io.netty.util.internal.shaded.org.jctools.queues.atomic.BaseMpscLinkedAtomicArrayQueueProducerFields"
-    },
-    {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
-      },
-      "type": "io.netty.util.internal.shaded.org.jctools.queues.atomic.MpmcAtomicArrayQueueConsumerIndexField"
-    },
-    {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
-      },
-      "type": "io.netty.util.internal.shaded.org.jctools.queues.atomic.MpmcAtomicArrayQueueProducerIndexField"
-    },
-    {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
-      },
-      "type": "io.vertx.core.eventbus.impl.EventBusImpl"
-    },
-    {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
-      },
-      "type": "io.vertx.core.logging.Log4j2LogDelegateFactory",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
-      },
-      "type": "io.vertx.core.logging.SLF4JLogDelegateFactory"
-    },
-    {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
-      },
-      "type": "java.lang.ProcessHandle",
-      "methods": [
-        {
-          "name": "current",
-          "parameterTypes": []
-        },
-        {
-          "name": "pid",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "io.vertx.ext.web.client.impl.HttpRequestImpl"
-      },
-      "type": "java.lang.Thread",
-      "methods": [
-        {
-          "name": "isVirtual",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
-      },
-      "type": "java.lang.Thread",
-      "methods": [
-        {
-          "name": "isVirtual",
-          "parameterTypes": []
-        },
-        {
-          "name": "ofVirtual",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
-      },
-      "type": "java.lang.Thread$Builder",
-      "methods": [
-        {
-          "name": "factory",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
-      },
-      "type": "java.lang.Thread$Builder$OfVirtual",
-      "methods": [
-        {
-          "name": "name",
-          "parameterTypes": [
-            "java.lang.String",
-            "long"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
-      },
-      "type": "java.lang.foreign.Arena",
-      "methods": [
-        {
-          "name": "ofShared",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
-      },
-      "type": "java.lang.foreign.MemorySegment",
-      "methods": [
-        {
-          "name": "asByteBuffer",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
-      },
-      "type": "java.lang.foreign.SegmentAllocator",
-      "methods": [
-        {
-          "name": "allocate",
-          "parameterTypes": [
-            "long"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
-      },
-      "type": "java.lang.management.ManagementFactory",
-      "methods": [
-        {
-          "name": "getRuntimeMXBean",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
-      },
-      "type": "java.lang.management.RuntimeMXBean",
-      "methods": [
-        {
-          "name": "getInputArguments",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
-      },
-      "type": "java.net.UnixDomainSocketAddress",
-      "methods": [
-        {
-          "name": "getPath",
-          "parameterTypes": []
-        },
-        {
-          "name": "of",
-          "parameterTypes": [
-            "java.nio.file.Path"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
-      },
-      "type": "java.nio.ByteBuffer",
-      "methods": [
-        {
-          "name": "alignedSlice",
-          "parameterTypes": [
-            "int"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
-      },
-      "type": "java.nio.channels.spi.SelectorProvider"
-    },
-    {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
-      },
-      "type": "sun.nio.ch.SelectorImpl"
-    },
-    {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
-      },
-      "type": "sun.security.provider.NativePRNG",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.security.SecureRandomParameters"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
-      },
-      "type": "sun.security.provider.SHA",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "isVirtual",
+          "parameterTypes" : [ ]
         }
       ]
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "io.vertx.ext.web.client.impl.HttpRequestImpl"
+      "condition" : {
+        "typeReached" : "io.vertx.ext.web.client.impl.HttpRequestImpl"
       },
-      "glob": "META-INF/services/io.vertx.core.spi.JsonFactory"
+      "glob" : "META-INF/services/io.vertx.core.spi.JsonFactory"
     },
     {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      "condition" : {
+        "typeReached" : "io.vertx.ext.web.client.WebClientOptions"
       },
-      "glob": "META-INF/services/io.vertx.core.spi.VerticleFactory"
-    },
-    {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
-      },
-      "glob": "META-INF/services/io.vertx.core.spi.VertxServiceProvider"
-    },
-    {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
-      },
-      "glob": "META-INF/services/org.assertj.core.configuration.Configuration"
-    },
-    {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
-      },
-      "glob": "META-INF/services/org.assertj.core.presentation.Representation"
-    },
-    {
-      "condition": {
-        "typeReached": "io.vertx.ext.web.client.WebClientOptions"
-      },
-      "glob": "META-INF/vertx/vertx-version.txt"
-    },
-    {
-      "condition": {
-        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
-      },
-      "glob": "vertx-default-jul-logging.properties"
+      "glob" : "META-INF/vertx/vertx-version.txt"
     }
   ]
 }

--- a/metadata/io.vertx/vertx-web-client/5.0.1/reachability-metadata.json
+++ b/metadata/io.vertx/vertx-web-client/5.0.1/reachability-metadata.json
@@ -1,0 +1,428 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "io.netty.bootstrap.ServerBootstrap$1"
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "io.netty.buffer.AbstractByteBufAllocator"
+    },
+    {
+      "condition": {
+        "typeReached": "io.vertx.ext.web.client.impl.HttpRequestImpl"
+      },
+      "type": "io.netty.buffer.AbstractReferenceCountedByteBuf"
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "io.netty.buffer.AdaptivePoolingAllocator$Chunk"
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "io.netty.buffer.AdaptivePoolingAllocator$Magazine"
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "io.netty.channel.AbstractChannelHandlerContext"
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "io.netty.channel.ChannelOutboundBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "io.netty.channel.DefaultChannelConfig"
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "io.netty.channel.DefaultChannelPipeline"
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "io.netty.channel.DefaultChannelPipeline$HeadContext"
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "io.netty.channel.DefaultChannelPipeline$TailContext"
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "io.netty.resolver.dns.Cache$Entries"
+    },
+    {
+      "condition": {
+        "typeReached": "io.vertx.ext.web.client.impl.HttpContext"
+      },
+      "type": "io.netty.util.AbstractReferenceCounted"
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "io.netty.util.DefaultAttributeMap"
+    },
+    {
+      "condition": {
+        "typeReached": "io.vertx.ext.web.client.impl.HttpContext"
+      },
+      "type": "io.netty.util.Recycler$DefaultHandle"
+    },
+    {
+      "condition": {
+        "typeReached": "io.vertx.ext.web.client.impl.HttpContext"
+      },
+      "type": "io.netty.util.ReferenceCountUtil"
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "io.netty.util.concurrent.DefaultPromise"
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "io.netty.util.concurrent.SingleThreadEventExecutor"
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "io.netty.util.internal.CleanerJava24$CleanableDirectBufferImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.AutoCloseable",
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.vertx.ext.web.client.impl.HttpRequestImpl"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.atomic.BaseMpscLinkedAtomicArrayQueueColdProducerFields"
+    },
+    {
+      "condition": {
+        "typeReached": "io.vertx.ext.web.client.impl.HttpRequestImpl"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.atomic.BaseMpscLinkedAtomicArrayQueueConsumerFields"
+    },
+    {
+      "condition": {
+        "typeReached": "io.vertx.ext.web.client.impl.HttpRequestImpl"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.atomic.BaseMpscLinkedAtomicArrayQueueProducerFields"
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.atomic.MpmcAtomicArrayQueueConsumerIndexField"
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.atomic.MpmcAtomicArrayQueueProducerIndexField"
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "io.vertx.core.eventbus.impl.EventBusImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "io.vertx.core.logging.Log4j2LogDelegateFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "io.vertx.core.logging.SLF4JLogDelegateFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "java.lang.ProcessHandle",
+      "methods": [
+        {
+          "name": "current",
+          "parameterTypes": []
+        },
+        {
+          "name": "pid",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.vertx.ext.web.client.impl.HttpRequestImpl"
+      },
+      "type": "java.lang.Thread",
+      "methods": [
+        {
+          "name": "isVirtual",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "java.lang.Thread",
+      "methods": [
+        {
+          "name": "isVirtual",
+          "parameterTypes": []
+        },
+        {
+          "name": "ofVirtual",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "java.lang.Thread$Builder",
+      "methods": [
+        {
+          "name": "factory",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "java.lang.Thread$Builder$OfVirtual",
+      "methods": [
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String",
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "java.lang.foreign.Arena",
+      "methods": [
+        {
+          "name": "ofShared",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "java.lang.foreign.MemorySegment",
+      "methods": [
+        {
+          "name": "asByteBuffer",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "java.lang.foreign.SegmentAllocator",
+      "methods": [
+        {
+          "name": "allocate",
+          "parameterTypes": [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "java.lang.management.ManagementFactory",
+      "methods": [
+        {
+          "name": "getRuntimeMXBean",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "java.lang.management.RuntimeMXBean",
+      "methods": [
+        {
+          "name": "getInputArguments",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "java.net.UnixDomainSocketAddress",
+      "methods": [
+        {
+          "name": "getPath",
+          "parameterTypes": []
+        },
+        {
+          "name": "of",
+          "parameterTypes": [
+            "java.nio.file.Path"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "java.nio.ByteBuffer",
+      "methods": [
+        {
+          "name": "alignedSlice",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "java.nio.channels.spi.SelectorProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "sun.nio.ch.SelectorImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type": "sun.security.provider.SHA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.vertx.ext.web.client.impl.HttpRequestImpl"
+      },
+      "glob": "META-INF/services/io.vertx.core.spi.JsonFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "glob": "META-INF/services/io.vertx.core.spi.VerticleFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "glob": "META-INF/services/io.vertx.core.spi.VertxServiceProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "glob": "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "glob": "META-INF/services/org.assertj.core.presentation.Representation"
+    },
+    {
+      "condition": {
+        "typeReached": "io.vertx.ext.web.client.WebClientOptions"
+      },
+      "glob": "META-INF/vertx/vertx-version.txt"
+    },
+    {
+      "condition": {
+        "typeReached": "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "glob": "vertx-default-jul-logging.properties"
+    }
+  ]
+}

--- a/metadata/io.vertx/vertx-web-client/index.json
+++ b/metadata/io.vertx/vertx-web-client/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "5.0.1",
+    "test-version" : "5.0.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/vertx/vertx-web-client/$version$/vertx-web-client-$version$-sources.jar",
+    "repository-url" : "https://github.com/vert-x3/vertx-web",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/io/vertx/vertx-web-client/$version$/vertx-web-client-$version$-test-sources.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/vertx/vertx-web-client/$version$/vertx-web-client-$version$-javadoc.jar",
+    "description" : "Vert.x Web Client is an asynchronous HTTP and HTTP/2 client built on Vert.x for sending requests, handling responses, forms, redirects, cookies, sessions, and response predicates. It provides a higher-level API than the core Vert.x HTTP client for service-to-service calls and web integrations in JVM applications.",
+    "tested-versions" : [
+      "5.0.1"
+    ],
+    "allowed-packages" : [
+      "io.vertx.ext.web.client"
+    ]
+  },
+  {
     "metadata-version" : "5.0.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/vertx/vertx-web-client/$version$/vertx-web-client-$version$-sources.jar",
     "repository-url" : "https://github.com/vert-x3/vertx-web",

--- a/stats/io.vertx/vertx-web-client/5.0.1/execution-metrics.json
+++ b/stats/io.vertx/vertx-web-client/5.0.1/execution-metrics.json
@@ -1,0 +1,122 @@
+{
+  "fix_ni_run:2026-06-11": {
+    "timestamp": "2026-06-11T00:42:23.880796Z",
+    "library": "io.vertx:vertx-web-client:5.0.1",
+    "starting_commit": "336c8c3268b2098fcfa23bb03ed5e2d4a276e401",
+    "ending_commit": "cd7686770dfb0f3fb10498a8c7eedc191c46ca28",
+    "previous_library": "io.vertx:vertx-web-client:5.0.0",
+    "strategy_name": "library_update_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "5.0.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3051,
+          "missed": 4056,
+          "ratio": 0.429295,
+          "total": 7107
+        },
+        "line": {
+          "covered": 747,
+          "missed": 904,
+          "ratio": 0.452453,
+          "total": 1651
+        },
+        "method": {
+          "covered": 182,
+          "missed": 375,
+          "ratio": 0.32675,
+          "total": 557
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "5.0.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3051,
+          "missed": 4056,
+          "ratio": 0.429295,
+          "total": 7107
+        },
+        "line": {
+          "covered": 747,
+          "missed": 904,
+          "ratio": 0.452453,
+          "total": 1651
+        },
+        "method": {
+          "covered": 182,
+          "missed": 375,
+          "ratio": 0.32675,
+          "total": 557
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "advisory_preparation",
+      "issue_number": 7998,
+      "issue_label": "fails-native-image-run",
+      "library": "io.vertx:vertx-web-client:5.0.1",
+      "summary": "Vert.x Web Client 5.0.1 is usable with its normal transitive dependencies and can be meaningfully covered against an in-process Vert.x HTTP server, but its Netty 4.2.x runtime path needs the same native-run system properties already used for 5.0.0 on JDK 25.",
+      "deterministic_setup": [],
+      "agent_guidance": "Ensure generated native tests pass the Vert.x/Netty runtime properties for 5.0.1 as well as 5.0.0: `-Dsun.misc.unsafe.memory.access=allow` and `-Dio.netty.tryReflectionSetAccessible=true`. A local `Vertx` HTTP server is sufficient for meaningful WebClient coverage; no external service is required.",
+      "risks": [
+        "If the generated tests choose to exercise POJO JSON mapping via `sendJson` rather than `JsonObject`/buffer/string APIs, Jackson databind may become relevant, but it is not required for core WebClient coverage.",
+        "TLS, OAuth2, or native-transport-specific scenarios may require additional optional dependencies, but they are not necessary for representative WebClient request/response, form, multipart, caching, redirect, and session coverage."
+      ],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#7998 [Automation] native-image run fails for io.vertx:vertx-web-client:5.0.1; label=fails-native-image-run; body_chars=8015"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "6 existing test file path(s) included"
+        }
+      ],
+      "current_library": "io.vertx:vertx-web-client:5.0.0",
+      "new_version": "5.0.1",
+      "model": "oca/gpt-5.5",
+      "input_tokens_used": 87674,
+      "output_tokens_used": 2947,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/io.vertx:vertx-web-client:5.0.1/library-preparation-preflight/pi-generation-2026-06-11T00-13-36-037685Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 0,
+      "cached_input_tokens_used": 0,
+      "output_tokens_used": 0,
+      "iterations": 0,
+      "cost_usd": 0.0,
+      "tested_library_loc": 747,
+      "metadata_entries": 11,
+      "test_only_metadata_entries": 58,
+      "previous_library_metadata_entries": 57,
+      "previous_library_test_only_metadata_entries": 58,
+      "code_coverage_percent": 45.25,
+      "previous_library_coverage_percent": 45.25
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.vertx/vertx-web-client/5.0.0/src/test/java/io_vertx/vertx_web_client/Vertx_web_clientTest.java",
+      "metadata_file": "metadata/io.vertx/vertx-web-client/5.0.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.vertx/vertx-web-client/5.0.1/stats.json
+++ b/stats/io.vertx/vertx-web-client/5.0.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "5.0.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3051,
+        "missed" : 4056,
+        "ratio" : 0.429295,
+        "total" : 7107
+      },
+      "line" : {
+        "covered" : 747,
+        "missed" : 904,
+        "ratio" : 0.452453,
+        "total" : 1651
+      },
+      "method" : {
+        "covered" : 182,
+        "missed" : 375,
+        "ratio" : 0.32675,
+        "total" : 557
+      }
+    }
+  } ]
+}

--- a/tests/src/io.vertx/vertx-web-client/5.0.0/build.gradle
+++ b/tests/src/io.vertx/vertx-web-client/5.0.0/build.gradle
@@ -16,8 +16,8 @@ dependencies {
 }
 
 tasks.named("nativeTest") {
-    if (libraryVersion == '5.0.0') {
-        // Vert.x 5.0.0 pulls in Netty 4.2.x, which requires explicit unsafe access on Java 25 native runs.
+    if (libraryVersion in ['5.0.0', '5.0.1']) {
+        // Vert.x 5.0.x pulls in Netty 4.2.x, which requires explicit unsafe access on Java 25 native runs.
         runtimeArgs.addAll([
                 '-Dsun.misc.unsafe.memory.access=allow',
                 '-Dio.netty.tryReflectionSetAccessible=true'

--- a/tests/src/io.vertx/vertx-web-client/5.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/io.vertx/vertx-web-client/5.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,362 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "io.netty.bootstrap.ServerBootstrap$1"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "io.netty.buffer.AbstractByteBufAllocator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "io.netty.buffer.AdaptivePoolingAllocator$Chunk"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "io.netty.buffer.AdaptivePoolingAllocator$Magazine"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "io.netty.channel.AbstractChannelHandlerContext"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "io.netty.channel.ChannelOutboundBuffer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "io.netty.channel.DefaultChannelConfig"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "io.netty.channel.DefaultChannelPipeline"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "io.netty.channel.DefaultChannelPipeline$HeadContext"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "io.netty.channel.DefaultChannelPipeline$TailContext"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "io.netty.resolver.dns.Cache$Entries"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "io.netty.util.DefaultAttributeMap"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "io.netty.util.concurrent.DefaultPromise"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "io.netty.util.concurrent.SingleThreadEventExecutor"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "io.netty.util.internal.CleanerJava24$CleanableDirectBufferImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.AutoCloseable",
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "io.netty.util.internal.shaded.org.jctools.queues.atomic.MpmcAtomicArrayQueueConsumerIndexField"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "io.netty.util.internal.shaded.org.jctools.queues.atomic.MpmcAtomicArrayQueueProducerIndexField"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "io.vertx.core.eventbus.impl.EventBusImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "io.vertx.core.logging.Log4j2LogDelegateFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "io.vertx.core.logging.SLF4JLogDelegateFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "java.lang.ProcessHandle",
+      "methods" : [
+        {
+          "name" : "current",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "pid",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "java.lang.Thread",
+      "methods" : [
+        {
+          "name" : "isVirtual",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "ofVirtual",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "java.lang.Thread$Builder",
+      "methods" : [
+        {
+          "name" : "factory",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "java.lang.Thread$Builder$OfVirtual",
+      "methods" : [
+        {
+          "name" : "name",
+          "parameterTypes" : [
+            "java.lang.String",
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "java.lang.foreign.Arena",
+      "methods" : [
+        {
+          "name" : "ofShared",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "java.lang.foreign.MemorySegment",
+      "methods" : [
+        {
+          "name" : "asByteBuffer",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "java.lang.foreign.SegmentAllocator",
+      "methods" : [
+        {
+          "name" : "allocate",
+          "parameterTypes" : [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "java.lang.management.ManagementFactory",
+      "methods" : [
+        {
+          "name" : "getRuntimeMXBean",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "java.lang.management.RuntimeMXBean",
+      "methods" : [
+        {
+          "name" : "getInputArguments",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "java.net.UnixDomainSocketAddress",
+      "methods" : [
+        {
+          "name" : "getPath",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "of",
+          "parameterTypes" : [
+            "java.nio.file.Path"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "java.nio.ByteBuffer",
+      "methods" : [
+        {
+          "name" : "alignedSlice",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "java.nio.channels.spi.SelectorProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "sun.nio.ch.SelectorImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "glob" : "META-INF/services/io.vertx.core.spi.VerticleFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "glob" : "META-INF/services/io.vertx.core.spi.VertxServiceProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_vertx.vertx_web_client.Vertx_web_clientTest"
+      },
+      "glob" : "vertx-default-jul-logging.properties"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: oracle/graalvm-reachability-metadata#7998

This PR provides new metadata needed for the io.vertx:vertx-web-client:5.0.1, addressing Native Image run failures caused by changes in the updated library version.

Summary:
- Metadata entries (previous `io.vertx:vertx-web-client:5.0.0`): 57
- Test-only metadata entries (previous `io.vertx:vertx-web-client:5.0.0`): 58
- Metadata entries (new `io.vertx:vertx-web-client:5.0.1`): 11
- Test-only metadata entries (new `io.vertx:vertx-web-client:5.0.1`): 58
- Library coverage (previous): 45.25%
- Library coverage (new): 45.25%
- Strategy: library_update_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 0
- Cached input tokens: 0
- Output tokens: 0
- Iterations: 0

### Forge

- Forge monitored branch: `forge-native-image-prompt-rules`
- Forge branch: `forge-native-image-prompt-rules`
- Forge commit hash: `3a1787c67e77916e69d7998f7b59f29ddc1aa076`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.vertx:vertx-web-client:5.0.0: 0/0 covered calls (100.00%)
- io.vertx:vertx-web-client:5.0.1: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.vertx:vertx-web-client:5.0.0: 3051/7107 (42.93%)
- io.vertx:vertx-web-client:5.0.1: 3051/7107 (42.93%)

**Line:**
- io.vertx:vertx-web-client:5.0.0: 747/1651 (45.25%)
- io.vertx:vertx-web-client:5.0.1: 747/1651 (45.25%)

**Method:**
- io.vertx:vertx-web-client:5.0.0: 182/557 (32.67%)
- io.vertx:vertx-web-client:5.0.1: 182/557 (32.67%)


### Human Intervention: Severe Metadata Drop

Forge detected a severe drop in reachability metadata entries for this Native Image run fix. This PR needs human review unless the branch includes concrete proof that the new library version no longer needs the removed registrations.

- Previous metadata entries (`io.vertx:vertx-web-client:5.0.0`): 57
- New metadata entries (`io.vertx:vertx-web-client:5.0.1`): 11
- Retained metadata entries: 19.30%
### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
