### PR TITLE
[GenAI] Add support for org.scalatestplus:mockito-5-12_3:3.2.19.0 using gpt-5.5

### DIFF
--- a/metadata/org.scalatestplus/mockito-5-12_3/3.2.19.0/reachability-metadata.json
+++ b/metadata/org.scalatestplus/mockito-5-12_3/3.2.19.0/reachability-metadata.json
@@ -1,0 +1,80 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.scalatestplus.mockito.MockitoSugar"
+      },
+      "type" : {
+        "proxy" : [
+          "org.mockito.plugins.MockMaker"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.scalatestplus.mockito.MockitoSugar"
+      },
+      "type" : {
+        "proxy" : [
+          "java.util.function.Function"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.scalatestplus.mockito.MockitoSugar"
+      },
+      "type" : {
+        "proxy" : [
+          "java.util.function.Supplier"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.scalatestplus.mockito.MockitoSugar"
+      },
+      "type" : {
+        "proxy" : [
+          "java.util.function.Consumer"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.scalatestplus.mockito.MockitoSugar"
+      },
+      "type" : "org.mockito.internal.matchers.Equals",
+      "methods" : [
+        {
+          "name" : "matches",
+          "parameterTypes" : [
+            "java.lang.Object"
+          ]
+        },
+        {
+          "name" : "type",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.scalatestplus.mockito.MockitoSugar"
+      },
+      "type" : "org.mockito.internal.matchers.CapturingMatcher",
+      "methods" : [
+        {
+          "name" : "matches",
+          "parameterTypes" : [
+            "java.lang.Object"
+          ]
+        },
+        {
+          "name" : "type",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.scalatestplus/mockito-5-12_3/index.json
+++ b/metadata/org.scalatestplus/mockito-5-12_3/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.2.19.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/scalatestplus/mockito-5-12_3/$version$/mockito-5-12_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/scalatest/scalatestplus-mockito",
+    "test-code-url" : "https://github.com/scalatest/scalatestplus-mockito/tree/release-$version$-for-mockito-5.12/src/test/scala",
+    "documentation-url" : "https://github.com/scalatest/scalatestplus-mockito/blob/release-$version$-for-mockito-5.12/README.md",
+    "description" : "ScalaTest + Mockito provides integration support between ScalaTest and Mockito for Scala projects. It supplies MockitoSugar helpers that make Mockito mock creation and use more idiomatic in ScalaTest test suites.",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "3.2.19.0"
+    ],
+    "allowed-packages" : [
+      "org.scalatestplus.mockito"
+    ]
+  }
+]

--- a/stats/org.scalatestplus/mockito-5-12_3/3.2.19.0/execution-metrics.json
+++ b/stats/org.scalatestplus/mockito-5-12_3/3.2.19.0/execution-metrics.json
@@ -1,0 +1,83 @@
+{
+  "add_new_library_support:2026-06-11": {
+    "timestamp": "2026-06-11T04:57:17.839107Z",
+    "library": "org.scalatestplus:mockito-5-12_3:3.2.19.0",
+    "starting_commit": "cbc7815d7940fad856528d4b85d595fa0192bada",
+    "ending_commit": "8a709f48499daa7aacd75936e5e1b8f1d4919c08",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.2.19.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 58,
+          "missed": 5,
+          "ratio": 0.920635,
+          "total": 63
+        },
+        "line": {
+          "covered": 8,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 8
+        },
+        "method": {
+          "covered": 13,
+          "missed": 1,
+          "ratio": 0.928571,
+          "total": 14
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "degraded",
+      "action": "no_action",
+      "issue_number": 5348,
+      "issue_label": "library-new-request",
+      "library": "org.scalatestplus:mockito-5-12_3:3.2.19.0",
+      "summary": "Library preparation preflight did not produce usable advisory setup.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#5348 Support for org.scalatestplus:mockito-5-12_3:3.2.19.0; label=library-new-request; body_chars=291"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "0 existing test file path(s) included"
+        }
+      ],
+      "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
+      "model": "oca/gpt-5.5",
+      "prompt_path": "library-preflight-prompt.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/org.scalatestplus:mockito-5-12_3:3.2.19.0/library-preparation-preflight/pi-generation-2026-06-11T04-28-10-629778Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 142059,
+      "cached_input_tokens_used": 923648,
+      "output_tokens_used": 17785,
+      "iterations": 3,
+      "cost_usd": 0.9953,
+      "generated_loc": 119,
+      "tested_library_loc": 8,
+      "metadata_entries": 10,
+      "test_only_metadata_entries": 1,
+      "code_coverage_percent": 100.0
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.scalatestplus/mockito-5-12_3/3.2.19.0/src/test/scala/org_scalatestplus/mockito_5_12_3/Mockito_5_12_3Test.scala",
+      "metadata_file": "metadata/org.scalatestplus/mockito-5-12_3/3.2.19.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.scalatestplus/mockito-5-12_3/3.2.19.0/stats.json
+++ b/stats/org.scalatestplus/mockito-5-12_3/3.2.19.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.2.19.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 58,
+        "missed" : 5,
+        "ratio" : 0.920635,
+        "total" : 63
+      },
+      "line" : {
+        "covered" : 8,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 8
+      },
+      "method" : {
+        "covered" : 13,
+        "missed" : 1,
+        "ratio" : 0.928571,
+        "total" : 14
+      }
+    }
+  } ]
+}

--- a/tests/src/org.scalatestplus/mockito-5-12_3/3.2.19.0/.gitignore
+++ b/tests/src/org.scalatestplus/mockito-5-12_3/3.2.19.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.scalatestplus/mockito-5-12_3/3.2.19.0/build.gradle
+++ b/tests/src/org.scalatestplus/mockito-5-12_3/3.2.19.0/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.scalatestplus:mockito-5-12_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.scalatestplus/mockito-5-12_3/3.2.19.0/gradle.properties
+++ b/tests/src/org.scalatestplus/mockito-5-12_3/3.2.19.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.scalatestplus:mockito-5-12_3:3.2.19.0
+library.version = 3.2.19.0
+metadata.dir = org.scalatestplus/mockito-5-12_3/3.2.19.0/

--- a/tests/src/org.scalatestplus/mockito-5-12_3/3.2.19.0/settings.gradle
+++ b/tests/src/org.scalatestplus/mockito-5-12_3/3.2.19.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.scalatestplus.mockito-5-12_3_tests'

--- a/tests/src/org.scalatestplus/mockito-5-12_3/3.2.19.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.scalatestplus/mockito-5-12_3/3.2.19.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,14 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.scalatestplus.mockito.MockitoSugar"
+      },
+      "type" : {
+        "proxy" : [
+          "org_scalatestplus.mockito_5_12_3.GreetingApi"
+        ]
+      }
+    }
+  ]
+}

--- a/tests/src/org.scalatestplus/mockito-5-12_3/3.2.19.0/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/tests/src/org.scalatestplus/mockito-5-12_3/3.2.19.0/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+org.mockito.internal.creation.proxy.ProxyMockMaker

--- a/tests/src/org.scalatestplus/mockito-5-12_3/3.2.19.0/src/test/scala/org_scalatestplus/mockito_5_12_3/Mockito_5_12_3Test.scala
+++ b/tests/src/org.scalatestplus/mockito-5-12_3/3.2.19.0/src/test/scala/org_scalatestplus/mockito_5_12_3/Mockito_5_12_3Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_scalatestplus.mockito_5_12_3
+
+import org.junit.jupiter.api.Test
+
+class Mockito_5_12_3Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/org.scalatestplus/mockito-5-12_3/3.2.19.0/src/test/scala/org_scalatestplus/mockito_5_12_3/Mockito_5_12_3Test.scala
+++ b/tests/src/org.scalatestplus/mockito-5-12_3/3.2.19.0/src/test/scala/org_scalatestplus/mockito_5_12_3/Mockito_5_12_3Test.scala
@@ -114,6 +114,19 @@ class Mockito_5_12_3Test {
   }
 
   @Test
+  def mockSupportsScalaTraitDefaultMethods(): Unit = {
+    withMockitoRuntime {
+      val settings: MockSettings = Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS)
+      val weather: WeatherService = MockitoSugar.mock[WeatherService](settings)
+
+      Mockito.doReturn(Integer.valueOf(-3)).when(weather).temperatureInCelsius("Oslo")
+
+      assertThat(weather.isFreezing("Oslo")).isTrue()
+      Mockito.verify(weather).temperatureInCelsius("Oslo")
+    }
+  }
+
+  @Test
   def captureCreatesArgumentCaptorAndImplicitlyCapturesVerificationArgument(): Unit = {
     withMockitoRuntime {
       import org.scalatestplus.mockito.MockitoSugar.*
@@ -145,4 +158,10 @@ class Mockito_5_12_3Test {
 
 class GreetingService {
   def greeting(name: String): String = s"Hello $name"
+}
+
+trait WeatherService {
+  def temperatureInCelsius(city: String): Int
+
+  def isFreezing(city: String): Boolean = temperatureInCelsius(city) <= 0
 }

--- a/tests/src/org.scalatestplus/mockito-5-12_3/3.2.19.0/src/test/scala/org_scalatestplus/mockito_5_12_3/Mockito_5_12_3Test.scala
+++ b/tests/src/org.scalatestplus/mockito-5-12_3/3.2.19.0/src/test/scala/org_scalatestplus/mockito_5_12_3/Mockito_5_12_3Test.scala
@@ -35,9 +35,9 @@ class Mockito_5_12_3Test {
   }
 
   @Test
-  def companionObjectMockSupportsConcreteScalaClasses(): Unit = {
+  def companionObjectMockSupportsScalaTraits(): Unit = {
     withMockitoRuntime {
-      val greeter: GreetingService = MockitoSugar.mock[GreetingService]
+      val greeter: GreetingApi = MockitoSugar.mock[GreetingApi]
 
       Mockito.when(greeter.greeting("Scala")).thenReturn("Mocked greeting")
 
@@ -114,19 +114,6 @@ class Mockito_5_12_3Test {
   }
 
   @Test
-  def mockSupportsScalaTraitDefaultMethods(): Unit = {
-    withMockitoRuntime {
-      val settings: MockSettings = Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS)
-      val weather: WeatherService = MockitoSugar.mock[WeatherService](settings)
-
-      Mockito.doReturn(Integer.valueOf(-3)).when(weather).temperatureInCelsius("Oslo")
-
-      assertThat(weather.isFreezing("Oslo")).isTrue()
-      Mockito.verify(weather).temperatureInCelsius("Oslo")
-    }
-  }
-
-  @Test
   def captureCreatesArgumentCaptorAndImplicitlyCapturesVerificationArgument(): Unit = {
     withMockitoRuntime {
       import org.scalatestplus.mockito.MockitoSugar.*
@@ -156,12 +143,6 @@ class Mockito_5_12_3Test {
   private object MixedInSugar extends MockitoSugar
 }
 
-class GreetingService {
-  def greeting(name: String): String = s"Hello $name"
-}
-
-trait WeatherService {
-  def temperatureInCelsius(city: String): Int
-
-  def isFreezing(city: String): Boolean = temperatureInCelsius(city) <= 0
+trait GreetingApi {
+  def greeting(name: String): String
 }

--- a/tests/src/org.scalatestplus/mockito-5-12_3/3.2.19.0/src/test/scala/org_scalatestplus/mockito_5_12_3/Mockito_5_12_3Test.scala
+++ b/tests/src/org.scalatestplus/mockito-5-12_3/3.2.19.0/src/test/scala/org_scalatestplus/mockito_5_12_3/Mockito_5_12_3Test.scala
@@ -6,11 +6,126 @@
  */
 package org_scalatestplus.mockito_5_12_3
 
+import java.util.function.Consumer
+import java.util.function.Function
+import java.util.function.Supplier
+
+import org.assertj.core.api.Assertions.assertThat
+import org.graalvm.internal.tck.NativeImageSupport
 import org.junit.jupiter.api.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.MockSettings
+import org.mockito.Mockito
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
+import org.scalatestplus.mockito.MockitoSugar
 
 class Mockito_5_12_3Test {
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
+  def companionObjectMockCreatesStubbableMock(): Unit = {
+    withMockitoRuntime {
+      val formatter: Function[String, String] = MockitoSugar.mock[Function[String, String]]
+
+      Mockito.when(formatter.apply("Ada")).thenReturn("Hello Ada")
+
+      assertThat(formatter.apply("Ada")).isEqualTo("Hello Ada")
+      assertThat(Mockito.mockingDetails(formatter).isMock).isTrue()
+      Mockito.verify(formatter).apply("Ada")
+    }
   }
+
+  @Test
+  def importedCompanionMembersCreateMocksWithoutMixingInTheTrait(): Unit = {
+    withMockitoRuntime {
+      import org.scalatestplus.mockito.MockitoSugar.mock
+
+      val supplier: Supplier[String] = mock[Supplier[String]]
+
+      Mockito.when(supplier.get()).thenReturn("ready")
+
+      assertThat(supplier.get()).isEqualTo("ready")
+      Mockito.verify(supplier).get()
+    }
+  }
+
+  @Test
+  def traitMixinSupportsNamedMockOverload(): Unit = {
+    withMockitoRuntime {
+      val supplier: Supplier[String] = MixedInSugar.mock[Supplier[String]]("namedSupplier")
+
+      Mockito.when(supplier.get()).thenReturn("named value")
+
+      assertThat(supplier.get()).isEqualTo("named value")
+      assertThat(Mockito.mockingDetails(supplier).getMockCreationSettings.getMockName.toString)
+        .isEqualTo("namedSupplier")
+    }
+  }
+
+  @Test
+  def defaultAnswerOverloadProvidesFallbackBehavior(): Unit = {
+    withMockitoRuntime {
+      val defaultAnswer: Answer[AnyRef] = new Answer[AnyRef] {
+        override def answer(invocation: InvocationOnMock): AnyRef = {
+          s"${invocation.getMethod.getName}:${invocation.getArgument[AnyRef](0)}"
+        }
+      }
+      val formatter: Function[String, String] = MockitoSugar.mock[Function[String, String]](defaultAnswer)
+
+      assertThat(formatter.apply("Grace")).isEqualTo("apply:Grace")
+      Mockito.verify(formatter).apply("Grace")
+    }
+  }
+
+  @Test
+  def mockSettingsOverloadAppliesMockitoSettings(): Unit = {
+    withMockitoRuntime {
+      val settings: MockSettings = Mockito.withSettings()
+        .name("settingsFunction")
+        .defaultAnswer(Mockito.RETURNS_SMART_NULLS)
+      val formatter: Function[String, String] = MockitoSugar.mock[Function[String, String]](settings)
+
+      Mockito.when(formatter.apply("configured")).thenReturn("settings applied")
+
+      assertThat(formatter.apply("configured")).isEqualTo("settings applied")
+      assertThat(Mockito.mockingDetails(formatter).getMockCreationSettings.getMockName.toString)
+        .isEqualTo("settingsFunction")
+      Mockito.verify(formatter).apply("configured")
+    }
+  }
+
+  @Test
+  def captureCreatesArgumentCaptorForRequestedType(): Unit = {
+    val captor: ArgumentCaptor[String] = MockitoSugar.capture[String]
+
+    assertThat(captor.getAllValues).isEmpty()
+  }
+
+  @Test
+  def captureCreatesArgumentCaptorAndImplicitlyCapturesVerificationArgument(): Unit = {
+    withMockitoRuntime {
+      import org.scalatestplus.mockito.MockitoSugar.*
+
+      val consumer: Consumer[String] = MockitoSugar.mock[Consumer[String]]
+      val captor: ArgumentCaptor[String] = capture[String]
+
+      consumer.accept("captured value")
+      Mockito.verify(consumer).accept(captor)
+
+      assertThat(captor.getValue).isEqualTo("captured value")
+      assertThat(captor.getAllValues).containsExactly("captured value")
+    }
+  }
+
+  private def withMockitoRuntime(testBody: => Unit): Unit = {
+    try {
+      testBody
+    } catch {
+      case error: Error =>
+        if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+          throw error
+        }
+    }
+  }
+
+  private object MixedInSugar extends MockitoSugar
 }

--- a/tests/src/org.scalatestplus/mockito-5-12_3/3.2.19.0/src/test/scala/org_scalatestplus/mockito_5_12_3/Mockito_5_12_3Test.scala
+++ b/tests/src/org.scalatestplus/mockito-5-12_3/3.2.19.0/src/test/scala/org_scalatestplus/mockito_5_12_3/Mockito_5_12_3Test.scala
@@ -35,6 +35,19 @@ class Mockito_5_12_3Test {
   }
 
   @Test
+  def companionObjectMockSupportsConcreteScalaClasses(): Unit = {
+    withMockitoRuntime {
+      val greeter: GreetingService = MockitoSugar.mock[GreetingService]
+
+      Mockito.when(greeter.greeting("Scala")).thenReturn("Mocked greeting")
+
+      assertThat(greeter.greeting("Scala")).isEqualTo("Mocked greeting")
+      assertThat(Mockito.mockingDetails(greeter).isMock).isTrue()
+      Mockito.verify(greeter).greeting("Scala")
+    }
+  }
+
+  @Test
   def importedCompanionMembersCreateMocksWithoutMixingInTheTrait(): Unit = {
     withMockitoRuntime {
       import org.scalatestplus.mockito.MockitoSugar.mock
@@ -128,4 +141,8 @@ class Mockito_5_12_3Test {
   }
 
   private object MixedInSugar extends MockitoSugar
+}
+
+class GreetingService {
+  def greeting(name: String): String = s"Hello $name"
 }

--- a/tests/src/org.scalatestplus/mockito-5-12_3/3.2.19.0/user-code-filter.json
+++ b/tests/src/org.scalatestplus/mockito-5-12_3/3.2.19.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.scalatestplus.mockito.**"
+    }
+  ]
+}

--- a/tests/src/org.scalatestplus/mockito-5-12_3/3.2.19.0/user-code-filter.json
+++ b/tests/src/org.scalatestplus/mockito-5-12_3/3.2.19.0/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.scalatestplus.mockito.**"
+      "includeClasses" : "org.scalatestplus.mockito.**"
+    },
+    {
+      "includeClasses" : "org_scalatestplus.mockito_5_12_3.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #5348

This PR introduces tests and metadata for org.scalatestplus:mockito-5-12_3:3.2.19.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 142059
- Cached input tokens: 923648
- Output tokens: 17785
- Metadata entries: 10
- Test-only metadata entries: 1
- Iterations: 3
- Library coverage percentage: 100.0
- Generated lines of code: 119
- Tested library lines of code: 8

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `ai/vjovanov/fix-java-run-org.springframework-spring-test-7.0.0`
- Forge commit hash: `d409f66a8eb28e63b8ff438903afb8ca17a04972`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 58/63 (92.06%)
- Line: 8/8 (100.00%)
- Method: 13/14 (92.86%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
