### PR TITLE
[Automation] Generated metadata for com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.191.2

### DIFF
--- a/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.191.2/reachability-metadata.json
+++ b/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.191.2/reachability-metadata.json
@@ -1,0 +1,304 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type": "com.google.api.FieldBehavior"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type": "com.google.api.FieldBehavior",
+      "methods": [
+        {
+          "name": "valueOf",
+          "parameterTypes": [
+            "com.google.protobuf.Descriptors$EnumValueDescriptor"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1beta2.ArrowSchema"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1beta2.AvroSchema"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1beta2.DataFormat"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1beta2.ReadSession$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1beta2.ReadSession$TableModifiers"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1beta2.ReadSession$TableReadOptions"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1beta2.ReadStream"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$EnforceNamingStyle"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$EnumType"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$FieldPresence"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$JsonFormat"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$MessageEncoding"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$RepeatedFieldEncoding"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$Utf8Validation"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$VisibilityFeature$DefaultSymbolVisibility"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$CType"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$EditionDefault"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$FeatureSupport"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$JSType"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$OptionRetention"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$OptionTargetType"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FileOptions"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FileOptions$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FileOptions$OptimizeMode"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$MessageOptions"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$MessageOptions$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$MethodOptions"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$MethodOptions$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$MethodOptions$IdempotencyLevel"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$ServiceOptions"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$ServiceOptions$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadRowsRequest"
+      },
+      "type": "com.google.protobuf.ExtensionRegistry",
+      "methods": [
+        {
+          "name": "getEmptyRegistry",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type": "com.google.protobuf.Timestamp"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadRowsRequest"
+      },
+      "type": "java.nio.Buffer",
+      "fields": [
+        {
+          "name": "address"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadRowsRequest"
+      },
+      "type": "libcore.io.Memory"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadRowsRequest"
+      },
+      "type": "org.robolectric.Robolectric"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadRowsRequest"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.191.2/reachability-metadata.json
+++ b/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.191.2/reachability-metadata.json
@@ -1,302 +1,168 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.TableProto"
       },
-      "type": "com.google.api.FieldBehavior"
+      "type" : "com.google.api.FieldBehavior"
     },
     {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
       },
-      "type": "com.google.api.FieldBehavior",
-      "methods": [
+      "type" : "com.google.cloud.bigquery.storage.v1beta2.ArrowSchema"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type" : "com.google.cloud.bigquery.storage.v1beta2.AvroSchema"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type" : "com.google.cloud.bigquery.storage.v1beta2.DataFormat"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type" : "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type" : "com.google.cloud.bigquery.storage.v1beta2.ReadSession$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type" : "com.google.cloud.bigquery.storage.v1beta2.ReadSession$TableModifiers"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type" : "com.google.cloud.bigquery.storage.v1beta2.ReadSession$TableReadOptions"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type" : "com.google.cloud.bigquery.storage.v1beta2.ReadStream"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$EnforceNamingStyle"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$EnumType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$FieldPresence"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$JsonFormat"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$MessageEncoding"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$RepeatedFieldEncoding"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$Utf8Validation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$VisibilityFeature$DefaultSymbolVisibility"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.ReadRowsRequest"
+      },
+      "type" : "com.google.protobuf.ExtensionRegistry",
+      "methods" : [
         {
-          "name": "valueOf",
-          "parameterTypes": [
-            "com.google.protobuf.Descriptors$EnumValueDescriptor"
-          ]
+          "name" : "getEmptyRegistry",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
       },
-      "type": "com.google.cloud.bigquery.storage.v1beta2.ArrowSchema"
+      "type" : "com.google.protobuf.Timestamp"
     },
     {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.ReadRowsRequest"
       },
-      "type": "com.google.cloud.bigquery.storage.v1beta2.AvroSchema"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
-      },
-      "type": "com.google.cloud.bigquery.storage.v1beta2.DataFormat"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
-      },
-      "type": "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
-      },
-      "type": "com.google.cloud.bigquery.storage.v1beta2.ReadSession$Builder"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
-      },
-      "type": "com.google.cloud.bigquery.storage.v1beta2.ReadSession$TableModifiers"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
-      },
-      "type": "com.google.cloud.bigquery.storage.v1beta2.ReadSession$TableReadOptions"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
-      },
-      "type": "com.google.cloud.bigquery.storage.v1beta2.ReadStream"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.TableProto"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FeatureSet"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FeatureSet"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.TableProto"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$Builder"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.TableProto"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$EnforceNamingStyle"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.TableProto"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$EnumType"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.TableProto"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$FieldPresence"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.TableProto"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$JsonFormat"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.TableProto"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$MessageEncoding"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.TableProto"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$RepeatedFieldEncoding"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.TableProto"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$Utf8Validation"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.TableProto"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$VisibilityFeature$DefaultSymbolVisibility"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FieldOptions"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$Builder"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$CType"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$EditionDefault"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$FeatureSupport"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$JSType"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$OptionRetention"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$OptionTargetType"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FileOptions"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FileOptions$Builder"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FileOptions$OptimizeMode"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$MessageOptions"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$MessageOptions$Builder"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$MethodOptions"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$MethodOptions$Builder"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$MethodOptions$IdempotencyLevel"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$ServiceOptions"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$ServiceOptions$Builder"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadRowsRequest"
-      },
-      "type": "com.google.protobuf.ExtensionRegistry",
-      "methods": [
+      "type" : "java.nio.Buffer",
+      "fields" : [
         {
-          "name": "getEmptyRegistry",
-          "parameterTypes": []
+          "name" : "address"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.ReadRowsRequest"
       },
-      "type": "com.google.protobuf.Timestamp"
+      "type" : "libcore.io.Memory"
     },
     {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadRowsRequest"
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.ReadRowsRequest"
       },
-      "type": "java.nio.Buffer",
-      "fields": [
+      "type" : "org.robolectric.Robolectric"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1beta2.ReadRowsRequest"
+      },
+      "type" : "sun.misc.Unsafe",
+      "fields" : [
         {
-          "name": "address"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadRowsRequest"
-      },
-      "type": "libcore.io.Memory"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadRowsRequest"
-      },
-      "type": "org.robolectric.Robolectric"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadRowsRequest"
-      },
-      "type": "sun.misc.Unsafe",
-      "fields": [
-        {
-          "name": "theUnsafe"
+          "name" : "theUnsafe"
         }
       ]
     }

--- a/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/index.json
+++ b/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "0.191.2",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1beta2/$version$/proto-google-cloud-bigquerystorage-v1beta2-$version$-sources.jar",
+    "repository-url" : "https://github.com/googleapis/java-bigquerystorage",
+    "test-code-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1beta2/$version$/proto-google-cloud-bigquerystorage-v1beta2-$version$-tests.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1beta2/$version$/proto-google-cloud-bigquerystorage-v1beta2-$version$-javadoc.jar",
+    "description" : "This artifact provides the Java Protocol Buffer message classes and descriptors for the BigQuery Storage API v1beta2. JVM and gRPC clients use it to serialize requests and responses for reading from and writing to BigQuery table storage.",
+    "test-version" : "0.186.1",
+    "tested-versions" : [
+      "0.191.2"
+    ],
+    "allowed-packages" : [
+      "com.google.cloud.bigquery.storage.v1beta2"
+    ]
+  },
+  {
     "metadata-version" : "0.186.1",
     "source-code-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1beta2/$version$/proto-google-cloud-bigquerystorage-v1beta2-$version$-sources.jar",
     "repository-url" : "https://github.com/googleapis/java-bigquerystorage",

--- a/stats/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.191.2/execution-metrics.json
+++ b/stats/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.191.2/execution-metrics.json
@@ -1,0 +1,117 @@
+{
+  "fix_ni_run:2026-06-11": {
+    "timestamp": "2026-06-11T01:18:19.265934Z",
+    "library": "com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.191.2",
+    "starting_commit": "ebc27903419a213770b1c1ae7b65d12d1e285a83",
+    "ending_commit": "d05b77bd714348032ccdfa72b7edd63a57eabe42",
+    "previous_library": "com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.186.1",
+    "strategy_name": "library_update_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "0.191.2",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 15464,
+          "missed": 23337,
+          "ratio": 0.398546,
+          "total": 38801
+        },
+        "line": {
+          "covered": 4283,
+          "missed": 6344,
+          "ratio": 0.40303,
+          "total": 10627
+        },
+        "method": {
+          "covered": 1007,
+          "missed": 1659,
+          "ratio": 0.377719,
+          "total": 2666
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "0.186.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 15203,
+          "missed": 24969,
+          "ratio": 0.378448,
+          "total": 40172
+        },
+        "line": {
+          "covered": 4217,
+          "missed": 6652,
+          "ratio": 0.387984,
+          "total": 10869
+        },
+        "method": {
+          "covered": 1009,
+          "missed": 1972,
+          "ratio": 0.338477,
+          "total": 2981
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "degraded",
+      "action": "no_action",
+      "issue_number": 5777,
+      "issue_label": "fails-native-image-run",
+      "library": "com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.191.2",
+      "summary": "Library preparation preflight did not produce usable advisory setup.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#5777 [Automation] native-image run fails for com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.191.2; label=fails-native-image-run; body_chars=8015"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "6 existing test file path(s) included"
+        }
+      ],
+      "current_library": "com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.186.1",
+      "new_version": "0.191.2",
+      "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
+      "model": "oca/gpt-5.5",
+      "prompt_path": "library-preflight-prompt.txt",
+      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.191.2/library-preparation-preflight/pi-generation-2026-06-11T01-03-34-333749Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 0,
+      "cached_input_tokens_used": 0,
+      "output_tokens_used": 0,
+      "iterations": 0,
+      "cost_usd": 0.0,
+      "tested_library_loc": 4283,
+      "metadata_entries": 28,
+      "test_only_metadata_entries": 22,
+      "previous_library_metadata_entries": 120,
+      "previous_library_test_only_metadata_entries": 22,
+      "code_coverage_percent": 40.3,
+      "previous_library_coverage_percent": 38.8
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1beta2/Proto_google_cloud_bigquerystorage_v1beta2Test.java",
+      "metadata_file": "metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.191.2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.191.2/stats.json
+++ b/stats/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.191.2/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "0.191.2",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 15464,
+        "missed" : 23337,
+        "ratio" : 0.398546,
+        "total" : 38801
+      },
+      "line" : {
+        "covered" : 4283,
+        "missed" : 6344,
+        "ratio" : 0.40303,
+        "total" : 10627
+      },
+      "method" : {
+        "covered" : 1007,
+        "missed" : 1659,
+        "ratio" : 0.377719,
+        "total" : 2666
+      }
+    }
+  } ]
+}

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,138 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.api.FieldBehavior",
+      "methods" : [
+        {
+          "name" : "valueOf",
+          "parameterTypes" : [
+            "com.google.protobuf.Descriptors$EnumValueDescriptor"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FieldOptions"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FieldOptions$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FieldOptions$CType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FieldOptions$EditionDefault"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FieldOptions$FeatureSupport"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FieldOptions$JSType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FieldOptions$OptionRetention"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FieldOptions$OptionTargetType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FileOptions"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FileOptions$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FileOptions$OptimizeMode"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$MessageOptions"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$MessageOptions$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$MethodOptions"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$MethodOptions$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$MethodOptions$IdempotencyLevel"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$ServiceOptions"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$ServiceOptions$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.Proto_google_cloud_bigquerystorage_v1beta2Test"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$UninterpretedOption"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: oracle/graalvm-reachability-metadata#5777

This PR provides new metadata needed for the com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.191.2, addressing Native Image run failures caused by changes in the updated library version.

Summary:
- Metadata entries (previous `com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.186.1`): 120
- Test-only metadata entries (previous `com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.186.1`): 22
- Metadata entries (new `com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.191.2`): 28
- Test-only metadata entries (new `com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.191.2`): 22
- Library coverage (previous): 38.80%
- Library coverage (new): 40.30%
- Strategy: library_update_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 0
- Cached input tokens: 0
- Output tokens: 0
- Iterations: 0

### Forge

- Forge monitored branch: `forge-native-image-prompt-rules`
- Forge branch: `forge-native-image-prompt-rules`
- Forge commit hash: `3a1787c67e77916e69d7998f7b59f29ddc1aa076`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.186.1: 0/0 covered calls (100.00%)
- com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.191.2: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.186.1: 15203/40172 (37.84%)
- com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.191.2: 15464/38801 (39.85%)

**Line:**
- com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.186.1: 4217/10869 (38.80%)
- com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.191.2: 4283/10627 (40.30%)

**Method:**
- com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.186.1: 1009/2981 (33.85%)
- com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.191.2: 1007/2666 (37.77%)


### Human Intervention: Severe Metadata Drop

Forge detected a severe drop in reachability metadata entries for this Native Image run fix. This PR needs human review unless the branch includes concrete proof that the new library version no longer needs the removed registrations.

- Previous metadata entries (`com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.186.1`): 120
- New metadata entries (`com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.191.2`): 28
- Retained metadata entries: 23.33%
### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
