### PR TITLE
[GenAI] Test fix for org.jboss:jandex:3.1.0 using gpt-5.5

### DIFF
--- a/metadata/org.jboss/jandex/3.1.0/reachability-metadata.json
+++ b/metadata/org.jboss/jandex/3.1.0/reachability-metadata.json
@@ -1,105 +1,105 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org.jboss.jandex.StrongInternPool"
+      "condition" : {
+        "typeReached" : "org.jboss.jandex.StrongInternPool"
       },
-      "type": "byte[][]"
+      "type" : "byte[][]"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.jandex.StrongInternPool"
+      "condition" : {
+        "typeReached" : "org.jboss.jandex.StrongInternPool"
       },
-      "type": "java.lang.Object"
+      "type" : "java.lang.Object"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.jandex.StrongInternPool"
+      "condition" : {
+        "typeReached" : "org.jboss.jandex.StrongInternPool"
       },
-      "type": "java.lang.String",
-      "serializable": true
+      "type" : "java.lang.String",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.jandex.StrongInternPool"
+      "condition" : {
+        "typeReached" : "org.jboss.jandex.StrongInternPool"
       },
-      "type": "java.lang.String[]"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.jandex.StrongInternPool$IdentityHashSetIterator"
+      "condition" : {
+        "typeReached" : "org.jboss.jandex.StrongInternPool$IdentityHashSetIterator"
       },
-      "type": "java.lang.String[]"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.jandex.StrongInternPool"
+      "condition" : {
+        "typeReached" : "org.jboss.jandex.StrongInternPool"
       },
-      "type": "java.lang.reflect.Constructor[]"
+      "type" : "java.lang.reflect.Constructor[]"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.jandex.Utils"
+      "condition" : {
+        "typeReached" : "org.jboss.jandex.Utils"
       },
-      "type": "org.jboss.jandex.AnnotationInstance[]"
+      "type" : "org.jboss.jandex.AnnotationInstance[]"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.jandex.Utils"
+      "condition" : {
+        "typeReached" : "org.jboss.jandex.Utils"
       },
-      "type": "org.jboss.jandex.ClassInfo[]"
+      "type" : "org.jboss.jandex.ClassInfo[]"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.jandex.StrongInternPool"
+      "condition" : {
+        "typeReached" : "org.jboss.jandex.StrongInternPool"
       },
-      "type": "org.jboss.jandex.FieldInternal[]"
+      "type" : "org.jboss.jandex.FieldInternal[]"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.jandex.StrongInternPool"
+      "condition" : {
+        "typeReached" : "org.jboss.jandex.StrongInternPool"
       },
-      "type": "org.jboss.jandex.MethodInternal[]"
+      "type" : "org.jboss.jandex.MethodInternal[]"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.jandex.StrongInternPool"
+      "condition" : {
+        "typeReached" : "org.jboss.jandex.StrongInternPool"
       },
-      "type": "org.jboss.jandex.RecordComponentInternal[]"
+      "type" : "org.jboss.jandex.RecordComponentInternal[]"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.jandex.StrongInternPool"
+      "condition" : {
+        "typeReached" : "org.jboss.jandex.StrongInternPool"
       },
-      "type": "org.jboss.jandex.StrongInternPool",
-      "serializable": true
+      "type" : "org.jboss.jandex.StrongInternPool",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.jandex.StrongInternPool"
+      "condition" : {
+        "typeReached" : "org.jboss.jandex.StrongInternPool"
       },
-      "type": "org.jboss.jandex.StrongInternPool$StringInternPool",
-      "serializable": true
+      "type" : "org.jboss.jandex.StrongInternPool$StringInternPool",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.jandex.StrongInternPool"
+      "condition" : {
+        "typeReached" : "org.jboss.jandex.StrongInternPool"
       },
-      "type": "org.jboss.jandex.Type[]"
+      "type" : "org.jboss.jandex.Type[]"
     },
     {
-      "condition": {
-        "typeReached": "org.jboss.jandex.StrongInternPool"
+      "condition" : {
+        "typeReached" : "org.jboss.jandex.StrongInternPool"
       },
-      "type": "org.jboss.jandex.Type[][]"
+      "type" : "org.jboss.jandex.Type[][]"
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "org.jboss.jandex.Indexer"
+      "condition" : {
+        "typeReached" : "org.jboss.jandex.Indexer"
       },
-      "glob": "org_jboss/jandex/IndexerTest$IndexedSample.class"
+      "glob" : "org_jboss/jandex/IndexerTest$IndexedSample.class"
     }
   ]
 }

--- a/metadata/org.jboss/jandex/3.1.0/reachability-metadata.json
+++ b/metadata/org.jboss/jandex/3.1.0/reachability-metadata.json
@@ -1,0 +1,105 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.jboss.jandex.StrongInternPool"
+      },
+      "type": "byte[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.jandex.StrongInternPool"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.jandex.StrongInternPool"
+      },
+      "type": "java.lang.String",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.jandex.StrongInternPool"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.jandex.StrongInternPool$IdentityHashSetIterator"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.jandex.StrongInternPool"
+      },
+      "type": "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.jandex.Utils"
+      },
+      "type": "org.jboss.jandex.AnnotationInstance[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.jandex.Utils"
+      },
+      "type": "org.jboss.jandex.ClassInfo[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.jandex.StrongInternPool"
+      },
+      "type": "org.jboss.jandex.FieldInternal[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.jandex.StrongInternPool"
+      },
+      "type": "org.jboss.jandex.MethodInternal[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.jandex.StrongInternPool"
+      },
+      "type": "org.jboss.jandex.RecordComponentInternal[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.jandex.StrongInternPool"
+      },
+      "type": "org.jboss.jandex.StrongInternPool",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.jandex.StrongInternPool"
+      },
+      "type": "org.jboss.jandex.StrongInternPool$StringInternPool",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.jandex.StrongInternPool"
+      },
+      "type": "org.jboss.jandex.Type[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.jandex.StrongInternPool"
+      },
+      "type": "org.jboss.jandex.Type[][]"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.jboss.jandex.Indexer"
+      },
+      "glob": "org_jboss/jandex/IndexerTest$IndexedSample.class"
+    }
+  ]
+}

--- a/metadata/org.jboss/jandex/index.json
+++ b/metadata/org.jboss/jandex/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.1.0",
+    "tested-versions" : [
+      "3.1.0"
+    ],
+    "allowed-packages" : [
+      "org.jboss.jandex"
+    ]
+  },
+  {
     "metadata-version" : "3.0.7",
     "test-version" : "3.0.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/smallrye/jandex/$version$/jandex-$version$-sources.jar",

--- a/metadata/org.jboss/jandex/index.json
+++ b/metadata/org.jboss/jandex/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "3.1.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/smallrye/jandex/$version$/jandex-$version$-sources.jar",
+    "repository-url" : "https://github.com/smallrye/jandex",
+    "test-code-url" : "https://github.com/smallrye/jandex/tree/$version$/core/src/test/java",
+    "documentation-url" : "https://github.com/smallrye/jandex/blob/$version$/doc/modules/ROOT/pages/index.adoc",
+    "description" : "Jandex is a Java class file indexer and offline reflection library that builds a compact index of class metadata, annotations, declarations, types, and inheritance information. It provides APIs and tools to query, persist, and reload that index for build-time or runtime frameworks without scanning bytecode repeatedly.",
     "tested-versions" : [
       "3.1.0"
     ],

--- a/stats/org.jboss/jandex/3.1.0/execution-metrics.json
+++ b/stats/org.jboss/jandex/3.1.0/execution-metrics.json
@@ -1,0 +1,139 @@
+{
+  "fix_java_run_fail:2026-06-11": {
+    "timestamp": "2026-06-11T03:46:14.152517Z",
+    "library": "org.jboss:jandex:3.1.0",
+    "starting_commit": "452ed224eedd39c6aa62fbe74e26ecdf49f163ec",
+    "ending_commit": "2cedadd0c6d82854d5f94a13a078bdb529f53731",
+    "previous_library": "org.jboss:jandex:3.0.0",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.1.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 6,
+            "totalCalls": 6
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 7,
+        "totalCalls": 7
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 6514,
+          "missed": 32926,
+          "ratio": 0.165162,
+          "total": 39440
+        },
+        "line": {
+          "covered": 1210,
+          "missed": 6922,
+          "ratio": 0.148795,
+          "total": 8132
+        },
+        "method": {
+          "covered": 254,
+          "missed": 1430,
+          "ratio": 0.150831,
+          "total": 1684
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.0.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 5,
+        "totalCalls": 5
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 6004,
+          "missed": 30499,
+          "ratio": 0.16448,
+          "total": 36503
+        },
+        "line": {
+          "covered": 1043,
+          "missed": 6341,
+          "ratio": 0.141251,
+          "total": 7384
+        },
+        "method": {
+          "covered": 212,
+          "missed": 1276,
+          "ratio": 0.142473,
+          "total": 1488
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "degraded",
+      "action": "no_action",
+      "issue_number": 8355,
+      "issue_label": "fails-java-run",
+      "library": "org.jboss:jandex:3.1.0",
+      "summary": "Library preparation preflight did not produce usable advisory setup.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#8355 [Automation] java run fails for org.jboss:jandex:3.1.0; label=fails-java-run; body_chars=8015"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "9 existing test file path(s) included"
+        }
+      ],
+      "current_library": "org.jboss:jandex:3.0.0",
+      "new_version": "3.1.0",
+      "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
+      "model": "oca/gpt-5.5",
+      "prompt_path": "library-preflight-prompt.txt",
+      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.jboss:jandex:3.1.0/library-preparation-preflight/pi-generation-2026-06-11T03-20-23-675560Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 59470,
+      "cached_input_tokens_used": 454656,
+      "output_tokens_used": 7168,
+      "iterations": 2,
+      "cost_usd": 0.4423,
+      "tested_library_loc": 1210,
+      "metadata_entries": 19,
+      "test_only_metadata_entries": 2,
+      "previous_library_metadata_entries": 6,
+      "previous_library_test_only_metadata_entries": 2,
+      "code_coverage_percent": 14.88,
+      "previous_library_coverage_percent": 14.13
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.jboss/jandex/3.1.0/src/test/java/org_jboss/jandex/IndexerTest.java",
+      "metadata_file": "metadata/org.jboss/jandex/3.1.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.jboss/jandex/3.1.0/stats.json
+++ b/stats/org.jboss/jandex/3.1.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "3.1.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 6,
+          "totalCalls" : 6
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 7,
+      "totalCalls" : 7
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 6514,
+        "missed" : 32926,
+        "ratio" : 0.165162,
+        "total" : 39440
+      },
+      "line" : {
+        "covered" : 1210,
+        "missed" : 6922,
+        "ratio" : 0.148795,
+        "total" : 8132
+      },
+      "method" : {
+        "covered" : 254,
+        "missed" : 1430,
+        "ratio" : 0.150831,
+        "total" : 1684
+      }
+    }
+  } ]
+}

--- a/tests/src/org.jboss/jandex/3.1.0/.gitignore
+++ b/tests/src/org.jboss/jandex/3.1.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.jboss/jandex/3.1.0/build.gradle
+++ b/tests/src/org.jboss/jandex/3.1.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.jboss:jandex:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.jboss/jandex/3.1.0/gradle.properties
+++ b/tests/src/org.jboss/jandex/3.1.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.jboss:jandex:3.1.0
+library.version = 3.1.0
+metadata.dir = org.jboss/jandex/3.1.0/

--- a/tests/src/org.jboss/jandex/3.1.0/settings.gradle
+++ b/tests/src/org.jboss/jandex/3.1.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.jboss.jandex_tests'

--- a/tests/src/org.jboss/jandex/3.1.0/src/test/java/org_jboss/jandex/IndexerTest.java
+++ b/tests/src/org.jboss/jandex/3.1.0/src/test/java/org_jboss/jandex/IndexerTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss.jandex;
+
+import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.Indexer;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class IndexerTest {
+    @Test
+    void indexesLoadedClassFromItsClassResource() throws IOException {
+        Indexer indexer = new Indexer();
+
+        indexer.indexClass(IndexedSample.class);
+        Index index = indexer.complete();
+        ClassInfo classInfo = index.getClassByName(IndexedSample.class);
+
+        assertThat(classInfo).isNotNull();
+        assertThat(classInfo.name().toString()).isEqualTo(IndexedSample.class.getName());
+        assertThat(classInfo.declaredAnnotation(DotName.createSimple(SampleAnnotation.class.getName()))).isNotNull();
+        assertThat(classInfo.firstMethod("value")).isNotNull();
+        assertThat(index.getClassByName(IndexedSample.class)).isSameAs(classInfo);
+    }
+
+    @SampleAnnotation("sample")
+    static class IndexedSample {
+        String value() {
+            return "value";
+        }
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    @interface SampleAnnotation {
+        String value();
+    }
+}

--- a/tests/src/org.jboss/jandex/3.1.0/src/test/java/org_jboss/jandex/JandexReflectionTest.java
+++ b/tests/src/org.jboss/jandex/3.1.0/src/test/java/org_jboss/jandex/JandexReflectionTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss.jandex;
+
+import org.jboss.jandex.ArrayType;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.JandexReflection;
+import org.jboss.jandex.Type;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JandexReflectionTest {
+    @Test
+    void loadsRawArrayClassFromJandexClassType() {
+        Type componentType = Type.create(DotName.createSimple(SampleType.class.getName()), Type.Kind.CLASS);
+        ArrayType arrayType = ArrayType.create(componentType, 2);
+
+        Class<?> loadedType = JandexReflection.loadRawType(arrayType);
+
+        assertThat(loadedType).isEqualTo(SampleType[][].class);
+    }
+
+    static final class SampleType {
+    }
+}

--- a/tests/src/org.jboss/jandex/3.1.0/src/test/java/org_jboss/jandex/StrongInternPoolInnerIdentityHashSetIteratorTest.java
+++ b/tests/src/org.jboss/jandex/3.1.0/src/test/java/org_jboss/jandex/StrongInternPoolInnerIdentityHashSetIteratorTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss.jandex;
+
+import java.lang.reflect.Method;
+import java.util.Iterator;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StrongInternPoolInnerIdentityHashSetIteratorTest {
+    @Test
+    void iteratorRemoveRelocatesEntriesFromWrappedCluster() throws Exception {
+        Object pool = newPool();
+        expandTable(pool);
+        clear(pool);
+
+        intern(pool, "n");
+        intern(pool, "ao");
+        intern(pool, "bp");
+
+        Iterator<?> iterator = iterator(pool);
+        assertThat(iterator.next()).isEqualTo("bp");
+        assertThat(iterator.next()).isEqualTo("n");
+        assertThat(iterator.next()).isEqualTo("ao");
+
+        iterator.remove();
+
+        assertThat(iterator.hasNext()).isFalse();
+        assertThat(size(pool)).isEqualTo(2);
+        assertThat(contains(pool, "n")).isTrue();
+        assertThat(contains(pool, "bp")).isTrue();
+        assertThat(contains(pool, "ao")).isFalse();
+    }
+
+    private static Object newPool() throws Exception {
+        Method method = strongInternPoolClass().getDeclaredMethod("forStrings");
+        method.setAccessible(true);
+        return method.invoke(null);
+    }
+
+    private static void expandTable(Object pool) throws Exception {
+        intern(pool, "alpha");
+        intern(pool, "bravo");
+        intern(pool, "charlie");
+        intern(pool, "delta");
+        intern(pool, "echo");
+    }
+
+    private static Object intern(Object pool, String entry) throws Exception {
+        Method method = strongInternPoolClass().getDeclaredMethod("intern", Object.class);
+        method.setAccessible(true);
+        return method.invoke(pool, entry);
+    }
+
+    private static void clear(Object pool) throws Exception {
+        Method method = strongInternPoolClass().getDeclaredMethod("clear");
+        method.setAccessible(true);
+        method.invoke(pool);
+    }
+
+    private static Iterator<?> iterator(Object pool) throws Exception {
+        Method method = strongInternPoolClass().getDeclaredMethod("iterator");
+        method.setAccessible(true);
+        return (Iterator<?>) method.invoke(pool);
+    }
+
+    private static int size(Object pool) throws Exception {
+        Method method = strongInternPoolClass().getDeclaredMethod("size");
+        method.setAccessible(true);
+        return (Integer) method.invoke(pool);
+    }
+
+    private static boolean contains(Object pool, String entry) throws Exception {
+        Method method = strongInternPoolClass().getDeclaredMethod("contains", Object.class);
+        method.setAccessible(true);
+        return (Boolean) method.invoke(pool, entry);
+    }
+
+    private static Class<?> strongInternPoolClass() throws ClassNotFoundException {
+        return Class.forName("org.jboss.jandex.StrongInternPool");
+    }
+}

--- a/tests/src/org.jboss/jandex/3.1.0/src/test/java/org_jboss/jandex/StrongInternPoolTest.java
+++ b/tests/src/org.jboss/jandex/3.1.0/src/test/java/org_jboss/jandex/StrongInternPoolTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss.jandex;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StrongInternPoolTest {
+    @Test
+    void serializesAndDeserializesInternedEntries() throws Exception {
+        Object pool = newPool();
+
+        String alpha = new String("alpha");
+        String beta = new String("beta");
+
+        assertThat(intern(pool, alpha)).isSameAs(alpha);
+        assertThat(intern(pool, new String("alpha"))).isSameAs(alpha);
+        assertThat(intern(pool, beta)).isSameAs(beta);
+        assertThat(intern(pool, null)).isNull();
+        assertThat(size(pool)).isEqualTo(3);
+
+        Object restoredPool = deserialize(serialize(pool));
+
+        assertThat(size(restoredPool)).isEqualTo(3);
+        assertThat(contains(restoredPool, "alpha")).isTrue();
+        assertThat(contains(restoredPool, "beta")).isTrue();
+        assertThat(contains(restoredPool, null)).isTrue();
+
+        String duplicateAlpha = new String("alpha");
+        Object restoredAlpha = intern(restoredPool, duplicateAlpha);
+        assertThat(restoredAlpha).isEqualTo("alpha");
+        assertThat(restoredAlpha).isNotSameAs(duplicateAlpha);
+        assertThat(size(restoredPool)).isEqualTo(3);
+    }
+
+    private static Object newPool() throws Exception {
+        Constructor<?> constructor = strongInternPoolClass().getDeclaredConstructor();
+        constructor.setAccessible(true);
+        return constructor.newInstance();
+    }
+
+    private static Object intern(Object pool, Object entry) throws Exception {
+        Method method = strongInternPoolClass().getDeclaredMethod("intern", Object.class);
+        method.setAccessible(true);
+        return method.invoke(pool, entry);
+    }
+
+    private static int size(Object pool) throws Exception {
+        Method method = strongInternPoolClass().getDeclaredMethod("size");
+        method.setAccessible(true);
+        return (Integer) method.invoke(pool);
+    }
+
+    private static boolean contains(Object pool, Object entry) throws Exception {
+        Method method = strongInternPoolClass().getDeclaredMethod("contains", Object.class);
+        method.setAccessible(true);
+        return (Boolean) method.invoke(pool, entry);
+    }
+
+    private static byte[] serialize(Object pool) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+            output.writeObject(pool);
+        }
+        return bytes.toByteArray();
+    }
+
+    private static Object deserialize(byte[] bytes) throws Exception {
+        try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+            return input.readObject();
+        }
+    }
+
+    private static Class<?> strongInternPoolClass() throws ClassNotFoundException {
+        return Class.forName("org.jboss.jandex.StrongInternPool");
+    }
+}

--- a/tests/src/org.jboss/jandex/3.1.0/src/test/java/org_jboss/jandex/StrongInternPoolTest.java
+++ b/tests/src/org.jboss/jandex/3.1.0/src/test/java/org_jboss/jandex/StrongInternPoolTest.java
@@ -10,7 +10,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 
 import org.junit.jupiter.api.Test;
@@ -28,27 +27,25 @@ public class StrongInternPoolTest {
         assertThat(intern(pool, alpha)).isSameAs(alpha);
         assertThat(intern(pool, new String("alpha"))).isSameAs(alpha);
         assertThat(intern(pool, beta)).isSameAs(beta);
-        assertThat(intern(pool, null)).isNull();
-        assertThat(size(pool)).isEqualTo(3);
+        assertThat(size(pool)).isEqualTo(2);
 
         Object restoredPool = deserialize(serialize(pool));
 
-        assertThat(size(restoredPool)).isEqualTo(3);
+        assertThat(size(restoredPool)).isEqualTo(2);
         assertThat(contains(restoredPool, "alpha")).isTrue();
         assertThat(contains(restoredPool, "beta")).isTrue();
-        assertThat(contains(restoredPool, null)).isTrue();
 
         String duplicateAlpha = new String("alpha");
         Object restoredAlpha = intern(restoredPool, duplicateAlpha);
         assertThat(restoredAlpha).isEqualTo("alpha");
         assertThat(restoredAlpha).isNotSameAs(duplicateAlpha);
-        assertThat(size(restoredPool)).isEqualTo(3);
+        assertThat(size(restoredPool)).isEqualTo(2);
     }
 
     private static Object newPool() throws Exception {
-        Constructor<?> constructor = strongInternPoolClass().getDeclaredConstructor();
-        constructor.setAccessible(true);
-        return constructor.newInstance();
+        Method method = strongInternPoolClass().getDeclaredMethod("forStrings");
+        method.setAccessible(true);
+        return method.invoke(null);
     }
 
     private static Object intern(Object pool, Object entry) throws Exception {

--- a/tests/src/org.jboss/jandex/3.1.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.jboss/jandex/3.1.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.jandex.JandexReflection"
+      },
+      "type" : "org_jboss.jandex.JandexReflectionTest$SampleType[][]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.jandex.JandexReflection"
+      },
+      "type" : "org_jboss.jandex.JandexReflectionTest$SampleType"
+    }
+  ]
+}

--- a/tests/src/org.jboss/jandex/3.1.0/user-code-filter.json
+++ b/tests/src/org.jboss/jandex/3.1.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.jboss.jandex.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #8355

This PR provides test fixes and new metadata for org.jboss:jandex:3.1.0, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 59470
- Cached input tokens: 454656
- Output tokens: 7168
- Metadata entries: 19
- Test-only metadata entries: 2
- Iterations: 2
- Library coverage percentage: 14.88
- Previous library version metadata entries: 6
- Previous library version test-only metadata entries: 2
- Previous library version coverage percentage: 14.13

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `83ba2cf16ef635fa123f2ed2fc9596a6a05ca131`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.jboss:jandex:3.0.0: 5/5 covered calls (100.00%)
- org.jboss:jandex:3.1.0: 7/7 covered calls (100.00%)

**Reflection:**
- org.jboss:jandex:3.0.0: 4/4 covered calls (100.00%)
- org.jboss:jandex:3.1.0: 6/6 covered calls (100.00%)

**Resources:**
- org.jboss:jandex:3.0.0: 1/1 covered calls (100.00%)
- org.jboss:jandex:3.1.0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.jboss:jandex:3.0.0: 6004/36503 (16.45%)
- org.jboss:jandex:3.1.0: 6514/39440 (16.52%)

**Line:**
- org.jboss:jandex:3.0.0: 1043/7384 (14.13%)
- org.jboss:jandex:3.1.0: 1210/8132 (14.88%)

**Method:**
- org.jboss:jandex:3.0.0: 212/1488 (14.25%)
- org.jboss:jandex:3.1.0: 254/1684 (15.08%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git a/tests/src/org.jboss/jandex/3.1.0/src/test/java/org_jboss/jandex/StrongInternPoolInnerIdentityHashSetIteratorTest.java b/tests/src/org.jboss/jandex/3.1.0/src/test/java/org_jboss/jandex/StrongInternPoolInnerIdentityHashSetIteratorTest.java
new file mode 100644
index 0000000000..c72034aa0d
--- /dev/null
+++ b/tests/src/org.jboss/jandex/3.1.0/src/test/java/org_jboss/jandex/StrongInternPoolInnerIdentityHashSetIteratorTest.java
@@ -0,0 +1,88 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss.jandex;
+
+import java.lang.reflect.Method;
+import java.util.Iterator;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StrongInternPoolInnerIdentityHashSetIteratorTest {
+    @Test
+    void iteratorRemoveRelocatesEntriesFromWrappedCluster() throws Exception {
+        Object pool = newPool();
+        expandTable(pool);
+        clear(pool);
+
+        intern(pool, "n");
+        intern(pool, "ao");
+        intern(pool, "bp");
+
+        Iterator<?> iterator = iterator(pool);
+        assertThat(iterator.next()).isEqualTo("bp");
+        assertThat(iterator.next()).isEqualTo("n");
+        assertThat(iterator.next()).isEqualTo("ao");
+
+        iterator.remove();
+
+        assertThat(iterator.hasNext()).isFalse();
+        assertThat(size(pool)).isEqualTo(2);
+        assertThat(contains(pool, "n")).isTrue();
+        assertThat(contains(pool, "bp")).isTrue();
+        assertThat(contains(pool, "ao")).isFalse();
+    }
+
+    private static Object newPool() throws Exception {
+        Method method = strongInternPoolClass().getDeclaredMethod("forStrings");
+        method.setAccessible(true);
+        return method.invoke(null);
+    }
+
+    private static void expandTable(Object pool) throws Exception {
+        intern(pool, "alpha");
+        intern(pool, "bravo");
+        intern(pool, "charlie");
+        intern(pool, "delta");
+        intern(pool, "echo");
+    }
+
+    private static Object intern(Object pool, String entry) throws Exception {
+        Method method = strongInternPoolClass().getDeclaredMethod("intern", Object.class);
+        method.setAccessible(true);
+        return method.invoke(pool, entry);
+    }
+
+    private static void clear(Object pool) throws Exception {
+        Method method = strongInternPoolClass().getDeclaredMethod("clear");
+        method.setAccessible(true);
+        method.invoke(pool);
+    }
+
+    private static Iterator<?> iterator(Object pool) throws Exception {
+        Method method = strongInternPoolClass().getDeclaredMethod("iterator");
+        method.setAccessible(true);
+        return (Iterator<?>) method.invoke(pool);
+    }
+
+    private static int size(Object pool) throws Exception {
+        Method method = strongInternPoolClass().getDeclaredMethod("size");
+        method.setAccessible(true);
+        return (Integer) method.invoke(pool);
+    }
+
+    private static boolean contains(Object pool, String entry) throws Exception {
+        Method method = strongInternPoolClass().getDeclaredMethod("contains", Object.class);
+        method.setAccessible(true);
+        return (Boolean) method.invoke(pool, entry);
+    }
+
+    private static Class<?> strongInternPoolClass() throws ClassNotFoundException {
+        return Class.forName("org.jboss.jandex.StrongInternPool");
+    }
+}
diff --git a/tests/src/org.jboss/jandex/3.0.0/src/test/java/org_jboss/jandex/StrongInternPoolTest.java b/tests/src/org.jboss/jandex/3.1.0/src/test/java/org_jboss/jandex/StrongInternPoolTest.java
index 4a05213cb7..0aadef644c 100644
--- a/tests/src/org.jboss/jandex/3.0.0/src/test/java/org_jboss/jandex/StrongInternPoolTest.java
+++ b/tests/src/org.jboss/jandex/3.1.0/src/test/java/org_jboss/jandex/StrongInternPoolTest.java
@@ -10,7 +10,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 
 import org.junit.jupiter.api.Test;
@@ -28,27 +27,25 @@ public class StrongInternPoolTest {
         assertThat(intern(pool, alpha)).isSameAs(alpha);
         assertThat(intern(pool, new String("alpha"))).isSameAs(alpha);
         assertThat(intern(pool, beta)).isSameAs(beta);
-        assertThat(intern(pool, null)).isNull();
-        assertThat(size(pool)).isEqualTo(3);
+        assertThat(size(pool)).isEqualTo(2);
 
         Object restoredPool = deserialize(serialize(pool));
 
-        assertThat(size(restoredPool)).isEqualTo(3);
+        assertThat(size(restoredPool)).isEqualTo(2);
         assertThat(contains(restoredPool, "alpha")).isTrue();
         assertThat(contains(restoredPool, "beta")).isTrue();
-        assertThat(contains(restoredPool, null)).isTrue();
 
         String duplicateAlpha = new String("alpha");
         Object restoredAlpha = intern(restoredPool, duplicateAlpha);
         assertThat(restoredAlpha).isEqualTo("alpha");
         assertThat(restoredAlpha).isNotSameAs(duplicateAlpha);
-        assertThat(size(restoredPool)).isEqualTo(3);
+        assertThat(size(restoredPool)).isEqualTo(2);
     }
 
     private static Object newPool() throws Exception {
-        Constructor<?> constructor = strongInternPoolClass().getDeclaredConstructor();
-        constructor.setAccessible(true);
-        return constructor.newInstance();
+        Method method = strongInternPoolClass().getDeclaredMethod("forStrings");
+        method.setAccessible(true);
+        return method.invoke(null);
     }
 
     private static Object intern(Object pool, Object entry) throws Exception {

```

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
