### PR TITLE
[Automation] Generated metadata for org.springframework.boot:spring-boot-kafka:4.1.0

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-kafka/4.1.0/reachability-metadata.json
+++ b/metadata/org.springframework.boot/spring-boot-kafka/4.1.0/reachability-metadata.json
@@ -1,0 +1,395 @@
+{
+  "reflection": [
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaAutoConfiguration",
+      "allDeclaredConstructors": true,
+      "methods": [
+        {
+          "name": "kafkaConnectionDetails",
+          "parameterTypes": [
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        },
+        {
+          "name": "kafkaTemplate",
+          "parameterTypes": [
+            "org.springframework.kafka.core.ProducerFactory",
+            "org.springframework.kafka.support.ProducerListener",
+            "org.springframework.beans.factory.ObjectProvider",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        },
+        {
+          "name": "kafkaProducerListener",
+          "parameterTypes": []
+        },
+        {
+          "name": "kafkaConsumerFactory",
+          "parameterTypes": [
+            "org.springframework.boot.kafka.autoconfigure.KafkaConnectionDetails",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        },
+        {
+          "name": "kafkaProducerFactory",
+          "parameterTypes": [
+            "org.springframework.boot.kafka.autoconfigure.KafkaConnectionDetails",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        },
+        {
+          "name": "kafkaTransactionManager",
+          "parameterTypes": [
+            "org.springframework.kafka.core.ProducerFactory"
+          ]
+        },
+        {
+          "name": "kafkaJaasInitializer",
+          "parameterTypes": []
+        },
+        {
+          "name": "kafkaAdmin",
+          "parameterTypes": [
+            "org.springframework.boot.kafka.autoconfigure.KafkaConnectionDetails"
+          ]
+        },
+        {
+          "name": "kafkaRetryTopicConfiguration",
+          "parameterTypes": [
+            "org.springframework.kafka.core.KafkaTemplate"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties$Admin",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties$Cleanup",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties$Consumer",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties$IsolationLevel",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties$Jaas",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties$Listener",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties$Listener$Type",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties$Producer",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties$Properties",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties$Retry",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties$Retry$Topic",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties$Retry$Topic$Backoff",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties$Security",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties$Ssl",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties$Streams",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaProperties$Template",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.OnClassCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.OnBeanCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.OnPropertyCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.OnThreadingCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.kafka.annotation.KafkaListenerConfigurationSelector",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "selectImports",
+          "parameterTypes": [
+            "org.springframework.core.type.AnnotationMetadata"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.kafka.annotation.KafkaBootstrapConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "registerBeanDefinitions",
+          "parameterTypes": [
+            "org.springframework.core.type.AnnotationMetadata",
+            "org.springframework.beans.factory.support.BeanDefinitionRegistry"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.kafka.annotation.KafkaListenerAnnotationBeanPostProcessor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.kafka.config.KafkaListenerEndpointRegistry",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.apache.kafka.common.serialization.StringDeserializer",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.kafka.common.serialization.StringSerializer",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.springframework.kafka.listener.ContainerProperties$AckMode",
+      "allDeclaredFields": true,
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.springframework.kafka.listener.ContainerProperties",
+      "allPublicMethods": true
+    },
+    {
+      "type": "sun.security.provider.ConfigFile",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.springframework.context.annotation.ConfigurationClassParser$DefaultDeferredImportSelectorGroup",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaAnnotationDrivenConfiguration",
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaAnnotationDrivenConfiguration$EnableKafkaConfiguration",
+      "allDeclaredConstructors": true
+    },
+    {
+      "type": "org.springframework.boot.kafka.autoconfigure.KafkaStreamsAnnotationDrivenConfiguration",
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.springframework.boot.autoconfigure.AutoConfiguration"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.springframework.boot.autoconfigure.condition.ConditionalOnClass"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.springframework.boot.context.properties.EnableConfigurationProperties"
+        ]
+      }
+    },
+    {
+      "type": "org.springframework.boot.context.properties.EnableConfigurationPropertiesRegistrar",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.properties.ConfigurationPropertiesBindingPostProcessor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.properties.ConfigurationPropertiesBinder$ConfigurationPropertiesBinderFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.properties.BoundConfigurationProperties",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.validation.beanvalidation.MethodValidationExcludeFilter",
+      "methods": [
+        {
+          "name": "byAnnotation",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.springframework.context.ConfigurableApplicationContext",
+          "org.springframework.boot.test.context.assertj.AssertableApplicationContext"
+        ]
+      }
+    }
+  ],
+  "resources": [
+    {
+      "glob": "org/springframework/boot/kafka/autoconfigure/*.class"
+    },
+    {
+      "glob": "org/springframework/kafka/annotation/*.class"
+    },
+    {
+      "glob": "org/springframework/context/annotation/*.class"
+    },
+    {
+      "glob": "META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports"
+    },
+    {
+      "glob": "META-INF/spring-autoconfigure-metadata.properties"
+    },
+    {
+      "glob": "org/springframework/boot/context/properties/EnableConfigurationPropertiesRegistrar.class"
+    }
+  ]
+}

--- a/metadata/org.springframework.boot/spring-boot-kafka/index.json
+++ b/metadata/org.springframework.boot/spring-boot-kafka/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "4.1.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-kafka/$version$/spring-boot-kafka-$version$-sources.jar",
+    "repository-url" : "https://github.com/spring-projects/spring-boot",
+    "test-code-url" : "https://github.com/spring-projects/spring-boot/tree/v$version$/module/spring-boot-kafka/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-kafka/$version$/spring-boot-kafka-$version$-javadoc.jar",
+    "description" : "Spring Boot Kafka provides auto-configuration and support classes for integrating Spring Boot applications with Apache Kafka through Spring for Apache Kafka. It configures Kafka producers, consumers, listener containers, transactions, metrics, Kafka Streams, and Testcontainers connection details based on Spring Boot properties and user-defined beans.",
+    "test-version" : "4.0.2",
+    "tested-versions" : [
+      "4.1.0"
+    ],
+    "allowed-packages" : [
+      "org.springframework.boot.kafka"
+    ]
+  },
+  {
     "metadata-version" : "4.0.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-kafka/$version$/spring-boot-kafka-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-boot",

--- a/stats/org.springframework.boot/spring-boot-kafka/4.1.0/execution-metrics.json
+++ b/stats/org.springframework.boot/spring-boot-kafka/4.1.0/execution-metrics.json
@@ -1,0 +1,115 @@
+{
+  "fix_ni_run:2026-06-11": {
+    "timestamp": "2026-06-11T04:13:23.659751Z",
+    "library": "org.springframework.boot:spring-boot-kafka:4.1.0",
+    "starting_commit": "b37edfea3f9a1266193ca1b9ab92d961d3a11559",
+    "ending_commit": "4590f43269ca7b1ac11bc743fdce1d9f354f3bb3",
+    "previous_library": "org.springframework.boot:spring-boot-kafka:4.0.2",
+    "strategy_name": "library_update_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.1.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2547,
+          "missed": 832,
+          "ratio": 0.753773,
+          "total": 3379
+        },
+        "line": {
+          "covered": 592,
+          "missed": 256,
+          "ratio": 0.698113,
+          "total": 848
+        },
+        "method": {
+          "covered": 226,
+          "missed": 135,
+          "ratio": 0.626039,
+          "total": 361
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "4.0.2",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2488,
+          "missed": 824,
+          "ratio": 0.751208,
+          "total": 3312
+        },
+        "line": {
+          "covered": 580,
+          "missed": 252,
+          "ratio": 0.697115,
+          "total": 832
+        },
+        "method": {
+          "covered": 223,
+          "missed": 133,
+          "ratio": 0.626404,
+          "total": 356
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "degraded",
+      "action": "no_action",
+      "issue_number": 8357,
+      "issue_label": "fails-native-image-run",
+      "library": "org.springframework.boot:spring-boot-kafka:4.1.0",
+      "summary": "Library preparation preflight did not produce usable advisory setup.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#8357 [Automation] native-image run fails for org.springframework.boot:spring-boot-kafka:4.1.0; label=fails-native-image-run; body_chars=8015"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "6 existing test file path(s) included"
+        }
+      ],
+      "current_library": "org.springframework.boot:spring-boot-kafka:4.0.2",
+      "new_version": "4.1.0",
+      "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
+      "model": "oca/gpt-5.5",
+      "prompt_path": "library-preflight-prompt.txt",
+      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.springframework.boot:spring-boot-kafka:4.1.0/library-preparation-preflight/pi-generation-2026-06-11T03-49-19-573569Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 0,
+      "cached_input_tokens_used": 0,
+      "output_tokens_used": 0,
+      "iterations": 0,
+      "cost_usd": 0.0,
+      "tested_library_loc": 592,
+      "metadata_entries": 141,
+      "previous_library_metadata_entries": 141,
+      "code_coverage_percent": 69.81,
+      "previous_library_coverage_percent": 69.71
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.springframework.boot/spring-boot-kafka/4.0.2/src/test/java/org_springframework_boot/spring_boot_kafka/Spring_boot_kafkaTest.java",
+      "metadata_file": "metadata/org.springframework.boot/spring-boot-kafka/4.1.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.springframework.boot/spring-boot-kafka/4.1.0/stats.json
+++ b/stats/org.springframework.boot/spring-boot-kafka/4.1.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.1.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2547,
+        "missed" : 832,
+        "ratio" : 0.753773,
+        "total" : 3379
+      },
+      "line" : {
+        "covered" : 592,
+        "missed" : 256,
+        "ratio" : 0.698113,
+        "total" : 848
+      },
+      "method" : {
+        "covered" : 226,
+        "missed" : 135,
+        "ratio" : 0.626039,
+        "total" : 361
+      }
+    }
+  } ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: oracle/graalvm-reachability-metadata#8357

This PR provides new metadata needed for the org.springframework.boot:spring-boot-kafka:4.1.0, addressing Native Image run failures caused by changes in the updated library version.

Summary:
- Metadata entries (previous `org.springframework.boot:spring-boot-kafka:4.0.2`): 141
- Metadata entries (new `org.springframework.boot:spring-boot-kafka:4.1.0`): 141
- Library coverage (previous): 69.71%
- Library coverage (new): 69.81%
- Strategy: library_update_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 0
- Cached input tokens: 0
- Output tokens: 0
- Iterations: 0

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `83ba2cf16ef635fa123f2ed2fc9596a6a05ca131`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.springframework.boot:spring-boot-kafka:4.0.2: 0/0 covered calls (100.00%)
- org.springframework.boot:spring-boot-kafka:4.1.0: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.springframework.boot:spring-boot-kafka:4.0.2: 2488/3312 (75.12%)
- org.springframework.boot:spring-boot-kafka:4.1.0: 2547/3379 (75.38%)

**Line:**
- org.springframework.boot:spring-boot-kafka:4.0.2: 580/832 (69.71%)
- org.springframework.boot:spring-boot-kafka:4.1.0: 592/848 (69.81%)

**Method:**
- org.springframework.boot:spring-boot-kafka:4.0.2: 223/356 (62.64%)
- org.springframework.boot:spring-boot-kafka:4.1.0: 226/361 (62.60%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
