### PR TITLE
Add top dynamic-access coordinate listing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -146,6 +146,7 @@ static List<Map> testInfraCommands(String gradleCmd, String target) {
             "generateDynamicAccessReport",
             "generateDynamicAccessCoverageReport",
             "generateLibraryStats",
+            "listTopCoordinatesByMetric",
             "listCoordinates",
             "generateDependencyGraph",
             "splitTestOnlyMetadata"

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -173,9 +173,11 @@ Schema:
 ```console
 ./gradlew generateLibraryStats -Pcoordinates=[group:artifact:version|group:artifact|k/n|all]
 ./gradlew validateLibraryStats
+./gradlew listTopCoordinatesByMetric --metric=dynamic-accesses --limit=256
 ```
 
 - `generateLibraryStats`: recomputes selected coordinates and updates matching exploded stats files under `stats/`.
+- `listTopCoordinatesByMetric`: prints the top-N `group:artifact:version` coordinates from committed stats, currently ordered by `dynamic-accesses`.
 - Workflow scripts write execution metrics under `stats/<groupId>/<artifactId>/<metadata-version>/execution-metrics.json`.
 - `validateLibraryStats`: validates mirrored committed stats files, schema compliance, and normalized sorting without recomputing metrics.
 

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -58,7 +58,7 @@ A Gradle-based TCK that, given a library coordinate `group:artifact:version`, ru
 - Compilation, JVM-mode tests (`javaTest`), and native-image tests (`nativeTest`).
 - Coverage collection (JaCoCo) and dynamic-access reporting per coordinate.
 
-The harness uses a single coordinates filter `-Pcoordinates=` accepting `all`, `group:artifact`, `group:artifact:version`, or shard `k/n`. It also exposes authoring helpers (`generateMetadata`, `splitTestOnlyMetadata`, `fixTestNativeImageRun`, `addTestedVersion`, `fetchExistingLibrariesWithNewerVersions`), reporting tasks (`jacocoTestReport`, `generateDynamicAccessCoverageReport`, `generateLibraryStats`, `analyzeExternalLibraryDynamicAccess`), and the `package` release task. Its task groups and the Gradle harness that delegates `-Pcoordinates=` to per-coordinate sub-builds are specified in §TCK-test-harness; the test sources it drives in §TESTS-suite. The full task reference lives in [DEVELOPING.md](DEVELOPING.md).
+The harness uses a single coordinates filter `-Pcoordinates=` accepting `all`, `group:artifact`, `group:artifact:version`, or shard `k/n`. It also exposes authoring helpers (`generateMetadata`, `splitTestOnlyMetadata`, `fixTestNativeImageRun`, `addTestedVersion`, `fetchExistingLibrariesWithNewerVersions`), reporting tasks (`jacocoTestReport`, `generateDynamicAccessCoverageReport`, `generateLibraryStats`, `analyzeExternalLibraryDynamicAccess`, `listTopCoordinatesByMetric`), and the `package` release task. Its task groups and the Gradle harness that delegates `-Pcoordinates=` to per-coordinate sub-builds are specified in §TCK-test-harness; the test sources it drives in §TESTS-suite. The full task reference lives in [DEVELOPING.md](DEVELOPING.md).
 
 ### 4.3 Continuous integration
 §CI-repository-ci

--- a/docs/tck.md
+++ b/docs/tck.md
@@ -115,5 +115,5 @@ These emit the GitHub Actions matrices the workflows consume, all driven by
 | --- | --- |
 | `jacocoTestReport` | JaCoCo coverage for a coordinate. |
 | `generateDynamicAccessCoverageReport`, `analyzeExternalLibraryDynamicAccess` | Dynamic-access coverage reporting (§FS-repository-functional-spec.4.5). |
-| `generateLibraryStats`, `generateReadmeBadgeSummary`, `generateDependencyGraph` | Produce the stats mirror, README badge inputs, and dependency graphs that feed the coverage dashboard (§CI-publish-scheduled-coverage). |
+| `generateLibraryStats`, `listTopCoordinatesByMetric`, `generateReadmeBadgeSummary`, `generateDependencyGraph` | Produce and query the stats mirror, README badge inputs, and dependency graphs that feed the coverage dashboard (§CI-publish-scheduled-coverage). |
 | `package` | Zip the `metadata/` directory into the release artifact consumed by native-build-tools (§FS-repository-functional-spec.4). |

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
@@ -42,6 +42,7 @@ import org.graalvm.internal.tck.utils.MetadataGenerationUtils
 import org.graalvm.internal.tck.harness.tasks.JacocoTestReportInvocationTask
 import org.graalvm.internal.tck.harness.tasks.GenerateDependencyGraphTask
 import org.graalvm.internal.tck.harness.tasks.GenerateLibraryStatsTask
+import org.graalvm.internal.tck.harness.tasks.ListTopCoordinatesByMetricTask
 import org.graalvm.internal.tck.harness.tasks.ValidateLibraryStatsTask
 import org.graalvm.internal.tck.harness.tasks.AnalyzeExternalLibraryDynamicAccessTask
 import org.graalvm.internal.tck.harness.tasks.GenerateReadmeBadgeSummaryTask
@@ -323,6 +324,12 @@ tasks.register("generateDynamicAccessCoverageReport", GenerateDynamicAccessCover
 
 tasks.register("generateLibraryStats", GenerateLibraryStatsTask.class) { task ->
     task.setDescription("Generates local library stats and updates stats/<group>/<artifact>/<metadata-version>/stats.json")
+    task.setGroup(METADATA_GROUP)
+}
+
+// §TCK-test-harness.8
+tasks.register("listTopCoordinatesByMetric", ListTopCoordinatesByMetricTask.class) { task ->
+    task.setDescription("Lists top-N coordinates from committed library stats by metric")
     task.setGroup(METADATA_GROUP)
 }
 

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/ListTopCoordinatesByMetricTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/ListTopCoordinatesByMetricTask.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.internal.tck.harness.tasks;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.options.Option;
+import org.graalvm.internal.tck.stats.LibraryStatsModels;
+import org.graalvm.internal.tck.stats.LibraryStatsSupport;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+
+/**
+ * Lists top coordinates from committed library stats.
+ * <p>
+ * Implements §TCK-test-harness.8 — the {@code listTopCoordinatesByMetric} reporting task.
+ */
+@SuppressWarnings("unused")
+public abstract class ListTopCoordinatesByMetricTask extends DefaultTask {
+
+    private static final int DEFAULT_LIMIT = 256;
+
+    @Input
+    public abstract Property<@NotNull String> getMetric();
+
+    @Input
+    public abstract Property<@NotNull Integer> getLimit();
+
+    public ListTopCoordinatesByMetricTask() {
+        getMetric().convention(getProject().getProviders()
+                .gradleProperty("metric")
+                .orElse(LibraryStatsSupport.DYNAMIC_ACCESSES_METRIC));
+        getLimit().convention(getProject().getProviders()
+                .gradleProperty("limit")
+                .orElse(getProject().getProviders().gradleProperty("topN"))
+                .map(Integer::parseInt)
+                .orElse(DEFAULT_LIMIT));
+    }
+
+    @Option(option = "metric", description = "Library stats metric to rank by. Supported: dynamic-accesses")
+    public void setMetricOption(String value) {
+        getMetric().set(value);
+    }
+
+    @Option(option = "limit", description = "Maximum number of coordinates to print")
+    public void setLimitOption(String value) {
+        try {
+            getLimit().set(Integer.parseInt(value));
+        } catch (NumberFormatException e) {
+            throw new GradleException("Property 'limit' must be an integer. Got: " + value, e);
+        }
+    }
+
+    @TaskAction
+    public void list() {
+        Path statsRoot = getProject().getRootProject().getProjectDir().toPath().resolve("stats");
+        List<LibraryStatsModels.CoordinateMetric> topCoordinates = LibraryStatsSupport.topCoordinatesByMetric(
+                LibraryStatsSupport.loadRepositoryStats(statsRoot),
+                getMetric().get(),
+                getLimit().get()
+        );
+        List<String> coordinates = topCoordinates.stream()
+                .map(LibraryStatsModels.CoordinateMetric::coordinate)
+                .toList();
+        coordinates.forEach(coordinate -> getLogger().quiet(coordinate));
+        writeGithubOutput("coordinates", String.join(" ", coordinates));
+    }
+
+    private void writeGithubOutput(String key, String value) {
+        String outputPath = System.getenv("GITHUB_OUTPUT");
+        if (outputPath == null || outputPath.isBlank()) {
+            return;
+        }
+        try {
+            Files.writeString(
+                    Path.of(outputPath),
+                    key + "=" + value + System.lineSeparator(),
+                    StandardCharsets.UTF_8,
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.APPEND
+            );
+        } catch (IOException e) {
+            throw new GradleException("Failed to write GitHub output " + key + " to " + outputPath, e);
+        }
+    }
+}

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/LibraryStatsModels.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/LibraryStatsModels.java
@@ -36,6 +36,12 @@ public final class LibraryStatsModels {
     ) {
     }
 
+    public record CoordinateMetric(
+            String coordinate,
+            long value
+    ) {
+    }
+
     public record ArtifactStats(
             Map<String, MetadataVersionStats> metadataVersions
     ) {

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/LibraryStatsSupport.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/LibraryStatsSupport.java
@@ -49,6 +49,8 @@ import java.util.stream.Stream;
  */
 public final class LibraryStatsSupport {
 
+    public static final String DYNAMIC_ACCESSES_METRIC = "dynamic-accesses";
+
     private static final TypeReference<LibraryStatsModels.LibraryStats> LIBRARY_STATS_TYPE = new TypeReference<>() {
     };
     private static final TypeReference<LibraryStatsModels.MetadataVersionStats> METADATA_VERSION_STATS_TYPE = new TypeReference<>() {
@@ -134,6 +136,44 @@ public final class LibraryStatsSupport {
             throw new GradleException("Failed to traverse repository stats root " + statsRoot, e);
         }
         return libraryStats;
+    }
+
+    public static List<LibraryStatsModels.CoordinateMetric> topCoordinatesByMetric(
+            LibraryStatsModels.LibraryStats libraryStats,
+            String metric,
+            int limit
+    ) {
+        if (limit < 1) {
+            throw new GradleException("Top coordinate limit must be positive. Got: " + limit);
+        }
+        if (!DYNAMIC_ACCESSES_METRIC.equals(metric)) {
+            throw new GradleException("Unsupported library stats metric '" + metric + "'. Supported metrics: " + DYNAMIC_ACCESSES_METRIC);
+        }
+
+        Map<String, Long> metricByCoordinate = new HashMap<>();
+        LibraryStatsModels.LibraryStats normalizedStats = normalizeLibraryStats(libraryStats);
+        for (Map.Entry<String, LibraryStatsModels.ArtifactStats> artifactEntry : normalizedStats.entries().entrySet()) {
+            String artifact = artifactEntry.getKey();
+            LibraryStatsModels.ArtifactStats artifactStats = artifactEntry.getValue();
+            for (LibraryStatsModels.MetadataVersionStats metadataVersionStats : artifactStats.metadataVersions().values()) {
+                for (LibraryStatsModels.VersionStats versionStats : metadataVersionStats.versions()) {
+                    if (versionStats.dynamicAccess() == null || !versionStats.dynamicAccess().isAvailable()) {
+                        continue;
+                    }
+                    String coordinate = artifact + ":" + versionStats.version();
+                    metricByCoordinate.merge(coordinate, versionStats.dynamicAccess().totalCalls(), Math::max);
+                }
+            }
+        }
+
+        return metricByCoordinate.entrySet().stream()
+                .map(entry -> new LibraryStatsModels.CoordinateMetric(entry.getKey(), entry.getValue()))
+                .sorted(Comparator
+                        .comparingLong(LibraryStatsModels.CoordinateMetric::value)
+                        .reversed()
+                        .thenComparing(LibraryStatsModels.CoordinateMetric::coordinate))
+                .limit(limit)
+                .toList();
     }
 
     private static void writeJsonWithTrailingNewline(Path targetFile, Object value, String errorPrefix) {

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/stats/LibraryStatsSupportTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/stats/LibraryStatsSupportTests.java
@@ -20,6 +20,7 @@ import java.util.jar.JarOutputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class LibraryStatsSupportTests {
 
@@ -740,6 +741,62 @@ class LibraryStatsSupportTests {
         assertThat(LibraryStatsSupport.metadataVersionStats(libraryStats, "org.demo:alpha", "2.0.0").versions())
                 .extracting(LibraryStatsModels.VersionStats::version)
                 .containsExactly("2.0.1");
+    }
+
+    @Test
+    void topCoordinatesByMetricRanksDynamicAccessAndDeduplicatesCoordinates() {
+        LibraryStatsModels.LibraryStats libraryStats = new LibraryStatsModels.LibraryStats(Map.of());
+        libraryStats = LibraryStatsSupport.withMetadataVersionStats(
+                libraryStats,
+                "com.example:alpha",
+                "1.0.0",
+                new LibraryStatsModels.MetadataVersionStats(List.of(
+                        createVersionStats("1.0.0", 10, 3),
+                        createVersionStats("1.1.0", 6, 2)
+                ))
+        );
+        libraryStats = LibraryStatsSupport.withMetadataVersionStats(
+                libraryStats,
+                "com.example:alpha",
+                "2.0.0",
+                new LibraryStatsModels.MetadataVersionStats(List.of(createVersionStats("1.0.0", 12, 4)))
+        );
+        libraryStats = LibraryStatsSupport.withMetadataVersionStats(
+                libraryStats,
+                "org.demo:beta",
+                "1.0.0",
+                new LibraryStatsModels.MetadataVersionStats(List.of(
+                        createVersionStats("3.0.0", 12, 5),
+                        new LibraryStatsModels.VersionStats(
+                                "4.0.0",
+                                LibraryStatsModels.DynamicAccessStatsValue.notAvailable(),
+                                LibraryStatsSupport.unavailableLibraryCoverage()
+                        )
+                ))
+        );
+
+        List<LibraryStatsModels.CoordinateMetric> topCoordinates = LibraryStatsSupport.topCoordinatesByMetric(
+                libraryStats,
+                LibraryStatsSupport.DYNAMIC_ACCESSES_METRIC,
+                3
+        );
+
+        assertThat(topCoordinates)
+                .extracting(LibraryStatsModels.CoordinateMetric::coordinate)
+                .containsExactly("com.example:alpha:1.0.0", "org.demo:beta:3.0.0", "com.example:alpha:1.1.0");
+        assertThat(topCoordinates)
+                .extracting(LibraryStatsModels.CoordinateMetric::value)
+                .containsExactly(12L, 12L, 6L);
+    }
+
+    @Test
+    void topCoordinatesByMetricRejectsUnsupportedInputs() {
+        LibraryStatsModels.LibraryStats libraryStats = new LibraryStatsModels.LibraryStats(Map.of());
+
+        assertThatThrownBy(() -> LibraryStatsSupport.topCoordinatesByMetric(libraryStats, "coverage", 1))
+                .hasMessageContaining("Unsupported library stats metric 'coverage'");
+        assertThatThrownBy(() -> LibraryStatsSupport.topCoordinatesByMetric(libraryStats, LibraryStatsSupport.DYNAMIC_ACCESSES_METRIC, 0))
+                .hasMessageContaining("Top coordinate limit must be positive");
     }
 
     private LibraryStatsModels.VersionStats createVersionStats(


### PR DESCRIPTION
## Summary

Fixes #8374.

Adds a reusable top-N selector for committed library stats and exposes it through the TCK harness:

- `LibraryStatsSupport.topCoordinatesByMetric(...)` ranks concrete `group:artifact:version` coordinates.
- The initial supported metric is `dynamic-accesses`, mapped to `dynamicAccess.totalCalls`.
- Duplicate GAVs across metadata-version stats files are collapsed by keeping the highest metric value.
- Results are sorted by metric descending, then coordinate ascending for deterministic ties.
- New Gradle task: `listTopCoordinatesByMetric`.
- Default limit is 256; callers can pass `--limit=...`, `-Plimit=...`, or `-PtopN=...`.
- The task prints one coordinate per line and writes a space-separated `coordinates` value to `GITHUB_OUTPUT` when running in GitHub Actions.

Docs/spec updates:

- Documents the task in the TCK reporting surface.
- Adds usage to `docs/DEVELOPING.md`.
- Includes the task in `testInfra` command coverage.

## Validation

- `./gradlew -p tests/tck-build-logic test --tests org.graalvm.internal.tck.stats.LibraryStatsSupportTests --stacktrace`
- `git diff --check`

Note: `./gradlew -p tests/tck-build-logic check --stacktrace` fails in this sparse/partial local clone in existing `MetadataFilesCheckerTaskTests`, which require metadata/schema fixture files not present in the sparse checkout. The focused stats tests compile the changed build logic and pass.
