### PR TITLE
[Automation] Generated metadata for com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.19.2

### DIFF
--- a/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.19.2/reachability-metadata.json
+++ b/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.19.2/reachability-metadata.json
@@ -1,264 +1,116 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
       },
-      "type": "com.google.api.FieldBehavior"
+      "type" : "com.google.api.FieldBehavior"
     },
     {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
       },
-      "type": "com.google.api.FieldBehavior",
-      "methods": [
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$EnforceNamingStyle"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$EnumType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$FieldPresence"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$JsonFormat"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$MessageEncoding"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$RepeatedFieldEncoding"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$Utf8Validation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet$VisibilityFeature$DefaultSymbolVisibility"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type" : "com.google.protobuf.ExtensionRegistry",
+      "methods" : [
         {
-          "name": "valueOf",
-          "parameterTypes": [
-            "com.google.protobuf.Descriptors$EnumValueDescriptor"
-          ]
+          "name" : "getEmptyRegistry",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
       },
-      "type": "com.google.protobuf.DescriptorProtos$FeatureSet"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FeatureSet"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$Builder"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$EnforceNamingStyle"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$EnumType"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$FieldPresence"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$JsonFormat"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$MessageEncoding"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$RepeatedFieldEncoding"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$Utf8Validation"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$VisibilityFeature$DefaultSymbolVisibility"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FieldOptions"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$Builder"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$CType"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$EditionDefault"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$FeatureSupport"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$JSType"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$OptionRetention"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$OptionTargetType"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FileOptions"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FileOptions$Builder"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$FileOptions$OptimizeMode"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$MessageOptions"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$MessageOptions$Builder"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$MethodOptions"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$MethodOptions$Builder"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$MethodOptions$IdempotencyLevel"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$ServiceOptions"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$ServiceOptions$Builder"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
-      },
-      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
-      },
-      "type": "com.google.protobuf.ExtensionRegistry",
-      "methods": [
+      "type" : "java.nio.Buffer",
+      "fields" : [
         {
-          "name": "getEmptyRegistry",
-          "parameterTypes": []
+          "name" : "address"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
       },
-      "type": "java.nio.Buffer",
-      "fields": [
+      "type" : "libcore.io.Memory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type" : "org.robolectric.Robolectric"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type" : "sun.misc.Unsafe",
+      "fields" : [
         {
-          "name": "address"
+          "name" : "theUnsafe"
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
-      },
-      "type": "libcore.io.Memory"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
-      },
-      "type": "org.robolectric.Robolectric"
-    },
-    {
-      "condition": {
-        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
-      },
-      "type": "sun.misc.Unsafe",
-      "fields": [
-        {
-          "name": "theUnsafe"
-        }
-      ]
-    }
-  ],
-  "resources": [
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
-      },
-      "glob": "META-INF/services/org.assertj.core.configuration.Configuration"
-    },
-    {
-      "condition": {
-        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
-      },
-      "glob": "META-INF/services/org.assertj.core.presentation.Representation"
     }
   ]
 }

--- a/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.19.2/reachability-metadata.json
+++ b/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.19.2/reachability-metadata.json
@@ -1,0 +1,264 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.api.FieldBehavior"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type": "com.google.api.FieldBehavior",
+      "methods": [
+        {
+          "name": "valueOf",
+          "parameterTypes": [
+            "com.google.protobuf.Descriptors$EnumValueDescriptor"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$EnforceNamingStyle"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$EnumType"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$FieldPresence"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$JsonFormat"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$MessageEncoding"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$RepeatedFieldEncoding"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$Utf8Validation"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$VisibilityFeature$DefaultSymbolVisibility"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$CType"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$EditionDefault"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$FeatureSupport"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$JSType"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$OptionRetention"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$OptionTargetType"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FileOptions"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FileOptions$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FileOptions$OptimizeMode"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$MessageOptions"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$MessageOptions$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$MethodOptions"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$MethodOptions$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$MethodOptions$IdempotencyLevel"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$ServiceOptions"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$ServiceOptions$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.ExtensionRegistry",
+      "methods": [
+        {
+          "name": "getEmptyRegistry",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "java.nio.Buffer",
+      "fields": [
+        {
+          "name": "address"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "libcore.io.Memory"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "org.robolectric.Robolectric"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "glob": "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition": {
+        "typeReached": "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "glob": "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/index.json
+++ b/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.19.2",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1alpha/$version$/proto-google-cloud-bigquerystorage-v1alpha-$version$-sources.jar",
+    "repository-url" : "https://github.com/googleapis/java-bigquerystorage",
+    "test-code-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1alpha/$version$/proto-google-cloud-bigquerystorage-v1alpha-$version$-tests.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1alpha/$version$/proto-google-cloud-bigquerystorage-v1alpha-$version$-javadoc.jar",
+    "description" : "This artifact provides generated Java Protocol Buffer classes and descriptors for the Google Cloud BigQuery Storage v1alpha API. It defines messages, resource names, and service-related types used by JVM clients and gRPC stubs to serialize BigQuery Storage requests and responses.",
+    "test-version" : "3.14.1",
+    "tested-versions" : [
+      "3.19.2"
+    ],
+    "allowed-packages" : [
+      "com.google.cloud.bigquery.storage.v1alpha"
+    ]
+  },
+  {
     "metadata-version" : "3.14.1",
     "source-code-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1alpha/$version$/proto-google-cloud-bigquerystorage-v1alpha-$version$-sources.jar",
     "repository-url" : "https://github.com/googleapis/java-bigquerystorage",

--- a/stats/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.19.2/execution-metrics.json
+++ b/stats/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.19.2/execution-metrics.json
@@ -1,0 +1,117 @@
+{
+  "fix_ni_run:2026-06-11": {
+    "timestamp": "2026-06-11T01:35:39.575654Z",
+    "library": "com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.19.2",
+    "starting_commit": "623d8509eed29f3edc47c47dd4eedfe417941925",
+    "ending_commit": "1a0de202d4744cfdf15d2cd13fec42d6da02f289",
+    "previous_library": "com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.14.1",
+    "strategy_name": "library_update_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.19.2",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 9190,
+          "missed": 14312,
+          "ratio": 0.391031,
+          "total": 23502
+        },
+        "line": {
+          "covered": 2531,
+          "missed": 3904,
+          "ratio": 0.393318,
+          "total": 6435
+        },
+        "method": {
+          "covered": 540,
+          "missed": 1014,
+          "ratio": 0.34749,
+          "total": 1554
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.14.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 9091,
+          "missed": 15237,
+          "ratio": 0.373685,
+          "total": 24328
+        },
+        "line": {
+          "covered": 2509,
+          "missed": 4080,
+          "ratio": 0.380786,
+          "total": 6589
+        },
+        "method": {
+          "covered": 543,
+          "missed": 1191,
+          "ratio": 0.313149,
+          "total": 1734
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "degraded",
+      "action": "no_action",
+      "issue_number": 5934,
+      "issue_label": "fails-native-image-run",
+      "library": "com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.19.2",
+      "summary": "Library preparation preflight did not produce usable advisory setup.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#5934 [Automation] native-image run fails for com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.19.2; label=fails-native-image-run; body_chars=8015"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "6 existing test file path(s) included"
+        }
+      ],
+      "current_library": "com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.14.1",
+      "new_version": "3.19.2",
+      "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
+      "model": "oca/gpt-5.5",
+      "prompt_path": "library-preflight-prompt.txt",
+      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.19.2/library-preparation-preflight/pi-generation-2026-06-11T01-19-55-007783Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 0,
+      "cached_input_tokens_used": 0,
+      "output_tokens_used": 0,
+      "iterations": 0,
+      "cost_usd": 0.0,
+      "tested_library_loc": 2531,
+      "metadata_entries": 19,
+      "test_only_metadata_entries": 24,
+      "previous_library_metadata_entries": 86,
+      "previous_library_test_only_metadata_entries": 24,
+      "code_coverage_percent": 39.33,
+      "previous_library_coverage_percent": 38.08
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1alpha/Proto_google_cloud_bigquerystorage_v1alphaTest.java",
+      "metadata_file": "metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.19.2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.19.2/stats.json
+++ b/stats/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.19.2/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.19.2",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 9190,
+        "missed" : 14312,
+        "ratio" : 0.391031,
+        "total" : 23502
+      },
+      "line" : {
+        "covered" : 2531,
+        "missed" : 3904,
+        "ratio" : 0.393318,
+        "total" : 6435
+      },
+      "method" : {
+        "covered" : 540,
+        "missed" : 1014,
+        "ratio" : 0.34749,
+        "total" : 1554
+      }
+    }
+  } ]
+}

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,152 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.api.FieldBehavior",
+      "methods" : [
+        {
+          "name" : "valueOf",
+          "parameterTypes" : [
+            "com.google.protobuf.Descriptors$EnumValueDescriptor"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FeatureSet"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FieldOptions"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FieldOptions$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FieldOptions$CType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FieldOptions$EditionDefault"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FieldOptions$FeatureSupport"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FieldOptions$JSType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FieldOptions$OptionRetention"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FieldOptions$OptionTargetType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FileOptions"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FileOptions$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$FileOptions$OptimizeMode"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$MessageOptions"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$MessageOptions$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$MethodOptions"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$MethodOptions$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$MethodOptions$IdempotencyLevel"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$ServiceOptions"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$ServiceOptions$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "type" : "com.google.protobuf.DescriptorProtos$UninterpretedOption"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.Proto_google_cloud_bigquerystorage_v1alphaTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: oracle/graalvm-reachability-metadata#5934

This PR provides new metadata needed for the com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.19.2, addressing Native Image run failures caused by changes in the updated library version.

Summary:
- Metadata entries (previous `com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.14.1`): 86
- Test-only metadata entries (previous `com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.14.1`): 24
- Metadata entries (new `com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.19.2`): 19
- Test-only metadata entries (new `com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.19.2`): 24
- Library coverage (previous): 38.08%
- Library coverage (new): 39.33%
- Strategy: library_update_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 0
- Cached input tokens: 0
- Output tokens: 0
- Iterations: 0

### Forge

- Forge monitored branch: `forge-native-image-prompt-rules`
- Forge branch: `forge-native-image-prompt-rules`
- Forge commit hash: `3a1787c67e77916e69d7998f7b59f29ddc1aa076`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.14.1: 0/0 covered calls (100.00%)
- com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.19.2: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.14.1: 9091/24328 (37.37%)
- com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.19.2: 9190/23502 (39.10%)

**Line:**
- com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.14.1: 2509/6589 (38.08%)
- com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.19.2: 2531/6435 (39.33%)

**Method:**
- com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.14.1: 543/1734 (31.31%)
- com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.19.2: 540/1554 (34.75%)


### Human Intervention: Severe Metadata Drop

Forge detected a severe drop in reachability metadata entries for this Native Image run fix. This PR needs human review unless the branch includes concrete proof that the new library version no longer needs the removed registrations.

- Previous metadata entries (`com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.14.1`): 86
- New metadata entries (`com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.19.2`): 19
- Retained metadata entries: 22.09%
### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
