### PR TITLE
[GenAI] Add support for org.tpolecat:doobie-postgres_3:0.13.4 using gpt-5.5

### DIFF
--- a/metadata/org.tpolecat/doobie-postgres_3/0.13.4/reachability-metadata.json
+++ b/metadata/org.tpolecat/doobie-postgres_3/0.13.4/reachability-metadata.json
@@ -1,0 +1,235 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "doobie.postgres.package$implicits$"
+      },
+      "type": "doobie.postgres.package$implicits$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "doobie.postgres.hi.package$"
+      },
+      "type": "doobie.postgres.hi.package$",
+      "fields": [
+        {
+          "name": "0bitmap$2"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "doobie.postgres.Instances"
+      },
+      "type": "doobie.package$",
+      "fields": [
+        {
+          "name": "0bitmap$2"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "doobie.postgres.Instances"
+      },
+      "type": "doobie.free.package$",
+      "fields": [
+        {
+          "name": "0bitmap$2"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "doobie.postgres.Instances"
+      },
+      "type": "doobie.free.package$implicits$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "doobie.postgres.Instances"
+      },
+      "type": "doobie.hi.package$",
+      "fields": [
+        {
+          "name": "0bitmap$2"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "doobie.postgres.Instances"
+      },
+      "type": "doobie.hi.package$implicits$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "doobie.postgres.Instances"
+      },
+      "type": "doobie.package$implicits$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "doobie.postgres.Instances"
+      },
+      "type": "doobie.util.analysis$Analysis",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "doobie.postgres.Instances"
+      },
+      "type": "doobie.util.fragment$Fragment",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "doobie.postgres.Instances"
+      },
+      "type": "doobie.util.meta.Meta$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "doobie.postgres.Instances"
+      },
+      "type": "doobie.util.meta.SqlMeta$javasql$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "doobie.postgres.Instances"
+      },
+      "type": "doobie.util.meta.TimeMeta$javatime$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "doobie.postgres.Instances"
+      },
+      "type": "doobie.util.meta.TimeMeta$javatimedrivernative$",
+      "fields": [
+        {
+          "name": "0bitmap$2"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "doobie.postgres.Instances"
+      },
+      "type": "doobie.util.meta.LegacyMeta$legacy$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "doobie.postgres.Instances"
+      },
+      "type": "doobie.util.pretty$Block",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "doobie.postgres.Instances"
+      },
+      "type": "doobie.util.Read$",
+      "fields": [
+        {
+          "name": "0bitmap$2"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "doobie.postgres.Instances"
+      },
+      "type": "doobie.util.Read",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "doobie.postgres.Instances"
+      },
+      "type": "doobie.util.Write$",
+      "fields": [
+        {
+          "name": "0bitmap$2"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "doobie.postgres.Instances"
+      },
+      "type": "doobie.util.Write",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "doobie.postgres.Instances"
+      },
+      "type": "doobie.util.transactor$Transactor$fromDriverManager$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.tpolecat/doobie-postgres_3/index.json
+++ b/metadata/org.tpolecat/doobie-postgres_3/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "0.13.4",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/tpolecat/doobie-postgres_3/$version$/doobie-postgres_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/typelevel/doobie",
+    "test-code-url" : "https://github.com/typelevel/doobie/tree/v$version$/modules/postgres/src/test",
+    "documentation-url" : "https://github.com/typelevel/doobie/blob/v$version$/modules/docs/src/main/mdoc/docs/15-Extensions-PostgreSQL.md",
+    "description" : "Doobie is a functional JDBC layer for Scala that provides typechecked database access built on Cats and Cats Effect. The doobie-postgres module adds PostgreSQL-specific support, including PostgreSQL JDBC integration, copy and large-object APIs, and mappings for PostgreSQL data types.",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "0.13.4"
+    ],
+    "allowed-packages" : [
+      "doobie.postgres"
+    ]
+  }
+]

--- a/stats/org.tpolecat/doobie-postgres_3/0.13.4/execution-metrics.json
+++ b/stats/org.tpolecat/doobie-postgres_3/0.13.4/execution-metrics.json
@@ -1,0 +1,82 @@
+{
+  "add_new_library_support:2026-06-11": {
+    "timestamp": "2026-06-11T04:27:50.788175Z",
+    "library": "org.tpolecat:doobie-postgres_3:0.13.4",
+    "starting_commit": "88445b3b68033e7ab55942319c09dd7a77efb687",
+    "ending_commit": "9a78b9de12ee98ad1f1680664d5c15c756ed5f17",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "0.13.4",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3465,
+          "missed": 42299,
+          "ratio": 0.075715,
+          "total": 45764
+        },
+        "line": {
+          "covered": 372,
+          "missed": 1117,
+          "ratio": 0.249832,
+          "total": 1489
+        },
+        "method": {
+          "covered": 519,
+          "missed": 4939,
+          "ratio": 0.09509,
+          "total": 5458
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "degraded",
+      "action": "no_action",
+      "issue_number": 5341,
+      "issue_label": "library-new-request",
+      "library": "org.tpolecat:doobie-postgres_3:0.13.4",
+      "summary": "Library preparation preflight did not produce usable advisory setup.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#5341 Support for org.tpolecat:doobie-postgres_3:0.13.4; label=library-new-request; body_chars=287"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "0 existing test file path(s) included"
+        }
+      ],
+      "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
+      "model": "oca/gpt-5.5",
+      "prompt_path": "library-preflight-prompt.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.tpolecat:doobie-postgres_3:0.13.4/library-preparation-preflight/pi-generation-2026-06-11T03-57-24-428883Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 309468,
+      "cached_input_tokens_used": 3613184,
+      "output_tokens_used": 21945,
+      "iterations": 4,
+      "cost_usd": 2.4649,
+      "generated_loc": 403,
+      "tested_library_loc": 372,
+      "metadata_entries": 42,
+      "code_coverage_percent": 24.98
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.tpolecat/doobie-postgres_3/0.13.4/src/test/scala/org_tpolecat/doobie_postgres_3/Doobie_postgres_3Test.scala",
+      "metadata_file": "metadata/org.tpolecat/doobie-postgres_3/0.13.4/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.tpolecat/doobie-postgres_3/0.13.4/stats.json
+++ b/stats/org.tpolecat/doobie-postgres_3/0.13.4/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "0.13.4",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3465,
+        "missed" : 42299,
+        "ratio" : 0.075715,
+        "total" : 45764
+      },
+      "line" : {
+        "covered" : 372,
+        "missed" : 1117,
+        "ratio" : 0.249832,
+        "total" : 1489
+      },
+      "method" : {
+        "covered" : 519,
+        "missed" : 4939,
+        "ratio" : 0.09509,
+        "total" : 5458
+      }
+    }
+  } ]
+}

--- a/tests/src/org.tpolecat/doobie-postgres_3/0.13.4/.gitignore
+++ b/tests/src/org.tpolecat/doobie-postgres_3/0.13.4/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.tpolecat/doobie-postgres_3/0.13.4/build.gradle
+++ b/tests/src/org.tpolecat/doobie-postgres_3/0.13.4/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.tpolecat:doobie-postgres_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.tpolecat/doobie-postgres_3/0.13.4/gradle.properties
+++ b/tests/src/org.tpolecat/doobie-postgres_3/0.13.4/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.tpolecat:doobie-postgres_3:0.13.4
+library.version = 0.13.4
+metadata.dir = org.tpolecat/doobie-postgres_3/0.13.4/

--- a/tests/src/org.tpolecat/doobie-postgres_3/0.13.4/settings.gradle
+++ b/tests/src/org.tpolecat/doobie-postgres_3/0.13.4/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.tpolecat.doobie-postgres_3_tests'

--- a/tests/src/org.tpolecat/doobie-postgres_3/0.13.4/src/test/scala/org_tpolecat/doobie_postgres_3/Doobie_postgres_3Test.scala
+++ b/tests/src/org.tpolecat/doobie-postgres_3/0.13.4/src/test/scala/org_tpolecat/doobie_postgres_3/Doobie_postgres_3Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_tpolecat.doobie_postgres_3
+
+import org.junit.jupiter.api.Test
+
+class Doobie_postgres_3Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/org.tpolecat/doobie-postgres_3/0.13.4/src/test/scala/org_tpolecat/doobie_postgres_3/Doobie_postgres_3Test.scala
+++ b/tests/src/org.tpolecat/doobie-postgres_3/0.13.4/src/test/scala/org_tpolecat/doobie_postgres_3/Doobie_postgres_3Test.scala
@@ -6,11 +6,374 @@
  */
 package org_tpolecat.doobie_postgres_3
 
+import cats.Id
+import cats.catsInstancesForId
+import cats.~>
+import doobie.Meta
+import doobie.enumerated.SqlState
+import doobie.postgres.Text
+import doobie.postgres.free.Embedded
+import doobie.postgres.free.copyin
+import doobie.postgres.free.copyin.CopyInOp
+import doobie.postgres.free.copymanager
+import doobie.postgres.free.copymanager.CopyManagerOp
+import doobie.postgres.free.copyout
+import doobie.postgres.free.copyout.CopyOutOp
+import doobie.postgres.free.largeobject
+import doobie.postgres.free.largeobject.LargeObjectOp
+import doobie.postgres.free.largeobjectmanager
+import doobie.postgres.free.largeobjectmanager.LargeObjectManagerOp
+import doobie.postgres.free.pgconnection
+import doobie.postgres.free.pgconnection.PGConnectionOp
+import doobie.postgres.implicits._
+import doobie.postgres.sqlstate
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
+import org.postgresql.copy.CopyManager
+import org.postgresql.jdbc.AutoSave
+import org.postgresql.jdbc.PreferQueryMode
+import org.postgresql.largeobject.LargeObject
+import org.postgresql.largeobject.LargeObjectManager
+import org.postgresql.geometric.PGpoint
+import org.postgresql.util.PGInterval
+import org.postgresql.util.PGobject
+
+import java.io.Reader
+import java.io.StringReader
+import java.net.InetAddress
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.OffsetDateTime
+import java.time.ZonedDateTime
+import java.util.UUID
+import scala.collection.mutable.ArrayBuffer
 
 class Doobie_postgres_3Test {
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
+  def textEncodersRenderPostgresCopyLiterals(): Unit = {
+    assertEquals("plain", Text[String].encode("plain"))
+    assertEquals("line\\tbreak\\nslash\\\\", Text[String].encode("line\tbreak\nslash\\"))
+    assertEquals("\\N", Text[Option[String]].encode(None))
+    assertEquals("value", Text[Option[String]].encode(Some("value")))
+    assertEquals("42\talpha\\tbeta", Text[Int].product(Text[String]).encode((42, "alpha\tbeta")))
+    assertEquals("\\\\x00012aff", Text[Array[Byte]].encode(Array[Byte](0, 1, 42, -1)))
+    assertEquals("{1,2,3}", Text[List[Int]].encode(List(1, 2, 3)))
+    assertEquals("{\"alpha\",\"beta\"}", Text[List[String]].encode(List("alpha", "beta")))
+  }
+
+  @Test
+  def postgresImplicitMetaInstancesCoverNativeJdbcTypes(): Unit = {
+    assertNotNull(summon[Meta[UUID]])
+    assertNotNull(summon[Meta[InetAddress]])
+    assertNotNull(summon[Meta[PGInterval]])
+    assertNotNull(summon[Meta[PGpoint]])
+    assertNotNull(summon[Meta[java.util.Map[String, String]]])
+    assertNotNull(summon[Meta[Map[String, String]]])
+    assertNotNull(summon[Meta[Array[Int]]])
+    assertNotNull(summon[Meta[Array[Option[Int]]]])
+    assertNotNull(summon[Meta[Array[String]]])
+    assertNotNull(summon[Meta[Array[Option[String]]]])
+    assertNotNull(summon[Meta[Instant]])
+    assertNotNull(summon[Meta[OffsetDateTime]])
+    assertNotNull(summon[Meta[ZonedDateTime]])
+    assertNotNull(summon[Meta[LocalDateTime]])
+    assertNotNull(summon[Meta[LocalDate]])
+    assertNotNull(summon[Meta[LocalTime]])
+  }
+
+  @Test
+  def sqlStateConstantsExposePostgresErrorClasses(): Unit = {
+    assertEquals(SqlState("00000"), sqlstate.class00.SUCCESSFUL_COMPLETION)
+    assertEquals(SqlState("23505"), sqlstate.class23.UNIQUE_VIOLATION)
+    assertEquals(SqlState("23503"), sqlstate.class23.FOREIGN_KEY_VIOLATION)
+    assertEquals(SqlState("40001"), sqlstate.class40.SERIALIZATION_FAILURE)
+    assertEquals(SqlState("42P01"), sqlstate.class42.UNDEFINED_TABLE)
+    assertEquals("23505", sqlstate.class23.UNIQUE_VIOLATION.value)
+  }
+
+  @Test
+  def pgConnectionAlgebraSupportsDriverOperationsAndEmbeddedCopyManagerPrograms(): Unit = {
+    val events: ArrayBuffer[String] = ArrayBuffer.empty[String]
+    val copyManagerTarget: CopyManager = null.asInstanceOf[CopyManager]
+
+    val copyManagerInterpreter: CopyManagerOp ~> Id = new (CopyManagerOp ~> Id) {
+      override def apply[A](operation: CopyManagerOp[A]): Id[A] = operation match {
+        case CopyManagerOp.CopyIn4(sql, reader) =>
+          events += s"copyManager.copyIn:$sql:${readAll(reader)}"
+          2L.asInstanceOf[A]
+        case CopyManagerOp.CopyOut2(sql, writer) =>
+          writer.write("id\tname\n1\tAda\n")
+          events += s"copyManager.copyOut:$sql"
+          1L.asInstanceOf[A]
+        case other => fail(s"Unexpected copy manager operation: $other")
+      }
+    }
+
+    val pgConnectionInterpreter: PGConnectionOp ~> Id = new (PGConnectionOp ~> Id) {
+      override def apply[A](operation: PGConnectionOp[A]): Id[A] = operation match {
+        case PGConnectionOp.AddDataType(name, clazz) =>
+          assertSame(classOf[PGobject], clazz)
+          events += s"pg.addDataType:$name"
+          ().asInstanceOf[A]
+        case PGConnectionOp.SetAutosave(value) =>
+          events += s"pg.setAutosave:$value"
+          ().asInstanceOf[A]
+        case PGConnectionOp.SetDefaultFetchSize(value) =>
+          events += s"pg.setDefaultFetchSize:$value"
+          ().asInstanceOf[A]
+        case PGConnectionOp.SetPrepareThreshold(value) =>
+          events += s"pg.setPrepareThreshold:$value"
+          ().asInstanceOf[A]
+        case PGConnectionOp.GetAutosave => AutoSave.ALWAYS.asInstanceOf[A]
+        case PGConnectionOp.GetBackendPID => 12345.asInstanceOf[A]
+        case PGConnectionOp.GetDefaultFetchSize => 128.asInstanceOf[A]
+        case PGConnectionOp.GetParameterStatus(name) => s"status:$name".asInstanceOf[A]
+        case PGConnectionOp.GetPreferQueryMode => PreferQueryMode.SIMPLE.asInstanceOf[A]
+        case PGConnectionOp.GetPrepareThreshold => 5.asInstanceOf[A]
+        case PGConnectionOp.EscapeIdentifier(identifier) => s"\"${identifier.replace("\"", "\"\"")}\"".asInstanceOf[A]
+        case PGConnectionOp.EscapeLiteral(literal) => s"'${literal.replace("'", "''")}'".asInstanceOf[A]
+        case PGConnectionOp.Embed(Embedded.CopyManager(target, program)) =>
+          assertSame(copyManagerTarget, target)
+          program.foldMap(copyManagerInterpreter).asInstanceOf[A]
+        case other => fail(s"Unexpected PG connection operation: $other")
+      }
+    }
+
+    val out = new java.io.StringWriter
+    val program: pgconnection.PGConnectionIO[(AutoSave, Int, Int, String, PreferQueryMode, Int, String, String, Long, Long)] =
+      for {
+        _ <- pgconnection.addDataType("custom_json", classOf[PGobject])
+        _ <- pgconnection.setAutosave(AutoSave.ALWAYS)
+        _ <- pgconnection.setDefaultFetchSize(128)
+        _ <- pgconnection.setPrepareThreshold(5)
+        autosave <- pgconnection.getAutosave
+        backendPid <- pgconnection.getBackendPID
+        fetchSize <- pgconnection.getDefaultFetchSize
+        parameterStatus <- pgconnection.getParameterStatus("server_version")
+        queryMode <- pgconnection.getPreferQueryMode
+        threshold <- pgconnection.getPrepareThreshold
+        escapedIdentifier <- pgconnection.escapeIdentifier("account\"name")
+        escapedLiteral <- pgconnection.escapeLiteral("Ada's account")
+        copiedIn <- pgconnection.embed(copyManagerTarget, copymanager.copyIn("COPY accounts FROM STDIN", new StringReader("1\tAda\n")))
+        copiedOut <- pgconnection.embed(copyManagerTarget, copymanager.copyOut("COPY accounts TO STDOUT", out))
+      } yield (autosave, backendPid, fetchSize, parameterStatus, queryMode, threshold, escapedIdentifier, escapedLiteral, copiedIn, copiedOut)
+
+    val result = program.foldMap(pgConnectionInterpreter)
+
+    assertEquals(AutoSave.ALWAYS, result._1)
+    assertEquals(12345, result._2)
+    assertEquals(128, result._3)
+    assertEquals("status:server_version", result._4)
+    assertEquals(PreferQueryMode.SIMPLE, result._5)
+    assertEquals(5, result._6)
+    assertEquals("\"account\"\"name\"", result._7)
+    assertEquals("'Ada''s account'", result._8)
+    assertEquals(2L, result._9)
+    assertEquals(1L, result._10)
+    assertEquals("id\tname\n1\tAda\n", out.toString)
+    assertEquals(
+      Seq(
+        "pg.addDataType:custom_json",
+        "pg.setAutosave:ALWAYS",
+        "pg.setDefaultFetchSize:128",
+        "pg.setPrepareThreshold:5",
+        "copyManager.copyIn:COPY accounts FROM STDIN:1\tAda\n",
+        "copyManager.copyOut:COPY accounts TO STDOUT"
+      ),
+      events.toSeq
+    )
+  }
+
+  @Test
+  def copyInAndCopyOutAlgebrasDescribeStreamingCopyProtocol(): Unit = {
+    val copyInEvents: ArrayBuffer[String] = ArrayBuffer.empty[String]
+    val copyInInterpreter: CopyInOp ~> Id = new (CopyInOp ~> Id) {
+      override def apply[A](operation: CopyInOp[A]): Id[A] = operation match {
+        case CopyInOp.WriteToCopy(bytes, offset, length) =>
+          copyInEvents += s"write:${new String(bytes.slice(offset, offset + length), java.nio.charset.StandardCharsets.UTF_8)}"
+          ().asInstanceOf[A]
+        case CopyInOp.FlushCopy =>
+          copyInEvents += "flush"
+          ().asInstanceOf[A]
+        case CopyInOp.GetFieldCount => 2.asInstanceOf[A]
+        case CopyInOp.GetFieldFormat(index) =>
+          copyInEvents += s"fieldFormat:$index"
+          0.asInstanceOf[A]
+        case CopyInOp.GetFormat => 0.asInstanceOf[A]
+        case CopyInOp.GetHandledRowCount => 1L.asInstanceOf[A]
+        case CopyInOp.IsActive => true.asInstanceOf[A]
+        case CopyInOp.EndCopy =>
+          copyInEvents += "end"
+          1L.asInstanceOf[A]
+        case other => fail(s"Unexpected copy-in operation: $other")
+      }
+    }
+
+    val copyInBytes: Array[Byte] = "1\tAda\n".getBytes(java.nio.charset.StandardCharsets.UTF_8)
+    val copyInProgram: copyin.CopyInIO[(Int, Int, Int, Long, Boolean, Long)] =
+      for {
+        _ <- copyin.writeToCopy(copyInBytes, 0, copyInBytes.length)
+        _ <- copyin.flushCopy
+        fields <- copyin.getFieldCount
+        fieldFormat <- copyin.getFieldFormat(0)
+        format <- copyin.getFormat
+        handledBeforeEnd <- copyin.getHandledRowCount
+        active <- copyin.isActive
+        ended <- copyin.endCopy
+      } yield (fields, fieldFormat, format, handledBeforeEnd, active, ended)
+
+    val copyInResult = copyInProgram.foldMap(copyInInterpreter)
+
+    assertEquals((2, 0, 0, 1L, true, 1L), copyInResult)
+    assertEquals(Seq("write:1\tAda\n", "flush", "fieldFormat:0", "end"), copyInEvents.toSeq)
+
+    val copyOutEvents: ArrayBuffer[String] = ArrayBuffer.empty[String]
+    val copyOutInterpreter: CopyOutOp ~> Id = new (CopyOutOp ~> Id) {
+      override def apply[A](operation: CopyOutOp[A]): Id[A] = operation match {
+        case CopyOutOp.ReadFromCopy1(block) =>
+          copyOutEvents += s"read:$block"
+          "2\tGrace\n".getBytes(java.nio.charset.StandardCharsets.UTF_8).asInstanceOf[A]
+        case CopyOutOp.GetFieldCount => 2.asInstanceOf[A]
+        case CopyOutOp.GetFieldFormat(index) =>
+          copyOutEvents += s"fieldFormat:$index"
+          0.asInstanceOf[A]
+        case CopyOutOp.GetFormat => 0.asInstanceOf[A]
+        case CopyOutOp.GetHandledRowCount => 1L.asInstanceOf[A]
+        case CopyOutOp.IsActive => false.asInstanceOf[A]
+        case CopyOutOp.CancelCopy =>
+          copyOutEvents += "cancel"
+          ().asInstanceOf[A]
+        case other => fail(s"Unexpected copy-out operation: $other")
+      }
+    }
+
+    val copyOutProgram: copyout.CopyOutIO[(Array[Byte], Int, Int, Int, Long, Boolean)] =
+      for {
+        bytes <- copyout.readFromCopy(false)
+        fields <- copyout.getFieldCount
+        fieldFormat <- copyout.getFieldFormat(1)
+        format <- copyout.getFormat
+        handled <- copyout.getHandledRowCount
+        active <- copyout.isActive
+        _ <- copyout.cancelCopy
+      } yield (bytes, fields, fieldFormat, format, handled, active)
+
+    val copyOutResult = copyOutProgram.foldMap(copyOutInterpreter)
+
+    assertArrayEquals("2\tGrace\n".getBytes(java.nio.charset.StandardCharsets.UTF_8), copyOutResult._1)
+    assertEquals(2, copyOutResult._2)
+    assertEquals(0, copyOutResult._3)
+    assertEquals(0, copyOutResult._4)
+    assertEquals(1L, copyOutResult._5)
+    assertFalse(copyOutResult._6)
+    assertEquals(Seq("read:false", "fieldFormat:1", "cancel"), copyOutEvents.toSeq)
+  }
+
+  @Test
+  def largeObjectAlgebrasDescribeManagerAndObjectOperations(): Unit = {
+    val events: ArrayBuffer[String] = ArrayBuffer.empty[String]
+    val largeObjectTarget: LargeObject = null.asInstanceOf[LargeObject]
+
+    val largeObjectInterpreter: LargeObjectOp ~> Id = new (LargeObjectOp ~> Id) {
+      override def apply[A](operation: LargeObjectOp[A]): Id[A] = operation match {
+        case LargeObjectOp.GetLongOID => 9001L.asInstanceOf[A]
+        case LargeObjectOp.Write1(bytes, offset, length) =>
+          events += s"largeObject.write:${bytes.slice(offset, offset + length).mkString(",")}"
+          ().asInstanceOf[A]
+        case LargeObjectOp.Seek64(position, reference) =>
+          events += s"largeObject.seek64:$position:$reference"
+          ().asInstanceOf[A]
+        case LargeObjectOp.Read1(length) =>
+          events += s"largeObject.read:$length"
+          Array[Byte](10, 20, 30).asInstanceOf[A]
+        case LargeObjectOp.Size64 => 4096L.asInstanceOf[A]
+        case LargeObjectOp.Tell64 => 3L.asInstanceOf[A]
+        case LargeObjectOp.Truncate64(length) =>
+          events += s"largeObject.truncate64:$length"
+          ().asInstanceOf[A]
+        case LargeObjectOp.Close =>
+          events += "largeObject.close"
+          ().asInstanceOf[A]
+        case other => fail(s"Unexpected large object operation: $other")
+      }
+    }
+
+    val managerInterpreter: LargeObjectManagerOp ~> Id = new (LargeObjectManagerOp ~> Id) {
+      override def apply[A](operation: LargeObjectManagerOp[A]): Id[A] = operation match {
+        case LargeObjectManagerOp.CreateLO1(mode) =>
+          events += s"manager.createLO:$mode"
+          9001L.asInstanceOf[A]
+        case LargeObjectManagerOp.Open5(oid, mode, commitOnClose) =>
+          events += s"manager.open:$oid:$mode:$commitOnClose"
+          largeObjectTarget.asInstanceOf[A]
+        case LargeObjectManagerOp.Embed(Embedded.LargeObject(target, program)) =>
+          assertSame(largeObjectTarget, target)
+          program.foldMap(largeObjectInterpreter).asInstanceOf[A]
+        case LargeObjectManagerOp.Unlink(oid) =>
+          events += s"manager.unlink:$oid"
+          ().asInstanceOf[A]
+        case other => fail(s"Unexpected large object manager operation: $other")
+      }
+    }
+
+    val bytesToWrite: Array[Byte] = Array[Byte](1, 2, 3, 4)
+    val largeObjectProgram: largeobject.LargeObjectIO[(Long, Array[Byte], Long, Long)] =
+      for {
+        oid <- largeobject.getLongOID
+        _ <- largeobject.write(bytesToWrite, 1, 2)
+        _ <- largeobject.seek64(0L, 0)
+        readBytes <- largeobject.read(3)
+        size <- largeobject.size64
+        position <- largeobject.tell64
+        _ <- largeobject.truncate64(1024L)
+        _ <- largeobject.close
+      } yield (oid, readBytes, size, position)
+
+    val managerProgram: largeobjectmanager.LargeObjectManagerIO[(Long, Long, Array[Byte], Long, Long)] =
+      for {
+        oid <- largeobjectmanager.createLO(LargeObjectManager.WRITE)
+        opened <- largeobjectmanager.open(oid, LargeObjectManager.READ | LargeObjectManager.WRITE, true)
+        largeObjectResult <- largeobjectmanager.embed(opened, largeObjectProgram)
+        _ <- largeobjectmanager.unlink(oid)
+      } yield (oid, largeObjectResult._1, largeObjectResult._2, largeObjectResult._3, largeObjectResult._4)
+
+    val result = managerProgram.foldMap(managerInterpreter)
+
+    assertEquals(9001L, result._1)
+    assertEquals(9001L, result._2)
+    assertArrayEquals(Array[Byte](10, 20, 30), result._3)
+    assertEquals(4096L, result._4)
+    assertEquals(3L, result._5)
+    assertEquals(
+      Seq(
+        s"manager.createLO:${LargeObjectManager.WRITE}",
+        s"manager.open:9001:${LargeObjectManager.READ | LargeObjectManager.WRITE}:true",
+        "largeObject.write:2,3",
+        "largeObject.seek64:0:0",
+        "largeObject.read:3",
+        "largeObject.truncate64:1024",
+        "largeObject.close",
+        "manager.unlink:9001"
+      ),
+      events.toSeq
+    )
+  }
+
+  private def readAll(reader: Reader): String = {
+    val builder: StringBuilder = new StringBuilder
+    val buffer: Array[Char] = new Array[Char](128)
+    var read: Int = reader.read(buffer)
+    while (read != -1) {
+      builder.append(new String(buffer, 0, read))
+      read = reader.read(buffer)
+    }
+    builder.toString
   }
 }

--- a/tests/src/org.tpolecat/doobie-postgres_3/0.13.4/src/test/scala/org_tpolecat/doobie_postgres_3/Doobie_postgres_3Test.scala
+++ b/tests/src/org.tpolecat/doobie-postgres_3/0.13.4/src/test/scala/org_tpolecat/doobie_postgres_3/Doobie_postgres_3Test.scala
@@ -8,6 +8,7 @@ package org_tpolecat.doobie_postgres_3
 
 import cats.Id
 import cats.catsInstancesForId
+import cats.instances.either._
 import cats.~>
 import doobie.Meta
 import doobie.enumerated.SqlState
@@ -46,6 +47,7 @@ import org.postgresql.util.PGobject
 import java.io.Reader
 import java.io.StringReader
 import java.net.InetAddress
+import java.sql.SQLException
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -96,6 +98,30 @@ class Doobie_postgres_3Test {
     assertEquals(SqlState("40001"), sqlstate.class40.SERIALIZATION_FAILURE)
     assertEquals(SqlState("42P01"), sqlstate.class42.UNDEFINED_TABLE)
     assertEquals("23505", sqlstate.class23.UNIQUE_VIOLATION.value)
+  }
+
+  @Test
+  def postgresMonadErrorSyntaxRecoversSpecificSqlStates(): Unit = {
+    type Result[A] = Either[Throwable, A]
+
+    val duplicateKey: SQLException = new SQLException("duplicate key", sqlstate.class23.UNIQUE_VIOLATION.value)
+    val recoveredUniqueViolation: Result[String] =
+      (Left(duplicateKey): Result[String]).onUniqueViolation(Right("insert ignored"))
+    assertEquals(Right("insert ignored"), recoveredUniqueViolation)
+
+    val serializationFailure: SQLException =
+      new SQLException("serialization failure", sqlstate.class40.SERIALIZATION_FAILURE.value)
+    val recoveredSerializationFailure: Result[String] =
+      (Left(serializationFailure): Result[String]).onSerializationFailure(Right("retry transaction"))
+    assertEquals(Right("retry transaction"), recoveredSerializationFailure)
+
+    val undefinedTable: SQLException = new SQLException("undefined table", sqlstate.class42.UNDEFINED_TABLE.value)
+    val notRecoveredByUniqueViolationHandler: Result[String] =
+      (Left(undefinedTable): Result[String]).onUniqueViolation(Right("not used"))
+    notRecoveredByUniqueViolationHandler match {
+      case Left(error) => assertSame(undefinedTable, error)
+      case Right(value) => fail(s"Unexpected recovery for a different SQL state: $value")
+    }
   }
 
   @Test

--- a/tests/src/org.tpolecat/doobie-postgres_3/0.13.4/src/test/scala/org_tpolecat/doobie_postgres_3/Doobie_postgres_3Test.scala
+++ b/tests/src/org.tpolecat/doobie-postgres_3/0.13.4/src/test/scala/org_tpolecat/doobie_postgres_3/Doobie_postgres_3Test.scala
@@ -26,6 +26,7 @@ import doobie.postgres.free.largeobjectmanager
 import doobie.postgres.free.largeobjectmanager.LargeObjectManagerOp
 import doobie.postgres.free.pgconnection
 import doobie.postgres.free.pgconnection.PGConnectionOp
+import doobie.postgres.hi.{pgconnection => hiPgConnection}
 import doobie.postgres.implicits._
 import doobie.postgres.sqlstate
 import org.junit.jupiter.api.Assertions.assertArrayEquals
@@ -35,6 +36,7 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
+import org.postgresql.PGNotification
 import org.postgresql.copy.CopyManager
 import org.postgresql.jdbc.AutoSave
 import org.postgresql.jdbc.PreferQueryMode
@@ -218,6 +220,32 @@ class Doobie_postgres_3Test {
   }
 
   @Test
+  def highLevelPgConnectionNotificationsConvertDriverArraysToScalaLists(): Unit = {
+    val firstNotification: PGNotification = notification("account_events", "created", 101)
+    val secondNotification: PGNotification = notification("account_events", "updated", 102)
+
+    val arrayInterpreter: PGConnectionOp ~> Id = new (PGConnectionOp ~> Id) {
+      override def apply[A](operation: PGConnectionOp[A]): Id[A] = operation match {
+        case PGConnectionOp.GetNotifications => Array(firstNotification, secondNotification).asInstanceOf[A]
+        case other => fail(s"Unexpected PG connection operation: $other")
+      }
+    }
+
+    val emptyInterpreter: PGConnectionOp ~> Id = new (PGConnectionOp ~> Id) {
+      override def apply[A](operation: PGConnectionOp[A]): Id[A] = operation match {
+        case PGConnectionOp.GetNotifications => null.asInstanceOf[Array[PGNotification]].asInstanceOf[A]
+        case other => fail(s"Unexpected PG connection operation: $other")
+      }
+    }
+
+    assertEquals(
+      List(firstNotification, secondNotification),
+      hiPgConnection.getNotifications.foldMap(arrayInterpreter)
+    )
+    assertEquals(Nil, hiPgConnection.getNotifications.foldMap(emptyInterpreter))
+  }
+
+  @Test
   def copyInAndCopyOutAlgebrasDescribeStreamingCopyProtocol(): Unit = {
     val copyInEvents: ArrayBuffer[String] = ArrayBuffer.empty[String]
     val copyInInterpreter: CopyInOp ~> Id = new (CopyInOp ~> Id) {
@@ -390,6 +418,14 @@ class Doobie_postgres_3Test {
       ),
       events.toSeq
     )
+  }
+
+  private def notification(name: String, parameter: String, processId: Int): PGNotification = new PGNotification {
+    override def getName: String = name
+
+    override def getParameter: String = parameter
+
+    override def getPID: Int = processId
   }
 
   private def readAll(reader: Reader): String = {

--- a/tests/src/org.tpolecat/doobie-postgres_3/0.13.4/user-code-filter.json
+++ b/tests/src/org.tpolecat/doobie-postgres_3/0.13.4/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "doobie.postgres.**"
+      "includeClasses" : "doobie.postgres.**"
+    },
+    {
+      "includeClasses" : "org_tpolecat.doobie_postgres_3.**"
     }
   ]
 }

--- a/tests/src/org.tpolecat/doobie-postgres_3/0.13.4/user-code-filter.json
+++ b/tests/src/org.tpolecat/doobie-postgres_3/0.13.4/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "doobie.postgres.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #5341

This PR introduces tests and metadata for org.tpolecat:doobie-postgres_3:0.13.4, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 309468
- Cached input tokens: 3613184
- Output tokens: 21945
- Metadata entries: 42
- Iterations: 4
- Library coverage percentage: 24.98
- Generated lines of code: 403
- Tested library lines of code: 372

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `83ba2cf16ef635fa123f2ed2fc9596a6a05ca131`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 3465/45764 (7.57%)
- Line: 372/1489 (24.98%)
- Method: 519/5458 (9.51%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
