### PR TITLE
[GenAI] Improve coverage for com.google.auth:google-auth-library-oauth2-http:1.48.0 using gpt-5.5

### DIFF
--- a/metadata/com.google.auth/google-auth-library-oauth2-http/1.48.0/reachability-metadata.json
+++ b/metadata/com.google.auth/google-auth-library-oauth2-http/1.48.0/reachability-metadata.json
@@ -352,7 +352,41 @@
       "type" : "com.google.appengine.api.appidentity.AppIdentityService",
       "methods" : [
         {
+          "name" : "getAccessToken",
+          "parameterTypes" : [
+            "java.lang.Iterable"
+          ]
+        },
+        {
           "name" : "getServiceAccountName",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "signForApp",
+          "parameterTypes" : [
+            "byte[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.AppEngineCredentials"
+      },
+      "type" : "com.google.appengine.api.appidentity.AppIdentityService$GetAccessTokenResult",
+      "serializable" : true,
+      "fields" : [
+        {
+          "name" : "serialVersionUID"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "getAccessToken",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getExpirationTime",
           "parameterTypes" : [ ]
         }
       ]
@@ -361,7 +395,13 @@
       "condition" : {
         "typeReached" : "com.google.auth.oauth2.AppEngineCredentials"
       },
-      "type" : "com.google.appengine.api.appidentity.AppIdentityService$GetAccessTokenResult"
+      "type" : "com.google.appengine.api.appidentity.AppIdentityService$SigningResult",
+      "methods" : [
+        {
+          "name" : "getSignature",
+          "parameterTypes" : [ ]
+        }
+      ]
     },
     {
       "condition" : {
@@ -505,6 +545,13 @@
           "parameterTypes" : [ ]
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.AppEngineCredentials"
+      },
+      "type" : "java.util.Date",
+      "serializable" : true
     },
     {
       "condition" : {

--- a/metadata/com.google.auth/google-auth-library-oauth2-http/1.48.0/reachability-metadata.json
+++ b/metadata/com.google.auth/google-auth-library-oauth2-http/1.48.0/reachability-metadata.json
@@ -1,0 +1,588 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.DefaultCredentialsProvider"
+      },
+      "type" : "byte[][]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.IdToken"
+      },
+      "type" : "com.google.auth.oauth2.IdToken",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.IdToken"
+      },
+      "type" : "com.google.auth.oauth2.AccessToken",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.IdToken"
+      },
+      "type" : "java.lang.Long",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.IdToken"
+      },
+      "type" : "java.lang.Number",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.IdToken"
+      },
+      "type" : "java.lang.String",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.IdToken"
+      },
+      "type" : "java.util.ArrayList",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.UserCredentials"
+      },
+      "type" : "com.google.auth.oauth2.UserCredentials",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.UserCredentials"
+      },
+      "type" : "com.google.auth.oauth2.GoogleCredentials",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.UserCredentials"
+      },
+      "type" : "com.google.auth.oauth2.OAuth2Credentials",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.UserCredentials"
+      },
+      "type" : "com.google.auth.Credentials",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.UserCredentials"
+      },
+      "type" : "com.google.auth.oauth2.OAuth2Credentials$OAuthValue",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.UserCredentials"
+      },
+      "type" : "com.google.auth.oauth2.OAuth2Utils$DefaultHttpTransportFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.UserCredentials"
+      },
+      "type" : "java.net.URI",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.UserCredentials"
+      },
+      "type" : "java.time.Duration",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.UserCredentials"
+      },
+      "type" : "java.time.Ser",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.UserCredentials"
+      },
+      "type" : "com.google.common.collect.ImmutableMap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.UserCredentials"
+      },
+      "type" : "com.google.common.collect.ImmutableBiMap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.UserCredentials"
+      },
+      "type" : "com.google.common.collect.RegularImmutableMap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.UserCredentials"
+      },
+      "type" : "com.google.common.collect.SingletonImmutableBiMap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.UserCredentials"
+      },
+      "type" : "com.google.common.collect.ImmutableMap$SerializedForm",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.UserCredentials"
+      },
+      "type" : "com.google.common.collect.ImmutableBiMap$SerializedForm",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.UserCredentials"
+      },
+      "type" : "com.google.common.collect.ImmutableCollection",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.UserCredentials"
+      },
+      "type" : "com.google.common.collect.ImmutableList",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.UserCredentials"
+      },
+      "type" : "com.google.common.collect.RegularImmutableList",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.UserCredentials"
+      },
+      "type" : "com.google.common.collect.SingletonImmutableList",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.UserCredentials"
+      },
+      "type" : "com.google.common.collect.ImmutableList$SerializedForm",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.ClientId"
+      },
+      "type" : "com.google.api.client.json.GenericJson",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.IdToken"
+      },
+      "type" : "com.google.api.client.json.webtoken.JsonWebSignature$Header",
+      "fields" : [
+        {
+          "name" : "algorithm"
+        },
+        {
+          "name" : "jwkUrl"
+        },
+        {
+          "name" : "jwk"
+        },
+        {
+          "name" : "keyId"
+        },
+        {
+          "name" : "x509Url"
+        },
+        {
+          "name" : "x509Thumbprint"
+        },
+        {
+          "name" : "x509Certificates"
+        },
+        {
+          "name" : "critical"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setAlgorithm",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.IdToken"
+      },
+      "type" : "com.google.api.client.json.webtoken.JsonWebToken$Header",
+      "fields" : [
+        {
+          "name" : "type"
+        },
+        {
+          "name" : "contentType"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "setType",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.IdToken"
+      },
+      "type" : "com.google.api.client.json.webtoken.JsonWebToken$Payload",
+      "fields" : [
+        {
+          "name" : "expirationTimeSeconds"
+        },
+        {
+          "name" : "notBeforeTimeSeconds"
+        },
+        {
+          "name" : "issuedAtTimeSeconds"
+        },
+        {
+          "name" : "issuer"
+        },
+        {
+          "name" : "audience"
+        },
+        {
+          "name" : "jwtId"
+        },
+        {
+          "name" : "type"
+        },
+        {
+          "name" : "subject"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setAudience",
+          "parameterTypes" : [
+            "java.lang.Object"
+          ]
+        },
+        {
+          "name" : "setExpirationTimeSeconds",
+          "parameterTypes" : [
+            "java.lang.Long"
+          ]
+        },
+        {
+          "name" : "setIssuer",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setSubject",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.ClientId"
+      },
+      "type" : "com.google.api.client.util.ArrayMap"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.ClientId"
+      },
+      "type" : "com.google.api.client.util.GenericData"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.AppEngineCredentials"
+      },
+      "type" : "com.google.appengine.api.appidentity.AppIdentityService",
+      "methods" : [
+        {
+          "name" : "getServiceAccountName",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.AppEngineCredentials"
+      },
+      "type" : "com.google.appengine.api.appidentity.AppIdentityService$GetAccessTokenResult"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.AppEngineCredentials"
+      },
+      "type" : "com.google.appengine.api.appidentity.AppIdentityServiceFactory",
+      "methods" : [
+        {
+          "name" : "getAppIdentityService",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.AppEngineCredentials"
+      },
+      "type" : "com.google.appengine.api.appidentity.IAppIdentityServiceFactoryProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.AppEngineCredentials"
+      },
+      "type" : "com.google.appengine.api.backends.IBackendServiceFactoryProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.AppEngineCredentials"
+      },
+      "type" : "com.google.appengine.api.blobstore.IBlobstoreServiceFactoryProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.AppEngineCredentials"
+      },
+      "type" : "com.google.appengine.api.capabilities.ICapabilitiesServiceFactoryProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.AppEngineCredentials"
+      },
+      "type" : "com.google.appengine.api.datastore.IDatastoreServiceFactoryProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.AppEngineCredentials"
+      },
+      "type" : "com.google.appengine.api.images.IImagesServiceFactoryProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.AppEngineCredentials"
+      },
+      "type" : "com.google.appengine.api.log.ILogServiceFactoryProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.AppEngineCredentials"
+      },
+      "type" : "com.google.appengine.api.mail.IMailServiceFactoryProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.AppEngineCredentials"
+      },
+      "type" : "com.google.appengine.api.memcache.IMemcacheServiceFactoryProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.AppEngineCredentials"
+      },
+      "type" : "com.google.appengine.api.modules.IModulesServiceFactoryProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.AppEngineCredentials"
+      },
+      "type" : "com.google.appengine.api.oauth.IOAuthServiceFactoryProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.AppEngineCredentials"
+      },
+      "type" : "com.google.appengine.api.quota.IQuotaServiceFactoryProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.AppEngineCredentials"
+      },
+      "type" : "com.google.appengine.api.search.ISearchServiceFactoryProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.AppEngineCredentials"
+      },
+      "type" : "com.google.appengine.api.taskqueue.IQueueFactoryProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.AppEngineCredentials"
+      },
+      "type" : "com.google.appengine.api.urlfetch.IURLFetchServiceFactoryProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.AppEngineCredentials"
+      },
+      "type" : "com.google.appengine.api.users.IUserServiceFactoryProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.DefaultCredentialsProvider"
+      },
+      "type" : "com.google.appengine.api.utils.SystemProperty",
+      "fields" : [
+        {
+          "name" : "environment"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.DefaultCredentialsProvider"
+      },
+      "type" : "com.google.appengine.api.utils.SystemProperty$Environment",
+      "methods" : [
+        {
+          "name" : "value",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.AppEngineCredentials"
+      },
+      "type" : "com.google.appengine.repackaged.com.google.protobuf.ExtensionRegistry",
+      "methods" : [
+        {
+          "name" : "getEmptyRegistry",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.ClientId"
+      },
+      "type" : "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.ClientId"
+      },
+      "type" : "java.lang.reflect.Field[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.DefaultCredentialsProvider"
+      },
+      "type" : "java.lang.reflect.Method[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.ClientId"
+      },
+      "type" : "java.util.AbstractMap"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.ClientId"
+      },
+      "type" : "java.util.Map"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.IdToken"
+      },
+      "type" : {
+        "proxy" : [
+          "com.google.api.client.util.Key"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.AppEngineCredentials"
+      },
+      "type" : {
+        "proxy" : [
+          "com.google.appengine.spi.ServiceProvider"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.AppEngineCredentials"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.IdToken"
+      },
+      "type" : {
+        "proxy" : [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.OAuth2Credentials"
+      },
+      "glob" : "META-INF/services/com.google.auth.http.HttpTransportFactory"
+    }
+  ]
+}

--- a/metadata/com.google.auth/google-auth-library-oauth2-http/index.json
+++ b/metadata/com.google.auth/google-auth-library-oauth2-http/index.json
@@ -1,13 +1,12 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "1.10.0",
-    "source-code-url" : "https://repo1.maven.org/maven2/com/google/auth/google-auth-library-oauth2-http/$version$/google-auth-library-oauth2-http-$version$-sources.jar",
-    "repository-url" : "https://github.com/googleapis/google-auth-library-java",
-    "test-code-url" : "https://repo1.maven.org/maven2/com/google/auth/google-auth-library-oauth2-http/$version$/google-auth-library-oauth2-http-$version$-tests.jar",
-    "documentation-url" : "https://github.com/googleapis/google-auth-library-java/blob/v$version$/README.md#google-auth-library-oauth2-http",
-    "description" : "Google Auth Library OAuth2 HTTP provides Java credential implementations and helpers for OAuth2-based authentication to Google APIs. It supports Application Default Credentials, service account and user credentials, token verification, impersonation, downscoping, and workload or workforce identity federation over HTTP.",
-    "tested-versions" : [
+    "metadata-version": "1.10.0",
+    "source-code-url": "https://repo1.maven.org/maven2/com/google/auth/google-auth-library-oauth2-http/$version$/google-auth-library-oauth2-http-$version$-sources.jar",
+    "repository-url": "https://github.com/googleapis/google-auth-library-java",
+    "test-code-url": "https://repo1.maven.org/maven2/com/google/auth/google-auth-library-oauth2-http/$version$/google-auth-library-oauth2-http-$version$-tests.jar",
+    "documentation-url": "https://github.com/googleapis/google-auth-library-java/blob/v$version$/README.md#google-auth-library-oauth2-http",
+    "description": "Google Auth Library OAuth2 HTTP provides Java credential implementations and helpers for OAuth2-based authentication to Google APIs. It supports Application Default Credentials, service account and user credentials, token verification, impersonation, downscoping, and workload or workforce identity federation over HTTP.",
+    "tested-versions": [
       "1.10.0",
       "1.11.0",
       "1.12.0",
@@ -16,7 +15,22 @@
       "1.13.0",
       "1.14.0"
     ],
-    "allowed-packages" : [
+    "allowed-packages": [
+      "com.google.auth"
+    ]
+  },
+  {
+    "latest": true,
+    "metadata-version": "1.48.0",
+    "source-code-url": "https://repo1.maven.org/maven2/com/google/auth/google-auth-library-oauth2-http/$version$/google-auth-library-oauth2-http-$version$-sources.jar",
+    "repository-url": "https://github.com/googleapis/google-auth-library-java",
+    "test-code-url": "https://repo1.maven.org/maven2/com/google/auth/google-auth-library-oauth2-http/$version$/google-auth-library-oauth2-http-$version$-tests.jar",
+    "documentation-url": "https://github.com/googleapis/google-auth-library-java/blob/v$version$/README.md#google-auth-library-oauth2-http",
+    "description": "Google Auth Library OAuth2 HTTP provides Java credential implementations and helpers for OAuth2-based authentication to Google APIs. It supports Application Default Credentials, service account and user credentials, token verification, impersonation, downscoping, and workload or workforce identity federation over HTTP.",
+    "tested-versions": [
+      "1.48.0"
+    ],
+    "allowed-packages": [
       "com.google.auth"
     ]
   }

--- a/stats/com.google.auth/google-auth-library-oauth2-http/1.48.0/execution-metrics.json
+++ b/stats/com.google.auth/google-auth-library-oauth2-http/1.48.0/execution-metrics.json
@@ -1,0 +1,68 @@
+{
+  "add_new_library_support:2026-05-21": {
+    "timestamp": "2026-05-21T00:35:37.611467Z",
+    "library": "com.google.auth:google-auth-library-oauth2-http:1.48.0",
+    "starting_commit": "ff99f5589d154d7ff132ad0e879f27cea422911b",
+    "ending_commit": "3904d432ad5370362b9f336ea63dc843c08f76d8",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.48.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.625,
+            "coveredCalls": 15,
+            "totalCalls": 24
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 0.64,
+        "coveredCalls": 16,
+        "totalCalls": 25
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1102,
+          "missed": 13188,
+          "ratio": 0.077117,
+          "total": 14290
+        },
+        "line": {
+          "covered": 283,
+          "missed": 3246,
+          "ratio": 0.080193,
+          "total": 3529
+        },
+        "method": {
+          "covered": 81,
+          "missed": 757,
+          "ratio": 0.096659,
+          "total": 838
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 272718,
+      "cached_input_tokens_used": 2677248,
+      "output_tokens_used": 42212,
+      "iterations": 9,
+      "cost_usd": 2.605,
+      "generated_loc": 196,
+      "tested_library_loc": 283,
+      "metadata_entries": 113,
+      "test_only_metadata_entries": 1,
+      "code_coverage_percent": 8.02
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/src/test/java/com_google_auth/google_auth_library_oauth2_http/OAuth2CredentialsTest.java",
+      "metadata_file": "metadata/com.google.auth/google-auth-library-oauth2-http/1.48.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.google.auth/google-auth-library-oauth2-http/1.48.0/execution-metrics.json
+++ b/stats/com.google.auth/google-auth-library-oauth2-http/1.48.0/execution-metrics.json
@@ -64,5 +64,97 @@
       "test_file": "tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/src/test/java/com_google_auth/google_auth_library_oauth2_http/OAuth2CredentialsTest.java",
       "metadata_file": "metadata/com.google.auth/google-auth-library-oauth2-http/1.48.0/reachability-metadata.json"
     }
+  },
+  "improve_library_coverage:2026-06-11": {
+    "timestamp": "2026-06-11T11:16:14.930321Z",
+    "library": "com.google.auth:google-auth-library-oauth2-http:1.48.0",
+    "starting_commit": "4e114a88f9d2bc1140ddf16e6859482ec14690f8",
+    "ending_commit": "a814456ba4c626184b4af54d6bbf47b96d5ae736",
+    "strategy_name": "library_update_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.48.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 25,
+            "totalCalls": 25
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 26,
+        "totalCalls": 26
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1915,
+          "missed": 20166,
+          "ratio": 0.086726,
+          "total": 22081
+        },
+        "line": {
+          "covered": 491,
+          "missed": 5094,
+          "ratio": 0.087914,
+          "total": 5585
+        },
+        "method": {
+          "covered": 136,
+          "missed": 1151,
+          "ratio": 0.105672,
+          "total": 1287
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "degraded",
+      "action": "no_action",
+      "issue_number": 8371,
+      "issue_label": "library-update-request",
+      "library": "com.google.auth:google-auth-library-oauth2-http:1.48.0",
+      "summary": "Library preparation preflight did not produce usable advisory setup.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#8371 Update existing library: com.google.auth:google-auth-library-oauth2-http:1.48.0; label=library-update-request; body_chars=843"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "0 existing test file path(s) included"
+        }
+      ],
+      "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
+      "model": "oca/gpt-5.5",
+      "prompt_path": "library-preflight-prompt.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/com.google.auth:google-auth-library-oauth2-http:1.48.0/library-preparation-preflight/pi-generation-2026-06-11T10-25-51-266926Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 400143,
+      "cached_input_tokens_used": 4770304,
+      "output_tokens_used": 39003,
+      "iterations": 6,
+      "cost_usd": 3.5553,
+      "generated_loc": 624,
+      "tested_library_loc": 491,
+      "metadata_entries": 133,
+      "test_only_metadata_entries": 3,
+      "code_coverage_percent": 8.79
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/src/test/java/com_google_auth/google_auth_library_oauth2_http/OAuth2CredentialsTest.java",
+      "metadata_file": "metadata/com.google.auth/google-auth-library-oauth2-http/1.48.0/reachability-metadata.json"
+    }
   }
 }

--- a/stats/com.google.auth/google-auth-library-oauth2-http/1.48.0/stats.json
+++ b/stats/com.google.auth/google-auth-library-oauth2-http/1.48.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "1.48.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 25,
+          "totalCalls" : 25
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 26,
+      "totalCalls" : 26
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1915,
+        "missed" : 20166,
+        "ratio" : 0.086726,
+        "total" : 22081
+      },
+      "line" : {
+        "covered" : 491,
+        "missed" : 5094,
+        "ratio" : 0.087914,
+        "total" : 5585
+      },
+      "method" : {
+        "covered" : 136,
+        "missed" : 1151,
+        "ratio" : 0.105672,
+        "total" : 1287
+      }
+    }
+  } ]
+}

--- a/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/.gitignore
+++ b/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/build.gradle
+++ b/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/build.gradle
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.google.auth:google-auth-library-oauth2-http:$libraryVersion"
+    testImplementation 'com.google.appengine:appengine-api-1.0-sdk:2.0.4'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/gradle.properties
+++ b/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.google.auth:google-auth-library-oauth2-http:1.48.0
+library.version = 1.48.0
+metadata.dir = com.google.auth/google-auth-library-oauth2-http/1.48.0/

--- a/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/settings.gradle
+++ b/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.google.auth.google-auth-library-oauth2-http_tests'

--- a/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/src/test/java/com_google_auth/google_auth_library_oauth2_http/AppEngineCredentialsTest.java
+++ b/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/src/test/java/com_google_auth/google_auth_library_oauth2_http/AppEngineCredentialsTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_auth.google_auth_library_oauth2_http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.appengine.api.appidentity.AppIdentityServicePb.GetAccessTokenResponse;
+import com.google.appengine.api.appidentity.AppIdentityServicePb.GetServiceAccountNameResponse;
+import com.google.appengine.api.appidentity.AppIdentityServicePb.SignForAppResponse;
+import com.google.appengine.api.memcache.MemcacheServicePb.MemcacheGetResponse;
+import com.google.appengine.api.memcache.MemcacheServicePb.MemcacheGetResponse.GetStatusCode;
+import com.google.appengine.api.memcache.MemcacheServicePb.MemcacheSetResponse;
+import com.google.appengine.api.memcache.MemcacheServicePb.MemcacheSetResponse.SetStatusCode;
+import com.google.appengine.repackaged.com.google.protobuf.ByteString;
+import com.google.apphosting.api.ApiProxy;
+import com.google.auth.ServiceAccountSigner;
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+@ResourceLock("appengine-api-proxy")
+public class AppEngineCredentialsTest {
+    private static final String GAE_RUNTIME_VERSION_PROPERTY =
+            "com.google.appengine.runtime.version";
+    private static final String GAE_RUNTIME_ENVIRONMENT_PROPERTY =
+            "com.google.appengine.runtime.environment";
+    private static final String JETTY_LOGGER_PROPERTY =
+            "org.eclipse.jetty.util.log.class";
+    private static final String USER_HOME_PROPERTY = "user.home";
+    private static final String INITIAL_GAE_RUNTIME_VERSION =
+            System.getProperty(GAE_RUNTIME_VERSION_PROPERTY);
+    private static final String INITIAL_GAE_RUNTIME_ENVIRONMENT =
+            System.getProperty(GAE_RUNTIME_ENVIRONMENT_PROPERTY);
+    private static final String INITIAL_JETTY_LOGGER = System.getProperty(JETTY_LOGGER_PROPERTY);
+
+    static {
+        configureAppEngineStandardEnvironment();
+    }
+
+    @TempDir
+    Path temporaryHome;
+
+    private String previousUserHome;
+    private ApiProxy.EnvironmentFactory previousEnvironmentFactory;
+    private ApiProxy.Delegate<?> previousDelegate;
+
+    @BeforeEach
+    public void setUp() {
+        configureAppEngineStandardEnvironment();
+        previousUserHome = System.getProperty(USER_HOME_PROPERTY);
+        previousEnvironmentFactory = ApiProxy.getEnvironmentFactory();
+        previousDelegate = ApiProxy.getDelegate();
+        System.setProperty(USER_HOME_PROPERTY, temporaryHome.toString());
+        setUpAppEngineApiProxy();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        tearDownAppEngineApiProxy(previousEnvironmentFactory, previousDelegate);
+        restoreProperty(GAE_RUNTIME_VERSION_PROPERTY, INITIAL_GAE_RUNTIME_VERSION);
+        restoreProperty(GAE_RUNTIME_ENVIRONMENT_PROPERTY, INITIAL_GAE_RUNTIME_ENVIRONMENT);
+        restoreProperty(JETTY_LOGGER_PROPERTY, INITIAL_JETTY_LOGGER);
+        restoreProperty(USER_HOME_PROPERTY, previousUserHome);
+    }
+
+    @Test
+    public void appEngineCredentialsRefreshAccessTokenAndSignBytes() throws IOException {
+        GoogleCredentials credentials = GoogleCredentials.getApplicationDefault();
+
+        assertThat(credentials.getClass().getName())
+                .isEqualTo("com.google.auth.oauth2.AppEngineCredentials");
+        ServiceAccountSigner signer = (ServiceAccountSigner) credentials;
+
+        GoogleCredentials scopedCredentials =
+                credentials.createScoped(
+                        Collections.singletonList(
+                                "https://www.googleapis.com/auth/cloud-platform"));
+        AccessToken accessToken = scopedCredentials.refreshAccessToken();
+        assertThat(accessToken.getTokenValue()).isNotBlank();
+        assertThat(accessToken.getExpirationTime()).isNotNull();
+
+        byte[] signature = signer.sign("payload".getBytes(StandardCharsets.UTF_8));
+        assertThat(signature).isNotEmpty();
+    }
+
+    private static void configureAppEngineStandardEnvironment() {
+        System.setProperty(GAE_RUNTIME_VERSION_PROPERTY, "test-runtime");
+        System.setProperty(GAE_RUNTIME_ENVIRONMENT_PROPERTY, "Development");
+        System.clearProperty(JETTY_LOGGER_PROPERTY);
+    }
+
+    static void setUpAppEngineApiProxy() {
+        ApiProxy.setEnvironmentFactory(TestEnvironment::new);
+        ApiProxy.setEnvironmentForCurrentThread(new TestEnvironment());
+        ApiProxy.setDelegate(new TestAppIdentityDelegate());
+    }
+
+    static void tearDownAppEngineApiProxy(
+            ApiProxy.EnvironmentFactory previousEnvironmentFactory,
+            ApiProxy.Delegate<?> previousDelegate) {
+        ApiProxy.setDelegate(previousDelegate);
+        if (previousEnvironmentFactory != null) {
+            ApiProxy.setEnvironmentFactory(previousEnvironmentFactory);
+        }
+        ApiProxy.clearEnvironmentForCurrentThread();
+    }
+
+    private static void restoreProperty(String name, String value) {
+        if (value == null) {
+            System.clearProperty(name);
+        } else {
+            System.setProperty(name, value);
+        }
+    }
+
+    private static final class TestEnvironment implements ApiProxy.Environment {
+        private final Map<String, Object> attributes = new ConcurrentHashMap<>();
+
+        @Override
+        public String getAppId() {
+            return "test-app";
+        }
+
+        @Override
+        public String getModuleId() {
+            return "default";
+        }
+
+        @Override
+        public String getVersionId() {
+            return "1";
+        }
+
+        @Override
+        public String getEmail() {
+            return "test@example.com";
+        }
+
+        @Override
+        public boolean isLoggedIn() {
+            return true;
+        }
+
+        @Override
+        public boolean isAdmin() {
+            return true;
+        }
+
+        @Override
+        public String getAuthDomain() {
+            return "gmail.com";
+        }
+
+        @Override
+        public String getRequestNamespace() {
+            return "";
+        }
+
+        @Override
+        public Map<String, Object> getAttributes() {
+            return attributes;
+        }
+
+        @Override
+        public long getRemainingMillis() {
+            return 60_000L;
+        }
+    }
+
+    private static final class TestAppIdentityDelegate
+            implements ApiProxy.Delegate<ApiProxy.Environment> {
+        @Override
+        public byte[] makeSyncCall(
+                ApiProxy.Environment environment,
+                String packageName,
+                String methodName,
+                byte[] request) {
+            if ("memcache".equals(packageName) && "Get".equals(methodName)) {
+                return MemcacheGetResponse.newBuilder()
+                        .addGetStatus(GetStatusCode.MISS)
+                        .build()
+                        .toByteArray();
+            }
+            if ("memcache".equals(packageName) && "Set".equals(methodName)) {
+                return MemcacheSetResponse.newBuilder()
+                        .addSetStatus(SetStatusCode.STORED)
+                        .build()
+                        .toByteArray();
+            }
+            if ("GetServiceAccountName".equals(methodName)) {
+                return GetServiceAccountNameResponse.newBuilder()
+                        .setServiceAccountName("test-app@appspot.gserviceaccount.com")
+                        .build()
+                        .toByteArray();
+            }
+            if ("GetAccessToken".equals(methodName)) {
+                return GetAccessTokenResponse.newBuilder()
+                        .setAccessToken("test-access-token")
+                        .setExpirationTime(System.currentTimeMillis() / 1000L + 3_600L)
+                        .build()
+                        .toByteArray();
+            }
+            if ("SignForApp".equals(methodName)) {
+                return SignForAppResponse.newBuilder()
+                        .setKeyName("test-key")
+                        .setSignatureBytes(ByteString.copyFromUtf8("test-signature"))
+                        .build()
+                        .toByteArray();
+            }
+            throw new ApiProxy.ApplicationException(0, packageName + "." + methodName);
+        }
+
+        @Override
+        public Future<byte[]> makeAsyncCall(
+                ApiProxy.Environment environment,
+                String packageName,
+                String methodName,
+                byte[] request,
+                ApiProxy.ApiConfig apiConfig) {
+            return CompletableFuture.completedFuture(
+                    makeSyncCall(environment, packageName, methodName, request));
+        }
+
+        @Override
+        public void log(ApiProxy.Environment environment, ApiProxy.LogRecord logRecord) {
+            environment.getAttributes().put("lastLogLevel", logRecord.getLevel());
+        }
+
+        @Override
+        public void flushLogs(ApiProxy.Environment environment) {
+            environment.getAttributes().remove("lastLogLevel");
+        }
+
+        @Override
+        public List<Thread> getRequestThreads(ApiProxy.Environment environment) {
+            return Collections.singletonList(Thread.currentThread());
+        }
+    }
+}

--- a/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/src/test/java/com_google_auth/google_auth_library_oauth2_http/ClientIdTest.java
+++ b/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/src/test/java/com_google_auth/google_auth_library_oauth2_http/ClientIdTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_auth.google_auth_library_oauth2_http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.auth.oauth2.ClientId;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+public class ClientIdTest {
+    @Test
+    public void fromResourceLoadsClientIdJsonLocatedRelativeToCaller() throws IOException {
+        ClientId clientId = ClientId.fromResource(ClientIdTest.class, "client_id.json");
+
+        assertThat(clientId.getClientId()).isEqualTo("test-client-id.apps.googleusercontent.com");
+        assertThat(clientId.getClientSecret()).isEqualTo("test-client-secret");
+
+        ClientId rotatedClientId = clientId.toBuilder()
+                .setClientSecret("rotated-client-secret")
+                .build();
+        assertThat(rotatedClientId.getClientId()).isEqualTo(clientId.getClientId());
+        assertThat(rotatedClientId.getClientSecret()).isEqualTo("rotated-client-secret");
+    }
+}

--- a/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/src/test/java/com_google_auth/google_auth_library_oauth2_http/CustomHttpTransportFactory.java
+++ b/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/src/test/java/com_google_auth/google_auth_library_oauth2_http/CustomHttpTransportFactory.java
@@ -11,7 +11,8 @@ import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.auth.http.HttpTransportFactory;
 
 public final class CustomHttpTransportFactory implements HttpTransportFactory {
-    public CustomHttpTransportFactory() {}
+    public CustomHttpTransportFactory() {
+    }
 
     @Override
     public HttpTransport create() {

--- a/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/src/test/java/com_google_auth/google_auth_library_oauth2_http/CustomHttpTransportFactory.java
+++ b/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/src/test/java/com_google_auth/google_auth_library_oauth2_http/CustomHttpTransportFactory.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_auth.google_auth_library_oauth2_http;
+
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.auth.http.HttpTransportFactory;
+
+public final class CustomHttpTransportFactory implements HttpTransportFactory {
+    public CustomHttpTransportFactory() {}
+
+    @Override
+    public HttpTransport create() {
+        return new NetHttpTransport();
+    }
+}

--- a/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/src/test/java/com_google_auth/google_auth_library_oauth2_http/DefaultCredentialsProviderTest.java
+++ b/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/src/test/java/com_google_auth/google_auth_library_oauth2_http/DefaultCredentialsProviderTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_auth.google_auth_library_oauth2_http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import java.io.IOException;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class DefaultCredentialsProviderTest {
+    private static final String GAE_RUNTIME_VERSION_PROPERTY =
+            "com.google.appengine.runtime.version";
+    private static final String GAE_RUNTIME_ENVIRONMENT_PROPERTY =
+            "com.google.appengine.runtime.environment";
+    private static final String JETTY_LOGGER_PROPERTY =
+            "org.eclipse.jetty.util.log.class";
+    private static final String USER_HOME_PROPERTY = "user.home";
+    private static final String INITIAL_GAE_RUNTIME_VERSION =
+            System.getProperty(GAE_RUNTIME_VERSION_PROPERTY);
+    private static final String INITIAL_GAE_RUNTIME_ENVIRONMENT =
+            System.getProperty(GAE_RUNTIME_ENVIRONMENT_PROPERTY);
+    private static final String INITIAL_JETTY_LOGGER = System.getProperty(JETTY_LOGGER_PROPERTY);
+
+    static {
+        configureAppEngineStandardEnvironment();
+    }
+
+    @TempDir
+    Path temporaryHome;
+
+    private String previousUserHome;
+
+    @BeforeEach
+    public void setUp() {
+        configureAppEngineStandardEnvironment();
+        previousUserHome = System.getProperty(USER_HOME_PROPERTY);
+        System.setProperty(USER_HOME_PROPERTY, temporaryHome.toString());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        restoreProperty(GAE_RUNTIME_VERSION_PROPERTY, INITIAL_GAE_RUNTIME_VERSION);
+        restoreProperty(GAE_RUNTIME_ENVIRONMENT_PROPERTY, INITIAL_GAE_RUNTIME_ENVIRONMENT);
+        restoreProperty(JETTY_LOGGER_PROPERTY, INITIAL_JETTY_LOGGER);
+        restoreProperty(USER_HOME_PROPERTY, previousUserHome);
+    }
+
+    @Test
+    public void applicationDefaultCredentialsChecksAppEngineSignalClass() {
+        try {
+            GoogleCredentials credentials = GoogleCredentials.getApplicationDefault();
+
+            assertThat(credentials.getClass().getName())
+                    .isEqualTo("com.google.auth.oauth2.AppEngineCredentials");
+        } catch (IOException exception) {
+            assertThat(exception).hasMessageContaining("Google App Engine");
+        }
+    }
+
+    private static void configureAppEngineStandardEnvironment() {
+        System.setProperty(GAE_RUNTIME_VERSION_PROPERTY, "test-runtime");
+        System.setProperty(GAE_RUNTIME_ENVIRONMENT_PROPERTY, "Development");
+        System.clearProperty(JETTY_LOGGER_PROPERTY);
+    }
+
+    private static void restoreProperty(String name, String value) {
+        if (value == null) {
+            System.clearProperty(name);
+        } else {
+            System.setProperty(name, value);
+        }
+    }
+}

--- a/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/src/test/java/com_google_auth/google_auth_library_oauth2_http/IdTokenTest.java
+++ b/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/src/test/java/com_google_auth/google_auth_library_oauth2_http/IdTokenTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_auth.google_auth_library_oauth2_http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.auth.oauth2.IdToken;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.junit.jupiter.api.Test;
+
+public class IdTokenTest {
+    @Test
+    public void serializationRoundTripRestoresParsedJsonWebSignature() throws Exception {
+        String tokenValue = createUnsignedJwt();
+        IdToken token = IdToken.create(tokenValue);
+
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+            output.writeObject(token);
+        }
+
+        IdToken restored;
+        try (ObjectInputStream input = new ObjectInputStream(
+                new ByteArrayInputStream(bytes.toByteArray()))) {
+            restored = (IdToken) input.readObject();
+        }
+
+        assertThat(restored.getTokenValue()).isEqualTo(tokenValue);
+        assertThat(restored).isEqualTo(token);
+        assertThat(restored.hashCode()).isEqualTo(token.hashCode());
+        assertThat(restored.toString()).contains(tokenValue);
+    }
+
+    private static String createUnsignedJwt() {
+        String header = """
+                {"alg":"none","typ":"JWT"}
+                """;
+        String payload = """
+                {"iss":"https://accounts.google.com","sub":"subject","aud":"audience","exp":2524608000}
+                """;
+        return encode(header) + "." + encode(payload) + ".";
+    }
+
+    private static String encode(String value) {
+        return Base64.getUrlEncoder()
+                .withoutPadding()
+                .encodeToString(value.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/src/test/java/com_google_auth/google_auth_library_oauth2_http/MetricsUtilsTest.java
+++ b/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/src/test/java/com_google_auth/google_auth_library_oauth2_http/MetricsUtilsTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_auth.google_auth_library_oauth2_http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.LowLevelHttpRequest;
+import com.google.api.client.http.LowLevelHttpResponse;
+import com.google.auth.http.HttpTransportFactory;
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.UserCredentials;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class MetricsUtilsTest {
+    private static final String API_CLIENT_HEADER = "x-goog-api-client";
+    private static final URI TOKEN_SERVER_URI = URI.create("https://oauth2.example.test/token");
+
+    @Test
+    public void refreshAccessTokenSendsLibraryVersionMetricsHeader() throws IOException {
+        CapturingHttpTransport transport = new CapturingHttpTransport("""
+                {
+                  "access_token": "refreshed-access-token",
+                  "expires_in": 3600,
+                  "scope": "email profile"
+                }
+                """);
+        UserCredentials credentials = UserCredentials.newBuilder()
+                .setClientId("client-id")
+                .setClientSecret("client-secret")
+                .setRefreshToken("refresh-token")
+                .setTokenServerUri(TOKEN_SERVER_URI)
+                .setHttpTransportFactory(new FixedHttpTransportFactory(transport))
+                .build();
+
+        AccessToken accessToken = credentials.refreshAccessToken();
+
+        assertThat(accessToken.getTokenValue()).isEqualTo("refreshed-access-token");
+        assertThat(accessToken.getScopes()).containsExactly("email", "profile");
+        assertThat(transport.getRequestMethod()).isEqualTo("POST");
+        assertThat(transport.getRequestUrl()).isEqualTo(TOKEN_SERVER_URI.toString());
+        assertThat(transport.getRequestBody())
+                .contains("client_id=client-id")
+                .contains("client_secret=client-secret")
+                .contains("refresh_token=refresh-token")
+                .contains("grant_type=refresh_token");
+        assertThat(transport.getHeaderValues(API_CLIENT_HEADER))
+                .singleElement()
+                .satisfies(header -> assertThat(header)
+                        .contains("gl-java/", "auth/")
+                        .doesNotContain("auth/unknown-version"));
+    }
+
+    private static final class FixedHttpTransportFactory implements HttpTransportFactory {
+        private final HttpTransport transport;
+
+        private FixedHttpTransportFactory(HttpTransport transport) {
+            this.transport = transport;
+        }
+
+        @Override
+        public HttpTransport create() {
+            return transport;
+        }
+    }
+
+    private static final class CapturingHttpTransport extends HttpTransport {
+        private final String responseBody;
+        private final Map<String, List<String>> requestHeaders = new HashMap<>();
+        private String requestMethod;
+        private String requestUrl;
+        private String requestBody;
+
+        private CapturingHttpTransport(String responseBody) {
+            this.responseBody = responseBody;
+        }
+
+        @Override
+        protected LowLevelHttpRequest buildRequest(String method, String url) {
+            requestMethod = method;
+            requestUrl = url;
+            return new LowLevelHttpRequest() {
+                @Override
+                public void addHeader(String name, String value) {
+                    requestHeaders.computeIfAbsent(name, ignored -> new ArrayList<>()).add(value);
+                }
+
+                @Override
+                public LowLevelHttpResponse execute() throws IOException {
+                    ByteArrayOutputStream content = new ByteArrayOutputStream();
+                    if (getStreamingContent() != null) {
+                        getStreamingContent().writeTo(content);
+                    }
+                    requestBody = content.toString(StandardCharsets.UTF_8);
+                    return new JsonLowLevelHttpResponse(responseBody);
+                }
+            };
+        }
+
+        private String getRequestMethod() {
+            return requestMethod;
+        }
+
+        private String getRequestUrl() {
+            return requestUrl;
+        }
+
+        private String getRequestBody() {
+            return requestBody;
+        }
+
+        private List<String> getHeaderValues(String name) {
+            for (Map.Entry<String, List<String>> entry : requestHeaders.entrySet()) {
+                if (entry.getKey().equalsIgnoreCase(name)) {
+                    return entry.getValue();
+                }
+            }
+            return List.of();
+        }
+    }
+
+    private static final class JsonLowLevelHttpResponse extends LowLevelHttpResponse {
+        private final byte[] content;
+
+        private JsonLowLevelHttpResponse(String responseBody) {
+            content = responseBody.getBytes(StandardCharsets.UTF_8);
+        }
+
+        @Override
+        public InputStream getContent() {
+            return new ByteArrayInputStream(content);
+        }
+
+        @Override
+        public String getContentEncoding() {
+            return null;
+        }
+
+        @Override
+        public long getContentLength() {
+            return content.length;
+        }
+
+        @Override
+        public String getContentType() {
+            return "application/json; charset=utf-8";
+        }
+
+        @Override
+        public String getStatusLine() {
+            return "HTTP/1.1 200 OK";
+        }
+
+        @Override
+        public int getStatusCode() {
+            return 200;
+        }
+
+        @Override
+        public String getReasonPhrase() {
+            return "OK";
+        }
+
+        @Override
+        public int getHeaderCount() {
+            return 0;
+        }
+
+        @Override
+        public String getHeaderName(int index) {
+            return null;
+        }
+
+        @Override
+        public String getHeaderValue(int index) {
+            return null;
+        }
+    }
+}

--- a/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/src/test/java/com_google_auth/google_auth_library_oauth2_http/OAuth2CredentialsTest.java
+++ b/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/src/test/java/com_google_auth/google_auth_library_oauth2_http/OAuth2CredentialsTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_auth.google_auth_library_oauth2_http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.auth.http.AuthHttpConstants;
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.UserCredentials;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.net.URI;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class OAuth2CredentialsTest {
+    private static final URI AUDIENCE_URI = URI.create("https://example.test/resource");
+
+    @Test
+    public void userCredentialsDeserializationRestoresDefaultTransportFactory() throws Exception {
+        AccessToken accessToken = new AccessToken(
+                "access-token",
+                new Date(System.currentTimeMillis() + 3_600_000));
+        UserCredentials credentials = UserCredentials.newBuilder()
+                .setClientId("client-id")
+                .setClientSecret("client-secret")
+                .setAccessToken(accessToken)
+                .setQuotaProjectId("quota-project")
+                .build();
+
+        UserCredentials restored;
+        try (ObjectInputStream input = new ObjectInputStream(
+                new ByteArrayInputStream(serialize(credentials)))) {
+            restored = (UserCredentials) input.readObject();
+        }
+
+        Map<String, List<String>> requestMetadata = restored.getRequestMetadata(AUDIENCE_URI);
+        assertThat(requestMetadata)
+                .containsEntry(AuthHttpConstants.AUTHORIZATION, List.of("Bearer access-token"));
+        assertThat(restored).isEqualTo(credentials);
+        assertThat(restored.toString()).contains("client-id", "quota-project");
+    }
+
+    private static byte[] serialize(UserCredentials credentials) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+            output.writeObject(credentials);
+        }
+        return bytes.toByteArray();
+    }
+}

--- a/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/src/test/java/com_google_auth/google_auth_library_oauth2_http/OAuth2CredentialsTest.java
+++ b/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/src/test/java/com_google_auth/google_auth_library_oauth2_http/OAuth2CredentialsTest.java
@@ -36,17 +36,43 @@ public class OAuth2CredentialsTest {
                 .setQuotaProjectId("quota-project")
                 .build();
 
-        UserCredentials restored;
-        try (ObjectInputStream input = new ObjectInputStream(
-                new ByteArrayInputStream(serialize(credentials)))) {
-            restored = (UserCredentials) input.readObject();
-        }
+        UserCredentials restored = deserialize(credentials);
 
         Map<String, List<String>> requestMetadata = restored.getRequestMetadata(AUDIENCE_URI);
         assertThat(requestMetadata)
                 .containsEntry(AuthHttpConstants.AUTHORIZATION, List.of("Bearer access-token"));
         assertThat(restored).isEqualTo(credentials);
         assertThat(restored.toString()).contains("client-id", "quota-project");
+    }
+
+    @Test
+    public void userCredentialsDeserializationInstantiatesCustomTransportFactory()
+            throws Exception {
+        AccessToken accessToken = new AccessToken(
+                "custom-access-token",
+                new Date(System.currentTimeMillis() + 3_600_000));
+        UserCredentials credentials = UserCredentials.newBuilder()
+                .setClientId("client-id")
+                .setClientSecret("client-secret")
+                .setAccessToken(accessToken)
+                .setHttpTransportFactory(new CustomHttpTransportFactory())
+                .build();
+
+        UserCredentials restored = deserialize(credentials);
+
+        assertThat(restored.toBuilder().getHttpTransportFactory())
+                .isInstanceOf(CustomHttpTransportFactory.class);
+        assertThat(restored.getRequestMetadata(AUDIENCE_URI))
+                .containsEntry(
+                        AuthHttpConstants.AUTHORIZATION,
+                        List.of("Bearer custom-access-token"));
+    }
+
+    private static UserCredentials deserialize(UserCredentials credentials) throws Exception {
+        try (ObjectInputStream input = new ObjectInputStream(
+                new ByteArrayInputStream(serialize(credentials)))) {
+            return (UserCredentials) input.readObject();
+        }
     }
 
     private static byte[] serialize(UserCredentials credentials) throws Exception {

--- a/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.ClientId"
+      },
+      "glob" : "com_google_auth/google_auth_library_oauth2_http/client_id.json"
+    }
+  ]
+}

--- a/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,4 +1,18 @@
 {
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.google.auth.oauth2.UserCredentials"
+      },
+      "type" : "com_google_auth.google_auth_library_oauth2_http.CustomHttpTransportFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
   "resources" : [
     {
       "condition" : {

--- a/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/src/test/resources/com_google_auth/google_auth_library_oauth2_http/client_id.json
+++ b/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/src/test/resources/com_google_auth/google_auth_library_oauth2_http/client_id.json
@@ -1,0 +1,6 @@
+{
+  "installed": {
+    "client_id": "test-client-id.apps.googleusercontent.com",
+    "client_secret": "test-client-secret"
+  }
+}

--- a/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/user-code-filter.json
+++ b/tests/src/com.google.auth/google-auth-library-oauth2-http/1.48.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.google.auth.**"
+    },
+    {
+      "includeClasses" : "com_google_auth.google_auth_library_oauth2_http.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #8371

This PR improves dynamic-access coverage for com.google.auth:google-auth-library-oauth2-http:1.48.0 by generating additional tests.

Summary:
- Validation commands: `./gradlew test -Pcoordinates=com.google.auth:google-auth-library-oauth2-http:1.48.0`
- Validation result: `success`
- Requested coordinate: `com.google.auth:google-auth-library-oauth2-http:1.48.0`
- Match type: `new-version`
- Matched metadata version: `none`
- Matched test version: `none`
- Resolved metadata version: `1.48.0`
- Resolved test version: `1.48.0`
- Strategy: library_update_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 400143
- Cached input tokens: 4770304
- Output tokens: 39003
- Iterations: 6
- Library coverage percentage: 8.79
- Generated lines of code: 624
- Tested library lines of code: 491

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `ai/vjovanov/fix-java-run-org.springframework-spring-test-7.0.0`
- Forge commit hash: `d409f66a8eb28e63b8ff438903afb8ca17a04972`



### Stats comparison for `com.google.auth:google-auth-library-oauth2-http:1.48.0`

#### Dynamic access coverage

- Before (com.google.auth:google-auth-library-oauth2-http:1.48.0): N/A
- After (com.google.auth:google-auth-library-oauth2-http:1.48.0): 26/26 covered calls (100.00%)

**Reflection:**
- Before (com.google.auth:google-auth-library-oauth2-http:1.48.0): N/A
- After (com.google.auth:google-auth-library-oauth2-http:1.48.0): 25/25 covered calls (100.00%)

**Resources:**
- Before (com.google.auth:google-auth-library-oauth2-http:1.48.0): N/A
- After (com.google.auth:google-auth-library-oauth2-http:1.48.0): 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- Before (com.google.auth:google-auth-library-oauth2-http:1.48.0): N/A
- After (com.google.auth:google-auth-library-oauth2-http:1.48.0): 1915/22081 (8.67%)

**Line:**
- Before (com.google.auth:google-auth-library-oauth2-http:1.48.0): N/A
- After (com.google.auth:google-auth-library-oauth2-http:1.48.0): 491/5585 (8.79%)

**Method:**
- Before (com.google.auth:google-auth-library-oauth2-http:1.48.0): N/A
- After (com.google.auth:google-auth-library-oauth2-http:1.48.0): 136/1287 (10.57%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
