### PR TITLE
[Automation] Generated metadata for net.java.dev.jna:jna:5.19.0

### DIFF
--- a/metadata/net.java.dev.jna/jna/5.19.0/reachability-metadata.json
+++ b/metadata/net.java.dev.jna/jna/5.19.0/reachability-metadata.json
@@ -1,65 +1,71 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "com.sun.jna.Callback",
-      "jniAccessible": true
+      "type" : "com.oracle.svm.core.methodhandles.MethodHandleIntrinsicImpl"
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.CallbackReference"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "com.sun.jna.CallbackProxy"
+      "type" : "com.sun.jna.Callback",
+      "jniAccessible" : true
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.CallbackReference"
       },
-      "type": "com.sun.jna.CallbackProxy",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "com.sun.jna.CallbackProxy"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "com.sun.jna.CallbackProxy",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "callback",
-          "parameterTypes": [
+          "name" : "callback",
+          "parameterTypes" : [
             "java.lang.Object[]"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "com.sun.jna.CallbackReference",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "com.sun.jna.CallbackReference",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "getCallback",
-          "parameterTypes": [
+          "name" : "getCallback",
+          "parameterTypes" : [
             "java.lang.Class",
             "com.sun.jna.Pointer",
             "boolean"
           ]
         },
         {
-          "name": "getFunctionPointer",
-          "parameterTypes": [
+          "name" : "getFunctionPointer",
+          "parameterTypes" : [
             "com.sun.jna.Callback",
             "boolean"
           ]
         },
         {
-          "name": "getNativeString",
-          "parameterTypes": [
+          "name" : "getNativeString",
+          "parameterTypes" : [
             "java.lang.Object",
             "boolean"
           ]
         },
         {
-          "name": "initializeThread",
-          "parameterTypes": [
+          "name" : "initializeThread",
+          "parameterTypes" : [
             "com.sun.jna.Callback",
             "com.sun.jna.CallbackReference$AttachOptions"
           ]
@@ -67,86 +73,86 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "com.sun.jna.CallbackReference$AttachOptions",
-      "jniAccessible": true
+      "type" : "com.sun.jna.CallbackReference$AttachOptions",
+      "jniAccessible" : true
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "com.sun.jna.FromNativeConverter",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "com.sun.jna.FromNativeConverter",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "nativeType",
-          "parameterTypes": []
+          "name" : "nativeType",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "com.sun.jna.IntegerType",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "com.sun.jna.IntegerType",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "value"
+          "name" : "value"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "com.sun.jna.JNIEnv",
-      "jniAccessible": true
+      "type" : "com.sun.jna.JNIEnv",
+      "jniAccessible" : true
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "com.sun.jna.Native",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "com.sun.jna.Native",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "dispose",
-          "parameterTypes": []
+          "name" : "dispose",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "fromNative",
-          "parameterTypes": [
+          "name" : "fromNative",
+          "parameterTypes" : [
             "com.sun.jna.FromNativeConverter",
             "java.lang.Object",
             "java.lang.reflect.Method"
           ]
         },
         {
-          "name": "fromNative",
-          "parameterTypes": [
+          "name" : "fromNative",
+          "parameterTypes" : [
             "java.lang.Class",
             "java.lang.Object"
           ]
         },
         {
-          "name": "fromNative",
-          "parameterTypes": [
+          "name" : "fromNative",
+          "parameterTypes" : [
             "java.lang.reflect.Method",
             "java.lang.Object"
           ]
         },
         {
-          "name": "nativeType",
-          "parameterTypes": [
+          "name" : "nativeType",
+          "parameterTypes" : [
             "java.lang.Class"
           ]
         },
         {
-          "name": "toNative",
-          "parameterTypes": [
+          "name" : "toNative",
+          "parameterTypes" : [
             "com.sun.jna.ToNativeConverter",
             "java.lang.Object"
           ]
@@ -154,15 +160,15 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "com.sun.jna.Native$ffi_callback",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "com.sun.jna.Native$ffi_callback",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "invoke",
-          "parameterTypes": [
+          "name" : "invoke",
+          "parameterTypes" : [
             "long",
             "long",
             "long"
@@ -171,114 +177,96 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "com.sun.jna.NativeMapped",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "com.sun.jna.NativeMapped",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "toNative",
-          "parameterTypes": []
+          "name" : "toNative",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "com.sun.jna.Pointer",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "com.sun.jna.Pointer",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "peer"
+          "name" : "peer"
         }
       ],
-      "methods": [
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "long"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "com.sun.jna.PointerType",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "com.sun.jna.PointerType",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "pointer"
+          "name" : "pointer"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.ptr.ByReference"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "com.sun.jna.ptr.PointerByReference",
-      "methods": [
+      "type" : "com.sun.jna.SecurityManagerExposer",
+      "methods" : [
         {
-          "name": "getValue",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
-      },
-      "type": "com.oracle.svm.core.methodhandles.MethodHandleIntrinsicImpl"
-    },
-    {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
-      },
-      "type": "com.sun.jna.SecurityManagerExposer",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "getClassContext",
-          "parameterTypes": []
+          "name" : "getClassContext",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "com.sun.jna.Structure",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "com.sun.jna.Structure",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "memory"
+          "name" : "memory"
         },
         {
-          "name": "typeInfo"
+          "name" : "typeInfo"
         }
       ],
-      "methods": [
+      "methods" : [
         {
-          "name": "autoRead",
-          "parameterTypes": []
+          "name" : "autoRead",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "autoWrite",
-          "parameterTypes": []
+          "name" : "autoWrite",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "getTypeInfo",
-          "parameterTypes": []
+          "name" : "getTypeInfo",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "newInstance",
-          "parameterTypes": [
+          "name" : "newInstance",
+          "parameterTypes" : [
             "java.lang.Class",
             "long"
           ]
@@ -286,666 +274,866 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "com.sun.jna.Structure$ByValue",
-      "jniAccessible": true
+      "type" : "com.sun.jna.Structure$ByValue",
+      "jniAccessible" : true
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Structure"
       },
-      "type": "com.sun.jna.Structure$FFIType$FFITypes",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "com.sun.jna.Structure$FFIType",
+      "fields" : [
         {
-          "name": "ffi_type_double"
-        },
+          "name" : "size"
+        }
+      ],
+      "methods" : [
         {
-          "name": "ffi_type_float"
-        },
-        {
-          "name": "ffi_type_longdouble"
-        },
-        {
-          "name": "ffi_type_pointer"
-        },
-        {
-          "name": "ffi_type_sint16"
-        },
-        {
-          "name": "ffi_type_sint32"
-        },
-        {
-          "name": "ffi_type_sint64"
-        },
-        {
-          "name": "ffi_type_sint8"
-        },
-        {
-          "name": "ffi_type_uint16"
-        },
-        {
-          "name": "ffi_type_uint32"
-        },
-        {
-          "name": "ffi_type_uint64"
-        },
-        {
-          "name": "ffi_type_uint8"
-        },
-        {
-          "name": "ffi_type_void"
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Structure$FFIType"
       },
-      "type": "com.sun.jna.WString",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "com.sun.jna.Structure$FFIType",
+      "fields" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "alignment"
+        },
+        {
+          "name" : "elements"
+        },
+        {
+          "name" : "size"
+        },
+        {
+          "name" : "type"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "com.sun.jna.Structure$FFIType$FFITypes",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "ffi_type_double"
+        },
+        {
+          "name" : "ffi_type_float"
+        },
+        {
+          "name" : "ffi_type_longdouble"
+        },
+        {
+          "name" : "ffi_type_pointer"
+        },
+        {
+          "name" : "ffi_type_sint16"
+        },
+        {
+          "name" : "ffi_type_sint32"
+        },
+        {
+          "name" : "ffi_type_sint64"
+        },
+        {
+          "name" : "ffi_type_sint8"
+        },
+        {
+          "name" : "ffi_type_uint16"
+        },
+        {
+          "name" : "ffi_type_uint32"
+        },
+        {
+          "name" : "ffi_type_uint64"
+        },
+        {
+          "name" : "ffi_type_uint8"
+        },
+        {
+          "name" : "ffi_type_void"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.IntegerType"
+      },
+      "type" : "com.sun.jna.Structure$FFIType$size_t",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.NativeMappedConverter"
+      },
+      "type" : "com.sun.jna.Structure$FFIType$size_t",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "com.sun.jna.WString",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.String"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.ptr.ByReference"
       },
-      "type": "java.lang.Boolean",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "com.sun.jna.ptr.PointerByReference",
+      "methods" : [
         {
-          "name": "TYPE"
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "int"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.lang.Boolean",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "TYPE"
         },
         {
-          "name": "value"
+          "name" : "value"
         }
       ],
-      "methods": [
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "boolean"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.lang.Byte",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "java.lang.Byte",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "TYPE"
+          "name" : "TYPE"
         },
         {
-          "name": "value"
+          "name" : "value"
         }
       ],
-      "methods": [
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "byte"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.lang.Character",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "java.lang.Character",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "TYPE"
+          "name" : "TYPE"
         },
         {
-          "name": "value"
+          "name" : "value"
         }
       ],
-      "methods": [
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "char"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.lang.Class",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "java.lang.Class",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "getComponentType",
-          "parameterTypes": []
+          "name" : "getComponentType",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.lang.Double",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "java.lang.ClassLoader",
+      "methods" : [
         {
-          "name": "TYPE"
+          "name" : "findLibrary",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native$5"
+      },
+      "type" : "java.lang.ClassLoader"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.lang.Double",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "TYPE"
         },
         {
-          "name": "value"
+          "name" : "value"
         }
       ],
-      "methods": [
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "double"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.lang.Float",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "java.lang.Float",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "TYPE"
+          "name" : "TYPE"
         },
         {
-          "name": "value"
+          "name" : "value"
         }
       ],
-      "methods": [
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "float"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.lang.Integer",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "java.lang.Integer",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "TYPE"
+          "name" : "TYPE"
         },
         {
-          "name": "value"
+          "name" : "value"
         }
       ],
-      "methods": [
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "int"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.lang.Long",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "java.lang.Long",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "TYPE"
+          "name" : "TYPE"
         },
         {
-          "name": "value"
+          "name" : "value"
         }
       ],
-      "methods": [
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "long"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Library$Handler"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Library$Handler"
       },
-      "type": "java.lang.Object"
+      "type" : "java.lang.Object"
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.lang.Object",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "java.lang.Object",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "toString",
-          "parameterTypes": []
+          "name" : "toString",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.lang.Short",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "java.lang.Object[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.lang.Short",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "TYPE"
+          "name" : "TYPE"
         },
         {
-          "name": "value"
+          "name" : "value"
         }
       ],
-      "methods": [
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "short"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.lang.StackWalker",
-      "methods": [
+      "type" : "java.lang.StackWalker",
+      "methods" : [
         {
-          "name": "getInstance",
-          "parameterTypes": [
+          "name" : "getInstance",
+          "parameterTypes" : [
             "java.lang.StackWalker$Option"
           ]
         },
         {
-          "name": "walk",
-          "parameterTypes": [
+          "name" : "walk",
+          "parameterTypes" : [
             "java.util.function.Function"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.lang.StackWalker$Option"
+      "type" : "java.lang.StackWalker$Option"
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.lang.StackWalker$StackFrame",
-      "methods": [
+      "type" : "java.lang.StackWalker$StackFrame",
+      "methods" : [
         {
-          "name": "getDeclaringClass",
-          "parameterTypes": []
+          "name" : "getDeclaringClass",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.lang.String",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "java.lang.String",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "byte[]"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "byte[]",
             "java.lang.String"
           ]
         },
         {
-          "name": "getBytes",
-          "parameterTypes": []
+          "name" : "getBytes",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "getBytes",
-          "parameterTypes": [
+          "name" : "getBytes",
+          "parameterTypes" : [
             "java.lang.String"
           ]
         },
         {
-          "name": "toCharArray",
-          "parameterTypes": []
+          "name" : "toCharArray",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.lang.System",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "java.lang.System",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "getProperty",
-          "parameterTypes": [
+          "name" : "getProperty",
+          "parameterTypes" : [
             "java.lang.String"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.NativeLibrary"
+      "condition" : {
+        "typeReached" : "com.sun.jna.NativeLibrary"
       },
-      "type": "java.lang.Throwable"
-    },
-    {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
-      },
-      "type": "java.lang.Void",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "java.lang.Throwable",
+      "methods" : [
         {
-          "name": "TYPE"
+          "name" : "addSuppressed",
+          "parameterTypes" : [
+            "java.lang.Throwable"
+          ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.internal.ReflectionUtils"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.lang.invoke.MethodHandle"
-    },
-    {
-      "condition": {
-        "typeReached": "com.sun.jna.internal.ReflectionUtils"
-      },
-      "type": "java.lang.invoke.MethodHandles"
-    },
-    {
-      "condition": {
-        "typeReached": "com.sun.jna.internal.ReflectionUtils"
-      },
-      "type": "java.lang.invoke.MethodHandles$Lookup"
-    },
-    {
-      "condition": {
-        "typeReached": "com.sun.jna.internal.ReflectionUtils"
-      },
-      "type": "java.lang.invoke.MethodType"
-    },
-    {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
-      },
-      "type": "java.lang.reflect.Method",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "java.lang.UnsatisfiedLinkError",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "getParameterTypes",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.lang.Void",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "TYPE"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.internal.ReflectionUtils"
+      },
+      "type" : "java.lang.invoke.MethodHandle",
+      "methods" : [
+        {
+          "name" : "bindTo",
+          "parameterTypes" : [
+            "java.lang.Object"
+          ]
         },
         {
-          "name": "getReturnType",
-          "parameterTypes": []
+          "name" : "invokeWithArguments",
+          "parameterTypes" : [
+            "java.lang.Object[]"
+          ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.VarArgsChecker"
+      "condition" : {
+        "typeReached" : "com.sun.jna.internal.ReflectionUtils"
       },
-      "type": "java.lang.reflect.Method"
-    },
-    {
-      "condition": {
-        "typeReached": "com.sun.jna.internal.ReflectionUtils"
-      },
-      "type": "java.lang.reflect.Method",
-      "methods": [
+      "type" : "java.lang.invoke.MethodHandles",
+      "methods" : [
         {
-          "name": "isDefault",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
-      },
-      "type": "java.nio.Buffer",
-      "jniAccessible": true,
-      "methods": [
-        {
-          "name": "position",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "com.sun.jna.Platform"
-      },
-      "type": "java.nio.Buffer"
-    },
-    {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
-      },
-      "type": "java.nio.ByteBuffer",
-      "jniAccessible": true,
-      "methods": [
-        {
-          "name": "array",
-          "parameterTypes": []
+          "name" : "lookup",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "arrayOffset",
-          "parameterTypes": []
+          "name" : "privateLookupIn",
+          "parameterTypes" : [
+            "java.lang.Class",
+            "java.lang.invoke.MethodHandles$Lookup"
+          ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.internal.ReflectionUtils"
       },
-      "type": "java.nio.CharBuffer",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "java.lang.invoke.MethodHandles$Lookup",
+      "methods" : [
         {
-          "name": "array",
-          "parameterTypes": []
+          "name" : "findSpecial",
+          "parameterTypes" : [
+            "java.lang.Class",
+            "java.lang.String",
+            "java.lang.invoke.MethodType",
+            "java.lang.Class"
+          ]
         },
         {
-          "name": "arrayOffset",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
-      },
-      "type": "java.nio.DoubleBuffer",
-      "jniAccessible": true,
-      "methods": [
-        {
-          "name": "array",
-          "parameterTypes": []
+          "name" : "in",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
         },
         {
-          "name": "arrayOffset",
-          "parameterTypes": []
+          "name" : "unreflectSpecial",
+          "parameterTypes" : [
+            "java.lang.reflect.Method",
+            "java.lang.Class"
+          ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.internal.ReflectionUtils"
       },
-      "type": "java.nio.FloatBuffer",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "java.lang.invoke.MethodType",
+      "methods" : [
         {
-          "name": "array",
-          "parameterTypes": []
+          "name" : "methodType",
+          "parameterTypes" : [
+            "java.lang.Class",
+            "java.lang.Class[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.lang.reflect.Method",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "getParameterTypes",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "arrayOffset",
-          "parameterTypes": []
+          "name" : "getReturnType",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.VarArgsChecker"
       },
-      "type": "java.nio.IntBuffer",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "java.lang.reflect.Method"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.internal.ReflectionUtils"
+      },
+      "type" : "java.lang.reflect.Method",
+      "methods" : [
         {
-          "name": "array",
-          "parameterTypes": []
+          "name" : "isDefault",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.nio.Buffer",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "position",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Platform"
+      },
+      "type" : "java.nio.Buffer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.nio.ByteBuffer",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "array",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "arrayOffset",
-          "parameterTypes": []
+          "name" : "arrayOffset",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.nio.LongBuffer",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "java.nio.CharBuffer",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "array",
-          "parameterTypes": []
+          "name" : "array",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "arrayOffset",
-          "parameterTypes": []
+          "name" : "arrayOffset",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.nio.ShortBuffer",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "java.nio.DoubleBuffer",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "array",
-          "parameterTypes": []
+          "name" : "array",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "arrayOffset",
-          "parameterTypes": []
+          "name" : "arrayOffset",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "java.security.AccessController",
-      "methods": [
+      "type" : "java.nio.FloatBuffer",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "doPrivileged",
-          "parameterTypes": [
+          "name" : "array",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "arrayOffset",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.nio.IntBuffer",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "array",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "arrayOffset",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.nio.LongBuffer",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "array",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "arrayOffset",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.nio.ShortBuffer",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "array",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "arrayOffset",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "java.security.AccessController",
+      "methods" : [
+        {
+          "name" : "doPrivileged",
+          "parameterTypes" : [
             "java.security.PrivilegedAction"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "sun.security.provider.NativePRNG",
-      "methods": [
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.security.SecureRandomParameters"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "type": "sun.security.provider.SHA",
-      "methods": [
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "glob": "com/sun/jna/darwin-aarch64/libjnidispatch.jnilib"
+      "glob" : "com/sun/jna/darwin-aarch64/libjnidispatch.jnilib"
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "glob": "com/sun/jna/darwin-x86-64/libjnidispatch.jnilib"
+      "glob" : "com/sun/jna/darwin-x86-64/libjnidispatch.jnilib"
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "glob": "com/sun/jna/linux-aarch64/libjnidispatch.so"
+      "glob" : "com/sun/jna/linux-aarch64/libjnidispatch.so"
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "glob": "com/sun/jna/linux-x86-64/libjnidispatch.so"
+      "glob" : "com/sun/jna/linux-x86-64/libjnidispatch.so"
     },
     {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
       },
-      "glob": "com/sun/jna/win32-x86-64/jnidispatch.dll"
+      "glob" : "com/sun/jna/win32-x86-64/jnidispatch.dll"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.NativeLibrary"
+      },
+      "glob" : "libjna_suppressed_missing_library_probe_43b6fd2c.so"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.NativeLibrary"
+      },
+      "glob" : "linux-x86-64/libjna_suppressed_missing_library_probe_43b6fd2c.so"
     }
   ]
 }

--- a/metadata/net.java.dev.jna/jna/5.19.0/reachability-metadata.json
+++ b/metadata/net.java.dev.jna/jna/5.19.0/reachability-metadata.json
@@ -204,6 +204,12 @@
       "condition": {
         "typeReached": "com.sun.jna.Native"
       },
+      "type": "com.oracle.svm.core.methodhandles.MethodHandleIntrinsicImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
       "type": "com.sun.jna.SecurityManagerExposer",
       "methods": [
         {

--- a/metadata/net.java.dev.jna/jna/5.19.0/reachability-metadata.json
+++ b/metadata/net.java.dev.jna/jna/5.19.0/reachability-metadata.json
@@ -17,6 +17,21 @@
       "condition": {
         "typeReached": "com.sun.jna.Native"
       },
+      "type": "com.sun.jna.CallbackProxy",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "callback",
+          "parameterTypes": [
+            "java.lang.Object[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
       "type": "com.sun.jna.CallbackReference",
       "jniAccessible": true,
       "methods": [
@@ -197,6 +212,18 @@
       "fields": [
         {
           "name": "pointer"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.ptr.ByReference"
+      },
+      "type": "com.sun.jna.ptr.PointerByReference",
+      "methods": [
+        {
+          "name": "getValue",
+          "parameterTypes": []
         }
       ]
     },
@@ -887,16 +914,6 @@
           "parameterTypes": []
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "com.sun.jna.Native"
-      },
-      "type": {
-        "proxy": [
-          "net_java_dev_jna.jna.CLibrary"
-        ]
-      }
     }
   ],
   "resources": [
@@ -904,7 +921,31 @@
       "condition": {
         "typeReached": "com.sun.jna.Native"
       },
+      "glob": "com/sun/jna/darwin-aarch64/libjnidispatch.jnilib"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "glob": "com/sun/jna/darwin-x86-64/libjnidispatch.jnilib"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "glob": "com/sun/jna/linux-aarch64/libjnidispatch.so"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
       "glob": "com/sun/jna/linux-x86-64/libjnidispatch.so"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "glob": "com/sun/jna/win32-x86-64/jnidispatch.dll"
     }
   ]
 }

--- a/metadata/net.java.dev.jna/jna/5.19.0/reachability-metadata.json
+++ b/metadata/net.java.dev.jna/jna/5.19.0/reachability-metadata.json
@@ -1,0 +1,904 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "com.sun.jna.Callback",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.CallbackReference"
+      },
+      "type": "com.sun.jna.CallbackProxy"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "com.sun.jna.CallbackReference",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "getCallback",
+          "parameterTypes": [
+            "java.lang.Class",
+            "com.sun.jna.Pointer",
+            "boolean"
+          ]
+        },
+        {
+          "name": "getFunctionPointer",
+          "parameterTypes": [
+            "com.sun.jna.Callback",
+            "boolean"
+          ]
+        },
+        {
+          "name": "getNativeString",
+          "parameterTypes": [
+            "java.lang.Object",
+            "boolean"
+          ]
+        },
+        {
+          "name": "initializeThread",
+          "parameterTypes": [
+            "com.sun.jna.Callback",
+            "com.sun.jna.CallbackReference$AttachOptions"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "com.sun.jna.CallbackReference$AttachOptions",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "com.sun.jna.FromNativeConverter",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "nativeType",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "com.sun.jna.IntegerType",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "value"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "com.sun.jna.JNIEnv",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "com.sun.jna.Native",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "dispose",
+          "parameterTypes": []
+        },
+        {
+          "name": "fromNative",
+          "parameterTypes": [
+            "com.sun.jna.FromNativeConverter",
+            "java.lang.Object",
+            "java.lang.reflect.Method"
+          ]
+        },
+        {
+          "name": "fromNative",
+          "parameterTypes": [
+            "java.lang.Class",
+            "java.lang.Object"
+          ]
+        },
+        {
+          "name": "fromNative",
+          "parameterTypes": [
+            "java.lang.reflect.Method",
+            "java.lang.Object"
+          ]
+        },
+        {
+          "name": "nativeType",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name": "toNative",
+          "parameterTypes": [
+            "com.sun.jna.ToNativeConverter",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "com.sun.jna.Native$ffi_callback",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "invoke",
+          "parameterTypes": [
+            "long",
+            "long",
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "com.sun.jna.NativeMapped",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "toNative",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "com.sun.jna.Pointer",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "peer"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "com.sun.jna.PointerType",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "pointer"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "com.sun.jna.SecurityManagerExposer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "getClassContext",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "com.sun.jna.Structure",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "memory"
+        },
+        {
+          "name": "typeInfo"
+        }
+      ],
+      "methods": [
+        {
+          "name": "autoRead",
+          "parameterTypes": []
+        },
+        {
+          "name": "autoWrite",
+          "parameterTypes": []
+        },
+        {
+          "name": "getTypeInfo",
+          "parameterTypes": []
+        },
+        {
+          "name": "newInstance",
+          "parameterTypes": [
+            "java.lang.Class",
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "com.sun.jna.Structure$ByValue",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "com.sun.jna.Structure$FFIType$FFITypes",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "ffi_type_double"
+        },
+        {
+          "name": "ffi_type_float"
+        },
+        {
+          "name": "ffi_type_longdouble"
+        },
+        {
+          "name": "ffi_type_pointer"
+        },
+        {
+          "name": "ffi_type_sint16"
+        },
+        {
+          "name": "ffi_type_sint32"
+        },
+        {
+          "name": "ffi_type_sint64"
+        },
+        {
+          "name": "ffi_type_sint8"
+        },
+        {
+          "name": "ffi_type_uint16"
+        },
+        {
+          "name": "ffi_type_uint32"
+        },
+        {
+          "name": "ffi_type_uint64"
+        },
+        {
+          "name": "ffi_type_uint8"
+        },
+        {
+          "name": "ffi_type_void"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "com.sun.jna.WString",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "java.lang.Boolean",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "TYPE"
+        },
+        {
+          "name": "value"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "java.lang.Byte",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "TYPE"
+        },
+        {
+          "name": "value"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "byte"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "java.lang.Character",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "TYPE"
+        },
+        {
+          "name": "value"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "char"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "java.lang.Class",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "getComponentType",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "java.lang.Double",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "TYPE"
+        },
+        {
+          "name": "value"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "double"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "java.lang.Float",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "TYPE"
+        },
+        {
+          "name": "value"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "float"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "java.lang.Integer",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "TYPE"
+        },
+        {
+          "name": "value"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "java.lang.Long",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "TYPE"
+        },
+        {
+          "name": "value"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Library$Handler"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "java.lang.Object",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "toString",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "java.lang.Short",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "TYPE"
+        },
+        {
+          "name": "value"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "short"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "java.lang.StackWalker",
+      "methods": [
+        {
+          "name": "getInstance",
+          "parameterTypes": [
+            "java.lang.StackWalker$Option"
+          ]
+        },
+        {
+          "name": "walk",
+          "parameterTypes": [
+            "java.util.function.Function"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "java.lang.StackWalker$Option"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "java.lang.StackWalker$StackFrame",
+      "methods": [
+        {
+          "name": "getDeclaringClass",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "java.lang.String",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "byte[]"
+          ]
+        },
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "byte[]",
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "getBytes",
+          "parameterTypes": []
+        },
+        {
+          "name": "getBytes",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "toCharArray",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "java.lang.System",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "getProperty",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.NativeLibrary"
+      },
+      "type": "java.lang.Throwable"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "java.lang.Void",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "TYPE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.internal.ReflectionUtils"
+      },
+      "type": "java.lang.invoke.MethodHandle"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.internal.ReflectionUtils"
+      },
+      "type": "java.lang.invoke.MethodHandles"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.internal.ReflectionUtils"
+      },
+      "type": "java.lang.invoke.MethodHandles$Lookup"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.internal.ReflectionUtils"
+      },
+      "type": "java.lang.invoke.MethodType"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "java.lang.reflect.Method",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "getParameterTypes",
+          "parameterTypes": []
+        },
+        {
+          "name": "getReturnType",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.VarArgsChecker"
+      },
+      "type": "java.lang.reflect.Method"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.internal.ReflectionUtils"
+      },
+      "type": "java.lang.reflect.Method",
+      "methods": [
+        {
+          "name": "isDefault",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "java.nio.Buffer",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "position",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Platform"
+      },
+      "type": "java.nio.Buffer"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "java.nio.ByteBuffer",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "array",
+          "parameterTypes": []
+        },
+        {
+          "name": "arrayOffset",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "java.nio.CharBuffer",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "array",
+          "parameterTypes": []
+        },
+        {
+          "name": "arrayOffset",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "java.nio.DoubleBuffer",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "array",
+          "parameterTypes": []
+        },
+        {
+          "name": "arrayOffset",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "java.nio.FloatBuffer",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "array",
+          "parameterTypes": []
+        },
+        {
+          "name": "arrayOffset",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "java.nio.IntBuffer",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "array",
+          "parameterTypes": []
+        },
+        {
+          "name": "arrayOffset",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "java.nio.LongBuffer",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "array",
+          "parameterTypes": []
+        },
+        {
+          "name": "arrayOffset",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "java.nio.ShortBuffer",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "array",
+          "parameterTypes": []
+        },
+        {
+          "name": "arrayOffset",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "java.security.AccessController",
+      "methods": [
+        {
+          "name": "doPrivileged",
+          "parameterTypes": [
+            "java.security.PrivilegedAction"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "sun.security.provider.SHA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": {
+        "proxy": [
+          "net_java_dev_jna.jna.CLibrary"
+        ]
+      }
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "glob": "com/sun/jna/linux-x86-64/libjnidispatch.so"
+    }
+  ]
+}

--- a/metadata/net.java.dev.jna/jna/index.json
+++ b/metadata/net.java.dev.jna/jna/index.json
@@ -1,16 +1,28 @@
 [
   {
-    "latest": true,
-    "allowed-packages": [
-      "com.sun.jna"
+    "latest" : true,
+    "metadata-version" : "5.19.0",
+    "test-version" : "5.8.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/net/java/dev/jna/jna/$version$/jna-$version$-sources.jar",
+    "repository-url" : "https://github.com/java-native-access/jna",
+    "test-code-url" : "https://github.com/java-native-access/jna/tree/$version$/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/net/java/dev/jna/jna/$version$/jna-$version$-javadoc.jar",
+    "description" : "JNA provides Java programs with easy access to native shared libraries without requiring JNI code. It lets Java code call native functions and map native data structures through Java interfaces and classes.",
+    "tested-versions" : [
+      "5.19.0"
     ],
-    "metadata-version": "5.8.0",
-    "source-code-url": "https://repo1.maven.org/maven2/net/java/dev/jna/jna/$version$/jna-$version$-sources.jar",
-    "repository-url": "https://github.com/java-native-access/jna",
-    "test-code-url": "https://github.com/java-native-access/jna/tree/$version$/test",
-    "documentation-url": "https://repo1.maven.org/maven2/net/java/dev/jna/jna/$version$/jna-$version$-javadoc.jar",
-    "description": "JNA provides Java programs with easy access to native shared libraries without requiring JNI code. It lets Java code call native functions and map native data structures through Java interfaces and classes.",
-    "tested-versions": [
+    "allowed-packages" : [
+      "com.sun.jna"
+    ]
+  },
+  {
+    "metadata-version" : "5.8.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/net/java/dev/jna/jna/$version$/jna-$version$-sources.jar",
+    "repository-url" : "https://github.com/java-native-access/jna",
+    "test-code-url" : "https://github.com/java-native-access/jna/tree/$version$/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/net/java/dev/jna/jna/$version$/jna-$version$-javadoc.jar",
+    "description" : "JNA provides Java programs with easy access to native shared libraries without requiring JNI code. It lets Java code call native functions and map native data structures through Java interfaces and classes.",
+    "tested-versions" : [
       "5.8.0",
       "5.9.0",
       "5.10.0",
@@ -24,6 +36,9 @@
       "5.17.0",
       "5.18.0",
       "5.18.1"
+    ],
+    "allowed-packages" : [
+      "com.sun.jna"
     ]
   }
 ]

--- a/metadata/net.java.dev.jna/jna/index.json
+++ b/metadata/net.java.dev.jna/jna/index.json
@@ -1,28 +1,27 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "5.19.0",
-    "test-version" : "5.8.0",
-    "source-code-url" : "https://repo1.maven.org/maven2/net/java/dev/jna/jna/$version$/jna-$version$-sources.jar",
-    "repository-url" : "https://github.com/java-native-access/jna",
-    "test-code-url" : "https://github.com/java-native-access/jna/tree/$version$/test",
-    "documentation-url" : "https://repo1.maven.org/maven2/net/java/dev/jna/jna/$version$/jna-$version$-javadoc.jar",
-    "description" : "JNA provides Java programs with easy access to native shared libraries without requiring JNI code. It lets Java code call native functions and map native data structures through Java interfaces and classes.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "5.19.0",
+    "source-code-url": "https://repo1.maven.org/maven2/net/java/dev/jna/jna/$version$/jna-$version$-sources.jar",
+    "repository-url": "https://github.com/java-native-access/jna",
+    "test-code-url": "https://github.com/java-native-access/jna/tree/$version$/test",
+    "documentation-url": "https://repo1.maven.org/maven2/net/java/dev/jna/jna/$version$/jna-$version$-javadoc.jar",
+    "description": "JNA provides Java programs with easy access to native shared libraries without requiring JNI code. It lets Java code call native functions and map native data structures through Java interfaces and classes.",
+    "tested-versions": [
       "5.19.0"
     ],
-    "allowed-packages" : [
+    "allowed-packages": [
       "com.sun.jna"
     ]
   },
   {
-    "metadata-version" : "5.8.0",
-    "source-code-url" : "https://repo1.maven.org/maven2/net/java/dev/jna/jna/$version$/jna-$version$-sources.jar",
-    "repository-url" : "https://github.com/java-native-access/jna",
-    "test-code-url" : "https://github.com/java-native-access/jna/tree/$version$/test",
-    "documentation-url" : "https://repo1.maven.org/maven2/net/java/dev/jna/jna/$version$/jna-$version$-javadoc.jar",
-    "description" : "JNA provides Java programs with easy access to native shared libraries without requiring JNI code. It lets Java code call native functions and map native data structures through Java interfaces and classes.",
-    "tested-versions" : [
+    "metadata-version": "5.8.0",
+    "source-code-url": "https://repo1.maven.org/maven2/net/java/dev/jna/jna/$version$/jna-$version$-sources.jar",
+    "repository-url": "https://github.com/java-native-access/jna",
+    "test-code-url": "https://github.com/java-native-access/jna/tree/$version$/test",
+    "documentation-url": "https://repo1.maven.org/maven2/net/java/dev/jna/jna/$version$/jna-$version$-javadoc.jar",
+    "description": "JNA provides Java programs with easy access to native shared libraries without requiring JNI code. It lets Java code call native functions and map native data structures through Java interfaces and classes.",
+    "tested-versions": [
       "5.8.0",
       "5.9.0",
       "5.10.0",
@@ -37,7 +36,7 @@
       "5.18.0",
       "5.18.1"
     ],
-    "allowed-packages" : [
+    "allowed-packages": [
       "com.sun.jna"
     ]
   }

--- a/stats/net.java.dev.jna/jna/5.19.0/execution-metrics.json
+++ b/stats/net.java.dev.jna/jna/5.19.0/execution-metrics.json
@@ -1,0 +1,139 @@
+{
+  "fix_ni_run:2026-06-11": {
+    "timestamp": "2026-06-11T02:17:06.628655Z",
+    "library": "net.java.dev.jna:jna:5.19.0",
+    "starting_commit": "635bfcb53868206e98eb2f67f6ca536dcc55362d",
+    "ending_commit": "156737425dd5c1b4c785dc8332c556d28f8a0485",
+    "previous_library": "net.java.dev.jna:jna:5.8.0",
+    "strategy_name": "library_update_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "5.19.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.953488,
+            "coveredCalls": 41,
+            "totalCalls": 43
+          },
+          "resources": {
+            "coverageRatio": 0.6,
+            "coveredCalls": 3,
+            "totalCalls": 5
+          }
+        },
+        "coverageRatio": 0.916667,
+        "coveredCalls": 44,
+        "totalCalls": 48
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 7652,
+          "missed": 14870,
+          "ratio": 0.339757,
+          "total": 22522
+        },
+        "line": {
+          "covered": 1779,
+          "missed": 3107,
+          "ratio": 0.364102,
+          "total": 4886
+        },
+        "method": {
+          "covered": 319,
+          "missed": 550,
+          "ratio": 0.367089,
+          "total": 869
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "5.8.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.093023,
+            "coveredCalls": 4,
+            "totalCalls": 43
+          },
+          "resources": {
+            "coverageRatio": 0.2,
+            "coveredCalls": 1,
+            "totalCalls": 5
+          }
+        },
+        "coverageRatio": 0.104167,
+        "coveredCalls": 5,
+        "totalCalls": 48
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2528,
+          "missed": 19382,
+          "ratio": 0.115381,
+          "total": 21910
+        },
+        "line": {
+          "covered": 586,
+          "missed": 4098,
+          "ratio": 0.125107,
+          "total": 4684
+        },
+        "method": {
+          "covered": 105,
+          "missed": 730,
+          "ratio": 0.125749,
+          "total": 835
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "degraded",
+      "action": "no_action",
+      "issue_number": 7741,
+      "issue_label": "fails-native-image-run",
+      "library": "net.java.dev.jna:jna:5.19.0",
+      "summary": "Library preparation preflight did not produce usable advisory setup.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#7741 [Automation] native-image run fails for net.java.dev.jna:jna:5.19.0; label=fails-native-image-run; body_chars=8015"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "8 existing test file path(s) included"
+        }
+      ],
+      "current_library": "net.java.dev.jna:jna:5.8.0",
+      "new_version": "5.19.0",
+      "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
+      "model": "oca/gpt-5.5",
+      "prompt_path": "library-preflight-prompt.txt",
+      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/net.java.dev.jna:jna:5.19.0/library-preparation-preflight/pi-generation-2026-06-11T00-51-20-170417Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 422873,
+      "cached_input_tokens_used": 4189696,
+      "output_tokens_used": 45490,
+      "iterations": 11,
+      "cost_usd": 3.4595,
+      "tested_library_loc": 1779,
+      "metadata_entries": 229,
+      "test_only_metadata_entries": 38,
+      "previous_library_metadata_entries": 196,
+      "previous_library_test_only_metadata_entries": 1,
+      "code_coverage_percent": 36.41,
+      "previous_library_coverage_percent": 12.51
+    },
+    "artifacts": {
+      "test_file": "tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/ReflectionUtilsTest.java",
+      "metadata_file": "metadata/net.java.dev.jna/jna/5.19.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/net.java.dev.jna/jna/5.19.0/stats.json
+++ b/stats/net.java.dev.jna/jna/5.19.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "5.19.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.953488,
+          "coveredCalls" : 41,
+          "totalCalls" : 43
+        },
+        "resources" : {
+          "coverageRatio" : 0.6,
+          "coveredCalls" : 3,
+          "totalCalls" : 5
+        }
+      },
+      "coverageRatio" : 0.916667,
+      "coveredCalls" : 44,
+      "totalCalls" : 48
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 7652,
+        "missed" : 14870,
+        "ratio" : 0.339757,
+        "total" : 22522
+      },
+      "line" : {
+        "covered" : 1779,
+        "missed" : 3107,
+        "ratio" : 0.364102,
+        "total" : 4886
+      },
+      "method" : {
+        "covered" : 319,
+        "missed" : 550,
+        "ratio" : 0.367089,
+        "total" : 869
+      }
+    }
+  } ]
+}

--- a/tests/src/net.java.dev.jna/jna/5.19.0/.gitignore
+++ b/tests/src/net.java.dev.jna/jna/5.19.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/net.java.dev.jna/jna/5.19.0/build.gradle
+++ b/tests/src/net.java.dev.jna/jna/5.19.0/build.gradle
@@ -15,6 +15,10 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
+tasks.withType(Test).configureEach {
+    jvmArgs += ["--add-opens=java.base/java.lang=ALL-UNNAMED"]
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"
@@ -22,6 +26,11 @@ graalvmNative {
             conditional {
                 userCodeFilterPath = "user-code-filter.json"
             }
+        }
+    }
+    binaries {
+        all {
+            buildArgs.add('--add-opens=java.base/java.lang=ALL-UNNAMED')
         }
     }
 }

--- a/tests/src/net.java.dev.jna/jna/5.19.0/build.gradle
+++ b/tests/src/net.java.dev.jna/jna/5.19.0/build.gradle
@@ -16,7 +16,10 @@ dependencies {
 }
 
 tasks.withType(Test).configureEach {
-    jvmArgs += ["--add-opens=java.base/java.lang=ALL-UNNAMED"]
+    jvmArgs += [
+        "--add-opens=java.base/java.lang=ALL-UNNAMED",
+        "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED"
+    ]
 }
 
 graalvmNative {
@@ -31,6 +34,7 @@ graalvmNative {
     binaries {
         all {
             buildArgs.add('--add-opens=java.base/java.lang=ALL-UNNAMED')
+            buildArgs.add('--add-opens=java.base/java.lang.invoke=ALL-UNNAMED')
         }
     }
 }

--- a/tests/src/net.java.dev.jna/jna/5.19.0/build.gradle
+++ b/tests/src/net.java.dev.jna/jna/5.19.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "net.java.dev.jna:jna:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/net.java.dev.jna/jna/5.19.0/gradle.properties
+++ b/tests/src/net.java.dev.jna/jna/5.19.0/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 5.19.0
+metadata.dir = net.java.dev.jna/jna/5.19.0/

--- a/tests/src/net.java.dev.jna/jna/5.19.0/settings.gradle
+++ b/tests/src/net.java.dev.jna/jna/5.19.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'net.java.dev.jna.jna_tests'

--- a/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/ByReferenceTest.java
+++ b/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/ByReferenceTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_java_dev_jna.jna;
+
+import com.sun.jna.Memory;
+import com.sun.jna.Pointer;
+import com.sun.jna.ptr.PointerByReference;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ByReferenceTest {
+    @Test
+    void formatsPointerByReferenceValue() {
+        Memory pointer = new Memory(1);
+        PointerByReference reference = new PointerByReference(pointer);
+
+        String description = reference.toString();
+
+        assertThat(description)
+                .contains("Pointer@0x")
+                .contains("=native@0x");
+    }
+
+    @Test
+    void formatsNullPointerByReferenceValue() {
+        PointerByReference reference = new PointerByReference((Pointer) null);
+
+        String description = reference.toString();
+
+        assertThat(description)
+                .startsWith("null@0x")
+                .doesNotContain("ByReference Contract violated");
+    }
+}

--- a/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/CLibrary.java
+++ b/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/CLibrary.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_java_dev_jna.jna;
+
+import com.sun.jna.Library;
+import com.sun.jna.Native;
+
+public interface CLibrary extends Library {
+    CLibrary INSTANCE = Native.load("c", CLibrary.class);
+
+    int atol(String s);
+}

--- a/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/CallbackReferenceInnerDefaultCallbackProxyTest.java
+++ b/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/CallbackReferenceInnerDefaultCallbackProxyTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_java_dev_jna.jna;
+
+import com.sun.jna.Callback;
+import com.sun.jna.CallbackReference;
+import com.sun.jna.Function;
+import com.sun.jna.Pointer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CallbackReferenceInnerDefaultCallbackProxyTest {
+    @Test
+    void invokesJavaCallbackThroughFunctionPointer() {
+        AddCallback callback = (left, right) -> left + right;
+        Pointer functionPointer = CallbackReference.getFunctionPointer(callback);
+        Function callbackFunction = Function.getFunction(functionPointer);
+
+        Object result = callbackFunction.invoke(Integer.class, new Object[] {19, 23});
+
+        assertThat(result).isEqualTo(42);
+    }
+
+    public interface AddCallback extends Callback {
+        int invoke(int left, int right);
+    }
+}

--- a/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/CallbackReferenceTest.java
+++ b/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/CallbackReferenceTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_java_dev_jna.jna;
+
+import com.sun.jna.Callback;
+import com.sun.jna.CallbackReference;
+import com.sun.jna.Function;
+import com.sun.jna.NativeLibrary;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CallbackReferenceTest {
+    @Test
+    void createsCallbackProxyForNativeFunctionPointer() {
+        Function atol = NativeLibrary.getInstance("c").getFunction("atol");
+
+        AtolCallback callback = (AtolCallback) CallbackReference.getCallback(AtolCallback.class, atol);
+
+        assertThat(callback.atol("42")).isEqualTo(42);
+        assertThat(CallbackReference.getCallback(AtolCallback.class, atol)).isSameAs(callback);
+    }
+
+    public interface AtolCallback extends Callback {
+        int atol(String value);
+    }
+}

--- a/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/NativeLibraryTest.java
+++ b/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/NativeLibraryTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_java_dev_jna.jna;
+
+import com.sun.jna.NativeLibrary;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class NativeLibraryTest {
+    @Test
+    void reportsSuppressedCausesWhenLibraryCannotBeLoaded() {
+        String libraryName = "jna_suppressed_missing_library_probe_43b6fd2c";
+
+        assertThatThrownBy(() -> NativeLibrary.getInstance(libraryName))
+                .isInstanceOfSatisfying(UnsatisfiedLinkError.class, error -> {
+                    assertThat(error)
+                            .hasMessageContaining("Unable to load library")
+                            .hasMessageContaining(libraryName);
+                    assertThat(error.getSuppressed()).isNotEmpty();
+                });
+    }
+}

--- a/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/NativeTest.java
+++ b/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/NativeTest.java
@@ -72,7 +72,7 @@ public class NativeTest {
     }
 
     @Test
-    void registersDirectMappedOuterClassFromNestedInitializer() {
+    void registersDirectMappedOuterClassFromNestedInitializerWithExplicitClass() {
         DirectMappedOuter.Registrar.ensureRegistered();
 
         assertThat(DirectMappedOuter.atol("42")).isEqualTo(42);
@@ -202,7 +202,7 @@ public class NativeTest {
 
         public static class Registrar {
             static {
-                Native.register("c");
+                Native.register(DirectMappedOuter.class, "c");
             }
 
             public static void ensureRegistered() {

--- a/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/NativeTest.java
+++ b/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/NativeTest.java
@@ -18,8 +18,11 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -28,6 +31,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIOException;
 
 public class NativeTest {
+    private static final String DARWIN_RESOURCE_PREFIX = "darwin-x86-64";
+
+    static {
+        configureDarwinResourcePrefix();
+    }
+
     @Test
     void invokesFunctionThroughLibraryProxy() {
         int number = CLibrary.INSTANCE.atol("42");
@@ -107,6 +116,67 @@ public class NativeTest {
         } else {
             System.setProperty(name, previousValue);
         }
+    }
+
+    private static void configureDarwinResourcePrefix() {
+        try {
+            String mappedDispatchName = System.mapLibraryName("jnidispatch").replace(".dylib", ".jnilib");
+            String dispatchResource = "com/sun/jna/" + currentResourcePrefix() + "/" + mappedDispatchName;
+            Path bootDirectory = Files.createTempDirectory("jna-boot-library");
+            Path dispatchLibrary = bootDirectory.resolve(mappedDispatchName);
+            try (InputStream inputStream = NativeTest.class.getClassLoader().getResourceAsStream(dispatchResource)) {
+                if (inputStream == null) {
+                    throw new IllegalStateException("JNA dispatch resource not found: " + dispatchResource);
+                }
+                Files.copy(inputStream, dispatchLibrary);
+            }
+            dispatchLibrary.toFile().deleteOnExit();
+            bootDirectory.toFile().deleteOnExit();
+            System.setProperty("jna.boot.library.path", bootDirectory.toString());
+            System.setProperty("jna.prefix", DARWIN_RESOURCE_PREFIX);
+        } catch (IOException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private static String currentResourcePrefix() {
+        String osName = System.getProperty("os.name");
+        String arch = canonicalArchitecture(System.getProperty("os.arch"));
+        if (osName.startsWith("Linux")) {
+            return "linux-" + arch;
+        }
+        if (osName.startsWith("Mac") || osName.startsWith("Darwin")) {
+            return "darwin-" + arch;
+        }
+        if (osName.startsWith("Windows")) {
+            return "win32-" + arch;
+        }
+        String osPrefix = osName.toLowerCase();
+        int space = osPrefix.indexOf(' ');
+        if (space != -1) {
+            osPrefix = osPrefix.substring(0, space);
+        }
+        return osPrefix + "-" + arch;
+    }
+
+    private static String canonicalArchitecture(String arch) {
+        String canonicalArch = arch.toLowerCase().trim();
+        if ("powerpc".equals(canonicalArch)) {
+            return "ppc";
+        }
+        if ("powerpc64".equals(canonicalArch)) {
+            return "ppc64";
+        }
+        if ("i386".equals(canonicalArch) || "i686".equals(canonicalArch)) {
+            return "x86";
+        }
+        if ("x86_64".equals(canonicalArch) || "amd64".equals(canonicalArch)) {
+            return "x86-64";
+        }
+        if ("zarch_64".equals(canonicalArch)) {
+            return "s390x";
+        }
+        return canonicalArch;
     }
 
     public interface DeprecatedCLibrary extends Library {

--- a/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/NativeTest.java
+++ b/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/NativeTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_java_dev_jna.jna;
+
+import com.sun.jna.FromNativeConverter;
+import com.sun.jna.Library;
+import com.sun.jna.Native;
+import com.sun.jna.Platform;
+import com.sun.jna.Structure;
+import com.sun.jna.ToNativeConverter;
+import com.sun.jna.TypeMapper;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIOException;
+
+public class NativeTest {
+    @Test
+    void invokesFunctionThroughLibraryProxy() {
+        int number = CLibrary.INSTANCE.atol("42");
+
+        assertThat(number).isEqualTo(42);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void loadsDeprecatedLibraryProxyAndSynchronizedProxy() {
+        DeprecatedCLibrary library = Native.loadLibrary("c", DeprecatedCLibrary.class);
+        DeprecatedCLibrary synchronizedLibrary = (DeprecatedCLibrary) Native.synchronizedLibrary(library);
+
+        assertThat(library.atol("41")).isEqualTo(41);
+        assertThat(synchronizedLibrary.atol("42")).isEqualTo(42);
+    }
+
+    @Test
+    void readsOptionsFromPublicLibraryFields() {
+        Map<String, Object> options = Native.getLibraryOptions(FieldOptionsLibrary.class);
+
+        assertThat(options).containsEntry(Library.OPTION_TYPE_MAPPER, FieldOptionsLibrary.TYPE_MAPPER);
+        assertThat(options).containsEntry(Library.OPTION_STRUCTURE_ALIGNMENT, Structure.ALIGN_NONE);
+        assertThat(options).containsEntry(Library.OPTION_STRING_ENCODING, StandardCharsets.UTF_8.name());
+    }
+
+    @Test
+    void initializesPublicLibraryInstanceWhileResolvingOptions() {
+        Map<String, Object> options = Native.getLibraryOptions(InstanceOptionsLibrary.class);
+
+        assertThat(options).containsEntry(Library.OPTION_STRING_ENCODING, StandardCharsets.UTF_8.name());
+        assertThat(InstanceOptionsLibrary.INSTANCE.atol("42")).isEqualTo(42);
+    }
+
+    @Test
+    void registersDirectMappedOuterClassFromNestedInitializer() {
+        DirectMappedOuter.Registrar.ensureRegistered();
+
+        assertThat(DirectMappedOuter.atol("42")).isEqualTo(42);
+    }
+
+    @Test
+    void queriesWebStartLibraryPathWhenWebStartPropertyIsSet() {
+        String previousVersion = System.getProperty("javawebstart.version");
+        try {
+            System.setProperty("javawebstart.version", "test");
+
+            assertThat(Native.getWebStartLibraryPath("c")).isNull();
+        } finally {
+            restoreProperty("javawebstart.version", previousVersion);
+        }
+    }
+
+    @Test
+    void extractsLibraryResourceUsingUnprefixedFallback() throws IOException {
+        File libraryFile = File.createTempFile("jna-resource-probe", ".so");
+        libraryFile.deleteOnExit();
+        ClassLoader loader = new FallbackResourceClassLoader(libraryFile.toURI().toURL());
+
+        File extracted = Native.extractFromResourcePath("resourceprobe", loader);
+
+        assertThat(extracted).isEqualTo(libraryFile);
+    }
+
+    @Test
+    void reportsMissingAbsoluteJnaResourceAfterFallbackLookup() {
+        String missingResource = "/com/sun/jna/" + Platform.RESOURCE_PREFIX + "/libmissing-resource-probe.so";
+
+        assertThatIOException()
+                .isThrownBy(() -> Native.extractFromResourcePath(missingResource, new EmptyResourceClassLoader()))
+                .withMessageContaining("Native library");
+    }
+
+    private static void restoreProperty(String name, String previousValue) {
+        if (previousValue == null) {
+            System.clearProperty(name);
+        } else {
+            System.setProperty(name, previousValue);
+        }
+    }
+
+    public interface DeprecatedCLibrary extends Library {
+        int atol(String value);
+    }
+
+    public interface FieldOptionsLibrary extends Library {
+        Map<String, Object> OPTIONS = Collections.emptyMap();
+        TypeMapper TYPE_MAPPER = new NoopTypeMapper();
+        Integer STRUCTURE_ALIGNMENT = Structure.ALIGN_NONE;
+        String STRING_ENCODING = StandardCharsets.UTF_8.name();
+    }
+
+    public interface InstanceOptionsLibrary extends Library {
+        Map<String, Object> LOAD_OPTIONS = NativeTest.loadOptions();
+        InstanceOptionsLibrary INSTANCE = Native.load("c", InstanceOptionsLibrary.class, LOAD_OPTIONS);
+
+        int atol(String value);
+    }
+
+    public static class DirectMappedOuter {
+        public static native int atol(String value);
+
+        public static class Registrar {
+            static {
+                Native.register("c");
+            }
+
+            public static void ensureRegistered() {
+            }
+        }
+    }
+
+    private static Map<String, Object> loadOptions() {
+        Map<String, Object> options = new HashMap<>();
+        options.put(Library.OPTION_STRING_ENCODING, StandardCharsets.UTF_8.name());
+        return options;
+    }
+
+    private static final class NoopTypeMapper implements TypeMapper {
+        @Override
+        public FromNativeConverter getFromNativeConverter(Class<?> javaType) {
+            return null;
+        }
+
+        @Override
+        public ToNativeConverter getToNativeConverter(Class<?> javaType) {
+            return null;
+        }
+    }
+
+    private static final class FallbackResourceClassLoader extends ClassLoader {
+        private final URL libraryUrl;
+
+        private FallbackResourceClassLoader(URL libraryUrl) {
+            super(NativeTest.class.getClassLoader());
+            this.libraryUrl = libraryUrl;
+        }
+
+        @Override
+        public URL getResource(String name) {
+            if (name.contains("/") || !name.contains("resourceprobe")) {
+                return null;
+            }
+            return libraryUrl;
+        }
+    }
+
+    private static final class EmptyResourceClassLoader extends ClassLoader {
+        private EmptyResourceClassLoader() {
+            super(NativeTest.class.getClassLoader());
+        }
+
+        @Override
+        public URL getResource(String name) {
+            return null;
+        }
+    }
+}

--- a/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/ReflectionUtilsTest.java
+++ b/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/ReflectionUtilsTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_java_dev_jna.jna;
+
+import com.sun.jna.internal.ReflectionUtils;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReflectionUtilsTest {
+    @Test
+    void invokesDefaultMethodUsingPrivateLookupInPath() throws Throwable {
+        Method method = GreetingDefaults.class.getMethod("format", String.class, int.class);
+
+        assertThat(ReflectionUtils.isDefault(method)).isTrue();
+        Object methodHandle = ReflectionUtils.getMethodHandle(method);
+        Object result = ReflectionUtils.invokeDefaultMethod(
+                new GreetingDefaultsImplementation(), methodHandle, "jna", 5);
+
+        assertThat(result).isEqualTo("jna:5");
+    }
+
+    @Test
+    void invokesJdkDefaultMethodUsingLookupConstructorFallback() throws Throwable {
+        Method method = Iterator.class.getMethod("forEachRemaining", Consumer.class);
+        Iterator<String> iterator = Collections.singleton("jna").iterator();
+        List<String> values = new ArrayList<>();
+
+        Object methodHandle = ReflectionUtils.getMethodHandle(method);
+        ReflectionUtils.invokeDefaultMethod(iterator, methodHandle, (Consumer<String>) values::add);
+
+        assertThat(values).containsExactly("jna");
+    }
+
+    private interface GreetingDefaults {
+        default String format(String text, int count) {
+            return text + ":" + count;
+        }
+    }
+
+    private static final class GreetingDefaultsImplementation implements GreetingDefaults {
+    }
+}

--- a/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/StructureTest.java
+++ b/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/StructureTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_java_dev_jna.jna;
+
+import com.sun.jna.Callback;
+import com.sun.jna.CallbackReference;
+import com.sun.jna.Pointer;
+import com.sun.jna.Structure;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StructureTest {
+    @Test
+    void createsTypedArrayViewsFromStructureMemory() {
+        PointerBackedStructure structure = new PointerBackedStructure();
+        structure.value = 7;
+        structure.write();
+
+        PointerBackedStructure[] array = (PointerBackedStructure[]) structure.toArray(3);
+
+        assertThat(array).hasSize(3);
+        assertThat(array[0]).isSameAs(structure);
+        assertThat(array[1]).isInstanceOf(PointerBackedStructure.class);
+        assertThat(array[2]).isInstanceOf(PointerBackedStructure.class);
+    }
+
+    @Test
+    void createsStructureInstanceFromPointerConstructor() {
+        PointerBackedStructure original = new PointerBackedStructure();
+        original.value = 42;
+        original.write();
+
+        PointerBackedStructure overlay = Structure.newInstance(PointerBackedStructure.class, original.getPointer());
+        overlay.read();
+
+        assertThat(overlay.value).isEqualTo(42);
+        assertThat(overlay.getPointer()).isEqualTo(original.getPointer());
+    }
+
+    @Test
+    void validatesStructureCallbackParameterTypesWhenCreatingFunctionPointer() {
+        Pointer functionPointer = CallbackReference.getFunctionPointer(new NoopStructureCallback());
+
+        assertThat(functionPointer).isNotNull();
+    }
+
+    public interface StructureCallback extends Callback {
+        void invoke(PointerBackedStructure structure);
+    }
+
+    public static final class NoopStructureCallback implements StructureCallback {
+        @Override
+        public void invoke(PointerBackedStructure structure) {
+        }
+    }
+
+    public static class PointerBackedStructure extends Structure {
+        public int value;
+
+        public PointerBackedStructure() {
+        }
+
+        public PointerBackedStructure(Pointer pointer) {
+            super(pointer);
+        }
+
+        @Override
+        protected List<String> getFieldOrder() {
+            return Collections.singletonList("value");
+        }
+    }
+}

--- a/tests/src/net.java.dev.jna/jna/5.19.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/net.java.dev.jna/jna/5.19.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,11 @@
+{
+  "reflection": [
+    {
+      "type": {
+        "proxy": [
+          "net_java_dev_jna.jna.CLibrary"
+        ]
+      }
+    }
+  ]
+}

--- a/tests/src/net.java.dev.jna/jna/5.19.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/net.java.dev.jna/jna/5.19.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,11 +1,255 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "net_java_dev_jna.jna.CLibrary"
         ]
       }
+    },
+    {
+      "condition" : {
+        "typeReached" : "net_java_dev_jna.jna.ReflectionUtilsTest"
+      },
+      "type" : "java.lang.invoke.MethodHandles$Lookup",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "net_java_dev_jna.jna.ReflectionUtilsTest"
+      },
+      "type" : "java.util.Iterator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "net_java_dev_jna.jna.CallbackReferenceInnerDefaultCallbackProxyTest"
+      },
+      "type" : "net_java_dev_jna.jna.CallbackReferenceInnerDefaultCallbackProxyTest$AddCallback"
+    },
+    {
+      "condition" : {
+        "typeReached" : "net_java_dev_jna.jna.NativeTest"
+      },
+      "type" : "net_java_dev_jna.jna.NativeTest$FieldOptionsLibrary",
+      "fields" : [
+        {
+          "name" : "OPTIONS"
+        },
+        {
+          "name" : "STRING_ENCODING"
+        },
+        {
+          "name" : "STRUCTURE_ALIGNMENT"
+        },
+        {
+          "name" : "TYPE_MAPPER"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "net_java_dev_jna.jna.NativeTest"
+      },
+      "type" : "net_java_dev_jna.jna.NativeTest$InstanceOptionsLibrary",
+      "fields" : [
+        {
+          "name" : "INSTANCE"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "net_java_dev_jna.jna.ReflectionUtilsTest"
+      },
+      "type" : "net_java_dev_jna.jna.ReflectionUtilsTest$GreetingDefaults"
+    },
+    {
+      "condition" : {
+        "typeReached" : "net_java_dev_jna.jna.StructureTest"
+      },
+      "type" : "net_java_dev_jna.jna.StructureTest$NoopStructureCallback"
+    },
+    {
+      "condition" : {
+        "typeReached" : "net_java_dev_jna.jna.StructureTest"
+      },
+      "type" : "net_java_dev_jna.jna.StructureTest$PointerBackedStructure",
+      "fields" : [
+        {
+          "name" : "value"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "com.sun.jna.Pointer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "net_java_dev_jna.jna.StructureTest$PointerBackedStructure"
+      },
+      "type" : "net_java_dev_jna.jna.StructureTest$PointerBackedStructure",
+      "fields" : [
+        {
+          "name" : "value"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "net_java_dev_jna.jna.StructureTest"
+      },
+      "type" : "net_java_dev_jna.jna.StructureTest$StructureCallback"
+    },
+    {
+      "condition" : {
+        "typeReached" : "net_java_dev_jna.jna.NativeTest"
+      },
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.CallbackReference"
+      },
+      "type" : {
+        "proxy" : [
+          "net_java_dev_jna.jna.CallbackReferenceTest$AtolCallback"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : {
+        "proxy" : [
+          "net_java_dev_jna.jna.NativeTest$DeprecatedCLibrary"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "net_java_dev_jna.jna.NativeTest$InstanceOptionsLibrary"
+      },
+      "type" : {
+        "proxy" : [
+          "net_java_dev_jna.jna.NativeTest$InstanceOptionsLibrary"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "net_java_dev_jna.jna.CallbackReferenceInnerDefaultCallbackProxyTest"
+      },
+      "type" : {
+        "lambda" : {
+          "declaringClass" : "net_java_dev_jna.jna.CallbackReferenceInnerDefaultCallbackProxyTest",
+          "interfaces" : [
+            "net_java_dev_jna.jna.CallbackReferenceInnerDefaultCallbackProxyTest$AddCallback"
+          ]
+        }
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.CallbackReference$DefaultCallbackProxy"
+      },
+      "type" : "net_java_dev_jna.jna.CallbackReferenceInnerDefaultCallbackProxyTest$AddCallback",
+      "methods" : [
+        {
+          "name" : "invoke",
+          "parameterTypes" : [
+            "int",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.CallbackReference"
+      },
+      "type" : "net_java_dev_jna.jna.CallbackReferenceTest$AtolCallback"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : "net_java_dev_jna.jna.NativeTest$DirectMappedOuter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Structure"
+      },
+      "type" : "net_java_dev_jna.jna.StructureTest$PointerBackedStructure",
+      "fields" : [
+        {
+          "name" : "value"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "com.sun.jna.Pointer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Structure"
+      },
+      "type" : "net_java_dev_jna.jna.StructureTest$PointerBackedStructure[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.sun.jna.Native"
+      },
+      "type" : {
+        "proxy" : [
+          "net_java_dev_jna.jna.CLibrary"
+        ]
+      }
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "net_java_dev_jna.jna.ByReferenceTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "net_java_dev_jna.jna.ByReferenceTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "net_java_dev_jna.jna.NativeTest"
+      },
+      "glob" : "com/sun/jna/linux-x86-64/libjnidispatch.so"
     }
   ]
 }

--- a/tests/src/net.java.dev.jna/jna/5.19.0/user-code-filter.json
+++ b/tests/src/net.java.dev.jna/jna/5.19.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.sun.jna.**"
+    }
+  ]
+}

--- a/tests/src/net.java.dev.jna/jna/5.19.0/user-code-filter.json
+++ b/tests/src/net.java.dev.jna/jna/5.19.0/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.sun.jna.**"
+      "includeClasses" : "com.sun.jna.**"
+    },
+    {
+      "includeClasses" : "net_java_dev_jna.jna.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: oracle/graalvm-reachability-metadata#7741

This PR provides new metadata needed for the net.java.dev.jna:jna:5.19.0, addressing Native Image run failures caused by changes in the updated library version.

Summary:
- Metadata entries (previous `net.java.dev.jna:jna:5.8.0`): 196
- Test-only metadata entries (previous `net.java.dev.jna:jna:5.8.0`): 1
- Metadata entries (new `net.java.dev.jna:jna:5.19.0`): 229
- Test-only metadata entries (new `net.java.dev.jna:jna:5.19.0`): 38
- Library coverage (previous): 12.51%
- Library coverage (new): 36.41%
- Strategy: library_update_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 422873
- Cached input tokens: 4189696
- Output tokens: 45490
- Iterations: 11

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `c4175b38214e90963a30cfb2dd5a2d0ffafe172e`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- net.java.dev.jna:jna:5.8.0: 5/48 covered calls (10.42%)
- net.java.dev.jna:jna:5.19.0: 44/48 covered calls (91.67%)

**Reflection:**
- net.java.dev.jna:jna:5.8.0: 4/43 covered calls (9.30%)
- net.java.dev.jna:jna:5.19.0: 41/43 covered calls (95.35%)

**Resources:**
- net.java.dev.jna:jna:5.8.0: 1/5 covered calls (20.00%)
- net.java.dev.jna:jna:5.19.0: 3/5 covered calls (60.00%)

#### Library coverage

**Instruction:**
- net.java.dev.jna:jna:5.8.0: 2528/21910 (11.54%)
- net.java.dev.jna:jna:5.19.0: 7652/22522 (33.98%)

**Line:**
- net.java.dev.jna:jna:5.8.0: 586/4684 (12.51%)
- net.java.dev.jna:jna:5.19.0: 1779/4886 (36.41%)

**Method:**
- net.java.dev.jna:jna:5.8.0: 105/835 (12.57%)
- net.java.dev.jna:jna:5.19.0: 319/869 (36.71%)


**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/net.java.dev.jna/jna/5.8.0/build.gradle b/tests/src/net.java.dev.jna/jna/5.19.0/build.gradle
index de1710002d..99ebeabd24 100644
--- a/tests/src/net.java.dev.jna/jna/5.8.0/build.gradle
+++ b/tests/src/net.java.dev.jna/jna/5.19.0/build.gradle
@@ -15,6 +15,13 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
+tasks.withType(Test).configureEach {
+    jvmArgs += [
+        "--add-opens=java.base/java.lang=ALL-UNNAMED",
+        "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED"
+    ]
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"
@@ -24,4 +31,10 @@ graalvmNative {
             }
         }
     }
+    binaries {
+        all {
+            buildArgs.add('--add-opens=java.base/java.lang=ALL-UNNAMED')
+            buildArgs.add('--add-opens=java.base/java.lang.invoke=ALL-UNNAMED')
+        }
+    }
 }
diff --git a/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/ByReferenceTest.java b/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/ByReferenceTest.java
new file mode 100644
index 0000000000..2ccf2bc920
--- /dev/null
+++ b/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/ByReferenceTest.java
@@ -0,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_java_dev_jna.jna;
+
+import com.sun.jna.Memory;
+import com.sun.jna.Pointer;
+import com.sun.jna.ptr.PointerByReference;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ByReferenceTest {
+    @Test
+    void formatsPointerByReferenceValue() {
+        Memory pointer = new Memory(1);
+        PointerByReference reference = new PointerByReference(pointer);
+
+        String description = reference.toString();
+
+        assertThat(description)
+                .contains("Pointer@0x")
+                .contains("=native@0x");
+    }
+
+    @Test
+    void formatsNullPointerByReferenceValue() {
+        PointerByReference reference = new PointerByReference((Pointer) null);
+
+        String description = reference.toString();
+
+        assertThat(description)
+                .startsWith("null@0x")
+                .doesNotContain("ByReference Contract violated");
+    }
+}
diff --git a/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/CallbackReferenceInnerDefaultCallbackProxyTest.java b/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/CallbackReferenceInnerDefaultCallbackProxyTest.java
new file mode 100644
index 0000000000..c9ebdc4002
--- /dev/null
+++ b/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/CallbackReferenceInnerDefaultCallbackProxyTest.java
@@ -0,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_java_dev_jna.jna;
+
+import com.sun.jna.Callback;
+import com.sun.jna.CallbackReference;
+import com.sun.jna.Function;
+import com.sun.jna.Pointer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CallbackReferenceInnerDefaultCallbackProxyTest {
+    @Test
+    void invokesJavaCallbackThroughFunctionPointer() {
+        AddCallback callback = (left, right) -> left + right;
+        Pointer functionPointer = CallbackReference.getFunctionPointer(callback);
+        Function callbackFunction = Function.getFunction(functionPointer);
+
+        Object result = callbackFunction.invoke(Integer.class, new Object[] {19, 23});
+
+        assertThat(result).isEqualTo(42);
+    }
+
+    public interface AddCallback extends Callback {
+        int invoke(int left, int right);
+    }
+}
diff --git a/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/CallbackReferenceTest.java b/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/CallbackReferenceTest.java
new file mode 100644
index 0000000000..7d46f9f2d1
--- /dev/null
+++ b/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/CallbackReferenceTest.java
@@ -0,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_java_dev_jna.jna;
+
+import com.sun.jna.Callback;
+import com.sun.jna.CallbackReference;
+import com.sun.jna.Function;
+import com.sun.jna.NativeLibrary;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CallbackReferenceTest {
+    @Test
+    void createsCallbackProxyForNativeFunctionPointer() {
+        Function atol = NativeLibrary.getInstance("c").getFunction("atol");
+
+        AtolCallback callback = (AtolCallback) CallbackReference.getCallback(AtolCallback.class, atol);
+
+        assertThat(callback.atol("42")).isEqualTo(42);
+        assertThat(CallbackReference.getCallback(AtolCallback.class, atol)).isSameAs(callback);
+    }
+
+    public interface AtolCallback extends Callback {
+        int atol(String value);
+    }
+}
diff --git a/tests/src/net.java.dev.jna/jna/5.8.0/src/test/java/net_java_dev_jna/jna/JnaTest.java b/tests/src/net.java.dev.jna/jna/5.8.0/src/test/java/net_java_dev_jna/jna/JnaTest.java
deleted file mode 100644
index f7fb00907c..0000000000
--- a/tests/src/net.java.dev.jna/jna/5.8.0/src/test/java/net_java_dev_jna/jna/JnaTest.java
+++ /dev/null
@@ -1,19 +0,0 @@
-/*
- * Copyright and related rights waived via CC0
- *
- * You should have received a copy of the CC0 legalcode along with this
- * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
- */
-package net_java_dev_jna.jna;
-
-import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-class JnaTest {
-    @Test
-    void test() {
-        int number = CLibrary.INSTANCE.atol("42");
-        assertThat(number).isEqualTo(42);
-    }
-}
diff --git a/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/NativeLibraryTest.java b/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/NativeLibraryTest.java
new file mode 100644
index 0000000000..5eee835e22
--- /dev/null
+++ b/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/NativeLibraryTest.java
@@ -0,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_java_dev_jna.jna;
+
+import com.sun.jna.NativeLibrary;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class NativeLibraryTest {
+    @Test
+    void reportsSuppressedCausesWhenLibraryCannotBeLoaded() {
+        String libraryName = "jna_suppressed_missing_library_probe_43b6fd2c";
+
+        assertThatThrownBy(() -> NativeLibrary.getInstance(libraryName))
+                .isInstanceOfSatisfying(UnsatisfiedLinkError.class, error -> {
+                    assertThat(error)
+                            .hasMessageContaining("Unable to load library")
+                            .hasMessageContaining(libraryName);
+                    assertThat(error.getSuppressed()).isNotEmpty();
+                });
+    }
+}
diff --git a/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/NativeTest.java b/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/NativeTest.java
new file mode 100644
index 0000000000..bd4690cbf7
--- /dev/null
+++ b/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/NativeTest.java
@@ -0,0 +1,258 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_java_dev_jna.jna;
+
+import com.sun.jna.FromNativeConverter;
+import com.sun.jna.Library;
+import com.sun.jna.Native;
+import com.sun.jna.Platform;
+import com.sun.jna.Structure;
+import com.sun.jna.ToNativeConverter;
+import com.sun.jna.TypeMapper;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIOException;
+
+public class NativeTest {
+    private static final String DARWIN_RESOURCE_PREFIX = "darwin-x86-64";
+
+    static {
+        configureDarwinResourcePrefix();
+    }
+
+    @Test
+    void invokesFunctionThroughLibraryProxy() {
+        int number = CLibrary.INSTANCE.atol("42");
+
+        assertThat(number).isEqualTo(42);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void loadsDeprecatedLibraryProxyAndSynchronizedProxy() {
+        DeprecatedCLibrary library = Native.loadLibrary("c", DeprecatedCLibrary.class);
+        DeprecatedCLibrary synchronizedLibrary = (DeprecatedCLibrary) Native.synchronizedLibrary(library);
+
+        assertThat(library.atol("41")).isEqualTo(41);
+        assertThat(synchronizedLibrary.atol("42")).isEqualTo(42);
+    }
+
+    @Test
+    void readsOptionsFromPublicLibraryFields() {
+        Map<String, Object> options = Native.getLibraryOptions(FieldOptionsLibrary.class);
+
+        assertThat(options).containsEntry(Library.OPTION_TYPE_MAPPER, FieldOptionsLibrary.TYPE_MAPPER);
+        assertThat(options).containsEntry(Library.OPTION_STRUCTURE_ALIGNMENT, Structure.ALIGN_NONE);
+        assertThat(options).containsEntry(Library.OPTION_STRING_ENCODING, StandardCharsets.UTF_8.name());
+    }
+
+    @Test
+    void initializesPublicLibraryInstanceWhileResolvingOptions() {
+        Map<String, Object> options = Native.getLibraryOptions(InstanceOptionsLibrary.class);
+
+        assertThat(options).containsEntry(Library.OPTION_STRING_ENCODING, StandardCharsets.UTF_8.name());
+        assertThat(InstanceOptionsLibrary.INSTANCE.atol("42")).isEqualTo(42);
+    }
+
+    @Test
+    void registersDirectMappedOuterClassFromNestedInitializerWithExplicitClass() {
+        DirectMappedOuter.Registrar.ensureRegistered();
+
+        assertThat(DirectMappedOuter.atol("42")).isEqualTo(42);
+    }
+
+    @Test
+    void queriesWebStartLibraryPathWhenWebStartPropertyIsSet() {
+        String previousVersion = System.getProperty("javawebstart.version");
+        try {
+            System.setProperty("javawebstart.version", "test");
+
+            assertThat(Native.getWebStartLibraryPath("c")).isNull();
+        } finally {
+            restoreProperty("javawebstart.version", previousVersion);
+        }
+    }
+
+    @Test
+    void extractsLibraryResourceUsingUnprefixedFallback() throws IOException {
+        File libraryFile = File.createTempFile("jna-resource-probe", ".so");
+        libraryFile.deleteOnExit();
+        ClassLoader loader = new FallbackResourceClassLoader(libraryFile.toURI().toURL());
+
+        File extracted = Native.extractFromResourcePath("resourceprobe", loader);
+
+        assertThat(extracted).isEqualTo(libraryFile);
+    }
+
+    @Test
+    void reportsMissingAbsoluteJnaResourceAfterFallbackLookup() {
+        String missingResource = "/com/sun/jna/" + Platform.RESOURCE_PREFIX + "/libmissing-resource-probe.so";
+
+        assertThatIOException()
+                .isThrownBy(() -> Native.extractFromResourcePath(missingResource, new EmptyResourceClassLoader()))
+                .withMessageContaining("Native library");
+    }
+
+    private static void restoreProperty(String name, String previousValue) {
+        if (previousValue == null) {
+            System.clearProperty(name);
+        } else {
+            System.setProperty(name, previousValue);
+        }
+    }
+
+    private static void configureDarwinResourcePrefix() {
+        try {
+            String mappedDispatchName = System.mapLibraryName("jnidispatch").replace(".dylib", ".jnilib");
+            String dispatchResource = "com/sun/jna/" + currentResourcePrefix() + "/" + mappedDispatchName;
+            Path bootDirectory = Files.createTempDirectory("jna-boot-library");
+            Path dispatchLibrary = bootDirectory.resolve(mappedDispatchName);
+            try (InputStream inputStream = NativeTest.class.getClassLoader().getResourceAsStream(dispatchResource)) {
+                if (inputStream == null) {
+                    throw new IllegalStateException("JNA dispatch resource not found: " + dispatchResource);
+                }
+                Files.copy(inputStream, dispatchLibrary);
+            }
+            dispatchLibrary.toFile().deleteOnExit();
+            bootDirectory.toFile().deleteOnExit();
+            System.setProperty("jna.boot.library.path", bootDirectory.toString());
+            System.setProperty("jna.prefix", DARWIN_RESOURCE_PREFIX);
+        } catch (IOException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private static String currentResourcePrefix() {
+        String osName = System.getProperty("os.name");
+        String arch = canonicalArchitecture(System.getProperty("os.arch"));
+        if (osName.startsWith("Linux")) {
+            return "linux-" + arch;
+        }
+        if (osName.startsWith("Mac") || osName.startsWith("Darwin")) {
+            return "darwin-" + arch;
+        }
+        if (osName.startsWith("Windows")) {
+            return "win32-" + arch;
+        }
+        String osPrefix = osName.toLowerCase();
+        int space = osPrefix.indexOf(' ');
+        if (space != -1) {
+            osPrefix = osPrefix.substring(0, space);
+        }
+        return osPrefix + "-" + arch;
+    }
+
+    private static String canonicalArchitecture(String arch) {
+        String canonicalArch = arch.toLowerCase().trim();
+        if ("powerpc".equals(canonicalArch)) {
+            return "ppc";
+        }
+        if ("powerpc64".equals(canonicalArch)) {
+            return "ppc64";
+        }
+        if ("i386".equals(canonicalArch) || "i686".equals(canonicalArch)) {
+            return "x86";
+        }
+        if ("x86_64".equals(canonicalArch) || "amd64".equals(canonicalArch)) {
+            return "x86-64";
+        }
+        if ("zarch_64".equals(canonicalArch)) {
+            return "s390x";
+        }
+        return canonicalArch;
+    }
+
+    public interface DeprecatedCLibrary extends Library {
+        int atol(String value);
+    }
+
+    public interface FieldOptionsLibrary extends Library {
+        Map<String, Object> OPTIONS = Collections.emptyMap();
+        TypeMapper TYPE_MAPPER = new NoopTypeMapper();
+        Integer STRUCTURE_ALIGNMENT = Structure.ALIGN_NONE;
+        String STRING_ENCODING = StandardCharsets.UTF_8.name();
+    }
+
+    public interface InstanceOptionsLibrary extends Library {
+        Map<String, Object> LOAD_OPTIONS = NativeTest.loadOptions();
+        InstanceOptionsLibrary INSTANCE = Native.load("c", InstanceOptionsLibrary.class, LOAD_OPTIONS);
+
+        int atol(String value);
+    }
+
+    public static class DirectMappedOuter {
+        public static native int atol(String value);
+
+        public static class Registrar {
+            static {
+                Native.register(DirectMappedOuter.class, "c");
+            }
+
+            public static void ensureRegistered() {
+            }
+        }
+    }
+
+    private static Map<String, Object> loadOptions() {
+        Map<String, Object> options = new HashMap<>();
+        options.put(Library.OPTION_STRING_ENCODING, StandardCharsets.UTF_8.name());
+        return options;
+    }
+
+    private static final class NoopTypeMapper implements TypeMapper {
+        @Override
+        public FromNativeConverter getFromNativeConverter(Class<?> javaType) {
+            return null;
+        }
+
+        @Override
+        public ToNativeConverter getToNativeConverter(Class<?> javaType) {
+            return null;
+        }
+    }
+
+    private static final class FallbackResourceClassLoader extends ClassLoader {
+        private final URL libraryUrl;
+
+        private FallbackResourceClassLoader(URL libraryUrl) {
+            super(NativeTest.class.getClassLoader());
+            this.libraryUrl = libraryUrl;
+        }
+
+        @Override
+        public URL getResource(String name) {
+            if (name.contains("/") || !name.contains("resourceprobe")) {
+                return null;
+            }
+            return libraryUrl;
+        }
+    }
+
+    private static final class EmptyResourceClassLoader extends ClassLoader {
+        private EmptyResourceClassLoader() {
+            super(NativeTest.class.getClassLoader());
+        }
+
+        @Override
+        public URL getResource(String name) {
+            return null;
+        }
+    }
+}
diff --git a/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/ReflectionUtilsTest.java b/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/ReflectionUtilsTest.java
new file mode 100644
index 0000000000..896e1c9591
--- /dev/null
+++ b/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/ReflectionUtilsTest.java
@@ -0,0 +1,55 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_java_dev_jna.jna;
+
+import com.sun.jna.internal.ReflectionUtils;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReflectionUtilsTest {
+    @Test
+    void invokesDefaultMethodUsingPrivateLookupInPath() throws Throwable {
+        Method method = GreetingDefaults.class.getMethod("format", String.class, int.class);
+
+        assertThat(ReflectionUtils.isDefault(method)).isTrue();
+        Object methodHandle = ReflectionUtils.getMethodHandle(method);
+        Object result = ReflectionUtils.invokeDefaultMethod(
+                new GreetingDefaultsImplementation(), methodHandle, "jna", 5);
+
+        assertThat(result).isEqualTo("jna:5");
+    }
+
+    @Test
+    void invokesJdkDefaultMethodUsingLookupConstructorFallback() throws Throwable {
+        Method method = Iterator.class.getMethod("forEachRemaining", Consumer.class);
+        Iterator<String> iterator = Collections.singleton("jna").iterator();
+        List<String> values = new ArrayList<>();
+
+        Object methodHandle = ReflectionUtils.getMethodHandle(method);
+        ReflectionUtils.invokeDefaultMethod(iterator, methodHandle, (Consumer<String>) values::add);
+
+        assertThat(values).containsExactly("jna");
+    }
+
+    private interface GreetingDefaults {
+        default String format(String text, int count) {
+            return text + ":" + count;
+        }
+    }
+
+    private static final class GreetingDefaultsImplementation implements GreetingDefaults {
+    }
+}
diff --git a/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/StructureTest.java b/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/StructureTest.java
new file mode 100644
index 0000000000..b12789f2d3
--- /dev/null
+++ b/tests/src/net.java.dev.jna/jna/5.19.0/src/test/java/net_java_dev_jna/jna/StructureTest.java
@@ -0,0 +1,81 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_java_dev_jna.jna;
+
+import com.sun.jna.Callback;
+import com.sun.jna.CallbackReference;
+import com.sun.jna.Pointer;
+import com.sun.jna.Structure;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StructureTest {
+    @Test
+    void createsTypedArrayViewsFromStructureMemory() {
+        PointerBackedStructure structure = new PointerBackedStructure();
+        structure.value = 7;
+        structure.write();
+
+        PointerBackedStructure[] array = (PointerBackedStructure[]) structure.toArray(3);
+
+        assertThat(array).hasSize(3);
+        assertThat(array[0]).isSameAs(structure);
+        assertThat(array[1]).isInstanceOf(PointerBackedStructure.class);
+        assertThat(array[2]).isInstanceOf(PointerBackedStructure.class);
+    }
+
+    @Test
+    void createsStructureInstanceFromPointerConstructor() {
+        PointerBackedStructure original = new PointerBackedStructure();
+        original.value = 42;
+        original.write();
+
+        PointerBackedStructure overlay = Structure.newInstance(PointerBackedStructure.class, original.getPointer());
+        overlay.read();
+
+        assertThat(overlay.value).isEqualTo(42);
+        assertThat(overlay.getPointer()).isEqualTo(original.getPointer());
+    }
+
+    @Test
+    void validatesStructureCallbackParameterTypesWhenCreatingFunctionPointer() {
+        Pointer functionPointer = CallbackReference.getFunctionPointer(new NoopStructureCallback());
+
+        assertThat(functionPointer).isNotNull();
+    }
+
+    public interface StructureCallback extends Callback {
+        void invoke(PointerBackedStructure structure);
+    }
+
+    public static final class NoopStructureCallback implements StructureCallback {
+        @Override
+        public void invoke(PointerBackedStructure structure) {
+        }
+    }
+
+    public static class PointerBackedStructure extends Structure {
+        public int value;
+
+        public PointerBackedStructure() {
+        }
+
+        public PointerBackedStructure(Pointer pointer) {
+            super(pointer);
+        }
+
+        @Override
+        protected List<String> getFieldOrder() {
+            return Collections.singletonList("value");
+        }
+    }
+}
diff --git a/tests/src/net.java.dev.jna/jna/5.8.0/user-code-filter.json b/tests/src/net.java.dev.jna/jna/5.19.0/user-code-filter.json
index 6e6c791d35..eb25affbbb 100644
--- a/tests/src/net.java.dev.jna/jna/5.8.0/user-code-filter.json
+++ b/tests/src/net.java.dev.jna/jna/5.19.0/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.sun.jna.**"
+      "includeClasses" : "com.sun.jna.**"
+    },
+    {
+      "includeClasses" : "net_java_dev_jna.jna.**"
     }
   ]
 }

```
### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
