### PR TITLE
[Automation] Generated metadata for com.github.luben:zstd-jni:1.5.7-10

### DIFF
--- a/metadata/com.github.luben/zstd-jni/1.5.7-10/reachability-metadata.json
+++ b/metadata/com.github.luben/zstd-jni/1.5.7-10/reachability-metadata.json
@@ -1,0 +1,140 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.AutoCloseBase"
+      },
+      "type": "com.github.luben.zstd.AutoCloseBase"
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.ZstdDirectBufferDecompressingStreamNoFinalizer"
+      },
+      "type": "com.github.luben.zstd.BaseZstdBufferDecompressingStreamNoFinalizer",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "consumed"
+        },
+        {
+          "name": "produced"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.ZstdDictCompress"
+      },
+      "type": "com.github.luben.zstd.ZstdDictCompress",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "nativePtr"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.ZstdDictDecompress"
+      },
+      "type": "com.github.luben.zstd.ZstdDictDecompress",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "nativePtr"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.ZstdDirectBufferCompressingStreamNoFinalizer"
+      },
+      "type": "com.github.luben.zstd.ZstdDirectBufferCompressingStream$1"
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.ZstdDirectBufferCompressingStreamNoFinalizer"
+      },
+      "type": "com.github.luben.zstd.ZstdDirectBufferCompressingStreamNoFinalizer",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "consumed"
+        },
+        {
+          "name": "produced"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.ZstdDirectBufferDecompressingStreamNoFinalizer"
+      },
+      "type": "com.github.luben.zstd.ZstdDirectBufferDecompressingStream$1"
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.ZstdInputStreamNoFinalizer"
+      },
+      "type": "com.github.luben.zstd.ZstdInputStreamNoFinalizer",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "dstPos"
+        },
+        {
+          "name": "srcPos"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.ZstdOutputStreamNoFinalizer"
+      },
+      "type": "com.github.luben.zstd.ZstdOutputStreamNoFinalizer",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "dstPos"
+        },
+        {
+          "name": "srcPos"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.util.Native"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.util.Native"
+      },
+      "type": "sun.security.provider.SHA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "com.github.luben.zstd.util.Native"
+      },
+      "glob": "linux/amd64/libzstd-jni-1.5.7-10.so"
+    }
+  ]
+}

--- a/metadata/com.github.luben/zstd-jni/index.json
+++ b/metadata/com.github.luben/zstd-jni/index.json
@@ -1,5 +1,21 @@
 [
   {
+    "latest" : true,
+    "metadata-version" : "1.5.7-10",
+    "test-version" : "1.5.2-5",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/github/luben/zstd-jni/$version$/zstd-jni-$version$-sources.jar",
+    "repository-url" : "https://github.com/luben/zstd-jni",
+    "test-code-url" : "https://github.com/luben/zstd-jni/tree/7f1ffbed8778d505026fa4fe83cd9710ff10f9aa/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/github/luben/zstd-jni/$version$/zstd-jni-$version$-javadoc.jar",
+    "description" : "zstd-jni provides JNI bindings that expose the Zstandard compression library to Java, Android, and other JVM applications. It offers byte-array and stream APIs for compressing and decompressing data while bundling native binaries for supported platforms.",
+    "tested-versions" : [
+      "1.5.7-10"
+    ],
+    "allowed-packages" : [
+      "com.github.luben"
+    ]
+  },
+  {
     "metadata-version" : "1.5.2-5",
     "source-code-url" : "https://repo1.maven.org/maven2/com/github/luben/zstd-jni/$version$/zstd-jni-$version$-sources.jar",
     "repository-url" : "https://github.com/luben/zstd-jni/tree/c1.5.2-5",
@@ -57,7 +73,6 @@
     ]
   },
   {
-    "latest" : true,
     "metadata-version" : "1.5.7-2",
     "test-version" : "1.5.2-5",
     "tested-versions" : [

--- a/stats/com.github.luben/zstd-jni/1.5.7-10/execution-metrics.json
+++ b/stats/com.github.luben/zstd-jni/1.5.7-10/execution-metrics.json
@@ -1,0 +1,127 @@
+{
+  "fix_ni_run:2026-06-11": {
+    "timestamp": "2026-06-11T01:00:32.383144Z",
+    "library": "com.github.luben:zstd-jni:1.5.7-10",
+    "starting_commit": "45b568bf23b5735720c9a97247bfc06c408cb234",
+    "ending_commit": "8d881fa0495ee9c9956e3e14c0f87a9e64eedcf4",
+    "previous_library": "com.github.luben:zstd-jni:1.5.2-5",
+    "strategy_name": "library_update_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.5.7-10",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1724,
+          "missed": 4902,
+          "ratio": 0.260187,
+          "total": 6626
+        },
+        "line": {
+          "covered": 471,
+          "missed": 1170,
+          "ratio": 0.28702,
+          "total": 1641
+        },
+        "method": {
+          "covered": 102,
+          "missed": 274,
+          "ratio": 0.271277,
+          "total": 376
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.5.2-5",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1549,
+          "missed": 3130,
+          "ratio": 0.331054,
+          "total": 4679
+        },
+        "line": {
+          "covered": 426,
+          "missed": 733,
+          "ratio": 0.367558,
+          "total": 1159
+        },
+        "method": {
+          "covered": 90,
+          "missed": 170,
+          "ratio": 0.346154,
+          "total": 260
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "degraded",
+      "action": "no_action",
+      "issue_number": 7746,
+      "issue_label": "fails-native-image-run",
+      "library": "com.github.luben:zstd-jni:1.5.7-10",
+      "summary": "Library preparation preflight did not produce usable advisory setup.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#7746 [Automation] native-image run fails for com.github.luben:zstd-jni:1.5.7-10; label=fails-native-image-run; body_chars=8015"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "8 existing test file path(s) included"
+        }
+      ],
+      "current_library": "com.github.luben:zstd-jni:1.5.2-5",
+      "new_version": "1.5.7-10",
+      "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
+      "model": "oca/gpt-5.5",
+      "prompt_path": "library-preflight-prompt.txt",
+      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/com.github.luben:zstd-jni:1.5.7-10/library-preparation-preflight/pi-generation-2026-06-11T00-44-54-857514Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 0,
+      "cached_input_tokens_used": 0,
+      "output_tokens_used": 0,
+      "iterations": 0,
+      "cost_usd": 0.0,
+      "tested_library_loc": 471,
+      "metadata_entries": 30,
+      "previous_library_metadata_entries": 41,
+      "code_coverage_percent": 28.7,
+      "previous_library_coverage_percent": 36.76
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.github.luben/zstd-jni/1.5.2-5/src/test/java/com_github_luben/zstd_jni/Zstd_jniTest.java",
+      "metadata_file": "metadata/com.github.luben/zstd-jni/1.5.7-10/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.github.luben/zstd-jni/1.5.7-10/stats.json
+++ b/stats/com.github.luben/zstd-jni/1.5.7-10/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "1.5.7-10",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 1,
+      "totalCalls" : 1
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1724,
+        "missed" : 4902,
+        "ratio" : 0.260187,
+        "total" : 6626
+      },
+      "line" : {
+        "covered" : 471,
+        "missed" : 1170,
+        "ratio" : 0.28702,
+        "total" : 1641
+      },
+      "method" : {
+        "covered" : 102,
+        "missed" : 274,
+        "ratio" : 0.271277,
+        "total" : 376
+      }
+    }
+  } ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: oracle/graalvm-reachability-metadata#7746

This PR provides new metadata needed for the com.github.luben:zstd-jni:1.5.7-10, addressing Native Image run failures caused by changes in the updated library version.

Summary:
- Metadata entries (previous `com.github.luben:zstd-jni:1.5.2-5`): 41
- Metadata entries (new `com.github.luben:zstd-jni:1.5.7-10`): 30
- Library coverage (previous): 36.76%
- Library coverage (new): 28.70%
- Strategy: library_update_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 0
- Cached input tokens: 0
- Output tokens: 0
- Iterations: 0

### Forge

- Forge monitored branch: `forge-native-image-prompt-rules`
- Forge branch: `forge-native-image-prompt-rules`
- Forge commit hash: `3a1787c67e77916e69d7998f7b59f29ddc1aa076`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.github.luben:zstd-jni:1.5.2-5: 1/1 covered calls (100.00%)
- com.github.luben:zstd-jni:1.5.7-10: 1/1 covered calls (100.00%)

**Resources:**
- com.github.luben:zstd-jni:1.5.2-5: 1/1 covered calls (100.00%)
- com.github.luben:zstd-jni:1.5.7-10: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.github.luben:zstd-jni:1.5.2-5: 1549/4679 (33.11%)
- com.github.luben:zstd-jni:1.5.7-10: 1724/6626 (26.02%)

**Line:**
- com.github.luben:zstd-jni:1.5.2-5: 426/1159 (36.76%)
- com.github.luben:zstd-jni:1.5.7-10: 471/1641 (28.70%)

**Method:**
- com.github.luben:zstd-jni:1.5.2-5: 90/260 (34.62%)
- com.github.luben:zstd-jni:1.5.7-10: 102/376 (27.13%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
