### PR TITLE
[Automation] Generated metadata for org.codehaus.jackson:jackson-mapper-asl:1.9.0

### DIFF
--- a/metadata/org.codehaus.jackson/jackson-mapper-asl/1.9.0/reachability-metadata.json
+++ b/metadata/org.codehaus.jackson/jackson-mapper-asl/1.9.0/reachability-metadata.json
@@ -1,1176 +1,278 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.BasicSerializerFactoryTest"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.introspect.BasicClassIntrospector"
       },
-      "type": "java.io.Closeable"
+      "type" : "java.io.Serializable"
     },
     {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.introspect.BasicClassIntrospector"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.ser.impl.PropertySerializerMap"
       },
-      "type": "java.io.Serializable"
+      "type" : "java.io.Serializable"
     },
     {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.ser.impl.PropertySerializerMap"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.ser.impl.PropertySerializerMap"
       },
-      "type": "java.io.Serializable"
+      "type" : "java.lang.Boolean"
     },
     {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
       },
-      "type": "java.io.Serializable"
+      "type" : "java.lang.Cloneable"
     },
     {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerCalendarDeserializerTest"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
       },
-      "type": "java.io.Serializable"
+      "type" : "java.lang.Comparable"
     },
     {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerClassDeserializerTest"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.ser.impl.PropertySerializerMap"
       },
-      "type": "java.io.Serializable"
+      "type" : "java.lang.Comparable"
     },
     {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.BasicSerializerFactoryTest"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
       },
-      "type": "java.lang.AutoCloseable"
+      "type" : "java.lang.Enum"
     },
     {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.ser.impl.PropertySerializerMap"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.ser.impl.PropertySerializerMap"
       },
-      "type": "java.lang.Boolean"
+      "type" : "java.lang.Integer"
     },
     {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerClassDeserializerTest"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.type.TypeParser"
       },
-      "type": "java.lang.Class"
+      "type" : "java.lang.Integer"
     },
     {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
       },
-      "type": "java.lang.Cloneable"
+      "type" : "java.lang.Iterable"
     },
     {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerCalendarDeserializerTest"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.ser.impl.PropertySerializerMap"
       },
-      "type": "java.lang.Cloneable"
+      "type" : "java.lang.Number"
     },
     {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.introspect.AnnotatedClass"
       },
-      "type": "java.lang.Comparable"
+      "type" : "java.lang.Object"
     },
     {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.ser.impl.PropertySerializerMap"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.std.ClassDeserializer"
       },
-      "type": "java.lang.Comparable"
+      "type" : "java.lang.String"
     },
     {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.type.TypeParser"
       },
-      "type": "java.lang.Comparable"
+      "type" : "java.lang.String"
     },
     {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerCalendarDeserializerTest"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.util.ArrayBuilders"
       },
-      "type": "java.lang.Comparable"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.util.ObjectBuffer"
       },
-      "type": "java.lang.Enum"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.ser.impl.PropertySerializerMap"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
       },
-      "type": "java.lang.Integer"
+      "type" : "java.lang.constant.Constable"
     },
     {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.type.TypeParser"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.ser.impl.PropertySerializerMap"
       },
-      "type": "java.lang.Integer"
+      "type" : "java.lang.constant.Constable"
     },
     {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.ser.impl.PropertySerializerMap"
       },
-      "type": "java.lang.Integer"
+      "type" : "java.lang.constant.ConstantDesc"
     },
     {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
       },
-      "type": "java.lang.Iterable"
+      "type" : "java.util.AbstractCollection"
     },
     {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.ser.impl.PropertySerializerMap"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
       },
-      "type": "java.lang.Number"
+      "type" : "java.util.AbstractList"
     },
     {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
       },
-      "type": "java.lang.Number"
+      "type" : "java.util.AbstractMap"
     },
     {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.introspect.AnnotatedClass"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
       },
-      "type": "java.lang.Object"
+      "type" : "java.util.ArrayList"
     },
     {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
       },
-      "type": "java.lang.Object"
+      "type" : "java.util.Collection"
     },
     {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerDelegatingTest"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
       },
-      "type": "java.lang.Object"
+      "type" : "java.util.ConcurrentNavigableMap"
     },
     {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.SettableAnyPropertyTest"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.util.ClassUtil$EnumTypeLocator"
       },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.std.ClassDeserializer"
-      },
-      "type": "java.lang.String"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.type.TypeParser"
-      },
-      "type": "java.lang.String"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.util.ArrayBuilders"
-      },
-      "type": "java.lang.String[]"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.util.ObjectBuffer"
-      },
-      "type": "java.lang.String[]"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
-      },
-      "type": "java.lang.constant.Constable"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.ser.impl.PropertySerializerMap"
-      },
-      "type": "java.lang.constant.Constable"
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest"
-      },
-      "type": "java.lang.constant.Constable"
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerClassDeserializerTest"
-      },
-      "type": "java.lang.constant.Constable"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.ser.impl.PropertySerializerMap"
-      },
-      "type": "java.lang.constant.ConstantDesc"
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest"
-      },
-      "type": "java.lang.constant.ConstantDesc"
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerClassDeserializerTest"
-      },
-      "type": "java.lang.invoke.TypeDescriptor"
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerClassDeserializerTest"
-      },
-      "type": "java.lang.invoke.TypeDescriptor$OfField"
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerClassDeserializerTest"
-      },
-      "type": "java.lang.reflect.AnnotatedElement"
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerClassDeserializerTest"
-      },
-      "type": "java.lang.reflect.GenericDeclaration"
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerClassDeserializerTest"
-      },
-      "type": "java.lang.reflect.Type"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
-      },
-      "type": "java.util.AbstractCollection"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
-      },
-      "type": "java.util.AbstractList"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
-      },
-      "type": "java.util.AbstractMap"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
-      },
-      "type": "java.util.ArrayList"
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerCalendarDeserializerTest"
-      },
-      "type": "java.util.Calendar"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
-      },
-      "type": "java.util.Collection"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
-      },
-      "type": "java.util.ConcurrentNavigableMap"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.util.ClassUtil$EnumTypeLocator"
-      },
-      "type": "java.util.EnumMap",
-      "fields": [
+      "type" : "java.util.EnumMap",
+      "fields" : [
         {
-          "name": "keyType"
+          "name" : "keyType"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.util.ClassUtil$EnumTypeLocator"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.util.ClassUtil$EnumTypeLocator"
       },
-      "type": "java.util.EnumSet",
-      "fields": [
+      "type" : "java.util.EnumSet",
+      "fields" : [
         {
-          "name": "elementType"
+          "name" : "elementType"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.std.CalendarDeserializer"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.std.CalendarDeserializer"
       },
-      "type": "java.util.GregorianCalendar",
-      "methods": [
+      "type" : "java.util.GregorianCalendar",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerCalendarDeserializerTest"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
       },
-      "type": "java.util.GregorianCalendar"
+      "type" : "java.util.HashMap"
     },
     {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
       },
-      "type": "java.util.HashMap"
+      "type" : "java.util.LinkedHashMap"
     },
     {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.std.MapDeserializer"
       },
-      "type": "java.util.LinkedHashMap"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.std.MapDeserializer"
-      },
-      "type": "java.util.LinkedHashMap",
-      "methods": [
+      "type" : "java.util.LinkedHashMap",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
       },
-      "type": "java.util.List"
+      "type" : "java.util.List"
     },
     {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.type.TypeParser"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.type.TypeParser"
       },
-      "type": "java.util.List"
+      "type" : "java.util.List"
     },
     {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.SettableBeanPropertyInnerSetterlessPropertyTest"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
       },
-      "type": "java.util.List"
+      "type" : "java.util.Map"
     },
     {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.type.TypeParser"
       },
-      "type": "java.util.Map"
+      "type" : "java.util.Map"
     },
     {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.type.TypeParser"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
       },
-      "type": "java.util.Map"
+      "type" : "java.util.RandomAccess"
     },
     {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerDelegatingTest"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
       },
-      "type": "java.util.Map"
+      "type" : "java.util.SequencedCollection"
     },
     {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
       },
-      "type": "java.util.RandomAccess"
+      "type" : "java.util.SequencedMap"
     },
     {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.ext.OptionalHandlerFactory"
       },
-      "type": "java.util.SequencedCollection"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
-      },
-      "type": "java.util.SequencedMap"
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.BasicSerializerFactoryTest"
-      },
-      "type": "org.codehaus.jackson.JsonGenerator"
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.BasicSerializerFactoryTest"
-      },
-      "type": "org.codehaus.jackson.Versioned"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.ext.OptionalHandlerFactory"
-      },
-      "type": "org.codehaus.jackson.map.ext.CoreXMLSerializers",
-      "methods": [
+      "type" : "org.codehaus.jackson.map.ext.CoreXMLSerializers",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.ser.BasicSerializerFactory"
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.ser.BasicSerializerFactory"
       },
-      "type": "org.codehaus.jackson.map.ser.std.TokenBufferSerializer",
-      "methods": [
+      "type" : "org.codehaus.jackson.map.ser.std.TokenBufferSerializer",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.BasicSerializerFactoryTest"
-      },
-      "type": "org.codehaus.jackson.util.TokenBuffer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.introspect.AnnotatedClass"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest$BaseTarget"
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest$BaseTarget"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.introspect.AnnotatedClass"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest$CreatorTarget"
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest$CreatorTarget"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.introspect.AnnotatedClass"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest$CreatorTargetMixIn"
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest$CreatorTargetMixIn"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.introspect.AnnotatedClass"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest$ObjectMixIn"
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest$ObjectMixIn"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.introspect.AnnotatedField"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedFieldTest$FieldInjectionTarget",
-      "fields": [
-        {
-          "name": "requestId"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedFieldTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedFieldTest$FieldInjectionTarget",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.introspect.AnnotatedMethod"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedMethodTest$SetterTarget",
-      "methods": [
-        {
-          "name": "setName",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedMethodTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedMethodTest$SetterTarget"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.introspect.AnnotatedMethod"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedMethodTest$StaticFactory",
-      "methods": [
-        {
-          "name": "defaultName",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedMethodTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedMethodTest$StaticFactory"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.ser.AnyGetterWriter"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.AnyGetterWriterTest$BeanWithAnyGetter",
-      "methods": [
-        {
-          "name": "anyProperties",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.AnyGetterWriterTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.AnyGetterWriterTest$BeanWithAnyGetter",
-      "methods": [
-        {
-          "name": "getName",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.ArrayDeserializerTest$Value"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.std.ObjectArrayDeserializer"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.ArrayDeserializerTest$Value",
-      "fields": [
-        {
-          "name": "name"
-        }
-      ],
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.std.ObjectArrayDeserializer"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.ArrayDeserializerTest$Value[]"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.type.ArrayType"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.ArrayDeserializerTest$Value[]"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.SettableBeanProperty$InnerClassProperty"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.BeanDeserializerTest$OuterBean",
-      "fields": [
-        {
-          "name": "inner"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.BeanDeserializerTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.BeanDeserializerTest$OuterBean",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.BeanDeserializer"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.BeanDeserializerTest$OuterBean$InnerBean",
-      "fields": [
-        {
-          "name": "count"
-        },
-        {
-          "name": "name"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.SettableBeanProperty$InnerClassProperty"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.BeanDeserializerTest$OuterBean$InnerBean",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "org_codehaus_jackson.jackson_mapper_asl.BeanDeserializerTest$OuterBean"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.BeanDeserializerTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.BeanDeserializerTest$OuterBean$InnerBean"
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.BeanPropertyWriterTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.BeanPropertyWriterTest$AccessorBackedProperty",
-      "methods": [
-        {
-          "name": "getMethodValue",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.BeanPropertyWriterTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.BeanPropertyWriterTest$FieldBackedProperty",
-      "fields": [
-        {
-          "name": "fieldValue"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.jsontype.impl.TypeDeserializerBase"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.ClassNameIdResolverTest$Animal"
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.ClassNameIdResolverTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.ClassNameIdResolverTest$Animal"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.jsontype.impl.AsPropertyTypeDeserializer"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.ClassNameIdResolverTest$Dog",
-      "fields": [
-        {
-          "name": "name"
-        }
-      ],
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.jsontype.impl.ClassNameIdResolver"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.ClassNameIdResolverTest$Dog"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.jsontype.impl.TypeDeserializerBase"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.ClassNameIdResolverTest$Dog"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.util.ClassUtil"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.ClassUtilTest$PublicDefaultConstructor",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.std.CollectionDeserializer"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest$NumericValues",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest$NumericValues"
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerDelegatingTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerDelegatingTest$MapConstructorTarget",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.util.Map"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerDelegatingTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerDelegatingTest$MapFactoryTarget",
-      "methods": [
-        {
-          "name": "from",
-          "parameterTypes": [
-            "java.util.Map"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerNumberBasedTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerNumberBasedTest$IntegerConstructorTarget",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "int"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerNumberBasedTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerNumberBasedTest$IntegerFactoryTarget",
-      "methods": [
-        {
-          "name": "fromNumber",
-          "parameterTypes": [
-            "int"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerNumberBasedTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerNumberBasedTest$LongConstructorTarget",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "long"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerNumberBasedTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerNumberBasedTest$LongFactoryTarget",
-      "methods": [
-        {
-          "name": "fromNumber",
-          "parameterTypes": [
-            "long"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.introspect.AnnotatedConstructor"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerPropertyBasedTest$ConstructorTarget",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.String",
-            "int",
-            "boolean"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerPropertyBasedTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerPropertyBasedTest$ConstructorTarget"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.introspect.AnnotatedMethod"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerPropertyBasedTest$FactoryTarget",
-      "methods": [
-        {
-          "name": "fromProperties",
-          "parameterTypes": [
-            "java.lang.String",
-            "int",
-            "boolean"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerPropertyBasedTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerPropertyBasedTest$FactoryTarget"
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerStringBasedTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerStringBasedTest$ConstructorTarget",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerStringBasedTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerStringBasedTest$FactoryTarget",
-      "methods": [
-        {
-          "name": "fromString",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.EnumDeserializerInnerFactoryBasedDeserializerTest$FactoryBackedEnum"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.std.EnumDeserializer$FactoryBasedDeserializer"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.EnumDeserializerInnerFactoryBasedDeserializerTest$FactoryBackedEnum",
-      "methods": [
-        {
-          "name": "fromJson",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.ser.std.JsonValueSerializer"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.JsonValueSerializerTest$DefaultTypedJsonValue",
-      "methods": [
-        {
-          "name": "asJsonValue",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.JsonValueSerializerTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.JsonValueSerializerTest$DefaultTypedJsonValue"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.ser.std.JsonValueSerializer"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.JsonValueSerializerTest$JsonValueBackedObject",
-      "methods": [
-        {
-          "name": "asJsonValue",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.JsonValueSerializerTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.JsonValueSerializerTest$JsonValueBackedObject"
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.PropertyBuilderTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.PropertyBuilderTest$FieldBackedNonDefaultValue",
-      "fields": [
-        {
-          "name": "value"
-        }
-      ],
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.PropertyBuilderTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.PropertyBuilderTest$MethodBackedNonDefaultValue",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "getValue",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.SettableAnyProperty"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.SettableAnyPropertyTest$AnySetterBean",
-      "methods": [
-        {
-          "name": "putUnknownValue",
-          "parameterTypes": [
-            "java.lang.String",
-            "java.lang.Object"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.SettableAnyPropertyTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.SettableAnyPropertyTest$AnySetterBean",
-      "fields": [
-        {
-          "name": "name"
-        }
-      ],
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.SettableBeanProperty$MethodProperty"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.SettableBeanPropertyInnerMethodPropertyTest$SetterBackedBean",
-      "methods": [
-        {
-          "name": "setCount",
-          "parameterTypes": [
-            "int"
-          ]
-        },
-        {
-          "name": "setName",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.SettableBeanPropertyInnerMethodPropertyTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.SettableBeanPropertyInnerMethodPropertyTest$SetterBackedBean",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.SettableBeanProperty$SetterlessProperty"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.SettableBeanPropertyInnerSetterlessPropertyTest$GetterBackedBean",
-      "methods": [
-        {
-          "name": "getItems",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.SettableBeanPropertyInnerSetterlessPropertyTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.SettableBeanPropertyInnerSetterlessPropertyTest$GetterBackedBean",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.std.StdKeyDeserializer$StringCtorKeyDeserializer"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.StdKeyDeserializerInnerStringCtorKeyDeserializerTest$StringConstructorKey",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.StdKeyDeserializerInnerStringCtorKeyDeserializerTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.StdKeyDeserializerInnerStringCtorKeyDeserializerTest$StringConstructorKey"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.std.StdKeyDeserializer$StringFactoryKeyDeserializer"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.StdKeyDeserializerInnerStringFactoryKeyDeserializerTest$StringFactoryKey",
-      "methods": [
-        {
-          "name": "valueOf",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.StdKeyDeserializerInnerStringFactoryKeyDeserializerTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.StdKeyDeserializerInnerStringFactoryKeyDeserializerTest$StringFactoryKey"
-    },
-    {
-      "condition": {
-        "typeReached": "org.codehaus.jackson.map.deser.std.StringCollectionDeserializer"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.StringCollectionDeserializerTest$StringValues",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.StringCollectionDeserializerTest"
-      },
-      "type": "org_codehaus_jackson.jackson_mapper_asl.StringCollectionDeserializerTest$StringValues"
-    }
-  ],
-  "resources": [
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest"
-      },
-      "glob": "META-INF/services/org.assertj.core.configuration.Configuration"
-    },
-    {
-      "condition": {
-        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest"
-      },
-      "glob": "META-INF/services/org.assertj.core.presentation.Representation"
     }
   ]
 }

--- a/metadata/org.codehaus.jackson/jackson-mapper-asl/1.9.0/reachability-metadata.json
+++ b/metadata/org.codehaus.jackson/jackson-mapper-asl/1.9.0/reachability-metadata.json
@@ -140,6 +140,12 @@
     },
     {
       "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
         "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerDelegatingTest"
       },
       "type": "java.lang.Object"
@@ -450,6 +456,12 @@
     },
     {
       "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest$BaseTarget"
+    },
+    {
+      "condition": {
         "typeReached": "org.codehaus.jackson.map.introspect.AnnotatedClass"
       },
       "type": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest$CreatorTarget"
@@ -468,9 +480,82 @@
     },
     {
       "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest$CreatorTargetMixIn"
+    },
+    {
+      "condition": {
         "typeReached": "org.codehaus.jackson.map.introspect.AnnotatedClass"
       },
       "type": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest$ObjectMixIn"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest$ObjectMixIn"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.introspect.AnnotatedField"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedFieldTest$FieldInjectionTarget",
+      "fields": [
+        {
+          "name": "requestId"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedFieldTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedFieldTest$FieldInjectionTarget",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.introspect.AnnotatedMethod"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedMethodTest$SetterTarget",
+      "methods": [
+        {
+          "name": "setName",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedMethodTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedMethodTest$SetterTarget"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.introspect.AnnotatedMethod"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedMethodTest$StaticFactory",
+      "methods": [
+        {
+          "name": "defaultName",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedMethodTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedMethodTest$StaticFactory"
     },
     {
       "condition": {
@@ -530,6 +615,63 @@
         "typeReached": "org.codehaus.jackson.map.type.ArrayType"
       },
       "type": "org_codehaus_jackson.jackson_mapper_asl.ArrayDeserializerTest$Value[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.SettableBeanProperty$InnerClassProperty"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.BeanDeserializerTest$OuterBean",
+      "fields": [
+        {
+          "name": "inner"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.BeanDeserializerTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.BeanDeserializerTest$OuterBean",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.BeanDeserializer"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.BeanDeserializerTest$OuterBean$InnerBean",
+      "fields": [
+        {
+          "name": "count"
+        },
+        {
+          "name": "name"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.SettableBeanProperty$InnerClassProperty"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.BeanDeserializerTest$OuterBean$InnerBean",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org_codehaus_jackson.jackson_mapper_asl.BeanDeserializerTest$OuterBean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.BeanDeserializerTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.BeanDeserializerTest$OuterBean$InnerBean"
     },
     {
       "condition": {

--- a/metadata/org.codehaus.jackson/jackson-mapper-asl/1.9.0/reachability-metadata.json
+++ b/metadata/org.codehaus.jackson/jackson-mapper-asl/1.9.0/reachability-metadata.json
@@ -1,0 +1,1034 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.BasicSerializerFactoryTest"
+      },
+      "type": "java.io.Closeable"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.introspect.BasicClassIntrospector"
+      },
+      "type": "java.io.Serializable"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.ser.impl.PropertySerializerMap"
+      },
+      "type": "java.io.Serializable"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest"
+      },
+      "type": "java.io.Serializable"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerCalendarDeserializerTest"
+      },
+      "type": "java.io.Serializable"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerClassDeserializerTest"
+      },
+      "type": "java.io.Serializable"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.BasicSerializerFactoryTest"
+      },
+      "type": "java.lang.AutoCloseable"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.ser.impl.PropertySerializerMap"
+      },
+      "type": "java.lang.Boolean"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerClassDeserializerTest"
+      },
+      "type": "java.lang.Class"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type": "java.lang.Cloneable"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerCalendarDeserializerTest"
+      },
+      "type": "java.lang.Cloneable"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type": "java.lang.Comparable"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.ser.impl.PropertySerializerMap"
+      },
+      "type": "java.lang.Comparable"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest"
+      },
+      "type": "java.lang.Comparable"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerCalendarDeserializerTest"
+      },
+      "type": "java.lang.Comparable"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type": "java.lang.Enum"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.ser.impl.PropertySerializerMap"
+      },
+      "type": "java.lang.Integer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.type.TypeParser"
+      },
+      "type": "java.lang.Integer"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest"
+      },
+      "type": "java.lang.Integer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type": "java.lang.Iterable"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.ser.impl.PropertySerializerMap"
+      },
+      "type": "java.lang.Number"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest"
+      },
+      "type": "java.lang.Number"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.introspect.AnnotatedClass"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerDelegatingTest"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.SettableAnyPropertyTest"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.std.ClassDeserializer"
+      },
+      "type": "java.lang.String"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.type.TypeParser"
+      },
+      "type": "java.lang.String"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.util.ArrayBuilders"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.util.ObjectBuffer"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type": "java.lang.constant.Constable"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.ser.impl.PropertySerializerMap"
+      },
+      "type": "java.lang.constant.Constable"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest"
+      },
+      "type": "java.lang.constant.Constable"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerClassDeserializerTest"
+      },
+      "type": "java.lang.constant.Constable"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.ser.impl.PropertySerializerMap"
+      },
+      "type": "java.lang.constant.ConstantDesc"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest"
+      },
+      "type": "java.lang.constant.ConstantDesc"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerClassDeserializerTest"
+      },
+      "type": "java.lang.invoke.TypeDescriptor"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerClassDeserializerTest"
+      },
+      "type": "java.lang.invoke.TypeDescriptor$OfField"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerClassDeserializerTest"
+      },
+      "type": "java.lang.reflect.AnnotatedElement"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerClassDeserializerTest"
+      },
+      "type": "java.lang.reflect.GenericDeclaration"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerClassDeserializerTest"
+      },
+      "type": "java.lang.reflect.Type"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type": "java.util.AbstractCollection"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type": "java.util.AbstractList"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type": "java.util.AbstractMap"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type": "java.util.ArrayList"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerCalendarDeserializerTest"
+      },
+      "type": "java.util.Calendar"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type": "java.util.Collection"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type": "java.util.ConcurrentNavigableMap"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.util.ClassUtil$EnumTypeLocator"
+      },
+      "type": "java.util.EnumMap",
+      "fields": [
+        {
+          "name": "keyType"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.util.ClassUtil$EnumTypeLocator"
+      },
+      "type": "java.util.EnumSet",
+      "fields": [
+        {
+          "name": "elementType"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.std.CalendarDeserializer"
+      },
+      "type": "java.util.GregorianCalendar",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerCalendarDeserializerTest"
+      },
+      "type": "java.util.GregorianCalendar"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type": "java.util.HashMap"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type": "java.util.LinkedHashMap"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.std.MapDeserializer"
+      },
+      "type": "java.util.LinkedHashMap",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type": "java.util.List"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.type.TypeParser"
+      },
+      "type": "java.util.List"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.SettableBeanPropertyInnerSetterlessPropertyTest"
+      },
+      "type": "java.util.List"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type": "java.util.Map"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.type.TypeParser"
+      },
+      "type": "java.util.Map"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerDelegatingTest"
+      },
+      "type": "java.util.Map"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type": "java.util.RandomAccess"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type": "java.util.SequencedCollection"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type": "java.util.SequencedMap"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.BasicSerializerFactoryTest"
+      },
+      "type": "org.codehaus.jackson.JsonGenerator"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.BasicSerializerFactoryTest"
+      },
+      "type": "org.codehaus.jackson.Versioned"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.ext.OptionalHandlerFactory"
+      },
+      "type": "org.codehaus.jackson.map.ext.CoreXMLSerializers",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.ser.BasicSerializerFactory"
+      },
+      "type": "org.codehaus.jackson.map.ser.std.TokenBufferSerializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.BasicSerializerFactoryTest"
+      },
+      "type": "org.codehaus.jackson.util.TokenBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.introspect.AnnotatedClass"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest$BaseTarget"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.introspect.AnnotatedClass"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest$CreatorTarget"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest$CreatorTarget"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.introspect.AnnotatedClass"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest$CreatorTargetMixIn"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.introspect.AnnotatedClass"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest$ObjectMixIn"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.ser.AnyGetterWriter"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.AnyGetterWriterTest$BeanWithAnyGetter",
+      "methods": [
+        {
+          "name": "anyProperties",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.AnyGetterWriterTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.AnyGetterWriterTest$BeanWithAnyGetter",
+      "methods": [
+        {
+          "name": "getName",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.ArrayDeserializerTest$Value"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.std.ObjectArrayDeserializer"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.ArrayDeserializerTest$Value",
+      "fields": [
+        {
+          "name": "name"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.std.ObjectArrayDeserializer"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.ArrayDeserializerTest$Value[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.type.ArrayType"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.ArrayDeserializerTest$Value[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.BeanPropertyWriterTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.BeanPropertyWriterTest$AccessorBackedProperty",
+      "methods": [
+        {
+          "name": "getMethodValue",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.BeanPropertyWriterTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.BeanPropertyWriterTest$FieldBackedProperty",
+      "fields": [
+        {
+          "name": "fieldValue"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.jsontype.impl.TypeDeserializerBase"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.ClassNameIdResolverTest$Animal"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.ClassNameIdResolverTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.ClassNameIdResolverTest$Animal"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.jsontype.impl.AsPropertyTypeDeserializer"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.ClassNameIdResolverTest$Dog",
+      "fields": [
+        {
+          "name": "name"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.jsontype.impl.ClassNameIdResolver"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.ClassNameIdResolverTest$Dog"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.jsontype.impl.TypeDeserializerBase"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.ClassNameIdResolverTest$Dog"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.util.ClassUtil"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.ClassUtilTest$PublicDefaultConstructor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.std.CollectionDeserializer"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest$NumericValues",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest$NumericValues"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerDelegatingTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerDelegatingTest$MapConstructorTarget",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.util.Map"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerDelegatingTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerDelegatingTest$MapFactoryTarget",
+      "methods": [
+        {
+          "name": "from",
+          "parameterTypes": [
+            "java.util.Map"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerNumberBasedTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerNumberBasedTest$IntegerConstructorTarget",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerNumberBasedTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerNumberBasedTest$IntegerFactoryTarget",
+      "methods": [
+        {
+          "name": "fromNumber",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerNumberBasedTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerNumberBasedTest$LongConstructorTarget",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerNumberBasedTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerNumberBasedTest$LongFactoryTarget",
+      "methods": [
+        {
+          "name": "fromNumber",
+          "parameterTypes": [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.introspect.AnnotatedConstructor"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerPropertyBasedTest$ConstructorTarget",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String",
+            "int",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerPropertyBasedTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerPropertyBasedTest$ConstructorTarget"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.introspect.AnnotatedMethod"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerPropertyBasedTest$FactoryTarget",
+      "methods": [
+        {
+          "name": "fromProperties",
+          "parameterTypes": [
+            "java.lang.String",
+            "int",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerPropertyBasedTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerPropertyBasedTest$FactoryTarget"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerStringBasedTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerStringBasedTest$ConstructorTarget",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerStringBasedTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerStringBasedTest$FactoryTarget",
+      "methods": [
+        {
+          "name": "fromString",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.EnumDeserializerInnerFactoryBasedDeserializerTest$FactoryBackedEnum"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.std.EnumDeserializer$FactoryBasedDeserializer"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.EnumDeserializerInnerFactoryBasedDeserializerTest$FactoryBackedEnum",
+      "methods": [
+        {
+          "name": "fromJson",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.ser.std.JsonValueSerializer"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.JsonValueSerializerTest$DefaultTypedJsonValue",
+      "methods": [
+        {
+          "name": "asJsonValue",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.JsonValueSerializerTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.JsonValueSerializerTest$DefaultTypedJsonValue"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.ser.std.JsonValueSerializer"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.JsonValueSerializerTest$JsonValueBackedObject",
+      "methods": [
+        {
+          "name": "asJsonValue",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.JsonValueSerializerTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.JsonValueSerializerTest$JsonValueBackedObject"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.PropertyBuilderTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.PropertyBuilderTest$FieldBackedNonDefaultValue",
+      "fields": [
+        {
+          "name": "value"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.PropertyBuilderTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.PropertyBuilderTest$MethodBackedNonDefaultValue",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "getValue",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.SettableAnyProperty"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.SettableAnyPropertyTest$AnySetterBean",
+      "methods": [
+        {
+          "name": "putUnknownValue",
+          "parameterTypes": [
+            "java.lang.String",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.SettableAnyPropertyTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.SettableAnyPropertyTest$AnySetterBean",
+      "fields": [
+        {
+          "name": "name"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.SettableBeanProperty$MethodProperty"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.SettableBeanPropertyInnerMethodPropertyTest$SetterBackedBean",
+      "methods": [
+        {
+          "name": "setCount",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "setName",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.SettableBeanPropertyInnerMethodPropertyTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.SettableBeanPropertyInnerMethodPropertyTest$SetterBackedBean",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.SettableBeanProperty$SetterlessProperty"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.SettableBeanPropertyInnerSetterlessPropertyTest$GetterBackedBean",
+      "methods": [
+        {
+          "name": "getItems",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.SettableBeanPropertyInnerSetterlessPropertyTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.SettableBeanPropertyInnerSetterlessPropertyTest$GetterBackedBean",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.std.StdKeyDeserializer$StringCtorKeyDeserializer"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.StdKeyDeserializerInnerStringCtorKeyDeserializerTest$StringConstructorKey",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.StdKeyDeserializerInnerStringCtorKeyDeserializerTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.StdKeyDeserializerInnerStringCtorKeyDeserializerTest$StringConstructorKey"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.std.StdKeyDeserializer$StringFactoryKeyDeserializer"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.StdKeyDeserializerInnerStringFactoryKeyDeserializerTest$StringFactoryKey",
+      "methods": [
+        {
+          "name": "valueOf",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.StdKeyDeserializerInnerStringFactoryKeyDeserializerTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.StdKeyDeserializerInnerStringFactoryKeyDeserializerTest$StringFactoryKey"
+    },
+    {
+      "condition": {
+        "typeReached": "org.codehaus.jackson.map.deser.std.StringCollectionDeserializer"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.StringCollectionDeserializerTest$StringValues",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.StringCollectionDeserializerTest"
+      },
+      "type": "org_codehaus_jackson.jackson_mapper_asl.StringCollectionDeserializerTest$StringValues"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest"
+      },
+      "glob": "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition": {
+        "typeReached": "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest"
+      },
+      "glob": "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/metadata/org.codehaus.jackson/jackson-mapper-asl/index.json
+++ b/metadata/org.codehaus.jackson/jackson-mapper-asl/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.9.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/codehaus/jackson/jackson-mapper-asl/$version$/jackson-mapper-asl-$version$-sources.jar",
+    "repository-url" : "https://github.com/codehaus/jackson",
+    "test-code-url" : "https://github.com/codehaus/jackson/tree/refs/tags/1.9/$version$/src/test/org/codehaus/jackson/map",
+    "documentation-url" : "https://javadoc.io/doc/org.codehaus.jackson/jackson-mapper-asl/$version$",
+    "description" : "Jackson Mapper ASL 1.x provides the data-binding layer for the original Jackson JSON processor. It maps JSON to and from Java objects using ObjectMapper, serializers, deserializers, annotations, and type introspection built on jackson-core-asl.",
+    "test-version" : "1.8.3",
+    "tested-versions" : [
+      "1.9.0"
+    ],
+    "allowed-packages" : [
+      "org.codehaus.jackson"
+    ]
+  },
+  {
     "metadata-version" : "1.8.3",
     "source-code-url" : "https://repo1.maven.org/maven2/org/codehaus/jackson/jackson-mapper-asl/$version$/jackson-mapper-asl-$version$-sources.jar",
     "repository-url" : "https://github.com/codehaus/jackson",

--- a/metadata/org.codehaus.jackson/jackson-mapper-asl/index.json
+++ b/metadata/org.codehaus.jackson/jackson-mapper-asl/index.json
@@ -1,28 +1,27 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "1.9.0",
-    "source-code-url" : "https://repo1.maven.org/maven2/org/codehaus/jackson/jackson-mapper-asl/$version$/jackson-mapper-asl-$version$-sources.jar",
-    "repository-url" : "https://github.com/codehaus/jackson",
-    "test-code-url" : "https://github.com/codehaus/jackson/tree/refs/tags/1.9/$version$/src/test/org/codehaus/jackson/map",
-    "documentation-url" : "https://javadoc.io/doc/org.codehaus.jackson/jackson-mapper-asl/$version$",
-    "description" : "Jackson Mapper ASL 1.x provides the data-binding layer for the original Jackson JSON processor. It maps JSON to and from Java objects using ObjectMapper, serializers, deserializers, annotations, and type introspection built on jackson-core-asl.",
-    "test-version" : "1.8.3",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "1.9.0",
+    "source-code-url": "https://repo1.maven.org/maven2/org/codehaus/jackson/jackson-mapper-asl/$version$/jackson-mapper-asl-$version$-sources.jar",
+    "repository-url": "https://github.com/codehaus/jackson",
+    "test-code-url": "https://github.com/codehaus/jackson/tree/refs/tags/1.9/$version$/src/test/org/codehaus/jackson/map",
+    "documentation-url": "https://javadoc.io/doc/org.codehaus.jackson/jackson-mapper-asl/$version$",
+    "description": "Jackson Mapper ASL 1.x provides the data-binding layer for the original Jackson JSON processor. It maps JSON to and from Java objects using ObjectMapper, serializers, deserializers, annotations, and type introspection built on jackson-core-asl.",
+    "tested-versions": [
       "1.9.0"
     ],
-    "allowed-packages" : [
+    "allowed-packages": [
       "org.codehaus.jackson"
     ]
   },
   {
-    "metadata-version" : "1.8.3",
-    "source-code-url" : "https://repo1.maven.org/maven2/org/codehaus/jackson/jackson-mapper-asl/$version$/jackson-mapper-asl-$version$-sources.jar",
-    "repository-url" : "https://github.com/codehaus/jackson",
-    "test-code-url" : "https://github.com/codehaus/jackson/tree/refs/tags/1.8/$version$/src/test/org/codehaus/jackson/map",
-    "documentation-url" : "https://javadoc.io/doc/org.codehaus.jackson/jackson-mapper-asl/$version$",
-    "description" : "Jackson Mapper ASL 1.x provides the data-binding layer for the original Jackson JSON processor. It maps JSON to and from Java objects using ObjectMapper, serializers, deserializers, annotations, and type introspection built on jackson-core-asl.",
-    "tested-versions" : [
+    "metadata-version": "1.8.3",
+    "source-code-url": "https://repo1.maven.org/maven2/org/codehaus/jackson/jackson-mapper-asl/$version$/jackson-mapper-asl-$version$-sources.jar",
+    "repository-url": "https://github.com/codehaus/jackson",
+    "test-code-url": "https://github.com/codehaus/jackson/tree/refs/tags/1.8/$version$/src/test/org/codehaus/jackson/map",
+    "documentation-url": "https://javadoc.io/doc/org.codehaus.jackson/jackson-mapper-asl/$version$",
+    "description": "Jackson Mapper ASL 1.x provides the data-binding layer for the original Jackson JSON processor. It maps JSON to and from Java objects using ObjectMapper, serializers, deserializers, annotations, and type introspection built on jackson-core-asl.",
+    "tested-versions": [
       "1.8.3",
       "1.8.4",
       "1.8.5",
@@ -33,7 +32,7 @@
       "1.8.10",
       "1.8.11"
     ],
-    "allowed-packages" : [
+    "allowed-packages": [
       "org.codehaus.jackson"
     ]
   }

--- a/stats/org.codehaus.jackson/jackson-mapper-asl/1.9.0/execution-metrics.json
+++ b/stats/org.codehaus.jackson/jackson-mapper-asl/1.9.0/execution-metrics.json
@@ -1,0 +1,128 @@
+{
+  "fix_ni_run:2026-06-11": {
+    "timestamp": "2026-06-11T02:14:38.136175Z",
+    "library": "org.codehaus.jackson:jackson-mapper-asl:1.9.0",
+    "starting_commit": "f77015a6de63756a381daa16e8889f86fe65e871",
+    "ending_commit": "88a4d528094f6a364a8325fc57b5a34f54f91bbe",
+    "previous_library": "org.codehaus.jackson:jackson-mapper-asl:1.8.3",
+    "strategy_name": "library_update_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.9.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 51,
+            "totalCalls": 51
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 51,
+        "totalCalls": 51
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 18158,
+          "missed": 42077,
+          "ratio": 0.301453,
+          "total": 60235
+        },
+        "line": {
+          "covered": 4294,
+          "missed": 9299,
+          "ratio": 0.315898,
+          "total": 13593
+        },
+        "method": {
+          "covered": 1056,
+          "missed": 2365,
+          "ratio": 0.308682,
+          "total": 3421
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.8.3",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 55,
+            "totalCalls": 55
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 55,
+        "totalCalls": 55
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 16051,
+          "missed": 35045,
+          "ratio": 0.314134,
+          "total": 51096
+        },
+        "line": {
+          "covered": 3824,
+          "missed": 7793,
+          "ratio": 0.329173,
+          "total": 11617
+        },
+        "method": {
+          "covered": 923,
+          "missed": 2000,
+          "ratio": 0.315771,
+          "total": 2923
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "degraded",
+      "action": "no_action",
+      "issue_number": 6264,
+      "issue_label": "fails-native-image-run",
+      "library": "org.codehaus.jackson:jackson-mapper-asl:1.9.0",
+      "summary": "Library preparation preflight did not produce usable advisory setup.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#6264 [Automation] native-image run fails for org.codehaus.jackson:jackson-mapper-asl:1.9.0; label=fails-native-image-run; body_chars=8015"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "33 existing test file path(s) included"
+        }
+      ],
+      "current_library": "org.codehaus.jackson:jackson-mapper-asl:1.8.3",
+      "new_version": "1.9.0",
+      "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
+      "model": "oca/gpt-5.5",
+      "prompt_path": "library-preflight-prompt.txt",
+      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.codehaus.jackson:jackson-mapper-asl:1.9.0/library-preparation-preflight/pi-generation-2026-06-11T01-37-35-888621Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 130841,
+      "cached_input_tokens_used": 820224,
+      "output_tokens_used": 8594,
+      "iterations": 3,
+      "cost_usd": 0.6679,
+      "tested_library_loc": 4294,
+      "metadata_entries": 46,
+      "test_only_metadata_entries": 145,
+      "previous_library_metadata_entries": 12,
+      "code_coverage_percent": 31.59,
+      "previous_library_coverage_percent": 32.92
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/OptionalHandlerFactoryTest.java",
+      "metadata_file": "metadata/org.codehaus.jackson/jackson-mapper-asl/1.9.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.codehaus.jackson/jackson-mapper-asl/1.9.0/stats.json
+++ b/stats/org.codehaus.jackson/jackson-mapper-asl/1.9.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "1.9.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 51,
+          "totalCalls" : 51
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 51,
+      "totalCalls" : 51
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 18158,
+        "missed" : 42077,
+        "ratio" : 0.301453,
+        "total" : 60235
+      },
+      "line" : {
+        "covered" : 4294,
+        "missed" : 9299,
+        "ratio" : 0.315898,
+        "total" : 13593
+      },
+      "method" : {
+        "covered" : 1056,
+        "missed" : 2365,
+        "ratio" : 0.308682,
+        "total" : 3421
+      }
+    }
+  } ]
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/.gitignore
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/build.gradle
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.codehaus.jackson:jackson-mapper-asl:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+tasks.withType(Test).configureEach {
+    jvmArgs '--add-opens=java.base/java.util=ALL-UNNAMED'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+    binaries {
+        all {
+            buildArgs.add('--add-opens=java.base/java.util=ALL-UNNAMED')
+        }
+    }
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/gradle.properties
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.codehaus.jackson:jackson-mapper-asl:1.9.0
+library.version = 1.9.0
+metadata.dir = org.codehaus.jackson/jackson-mapper-asl/1.9.0/

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/settings.gradle
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.codehaus.jackson.jackson-mapper-asl_tests'

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/AnnotatedClassTest.java
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/AnnotatedClassTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.map.AnnotationIntrospector;
+import org.codehaus.jackson.map.ClassIntrospector.MixInResolver;
+import org.codehaus.jackson.map.introspect.AnnotatedClass;
+import org.codehaus.jackson.map.introspect.AnnotatedConstructor;
+import org.codehaus.jackson.map.introspect.AnnotatedField;
+import org.codehaus.jackson.map.introspect.AnnotatedMethod;
+import org.codehaus.jackson.map.introspect.JacksonAnnotationIntrospector;
+import org.junit.jupiter.api.Test;
+
+public class AnnotatedClassTest {
+    private static final AnnotationIntrospector INTROSPECTOR = new JacksonAnnotationIntrospector();
+    private static final Class<?>[] NO_PARAMETERS = new Class<?>[0];
+    private static final Class<?>[] STRING_PARAMETER = new Class<?>[] {String.class};
+
+    @Test
+    public void resolvesCreatorsMemberMethodsAndFieldsWithMixIns() {
+        AnnotatedClass annotatedClass = AnnotatedClass.construct(
+                CreatorTarget.class, INTROSPECTOR, new TargetMixInResolver());
+
+        annotatedClass.resolveCreators(true);
+        annotatedClass.resolveMemberMethods(null, true);
+        annotatedClass.resolveFields(true);
+
+        AnnotatedConstructor defaultConstructor = annotatedClass.getDefaultConstructor();
+        assertThat(defaultConstructor).isNotNull();
+        assertThat((defaultConstructor).getAnnotation(JsonCreator.class)).isNotNull();
+
+        AnnotatedConstructor stringConstructor = annotatedClass.getConstructors().get(0);
+        assertThat(stringConstructor.getParameterClass(0)).isEqualTo(String.class);
+        assertThat(stringConstructor.getParameter(0).getAnnotation(JsonProperty.class).value()).isEqualTo("ctorName");
+
+        AnnotatedMethod factory = findStaticMethod(annotatedClass, "fromName");
+        assertThat(factory.getParameter(0).getAnnotation(JsonProperty.class).value()).isEqualTo("factoryName");
+
+        AnnotatedMethod getter = annotatedClass.findMethod("getName", NO_PARAMETERS);
+        assertThat((getter).getAnnotation(JsonProperty.class).value()).isEqualTo("mixedName");
+
+        AnnotatedMethod inheritedSetter = annotatedClass.findMethod("setBaseName", STRING_PARAMETER);
+        assertThat(inheritedSetter).isNotNull();
+
+        AnnotatedMethod objectHashCode = annotatedClass.findMethod("hashCode", NO_PARAMETERS);
+        assertThat(objectHashCode.getDeclaringClass()).isEqualTo(Object.class);
+        assertThat((objectHashCode).getAnnotation(JsonProperty.class).value()).isEqualTo("objectHashCode");
+
+        AnnotatedField mixedField = findField(annotatedClass, "fieldName");
+        assertThat((mixedField).getAnnotation(JsonProperty.class).value()).isEqualTo("mixedFieldName");
+
+        AnnotatedField inheritedField = findField(annotatedClass, "baseName");
+        assertThat(inheritedField).isNotNull();
+    }
+
+    private static AnnotatedMethod findStaticMethod(AnnotatedClass annotatedClass, String name) {
+        for (AnnotatedMethod method : annotatedClass.getStaticMethods()) {
+            if (name.equals(method.getName())) {
+                return method;
+            }
+        }
+        throw new AssertionError("No static method named " + name);
+    }
+
+    private static AnnotatedField findField(AnnotatedClass annotatedClass, String name) {
+        for (AnnotatedField field : annotatedClass.fields()) {
+            if (name.equals(field.getName())) {
+                return field;
+            }
+        }
+        throw new AssertionError("No field named " + name);
+    }
+
+    private static final class TargetMixInResolver implements MixInResolver {
+        @Override
+        public Class<?> findMixInClassFor(Class<?> cls) {
+            if (cls == CreatorTarget.class) {
+                return CreatorTargetMixIn.class;
+            }
+            if (cls == Object.class) {
+                return ObjectMixIn.class;
+            }
+            return null;
+        }
+    }
+
+    private static class BaseTarget {
+        public String baseName;
+
+        public void setBaseName(String baseName) {
+            this.baseName = baseName;
+        }
+    }
+
+    private static final class CreatorTarget extends BaseTarget {
+        public String fieldName;
+        private final String name;
+
+        public CreatorTarget() {
+            this("default");
+        }
+
+        public CreatorTarget(String name) {
+            this.name = name;
+        }
+
+        public static CreatorTarget fromName(String name) {
+            return new CreatorTarget(name);
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+    private abstract static class CreatorTargetMixIn {
+        @JsonProperty("mixedFieldName")
+        public String fieldName;
+
+        @JsonCreator
+        public CreatorTargetMixIn() {
+        }
+
+        @JsonCreator
+        public CreatorTargetMixIn(@JsonProperty("ctorName") String name) {
+        }
+
+        public static CreatorTarget fromName(@JsonProperty("factoryName") String name) {
+            return null;
+        }
+
+        @JsonProperty("mixedName")
+        public abstract String getName();
+    }
+
+    private abstract static class ObjectMixIn {
+        @Override
+        @JsonProperty("objectHashCode")
+        public abstract int hashCode();
+    }
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/AnnotatedFieldTest.java
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/AnnotatedFieldTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.codehaus.jackson.map.InjectableValues;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.annotate.JacksonInject;
+import org.junit.jupiter.api.Test;
+
+public class AnnotatedFieldTest {
+    @Test
+    public void injectsValueIntoAnnotatedFieldDuringDeserialization() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        InjectableValues.Std injectableValues = new InjectableValues.Std()
+                .addValue("requestId", "request-123");
+        mapper.setInjectableValues(injectableValues);
+
+        FieldInjectionTarget target = mapper.readValue("{}", FieldInjectionTarget.class);
+
+        assertThat(target.requestId).isEqualTo("request-123");
+    }
+
+    public static final class FieldInjectionTarget {
+        @JacksonInject("requestId")
+        public String requestId;
+    }
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/AnnotatedMethodTest.java
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/AnnotatedMethodTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+
+import org.codehaus.jackson.map.AnnotationIntrospector;
+import org.codehaus.jackson.map.introspect.AnnotatedClass;
+import org.codehaus.jackson.map.introspect.AnnotatedMethod;
+import org.codehaus.jackson.map.introspect.AnnotationMap;
+import org.codehaus.jackson.map.introspect.JacksonAnnotationIntrospector;
+import org.junit.jupiter.api.Test;
+
+public class AnnotatedMethodTest {
+    private static final AnnotationIntrospector INTROSPECTOR = new JacksonAnnotationIntrospector();
+    private static final Class<?>[] STRING_PARAMETER = new Class<?>[] {String.class};
+
+    @Test
+    public void invokesStaticNoArgumentMethod() throws Exception {
+        Method method = StaticFactory.class.getDeclaredMethod("defaultName");
+        AnnotatedMethod annotatedMethod = new AnnotatedMethod(
+                method, new AnnotationMap(), new AnnotationMap[0]);
+
+        Object value = annotatedMethod.call();
+
+        assertThat(value).isEqualTo("default-name");
+    }
+
+    @Test
+    public void setsBeanValueThroughAnnotatedMethod() {
+        AnnotatedClass annotatedClass = AnnotatedClass.construct(
+                SetterTarget.class, INTROSPECTOR, null);
+        annotatedClass.resolveMemberMethods(null, true);
+        AnnotatedMethod setter = annotatedClass.findMethod("setName", STRING_PARAMETER);
+        SetterTarget target = new SetterTarget();
+
+        setter.setValue(target, "updated-name");
+
+        assertThat(target.name).isEqualTo("updated-name");
+    }
+
+    public static final class StaticFactory {
+        public static String defaultName() {
+            return "default-name";
+        }
+    }
+
+    public static final class SetterTarget {
+        private String name;
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/AnyGetterWriterTest.java
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/AnyGetterWriterTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.codehaus.jackson.annotate.JsonAnyGetter;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+public class AnyGetterWriterTest {
+    @Test
+    public void serializesEntriesReturnedByJsonAnyGetter() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        BeanWithAnyGetter bean = new BeanWithAnyGetter("catalog");
+        bean.put("enabled", true);
+        bean.put("priority", 3);
+
+        String json = mapper.writeValueAsString(bean);
+
+        assertThat(json)
+                .contains("\"name\":\"catalog\"")
+                .contains("\"enabled\":true")
+                .contains("\"priority\":3")
+                .doesNotContain("attributes")
+                .doesNotContain("anyProperties");
+    }
+
+    public static final class BeanWithAnyGetter {
+        private final String name;
+        private final Map<String, Object> attributes = new LinkedHashMap<String, Object>();
+
+        public BeanWithAnyGetter(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void put(String key, Object value) {
+            attributes.put(key, value);
+        }
+
+        @JsonAnyGetter
+        public Map<String, Object> anyProperties() {
+            return attributes;
+        }
+    }
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/ArrayBuildersTest.java
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/ArrayBuildersTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.codehaus.jackson.map.util.ArrayBuilders;
+import org.junit.jupiter.api.Test;
+
+public class ArrayBuildersTest {
+    @Test
+    public void insertInListPrependsElementInNewArrayWithSameComponentType() {
+        String[] values = new String[] {"first", "second"};
+
+        String[] result = ArrayBuilders.insertInList(values, "new");
+
+        assertThat(result).isNotSameAs(values);
+        assertThat(result.getClass().getComponentType()).isEqualTo(String.class);
+        assertThat(result).containsExactly("new", "first", "second");
+        assertThat(values).containsExactly("first", "second");
+    }
+
+    @Test
+    public void insertInListNoDupAllocatesSameComponentArrayForDuplicateNotAtHead() {
+        String first = "first";
+        String duplicate = "duplicate";
+        String[] values = new String[] {first, duplicate, "last"};
+
+        String[] result = ArrayBuilders.insertInListNoDup(values, duplicate);
+
+        assertThat(result).isNotSameAs(values);
+        assertThat(result).hasSameSizeAs(values);
+        assertThat(result.getClass().getComponentType()).isEqualTo(String.class);
+        assertThat(result[1]).isSameAs(first);
+    }
+
+    @Test
+    public void insertInListNoDupPrependsMissingElementInNewArrayWithSameComponentType() {
+        String[] values = new String[] {"first", "second"};
+
+        String[] result = ArrayBuilders.insertInListNoDup(values, "new");
+
+        assertThat(result).isNotSameAs(values);
+        assertThat(result.getClass().getComponentType()).isEqualTo(String.class);
+        assertThat(result).containsExactly("new", "first", "second");
+        assertThat(values).containsExactly("first", "second");
+    }
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/ArrayDeserializerTest.java
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/ArrayDeserializerTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.codehaus.jackson.map.DeserializationConfig;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+public class ArrayDeserializerTest {
+    @Test
+    public void deserializesSingleBeanValueAsTypedObjectArray() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationConfig.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+
+        Value[] values = mapper.readValue("{\"name\":\"single\"}", Value[].class);
+
+        assertThat(values).hasSize(1);
+        assertThat(values.getClass().getComponentType()).isEqualTo(Value.class);
+        assertThat(values[0].name).isEqualTo("single");
+    }
+
+    public static final class Value {
+        public String name;
+    }
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/BasicSerializerFactoryTest.java
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/BasicSerializerFactoryTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.util.TokenBuffer;
+import org.junit.jupiter.api.Test;
+
+public class BasicSerializerFactoryTest {
+    @Test
+    public void serializesTokenBufferUsingLazyStandardSerializer() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        TokenBuffer buffer = new TokenBuffer(mapper);
+        buffer.writeStartObject();
+        buffer.writeFieldName("status");
+        buffer.writeString("ok");
+        buffer.writeFieldName("count");
+        buffer.writeNumber(2);
+        buffer.writeEndObject();
+
+        String json = mapper.writeValueAsString(buffer);
+
+        assertThat(json).isEqualTo("{\"status\":\"ok\",\"count\":2}");
+    }
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/BeanDeserializerTest.java
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/BeanDeserializerTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+public class BeanDeserializerTest {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    public void deserializesNonStaticInnerClassProperty() throws Exception {
+        OuterBean outer = MAPPER.readValue("""
+                {"inner":{"name":"nested","count":7}}
+                """, OuterBean.class);
+
+        assertThat(outer.inner).isNotNull();
+        assertThat(outer.inner.name).isEqualTo("nested");
+        assertThat(outer.inner.count).isEqualTo(7);
+        assertThat(outer.inner.parent()).isSameAs(outer);
+    }
+
+    public static class OuterBean {
+        public InnerBean inner;
+
+        public class InnerBean {
+            public String name;
+            public int count;
+
+            public OuterBean parent() {
+                return OuterBean.this;
+            }
+        }
+    }
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/BeanPropertyWriterTest.java
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/BeanPropertyWriterTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+public class BeanPropertyWriterTest {
+    @Test
+    public void serializesBeanPropertyThroughAccessorMethod() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        AccessorBackedProperty bean = new AccessorBackedProperty("method-value");
+
+        String json = mapper.writeValueAsString(bean);
+
+        assertThat(json).isEqualTo("{\"methodValue\":\"method-value\"}");
+    }
+
+    @Test
+    public void serializesBeanPropertyThroughField() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        FieldBackedProperty bean = new FieldBackedProperty("field-value");
+
+        String json = mapper.writeValueAsString(bean);
+
+        assertThat(json).isEqualTo("{\"fieldValue\":\"field-value\"}");
+    }
+
+    public static final class AccessorBackedProperty {
+        private final String methodValue;
+
+        public AccessorBackedProperty(String methodValue) {
+            this.methodValue = methodValue;
+        }
+
+        public String getMethodValue() {
+            return methodValue;
+        }
+    }
+
+    public static final class FieldBackedProperty {
+        public final String fieldValue;
+
+        public FieldBackedProperty(String fieldValue) {
+            this.fieldValue = fieldValue;
+        }
+    }
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/ClassNameIdResolverTest.java
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/ClassNameIdResolverTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.codehaus.jackson.annotate.JsonTypeInfo;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+public class ClassNameIdResolverTest {
+    @Test
+    public void deserializesClassNameTypeId() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        String json = """
+                {"@class":"%s","name":"Fido"}
+                """.formatted(Dog.class.getName());
+
+        Animal animal = mapper.readValue(json, Animal.class);
+
+        assertThat(animal).isInstanceOf(Dog.class);
+        assertThat(((Dog) animal).name).isEqualTo("Fido");
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
+    public abstract static class Animal {
+    }
+
+    public static class Dog extends Animal {
+        public String name;
+    }
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/ClassUtilInnerEnumTypeLocatorTest.java
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/ClassUtilInnerEnumTypeLocatorTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.EnumMap;
+import java.util.EnumSet;
+
+import org.codehaus.jackson.map.util.ClassUtil;
+import org.junit.jupiter.api.Test;
+
+public class ClassUtilInnerEnumTypeLocatorTest {
+    @Test
+    public void locatesEnumTypeForEmptyEnumSet() {
+        EnumSet<Color> colors = EnumSet.noneOf(Color.class);
+
+        Class<? extends Enum<?>> enumType = ClassUtil.findEnumType(colors);
+
+        assertThat(enumType).isEqualTo(Color.class);
+    }
+
+    @Test
+    public void locatesEnumTypeForEmptyEnumMap() {
+        EnumMap<Color, String> colors = new EnumMap<Color, String>(Color.class);
+
+        Class<? extends Enum<?>> enumType = ClassUtil.findEnumType(colors);
+
+        assertThat(enumType).isEqualTo(Color.class);
+    }
+
+    private enum Color {
+        RED,
+        BLUE
+    }
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/ClassUtilTest.java
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/ClassUtilTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.codehaus.jackson.map.util.ClassUtil;
+import org.junit.jupiter.api.Test;
+
+public class ClassUtilTest {
+    @Test
+    public void createsInstanceUsingDefaultConstructor() {
+        PublicDefaultConstructor value = ClassUtil.createInstance(PublicDefaultConstructor.class, false);
+
+        assertThat(value.getName()).isEqualTo("constructed");
+    }
+
+    public static final class PublicDefaultConstructor {
+        private final String name;
+
+        public PublicDefaultConstructor() {
+            this.name = "constructed";
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/CollectionDeserializerTest.java
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/CollectionDeserializerTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+public class CollectionDeserializerTest {
+    @Test
+    public void deserializesConcreteCollectionWithDefaultConstructor() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        NumericValues values = mapper.readValue("[1,2,3]", NumericValues.class);
+
+        assertThat(values).containsExactly(1, 2, 3);
+    }
+
+    public static final class NumericValues extends ArrayList<Integer> {
+        private static final long serialVersionUID = 1L;
+    }
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/CreatorInnerDelegatingTest.java
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/CreatorInnerDelegatingTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+public class CreatorInnerDelegatingTest {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    public void deserializesObjectUsingDelegatingConstructor() throws Exception {
+        MapConstructorTarget target = MAPPER.readValue("""
+                {"name":"constructor","count":3}
+                """, MapConstructorTarget.class);
+
+        assertThat(target.name()).isEqualTo("constructor");
+        assertThat(target.count()).isEqualTo(3);
+    }
+
+    @Test
+    public void deserializesObjectUsingDelegatingFactoryMethod() throws Exception {
+        MapFactoryTarget target = MAPPER.readValue("""
+                {"name":"factory","count":4}
+                """, MapFactoryTarget.class);
+
+        assertThat(target.name()).isEqualTo("factory");
+        assertThat(target.count()).isEqualTo(4);
+        assertThat(target.createdByFactory).isTrue();
+    }
+
+    public static final class MapConstructorTarget {
+        private final Map<String, Object> values;
+
+        @JsonCreator
+        public MapConstructorTarget(Map<String, Object> values) {
+            this.values = values;
+        }
+
+        public String name() {
+            return (String) values.get("name");
+        }
+
+        public Integer count() {
+            return (Integer) values.get("count");
+        }
+    }
+
+    public static final class MapFactoryTarget {
+        private final Map<String, Object> values;
+        final boolean createdByFactory;
+
+        private MapFactoryTarget(Map<String, Object> values, boolean createdByFactory) {
+            this.values = values;
+            this.createdByFactory = createdByFactory;
+        }
+
+        @JsonCreator
+        public static MapFactoryTarget from(Map<String, Object> values) {
+            return new MapFactoryTarget(values, true);
+        }
+
+        public String name() {
+            return (String) values.get("name");
+        }
+
+        public Integer count() {
+            return (Integer) values.get("count");
+        }
+    }
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/CreatorInnerNumberBasedTest.java
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/CreatorInnerNumberBasedTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+public class CreatorInnerNumberBasedTest {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final long LONG_VALUE = 2147483648L;
+
+    @Test
+    public void deserializesIntegerUsingNumberBasedConstructor() throws Exception {
+        IntegerConstructorTarget target = MAPPER.readValue("37", IntegerConstructorTarget.class);
+
+        assertThat(target.value).isEqualTo(37);
+    }
+
+    @Test
+    public void deserializesIntegerUsingNumberBasedFactoryMethod() throws Exception {
+        IntegerFactoryTarget target = MAPPER.readValue("38", IntegerFactoryTarget.class);
+
+        assertThat(target.value).isEqualTo(38);
+        assertThat(target.createdByFactory).isTrue();
+    }
+
+    @Test
+    public void deserializesLongUsingNumberBasedConstructor() throws Exception {
+        LongConstructorTarget target = MAPPER.readValue(Long.toString(LONG_VALUE), LongConstructorTarget.class);
+
+        assertThat(target.value).isEqualTo(LONG_VALUE);
+    }
+
+    @Test
+    public void deserializesLongUsingNumberBasedFactoryMethod() throws Exception {
+        LongFactoryTarget target = MAPPER.readValue(Long.toString(LONG_VALUE + 1L), LongFactoryTarget.class);
+
+        assertThat(target.value).isEqualTo(LONG_VALUE + 1L);
+        assertThat(target.createdByFactory).isTrue();
+    }
+
+    public static final class IntegerConstructorTarget {
+        final int value;
+
+        @JsonCreator
+        public IntegerConstructorTarget(int value) {
+            this.value = value;
+        }
+    }
+
+    public static final class IntegerFactoryTarget {
+        final int value;
+        final boolean createdByFactory;
+
+        private IntegerFactoryTarget(int value, boolean createdByFactory) {
+            this.value = value;
+            this.createdByFactory = createdByFactory;
+        }
+
+        @JsonCreator
+        public static IntegerFactoryTarget fromNumber(int value) {
+            return new IntegerFactoryTarget(value, true);
+        }
+    }
+
+    public static final class LongConstructorTarget {
+        final long value;
+
+        @JsonCreator
+        public LongConstructorTarget(long value) {
+            this.value = value;
+        }
+    }
+
+    public static final class LongFactoryTarget {
+        final long value;
+        final boolean createdByFactory;
+
+        private LongFactoryTarget(long value, boolean createdByFactory) {
+            this.value = value;
+            this.createdByFactory = createdByFactory;
+        }
+
+        @JsonCreator
+        public static LongFactoryTarget fromNumber(long value) {
+            return new LongFactoryTarget(value, true);
+        }
+    }
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/CreatorInnerPropertyBasedTest.java
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/CreatorInnerPropertyBasedTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+public class CreatorInnerPropertyBasedTest {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    public void deserializesObjectUsingPropertyBasedConstructor() throws Exception {
+        ConstructorTarget target = MAPPER.readValue("""
+                {"name":"constructor","count":3,"enabled":true}
+                """, ConstructorTarget.class);
+
+        assertThat(target.name).isEqualTo("constructor");
+        assertThat(target.count).isEqualTo(3);
+        assertThat(target.enabled).isTrue();
+    }
+
+    @Test
+    public void deserializesObjectUsingPropertyBasedFactoryMethod() throws Exception {
+        FactoryTarget target = MAPPER.readValue("""
+                {"name":"factory","count":4,"enabled":false}
+                """, FactoryTarget.class);
+
+        assertThat(target.name).isEqualTo("factory");
+        assertThat(target.count).isEqualTo(4);
+        assertThat(target.enabled).isFalse();
+        assertThat(target.createdByFactory).isTrue();
+    }
+
+    public static final class ConstructorTarget {
+        final String name;
+        final int count;
+        final boolean enabled;
+
+        @JsonCreator
+        public ConstructorTarget(
+                @JsonProperty("name") String name,
+                @JsonProperty("count") int count,
+                @JsonProperty("enabled") boolean enabled) {
+            this.name = name;
+            this.count = count;
+            this.enabled = enabled;
+        }
+    }
+
+    public static final class FactoryTarget {
+        final String name;
+        final int count;
+        final boolean enabled;
+        final boolean createdByFactory;
+
+        private FactoryTarget(String name, int count, boolean enabled, boolean createdByFactory) {
+            this.name = name;
+            this.count = count;
+            this.enabled = enabled;
+            this.createdByFactory = createdByFactory;
+        }
+
+        @JsonCreator
+        public static FactoryTarget fromProperties(
+                @JsonProperty("name") String name,
+                @JsonProperty("count") int count,
+                @JsonProperty("enabled") boolean enabled) {
+            return new FactoryTarget(name, count, enabled, true);
+        }
+    }
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/CreatorInnerStringBasedTest.java
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/CreatorInnerStringBasedTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+public class CreatorInnerStringBasedTest {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    public void deserializesStringUsingStringBasedConstructor() throws Exception {
+        ConstructorTarget target = MAPPER.readValue("\"constructor-value\"", ConstructorTarget.class);
+
+        assertThat(target.value).isEqualTo("constructor-value");
+    }
+
+    @Test
+    public void deserializesStringUsingStringBasedFactoryMethod() throws Exception {
+        FactoryTarget target = MAPPER.readValue("\"factory-value\"", FactoryTarget.class);
+
+        assertThat(target.value).isEqualTo("factory-value");
+        assertThat(target.createdByFactory).isTrue();
+    }
+
+    public static final class ConstructorTarget {
+        final String value;
+
+        @JsonCreator
+        public ConstructorTarget(String value) {
+            this.value = value;
+        }
+    }
+
+    public static final class FactoryTarget {
+        final String value;
+        final boolean createdByFactory;
+
+        private FactoryTarget(String value, boolean createdByFactory) {
+            this.value = value;
+            this.createdByFactory = createdByFactory;
+        }
+
+        @JsonCreator
+        public static FactoryTarget fromString(String value) {
+            return new FactoryTarget(value, true);
+        }
+    }
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/EnumDeserializerInnerFactoryBasedDeserializerTest.java
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/EnumDeserializerInnerFactoryBasedDeserializerTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+public class EnumDeserializerInnerFactoryBasedDeserializerTest {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    public void deserializesEnumWithJsonCreatorFactoryMethod() throws Exception {
+        FactoryBackedEnum value = MAPPER.readValue("\"external-id\"", FactoryBackedEnum.class);
+
+        assertThat(value).isEqualTo(FactoryBackedEnum.MATCHED_BY_FACTORY);
+    }
+
+    public enum FactoryBackedEnum {
+        MATCHED_BY_FACTORY("external-id"),
+        OTHER("other-id");
+
+        private final String externalId;
+
+        FactoryBackedEnum(String externalId) {
+            this.externalId = externalId;
+        }
+
+        @JsonCreator
+        public static FactoryBackedEnum fromJson(String externalId) {
+            for (FactoryBackedEnum value : values()) {
+                if (value.externalId.equals(externalId)) {
+                    return value;
+                }
+            }
+            throw new IllegalArgumentException("Unknown enum id: " + externalId);
+        }
+    }
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/JsonValueSerializerTest.java
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/JsonValueSerializerTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.codehaus.jackson.annotate.JsonValue;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+public class JsonValueSerializerTest {
+    @Test
+    public void serializesObjectUsingJsonValueAccessor() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        JsonValueBackedObject value = new JsonValueBackedObject("plain-value");
+
+        String json = mapper.writeValueAsString(value);
+
+        assertThat(json).isEqualTo("\"plain-value\"");
+    }
+
+    @Test
+    public void serializesObjectWithTypeUsingJsonValueAccessor() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL);
+        DefaultTypedJsonValue value = new DefaultTypedJsonValue("typed-value");
+
+        String json = mapper.writeValueAsString(value);
+
+        assertThat(json)
+                .contains(DefaultTypedJsonValue.class.getName())
+                .contains("typed-value");
+    }
+
+    public static final class JsonValueBackedObject {
+        private final String value;
+
+        public JsonValueBackedObject(String value) {
+            this.value = value;
+        }
+
+        @JsonValue
+        public String asJsonValue() {
+            return value;
+        }
+    }
+
+    public static class DefaultTypedJsonValue {
+        private final String value;
+
+        public DefaultTypedJsonValue(String value) {
+            this.value = value;
+        }
+
+        @JsonValue
+        public String asJsonValue() {
+            return value;
+        }
+    }
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/ObjectBufferTest.java
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/ObjectBufferTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.codehaus.jackson.map.util.ObjectBuffer;
+import org.junit.jupiter.api.Test;
+
+public class ObjectBufferTest {
+    @Test
+    public void completeAndClearBufferCreatesTypedArrayFromBufferedChunks() {
+        ObjectBuffer buffer = new ObjectBuffer();
+        Object[] firstChunk = buffer.resetAndStart();
+        for (int i = 0; i < firstChunk.length; i++) {
+            firstChunk[i] = "chunk-" + i;
+        }
+        Object[] lastChunk = buffer.appendCompletedChunk(firstChunk);
+        lastChunk[0] = "tail-0";
+        lastChunk[1] = "tail-1";
+        lastChunk[2] = "tail-2";
+
+        String[] result = buffer.completeAndClearBuffer(lastChunk, 3, String.class);
+
+        assertThat(result.getClass().getComponentType()).isEqualTo(String.class);
+        assertThat(result).containsExactly(
+                "chunk-0",
+                "chunk-1",
+                "chunk-2",
+                "chunk-3",
+                "chunk-4",
+                "chunk-5",
+                "chunk-6",
+                "chunk-7",
+                "chunk-8",
+                "chunk-9",
+                "chunk-10",
+                "chunk-11",
+                "tail-0",
+                "tail-1",
+                "tail-2");
+        assertThat(buffer.bufferedSize()).isZero();
+        assertThat(buffer.initialCapacity()).isEqualTo(firstChunk.length);
+    }
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/OptionalHandlerFactoryTest.java
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/OptionalHandlerFactoryTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import org.codehaus.jackson.map.JsonSerializer;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.ext.OptionalHandlerFactory;
+import org.junit.jupiter.api.Test;
+
+public class OptionalHandlerFactoryTest {
+    @Test
+    public void instantiatesCoreXmlSerializerProviderForXmlTypes() {
+        ObjectMapper mapper = new ObjectMapper();
+
+        JsonSerializer<?> serializer = OptionalHandlerFactory.instance.findSerializer(
+                mapper.getSerializationConfig(), mapper.constructType(XMLGregorianCalendar.class));
+
+        assertThat(serializer).isNotNull();
+        assertThat(serializer.handledType()).isEqualTo(XMLGregorianCalendar.class);
+    }
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/PropertyBuilderTest.java
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/PropertyBuilderTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
+import org.junit.jupiter.api.Test;
+
+public class PropertyBuilderTest {
+    @Test
+    public void nonDefaultInclusionComparesAccessorPropertyWithDefaultBean() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        MethodBackedNonDefaultValue bean = new MethodBackedNonDefaultValue("custom-method-value");
+
+        String json = mapper.writeValueAsString(bean);
+
+        assertThat(json).isEqualTo("{\"value\":\"custom-method-value\"}");
+        assertThat(mapper.writeValueAsString(new MethodBackedNonDefaultValue())).isEqualTo("{}");
+    }
+
+    @Test
+    public void nonDefaultInclusionComparesFieldPropertyWithDefaultBean() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        FieldBackedNonDefaultValue bean = new FieldBackedNonDefaultValue("custom-field-value");
+
+        String json = mapper.writeValueAsString(bean);
+
+        assertThat(json).isEqualTo("{\"value\":\"custom-field-value\"}");
+        assertThat(mapper.writeValueAsString(new FieldBackedNonDefaultValue())).isEqualTo("{}");
+    }
+
+    @JsonSerialize(include = JsonSerialize.Inclusion.NON_DEFAULT)
+    public static final class MethodBackedNonDefaultValue {
+        private String value = "default-method-value";
+
+        public MethodBackedNonDefaultValue() {
+        }
+
+        public MethodBackedNonDefaultValue(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+
+    @JsonSerialize(include = JsonSerialize.Inclusion.NON_DEFAULT)
+    public static final class FieldBackedNonDefaultValue {
+        public String value = "default-field-value";
+
+        public FieldBackedNonDefaultValue() {
+        }
+
+        public FieldBackedNonDefaultValue(String value) {
+            this.value = value;
+        }
+    }
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/SettableAnyPropertyTest.java
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/SettableAnyPropertyTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.codehaus.jackson.annotate.JsonAnySetter;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+public class SettableAnyPropertyTest {
+    @Test
+    public void deserializesUnknownPropertiesThroughAnySetterMethod() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        AnySetterBean bean = mapper.readValue("""
+                {
+                  "name": "known",
+                  "extraText": "value",
+                  "extraNumber": 42,
+                  "extraBoolean": true
+                }
+                """, AnySetterBean.class);
+
+        assertThat(bean.name).isEqualTo("known");
+        assertThat(bean.values)
+                .containsEntry("extraText", "value")
+                .containsEntry("extraNumber", 42)
+                .containsEntry("extraBoolean", true);
+    }
+
+    public static final class AnySetterBean {
+        public String name;
+        private final Map<String, Object> values = new LinkedHashMap<String, Object>();
+
+        @JsonAnySetter
+        public void putUnknownValue(String propertyName, Object value) {
+            values.put(propertyName, value);
+        }
+    }
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/SettableBeanPropertyInnerMethodPropertyTest.java
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/SettableBeanPropertyInnerMethodPropertyTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+public class SettableBeanPropertyInnerMethodPropertyTest {
+    @Test
+    public void deserializesBeanPropertyThroughSetterMethod() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        SetterBackedBean bean = mapper.readValue("""
+                {
+                  "name": "method-value",
+                  "count": 3
+                }
+                """, SetterBackedBean.class);
+
+        assertThat(bean.getName()).isEqualTo("method-value");
+        assertThat(bean.getCount()).isEqualTo(3);
+        assertThat(bean.getSetterCallCount()).isEqualTo(2);
+    }
+
+    public static final class SetterBackedBean {
+        private String name;
+        private int count;
+        private int setterCallCount;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            setterCallCount++;
+            this.name = name;
+        }
+
+        public int getCount() {
+            return count;
+        }
+
+        public void setCount(int count) {
+            setterCallCount++;
+            this.count = count;
+        }
+
+        public int getSetterCallCount() {
+            return setterCallCount;
+        }
+    }
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/SettableBeanPropertyInnerSetterlessPropertyTest.java
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/SettableBeanPropertyInnerSetterlessPropertyTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+public class SettableBeanPropertyInnerSetterlessPropertyTest {
+    @Test
+    public void deserializesCollectionThroughGetterWithoutSetter() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        GetterBackedBean bean = mapper.readValue("""
+                {
+                  "items": ["first", "second"]
+                }
+                """, GetterBackedBean.class);
+
+        assertThat(bean.currentItems()).containsExactly("first", "second");
+        assertThat(bean.getGetterCallCount()).isEqualTo(1);
+    }
+
+    public static final class GetterBackedBean {
+        private final List<String> values = new ArrayList<String>();
+        private int getterCallCount;
+
+        public List<String> getItems() {
+            getterCallCount++;
+            return values;
+        }
+
+        public List<String> currentItems() {
+            return values;
+        }
+
+        public int getGetterCallCount() {
+            return getterCallCount;
+        }
+    }
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/StdDeserializerInnerCalendarDeserializerTest.java
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/StdDeserializerInnerCalendarDeserializerTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.GregorianCalendar;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+public class StdDeserializerInnerCalendarDeserializerTest {
+    @Test
+    public void deserializesGregorianCalendarUsingConcreteCalendarType() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        long timestamp = 1_234_567_890L;
+
+        GregorianCalendar calendar = mapper.readValue(Long.toString(timestamp), GregorianCalendar.class);
+
+        assertThat(calendar).isExactlyInstanceOf(GregorianCalendar.class);
+        assertThat(calendar.getTimeInMillis()).isEqualTo(timestamp);
+    }
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/StdDeserializerInnerClassDeserializerTest.java
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/StdDeserializerInnerClassDeserializerTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+public class StdDeserializerInnerClassDeserializerTest {
+    @Test
+    public void deserializesFullyQualifiedClassName() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Class<?> deserializedClass = mapper.readValue("\"java.lang.String\"", Class.class);
+
+        assertThat(deserializedClass).isSameAs(String.class);
+    }
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/StdKeyDeserializerInnerStringCtorKeyDeserializerTest.java
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/StdKeyDeserializerInnerStringCtorKeyDeserializerTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.type.JavaType;
+import org.junit.jupiter.api.Test;
+
+public class StdKeyDeserializerInnerStringCtorKeyDeserializerTest {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    public void deserializesMapKeyUsingStringConstructor() throws Exception {
+        JavaType mapType = MAPPER.getTypeFactory().constructMapType(
+                LinkedHashMap.class,
+                StringConstructorKey.class,
+                String.class);
+
+        Map<StringConstructorKey, String> values = MAPPER.readValue(
+                "{\"alpha\":\"first\",\"beta\":\"second\"}",
+                mapType);
+
+        assertThat(values)
+                .containsEntry(new StringConstructorKey("alpha"), "first")
+                .containsEntry(new StringConstructorKey("beta"), "second");
+    }
+
+    public static final class StringConstructorKey {
+        private final String value;
+
+        public StringConstructorKey(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (!(other instanceof StringConstructorKey)) {
+                return false;
+            }
+            StringConstructorKey that = (StringConstructorKey) other;
+            return value.equals(that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return value.hashCode();
+        }
+    }
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/StdKeyDeserializerInnerStringFactoryKeyDeserializerTest.java
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/StdKeyDeserializerInnerStringFactoryKeyDeserializerTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.type.JavaType;
+import org.junit.jupiter.api.Test;
+
+public class StdKeyDeserializerInnerStringFactoryKeyDeserializerTest {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    public void deserializesMapKeyUsingStaticStringFactoryMethod() throws Exception {
+        JavaType mapType = MAPPER.getTypeFactory().constructMapType(
+                LinkedHashMap.class,
+                StringFactoryKey.class,
+                String.class);
+
+        Map<StringFactoryKey, String> values = MAPPER.readValue(
+                "{\"alpha\":\"first\",\"beta\":\"second\"}",
+                mapType);
+
+        assertThat(values)
+                .containsEntry(StringFactoryKey.valueOf("alpha"), "first")
+                .containsEntry(StringFactoryKey.valueOf("beta"), "second");
+    }
+
+    public static final class StringFactoryKey {
+        private final String value;
+
+        private StringFactoryKey(String value, boolean fromFactory) {
+            this.value = value;
+        }
+
+        public static StringFactoryKey valueOf(String value) {
+            return new StringFactoryKey(value, true);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (!(other instanceof StringFactoryKey)) {
+                return false;
+            }
+            StringFactoryKey that = (StringFactoryKey) other;
+            return value.equals(that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return value.hashCode();
+        }
+    }
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/StringCollectionDeserializerTest.java
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/StringCollectionDeserializerTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+public class StringCollectionDeserializerTest {
+    @Test
+    public void deserializesConcreteStringCollectionWithDefaultConstructor() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        StringValues values = mapper.readValue("[\"alpha\",\"beta\",null]", StringValues.class);
+
+        assertThat(values).containsExactly("alpha", "beta", null);
+    }
+
+    public static final class StringValues extends ArrayList<String> {
+        private static final long serialVersionUID = 1L;
+    }
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/TypeParserTest.java
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/TypeParserTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.codehaus.jackson.map.type.TypeFactory;
+import org.codehaus.jackson.type.JavaType;
+import org.junit.jupiter.api.Test;
+
+public class TypeParserTest {
+    @Test
+    public void constructsParameterizedTypeFromCanonicalName() {
+        JavaType type = TypeFactory.defaultInstance().constructFromCanonical(
+                "java.util.Map<java.lang.String,java.util.List<java.lang.Integer>>");
+
+        assertThat(type.getRawClass()).isEqualTo(Map.class);
+        assertThat(type.getKeyType().getRawClass()).isEqualTo(String.class);
+        assertThat(type.getContentType().getRawClass()).isEqualTo(List.class);
+        assertThat(type.getContentType().getContentType().getRawClass()).isEqualTo(Integer.class);
+    }
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,902 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.BasicSerializerFactoryTest"
+      },
+      "type" : "java.io.Closeable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest"
+      },
+      "type" : "java.io.Serializable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerCalendarDeserializerTest"
+      },
+      "type" : "java.io.Serializable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerClassDeserializerTest"
+      },
+      "type" : "java.io.Serializable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.BasicSerializerFactoryTest"
+      },
+      "type" : "java.lang.AutoCloseable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerClassDeserializerTest"
+      },
+      "type" : "java.lang.Class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerCalendarDeserializerTest"
+      },
+      "type" : "java.lang.Cloneable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest"
+      },
+      "type" : "java.lang.Comparable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerCalendarDeserializerTest"
+      },
+      "type" : "java.lang.Comparable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest"
+      },
+      "type" : "java.lang.Integer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest"
+      },
+      "type" : "java.lang.Number"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerDelegatingTest"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.SettableAnyPropertyTest"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest"
+      },
+      "type" : "java.lang.constant.Constable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerClassDeserializerTest"
+      },
+      "type" : "java.lang.constant.Constable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest"
+      },
+      "type" : "java.lang.constant.ConstantDesc"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerClassDeserializerTest"
+      },
+      "type" : "java.lang.invoke.TypeDescriptor"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerClassDeserializerTest"
+      },
+      "type" : "java.lang.invoke.TypeDescriptor$OfField"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerClassDeserializerTest"
+      },
+      "type" : "java.lang.reflect.AnnotatedElement"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerClassDeserializerTest"
+      },
+      "type" : "java.lang.reflect.GenericDeclaration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerClassDeserializerTest"
+      },
+      "type" : "java.lang.reflect.Type"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerCalendarDeserializerTest"
+      },
+      "type" : "java.util.Calendar"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.StdDeserializerInnerCalendarDeserializerTest"
+      },
+      "type" : "java.util.GregorianCalendar"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.SettableBeanPropertyInnerSetterlessPropertyTest"
+      },
+      "type" : "java.util.List"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerDelegatingTest"
+      },
+      "type" : "java.util.Map"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.BasicSerializerFactoryTest"
+      },
+      "type" : "org.codehaus.jackson.JsonGenerator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.BasicSerializerFactoryTest"
+      },
+      "type" : "org.codehaus.jackson.Versioned"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.BasicSerializerFactoryTest"
+      },
+      "type" : "org.codehaus.jackson.util.TokenBuffer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.introspect.AnnotatedClass"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest$BaseTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest$BaseTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.introspect.AnnotatedClass"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest$CreatorTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest$CreatorTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.introspect.AnnotatedClass"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest$CreatorTargetMixIn"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest$CreatorTargetMixIn"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.introspect.AnnotatedClass"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest$ObjectMixIn"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest$ObjectMixIn"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.introspect.AnnotatedField"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.AnnotatedFieldTest$FieldInjectionTarget",
+      "fields" : [
+        {
+          "name" : "requestId"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.AnnotatedFieldTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.AnnotatedFieldTest$FieldInjectionTarget",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.introspect.AnnotatedMethod"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.AnnotatedMethodTest$SetterTarget",
+      "methods" : [
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.AnnotatedMethodTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.AnnotatedMethodTest$SetterTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.introspect.AnnotatedMethod"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.AnnotatedMethodTest$StaticFactory",
+      "methods" : [
+        {
+          "name" : "defaultName",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.AnnotatedMethodTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.AnnotatedMethodTest$StaticFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.ser.AnyGetterWriter"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.AnyGetterWriterTest$BeanWithAnyGetter",
+      "methods" : [
+        {
+          "name" : "anyProperties",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.AnyGetterWriterTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.AnyGetterWriterTest$BeanWithAnyGetter",
+      "methods" : [
+        {
+          "name" : "getName",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.ArrayDeserializerTest$Value"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.std.ObjectArrayDeserializer"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.ArrayDeserializerTest$Value",
+      "fields" : [
+        {
+          "name" : "name"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.std.ObjectArrayDeserializer"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.ArrayDeserializerTest$Value[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.type.ArrayType"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.ArrayDeserializerTest$Value[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.SettableBeanProperty$InnerClassProperty"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.BeanDeserializerTest$OuterBean",
+      "fields" : [
+        {
+          "name" : "inner"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.BeanDeserializerTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.BeanDeserializerTest$OuterBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BeanDeserializer"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.BeanDeserializerTest$OuterBean$InnerBean",
+      "fields" : [
+        {
+          "name" : "count"
+        },
+        {
+          "name" : "name"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.SettableBeanProperty$InnerClassProperty"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.BeanDeserializerTest$OuterBean$InnerBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org_codehaus_jackson.jackson_mapper_asl.BeanDeserializerTest$OuterBean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.BeanDeserializerTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.BeanDeserializerTest$OuterBean$InnerBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.BeanPropertyWriterTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.BeanPropertyWriterTest$AccessorBackedProperty",
+      "methods" : [
+        {
+          "name" : "getMethodValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.BeanPropertyWriterTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.BeanPropertyWriterTest$FieldBackedProperty",
+      "fields" : [
+        {
+          "name" : "fieldValue"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.jsontype.impl.TypeDeserializerBase"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.ClassNameIdResolverTest$Animal"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.ClassNameIdResolverTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.ClassNameIdResolverTest$Animal"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.jsontype.impl.AsPropertyTypeDeserializer"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.ClassNameIdResolverTest$Dog",
+      "fields" : [
+        {
+          "name" : "name"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.jsontype.impl.ClassNameIdResolver"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.ClassNameIdResolverTest$Dog"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.jsontype.impl.TypeDeserializerBase"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.ClassNameIdResolverTest$Dog"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.util.ClassUtil"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.ClassUtilTest$PublicDefaultConstructor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.std.CollectionDeserializer"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest$NumericValues",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.CollectionDeserializerTest$NumericValues"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerDelegatingTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerDelegatingTest$MapConstructorTarget",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.util.Map"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerDelegatingTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerDelegatingTest$MapFactoryTarget",
+      "methods" : [
+        {
+          "name" : "from",
+          "parameterTypes" : [
+            "java.util.Map"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerNumberBasedTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerNumberBasedTest$IntegerConstructorTarget",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerNumberBasedTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerNumberBasedTest$IntegerFactoryTarget",
+      "methods" : [
+        {
+          "name" : "fromNumber",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerNumberBasedTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerNumberBasedTest$LongConstructorTarget",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerNumberBasedTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerNumberBasedTest$LongFactoryTarget",
+      "methods" : [
+        {
+          "name" : "fromNumber",
+          "parameterTypes" : [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.introspect.AnnotatedConstructor"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerPropertyBasedTest$ConstructorTarget",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerPropertyBasedTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerPropertyBasedTest$ConstructorTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.introspect.AnnotatedMethod"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerPropertyBasedTest$FactoryTarget",
+      "methods" : [
+        {
+          "name" : "fromProperties",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerPropertyBasedTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerPropertyBasedTest$FactoryTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerStringBasedTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerStringBasedTest$ConstructorTarget",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerStringBasedTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.CreatorInnerStringBasedTest$FactoryTarget",
+      "methods" : [
+        {
+          "name" : "fromString",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.BasicDeserializerFactory"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.EnumDeserializerInnerFactoryBasedDeserializerTest$FactoryBackedEnum"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.std.EnumDeserializer$FactoryBasedDeserializer"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.EnumDeserializerInnerFactoryBasedDeserializerTest$FactoryBackedEnum",
+      "methods" : [
+        {
+          "name" : "fromJson",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.ser.std.JsonValueSerializer"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.JsonValueSerializerTest$DefaultTypedJsonValue",
+      "methods" : [
+        {
+          "name" : "asJsonValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.JsonValueSerializerTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.JsonValueSerializerTest$DefaultTypedJsonValue"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.ser.std.JsonValueSerializer"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.JsonValueSerializerTest$JsonValueBackedObject",
+      "methods" : [
+        {
+          "name" : "asJsonValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.JsonValueSerializerTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.JsonValueSerializerTest$JsonValueBackedObject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.PropertyBuilderTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.PropertyBuilderTest$FieldBackedNonDefaultValue",
+      "fields" : [
+        {
+          "name" : "value"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.PropertyBuilderTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.PropertyBuilderTest$MethodBackedNonDefaultValue",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.SettableAnyProperty"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.SettableAnyPropertyTest$AnySetterBean",
+      "methods" : [
+        {
+          "name" : "putUnknownValue",
+          "parameterTypes" : [
+            "java.lang.String",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.SettableAnyPropertyTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.SettableAnyPropertyTest$AnySetterBean",
+      "fields" : [
+        {
+          "name" : "name"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.SettableBeanProperty$MethodProperty"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.SettableBeanPropertyInnerMethodPropertyTest$SetterBackedBean",
+      "methods" : [
+        {
+          "name" : "setCount",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.SettableBeanPropertyInnerMethodPropertyTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.SettableBeanPropertyInnerMethodPropertyTest$SetterBackedBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.SettableBeanProperty$SetterlessProperty"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.SettableBeanPropertyInnerSetterlessPropertyTest$GetterBackedBean",
+      "methods" : [
+        {
+          "name" : "getItems",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.SettableBeanPropertyInnerSetterlessPropertyTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.SettableBeanPropertyInnerSetterlessPropertyTest$GetterBackedBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.std.StdKeyDeserializer$StringCtorKeyDeserializer"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.StdKeyDeserializerInnerStringCtorKeyDeserializerTest$StringConstructorKey",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.StdKeyDeserializerInnerStringCtorKeyDeserializerTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.StdKeyDeserializerInnerStringCtorKeyDeserializerTest$StringConstructorKey"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.std.StdKeyDeserializer$StringFactoryKeyDeserializer"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.StdKeyDeserializerInnerStringFactoryKeyDeserializerTest$StringFactoryKey",
+      "methods" : [
+        {
+          "name" : "valueOf",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.StdKeyDeserializerInnerStringFactoryKeyDeserializerTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.StdKeyDeserializerInnerStringFactoryKeyDeserializerTest$StringFactoryKey"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.jackson.map.deser.std.StringCollectionDeserializer"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.StringCollectionDeserializerTest$StringValues",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.StringCollectionDeserializerTest"
+      },
+      "type" : "org_codehaus_jackson.jackson_mapper_asl.StringCollectionDeserializerTest$StringValues"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_codehaus_jackson.jackson_mapper_asl.AnnotatedClassTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/user-code-filter.json
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.codehaus.jackson.**"
+    },
+    {
+      "includeClasses" : "org_codehaus_jackson.jackson_mapper_asl.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: oracle/graalvm-reachability-metadata#6264

This PR provides new metadata needed for the org.codehaus.jackson:jackson-mapper-asl:1.9.0, addressing Native Image run failures caused by changes in the updated library version.

Summary:
- Metadata entries (previous `org.codehaus.jackson:jackson-mapper-asl:1.8.3`): 12
- Metadata entries (new `org.codehaus.jackson:jackson-mapper-asl:1.9.0`): 46
- Test-only metadata entries (new `org.codehaus.jackson:jackson-mapper-asl:1.9.0`): 145
- Library coverage (previous): 32.92%
- Library coverage (new): 31.59%
- Strategy: library_update_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 130841
- Cached input tokens: 820224
- Output tokens: 8594
- Iterations: 3

### Forge

- Forge monitored branch: `forge-native-image-prompt-rules`
- Forge branch: `forge-native-image-prompt-rules`
- Forge commit hash: `3a1787c67e77916e69d7998f7b59f29ddc1aa076`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.codehaus.jackson:jackson-mapper-asl:1.8.3: 55/55 covered calls (100.00%)
- org.codehaus.jackson:jackson-mapper-asl:1.9.0: 51/51 covered calls (100.00%)

**Reflection:**
- org.codehaus.jackson:jackson-mapper-asl:1.8.3: 55/55 covered calls (100.00%)
- org.codehaus.jackson:jackson-mapper-asl:1.9.0: 51/51 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.codehaus.jackson:jackson-mapper-asl:1.8.3: 16051/51096 (31.41%)
- org.codehaus.jackson:jackson-mapper-asl:1.9.0: 18158/60235 (30.15%)

**Line:**
- org.codehaus.jackson:jackson-mapper-asl:1.8.3: 3824/11617 (32.92%)
- org.codehaus.jackson:jackson-mapper-asl:1.9.0: 4294/13593 (31.59%)

**Method:**
- org.codehaus.jackson:jackson-mapper-asl:1.8.3: 923/2923 (31.58%)
- org.codehaus.jackson:jackson-mapper-asl:1.9.0: 1056/3421 (30.87%)


**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/AnnotatedFieldTest.java b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/AnnotatedFieldTest.java
new file mode 100644
index 0000000000..f190906819
--- /dev/null
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/AnnotatedFieldTest.java
@@ -0,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.codehaus.jackson.map.InjectableValues;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.annotate.JacksonInject;
+import org.junit.jupiter.api.Test;
+
+public class AnnotatedFieldTest {
+    @Test
+    public void injectsValueIntoAnnotatedFieldDuringDeserialization() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        InjectableValues.Std injectableValues = new InjectableValues.Std()
+                .addValue("requestId", "request-123");
+        mapper.setInjectableValues(injectableValues);
+
+        FieldInjectionTarget target = mapper.readValue("{}", FieldInjectionTarget.class);
+
+        assertThat(target.requestId).isEqualTo("request-123");
+    }
+
+    public static final class FieldInjectionTarget {
+        @JacksonInject("requestId")
+        public String requestId;
+    }
+}
diff --git a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/AnnotatedMethodTest.java b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/AnnotatedMethodTest.java
new file mode 100644
index 0000000000..1d613ff5b2
--- /dev/null
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/AnnotatedMethodTest.java
@@ -0,0 +1,61 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+
+import org.codehaus.jackson.map.AnnotationIntrospector;
+import org.codehaus.jackson.map.introspect.AnnotatedClass;
+import org.codehaus.jackson.map.introspect.AnnotatedMethod;
+import org.codehaus.jackson.map.introspect.AnnotationMap;
+import org.codehaus.jackson.map.introspect.JacksonAnnotationIntrospector;
+import org.junit.jupiter.api.Test;
+
+public class AnnotatedMethodTest {
+    private static final AnnotationIntrospector INTROSPECTOR = new JacksonAnnotationIntrospector();
+    private static final Class<?>[] STRING_PARAMETER = new Class<?>[] {String.class};
+
+    @Test
+    public void invokesStaticNoArgumentMethod() throws Exception {
+        Method method = StaticFactory.class.getDeclaredMethod("defaultName");
+        AnnotatedMethod annotatedMethod = new AnnotatedMethod(
+                method, new AnnotationMap(), new AnnotationMap[0]);
+
+        Object value = annotatedMethod.call();
+
+        assertThat(value).isEqualTo("default-name");
+    }
+
+    @Test
+    public void setsBeanValueThroughAnnotatedMethod() {
+        AnnotatedClass annotatedClass = AnnotatedClass.construct(
+                SetterTarget.class, INTROSPECTOR, null);
+        annotatedClass.resolveMemberMethods(null, true);
+        AnnotatedMethod setter = annotatedClass.findMethod("setName", STRING_PARAMETER);
+        SetterTarget target = new SetterTarget();
+
+        setter.setValue(target, "updated-name");
+
+        assertThat(target.name).isEqualTo("updated-name");
+    }
+
+    public static final class StaticFactory {
+        public static String defaultName() {
+            return "default-name";
+        }
+    }
+
+    public static final class SetterTarget {
+        private String name;
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+}
diff --git a/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/BeanDeserializerTest.java b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/BeanDeserializerTest.java
new file mode 100644
index 0000000000..a90605344f
--- /dev/null
+++ b/tests/src/org.codehaus.jackson/jackson-mapper-asl/1.9.0/src/test/java/org_codehaus_jackson/jackson_mapper_asl/BeanDeserializerTest.java
@@ -0,0 +1,41 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_jackson.jackson_mapper_asl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+public class BeanDeserializerTest {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    public void deserializesNonStaticInnerClassProperty() throws Exception {
+        OuterBean outer = MAPPER.readValue("""
+                {"inner":{"name":"nested","count":7}}
+                """, OuterBean.class);
+
+        assertThat(outer.inner).isNotNull();
+        assertThat(outer.inner.name).isEqualTo("nested");
+        assertThat(outer.inner.count).isEqualTo(7);
+        assertThat(outer.inner.parent()).isSameAs(outer);
+    }
+
+    public static class OuterBean {
+        public InnerBean inner;
+
+        public class InnerBean {
+            public String name;
+            public int count;
+
+            public OuterBean parent() {
+                return OuterBean.this;
+            }
+        }
+    }
+}

```
### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
